### PR TITLE
feat(tui): swap home-screen search keybind from / to \

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1887,7 +1887,7 @@ impl HomeView {
                     self.open_tool_picker();
                 }
             }
-            KeyCode::Char('/') => {
+            KeyCode::Char('\\') => {
                 self.search_active = true;
                 self.search_query = Input::default();
             }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -800,7 +800,7 @@ impl HomeView {
                 .unwrap_or_else(|| " ".to_string());
             let after: String = value.chars().skip(cursor_pos + 1).collect();
 
-            let mut spans = vec![Span::styled("/", text_style)];
+            let mut spans = vec![Span::styled("\\", text_style)];
             if !before.is_empty() {
                 spans.push(Span::styled(before, text_style));
             }
@@ -822,7 +822,7 @@ impl HomeView {
 
             frame.render_widget(Paragraph::new(Line::from(spans)), search_area);
             if !self.has_overlay_above_search() {
-                set_prefixed_input_cursor_position(frame, search_area, "/", &self.search_query);
+                set_prefixed_input_cursor_position(frame, search_area, "\\", &self.search_query);
             }
         }
     }
@@ -2262,7 +2262,7 @@ impl HomeView {
             ]
         };
         // Key-only entry for keys universal enough that a description would be
-        // noise (? for help, / for search). Saves footer width at iPhone-Mosh
+        // noise (? for help, \ for search). Saves footer width at iPhone-Mosh
         // sizes.
         let mk_key =
             |key: &str| -> Vec<Span<'static>> { vec![Span::styled(key.to_string(), key_style)] };
@@ -2371,7 +2371,7 @@ impl HomeView {
             }
         }
 
