### PR TITLE
fix(cockpit): bump claude-agent-acp floor to 0.39.0

### DIFF
--- a/cockpit-worker/test-shim/shim.mjs
+++ b/cockpit-worker/test-shim/shim.mjs
@@ -44,7 +44,7 @@ class ShimAgent {
       },
       agentInfo: {
         name: "@agentclientprotocol/claude-agent-acp",
-        version: "0.38.0",
+        version: "0.39.0",
       },
     };
   }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN npm install -g @qwen-code/qwen-code
 # `gemini --acp`, `vibe-acp`) are already provided by their respective
 # CLIs above.
 RUN npm install -g \
-    @agentclientprotocol/claude-agent-acp@^0.38.0 \
+    @agentclientprotocol/claude-agent-acp@^0.39.0 \
     @zed-industries/codex-acp \
     pi-acp
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -693,7 +693,7 @@ manager (e.g., `brew reinstall aoe`).
 
 ### `aoe cockpit doctor` says claude-code adapter is missing
 
-Install the official adapter once. aoe requires v0.37.0 or newer; the
+Install the official adapter once. aoe requires v0.39.0 or newer; the
 cockpit refuses to enter a session with an older adapter and surfaces a
 dedicated remediation screen with the exact install command:
 
@@ -705,9 +705,10 @@ Then run `claude login` if you haven't already.
 
 The minimum version is enforced at the ACP `initialize` handshake; the
 check reads `agent_info.version` from the adapter's initialize response
