### PR TITLE
ci: run CI and Tests on PRs targeting cockpit-main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, cockpit-main]
   pull_request:
-    branches: [main]
+    branches: [main, cockpit-main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, cockpit-main]
   pull_request:
-    branches: [main]
+    branches: [main, cockpit-main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Description

The `cockpit-main` integration branch collects autonomous PRs before a batched merge into `main` (branch protection on `main` requires a human approval). CI and Tests only triggered on `main`, so PRs targeting `cockpit-main` ran no status checks. This adds `cockpit-main` to the `push` and `pull_request` branch filters of both gating workflows so the same checks run on the integration branch.

Deploy/cache workflows (`cachix-push`, `docs`, `nix-npm-hash`) are intentionally left main-only.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (Claude Code)

**Any Additional AI Details you'd like to share:**

CI trigger config edited by an AI agent.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR updates GitHub Actions workflow configurations to extend CI and Tests coverage to an additional integration branch.

**Files Modified:**
- `.github/workflows/ci.yml` (+2/-2 lines)
- `.github/workflows/tests.yml` (+2/-2 lines)

**Changes Made:**
Both workflow files now trigger on push and pull_request events for **both `main` and `cockpit-main` branches**, whereas previously they only targeted `main`. The `cockpit-main` branch is the integration branch where autonomous PRs are collected for batched merges into `main`.

## Benefits

- **Complete status checks**: Pull requests targeting `cockpit-main` will now automatically run CI and Tests workflows, previously they had no status checks
- **Consistent quality gate**: Both integration and production branches now enforce the same code quality standards
- **No impact on deployment workflows**: The cachix-push, docs, and nix-npm-hash workflows remain configured to run only on `main`, preserving deployment logic

## Technical Details

The changes update the GitHub Actions trigger conditions in both workflows:
- `push.branches`: `[main]` → `[main, cockpit-main]`
- `pull_request.branches`: `[main]` → `[main, cockpit-main]`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->