-        groups.push((4, mk_key("/")));
+        groups.push((4, mk_key("\\")));
         groups.push((4, mk(if strict { "^D" } else { "D" }, "Diff")));
         groups.push((1, mk("^K", "Cmds")));
         groups.push((0, mk_key("?")));

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -443,10 +443,10 @@ fn test_enter_on_cockpit_session_opens_cockpit_view() {
 
 #[test]
 #[serial]
-fn test_slash_enters_search_mode() {
+fn test_backslash_enters_search_mode() {
     let mut env = create_test_env_with_sessions(3);
     assert!(!env.view.search_active);
-    env.view.handle_key(key(KeyCode::Char('/')), None);
+    env.view.handle_key(key(KeyCode::Char('\\')), None);
     assert!(env.view.search_active);
     assert!(env.view.search_query.value().is_empty());
 }
@@ -455,7 +455,7 @@ fn test_slash_enters_search_mode() {
 #[serial]
 fn test_search_mode_captures_chars() {
     let mut env = create_test_env_with_sessions(3);
-    env.view.handle_key(key(KeyCode::Char('/')), None);
+    env.view.handle_key(key(KeyCode::Char('\\')), None);
     env.view.handle_key(key(KeyCode::Char('t')), None);
     env.view.handle_key(key(KeyCode::Char('e')), None);
     env.view.handle_key(key(KeyCode::Char('s')), None);
@@ -467,7 +467,7 @@ fn test_search_mode_captures_chars() {
 #[serial]
 fn test_search_mode_backspace() {
     let mut env = create_test_env_with_sessions(3);
-    env.view.handle_key(key(KeyCode::Char('/')), None);
+    env.view.handle_key(key(KeyCode::Char('\\')), None);
     env.view.handle_key(key(KeyCode::Char('a')), None);
     env.view.handle_key(key(KeyCode::Char('b')), None);
     env.view.handle_key(key(KeyCode::Backspace), None);
@@ -478,7 +478,7 @@ fn test_search_mode_backspace() {
 #[serial]
 fn test_search_mode_esc_exits_and_clears() {
     let mut env = create_test_env_with_sessions(3);
-    env.view.handle_key(key(KeyCode::Char('/')), None);
+    env.view.handle_key(key(KeyCode::Char('\\')), None);
     env.view.handle_key(key(KeyCode::Char('x')), None);
     env.view.handle_key(key(KeyCode::Esc), None);
     assert!(!env.view.search_active);
@@ -490,7 +490,7 @@ fn test_search_mode_esc_exits_and_clears() {
 #[serial]
 fn test_search_mode_enter_exits_and_clears_state() {
     let mut env = create_test_env_with_sessions(3);
-    env.view.handle_key(key(KeyCode::Char('/')), None);
+    env.view.handle_key(key(KeyCode::Char('\\')), None);
     env.view.handle_key(key(KeyCode::Char('s')), None);
     env.view.handle_key(key(KeyCode::Enter), None);
     assert!(!env.view.search_active);
@@ -683,7 +683,7 @@ fn test_search_shift_n_cycles_backward() {
 #[serial]
 fn test_esc_clears_search_matches() {
     let mut env = create_test_env_with_sessions(5);
-    env.view.handle_key(key(KeyCode::Char('/')), None);
+    env.view.handle_key(key(KeyCode::Char('\\')), None);
     env.view.handle_key(key(KeyCode::Char('s')), None);
     assert!(!env.view.search_matches.is_empty());
     env.view.handle_key(key(KeyCode::Esc), None);
@@ -696,7 +696,7 @@ fn test_esc_clears_search_matches() {
 fn test_enter_clears_matches_so_n_opens_new_dialog() {
     let mut env = create_test_env_with_sessions(5);
     // Search, then Enter to exit search mode
-    env.view.handle_key(key(KeyCode::Char('/')), None);
+    env.view.handle_key(key(KeyCode::Char('\\')), None);
     env.view.handle_key(key(KeyCode::Char('s')), None);
     env.view.handle_key(key(KeyCode::Enter), None);
     assert!(!env.view.search_active);
@@ -714,7 +714,7 @@ fn test_enter_clears_matches_so_n_opens_new_dialog() {
 fn test_reload_does_not_snap_cursor_after_enter() {
     let mut env = create_test_env_with_sessions(5);
     // Search and exit with Enter
-    env.view.handle_key(key(KeyCode::Char('/')), None);
+    env.view.handle_key(key(KeyCode::Char('\\')), None);
     env.view.handle_key(key(KeyCode::Char('s')), None);
     env.view.handle_key(key(KeyCode::Enter), None);
     assert!(!env.view.search_active);
@@ -734,7 +734,7 @@ fn test_reload_does_not_snap_cursor_after_enter() {
 #[serial]
 fn test_enter_clears_matches_and_resets_index() {
     let mut env = create_test_env_with_sessions(5);
-    env.view.handle_key(key(KeyCode::Char('/')), None);
+    env.view.handle_key(key(KeyCode::Char('\\')), None);
     env.view.handle_key(key(KeyCode::Char('s')), None);
     let match_count = env.view.search_matches.len();
     assert!(match_count > 0);
@@ -906,7 +906,7 @@ fn test_uppercase_p_in_search_mode_does_not_open_picker() {
     let mut view = env.view;
 
     // Enter search mode
-    view.handle_key(key(KeyCode::Char('/')), None);
+    view.handle_key(key(KeyCode::Char('\\')), None);
     assert!(view.search_active);
 
     // P should be treated as search input, not open picker
@@ -3493,7 +3493,7 @@ fn test_q_in_search_mode_types_q_not_quit() {
     let env = create_test_env_with_sessions(3);
     let mut view = env.view;
 
-    view.handle_key(key(KeyCode::Char('/')), None);
+    view.handle_key(key(KeyCode::Char('\\')), None);
     assert!(view.search_active);
 
     let action = view.handle_key(key(KeyCode::Char('q')), None);
@@ -3509,7 +3509,7 @@ fn test_has_dialog_true_when_search_active() {
     let mut view = env.view;
 
     assert!(!view.has_dialog());
-    view.handle_key(key(KeyCode::Char('/')), None);
+    view.handle_key(key(KeyCode::Char('\\')), None);
     assert!(view.has_dialog());
 }
 


### PR DESCRIPTION
## Summary

The home view binds bare `/` to "enter search mode". For users who frequently send slash-commands (`/goal`, `/think`, `/clear`, etc.) into a focused agent pane, the home view's `/` handler keeps swallowing the leading character when the home view still has focus — `/goal` lands as `Find: goal` and the command never reaches the agent.

This PR swaps the home search trigger from `/` to `\`. The change is mechanical and confined to one TUI surface: the home view's universal-key handler, the cursor prefix that styles the leading character in the search input, the footer entry, and the search-mode tests.

Settings search (separate handler in `src/tui/settings/input.rs`) is intentionally left on `/` to keep this PR small; happy to do the same swap there as a follow-up if desired.

## Changes

- `src/tui/home/input.rs:1890` — `KeyCode::Char('/')` → `KeyCode::Char('\\')`
- `src/tui/home/render.rs` — leading-char span (line 803), input cursor prefix (line 825), footer `mk_key` entry (line 2374), and the universal-key rationale comment (line 2265)
- `src/tui/home/tests.rs` — 13 search-mode test cases updated; `test_slash_enters_search_mode` renamed to `test_backslash_enters_search_mode`

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (runs in pre-commit hook)
- [x] `cargo test --release --lib home::tests::test` — 137 passed, 0 failed
- [ ] Manual: in TUI, press `\` on home view → search activates; press `/` → no longer triggers search

## Notes

Convention-wise `/` is the vim/less/more search idiom, so this is a non-trivial divergence — happy to discuss whether you'd prefer:

1. Hard swap (this PR): `/` no longer triggers search.
2. Add `\` as alias: both keys open search, no breakage.
3. Config-gated: a `search_keybind` setting with `/` as default.

I picked option 1 because it's the smallest diff and matches the muscle-memory fix the user actually wants. Easy to repivot to option 2 if you'd rather not drop `/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reassigns the home screen search activation keybind from `/` to `\`. The change prevents the forward slash from being consumed when users type slash-prefixed commands (like `/goal`) into the agent pane, which previously interrupted their input by triggering search mode instead.

### What Changed

- **Input handling**: Home view now responds to `\` instead of `/` to enter search mode
- **UI rendering**: Search indicator and cursor prefix updated from `/` to `\` throughout the home screen
- **Tests**: 13 search-related tests updated to verify the new `\` keybind; one test function renamed for clarity
- **Settings search**: Intentionally left unchanged (remains on `/`)

### Benefits

- Users can now type slash-prefixed commands without unintended search mode activation
- Minimal, focused change with no impact on other keybindings or functionality
- All existing tests pass after updates

### Technical Details

**Files Modified:**
- `src/tui/home/input.rs`: Single-line change swapping `KeyCode::Char('/')` to `KeyCode::Char('\\')`
- `src/tui/home/render.rs`: Four-line changes updating the search indicator in cursor position helper, cursor character, footer shortcut group, and adjacent comment
- `src/tui/home/tests.rs`: Thirteen-line changes updating test assertions and renaming `test_slash_enters_search_mode` → `test_backslash_enters_search_mode`

**Validation:**
- `cargo build --release`, `cargo fmt --check`, and `cargo clippy` all pass
- 137 home view tests pass with 0 failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->