### PR TITLE
fix(tui): show top preview row in live mode when info header is hidden

### DIFF
--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -468,7 +468,7 @@ impl Preview {
 /// makes `compute_scroll` walk one row too far past the bottom, clipping the
 /// top line of the capture, where a freshly started shell's prompt and cursor
 /// sit. That is the "first row is invisible in live mode" bug.
-fn output_visible_height(area_height: u16, has_banner: bool) -> usize {
+pub(crate) fn output_visible_height(area_height: u16, has_banner: bool) -> usize {
     if has_banner {
         area_height.saturating_sub(1) as usize
     } else {

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -150,8 +150,11 @@ impl Preview {
             area
         };
 
-        // Output section
-        let visible_height = output_area.height.saturating_sub(1) as usize;
+        // Output section. With the info section hidden there's no inner
+        // ` Terminal Output ` banner, so the paragraph gets the full
+        // `output_area`; the visible height must match or `compute_scroll`
+        // clips the top row (and a fresh shell's cursor) in live mode.
+        let visible_height = output_visible_height(output_area.height, render_info_section);
         // Use the pre-parsed cache when the terminal is up; suppress
         // it otherwise so the "press Enter to start terminal" hint
         // can take the inner area instead of a stale capture.
@@ -373,7 +376,11 @@ impl Preview {
         theme: &Theme,
         compact: bool,
     ) {
-        let visible_height = area.height.saturating_sub(1) as usize;
+        // `compact` here doubles as the "skip the inner ` Output ` banner"
+        // flag (see the `inner` split below), so the banner is present
+        // exactly when `!compact`. Match the visible height to the actual
+        // paragraph area or the top row gets clipped when the banner is gone.
+        let visible_height = output_visible_height(area.height, !compact);
         // The error path below returns early, so by the time we use
         // `parsed_output` for the output Paragraph the error case has
         // been handled. Until then `parsed_output` is just the cached
@@ -448,6 +455,24 @@ impl Preview {
                 .alignment(Alignment::Center);
             frame.render_widget(hint, inner);
         }
+    }
+}
+
+/// Rows of captured output actually visible in the preview body.
+///
+/// The body drops one row for the inner ` Output ` / ` Terminal Output `
+/// banner ONLY when that banner is rendered (info section shown, non-compact).
+/// When the banner is hidden (compact viewport or the user toggled the info
+/// header off) the output paragraph claims the full area, so the visible
+/// height must equal the full area height. Subtracting one unconditionally
+/// makes `compute_scroll` walk one row too far past the bottom, clipping the
+/// top line of the capture, where a freshly started shell's prompt and cursor
+/// sit. That is the "first row is invisible in live mode" bug.
+fn output_visible_height(area_height: u16, has_banner: bool) -> usize {
+    if has_banner {
+        area_height.saturating_sub(1) as usize
+    } else {
+        area_height as usize
     }
 }
 
@@ -577,6 +602,38 @@ mod tests {
                 assert_eq!(shortened, "~/projects/");
             }
         }
+    }
+
+    // Regression for the "first row hidden in live mode" bug: with the info
+    // header toggled off there's no inner banner, so the output paragraph
+    // claims the full area and the visible height must equal the area height.
+    // Subtracting one (the pre-fix behavior) made `compute_scroll` walk one
+    // row past the bottom, clipping the top line where a fresh shell's cursor
+    // sits.
+    #[test]
+    fn output_visible_height_matches_area_when_banner_hidden() {
+        assert_eq!(output_visible_height(40, false), 40);
+    }
+
+    #[test]
+    fn output_visible_height_drops_banner_row_when_shown() {
+        assert_eq!(output_visible_height(40, true), 39);
+    }
+
+    #[test]
+    fn output_visible_height_saturates_at_zero() {
+        assert_eq!(output_visible_height(0, true), 0);
+    }
+
+    // The bug end to end: a captured screen exactly as tall as the pane,
+    // live-following (offset 0). With the banner hidden the scroll must be 0
+    // so row 0 (the cursor row) stays on screen; the pre-fix height-1 produced
+    // a scroll of 1 and pushed that row off the top.
+    #[test]
+    fn full_height_capture_does_not_scroll_when_banner_hidden() {
+        let height = 40u16;
+        let visible = output_visible_height(height, false);
+        assert_eq!(compute_scroll(height as usize, visible, 0), 0);
     }
 
     #[test]

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -478,6 +478,16 @@ pub struct HomeView {
     /// see; tail-anchored display clipped those rows off the top, so
     /// every frame in info-expanded mode looked shifted up.
     pub(super) preview_pane_area: Rect,
+    /// Rows of captured output the renderer actually paints into the preview
+    /// body: the pane height minus the inner ` Output ` / ` Terminal Output `
+    /// banner row when (and only when) that banner is shown. Computed in
+    /// `render_preview` via `preview::output_visible_height` and shared with
+    /// `clamp_scroll_to_capture` and the live-send `[offset/max]` banner so
+    /// every consumer of "how many rows are visible" agrees with what's on
+    /// screen. Subtracting one unconditionally instead would let a phantom
+    /// scroll offset of 1 survive when content exactly fills a banner-less
+    /// pane, stalling live-follow one row early.
+    pub(super) preview_visible_rows: usize,
     /// Outer rect of the preview pane (block + borders + content), captured
     /// during `render_preview`. The live-send preview-only fast path uses
     /// this to call back into `render_preview` with the correct OUTER area,
@@ -779,6 +789,7 @@ impl HomeView {
             preview_scroll_offset: 0,
             preview_area: Rect::default(),
             preview_pane_area: Rect::default(),
+            preview_visible_rows: 0,
             preview_outer_area: Rect::default(),
             diff_area: Rect::default(),
             list_area: Rect::default(),

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -141,9 +141,18 @@ fn scroll_exceeds_cache(cache_captured_lines: usize, height: u16, scroll_offset:
 /// can actually render. Prevents the offset from drifting into "phantom"
 /// territory (M3 from the multi-AI review) when tmux history is shorter than
 /// `MAX_PREVIEW_SCROLL`.
-fn clamp_scroll_to_capture(scroll_offset: u16, captured_lines: usize, area_height: u16) -> u16 {
-    let visible = area_height.saturating_sub(1) as usize;
-    let real_max = captured_lines.saturating_sub(visible) as u16;
+///
+/// `visible_height` is the rendered output-body height the caller already
+/// computed (via `preview::output_visible_height`), NOT the raw pane height.
+/// Re-deriving it here with a fixed `- 1` would over-count the max offset by a
+/// row whenever the inner banner is hidden, leaving a phantom offset that
+/// stalls live-follow one row early.
+fn clamp_scroll_to_capture(
+    scroll_offset: u16,
+    captured_lines: usize,
+    visible_height: usize,
+) -> u16 {
+    let real_max = captured_lines.saturating_sub(visible_height) as u16;
     scroll_offset.min(real_max)
 }
 
@@ -1382,7 +1391,7 @@ impl HomeView {
                     self.preview_scroll_offset = clamp_scroll_to_capture(
                         self.preview_scroll_offset,
                         self.preview_cache.captured_lines,
-                        height,
+                        self.preview_visible_rows,
                     );
                 }
             }
@@ -1449,7 +1458,7 @@ impl HomeView {
                     self.preview_scroll_offset = clamp_scroll_to_capture(
                         self.preview_scroll_offset,
                         self.terminal_preview_cache.captured_lines,
-                        height,
+                        self.preview_visible_rows,
                     );
                 }
             }
@@ -1515,7 +1524,7 @@ impl HomeView {
                     self.preview_scroll_offset = clamp_scroll_to_capture(
                         self.preview_scroll_offset,
                         self.container_terminal_preview_cache.captured_lines,
-                        height,
+                        self.preview_visible_rows,
                     );
                 }
             }
@@ -1557,7 +1566,7 @@ impl HomeView {
                     self.preview_scroll_offset = clamp_scroll_to_capture(
                         self.preview_scroll_offset,
                         self.tool_preview_cache.captured_lines,
-                        height,
+                        self.preview_visible_rows,
                     );
                 }
             }
@@ -1723,6 +1732,11 @@ impl HomeView {
         // Default to `inner`; the Agent branch below refines it if it can
         // resolve the selected instance.
         self.preview_pane_area = inner;
+        // Track the rows the output body actually paints into, shared with the
+        // scroll clamp and the live banner so their math matches the renderer.
+        // Each view branch refines this after it resolves its real pane rect.
+        self.preview_visible_rows =
+            preview::output_visible_height(inner.height, !compact && self.show_preview_info);
         frame.render_widget(block, area);
 
         match self.view_mode {
@@ -1764,6 +1778,10 @@ impl HomeView {
                             .unwrap_or(inner)
                     };
                     self.preview_pane_area = pane_area;
+                    self.preview_visible_rows = preview::output_visible_height(
+                        pane_area.height,
+                        !compact && self.show_preview_info,
+                    );
                     // Refresh the raw `content` cache, then ensure the
                     // parsed `Text<'static>` cache reflects it. Doing
                     // the parse here (under `&mut self.preview_cache`)
@@ -1830,6 +1848,10 @@ impl HomeView {
                             .unwrap_or(inner)
                     };
                     self.preview_pane_area = pane_area;
+                    self.preview_visible_rows = preview::output_visible_height(
+                        pane_area.height,
+                        !compact && self.show_preview_info,
+                    );
 
                     // Refresh the appropriate cache, then warm the
                     // matching `parsed_text` so the render call below
@@ -1908,6 +1930,10 @@ impl HomeView {
                             .unwrap_or(inner)
                     };
                     self.preview_pane_area = pane_area;
+                    self.preview_visible_rows = preview::output_visible_height(
+                        pane_area.height,
+                        !compact && self.show_preview_info,
+                    );
 
                     self.refresh_tool_preview_cache_if_needed(
                         pane_area.width,
@@ -2152,13 +2178,13 @@ impl HomeView {
                 live_send::display_chord_list(&state.exit_chords)
             };
             let suffix = " to exit ";
-            // `preview_cache.dimensions` is the output pane area passed to
-            // `refresh_preview_cache_if_needed`, and `render_output_cached`
-            // uses `area.height - 1` as its visible height (one row of
-            // headroom for the inner " Output " banner / compact-branch
-            // padding). Match that here so the live `[offset/max]`
-            // indicator agrees with the actual scroll math.
-            let visible_height = (self.preview_cache.dimensions.1 as usize).saturating_sub(1);
+            // `preview_visible_rows` is the output-body height the renderer
+            // last painted into (pane height minus the inner banner row only
+            // when that banner is shown). Reuse it so the live `[offset/max]`
+            // indicator agrees with the actual scroll math; deriving it from
+            // `dimensions` with a fixed `- 1` would over-count the max by a
+            // row whenever the info header is hidden.
+            let visible_height = self.preview_visible_rows;
             let scroll = format_scroll_indicator(
                 self.preview_cache.captured_lines,
                 visible_height,
@@ -2657,6 +2683,24 @@ mod tests {
     #[test]
     fn capture_lines_for_adds_buffer_to_height() {
         assert_eq!(capture_lines_for(30, 0), 50);
+    }
+
+    #[test]
+    fn clamp_scroll_to_capture_uses_visible_height_verbatim() {
+        // Content exactly fills a 40-row banner-less pane: visible_height == 40,
+        // so there is nothing to scroll back to and any offset clamps to 0.
+        // The pre-fix code derived `area_height - 1` internally, which left a
+        // phantom max offset of 1 and stalled live-follow a row early.
+        assert_eq!(clamp_scroll_to_capture(1, 40, 40), 0);
+        assert_eq!(clamp_scroll_to_capture(5, 40, 40), 0);
+    }
+
+    #[test]
+    fn clamp_scroll_to_capture_allows_real_scrollback() {
+        // 60 captured lines into a 40-row view leaves 20 rows of real history;
+        // offsets within that range pass through, larger ones clamp to the max.
+        assert_eq!(clamp_scroll_to_capture(10, 60, 40), 10);
+        assert_eq!(clamp_scroll_to_capture(50, 60, 40), 20);
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1663,14 +1663,14 @@ impl HomeView {
             // ` Terminal Output ` banner (which usually carries the
             // scroll indicator) is also gone. Surface the indicator
             // here so users still see how far back they've scrolled.
-            // With borders::ALL the inner is area - 2; render_output_cached
-            // / render_terminal_preview then drops one more row before
-            // painting (their compact / info-hidden branches use
-            // height-1 for visible_height), so we match that to keep the
-            // count stable as the user scrolls.
+            // With borders::ALL the inner is area - 2; with the banner
+            // hidden the output paragraph claims that full inner, so the
+            // visible height is `inner_height` (no extra row dropped). This
+            // mirrors `output_visible_height(.., has_banner = false)` in the
+            // preview renderers so the indicator count stays in lockstep.
             let scroll_indicator = if !self.show_preview_info {
                 let inner_height = area.height.saturating_sub(2);
-                let visible_height = inner_height.saturating_sub(1) as usize;
+                let visible_height = inner_height as usize;
                 let captured_lines = match &self.view_mode {
                     ViewMode::Agent => self.preview_cache.captured_lines,
                     ViewMode::Tool(_) => self.tool_preview_cache.captured_lines,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1573,6 +1573,36 @@ impl HomeView {
         }
     }
 
+    /// `captured_lines` from whichever preview cache is currently on screen.
+    /// Both the preview's own scroll indicator and the live-send footer need
+    /// the active view's line count; reading `preview_cache` (the Agent cache)
+    /// unconditionally shows a stale or empty `[offset/max]` in Terminal or
+    /// Tool live mode, where a different cache backs the visible output.
+    fn active_captured_lines(&self) -> usize {
+        match &self.view_mode {
+            ViewMode::Agent => self.preview_cache.captured_lines,
+            ViewMode::Tool(_) => self.tool_preview_cache.captured_lines,
+            ViewMode::Terminal => {
+                let mode = self
+                    .selected_session
+                    .as_ref()
+                    .and_then(|id| self.get_instance(id).map(|inst| (id, inst)))
+                    .map(|(id, inst)| {
+                        if inst.is_sandboxed() {
+                            self.get_terminal_mode(id)
+                        } else {
+                            TerminalMode::Host
+                        }
+                    })
+                    .unwrap_or(TerminalMode::Host);
+                match mode {
+                    TerminalMode::Container => self.container_terminal_preview_cache.captured_lines,
+                    TerminalMode::Host => self.terminal_preview_cache.captured_lines,
+                }
+            }
+        }
+    }
+
     fn render_preview(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let compact = area.width < responsive::STACKED_BREAKPOINT;
         let (border_color, title_color) = match self.view_mode {
@@ -1680,30 +1710,7 @@ impl HomeView {
             let scroll_indicator = if !self.show_preview_info {
                 let inner_height = area.height.saturating_sub(2);
                 let visible_height = inner_height as usize;
-                let captured_lines = match &self.view_mode {
-                    ViewMode::Agent => self.preview_cache.captured_lines,
-                    ViewMode::Tool(_) => self.tool_preview_cache.captured_lines,
-                    ViewMode::Terminal => {
-                        let mode = self
-                            .selected_session
-                            .as_ref()
-                            .and_then(|id| self.get_instance(id).map(|inst| (id, inst)))
-                            .map(|(id, inst)| {
-                                if inst.is_sandboxed() {
-                                    self.get_terminal_mode(id)
-                                } else {
-                                    TerminalMode::Host
-                                }
-                            })
-                            .unwrap_or(TerminalMode::Host);
-                        match mode {
-                            TerminalMode::Container => {
-                                self.container_terminal_preview_cache.captured_lines
-                            }
-                            TerminalMode::Host => self.terminal_preview_cache.captured_lines,
-                        }
-                    }
-                };
+                let captured_lines = self.active_captured_lines();
                 format_scroll_indicator(captured_lines, visible_height, self.preview_scroll_offset)
             } else {
                 None
@@ -2185,8 +2192,11 @@ impl HomeView {
             // `dimensions` with a fixed `- 1` would over-count the max by a
             // row whenever the info header is hidden.
             let visible_height = self.preview_visible_rows;
+            // Pull `captured_lines` from whichever cache is on screen, not the
+            // Agent cache unconditionally: in Terminal/Tool live mode the
+            // wrong cache would show a stale or empty `[offset/max]`.
             let scroll = format_scroll_indicator(
-                self.preview_cache.captured_lines,
+                self.active_captured_lines(),
                 visible_height,
                 self.preview_scroll_offset,
             )


### PR DESCRIPTION
## Description

With the preview info header hidden (`i` toggle) or in compact viewports, entering live mode clipped the **top row** of the preview body. In Terminal view a freshly started shell has its prompt and cursor on row 0, so live mode appeared to hide the cursor entirely.

Root cause: in `src/tui/components/preview.rs`, `visible_height` was computed as `area.height - 1` unconditionally. That `-1` accounts for the inner ` Output ` / ` Terminal Output ` banner (a `Borders::TOP` row). But the compact / info-hidden branches skip that banner and give the output paragraph the full pane, so `compute_scroll` walked one row past the bottom and scrolled the top line out of view. The off-by-one dates to #865 (responsive layout), which added the banner-less branch but left the unconditional `-1`.

Fix: add `output_visible_height(area_height, has_banner)` and use it at both call sites (`render_terminal_preview`, `render_output_cached`), and fix the mirrored computation in the outer scroll indicator in `src/tui/home/render.rs` (it had intentionally matched the buggy `-1`). The tmux pane geometry was already correct, so this is purely the on-screen scroll offset.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (n/a, no doc-facing change)
- [x] For UI changes: included screenshot or recording (terminal capture below)

### Before / after (Terminal live mode, info hidden, fresh shell)

Captured by driving the real `aoe` binary in an isolated tmux server (120x40, scratch session), first row of the preview body shown:

```
BEFORE (clipped, first row blank, # prompt + cursor hidden):
  |                          <- empty
AFTER (fixed):
  | #                        <- shell prompt + cursor visible
```

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (Rust-only TUI change; no `web/` files touched)

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a formal e2e spec, because: the bug is a pure off-by-one in the scroll-height math, best locked down by deterministic unit tests on the extracted `output_visible_height` helper (an e2e screen-diff for a single clipped row would be flakier). Added 4 unit regression tests in `src/tui/components/preview.rs`, including `full_height_capture_does_not_scroll_when_banner_hidden` (full-height capture + offset 0 must scroll 0). Also verified end-to-end manually through the real binary in tmux (before/after above).

## Test plan

- [x] `cargo test --lib` — 2329 passed, 0 failed
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual e2e: drove `aoe` in tmux, confirmed the fresh-shell prompt/cursor is visible on the top preview row in live mode with info hidden (was blank before the fix)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause investigation, fix, unit regression tests, and the before/after tmux verification were done with Claude Code, reviewed by me.

- [ ] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes an off-by-one scrolling/display bug in the TUI preview pane that could clip the top row (e.g., a freshly-drawn shell prompt) when entering live-follow mode with the info header hidden or on compact viewports.

What changed (high-level)
- Centralized visible-output height calculation:
  - Added preview::output_visible_height(area_height, has_banner) to compute how many rows the preview actually paints (subtract the inner banner row only when present).
  - Replaced ad-hoc area.height - 1 math with the new helper in terminal preview rendering and cached-output rendering.
- Unified scroll/clamping logic:
  - HomeView now caches the computed preview_visible_rows (new HomeView field).
  - clamp_scroll_to_capture and callers use the resolved visible_height to prevent a phantom “max offset” when the banner is hidden.
  - Corrected the live scroll indicator math to match the actual painted output area.
- Tests & verification:
  - Added 4 unit regression tests (banner-present vs banner-hidden sizing and a full-height capture not scrolling when banner is hidden).
  - Ran cargo test (2329 passed), cargo clippy, cargo fmt; manual tmux verification confirms shell prompt/cursor visible.

Technical details
- New crate-visible helper: output_visible_height(area_height: u16, has_banner: bool) -> usize in src/tui/components/preview.rs.
- render_terminal_preview and render_output_cached now call output_visible_height(...) instead of subtracting 1 unconditionally.
- HomeView.preview_visible_rows: usize added (src/tui/home/mod.rs) and used to clamp preview scroll and drive the live-send [offset/max] indicator.
- clamp_scroll_to_capture now accepts visible_height explicitly and computes max offset as captured_lines - visible_height (no phantom -1).
- No tmux pane geometry changes — this only adjusts on-screen scroll offsets and live indicators.

Benefits
- Fixes the top-row clipping in live-follow mode when the info header/banner is hidden.
- Centralizes and clarifies visible-height logic, removing duplicated off-by-one math.
- Regression tests guard against reintroducing the bug.
- Minimal, targeted behavioral fix with clean CI results.

Notes
- PR type: Bug Fix. AI-assisted work noted (Claude Code) and co-author attribution included in commits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->