-and rejects anything below 0.37.0 with a structured `StartupError`
-event. Newer versions are accepted. The minimum exists because aoe
-relies on behavior that only landed in v0.37.0:
+and rejects anything below 0.39.0 with a structured `StartupError`
+event. Newer versions are accepted. The floor tracks the newest
+behavior aoe depends on; the earliest hard requirements landed in
+v0.37.0:
 
 - `memory_recall` tool calls (upstream
   agentclientprotocol/claude-agent-acp#703), so session-start memory
@@ -719,7 +720,7 @@ relies on behavior that only landed in v0.37.0:
   `end_turn`.
 
 If you have an older version pinned by an internal mirror, set up the
-mirror to ship 0.37.0 or override the global install with
+mirror to ship 0.39.0 or override the global install with
 `npm install -g @agentclientprotocol/claude-agent-acp@latest` before
 starting `aoe serve`.
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -33,7 +33,7 @@ The wizard greys out the cockpit option for tools not in this set.
 
 | aoe tool   | Substrate B (cockpit)                                      | Auth                                   |
 |------------|------------------------------------------------------------|----------------------------------------|
-| `claude`   | `claude-agent-acp` (Zed adapter for the Claude SDK, requires >=0.38.0) | `claude /login` writes `~/.claude/credentials`; or `ANTHROPIC_API_KEY` |
+| `claude`   | `claude-agent-acp` (Zed adapter for the Claude SDK, requires >=0.39.0) | `claude /login` writes `~/.claude/credentials`; or `ANTHROPIC_API_KEY` |
 | `opencode` | `opencode acp` (native, SST)                               | `OPENCODE_API_KEY` env var; or provider-specific env (set up via `opencode auth`) |
 | `gemini`   | `gemini --acp` (native, Google)                            | `GEMINI_API_KEY` env var, OAuth via `gemini auth`, or Vertex `GOOGLE_API_KEY` |
 | `codex`    | `codex-acp` (Zed adapter, npm `@zed-industries/codex-acp`) | `OPENAI_API_KEY` env var, or ChatGPT login (local-only) |
@@ -540,7 +540,7 @@ its cached list in full.
 ### When the pickers appear
 
 The pickers only render if the adapter publishes the matching
-category. `claude-agent-acp` v0.38.0+ advertises a model selector
+category. `claude-agent-acp` v0.39.0+ advertises a model selector
 for every session, and adds a reasoning-effort selector when the
 current model reports `supportsEffort=true`. Older adapters that
 emit no `config_option_update` show neither picker; this is by

--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -9,7 +9,7 @@ are first-class but lighter on per-tool polish.
 
 | Agent | ACP entry | Install |
 |-------|-----------|---------|
-| Claude | `claude-agent-acp` (Zed adapter, requires >=0.38.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` |
+| Claude | `claude-agent-acp` (Zed adapter, requires >=0.39.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` |
 | Codex (OpenAI) | `codex-acp` (Zed adapter) | `npm install -g @zed-industries/codex-acp` |
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -132,7 +132,7 @@ Example: `aoe-sandbox-a1b2c3d4`
 
 Cockpit-mode sessions can run inside the sandbox container. When both are enabled, the cockpit runner wraps the ACP agent in `docker exec`, so the adapter binary must exist inside the container. The published `aoe-sandbox` image bundles the npm-distributed ACP adapters for this:
 
-- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@^0.38.0`, floor pin)
+- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@^0.39.0`, floor pin)
 - `codex-acp` (`@zed-industries/codex-acp`)
 - `pi-acp`
 

--- a/src/cockpit/agent_compat.rs
+++ b/src/cockpit/agent_compat.rs
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn claude_above_minimum_accepted() {
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.38.1");
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.39.1");
         validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap();
     }
 

--- a/src/cockpit/agent_compat.rs
+++ b/src/cockpit/agent_compat.rs
@@ -7,7 +7,7 @@
 //! single hook to call after `initialize` succeeds, instead of scattering
 //! ad-hoc semver checks at every spawn site.
 //!
-//! Today only `ClaudeAgentAcp` carries a minimum version (>=0.38.0,
+//! Today only `ClaudeAgentAcp` carries a minimum version (>=0.39.0,
 //! required for `memory_recall` tool-call emission, native `cancelled`
 //! stop reason, Opus 4.8 model availability, and several other behaviors
 //! aoe builds on). Other agents
@@ -48,7 +48,7 @@ impl ExpectedAgent {
     /// separators, and the `.exe` / `.cmd` suffixes Windows shims add.
     /// Without this normalization a wrapped or Windows-installed
     /// `claude-agent-acp` would land in `Other` and silently bypass the
-    /// >=0.38.0 gate.
+    /// >=0.39.0 gate.
     pub fn from_command(command: &str) -> Self {
         // Scan every whitespace-separated token. The actual binary can
         // be the first token (`/usr/local/bin/claude-agent-acp`) but
@@ -56,7 +56,7 @@ impl ExpectedAgent {
         // (`bash claude-agent-acp`, `env -u FOO claude-agent-acp`,
         // `npx claude-agent-acp`, etc.). Match against the first token
         // that classifies as a known adapter so wrappers don't bypass
-        // the >=0.38.0 gate.
+        // the >=0.39.0 gate.
         command
             .split_whitespace()
             .find_map(|token| {
@@ -187,7 +187,7 @@ impl StartupError {
                 expected_package,
                 install_command,
             } => format!(
-                "Adapter did not report its package version. aoe requires {expected_package} >=0.38.0. Run: {install_command}",
+                "Adapter did not report its package version. aoe requires {expected_package} >=0.39.0. Run: {install_command}",
             ),
             Self::MismatchedAgentName {
                 expected,
@@ -385,12 +385,12 @@ mod tests {
             panic!()
         };
         assert_eq!(installed, "0.32.0");
-        assert_eq!(required, "0.38.0");
+        assert_eq!(required, "0.39.0");
     }
 
     #[test]
     fn claude_at_minimum_accepted() {
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.38.0");
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.39.0");
         validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap();
     }
 
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn claude_mismatched_name_rejected() {
-        let init = make_init("some-other-package", "0.38.0");
+        let init = make_init("some-other-package", "0.39.0");
         let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
         assert_eq!(err.kind(), "mismatched_agent_name");
     }
@@ -506,7 +506,7 @@ mod tests {
         );
         // `npx`-style npm-package-spec invocations are out of scope:
         // npx itself resolves the package and the spawned binary's
-        // argv[0] is `claude-agent-acp`, not `claude-agent-acp@0.38.0`.
+        // argv[0] is `claude-agent-acp`, not `claude-agent-acp@0.39.0`.
         // The version-suffixed form would only show up if a user wired
         // it manually into AgentSpec.command, which is not a supported
         // configuration today.

--- a/src/cockpit/agent_compat.rs
+++ b/src/cockpit/agent_compat.rs
@@ -99,7 +99,7 @@ impl ExpectedAgent {
         match self {
             Self::ClaudeAgentAcp => CompatibilityPolicy {
                 expected_name: Some("@agentclientprotocol/claude-agent-acp"),
-                min_version: Some(semver::Version::new(0, 38, 0)),
+                min_version: Some(semver::Version::new(0, 39, 0)),
                 required_protocol: ProtocolVersion::V1,
                 fail_on_missing_agent_info: true,
             },

--- a/web/src/components/cockpit/__tests__/StartupErrorScreen.test.tsx
+++ b/web/src/components/cockpit/__tests__/StartupErrorScreen.test.tsx
@@ -22,14 +22,14 @@ describe("StartupErrorScreen", () => {
           kind: "incompatible_agent_version",
           package_name: "@agentclientprotocol/claude-agent-acp",
           installed: "0.32.0",
-          required: "0.38.0",
+          required: "0.39.0",
           install_command:
             "npm install -g @agentclientprotocol/claude-agent-acp@latest",
         }}
       />,
     );
     expect(container.textContent).toContain("0.32.0");
-    expect(container.textContent).toContain("0.38.0");
+    expect(container.textContent).toContain("0.39.0");
     expect(container.textContent).toContain(
       "@agentclientprotocol/claude-agent-acp",
     );
@@ -81,14 +81,14 @@ describe("StartupErrorScreen", () => {
           kind: "unparseable_agent_version",
           package_name: "@agentclientprotocol/claude-agent-acp",
           raw_version: "not-semver",
-          required: "0.38.0",
+          required: "0.39.0",
           install_command:
             "npm install -g @agentclientprotocol/claude-agent-acp@latest",
         }}
       />,
     );
     expect(container.textContent).toContain("not-semver");
-    expect(container.textContent).toContain("0.38.0");
+    expect(container.textContent).toContain("0.39.0");
   });
 
   it("renders unsupported_protocol_version without an install command", () => {

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -1862,7 +1862,7 @@ describe("CockpitState reducer / silent-orphan watchdog (#1240)", () => {
   });
 });
 
-describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.38.0)", () => {
+describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.39.0)", () => {
   it("sets state.incompatibleAgent from the structured detail", () => {
     const next = applyEvent(emptyCockpitState(), {
       session_id: "s-1",
@@ -1873,7 +1873,7 @@ describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.38.0)", () => {
             kind: "incompatible_agent_version",
             package_name: "@agentclientprotocol/claude-agent-acp",
             installed: "0.32.0",
-            required: "0.38.0",
+            required: "0.39.0",
             install_command:
               "npm install -g @agentclientprotocol/claude-agent-acp@latest",
           },
@@ -1884,7 +1884,7 @@ describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.38.0)", () => {
     expect(next.incompatibleAgent?.kind).toBe("incompatible_agent_version");
     if (next.incompatibleAgent?.kind === "incompatible_agent_version") {
       expect(next.incompatibleAgent.installed).toBe("0.32.0");
-      expect(next.incompatibleAgent.required).toBe("0.38.0");
+      expect(next.incompatibleAgent.required).toBe("0.39.0");
     }
   });
 
@@ -1898,7 +1898,7 @@ describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.38.0)", () => {
             kind: "incompatible_agent_version",
             package_name: "@agentclientprotocol/claude-agent-acp",
             installed: "0.32.0",
-            required: "0.38.0",
+            required: "0.39.0",
             install_command:
               "npm install -g @agentclientprotocol/claude-agent-acp@latest",
           },

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -302,7 +302,7 @@ const INITIALIZE_RESULT = {
   },
   agentInfo: {
     name: "@agentclientprotocol/claude-agent-acp",
-    version: "0.38.0",
+    version: "0.39.0",
   },
   // No authMethods key at all. An empty array is interpreted by some
   // ACP client implementations as "auth methods listed but none

--- a/website/src/pages/docs/cockpit/multi-agent.md
+++ b/website/src/pages/docs/cockpit/multi-agent.md
@@ -13,7 +13,7 @@ are first-class but lighter on per-tool polish.
 
 | Agent | ACP entry | Install |
 |-------|-----------|---------|
-| Claude | `claude-agent-acp` (Zed adapter, requires >=0.38.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` |
+| Claude | `claude-agent-acp` (Zed adapter, requires >=0.39.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` |
 | Codex (OpenAI) | `codex-acp` (Zed adapter) | `npm install -g @zed-industries/codex-acp` |
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`claude-agent-acp` shipped a hotfix release [v0.39.0](https://github.com/agentclientprotocol/claude-agent-acp/releases/tag/v0.39.0) that updates the bundled `@anthropic-ai/claude-agent-sdk` to 0.3.156. This raises the cockpit version gate from `0.38.0` to `0.39.0` so installs still on the previous adapter get a clear upgrade nudge through the startup error UI.

Pure version-string bump, mirroring the 0.38.0 floor bump in #1603. Touches the compat gate (`src/cockpit/agent_compat.rs`), the docker sandbox image, the cockpit/sandbox docs, and the adapter test fixtures (test-shim, fake ACP agent, web reducer + startup-error specs). The historical `(Opus 4.8 added in v0.38.0)` note in `docs/cockpit.md` and the generated `CHANGELOG.md` entry are left untouched.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: version-string bump only; existing reducer + startup-error specs already assert the gate behavior and were updated to the new floor.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] Install the old adapter (`npm install -g @agentclientprotocol/claude-agent-acp@0.38.0`), open a cockpit Claude session, confirm the startup error UI nudges to upgrade with `>=0.39.0`.
- [ ] Upgrade to `@latest` (>=0.39.0), reopen the session, confirm it starts cleanly with the model + reasoning-effort pickers.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Implementation and prose drafted by Claude under my direction. I made the decision to mirror #1603, reviewed the diff, and own the change.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview
This PR bumps the minimum supported version of the Claude ACP adapter across the repository from 0.38.0 to 0.39.0 so Cockpit is compatible with claude-agent-acp v0.39.0 (which includes `@anthropic-ai/claude-agent-sdk` v0.3.156).

What changed (high-level)
- Updated the compatibility floor and user-facing upgrade messaging from 0.38.0 → 0.39.0.
- Updated test fixtures and unit/integration tests that assert or simulate adapter versions.
- Updated sandbox tooling and docs to install and document the newer adapter.
- Adjusted one Playwright test to be skipped because this is a version-string-only change.

Benefits
- Ensures Cockpit uses the adapter that includes the newer bundled Claude SDK and associated fixes.
- Keeps UI behavior (model picker, reasoning-effort picker) aligned with advertised adapter capabilities.
- Provides accurate upgrade guidance and clearer startup error messaging for incompatible adapters.

Technical details (files touched)
- src/cockpit/agent_compat.rs — compatibility gate messaging and tests updated to 0.39.0.
- cockpit-worker/test-shim/shim.mjs — shim advertises agentInfo.version 0.39.0.
- web/tests/helpers/fakeAcpAgent.mjs — fake agent advertises 0.39.0.
- web/src/components/cockpit/__tests__/StartupErrorScreen.test.tsx — expectations updated to require 0.39.0.
- web/src/lib/cockpitTypes.test.ts — reducer tests updated for v0.39.0.
- docker/Dockerfile — sandbox image installs `@agentclientprotocol/claude-agent-acp`@^0.39.0.
- docs/cockpit.md, docs/cockpit/multi-agent.md, docs/guides/sandbox.md, website/src/pages/docs/cockpit/multi-agent.md — documentation and remediation text updated to require >=0.39.0.

Backward-compat implications
- Instances running claude-agent-acp v0.38.0 will be prompted to upgrade; Cockpit startup requires >=0.39.0.

Testing notes
- Tests and fixtures updated where needed; one Playwright test skipped due to the version-only change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->