### PR TITLE
refactor(tui): single declarative registry for relocatable keybindings

### DIFF
--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -393,6 +393,36 @@ mod tests {
     }
 
     #[test]
+    fn help_shows_corrected_labels_for_relocated_actions() {
+        // The six strict-mode relocations must surface with their corrected
+        // chords in the `?` overlay, not the pre-fix labels. (bindings.rs
+        // `labels_match_mode` pins `label()`; this pins that the overlay
+        // actually renders those labels in both modes.)
+        // Format: (desc substring, non-strict key, strict key).
+        let cases = [
+            ("Diff view", "D", "Ctrl+D"),
+            ("Serve", "R", "Ctrl+R"),
+            ("Attach to terminal", "T", "Ctrl+T"),
+            ("New from selection", "N", "Ctrl+N"),
+            ("Projects", "p", "P"),
+            ("Profiles", "P", "Ctrl+P"),
+        ];
+        for (desc_sub, non_strict_key, strict_key) in cases {
+            for (strict, expected_key) in [(false, non_strict_key), (true, strict_key)] {
+                let all = shortcuts(strict, false);
+                let found = all.iter().any(|(_, keys)| {
+                    keys.iter()
+                        .any(|(k, desc)| k == expected_key && desc.contains(desc_sub))
+                });
+                assert!(
+                    found,
+                    "help overlay (strict={strict}) should list '{expected_key}' for '{desc_sub}'"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn help_lists_snooze() {
         // PR #1084 introduced the snooze primitive (H in strict mode, h in
         // non-strict) but did not advertise it in the help overlay. Lock the

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -30,157 +30,95 @@ const SMALL_VIEWPORT_WIDTH: u16 = 40;
 /// Same idea for height: drop top/bottom margin below this.
 const SMALL_VIEWPORT_HEIGHT: u16 = 16;
 
-fn shortcuts(
-    strict: bool,
-    live_on_enter: bool,
-) -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+fn shortcuts(strict: bool, live_on_enter: bool) -> Vec<(&'static str, Vec<(String, String)>)> {
+    use crate::tui::home::bindings::{self, HelpSection as Sec};
+
     let (enter_desc, tab_desc) = if live_on_enter {
         ("Live mode (send keys to agent)", "Attach to tmux session")
     } else {
         ("Attach to tmux session", "Live mode (send keys to agent)")
     };
-    if strict {
-        vec![
-            (
-                "Navigation",
-                vec![
-                    ("j/↓", "Move down"),
-                    ("k/↑", "Move up"),
-                    ("h/←", "Collapse group"),
-                    ("l/→", "Expand group"),
-                    ("Home/End/G", "Go to top / bottom"),
-                    ("PgUp/Dn", "Move 10 (also Shift+↑/↓, { })"),
-                ],
-            ),
-            (
-                "Actions (strict mode)",
-                vec![
-                    ("Enter", enter_desc),
-                    ("Tab", tab_desc),
-                    ("Ctrl+T", "Attach to terminal"),
-                    (";", "Open tool session"),
-                    ("N", "New session"),
-                    ("Ctrl+N", "New from selection"),
-                    ("B", "New session from project"),
-                    ("X", "Stop session"),
-                    ("D", "Delete session/group"),
-                    ("R", "Rename session/group"),
-                    ("M", "Send message to agent"),
-                    ("E", "Restart session (also F5)"),
-                ],
-            ),
-            (
-                "Attention (Attention sort only, except Archive)",
-                vec![
-                    ("w", "Jump to next waiting/idle"),
-                    ("F", "Toggle favorite (Attention sort)"),
-                    ("H", "Snooze (toggle, Attention sort)"),
-                    ("Z", "Archive (toggle, any sort)"),
-                ],
-            ),
-            (
-                "Views",
-                vec![
-                    ("T", "Toggle Agent/Terminal view"),
-                    ("C", "Toggle container/host (sandbox)"),
-                    ("Ctrl+D", "Diff view (git changes)"),
-                    ("< >", "Resize list panel"),
-                    ("I", "Toggle preview info header"),
-                    ("O", "Sort order"),
-                    ("Ctrl+O", "Sort order"),
-                    ("Ctrl+G", "Group by"),
-                ],
-            ),
-            (
-                "Other",
-                vec![
-                    ("/", "Search"),
-                    ("n/N", "Next/prev match"),
-                    ("S", "Settings"),
-                    ("P", "Profiles"),
-                    ("Ctrl+R", "Serve (LAN / Tunnel)"),
-                    ("u", "Update aoe (when available)"),
-                    ("Ctrl+x", "Dismiss update bar (this session)"),
-                    ("Shift+drag", "Select text in preview"),
-                    ("Drag", "Select + copy preview (live mode)"),
-                    ("Ctrl+K", "Command palette"),
-                    ("?", "Toggle help"),
-                    ("Q", "Quit"),
-                ],
-            ),
-        ]
-    } else {
-        vec![
-            (
-                "Navigation",
-                vec![
-                    ("j/↓", "Move down"),
-                    ("k/↑", "Move up"),
-                    ("←", "Collapse group"),
-                    ("l/→", "Expand group"),
-                    ("Home/End/G", "Go to top / bottom"),
-                    ("PgUp/Dn", "Move 10 (also Shift+↑/↓, { })"),
-                ],
-            ),
-            (
-                "Actions",
-                vec![
-                    ("Enter", enter_desc),
-                    ("Tab", tab_desc),
-                    ("T", "Attach to terminal"),
-                    (";", "Open tool session"),
-                    ("n", "New session"),
-                    ("N", "New from selection"),
-                    ("b", "New session from project"),
-                    ("x", "Stop session"),
-                    ("d", "Delete session/group"),
-                    ("r", "Rename session/group"),
-                    ("m", "Send message to agent"),
-                    ("e", "Restart session (also F5)"),
-                ],
-            ),
-            (
-                "Attention (Attention sort only, except Archive)",
-                vec![
-                    ("w", "Jump to next waiting/idle"),
-                    ("f", "Toggle favorite (Attention sort)"),
-                    ("h", "Snooze (toggle, Attention sort)"),
-                    ("z", "Archive (toggle, any sort)"),
-                ],
-            ),
-            (
-                "Views",
-                vec![
-                    ("t", "Toggle Agent/Terminal view"),
-                    ("c", "Toggle container/host (sandbox)"),
-                    ("D", "Diff view (git changes)"),
-                    ("< >", "Resize list panel"),
-                    ("i", "Toggle preview info header"),
-                    ("o", "Sort order"),
-                    ("Ctrl+o", "Sort order"),
-                    ("g", "Group by"),
-                ],
-            ),
-            (
-                "Other",
-                vec![
-                    ("/", "Search"),
-                    ("n/N", "Next/prev match"),
-                    ("s", "Settings"),
-                    ("P", "Profiles"),
-                    ("p", "Projects"),
-                    ("R", "Serve (LAN / Tunnel)"),
-                    ("u", "Update aoe (when available)"),
-                    ("Ctrl+x", "Dismiss update bar (this session)"),
-                    ("Shift+drag", "Select text in preview"),
-                    ("Drag", "Select + copy preview (live mode)"),
-                    ("Ctrl+K", "Command palette"),
-                    ("?", "Toggle help"),
-                    ("q", "Quit"),
-                ],
-            ),
-        ]
+
+    // Action rows are generated from the shared keybinding registry, bucketed
+    // by section in table order, so the help labels can never drift from the
+    // actual bindings. `label` formats each chord for the active mode; an
+    // action with no binding in this mode (only NextWaiting, in strict) falls
+    // back to its non-strict label so it stays discoverable.
+    let mut actions: Vec<(String, String)> = Vec::new();
+    let mut attention: Vec<(String, String)> = Vec::new();
+    let mut views: Vec<(String, String)> = Vec::new();
+    let mut other: Vec<(String, String)> = Vec::new();
+    for b in bindings::BINDINGS {
+        let Some(help) = &b.help else { continue };
+        let mut label = bindings::label(b.id, strict);
+        if label.is_empty() {
+            label = bindings::label(b.id, false);
+        }
+        if label.is_empty() {
+            continue;
+        }
+        let row = (label, help.desc.to_string());
+        match help.section {
+            Sec::Actions => actions.push(row),
+            Sec::Attention => attention.push(row),
+            Sec::Views => views.push(row),
+            Sec::Other => other.push(row),
+        }
     }
+
+    // Enter / Tab are structural keys (not relocatable registry actions); they
+    // lead the Actions section and swap descriptions with the attach mode.
+    let mut actions_rows = vec![
+        ("Enter".to_string(), enter_desc.to_string()),
+        ("Tab".to_string(), tab_desc.to_string()),
+    ];
+    actions_rows.append(&mut actions);
+
+    // Non-action rows with no single registry binding.
+    views.push(("< >".to_string(), "Resize list panel".to_string()));
+    other.push(("n/N".to_string(), "Next/prev match".to_string()));
+    other.push((
+        "Ctrl+x".to_string(),
+        "Dismiss update bar (this session)".to_string(),
+    ));
+    other.push((
+        "Shift+drag".to_string(),
+        "Select text in preview".to_string(),
+    ));
+    other.push((
+        "Drag".to_string(),
+        "Select + copy preview (live mode)".to_string(),
+    ));
+    other.push(("Ctrl+K".to_string(), "Command palette".to_string()));
+
+    // Navigation is mode-invariant except the collapse row: in non-strict mode
+    // bare `h` is the contextual snooze key, so only `<-` is advertised for
+    // collapse; in strict mode `h` always collapses.
+    let nav_collapse = if strict { "h/\u{2190}" } else { "\u{2190}" };
+    let navigation = vec![
+        ("j/\u{2193}".to_string(), "Move down".to_string()),
+        ("k/\u{2191}".to_string(), "Move up".to_string()),
+        (nav_collapse.to_string(), "Collapse group".to_string()),
+        ("l/\u{2192}".to_string(), "Expand group".to_string()),
+        ("Home/End/G".to_string(), "Go to top / bottom".to_string()),
+        (
+            "PgUp/Dn".to_string(),
+            "Move 10 (also Shift+\u{2191}/\u{2193}, { })".to_string(),
+        ),
+    ];
+
+    let actions_title = if strict {
+        "Actions (strict mode)"
+    } else {
+        "Actions"
+    };
+    vec![
+        ("Navigation", navigation),
+        (actions_title, actions_rows),
+        ("Attention (Attention sort only, except Archive)", attention),
+        ("Views", views),
+        ("Other", other),
+    ]
 }
 
 struct HelpSection {
@@ -193,10 +131,7 @@ fn build_sections(strict: bool, sort_order: SortOrder, live_on_enter: bool) -> V
     let sort_label = format!("(current sort: {})", sort_order.label());
     raw.into_iter()
         .map(|(title, keys)| {
-            let mut rows: Vec<(String, String)> = keys
-                .into_iter()
-                .map(|(k, d)| (k.to_string(), d.to_string()))
-                .collect();
+            let mut rows: Vec<(String, String)> = keys;
             if title == "Views" {
                 rows.push((String::new(), sort_label.clone()));
             }

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -696,7 +696,7 @@ mod tests {
     const PALETTE_EXEMPT: &[(ActionId, &str)] = &[
         (
             ActionId::Quit,
-            "added to the palette manually (Settings group), not via registry metadata",
+            "intentionally excluded from the palette; q is quick-exit, doesn't need discovery",
         ),
         (
             ActionId::ToolPicker,

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -756,7 +756,7 @@ mod tests {
                 bindings::BINDINGS
                     .iter()
                     .find(|b| b.id == *id)
-                    .map_or(true, |b| b.palette.is_some())
+                    .is_none_or(|b| b.palette.is_some())
             })
             .collect();
         assert!(

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -1,10 +1,11 @@
 //! Command palette dialog: fuzzy-searchable list of named TUI actions.
 //!
 //! Mirrors the web UI's `CommandPalette` (web/src/components/command-palette/).
-//! Activated with Ctrl+K. Each entry maps to either a synthesized `KeyEvent`
-//! that the existing input dispatcher consumes (so the palette is additive,
-//! not a parallel command implementation), or a "jump to cursor" payload for
-//! the dynamic session/group entries.
+//! Activated with Ctrl+K. Built-in entries are generated from the shared
+//! keybinding registry and carry an [`ActionId`] that `HomeView::run_action`
+//! executes directly (so the palette is additive, not a parallel command
+//! implementation, and can't drift from the keyboard). Dynamic session/group
+//! entries use a "jump to cursor" payload instead.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::prelude::*;
@@ -15,6 +16,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::DialogResult;
 use crate::tui::components::set_prefixed_input_cursor_position;
+use crate::tui::home::bindings::{self, ActionId};
 use crate::tui::styles::Theme;
 
 /// Group buckets, rendered in this order. Mirrors `web/src/components/command-palette/groups.ts`.
@@ -51,33 +53,21 @@ impl PaletteGroup {
 
 /// What the dialog asks the input handler to do when the user picks an entry.
 pub enum PaletteAction {
-    /// Synthesize a key event and run it through the normal action dispatcher.
-    /// Bypasses strict-hotkey normalization, so palette entries should encode
-    /// the lowercase / non-strict form of the binding (e.g. `n` not `N`).
-    Key(KeyEvent),
+    /// Run a registry action directly via `HomeView::run_action`. This is the
+    /// canonical path: it never synthesizes a keypress, so it can't misfire in
+    /// strict mode (where a synthesized bare letter would hit the typing-guard
+    /// or a relocated arm).
+    Invoke(ActionId),
+    /// Activate the selected session (the `Enter` action; not a relocatable
+    /// keybinding, so it's not in the registry).
+    Activate,
+    /// Enter live-send mode on the selected session (the `Tab` action; likewise
+    /// not a relocatable keybinding).
+    LiveSend,
     /// Move the cursor to a position in `flat_items` (used for session/group jump items).
     JumpToCursor(usize),
     /// Open a tool session by name (lazygit, yazi, etc.)
     ToolSession(String),
-    /// Enter live-send mode on the selected session. A dedicated variant
-    /// (rather than synthesizing the keypress) so the palette routes
-    /// correctly in strict mode, where the `m` binding is intentionally
-    /// defanged for the typing-guard.
-    EnterLiveSend,
-    /// Open the sort-order picker. Dedicated variant for the same reason as
-    /// `EnterLiveSend`: in strict mode, bare lowercase `o` is defanged for
-    /// the typing-guard, so a synthesized `Char('o')` would not fire.
-    OpenSortPicker,
-    /// Open the group-by picker. Dedicated variant because bare `g` is
-    /// defanged in strict mode (typing-guard) and `Char('G')` is bound to
-    /// End, so no single synthesized key reaches the show helper in both
-    /// modes.
-    OpenGroupPicker,
-    /// Open the saved-project picker that starts a new session pre-filled with
-    /// the chosen project's path. Dedicated variant because the lowercase `b`
-    /// binding is gated `!strict_hotkeys`, so a synthesized `Char('b')` would
-    /// not fire in strict mode.
-    OpenProjectSessionPicker,
 }
 
 /// One entry in the palette. `payload` is what gets returned when the user picks it.
@@ -87,256 +77,61 @@ pub struct PaletteCommand {
     pub group: PaletteGroup,
     pub keywords: Vec<&'static str>,
     /// Human-readable hotkey shown on the right (e.g. "n", "Ctrl+D"). Empty if no binding.
-    pub hotkey: &'static str,
+    pub hotkey: String,
     pub payload: PaletteAction,
 }
 
-/// Pick the right hotkey label for a binding given the strict-hotkeys setting.
-/// In strict mode, plain action letters require Shift; relocated bindings use
-/// Ctrl. The mapping mirrors `normalize_strict_key` in `home/input.rs` and the
-/// labels in `components/help.rs`.
-fn hotkey_label(non_strict: &'static str, strict: &'static str, strict_mode: bool) -> &'static str {
-    if strict_mode {
-        strict
-    } else {
-        non_strict
-    }
-}
-
-/// Built-in named commands. Excludes pure-navigation keys (j/k, arrows,
-/// PageUp/PageDown, h/l for collapse) since those don't belong in a palette.
-/// `strict_hotkeys` controls only the displayed hotkey label; the synthesized
-/// payload bypasses strict-mode normalization either way.
+/// Built-in named commands, generated from the shared keybinding registry so
+/// the palette's hotkey labels and dispatched actions can never drift from the
+/// keyboard dispatcher. Pure-navigation keys (j/k, arrows, h/l) are excluded.
+/// `Enter` (attach) and `Tab` (live-send) aren't relocatable keybindings, so
+/// they're appended explicitly rather than pulled from the registry.
 pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<PaletteCommand> {
-    let mut cmds = vec![
-        PaletteCommand {
-            id: "new-session",
-            title: "New session".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["create", "add", "spawn"],
-            hotkey: hotkey_label("n", "N", strict_hotkeys),
-            payload: PaletteAction::Key(key('n')),
-        },
-        PaletteCommand {
-            id: "new-from-selection",
-            title: "New session from selection".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["create", "duplicate", "clone"],
-            hotkey: hotkey_label("N", "Ctrl+N", strict_hotkeys),
-            payload: PaletteAction::Key(KeyEvent::new(KeyCode::Char('N'), KeyModifiers::SHIFT)),
-        },
-        PaletteCommand {
-            id: "new-from-project",
-            title: "New session from saved project".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["project", "saved", "registry", "create"],
-            hotkey: hotkey_label("b", "B", strict_hotkeys),
-            payload: PaletteAction::OpenProjectSessionPicker,
-        },
-        PaletteCommand {
-            id: "attach",
-            title: "Attach to selected session".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["open", "enter"],
-            hotkey: "Enter",
-            payload: PaletteAction::Key(key_code(KeyCode::Enter)),
-        },
-        PaletteCommand {
-            id: "attach-terminal",
-            title: "Attach to paired terminal".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["shell", "host"],
-            hotkey: hotkey_label("T", "Ctrl+T", strict_hotkeys),
-            payload: PaletteAction::Key(KeyEvent::new(KeyCode::Char('T'), KeyModifiers::SHIFT)),
-        },
-        PaletteCommand {
-            id: "send-message",
-            title: "Send message to agent".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["prompt", "tell", "say"],
-            hotkey: hotkey_label("m", "M", strict_hotkeys),
-            payload: PaletteAction::Key(key('m')),
-        },
-        PaletteCommand {
-            id: "live-send",
-            title: "Live send: pass keys straight to the agent".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec![
-                "live",
-                "passthrough",
-                "attach",
-                "keys",
-                "escape",
-                "arrow",
-                "tab",
-                "interrupt",
-            ],
-            // Tab is the direct binding in both modes (settings / cockpit
-            // / dialogs own their own Tab handlers, the home view's top
-            // level was free). Palette routing uses the dedicated
-            // variant so synthesizing a Tab keypress never accidentally
-            // re-fires this entry from inside a sub-handler.
-            hotkey: "Tab",
-            payload: PaletteAction::EnterLiveSend,
-        },
-        PaletteCommand {
-            id: "stop",
-            title: "Stop session".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["kill", "end", "halt"],
-            hotkey: hotkey_label("x", "X", strict_hotkeys),
-            payload: PaletteAction::Key(key('x')),
-        },
-        PaletteCommand {
-            id: "delete",
-            title: "Delete session or group".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["remove", "trash"],
-            hotkey: hotkey_label("d", "D", strict_hotkeys),
-            payload: PaletteAction::Key(key('d')),
-        },
-        PaletteCommand {
-            id: "rename",
-            title: "Rename or move to group".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["title", "label", "move", "regroup"],
-            hotkey: hotkey_label("r", "R", strict_hotkeys),
-            payload: PaletteAction::Key(key('r')),
-        },
-        PaletteCommand {
-            id: "favorite",
-            title: "Toggle favorite".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["star", "pin", "fav"],
-            hotkey: hotkey_label("f", "F", strict_hotkeys),
-            payload: PaletteAction::Key(key('f')),
-        },
-        PaletteCommand {
-            id: "archive",
-            title: "Toggle archive".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["park", "stash", "done", "zzz"],
-            hotkey: hotkey_label("z", "Z", strict_hotkeys),
-            payload: PaletteAction::Key(key('z')),
-        },
-        PaletteCommand {
-            id: "snooze",
-            title: "Toggle snooze".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["later", "defer", "wait"],
-            hotkey: hotkey_label("h", "H", strict_hotkeys),
-            payload: PaletteAction::Key(key('h')),
-        },
-        PaletteCommand {
-            id: "restart",
-            title: "Restart session".to_string(),
-            group: PaletteGroup::Actions,
-            keywords: vec!["reload", "respawn", "reset"],
-            hotkey: hotkey_label("e", "E", strict_hotkeys),
-            payload: PaletteAction::Key(key('e')),
-        },
-        PaletteCommand {
-            id: "diff",
-            title: "Open diff view".to_string(),
-            group: PaletteGroup::Views,
-            keywords: vec!["git", "changes"],
-            hotkey: hotkey_label("D", "Ctrl+D", strict_hotkeys),
-            payload: PaletteAction::Key(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT)),
-        },
-        PaletteCommand {
-            id: "toggle-view",
-            title: "Toggle Agent / Terminal view".to_string(),
-            group: PaletteGroup::Views,
-            keywords: vec!["switch", "shell"],
-            hotkey: hotkey_label("t", "T", strict_hotkeys),
-            payload: PaletteAction::Key(key('t')),
-        },
-        PaletteCommand {
-            id: "pick-sort",
-            title: "Sort order".to_string(),
-            group: PaletteGroup::Views,
-            keywords: vec!["order", "sort", "pick"],
-            hotkey: hotkey_label("o", "O", strict_hotkeys),
-            payload: PaletteAction::OpenSortPicker,
-        },
-        PaletteCommand {
-            id: "pick-group-by",
-            title: "Group by".to_string(),
-            group: PaletteGroup::Views,
-            keywords: vec!["group", "project", "pick"],
-            hotkey: hotkey_label("g", "Ctrl+G", strict_hotkeys),
-            payload: PaletteAction::OpenGroupPicker,
-        },
-        PaletteCommand {
-            id: "next-waiting",
-            title: "Jump to next waiting / idle session".to_string(),
-            group: PaletteGroup::Views,
-            keywords: vec!["jump", "next", "waiting", "idle"],
-            hotkey: "w",
-            payload: PaletteAction::Key(key('w')),
-        },
-        PaletteCommand {
-            id: "toggle-preview-info",
-            title: "Toggle preview info header".to_string(),
-            group: PaletteGroup::Views,
-            keywords: vec!["hide", "show", "info", "header", "preview"],
-            hotkey: hotkey_label("i", "I", strict_hotkeys),
-            payload: PaletteAction::Key(key('i')),
-        },
-        PaletteCommand {
-            id: "settings",
-            title: "Open settings".to_string(),
-            group: PaletteGroup::Settings,
-            keywords: vec!["preferences", "config"],
-            hotkey: hotkey_label("s", "S", strict_hotkeys),
-            payload: PaletteAction::Key(key('s')),
-        },
-        PaletteCommand {
-            id: "profiles",
-            title: "Switch profile".to_string(),
-            group: PaletteGroup::Settings,
-            keywords: vec!["account", "switch"],
-            hotkey: "P",
-            payload: PaletteAction::Key(KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT)),
-        },
-        PaletteCommand {
-            id: "projects",
-            title: "Manage projects".to_string(),
-            group: PaletteGroup::Settings,
-            keywords: vec!["registry", "repos", "multi-repo", "workspace"],
-            hotkey: "p",
-            payload: PaletteAction::Key(key('p')),
-        },
-        PaletteCommand {
-            id: "help",
-            title: "Show keyboard shortcuts".to_string(),
-            group: PaletteGroup::Settings,
-            keywords: vec!["keys", "shortcuts"],
-            hotkey: "?",
-            payload: PaletteAction::Key(key('?')),
-        },
-    ];
+    let mut cmds: Vec<PaletteCommand> = bindings::BINDINGS
+        .iter()
+        .filter_map(|b| {
+            let meta = b.palette.as_ref()?;
+            if meta.serve_only && !serve_enabled {
+                return None;
+            }
+            Some(PaletteCommand {
+                id: bindings::palette_id(b.id),
+                title: meta.title.to_string(),
+                group: meta.group,
+                keywords: meta.keywords.to_vec(),
+                hotkey: bindings::label(b.id, strict_hotkeys),
+                payload: PaletteAction::Invoke(b.id),
+            })
+        })
+        .collect();
 
-    if serve_enabled {
-        cmds.push(PaletteCommand {
-            id: "serve",
-            title: "Open serve (LAN / Tunnel)".to_string(),
-            group: PaletteGroup::Settings,
-            keywords: vec!["web", "remote", "phone", "tunnel"],
-            hotkey: hotkey_label("R", "Ctrl+R", strict_hotkeys),
-            payload: PaletteAction::Key(KeyEvent::new(KeyCode::Char('R'), KeyModifiers::SHIFT)),
-        });
-    }
+    cmds.push(PaletteCommand {
+        id: "attach",
+        title: "Attach to selected session".to_string(),
+        group: PaletteGroup::Actions,
+        keywords: vec!["open", "enter"],
+        hotkey: "Enter".to_string(),
+        payload: PaletteAction::Activate,
+    });
+    cmds.push(PaletteCommand {
+        id: "live-send",
+        title: "Live send: pass keys straight to the agent".to_string(),
+        group: PaletteGroup::Actions,
+        keywords: vec![
+            "live",
+            "passthrough",
+            "attach",
+            "keys",
+            "escape",
+            "arrow",
+            "tab",
+            "interrupt",
+        ],
+        hotkey: "Tab".to_string(),
+        payload: PaletteAction::LiveSend,
+    });
 
     cmds
-}
-
-fn key(c: char) -> KeyEvent {
-    KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
-}
-
-fn key_code(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
 }
 
 pub struct CommandPaletteDialog {
@@ -609,7 +404,10 @@ impl CommandPaletteDialog {
                     Span::raw(padding),
                 ];
                 if !cmd.hotkey.is_empty() {
-                    spans.push(Span::styled(cmd.hotkey, Style::default().fg(theme.hint)));
+                    spans.push(Span::styled(
+                        cmd.hotkey.clone(),
+                        Style::default().fg(theme.hint),
+                    ));
                 }
                 lines.push(Line::from(spans));
                 line_to_display_idx.push(Some(display_idx));
@@ -684,7 +482,7 @@ fn sort_indices_by_group(entries: &[PaletteCommand]) -> Vec<usize> {
 mod tests {
     use super::*;
     use crossterm::event::KeyModifiers;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashSet;
 
     fn ke(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -732,52 +530,33 @@ mod tests {
             .expect("builtin commands must include 'live-send'");
         assert_eq!(entry.hotkey, "Tab");
         assert!(
-            matches!(&entry.payload, PaletteAction::EnterLiveSend),
-            "live-send entry must dispatch PaletteAction::EnterLiveSend"
+            matches!(&entry.payload, PaletteAction::LiveSend),
+            "live-send entry must dispatch PaletteAction::LiveSend"
         );
     }
 
     #[test]
-    fn picker_entries_use_dedicated_payload_variants() {
-        // Regression guard: the sort and group picker palette entries must
-        // route through the dedicated `OpenSortPicker` / `OpenGroupPicker`
-        // payloads rather than synthesizing `Key('o')` / `Key('g')`. The
-        // synthesized lowercase keys are gated by `if !strict_hotkeys` in
-        // `dispatch_action_key`, so a palette pick in strict mode would
-        // silently no-op without the dedicated routing.
+    fn picker_entries_invoke_their_actions() {
+        // The sort and group picker palette entries route through
+        // `Invoke(ActionId::…)` so `run_action` opens the picker directly.
+        // Previously these synthesized `Key('o')` / `Key('g')`, which the
+        // strict-mode typing-guard would have swallowed.
         let cmds = builtin_commands(false, true);
         let sort = cmds
             .iter()
             .find(|c| c.id == "pick-sort")
             .expect("builtin commands must include 'pick-sort'");
         assert!(
-            matches!(&sort.payload, PaletteAction::OpenSortPicker),
-            "sort-picker entry must dispatch PaletteAction::OpenSortPicker"
+            matches!(&sort.payload, PaletteAction::Invoke(ActionId::SortPicker)),
+            "sort-picker entry must Invoke(SortPicker)"
         );
         let group = cmds
             .iter()
             .find(|c| c.id == "pick-group-by")
             .expect("builtin commands must include 'pick-group-by'");
         assert!(
-            matches!(&group.payload, PaletteAction::OpenGroupPicker),
-            "group-picker entry must dispatch PaletteAction::OpenGroupPicker"
-        );
-    }
-
-    #[test]
-    fn new_from_project_entry_uses_dedicated_payload() {
-        // Regression guard mirroring `picker_entries_use_dedicated_payload_variants`:
-        // the lowercase `b` binding is gated `!strict_hotkeys`, so the palette
-        // entry must route through `OpenProjectSessionPicker` rather than a
-        // synthesized `Key('b')` that would silently no-op in strict mode.
-        let cmds = builtin_commands(false, true);
-        let entry = cmds
-            .iter()
-            .find(|c| c.id == "new-from-project")
-            .expect("builtin commands must include 'new-from-project'");
-        assert!(
-            matches!(&entry.payload, PaletteAction::OpenProjectSessionPicker),
-            "new-from-project entry must dispatch PaletteAction::OpenProjectSessionPicker"
+            matches!(&group.payload, PaletteAction::Invoke(ActionId::GroupBy)),
+            "group-picker entry must Invoke(GroupBy)"
         );
     }
 
@@ -803,10 +582,10 @@ mod tests {
         }
         let result = dialog.handle_key(ke(KeyCode::Enter));
         match result {
-            DialogResult::Submit(PaletteAction::Key(synth)) => {
-                assert_eq!(synth.code, KeyCode::Char('s'));
+            DialogResult::Submit(PaletteAction::Invoke(id)) => {
+                assert_eq!(id, ActionId::Settings);
             }
-            _ => panic!("expected Submit(Key)"),
+            _ => panic!("expected Submit(Invoke(Settings))"),
         }
     }
 
@@ -899,7 +678,7 @@ mod tests {
             title: "Jump to my-session".to_string(),
             group: PaletteGroup::Sessions,
             keywords: vec!["session"],
-            hotkey: "",
+            hotkey: String::new(),
             payload: PaletteAction::JumpToCursor(7),
         }];
         let mut dialog = CommandPaletteDialog::new(entries);
@@ -910,135 +689,80 @@ mod tests {
         }
     }
 
-    /// Char-class single-key bindings in `home/input.rs` that intentionally
-    /// don't get a palette entry. Pure navigation, dismissal, and meta keys.
-    /// Compared case-insensitively against the chars scanned out of input.rs,
-    /// so listing the lowercase form covers both `j`/`J`, `q`/`Q`, etc.
-    ///
-    /// If you add a new home-view hotkey that shouldn't appear in the palette
-    /// (vim-style nav, search-state-only, modal dismiss), add the lowercase
-    /// char here with a one-line note. Otherwise add a PaletteCommand to
-    /// `builtin_commands` above and the drift test will pass automatically.
-    const PALETTE_EXEMPT: &[(char, &str)] = &[
-        ('j', "vim-style move down"),
-        ('k', "vim-style move up"),
-        ('l', "vim-style move right / expand"),
-        ('q', "quit; Esc and the global quit path cover this"),
-        ('u', "update-banner dismiss; meta key, not an action"),
-        (';', "Tool view escape; only meaningful while in Tool view"),
-        ('/', "search activation; modal trigger, not an action"),
-        ('c', "host/container terminal mode toggle; only valid on a sandboxed session in Terminal view"),
-        ('{', "vim-style page-up (10 rows); pure navigation"),
-        ('}', "vim-style page-down (10 rows); pure navigation"),
-        ('<', "shrink list pane width; layout tweak, not an action"),
-        ('>', "grow list pane width; layout tweak, not an action"),
+    /// Registry actions that intentionally have no palette command. Anything
+    /// not listed here must carry palette metadata in the registry; the palette
+    /// is generated from that metadata, so this is the one place "added an
+    /// action, forgot the palette" can still slip through.
+    const PALETTE_EXEMPT: &[(ActionId, &str)] = &[
+        (
+            ActionId::Quit,
+            "added to the palette manually (Settings group), not via registry metadata",
+        ),
+        (
+            ActionId::ToolPicker,
+            "Tool-view toggle; tool sessions get dynamic palette entries instead",
+        ),
+        (
+            ActionId::SearchStart,
+            "search activation; modal trigger, not an action",
+        ),
+        (
+            ActionId::Update,
+            "update-banner action; meta key, surfaced via the banner",
+        ),
+        (
+            ActionId::ToggleContainer,
+            "only valid on a sandboxed session in Terminal view",
+        ),
+        (
+            ActionId::SearchNext,
+            "search-cycle; only meaningful while a search is active",
+        ),
+        (
+            ActionId::SearchPrev,
+            "search-cycle; only meaningful while a search is active",
+        ),
     ];
 
-    /// Scan `home/input.rs` for `KeyCode::Char('X')` patterns and return the
-    /// case-folded set of bound chars. Shared by the two drift tests below.
-    /// The test module at the bottom of input.rs constructs synthetic
-    /// KeyEvents in assertions, which would inflate the set with chars that
-    /// aren't real bindings, so we truncate at the first `#[cfg(test)]`.
-    fn home_input_bound_chars() -> HashSet<char> {
-        let src = include_str!("../home/input.rs");
-        let scan_region = match src.find("#[cfg(test)]") {
-            Some(idx) => &src[..idx],
-            None => src,
-        };
-
-        let pat = b"KeyCode::Char('";
-        let bytes = scan_region.as_bytes();
-        let mut bound = HashSet::new();
-        let mut i = 0;
-        while i + pat.len() + 2 <= bytes.len() {
-            if &bytes[i..i + pat.len()] == pat {
-                let c = bytes[i + pat.len()];
-                let close = bytes[i + pat.len() + 1];
-                if close == b'\'' && c.is_ascii_graphic() {
-                    bound.insert((c as char).to_ascii_lowercase());
-                }
-                i += pat.len();
-            } else {
-                i += 1;
-            }
-        }
-        bound
-    }
-
-    /// Guard against the palette drifting from the input dispatcher. Asserts
-    /// every char bound in `home/input.rs` is either covered by a palette
-    /// entry or in `PALETTE_EXEMPT`. Catches the "added a hotkey and forgot
-    /// the palette" failure mode at test time instead of at user-bug-report
-    /// time.
+    /// Drift guard. The palette is generated from `bindings::BINDINGS`, so a
+    /// binding either exposes palette metadata (and thus a command) or is on
+    /// the exempt list. Catches "added an action, forgot to decide whether it
+    /// belongs in the palette."
     #[test]
-    fn home_view_hotkeys_appear_in_palette_or_exempt() {
-        let bound = home_input_bound_chars();
-
-        // Build palette char set with serve toggled on so serve-only commands
-        // still count as covered. `OpenSortPicker` / `OpenGroupPicker` are
-        // dedicated payload variants that exist precisely to route around
-        // strict-mode key gating; they count as covering their canonical
-        // hotkey ('o' and 'g' respectively). `EnterLiveSend` is bound to Tab,
-        // so it does not cover any letter char.
-        let mut palette_chars: HashSet<char> = HashSet::new();
-        for cmd in builtin_commands(true, false) {
-            match cmd.payload {
-                PaletteAction::Key(ke) => {
-                    if let KeyCode::Char(c) = ke.code {
-                        palette_chars.insert(c.to_ascii_lowercase());
-                    }
-                }
-                PaletteAction::OpenSortPicker => {
-                    palette_chars.insert('o');
-                }
-                PaletteAction::OpenGroupPicker => {
-                    palette_chars.insert('g');
-                }
-                PaletteAction::OpenProjectSessionPicker => {
-                    palette_chars.insert('b');
-                }
-                PaletteAction::EnterLiveSend
-                | PaletteAction::JumpToCursor(_)
-                | PaletteAction::ToolSession(_) => {}
-            }
-        }
-
-        let exempt: HashMap<char, &str> = PALETTE_EXEMPT.iter().copied().collect();
-
-        let missing: Vec<char> = bound
+    fn registry_actions_have_palette_or_are_exempt() {
+        let exempt: HashSet<ActionId> = PALETTE_EXEMPT.iter().map(|(id, _)| *id).collect();
+        let missing: Vec<ActionId> = bindings::BINDINGS
             .iter()
-            .filter(|c| !palette_chars.contains(c) && !exempt.contains_key(c))
-            .copied()
+            .filter(|b| b.palette.is_none() && !exempt.contains(&b.id))
+            .map(|b| b.id)
             .collect();
-
         assert!(
             missing.is_empty(),
-            "Hotkeys bound in src/tui/home/input.rs but missing from the command palette \
-             (and not in PALETTE_EXEMPT):\n  {:?}\n\n\
-             Either add a PaletteCommand to builtin_commands() in command_palette.rs, \
-             or add the key to PALETTE_EXEMPT in this test with a note explaining \
-             why it shouldn't appear in the palette.",
+            "registry actions with no palette metadata and not in PALETTE_EXEMPT: {:?}\n\
+             Add a PaletteMeta to the binding in home/bindings.rs, or add the action to \
+             PALETTE_EXEMPT here with a note.",
             missing
         );
     }
 
-    /// Catch the reverse drift: a PALETTE_EXEMPT entry that's no longer bound
-    /// anywhere in input.rs. Without this, stale exemptions silently mask new
-    /// real bindings that happen to reuse the same key.
+    /// Reverse drift: an exempt action that no longer exists or that gained
+    /// palette metadata (so the exemption is now stale/contradictory).
     #[test]
-    fn palette_exempt_entries_are_still_bound() {
-        let bound = home_input_bound_chars();
-
-        let stale: Vec<char> = PALETTE_EXEMPT
+    fn palette_exempt_entries_are_still_exempt() {
+        let stale: Vec<ActionId> = PALETTE_EXEMPT
             .iter()
-            .map(|(c, _)| *c)
-            .filter(|c| !bound.contains(c))
+            .map(|(id, _)| *id)
+            .filter(|id| {
+                bindings::BINDINGS
+                    .iter()
+                    .find(|b| b.id == *id)
+                    .map_or(true, |b| b.palette.is_some())
+            })
             .collect();
-
         assert!(
             stale.is_empty(),
-            "PALETTE_EXEMPT lists keys no longer bound in src/tui/home/input.rs: {:?}. \
-             Remove them from PALETTE_EXEMPT.",
+            "PALETTE_EXEMPT lists actions that no longer exist or now have palette \
+             metadata: {:?}. Remove them from PALETTE_EXEMPT.",
             stale
         );
     }

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -1,0 +1,831 @@
+//! Single source of truth for home-view action keybindings.
+//!
+//! Every relocatable action (one that binds to a different chord in strict vs
+//! non-strict mode) is declared exactly once in [`BINDINGS`]. The dispatcher
+//! ([`resolve`]), the command palette, and the help overlay all derive from
+//! this table, so a binding can no longer drift between those surfaces.
+//!
+//! Pure navigation keys (arrows, `j`/`k`/`h`/`l`, Home/End, PageUp/Down,
+//! `{`/`}`, `<`/`>`, Enter, Tab) are NOT here: they never relocate between
+//! modes and were never the source of the strict-mode bugs. They stay as
+//! explicit arms in `dispatch_action_key`, tried after this table.
+//!
+//! ## Strict-mode relocation rule
+//!
+//! In strict mode bare lowercase letters are reserved for the typing-guard, so
+//! actions move under a modifier. The consistent rule, applied uniformly:
+//!   - the bare-lowercase (primary) action  -> `Shift`+letter
+//!   - the `Shift`+letter (secondary) action -> `Ctrl`+letter
+//!
+//! e.g. `d`=delete / `Shift+D`=diff (non-strict) become `Shift+D`=delete /
+//! `Ctrl+D`=diff (strict). `p`=projects / `Shift+P`=profiles likewise become
+//! `Shift+P`=projects / `Ctrl+P`=profiles.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::ViewMode;
+use crate::session::config::SortOrder;
+use crate::tui::dialogs::PaletteGroup;
+
+/// Logical action. Each variant is dispatched by `HomeView::run_action`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ActionId {
+    Quit,
+    Help,
+    ToolPicker,
+    SearchStart,
+    SearchNext,
+    SearchPrev,
+    NewSession,
+    NewFromSelection,
+    NewFromProject,
+    AttachTerminal,
+    ToggleView,
+    SendMessage,
+    Stop,
+    Delete,
+    Rename,
+    Diff,
+    Serve,
+    Settings,
+    Profiles,
+    Projects,
+    Restart,
+    Update,
+    ToggleArchive,
+    ToggleFavorite,
+    ToggleSnooze,
+    ToggleContainer,
+    TogglePreviewInfo,
+    SortPicker,
+    GroupBy,
+    NextWaiting,
+}
+
+/// A single chord. `ctrl` requires the Control modifier; Shift is implicit in
+/// the uppercase letter `code` (terminals deliver `Shift+d` as `Char('D')`,
+/// and iOS Mosh delivers a bare uppercase keycode with no Shift modifier, so
+/// matching on the uppercase code rather than a Shift flag covers both).
+#[derive(Debug, Clone, Copy)]
+pub struct Chord {
+    pub code: KeyCode,
+    pub ctrl: bool,
+}
+
+const fn k(c: char) -> Chord {
+    Chord {
+        code: KeyCode::Char(c),
+        ctrl: false,
+    }
+}
+
+const fn ctrl(c: char) -> Chord {
+    Chord {
+        code: KeyCode::Char(c),
+        ctrl: true,
+    }
+}
+
+const fn f(n: u8) -> Chord {
+    Chord {
+        code: KeyCode::F(n),
+        ctrl: false,
+    }
+}
+
+/// Contextual guard: a binding only resolves when its context holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Context {
+    Always,
+    TerminalView,
+    AttentionSort,
+    SearchActive,
+}
+
+/// Help-overlay section. Ordering mirrors `components/help.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelpSection {
+    Actions,
+    Attention,
+    Views,
+    Other,
+}
+
+pub struct HelpMeta {
+    pub section: HelpSection,
+    pub desc: &'static str,
+}
+
+pub struct PaletteMeta {
+    pub title: &'static str,
+    pub keywords: &'static [&'static str],
+    pub group: PaletteGroup,
+    /// Only included when the `serve` feature is on (just the Serve command).
+    pub serve_only: bool,
+}
+
+pub struct Binding {
+    pub id: ActionId,
+    pub non_strict: &'static [Chord],
+    pub strict: &'static [Chord],
+    pub context: Context,
+    pub help: Option<HelpMeta>,
+    pub palette: Option<PaletteMeta>,
+}
+
+/// Runtime state the guards consult.
+pub struct Ctx {
+    pub view_mode: ViewMode,
+    pub sort_order: SortOrder,
+    pub has_search: bool,
+}
+
+fn chord_matches(c: &Chord, key: &KeyEvent) -> bool {
+    key.code == c.code && (!c.ctrl || key.modifiers.contains(KeyModifiers::CONTROL))
+}
+
+fn context_holds(context: Context, ctx: &Ctx) -> bool {
+    match context {
+        Context::Always => true,
+        Context::TerminalView => ctx.view_mode == ViewMode::Terminal,
+        Context::AttentionSort => ctx.sort_order == SortOrder::Attention,
+        Context::SearchActive => ctx.has_search,
+    }
+}
+
+/// Resolve a key event to an action, honoring strict mode and context guards.
+/// Returns the first matching binding in table order; context-guarded entries
+/// are listed before the unguarded entries that share their chord.
+pub fn resolve(key: &KeyEvent, strict: bool, ctx: &Ctx) -> Option<ActionId> {
+    for b in BINDINGS {
+        let chords = if strict { b.strict } else { b.non_strict };
+        if context_holds(b.context, ctx) && chords.iter().any(|c| chord_matches(c, key)) {
+            return Some(b.id);
+        }
+    }
+    None
+}
+
+/// Human-readable label for a binding's primary chord in the given mode, e.g.
+/// `"D"`, `"Ctrl+D"`, `"F5"`. Returns `""` if the action has no binding in the
+/// requested mode (e.g. `NextWaiting` in strict).
+pub fn label(id: ActionId, strict: bool) -> String {
+    let Some(b) = BINDINGS.iter().find(|b| b.id == id) else {
+        return String::new();
+    };
+    let chords = if strict { b.strict } else { b.non_strict };
+    chords.first().map(format_chord).unwrap_or_default()
+}
+
+fn format_chord(c: &Chord) -> String {
+    match c.code {
+        KeyCode::Char(ch) if c.ctrl => format!("Ctrl+{}", ch.to_ascii_uppercase()),
+        KeyCode::Char(ch) => ch.to_string(),
+        KeyCode::F(n) => format!("F{n}"),
+        _ => String::new(),
+    }
+}
+
+// Order matters: context-guarded bindings that share a chord with an unguarded
+// one (search-cycle vs new, etc.) come first so they win when their guard holds.
+pub static BINDINGS: &[Binding] = &[
+    // --- search cycle (only while matches are active; both modes) ---
+    Binding {
+        id: ActionId::SearchNext,
+        non_strict: &[k('n')],
+        strict: &[k('n')],
+        context: Context::SearchActive,
+        help: None,
+        palette: None,
+    },
+    Binding {
+        id: ActionId::SearchPrev,
+        non_strict: &[k('N')],
+        strict: &[k('N')],
+        context: Context::SearchActive,
+        help: None,
+        palette: None,
+    },
+    // --- attention-sort triage ---
+    Binding {
+        id: ActionId::ToggleFavorite,
+        non_strict: &[k('f')],
+        strict: &[k('F')],
+        context: Context::AttentionSort,
+        help: Some(HelpMeta {
+            section: HelpSection::Attention,
+            desc: "Toggle favorite (Attention sort)",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Toggle favorite",
+            keywords: &["star", "pin", "fav"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::ToggleSnooze,
+        non_strict: &[k('h')],
+        strict: &[k('H')],
+        context: Context::AttentionSort,
+        help: Some(HelpMeta {
+            section: HelpSection::Attention,
+            desc: "Snooze (toggle, Attention sort)",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Toggle snooze",
+            keywords: &["later", "defer", "wait"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    // --- terminal-view only ---
+    Binding {
+        id: ActionId::ToggleContainer,
+        non_strict: &[k('c')],
+        strict: &[k('C')],
+        context: Context::TerminalView,
+        help: Some(HelpMeta {
+            section: HelpSection::Views,
+            desc: "Toggle container/host (sandbox)",
+        }),
+        palette: None,
+    },
+    // --- always-on actions ---
+    Binding {
+        id: ActionId::Quit,
+        non_strict: &[k('q')],
+        strict: &[k('q')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Other,
+            desc: "Quit",
+        }),
+        palette: None,
+    },
+    Binding {
+        id: ActionId::Help,
+        non_strict: &[k('?')],
+        strict: &[k('?')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Other,
+            desc: "Toggle help",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Show keyboard shortcuts",
+            keywords: &["keys", "shortcuts"],
+            group: PaletteGroup::Settings,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::ToolPicker,
+        non_strict: &[k(';')],
+        strict: &[k(';')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "Open tool session",
+        }),
+        palette: None,
+    },
+    Binding {
+        id: ActionId::SearchStart,
+        non_strict: &[k('/')],
+        strict: &[k('/')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Other,
+            desc: "Search",
+        }),
+        palette: None,
+    },
+    Binding {
+        id: ActionId::NewSession,
+        non_strict: &[k('n')],
+        strict: &[k('N')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "New session",
+        }),
+        palette: Some(PaletteMeta {
+            title: "New session",
+            keywords: &["create", "add", "spawn"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::NewFromSelection,
+        non_strict: &[k('N')],
+        strict: &[ctrl('n')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "New from selection",
+        }),
+        palette: Some(PaletteMeta {
+            title: "New session from selection",
+            keywords: &["create", "duplicate", "clone"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    // New session from a saved project. Follows the bare->Shift relocation
+    // rule: `b` non-strict, `Shift+B` in strict.
+    Binding {
+        id: ActionId::NewFromProject,
+        non_strict: &[k('b')],
+        strict: &[k('B')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "New session from project",
+        }),
+        palette: Some(PaletteMeta {
+            title: "New session from saved project",
+            keywords: &["project", "saved", "registry", "create"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::AttachTerminal,
+        non_strict: &[k('T')],
+        strict: &[ctrl('t')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "Attach to terminal",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Attach to paired terminal",
+            keywords: &["shell", "host"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::ToggleView,
+        non_strict: &[k('t')],
+        strict: &[k('T')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Views,
+            desc: "Toggle Agent/Terminal view",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Toggle Agent / Terminal view",
+            keywords: &["switch", "shell"],
+            group: PaletteGroup::Views,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::SendMessage,
+        non_strict: &[k('m')],
+        strict: &[k('M')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "Send message to agent",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Send message to agent",
+            keywords: &["prompt", "tell", "say"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::Stop,
+        non_strict: &[k('x')],
+        strict: &[k('X')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "Stop session",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Stop session",
+            keywords: &["kill", "end", "halt"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::Delete,
+        non_strict: &[k('d')],
+        strict: &[k('D')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "Delete session/group",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Delete session or group",
+            keywords: &["remove", "trash"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::Rename,
+        non_strict: &[k('r')],
+        strict: &[k('R')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "Rename session/group",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Rename or move to group",
+            keywords: &["title", "label", "move", "regroup"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::Diff,
+        non_strict: &[k('D')],
+        strict: &[ctrl('d')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Views,
+            desc: "Diff view (git changes)",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Open diff view",
+            keywords: &["git", "changes"],
+            group: PaletteGroup::Views,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::Serve,
+        non_strict: &[k('R')],
+        strict: &[ctrl('r')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Other,
+            desc: "Serve (LAN / Tunnel)",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Open serve (LAN / Tunnel)",
+            keywords: &["web", "remote", "phone", "tunnel"],
+            group: PaletteGroup::Settings,
+            serve_only: true,
+        }),
+    },
+    Binding {
+        id: ActionId::Settings,
+        non_strict: &[k('s')],
+        strict: &[k('S')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Other,
+            desc: "Settings",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Open settings",
+            keywords: &["preferences", "config"],
+            group: PaletteGroup::Settings,
+            serve_only: false,
+        }),
+    },
+    // P flip: Projects is the primary (bare `p`) action -> Shift+P in strict;
+    // Profiles is the secondary (`Shift+P`) action -> Ctrl+P in strict.
+    Binding {
+        id: ActionId::Projects,
+        non_strict: &[k('p')],
+        strict: &[k('P')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Other,
+            desc: "Projects",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Manage projects",
+            keywords: &["registry", "repos", "multi-repo", "workspace"],
+            group: PaletteGroup::Settings,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::Profiles,
+        non_strict: &[k('P')],
+        strict: &[ctrl('p')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Other,
+            desc: "Profiles",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Switch profile",
+            keywords: &["account", "switch"],
+            group: PaletteGroup::Settings,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::Restart,
+        non_strict: &[k('e'), f(5)],
+        strict: &[k('E'), f(5)],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "Restart session (also F5)",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Restart session",
+            keywords: &["reload", "respawn", "reset"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::Update,
+        non_strict: &[k('u')],
+        strict: &[k('u')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Other,
+            desc: "Update aoe (when available)",
+        }),
+        palette: None,
+    },
+    Binding {
+        id: ActionId::ToggleArchive,
+        non_strict: &[k('z')],
+        strict: &[k('Z')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Attention,
+            desc: "Archive (toggle, any sort)",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Toggle archive",
+            keywords: &["park", "stash", "done", "zzz"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::TogglePreviewInfo,
+        non_strict: &[k('i')],
+        strict: &[k('I')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Views,
+            desc: "Toggle preview info header",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Toggle preview info header",
+            keywords: &["hide", "show", "info", "header", "preview"],
+            group: PaletteGroup::Views,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::SortPicker,
+        // Shift+O sorts in both modes; bare `o` only outside strict.
+        non_strict: &[k('o'), k('O'), ctrl('o')],
+        strict: &[k('O'), ctrl('o')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Views,
+            desc: "Sort order",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Sort order",
+            keywords: &["order", "sort", "pick"],
+            group: PaletteGroup::Views,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::GroupBy,
+        non_strict: &[k('g')],
+        strict: &[ctrl('g')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Views,
+            desc: "Group by",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Group by",
+            keywords: &["group", "project", "pick"],
+            group: PaletteGroup::Views,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::NextWaiting,
+        non_strict: &[k('w')],
+        strict: &[],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Attention,
+            desc: "Jump to next waiting/idle",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Jump to next waiting / idle session",
+            keywords: &["jump", "next", "waiting", "idle"],
+            group: PaletteGroup::Views,
+            serve_only: false,
+        }),
+    },
+];
+
+/// Stable palette/test id for an action (matches the legacy `builtin_commands`
+/// ids). Only actions that surface in the palette need one.
+pub fn palette_id(id: ActionId) -> &'static str {
+    match id {
+        ActionId::NewSession => "new-session",
+        ActionId::NewFromSelection => "new-from-selection",
+        ActionId::NewFromProject => "new-from-project",
+        ActionId::AttachTerminal => "attach-terminal",
+        ActionId::ToggleView => "toggle-view",
+        ActionId::SendMessage => "send-message",
+        ActionId::Stop => "stop",
+        ActionId::Delete => "delete",
+        ActionId::Rename => "rename",
+        ActionId::Diff => "diff",
+        ActionId::Serve => "serve",
+        ActionId::Settings => "settings",
+        ActionId::Profiles => "profiles",
+        ActionId::Projects => "projects",
+        ActionId::Restart => "restart",
+        ActionId::ToggleArchive => "archive",
+        ActionId::ToggleFavorite => "favorite",
+        ActionId::ToggleSnooze => "snooze",
+        ActionId::TogglePreviewInfo => "toggle-preview-info",
+        ActionId::SortPicker => "pick-sort",
+        ActionId::GroupBy => "pick-group-by",
+        ActionId::Help => "help",
+        ActionId::NextWaiting => "next-waiting",
+        ActionId::Quit => "quit",
+        ActionId::ToolPicker => "tool-picker",
+        ActionId::SearchStart => "search",
+        ActionId::SearchNext => "search-next",
+        ActionId::SearchPrev => "search-prev",
+        ActionId::Update => "update",
+        ActionId::ToggleContainer => "toggle-container",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> Ctx {
+        Ctx {
+            view_mode: ViewMode::Agent,
+            sort_order: SortOrder::Newest,
+            has_search: false,
+        }
+    }
+
+    fn key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    fn ctrl_key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn non_strict_resolution() {
+        let c = ctx();
+        let cases = [
+            ('d', ActionId::Delete),
+            ('D', ActionId::Diff),
+            ('r', ActionId::Rename),
+            ('R', ActionId::Serve),
+            ('t', ActionId::ToggleView),
+            ('T', ActionId::AttachTerminal),
+            ('n', ActionId::NewSession),
+            ('N', ActionId::NewFromSelection),
+            ('p', ActionId::Projects),
+            ('P', ActionId::Profiles),
+            ('o', ActionId::SortPicker),
+            ('g', ActionId::GroupBy),
+            ('q', ActionId::Quit),
+        ];
+        for (ch, want) in cases {
+            assert_eq!(
+                resolve(&key(ch), false, &c),
+                Some(want),
+                "non-strict '{ch}'"
+            );
+        }
+    }
+
+    #[test]
+    fn strict_relocation_is_consistent() {
+        let c = ctx();
+        // Shift+letter (the uppercase code) drives the primary action; the
+        // secondary action moves to Ctrl+letter. No bare lowercase action keys.
+        let shifted = [
+            ('D', ActionId::Delete),
+            ('R', ActionId::Rename),
+            ('T', ActionId::ToggleView),
+            ('N', ActionId::NewSession),
+            ('P', ActionId::Projects),
+            ('O', ActionId::SortPicker),
+        ];
+        for (ch, want) in shifted {
+            assert_eq!(resolve(&key(ch), true, &c), Some(want), "strict '{ch}'");
+        }
+        let ctrled = [
+            ('d', ActionId::Diff),
+            ('r', ActionId::Serve),
+            ('t', ActionId::AttachTerminal),
+            ('n', ActionId::NewFromSelection),
+            ('p', ActionId::Profiles),
+            ('g', ActionId::GroupBy),
+        ];
+        for (ch, want) in ctrled {
+            assert_eq!(
+                resolve(&ctrl_key(ch), true, &c),
+                Some(want),
+                "strict Ctrl+{ch}"
+            );
+        }
+    }
+
+    #[test]
+    fn strict_bare_lowercase_action_letters_are_unbound() {
+        // They fall through to the dispatcher's typing-guard, not an action.
+        let c = ctx();
+        for ch in [
+            'd', 'r', 't', 'n', 'p', 's', 'x', 'm', 'e', 'i', 'z', 'g', 'o',
+        ] {
+            assert_eq!(resolve(&key(ch), true, &c), None, "strict bare '{ch}'");
+        }
+    }
+
+    #[test]
+    fn search_cycle_overrides_new_session_when_active() {
+        let mut c = ctx();
+        c.has_search = true;
+        for strict in [false, true] {
+            assert_eq!(resolve(&key('n'), strict, &c), Some(ActionId::SearchNext));
+            assert_eq!(resolve(&key('N'), strict, &c), Some(ActionId::SearchPrev));
+        }
+        // Without an active search, the same keys are new-session actions.
+        c.has_search = false;
+        assert_eq!(resolve(&key('n'), false, &c), Some(ActionId::NewSession));
+        assert_eq!(resolve(&key('N'), true, &c), Some(ActionId::NewSession));
+    }
+
+    #[test]
+    fn context_guards_gate_attention_and_terminal_actions() {
+        // Favorite/snooze only resolve in Attention sort.
+        let mut c = ctx();
+        assert_eq!(resolve(&key('f'), false, &c), None);
+        c.sort_order = SortOrder::Attention;
+        assert_eq!(
+            resolve(&key('f'), false, &c),
+            Some(ActionId::ToggleFavorite)
+        );
+        assert_eq!(resolve(&key('h'), false, &c), Some(ActionId::ToggleSnooze));
+
+        // Container toggle only resolves in Terminal view.
+        let mut c = ctx();
+        assert_eq!(resolve(&key('c'), false, &c), None);
+        c.view_mode = ViewMode::Terminal;
+        assert_eq!(
+            resolve(&key('c'), false, &c),
+            Some(ActionId::ToggleContainer)
+        );
+    }
+
+    #[test]
+    fn ctrl_o_sorts_in_both_modes() {
+        let c = ctx();
+        assert_eq!(
+            resolve(&ctrl_key('o'), false, &c),
+            Some(ActionId::SortPicker)
+        );
+        assert_eq!(
+            resolve(&ctrl_key('o'), true, &c),
+            Some(ActionId::SortPicker)
+        );
+    }
+
+    #[test]
+    fn labels_match_mode() {
+        assert_eq!(label(ActionId::Diff, false), "D");
+        assert_eq!(label(ActionId::Diff, true), "Ctrl+D");
+        assert_eq!(label(ActionId::Delete, true), "D");
+        assert_eq!(label(ActionId::Projects, false), "p");
+        assert_eq!(label(ActionId::Projects, true), "P");
+        assert_eq!(label(ActionId::Profiles, true), "Ctrl+P");
+        assert_eq!(label(ActionId::Restart, false), "e");
+        // NextWaiting has no strict binding.
+        assert_eq!(label(ActionId::NextWaiting, true), "");
+    }
+}

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1910,11 +1910,17 @@ impl HomeView {
                 self.search_query = Input::default();
             }
             ActionId::SearchNext => {
+                if self.search_matches.is_empty() {
+                    return None;
+                }
                 self.search_match_index = (self.search_match_index + 1) % self.search_matches.len();
                 self.cursor = self.search_matches[self.search_match_index];
                 self.update_selected();
             }
             ActionId::SearchPrev => {
+                if self.search_matches.is_empty() {
+                    return None;
+                }
                 self.search_match_index = if self.search_match_index == 0 {
                     self.search_matches.len() - 1
                 } else {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5,6 +5,7 @@ use ratatui::prelude::Position;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
+use super::bindings::{self, ActionId};
 use super::{live_send, DragKind, HomeView, PreviewSelection, TerminalMode, ViewMode};
 use crate::session::config::{load_config, save_config, GroupByMode, SortOrder};
 use crate::session::{list_profiles, repo_config, resolve_config_or_warn, Item, Status};
@@ -1736,39 +1737,28 @@ impl HomeView {
             return None;
         }
 
-        // In strict_hotkeys mode, normalize shifted/ctrl keys to their standard
-        // equivalents so the match block below doesn't need duplication.
-        //
-        // Mapping (strict mode only):
-        //   Shift+letter actions -> pass through unchanged: each has its own
-        //     `Char('UPPER') if self.strict_hotkeys` arm in the main match.
-        //   Ctrl+letter relocated bindings -> uppercase: Ctrl+D->D, Ctrl+R->R, Ctrl+P->P
-        //   Ctrl+T, Ctrl+N, Ctrl+G, Ctrl+O -> pass through with CTRL intact.
-        //     Ctrl+T/Ctrl+N have distinct secondary arms that would be
-        //     orphaned if folded onto Shift+T/Shift+N; Ctrl+G/Ctrl+O match
-        //     with their modifier and stripping CTRL would collide with the
-        //     bare-lowercase typing-guard.
-        //   Bare lowercase action letters -> blocked (return None)
-        let key = if self.strict_hotkeys {
-            self.normalize_strict_key(key)
-        } else {
-            Some(key)
-        };
-        let key = key?;
-
+        // Strict-mode relocation is handled inside dispatch_action_key via the
+        // shared bindings registry (resolve picks the right chord per mode and
+        // a typing-guard catches unbound bare lowercase), so no key rewriting
+        // happens here.
         self.dispatch_action_key(key, update_info)
     }
 
-    /// Run the main action dispatch (the giant match block) on a key.
-    /// Extracted from `handle_key` so the command palette can synthesize
-    /// keys and run them through the same code path without re-entering
-    /// dialog routing or strict-mode normalization.
+    /// Run the main action dispatch on a key.
+    ///
+    /// Extracted from `handle_key` so the command palette can route through the
+    /// same code path. Relocatable action keys are resolved through the shared
+    /// [`bindings`](super::bindings) registry, so the dispatcher, palette, and
+    /// help overlay can't drift on which chord (or mode) an action binds to.
+    /// Pure navigation/structural keys, which never relocate between modes,
+    /// stay as explicit arms below and are tried after the registry. The
+    /// strict-mode typing-guard is the final fallback.
     fn dispatch_action_key(
         &mut self,
         key: KeyEvent,
         update_info: Option<&crate::update::UpdateInfo>,
     ) -> Option<Action> {
-        // Dynamic tool session hotkeys (checked before static match block)
+        // Dynamic tool session hotkeys (checked before everything else).
         if let Some(tool_name) = self.match_tool_hotkey(&key) {
             if matches!(&self.view_mode, ViewMode::Tool(current) if current == &tool_name) {
                 self.view_mode = ViewMode::Agent;
@@ -1780,605 +1770,64 @@ impl HomeView {
             return None;
         }
 
-        // Normal mode keybindings
+        // Context-dependent Esc handling (not a relocatable action).
         match key.code {
             KeyCode::Esc if !self.search_matches.is_empty() => {
                 self.search_matches.clear();
                 self.search_match_index = 0;
                 self.search_query = Input::default();
+                return None;
             }
             KeyCode::Esc if matches!(self.view_mode, ViewMode::Tool(_)) => {
                 self.view_mode = ViewMode::Agent;
+                return None;
             }
-            KeyCode::Char('q') => return Some(Action::Quit),
-            // `h` / `H` (snooze) and `f` / `F` (favorite) are gated to
-            // Attention sort. Snooze and favorite are triage primitives; they
-            // only have a visible effect (and a sort impact) in Attention mode.
-            // Outside Attention, mutating these flags would silently change
-            // persisted state with no on-screen feedback, so we ignore the
-            // press entirely (`h` then falls through to the group-collapse
-            // binding). Snooze used to also live on `w` / `W`, which shadowed
-            // the jump-to-next-waiting binding below in Attention sort; #1524
-            // moved it off so `w` is navigation again.
-            KeyCode::Char('h')
-                if !self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
-            {
-                if let Err(e) = self.toggle_snooze_at_cursor() {
-                    tracing::error!("toggle_snooze_at_cursor failed: {}", e);
-                }
-            }
-            KeyCode::Char('H')
-                if self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
-            {
-                if let Err(e) = self.toggle_snooze_at_cursor() {
-                    tracing::error!("toggle_snooze_at_cursor failed: {}", e);
-                }
-            }
-            KeyCode::Char('f')
-                if !self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
-            {
-                if let Err(e) = self.toggle_favorite_at_cursor() {
-                    tracing::error!("toggle_favorite_at_cursor failed: {}", e);
-                }
-            }
-            KeyCode::Char('F')
-                if self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
-            {
-                if let Err(e) = self.toggle_favorite_at_cursor() {
-                    tracing::error!("toggle_favorite_at_cursor failed: {}", e);
-                }
-            }
-            // `z` / `Z`: toggle archive on the cursor's session. Archive is
-            // the "park this, I'm done with it" sink. The row drops to tier
-            // 99 in the Attention sort, the spinner stops, and the agent
-            // pane is killed so a stale process can't keep claiming attention.
-            // Pressing it again on an archived row unarchives (no kill, the
-            // pane stays gone). Mnemonic: Zzz / archive box. Distinct from
-            // `h`/`H` snooze (temporary, auto wakes) and separate from `d`/`D`
-            // (destructive delete, unchanged).
-            KeyCode::Char('z') if !self.strict_hotkeys => {
-                if let Err(e) = self.toggle_archive_at_cursor() {
-                    tracing::error!("toggle_archive_at_cursor failed: {}", e);
-                }
-            }
-            KeyCode::Char('Z') if self.strict_hotkeys => {
-                if let Err(e) = self.toggle_archive_at_cursor() {
-                    tracing::error!("toggle_archive_at_cursor failed: {}", e);
-                }
-            }
-            KeyCode::Char('?') => {
-                self.show_help = true;
-                self.help_scroll = 0;
-            }
-            KeyCode::Char('e') if !self.strict_hotkeys => {
-                self.open_restart_dialog();
-            }
-            KeyCode::Char('E') if self.strict_hotkeys => {
-                self.open_restart_dialog();
-            }
-            KeyCode::F(5) => {
-                self.open_restart_dialog();
-            }
-            KeyCode::Char('P') => {
-                self.show_profile_picker();
-            }
-            KeyCode::Char('p') if !self.strict_hotkeys => {
-                let profile = self.config_profile();
-                self.projects_dialog = Some(ProjectsDialog::new(&profile));
-            }
-            KeyCode::Char('p')
-                if self.strict_hotkeys && key.modifiers.contains(KeyModifiers::CONTROL) =>
-            {
-                self.show_profile_picker();
-            }
-            KeyCode::Char('b') if !self.strict_hotkeys => {
-                self.open_project_session_picker();
-            }
-            KeyCode::Char('B') if self.strict_hotkeys => {
-                self.open_project_session_picker();
-            }
-            #[cfg(feature = "serve")]
-            KeyCode::Char('R') if !self.strict_hotkeys => {
-                self.serve_view = Some(crate::tui::dialogs::ServeView::new());
-            }
-            #[cfg(feature = "serve")]
-            KeyCode::Char('r')
-                if self.strict_hotkeys && key.modifiers.contains(KeyModifiers::CONTROL) =>
-            {
-                self.serve_view = Some(crate::tui::dialogs::ServeView::new());
-            }
-            #[cfg(not(feature = "serve"))]
-            KeyCode::Char('R') if !self.strict_hotkeys => {
-                self.info_dialog = Some(InfoDialog::new(
-                    "Serve unavailable",
-                    "This `aoe` binary was built without the `serve` feature, \
-                     so the web dashboard, local network serving, and \
-                     Cloudflare Tunnel integration are not included.\n\n\
-                     To serve to your phone (LAN / Tailscale / tunnel):\n\
-                       \u{2022} Install a release build from GitHub Releases, or\n\
-                       \u{2022} Build from source with:\n\
-                         cargo build --release --features serve\n\n\
-                     Once you have a `serve`-enabled binary, press R again to \
-                     open the serve dialog.",
-                ));
-            }
-            #[cfg(not(feature = "serve"))]
-            KeyCode::Char('r')
-                if self.strict_hotkeys && key.modifiers.contains(KeyModifiers::CONTROL) =>
-            {
-                self.info_dialog = Some(InfoDialog::new(
-                    "Serve unavailable",
-                    "This `aoe` binary was built without the `serve` feature, \
-                     so the web dashboard, local network serving, and \
-                     Cloudflare Tunnel integration are not included.\n\n\
-                     To serve to your phone (LAN / Tailscale / tunnel):\n\
-                       \u{2022} Install a release build from GitHub Releases, or\n\
-                       \u{2022} Build from source with:\n\
-                         cargo build --release --features serve\n\n\
-                     Once you have a `serve`-enabled binary, press R again to \
-                     open the serve dialog.",
-                ));
-            }
-            KeyCode::Char('t') if !self.strict_hotkeys => {
-                self.view_mode = match self.view_mode {
-                    ViewMode::Agent => ViewMode::Terminal,
-                    ViewMode::Terminal | ViewMode::Tool(_) => ViewMode::Agent,
-                };
-            }
-            KeyCode::Char('T') if self.strict_hotkeys => {
-                self.view_mode = match self.view_mode {
-                    ViewMode::Agent => ViewMode::Terminal,
-                    ViewMode::Terminal | ViewMode::Tool(_) => ViewMode::Agent,
-                };
-            }
-            KeyCode::Char('T') if !self.strict_hotkeys => {
-                // Quick-attach to paired terminal from any view
-                if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(id) {
-                        if matches!(inst.status, Status::Deleting | Status::Creating) {
-                            return None;
-                        }
-                    }
-                    let terminal_mode = if let Some(inst) = self.get_instance(id) {
-                        if inst.is_sandboxed() {
-                            self.get_terminal_mode(id)
-                        } else {
-                            TerminalMode::Host
-                        }
-                    } else {
-                        TerminalMode::Host
-                    };
-                    return Some(Action::AttachTerminal(id.clone(), terminal_mode));
-                }
-            }
-            KeyCode::Char('t')
-                if self.strict_hotkeys && key.modifiers.contains(KeyModifiers::CONTROL) =>
-            {
-                // Quick-attach to paired terminal from any view
-                if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(id) {
-                        if matches!(inst.status, Status::Deleting | Status::Creating) {
-                            return None;
-                        }
-                    }
-                    let terminal_mode = if let Some(inst) = self.get_instance(id) {
-                        if inst.is_sandboxed() {
-                            self.get_terminal_mode(id)
-                        } else {
-                            TerminalMode::Host
-                        }
-                    } else {
-                        TerminalMode::Host
-                    };
-                    return Some(Action::AttachTerminal(id.clone(), terminal_mode));
-                }
-            }
-            KeyCode::Char('c') if !self.strict_hotkeys && self.view_mode == ViewMode::Terminal => {
-                if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(id) {
-                        if inst.is_sandboxed() {
-                            let id = id.clone();
-                            self.toggle_terminal_mode(&id);
-                        } else {
-                            self.info_dialog = Some(InfoDialog::new(
-                                "Not Available",
-                                "Only sandboxed sessions support container terminals. This session runs directly on the host.",
-                            ));
-                        }
-                    }
-                }
-            }
-            KeyCode::Char('C') if self.strict_hotkeys && self.view_mode == ViewMode::Terminal => {
-                if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(id) {
-                        if inst.is_sandboxed() {
-                            let id = id.clone();
-                            self.toggle_terminal_mode(&id);
-                        } else {
-                            self.info_dialog = Some(InfoDialog::new(
-                                "Not Available",
-                                "Only sandboxed sessions support container terminals. This session runs directly on the host.",
-                            ));
-                        }
-                    }
-                }
-            }
-            KeyCode::Char(';') => {
-                if matches!(self.view_mode, ViewMode::Tool(_)) {
-                    self.view_mode = ViewMode::Agent;
-                } else if !self.tool_configs.is_empty() {
-                    self.open_tool_picker();
-                }
-            }
-            KeyCode::Char('/') => {
-                self.search_active = true;
-                self.search_query = Input::default();
-            }
-            KeyCode::Char('n') if !self.search_matches.is_empty() => {
-                self.search_match_index = (self.search_match_index + 1) % self.search_matches.len();
-                self.cursor = self.search_matches[self.search_match_index];
+            _ => {}
+        }
+
+        // Registry-driven action keys.
+        let ctx = bindings::Ctx {
+            view_mode: self.view_mode.clone(),
+            sort_order: self.sort_order,
+            has_search: !self.search_matches.is_empty(),
+        };
+        if let Some(id) = bindings::resolve(&key, self.strict_hotkeys, &ctx) {
+            return self.run_action(id, update_info);
+        }
+
+        // Navigation / structural keys: identical in both modes, never relocate.
+        match key.code {
+            KeyCode::Up if key.modifiers.contains(KeyModifiers::SHIFT) => self.move_cursor(-10),
+            KeyCode::Down if key.modifiers.contains(KeyModifiers::SHIFT) => self.move_cursor(10),
+            KeyCode::Char('{') => self.move_cursor(-10),
+            KeyCode::Char('}') => self.move_cursor(10),
+            KeyCode::Up | KeyCode::Char('k') => self.move_cursor(-1),
+            KeyCode::Down | KeyCode::Char('j') => self.move_cursor(1),
+            KeyCode::PageUp => self.move_cursor(-10),
+            KeyCode::PageDown => self.move_cursor(10),
+            KeyCode::Home => {
+                self.cursor = 0;
+                self.mouse_pos = None;
                 self.update_selected();
             }
-            KeyCode::Char('n') if !self.strict_hotkeys => {
-                self.open_new_session_dialog();
-            }
-            KeyCode::Char('N') if self.strict_hotkeys && self.search_matches.is_empty() => {
-                if self.creating_stub_id.is_some() {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Please Wait",
-                        "A session is already being created. Wait for it to finish or press Ctrl+C to cancel.",
-                    ));
-                } else {
-                    let existing_groups: Vec<String> =
-                        self.all_groups().iter().map(|g| g.path.clone()).collect();
-                    let current_profile = self.config_profile();
-                    let profiles =
-                        list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-                    self.new_dialog = Some(NewSessionDialog::new(
-                        self.available_tools.clone(),
-                        existing_groups,
-                        &current_profile,
-                        profiles,
-                    ));
-                }
-            }
-            KeyCode::Char('N') if !self.search_matches.is_empty() => {
-                self.search_match_index = if self.search_match_index == 0 {
-                    self.search_matches.len() - 1
-                } else {
-                    self.search_match_index - 1
-                };
-                self.cursor = self.search_matches[self.search_match_index];
+            KeyCode::End | KeyCode::Char('G') if !self.flat_items.is_empty() => {
+                self.cursor = self.flat_items.len() - 1;
+                self.mouse_pos = None;
                 self.update_selected();
             }
-            KeyCode::Char('N') if !self.strict_hotkeys => {
-                if !self.search_matches.is_empty() {
-                    self.search_match_index = if self.search_match_index == 0 {
-                        self.search_matches.len() - 1
-                    } else {
-                        self.search_match_index - 1
-                    };
-                    self.cursor = self.search_matches[self.search_match_index];
-                    self.update_selected();
-                } else if self.creating_stub_id.is_some() {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Please Wait",
-                        "A session is already being created. Wait for it to finish or press Ctrl+C to cancel.",
-                    ));
-                } else {
-                    // Pre-filled new session from selection
-                    let prefill_path = self
-                        .selected_session
-                        .as_ref()
-                        .and_then(|id| self.get_instance(id))
-                        .map(|inst| {
-                            inst.worktree_info
-                                .as_ref()
-                                .map(|wt| wt.main_repo_path.clone())
-                                .unwrap_or_else(|| inst.project_path.clone())
-                        });
-                    let prefill_group = self
-                        .selected_session
-                        .as_ref()
-                        .and_then(|id| self.get_instance(id))
-                        .and_then(|inst| {
-                            if inst.group_path.is_empty() {
-                                None
-                            } else {
-                                Some(inst.group_path.clone())
-                            }
-                        })
-                        .or_else(|| self.selected_group.clone());
-
-                    if prefill_path.is_some() || prefill_group.is_some() {
-                        let existing_groups: Vec<String> =
-                            self.all_groups().iter().map(|g| g.path.clone()).collect();
-                        let current_profile = self
-                            .profile_for_cursor(self.cursor)
-                            .unwrap_or_else(|| self.config_profile());
-                        let profiles =
-                            list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-                        let mut dialog = NewSessionDialog::new(
-                            self.available_tools.clone(),
-                            existing_groups,
-                            &current_profile,
-                            profiles,
-                        );
-                        if let Some(path) = prefill_path {
-                            dialog.set_path(path);
-                        }
-                        if let Some(group) = prefill_group {
-                            dialog.set_group(group);
-                        }
-                        self.new_dialog = Some(dialog);
-                    }
+            KeyCode::Char('<') => self.shrink_list(),
+            KeyCode::Char('>') => self.grow_list(),
+            KeyCode::Enter => {
+                if self.selected_session.is_some() {
+                    return self.activate_selected_session();
+                } else if let Some(Item::Group { path, .. }) = self.flat_items.get(self.cursor) {
+                    let path = path.clone();
+                    self.toggle_group_collapsed(&path);
                 }
             }
-            KeyCode::Char('n')
-                if self.strict_hotkeys && key.modifiers.contains(KeyModifiers::CONTROL) =>
-            {
-                // Strict mode: Ctrl+N = prefill-new (legacy Shift+N relocation)
-                if self.creating_stub_id.is_some() {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Please Wait",
-                        "A session is already being created. Wait for it to finish or press Ctrl+C to cancel.",
-                    ));
-                } else {
-                    let prefill_path = self
-                        .selected_session
-                        .as_ref()
-                        .and_then(|id| self.get_instance(id))
-                        .map(|inst| {
-                            inst.worktree_info
-                                .as_ref()
-                                .map(|wt| wt.main_repo_path.clone())
-                                .unwrap_or_else(|| inst.project_path.clone())
-                        });
-                    let prefill_group = self
-                        .selected_session
-                        .as_ref()
-                        .and_then(|id| self.get_instance(id))
-                        .and_then(|inst| {
-                            if inst.group_path.is_empty() {
-                                None
-                            } else {
-                                Some(inst.group_path.clone())
-                            }
-                        })
-                        .or_else(|| self.selected_group.clone());
-
-                    if prefill_path.is_some() || prefill_group.is_some() {
-                        let existing_groups: Vec<String> =
-                            self.all_groups().iter().map(|g| g.path.clone()).collect();
-                        let current_profile = self
-                            .profile_for_cursor(self.cursor)
-                            .unwrap_or_else(|| self.config_profile());
-                        let profiles =
-                            list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-                        let mut dialog = NewSessionDialog::new(
-                            self.available_tools.clone(),
-                            existing_groups,
-                            &current_profile,
-                            profiles,
-                        );
-                        if let Some(path) = prefill_path {
-                            dialog.set_path(path);
-                        }
-                        if let Some(group) = prefill_group {
-                            dialog.set_group(group);
-                        }
-                        self.new_dialog = Some(dialog);
-                    }
-                }
-            }
-            KeyCode::Char('s') if !self.strict_hotkeys => {
-                let project_path = self
-                    .selected_session
-                    .as_ref()
-                    .and_then(|id| self.get_instance(id))
-                    .map(|inst| inst.project_path.clone());
-                match SettingsView::new(&self.config_profile(), project_path) {
-                    Ok(view) => self.settings_view = Some(view),
-                    Err(e) => {
-                        tracing::error!("Failed to open settings: {}", e);
-                        self.info_dialog = Some(InfoDialog::new(
-                            "Error",
-                            &format!("Failed to open settings: {}", e),
-                        ));
-                    }
-                }
-            }
-            KeyCode::Char('S') if self.strict_hotkeys => {
-                let project_path = self
-                    .selected_session
-                    .as_ref()
-                    .and_then(|id| self.get_instance(id))
-                    .map(|inst| inst.project_path.clone());
-                match SettingsView::new(&self.config_profile(), project_path) {
-                    Ok(view) => self.settings_view = Some(view),
-                    Err(e) => {
-                        tracing::error!(target: "tui.input", "Failed to open settings: {}", e);
-                        self.info_dialog = Some(InfoDialog::new(
-                            "Error",
-                            &format!("Failed to open settings: {}", e),
-                        ));
-                    }
-                }
-            }
-            KeyCode::Char('u') => {
-                if let Some(info) = update_info {
-                    if info.available && self.update_confirm_dialog.is_none() {
-                        let method = match crate::update::install::detect_install_method() {
-                            Ok(m) => m,
-                            Err(e) => {
-                                tracing::warn!(target: "tui.input", "update detection failed: {e}");
-                                return None;
-                            }
-                        };
-                        use crate::update::install::InstallMethod;
-                        if !matches!(
-                            &method,
-                            InstallMethod::Homebrew | InstallMethod::Tarball { .. }
-                        ) {
-                            let msg = match &method {
-                                InstallMethod::Nix => {
-                                    "Nix install: run `nix run github:agent-of-empires/agent-of-empires` to update".to_string()
-                                }
-                                InstallMethod::Cargo => {
-                                    "Cargo install: run `cargo install --git https://github.com/agent-of-empires/agent-of-empires aoe`".to_string()
-                                }
-                                InstallMethod::Unknown { .. } => {
-                                    "Unknown install method: run `aoe update` in a terminal for instructions".to_string()
-                                }
-                                _ => unreachable!(),
-                            };
-                            return Some(Action::SetTransientStatus(msg));
-                        }
-                        let needs_sudo = matches!(
-                            &method,
-                            InstallMethod::Tarball { binary_path }
-                                if !crate::update::install::parent_is_writable(binary_path)
-                        );
-                        self.update_confirm_dialog =
-                            Some(crate::tui::dialogs::UpdateConfirmDialog::new(
-                                info.current_version.clone(),
-                                info.latest_version.clone(),
-                                method,
-                                needs_sudo,
-                            ));
-                    }
-                }
-            }
-            KeyCode::Char('D') if !self.strict_hotkeys => {
-                // Open diff view - requires a selected session
-                let Some(session_id) = &self.selected_session else {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "No Session Selected",
-                        "Select a session to view its diff.",
-                    ));
-                    return None;
-                };
-
-                let Some(inst) = self.get_instance(session_id) else {
-                    self.info_dialog =
-                        Some(InfoDialog::new("Error", "Could not find session data."));
-                    return None;
-                };
-
-                let repo_path = std::path::PathBuf::from(&inst.project_path);
-                let session_id_owned = inst.id.clone();
-                let profile = inst.source_profile.clone();
-                let base_override = inst.base_branch_override.clone();
-                match DiffView::new_for_session(
-                    repo_path,
-                    Some(session_id_owned),
-                    profile,
-                    base_override,
-                ) {
-                    Ok(view) => self.diff_view = Some(view),
-                    Err(e) => {
-                        tracing::error!(target: "tui.input", "Failed to open diff view: {}", e);
-                        self.info_dialog = Some(InfoDialog::new(
-                            "Error",
-                            &format!("Failed to open diff view: {}", e),
-                        ));
-                    }
-                }
-            }
-            KeyCode::Char('d')
-                if self.strict_hotkeys && key.modifiers.contains(KeyModifiers::CONTROL) =>
-            {
-                // Strict mode: Ctrl+D = diff (legacy Shift+D relocation)
-                let Some(session_id) = &self.selected_session else {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "No Session Selected",
-                        "Select a session to view its diff.",
-                    ));
-                    return None;
-                };
-
-                let Some(inst) = self.get_instance(session_id) else {
-                    self.info_dialog =
-                        Some(InfoDialog::new("Error", "Could not find session data."));
-                    return None;
-                };
-
-                let repo_path = std::path::PathBuf::from(&inst.project_path);
-                match DiffView::new(repo_path) {
-                    Ok(view) => self.diff_view = Some(view),
-                    Err(e) => {
-                        tracing::error!("Failed to open diff view: {}", e);
-                        self.info_dialog = Some(InfoDialog::new(
-                            "Error",
-                            &format!("Failed to open diff view: {}", e),
-                        ));
-                    }
-                }
-            }
-            KeyCode::Char('x') if !self.strict_hotkeys => {
-                if let Some(session_id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(session_id) {
-                        if matches!(
-                            inst.status,
-                            Status::Stopped | Status::Deleting | Status::Creating
-                        ) {
-                            return None;
-                        }
-                        let message = format!("Are you sure you want to stop '{}'?", inst.title);
-                        self.pending_stop_session = Some(session_id.clone());
-                        self.confirm_dialog =
-                            Some(ConfirmDialog::new("Stop Session", &message, "stop_session"));
-                    }
-                }
-            }
-            KeyCode::Char('X') if self.strict_hotkeys => {
-                if let Some(session_id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(session_id) {
-                        if matches!(
-                            inst.status,
-                            Status::Stopped | Status::Deleting | Status::Creating
-                        ) {
-                            return None;
-                        }
-                        let message = format!("Are you sure you want to stop '{}'?", inst.title);
-                        self.pending_stop_session = Some(session_id.clone());
-                        self.confirm_dialog =
-                            Some(ConfirmDialog::new("Stop Session", &message, "stop_session"));
-                    }
-                }
-            }
-            KeyCode::Char('d') if !self.strict_hotkeys => {
-                self.open_delete_for_selected();
-            }
-            KeyCode::Char('D') if self.strict_hotkeys => {
-                self.open_delete_for_selected();
-            }
-            KeyCode::Char('r') if !self.strict_hotkeys => {
-                self.open_rename_for_selected();
-            }
-            KeyCode::Char('R') if self.strict_hotkeys => {
-                self.open_rename_for_selected();
-            }
-            KeyCode::Char('m') if !self.strict_hotkeys => {
-                self.open_send_message_dialog();
-            }
-            KeyCode::Char('M') if self.strict_hotkeys => {
-                self.open_send_message_dialog();
-            }
-            // Tab is the activation key's complement: it does whichever
-            // of (live-send, tmux attach) `Enter` doesn't. When
-            // `default_attach_mode = LiveSend`, Enter activates live
-            // mode, so Tab swaps to a full tmux attach (the escape
-            // hatch). When `default_attach_mode = Tmux` (the default),
-            // Enter still attaches and Tab keeps its historical
-            // live-send role.
-            //
-            // Free at the home-view top level (settings/cockpit/dialogs
-            // own their own Tab handlers), and the entry-vs-send
-            // distinction is unambiguous: this branch only fires when
-            // `live_send` is None, because the live-send capture at the
-            // top of `handle_key` short-circuits otherwise. While in
-            // live mode Tab is sent verbatim to the agent.
+            // Tab is the activation key's complement: it does whichever of
+            // (live-send, tmux attach) `Enter` doesn't. Only fires when
+            // `live_send` is None (the live-send capture short-circuits above).
             KeyCode::Tab => {
                 let swap_to_attach = self
                     .selected_session
@@ -2398,103 +1847,6 @@ impl HomeView {
                     return Some(action);
                 }
             }
-            KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.show_sort_picker();
-            }
-            // Plain lowercase 'o' opens the sort picker only OUTSIDE strict mode.
-            // In strict mode, bare 'o' falls through to the typing-guard catch-all
-            // (compose dialog), per the no-destructive-lowercase contract.
-            KeyCode::Char('o') if !self.strict_hotkeys => {
-                self.show_sort_picker();
-            }
-            // Shift+O in strict mode arrives here as Char('O') (normalize_strict_key
-            // no longer lowercases 'O') so it's the one bare-letter sort hotkey in
-            // strict mode. Also matches Shift+O in non-strict mode.
-            KeyCode::Char('O') => {
-                self.show_sort_picker();
-            }
-            // ±10 navigation: Shift+Up/Down, PageUp/PageDown, OR { / }.
-            // iPad-friendly ±10 aliases for PageUp/PageDown. iPads have no
-            // PageUp/PageDown keys, and Cmd combos are typically stripped by
-            // SSH/Mosh before reaching the TTY. Shift+Up/Down arrives intact
-            // on every terminal we test, and `{` / `}` (Shift+`[` / Shift+`]`)
-            // pass through as plain chars so Cmd+Shift+`[` / `]` works whether
-            // or not the terminal forwards Cmd. Both bind to the same step
-            // size as PageUp/PageDown to keep the mental model simple.
-            KeyCode::Up if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                self.move_cursor(-10);
-            }
-            KeyCode::Down if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                self.move_cursor(10);
-            }
-            KeyCode::Char('{') => {
-                self.move_cursor(-10);
-            }
-            KeyCode::Char('}') => {
-                self.move_cursor(10);
-            }
-            KeyCode::Up | KeyCode::Char('k') => {
-                self.move_cursor(-1);
-            }
-            KeyCode::Down | KeyCode::Char('j') => {
-                self.move_cursor(1);
-            }
-            KeyCode::PageUp => {
-                self.move_cursor(-10);
-            }
-            KeyCode::PageDown => {
-                self.move_cursor(10);
-            }
-            KeyCode::Home => {
-                self.cursor = 0;
-                self.mouse_pos = None;
-                self.update_selected();
-            }
-            KeyCode::Char('g')
-                if self.strict_hotkeys && key.modifiers.contains(KeyModifiers::CONTROL) =>
-            {
-                self.show_group_picker();
-            }
-            KeyCode::Char('g') if !self.strict_hotkeys => {
-                self.show_group_picker();
-            }
-            KeyCode::End | KeyCode::Char('G') if !self.flat_items.is_empty() => {
-                self.cursor = self.flat_items.len() - 1;
-                self.mouse_pos = None;
-                self.update_selected();
-            }
-            KeyCode::Enter => {
-                if self.selected_session.is_some() {
-                    return self.activate_selected_session();
-                } else if let Some(Item::Group { path, .. }) = self.flat_items.get(self.cursor) {
-                    let path = path.clone();
-                    self.toggle_group_collapsed(&path);
-                }
-            }
-            // `<` shrinks the list pane width; `>` grows it. Capital
-            // H/L used to be aliases here but H is now the advertised
-            // snooze key (mnemonic: Hide), so width controls live on
-            // the angle-bracket characters only.
-            KeyCode::Char('<') => {
-                self.shrink_list();
-            }
-            KeyCode::Char('>') => {
-                self.grow_list();
-            }
-            // `i`/`I`: toggle the preview info header (profile/tool/path/
-            // status/sandbox/worktree). Persisted across runs. The hint
-            // rendered on the outer Preview block title advertises this.
-            KeyCode::Char('i') if !self.strict_hotkeys => {
-                self.toggle_preview_info();
-            }
-            KeyCode::Char('I') if self.strict_hotkeys => {
-                self.toggle_preview_info();
-            }
-            // Bare `h` collapses only in strict mode; in non-strict the
-            // earlier `Char('h') if !self.strict_hotkeys` arm catches it
-            // for Snooze, so we'd never reach here. Pairing it with Left
-            // keeps the help overlay's "h/←" claim honest and mirrors the
-            // unconditional `l`/Right binding below.
             KeyCode::Left | KeyCode::Char('h') => {
                 if let Some(Item::Group {
                     path, collapsed, ..
@@ -2517,18 +1869,9 @@ impl HomeView {
                     }
                 }
             }
-            // Jump to the next waiting/idle session (PR #796). Snooze moved off
-            // `w`/`W` onto `h`/`H` (#1524), so in Attention sort `w` is no
-            // longer shadowed by a snooze arm and this finally fires across
-            // every sort mode. Strict mode keeps bare lowercase `w` for the
-            // typing-guard below.
-            KeyCode::Char('w') if !self.strict_hotkeys => {
-                self.jump_to_next_waiting();
-            }
-            // Strict-mode typing guard: any bare lowercase letter that isn't a
-            // navigation key (j/k/h/l) is treated as inadvertent typing; open
-            // the compose dialog pre-filled with that character instead of
-            // firing an action or swallowing the keypress.
+            // Strict-mode typing guard: any bare lowercase letter not bound to
+            // an action or navigation key opens the compose dialog pre-filled
+            // with that character (the no-destructive-lowercase contract).
             KeyCode::Char(c)
                 if self.strict_hotkeys
                     && key.modifiers == KeyModifiers::NONE
@@ -2538,28 +1881,335 @@ impl HomeView {
             }
             _ => {}
         }
-
         None
     }
 
-    /// Build and show the command palette. Combines the static `builtin_commands`
-    /// with dynamic jump-to-session and jump-to-group entries built from the
-    /// current `flat_items`.
+    /// Execute a resolved [`ActionId`]. The single home for each action's
+    /// behavior: the keyboard dispatcher and the command palette both route
+    /// here, so they can't diverge on what an action does.
+    fn run_action(
+        &mut self,
+        id: ActionId,
+        update_info: Option<&crate::update::UpdateInfo>,
+    ) -> Option<Action> {
+        match id {
+            ActionId::Quit => return Some(Action::Quit),
+            ActionId::Help => {
+                self.show_help = true;
+                self.help_scroll = 0;
+            }
+            ActionId::ToolPicker => {
+                if matches!(self.view_mode, ViewMode::Tool(_)) {
+                    self.view_mode = ViewMode::Agent;
+                } else if !self.tool_configs.is_empty() {
+                    self.open_tool_picker();
+                }
+            }
+            ActionId::SearchStart => {
+                self.search_active = true;
+                self.search_query = Input::default();
+            }
+            ActionId::SearchNext => {
+                self.search_match_index = (self.search_match_index + 1) % self.search_matches.len();
+                self.cursor = self.search_matches[self.search_match_index];
+                self.update_selected();
+            }
+            ActionId::SearchPrev => {
+                self.search_match_index = if self.search_match_index == 0 {
+                    self.search_matches.len() - 1
+                } else {
+                    self.search_match_index - 1
+                };
+                self.cursor = self.search_matches[self.search_match_index];
+                self.update_selected();
+            }
+            ActionId::NewSession => self.open_new_session_dialog(),
+            ActionId::NewFromSelection => self.open_new_from_selection(),
+            ActionId::NewFromProject => self.open_project_session_picker(),
+            ActionId::AttachTerminal => return self.attach_terminal_for_selected(),
+            ActionId::ToggleView => {
+                self.view_mode = match self.view_mode {
+                    ViewMode::Agent => ViewMode::Terminal,
+                    ViewMode::Terminal | ViewMode::Tool(_) => ViewMode::Agent,
+                };
+            }
+            ActionId::SendMessage => self.open_send_message_dialog(),
+            ActionId::Stop => self.stop_selected(),
+            ActionId::Delete => self.open_delete_for_selected(),
+            ActionId::Rename => self.open_rename_for_selected(),
+            ActionId::Diff => self.open_diff_for_selected(),
+            ActionId::Serve => self.open_serve(),
+            ActionId::Settings => self.open_settings(),
+            ActionId::Profiles => self.show_profile_picker(),
+            ActionId::Projects => {
+                let profile = self.config_profile();
+                self.projects_dialog = Some(ProjectsDialog::new(&profile));
+            }
+            ActionId::Restart => self.open_restart_dialog(),
+            ActionId::Update => return self.run_update(update_info),
+            ActionId::ToggleArchive => {
+                if let Err(e) = self.toggle_archive_at_cursor() {
+                    tracing::error!("toggle_archive_at_cursor failed: {}", e);
+                }
+            }
+            ActionId::ToggleFavorite => {
+                if let Err(e) = self.toggle_favorite_at_cursor() {
+                    tracing::error!("toggle_favorite_at_cursor failed: {}", e);
+                }
+            }
+            ActionId::ToggleSnooze => {
+                if let Err(e) = self.toggle_snooze_at_cursor() {
+                    tracing::error!("toggle_snooze_at_cursor failed: {}", e);
+                }
+            }
+            ActionId::ToggleContainer => self.toggle_container_for_selected(),
+            ActionId::TogglePreviewInfo => self.toggle_preview_info(),
+            ActionId::SortPicker => self.show_sort_picker(),
+            ActionId::GroupBy => self.show_group_picker(),
+            ActionId::NextWaiting => self.jump_to_next_waiting(),
+        }
+        None
+    }
+
+    fn open_new_from_selection(&mut self) {
+        if self.creating_stub_id.is_some() {
+            self.info_dialog = Some(InfoDialog::new(
+                "Please Wait",
+                "A session is already being created. Wait for it to finish or press Ctrl+C to cancel.",
+            ));
+            return;
+        }
+        let prefill_path = self
+            .selected_session
+            .as_ref()
+            .and_then(|id| self.get_instance(id))
+            .map(|inst| {
+                inst.worktree_info
+                    .as_ref()
+                    .map(|wt| wt.main_repo_path.clone())
+                    .unwrap_or_else(|| inst.project_path.clone())
+            });
+        let prefill_group = self
+            .selected_session
+            .as_ref()
+            .and_then(|id| self.get_instance(id))
+            .and_then(|inst| {
+                if inst.group_path.is_empty() {
+                    None
+                } else {
+                    Some(inst.group_path.clone())
+                }
+            })
+            .or_else(|| self.selected_group.clone());
+
+        if prefill_path.is_some() || prefill_group.is_some() {
+            let existing_groups: Vec<String> =
+                self.all_groups().iter().map(|g| g.path.clone()).collect();
+            let current_profile = self
+                .profile_for_cursor(self.cursor)
+                .unwrap_or_else(|| self.config_profile());
+            let profiles = list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
+            let mut dialog = NewSessionDialog::new(
+                self.available_tools.clone(),
+                existing_groups,
+                &current_profile,
+                profiles,
+            );
+            if let Some(path) = prefill_path {
+                dialog.set_path(path);
+            }
+            if let Some(group) = prefill_group {
+                dialog.set_group(group);
+            }
+            self.new_dialog = Some(dialog);
+        }
+    }
+
+    fn attach_terminal_for_selected(&mut self) -> Option<Action> {
+        // Quick-attach to paired terminal from any view.
+        if let Some(id) = &self.selected_session {
+            if let Some(inst) = self.get_instance(id) {
+                if matches!(inst.status, Status::Deleting | Status::Creating) {
+                    return None;
+                }
+            }
+            let terminal_mode = if let Some(inst) = self.get_instance(id) {
+                if inst.is_sandboxed() {
+                    self.get_terminal_mode(id)
+                } else {
+                    TerminalMode::Host
+                }
+            } else {
+                TerminalMode::Host
+            };
+            return Some(Action::AttachTerminal(id.clone(), terminal_mode));
+        }
+        None
+    }
+
+    fn stop_selected(&mut self) {
+        if let Some(session_id) = &self.selected_session {
+            if let Some(inst) = self.get_instance(session_id) {
+                if matches!(
+                    inst.status,
+                    Status::Stopped | Status::Deleting | Status::Creating
+                ) {
+                    return;
+                }
+                let message = format!("Are you sure you want to stop '{}'?", inst.title);
+                self.pending_stop_session = Some(session_id.clone());
+                self.confirm_dialog =
+                    Some(ConfirmDialog::new("Stop Session", &message, "stop_session"));
+            }
+        }
+    }
+
+    fn open_diff_for_selected(&mut self) {
+        // Open diff view - requires a selected session.
+        let Some(session_id) = &self.selected_session else {
+            self.info_dialog = Some(InfoDialog::new(
+                "No Session Selected",
+                "Select a session to view its diff.",
+            ));
+            return;
+        };
+
+        let Some(inst) = self.get_instance(session_id) else {
+            self.info_dialog = Some(InfoDialog::new("Error", "Could not find session data."));
+            return;
+        };
+
+        let repo_path = std::path::PathBuf::from(&inst.project_path);
+        let session_id_owned = inst.id.clone();
+        let profile = inst.source_profile.clone();
+        let base_override = inst.base_branch_override.clone();
+        match DiffView::new_for_session(repo_path, Some(session_id_owned), profile, base_override) {
+            Ok(view) => self.diff_view = Some(view),
+            Err(e) => {
+                tracing::error!(target: "tui.input", "Failed to open diff view: {}", e);
+                self.info_dialog = Some(InfoDialog::new(
+                    "Error",
+                    &format!("Failed to open diff view: {}", e),
+                ));
+            }
+        }
+    }
+
+    fn open_serve(&mut self) {
+        #[cfg(feature = "serve")]
+        {
+            self.serve_view = Some(crate::tui::dialogs::ServeView::new());
+        }
+        #[cfg(not(feature = "serve"))]
+        {
+            self.info_dialog = Some(InfoDialog::new(
+                "Serve unavailable",
+                "This `aoe` binary was built without the `serve` feature, \
+                 so the web dashboard, local network serving, and \
+                 Cloudflare Tunnel integration are not included.\n\n\
+                 To serve to your phone (LAN / Tailscale / tunnel):\n\
+                   \u{2022} Install a release build from GitHub Releases, or\n\
+                   \u{2022} Build from source with:\n\
+                     cargo build --release --features serve\n\n\
+                 Once you have a `serve`-enabled binary, press R again to \
+                 open the serve dialog.",
+            ));
+        }
+    }
+
+    fn open_settings(&mut self) {
+        let project_path = self
+            .selected_session
+            .as_ref()
+            .and_then(|id| self.get_instance(id))
+            .map(|inst| inst.project_path.clone());
+        match SettingsView::new(&self.config_profile(), project_path) {
+            Ok(view) => self.settings_view = Some(view),
+            Err(e) => {
+                tracing::error!(target: "tui.input", "Failed to open settings: {}", e);
+                self.info_dialog = Some(InfoDialog::new(
+                    "Error",
+                    &format!("Failed to open settings: {}", e),
+                ));
+            }
+        }
+    }
+
+    fn run_update(&mut self, update_info: Option<&crate::update::UpdateInfo>) -> Option<Action> {
+        if let Some(info) = update_info {
+            if info.available && self.update_confirm_dialog.is_none() {
+                let method = match crate::update::install::detect_install_method() {
+                    Ok(m) => m,
+                    Err(e) => {
+                        tracing::warn!(target: "tui.input", "update detection failed: {e}");
+                        return None;
+                    }
+                };
+                use crate::update::install::InstallMethod;
+                if !matches!(
+                    &method,
+                    InstallMethod::Homebrew | InstallMethod::Tarball { .. }
+                ) {
+                    let msg = match &method {
+                        InstallMethod::Nix => {
+                            "Nix install: run `nix run github:agent-of-empires/agent-of-empires` to update".to_string()
+                        }
+                        InstallMethod::Cargo => {
+                            "Cargo install: run `cargo install --git https://github.com/agent-of-empires/agent-of-empires aoe`".to_string()
+                        }
+                        InstallMethod::Unknown { .. } => {
+                            "Unknown install method: run `aoe update` in a terminal for instructions".to_string()
+                        }
+                        _ => unreachable!(),
+                    };
+                    return Some(Action::SetTransientStatus(msg));
+                }
+                let needs_sudo = matches!(
+                    &method,
+                    InstallMethod::Tarball { binary_path }
+                        if !crate::update::install::parent_is_writable(binary_path)
+                );
+                self.update_confirm_dialog = Some(crate::tui::dialogs::UpdateConfirmDialog::new(
+                    info.current_version.clone(),
+                    info.latest_version.clone(),
+                    method,
+                    needs_sudo,
+                ));
+            }
+        }
+        None
+    }
+
+    fn toggle_container_for_selected(&mut self) {
+        if let Some(id) = &self.selected_session {
+            if let Some(inst) = self.get_instance(id) {
+                if inst.is_sandboxed() {
+                    let id = id.clone();
+                    self.toggle_terminal_mode(&id);
+                } else {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Not Available",
+                        "Only sandboxed sessions support container terminals. This session runs directly on the host.",
+                    ));
+                }
+            }
+        }
+    }
+
     fn open_command_palette(&mut self) {
         let serve_enabled = cfg!(feature = "serve");
         let mut entries: Vec<PaletteCommand> = builtin_commands(serve_enabled, self.strict_hotkeys);
 
-        // Quit command (separate so the lifetime mapping is clear and we
-        // can keep it out of `builtin_commands` to avoid pulling KeyCode
-        // imports into the palette module).
-        let quit_hotkey = if self.strict_hotkeys { "Q" } else { "q" };
+        // Quit lives in the registry but is excluded from `builtin_commands`
+        // (no palette metadata) so it can sit in the Settings group at the end;
+        // add it here, still routed through the shared action dispatch.
         entries.push(PaletteCommand {
-            id: "quit",
+            id: bindings::palette_id(ActionId::Quit),
             title: "Quit Agent of Empires".to_string(),
             group: PaletteGroup::Settings,
             keywords: vec!["exit", "close"],
-            hotkey: quit_hotkey,
-            payload: PaletteAction::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE)),
+            hotkey: bindings::label(ActionId::Quit, self.strict_hotkeys),
+            payload: PaletteAction::Invoke(ActionId::Quit),
         });
 
         // Dynamic session/group entries: one per flat_items row, so the user
@@ -2591,7 +2241,7 @@ impl HomeView {
                         title,
                         group: PaletteGroup::Sessions,
                         keywords: vec!["session", "jump", "select"],
-                        hotkey: "",
+                        hotkey: String::new(),
                         payload: PaletteAction::JumpToCursor(idx),
                     });
                 }
@@ -2615,7 +2265,7 @@ impl HomeView {
                         title: label,
                         group: PaletteGroup::Groups,
                         keywords: vec!["group", "jump"],
-                        hotkey: "",
+                        hotkey: String::new(),
                         payload: PaletteAction::JumpToCursor(idx),
                     });
                 }
@@ -2637,7 +2287,7 @@ impl HomeView {
                 title: format!("Open tool: {}{}", name, hotkey_label),
                 group: PaletteGroup::Actions,
                 keywords: vec!["tool", "session"],
-                hotkey: "",
+                hotkey: String::new(),
                 payload: PaletteAction::ToolSession(name.clone()),
             });
         }
@@ -2654,19 +2304,19 @@ impl HomeView {
         update_info: Option<&crate::update::UpdateInfo>,
     ) -> Option<Action> {
         match action {
-            PaletteAction::Key(synth) => {
-                // Clear leftover search-cycle state before dispatching. Some
-                // action keys (`n`, `N`) are dual-purpose: they cycle search
-                // matches when matches are active, otherwise open new-session
-                // dialogs. The palette's mental model is "run the named
-                // action," so we drop search state here to make sure a pick
-                // of "New session" never silently turns into a search-cycle.
+            PaletteAction::Invoke(id) => {
+                // The palette's mental model is "run the named action," so clear
+                // any leftover search-cycle state first: otherwise picking "New
+                // session" while a search is active would route the dual-purpose
+                // `n`/`N` actions into a search-cycle instead.
                 if !self.search_matches.is_empty() {
                     self.search_matches.clear();
                     self.search_match_index = 0;
                 }
-                self.dispatch_action_key(synth, update_info)
+                self.run_action(id, update_info)
             }
+            PaletteAction::Activate => self.activate_selected_session(),
+            PaletteAction::LiveSend => self.start_live_send(),
             PaletteAction::JumpToCursor(idx) => {
                 if !self.flat_items.is_empty() {
                     self.cursor = idx.min(self.flat_items.len() - 1);
@@ -2678,19 +2328,6 @@ impl HomeView {
                 self.view_mode = ViewMode::Tool(tool_name);
                 self.preview_scroll_offset = 0;
                 self.tool_preview_cache = super::PreviewCache::default();
-                None
-            }
-            PaletteAction::EnterLiveSend => self.start_live_send(),
-            PaletteAction::OpenSortPicker => {
-                self.show_sort_picker();
-                None
-            }
-            PaletteAction::OpenGroupPicker => {
-                self.show_group_picker();
-                None
-            }
-            PaletteAction::OpenProjectSessionPicker => {
-                self.open_project_session_picker();
                 None
             }
         }
@@ -4289,65 +3926,6 @@ impl HomeView {
                 }
                 None
             }
-        }
-    }
-
-    /// In strict_hotkeys mode, normalize key events so the main match block
-    /// doesn't need per-key duplication. Returns `None` to swallow bare
-    /// lowercase action letters that would otherwise fire destructive actions.
-    fn normalize_strict_key(&self, key: KeyEvent) -> Option<KeyEvent> {
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let bare = key.modifiers == KeyModifiers::NONE;
-        let shift_only = key.modifiers == KeyModifiers::SHIFT;
-        let has_search = !self.search_matches.is_empty();
-
-        // n/N are dual-purpose: search next/prev AND new session/new-from-selection.
-        // When search matches exist, let them through unchanged for vi-style navigation.
-        if has_search {
-            match key.code {
-                KeyCode::Char('n') if bare => return Some(key),
-                KeyCode::Char('N') if bare || shift_only => return Some(key),
-                _ => {}
-            }
-        }
-
-        match key.code {
-            // Ctrl+letter relocations whose secondary action shares an
-            // UPPERCASE arm with nothing else: fold to the uppercase letter.
-            // Ctrl+D -> D (diff view), Ctrl+R -> R (serve), Ctrl+P -> P (profiles).
-            KeyCode::Char(c @ ('d' | 'r' | 'p')) if ctrl => Some(KeyEvent::new(
-                KeyCode::Char(c.to_ascii_uppercase()),
-                KeyModifiers::NONE,
-            )),
-            // Ctrl+T and Ctrl+N must KEEP their CTRL modifier. Their bare
-            // uppercase forms (Shift+T, Shift+N) already drive distinct
-            // primary actions (toggle view, plain new session), so folding
-            // Ctrl+T/Ctrl+N to T/N collides with those and orphans the
-            // secondary arms (quick-attach terminal, new-from-selection) as
-            // dead code. Passing through with CTRL intact lets the
-            // `Char('t'|'n') if strict && CONTROL` arms fire.
-            KeyCode::Char('t' | 'n') if ctrl => Some(key),
-            // Ctrl+G and Ctrl+O stay as-is. The dispatch table already has
-            // strict-mode arms that match `Char('g')`/`Char('o')` *with*
-            // the CTRL modifier; stripping CTRL here would make the
-            // post-normalize key indistinguishable from bare lowercase
-            // input and route Ctrl+G into the typing-guard catch-all.
-            KeyCode::Char('g') if ctrl => Some(key),
-            KeyCode::Char('o') if ctrl => Some(key),
-            // Shifted action letters pass through unchanged. Each letter has its
-            // own `Char('UPPER') if self.strict_hotkeys` arm in the main match.
-            // Lowercasing here would route the chord into a dead arm guarded
-            // `if !self.strict_hotkeys`, so the action would silently no-op.
-            // Affects D (delete), R (rename), N, X, S, M, T, C, Q, O.
-            //
-            // Side benefit: passing through unchanged also makes the chords work
-            // on iOS Mosh, where Shift+letter is delivered as the bare uppercase
-            // keycode without a Shift modifier.
-            // Bare lowercase letters pass through; the main match falls through
-            // to a catch-all that opens the compose dialog pre-filled with the
-            // letter (strict-mode typing-guard). Navigation keys j/k/h/l are
-            // handled by their own arms before the catch-all fires.
-            _ => Some(key),
         }
     }
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1742,10 +1742,12 @@ impl HomeView {
         // Mapping (strict mode only):
         //   Shift+letter actions -> pass through unchanged: each has its own
         //     `Char('UPPER') if self.strict_hotkeys` arm in the main match.
-        //   Ctrl+letter relocated bindings -> uppercase: Ctrl+T->T, Ctrl+D->D, Ctrl+R->R, Ctrl+P->P, Ctrl+N->N
-        //   Ctrl+G, Ctrl+O -> pass through with CTRL intact (the dispatch
-        //     table matches them with their modifier; stripping CTRL would
-        //     collide with the bare-lowercase typing-guard).
+        //   Ctrl+letter relocated bindings -> uppercase: Ctrl+D->D, Ctrl+R->R, Ctrl+P->P
+        //   Ctrl+T, Ctrl+N, Ctrl+G, Ctrl+O -> pass through with CTRL intact.
+        //     Ctrl+T/Ctrl+N have distinct secondary arms that would be
+        //     orphaned if folded onto Shift+T/Shift+N; Ctrl+G/Ctrl+O match
+        //     with their modifier and stripping CTRL would collide with the
+        //     bare-lowercase typing-guard.
         //   Bare lowercase action letters -> blocked (return None)
         let key = if self.strict_hotkeys {
             self.normalize_strict_key(key)
@@ -4310,13 +4312,21 @@ impl HomeView {
         }
 
         match key.code {
-            // Ctrl+letter relocations: map to the uppercase letter they replace
-            // Ctrl+T -> T (attach terminal), Ctrl+D -> D (diff view),
-            // Ctrl+R -> R (serve), Ctrl+P -> P (profiles), Ctrl+N -> N (new from selection)
-            KeyCode::Char(c @ ('t' | 'd' | 'r' | 'p' | 'n')) if ctrl => Some(KeyEvent::new(
+            // Ctrl+letter relocations whose secondary action shares an
+            // UPPERCASE arm with nothing else: fold to the uppercase letter.
+            // Ctrl+D -> D (diff view), Ctrl+R -> R (serve), Ctrl+P -> P (profiles).
+            KeyCode::Char(c @ ('d' | 'r' | 'p')) if ctrl => Some(KeyEvent::new(
                 KeyCode::Char(c.to_ascii_uppercase()),
                 KeyModifiers::NONE,
             )),
+            // Ctrl+T and Ctrl+N must KEEP their CTRL modifier. Their bare
+            // uppercase forms (Shift+T, Shift+N) already drive distinct
+            // primary actions (toggle view, plain new session), so folding
+            // Ctrl+T/Ctrl+N to T/N collides with those and orphans the
+            // secondary arms (quick-attach terminal, new-from-selection) as
+            // dead code. Passing through with CTRL intact lets the
+            // `Char('t'|'n') if strict && CONTROL` arms fire.
+            KeyCode::Char('t' | 'n') if ctrl => Some(key),
             // Ctrl+G and Ctrl+O stay as-is. The dispatch table already has
             // strict-mode arms that match `Char('g')`/`Char('o')` *with*
             // the CTRL modifier; stripping CTRL here would make the

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1,5 +1,6 @@
 //! Home view - main session list and navigation
 
+pub(crate) mod bindings;
 mod input;
 mod live_send;
 mod operations;

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1923,10 +1923,9 @@ fn test_o_key_opens_sort_picker() {
 #[test]
 #[serial]
 fn test_shift_o_opens_sort_picker_in_strict_mode() {
-    // Regression guard: normalize_strict_key maps Shift+O → bare 'o'. The main
-    // match must handle 'o' without an `if !self.strict_hotkeys` guard,
-    // otherwise the key falls through to capture_letter_to_compose and opens
-    // the message dialog instead of the sort picker.
+    // Regression guard: the SortPicker binding lists Shift+O (Char('O')) for
+    // strict mode, so it must resolve to the sort picker rather than falling
+    // through to the typing-guard (capture_letter_to_compose).
     use crate::session::config::SortOrder;
 
     let mut env = create_test_env_with_mixed_sessions();
@@ -2167,12 +2166,9 @@ fn test_non_strict_w_jumps_to_next_waiting_in_attention_sort() {
 #[test]
 #[serial]
 fn test_strict_mode_ctrl_g_opens_group_picker() {
-    // Regression guard: the help overlay lists "Ctrl+G" for Group by in
-    // strict mode. Previously normalize_strict_key stripped CTRL and routed
-    // the result into the typing-guard catch-all, so the advertised hotkey
-    // was a no-op (the bare 'g' landed in pending_paste). Ctrl+G must now
-    // keep its modifier and open the group picker, while bare 'g' continues
-    // to fall into the typing-guard catch-all.
+    // Regression guard: the GroupBy binding is Ctrl+G in strict mode. It must
+    // open the group picker, while bare 'g' continues to fall into the
+    // typing-guard catch-all (it lands in pending_paste).
     use crate::session::config::GroupByMode;
 
     let mut env = create_test_env_with_sessions(3);
@@ -2278,6 +2274,141 @@ fn test_strict_mode_ctrl_t_and_ctrl_n_reach_secondary_actions() {
     assert!(
         env.view.new_dialog.is_some(),
         "Ctrl+N in strict mode must open the new-from-selection dialog"
+    );
+}
+
+#[test]
+#[serial]
+fn test_strict_mode_ctrl_d_r_p_reach_secondary_actions() {
+    // Regression guard (2026-05-29): normalize_strict_key used to fold
+    // Ctrl+D/Ctrl+R/Ctrl+P to bare 'D'/'R'/'P', which collided with the
+    // Shift+letter primary arms. In strict mode Shift+D=delete, Shift+R=rename,
+    // Shift+P=profiles, so the folds made Ctrl+D fire delete (not diff), Ctrl+R
+    // fire rename (not serve), and orphaned the diff/serve/projects arms. All
+    // three Ctrl chords must keep CTRL so their secondary arms fire.
+    let mut env = create_test_env_with_sessions(1);
+    env.view.strict_hotkeys = true;
+    env.view.cursor = 0;
+    env.view.update_selected();
+
+    // Shift+D opens the delete confirmation (primary uppercase action).
+    assert!(env.view.unified_delete_dialog.is_none());
+    env.view
+        .handle_key(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT), None);
+    assert!(
+        env.view.unified_delete_dialog.is_some(),
+        "Shift+D must open the delete dialog"
+    );
+    env.view.unified_delete_dialog = None;
+
+    // Ctrl+D routes to the diff arm, NOT delete. The test session's path is not
+    // a real git worktree so the diff view may fail to open (info dialog) or
+    // open empty; either way the regression is that Ctrl+D must never reach
+    // open_delete_for_selected. Clear any takeover the diff arm leaves behind so
+    // it doesn't swallow the next keypress.
+    env.view.handle_key(
+        KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL),
+        None,
+    );
+    assert!(
+        env.view.unified_delete_dialog.is_none(),
+        "Ctrl+D in strict mode must NOT open the delete dialog (it targets diff)"
+    );
+    env.view.diff_view = None;
+    env.view.info_dialog = None;
+
+    // Shift+R opens the rename dialog (primary uppercase action).
+    assert!(env.view.rename_dialog.is_none());
+    env.view
+        .handle_key(KeyEvent::new(KeyCode::Char('R'), KeyModifiers::SHIFT), None);
+    assert!(
+        env.view.rename_dialog.is_some(),
+        "Shift+R must open the rename dialog"
+    );
+    env.view.rename_dialog = None;
+
+    // Ctrl+R routes to the serve arm, NOT rename.
+    env.view.handle_key(
+        KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
+        None,
+    );
+    assert!(
+        env.view.rename_dialog.is_none(),
+        "Ctrl+R in strict mode must NOT open the rename dialog (it targets serve)"
+    );
+    env.view.info_dialog = None;
+    #[cfg(feature = "serve")]
+    {
+        env.view.serve_view = None;
+    }
+
+    // P follows the same relocation rule as D/R/T/N: the bare-`p` (primary)
+    // action -> Shift+P, the Shift+P (secondary) action -> Ctrl+P. So in strict
+    // mode Shift+P opens projects and Ctrl+P opens profiles.
+    assert!(env.view.projects_dialog.is_none());
+    env.view
+        .handle_key(KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT), None);
+    assert!(
+        env.view.projects_dialog.is_some(),
+        "Shift+P in strict mode must open the projects dialog"
+    );
+    assert!(
+        env.view.profile_picker_dialog.is_none(),
+        "Shift+P must not open the profile picker"
+    );
+    env.view.projects_dialog = None;
+
+    // Ctrl+P opens the profile picker, NOT projects.
+    assert!(env.view.profile_picker_dialog.is_none());
+    env.view.handle_key(
+        KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+        None,
+    );
+    assert!(
+        env.view.profile_picker_dialog.is_some(),
+        "Ctrl+P in strict mode must open the profile picker"
+    );
+    assert!(
+        env.view.projects_dialog.is_none(),
+        "Ctrl+P must not open the projects dialog"
+    );
+}
+
+#[test]
+#[serial]
+fn test_command_palette_diff_invokes_diff_in_strict_mode() {
+    // Regression guard for the palette half of the strict-mode bug: the palette
+    // used to synthesize a keypress, so picking "Open diff view" in strict mode
+    // routed through Shift+D and fired DELETE instead. Palette entries now carry
+    // an ActionId and run the action directly, so the mode can't matter.
+    let mut env = create_test_env_with_sessions(1);
+    env.view.strict_hotkeys = true;
+    env.view.cursor = 0;
+    env.view.update_selected();
+
+    // Open the palette and filter to the diff command.
+    env.view.handle_key(
+        KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL),
+        None,
+    );
+    assert!(
+        env.view.command_palette.is_some(),
+        "Ctrl+K opens the palette"
+    );
+    for ch in "diff view".chars() {
+        env.view.handle_key(key(KeyCode::Char(ch)), None);
+    }
+    env.view.handle_key(key(KeyCode::Enter), None);
+
+    // The diff action ran (opened the diff view, or raised an info dialog if the
+    // temp path isn't a real git repo). Crucially, it did NOT delete.
+    assert!(
+        env.view.unified_delete_dialog.is_none(),
+        "palette 'diff' in strict mode must not open the delete dialog"
+    );
+    assert!(
+        env.view.diff_view.is_some() || env.view.info_dialog.is_some(),
+        "palette 'diff' in strict mode must attempt to open the diff view"
     );
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2215,6 +2215,74 @@ fn test_strict_mode_ctrl_g_opens_group_picker() {
 
 #[test]
 #[serial]
+fn test_strict_mode_ctrl_t_and_ctrl_n_reach_secondary_actions() {
+    // Regression guard (2026-05-29): in strict_hotkeys mode, normalize_strict_key
+    // used to fold Ctrl+T -> 'T' and Ctrl+N -> 'N' (modifier stripped), which
+    // collided with the Shift+T / Shift+N primary arms (toggle view, plain new
+    // session) and left the Ctrl+T / Ctrl+N secondary arms (quick-attach
+    // terminal, new-from-selection) as unreachable dead code. Both chords must
+    // keep CTRL so the secondary arms fire.
+    let mut env = create_test_env_with_sessions(1);
+    env.view.strict_hotkeys = true;
+    env.view.cursor = 0;
+    env.view.update_selected();
+
+    // Shift+T toggles the view (primary action), no terminal attach.
+    assert_eq!(env.view.view_mode, ViewMode::Agent);
+    let shift_t = env
+        .view
+        .handle_key(KeyEvent::new(KeyCode::Char('T'), KeyModifiers::SHIFT), None);
+    assert_eq!(env.view.view_mode, ViewMode::Terminal);
+    assert!(
+        !matches!(shift_t, Some(Action::AttachTerminal(_, _))),
+        "Shift+T must toggle view, not attach terminal"
+    );
+    // Reset to Agent view.
+    env.view
+        .handle_key(KeyEvent::new(KeyCode::Char('T'), KeyModifiers::SHIFT), None);
+    assert_eq!(env.view.view_mode, ViewMode::Agent);
+
+    // Ctrl+T quick-attaches the paired terminal (secondary action) and must
+    // NOT toggle the view.
+    let ctrl_t = env.view.handle_key(
+        KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+        None,
+    );
+    assert!(
+        matches!(ctrl_t, Some(Action::AttachTerminal(_, _))),
+        "Ctrl+T in strict mode must quick-attach the paired terminal"
+    );
+    assert_eq!(
+        env.view.view_mode,
+        ViewMode::Agent,
+        "Ctrl+T must not toggle the view"
+    );
+
+    // Shift+N opens the plain new-session dialog (no prefill from selection).
+    assert!(env.view.new_dialog.is_none());
+    env.view
+        .handle_key(KeyEvent::new(KeyCode::Char('N'), KeyModifiers::SHIFT), None);
+    assert!(
+        env.view.new_dialog.is_some(),
+        "Shift+N must open the new-session dialog"
+    );
+    env.view.new_dialog = None;
+
+    // Ctrl+N opens the new-from-selection dialog (secondary action). It also
+    // routes through open_new_session_dialog, so assert it reaches the arm by
+    // confirming the dialog opens with CTRL intact rather than being swallowed.
+    env.view.handle_key(
+        KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL),
+        None,
+    );
+    assert!(
+        env.view.new_dialog.is_some(),
+        "Ctrl+N in strict mode must open the new-from-selection dialog"
+    );
+}
+
+#[test]
+#[serial]
 fn test_f5_and_e_both_open_restart_dialog() {
     // Pin the equivalence: F5 and `e`/`E` all open the restart dialog. The
     // help overlay collapses them onto one row as "Restart session (also


### PR DESCRIPTION
## Description

Relocatable home-view action keybindings (the ones that bind to a different chord in `strict_hotkeys` mode) were defined three times: the ~750-line `match key.code` dispatch with duplicated `if strict` arms, the command palette, and the help overlay. They drifted, and strict-mode chords had several latent bugs.

This PR introduces **one declarative registry** (`src/tui/home/bindings.rs`) as the single source of truth, and the dispatcher, command palette, and help overlay all derive from it.

<img src="https://github.com/user-attachments/assets/64812010-0e30-4d17-849d-fa8769098c01" width="900" alt="architecture" />

The palette now carries an `ActionId` and calls `run_action` directly instead of synthesizing a keypress, so strict-mode palette misfires are structurally impossible. Net `-1341 / +754` in the touched files plus the new registry; adding or moving a binding is now a one-line edit that all three surfaces follow.

### Behavior changes

Six strict-mode fixes (flagged in the keymap below); every non-strict binding is unchanged. The `Ctrl+T` / `Ctrl+N` fixes landed first as a standalone commit (the PR's original scope); the registry generalizes that and makes `Ctrl+D` / `Ctrl+R` / `Shift+P` structural rather than special-cased. Strict diff also now uses `DiffView::new_for_session` (with session context), matching non-strict.

<img src="https://github.com/user-attachments/assets/86c70913-cb94-4794-9434-d00bf8eb4748" width="900" alt="registry" />

## Proving the bug

With `strict_hotkeys = true` and a session selected, pressing **Ctrl+D** (which the footer and `?` overlay both label "Diff"):

| | Ctrl+D in strict mode |
| --- | --- |
| Parent commit (`26a587f`) | ❌ opens the **Delete session?** confirmation |
| This branch | ✅ opens the **diff view** |

The same root cause silently mis-fired `Ctrl+R` (→ rename instead of serve), `Ctrl+T` (→ toggle view instead of attach), and `Ctrl+N` (→ plain new session), and left Projects unreachable in strict mode.

**Before** (parent commit) — `Ctrl+D` deletes:

<img src="https://github.com/user-attachments/assets/38712db7-7831-40dc-9a6c-59a58b5e5473" width="857" alt="before" />

**After** (this branch) — `Ctrl+D` opens the diff:

<img src="https://github.com/user-attachments/assets/e822d055-5ec7-41be-9194-c4c56cc217c8" width="857" alt="after" />

<details><summary>Reproduce manually</summary>

1. `git checkout 26a587f` (the parent commit), build and run `aoe`.
2. Enable strict hotkeys (Settings → "Strict hotkeys", or `strict_hotkeys = true` under `[session]` in `config.toml`).
3. Select a session and press `Ctrl+D`. The footer advertises `^D Diff`, but the **Delete session?** dialog appears.
4. Repeat on this branch: `Ctrl+D` opens the diff view.

</details>

## PR Type

- [x] Refactor
- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test:
  - Registry resolution table test covering both modes, context guards, the search-cycle override, and labels (`src/tui/home/bindings.rs`).
  - Behavior tests through `handle_key` for all six strict-mode changes (`src/tui/home/tests.rs`).
  - Strict-mode palette test driving the real `Ctrl+K` → filter → `Enter` path to prove "diff" no longer deletes (`src/tui/home/tests.rs`).
  - Help-overlay test pinning the six corrected strict labels in both modes (`src/tui/components/help.rs`).
  - Drift guards rewritten to assert against the registry (every action has palette metadata or is explicitly exempt).

Verified locally: `cargo fmt`, `cargo clippy --all-targets` (with and without `serve`) clean; 3020 lib tests pass; e2e 80/81 (the one failure is a pre-existing tmux-timing flake in the right-click context-menu path, unrelated; passes in isolation).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-level summary

This PR centralizes and cleans up home-view keybinding handling by introducing a single declarative registry (src/tui/home/bindings.rs) used as the single source of truth for relocatable action chords, context guards, and optional help/palette metadata. The dispatcher, command palette, and help overlay are derived from that registry instead of each keeping separate definitions. The command palette now invokes actions by ActionId (no synthesized keypresses), avoiding strict-mode palette misfires. Net result: fewer duplicated definitions and simpler, one-line edits to add or move a binding.

What moved/was added/removed
- Added: a full bindings registry and API (ActionId, Chord, Context, HelpMeta, PaletteMeta, BINDINGS, resolve/label/palette_id, Ctx) at src/tui/home/bindings.rs.
- Changed: home input flow (src/tui/home/input.rs) to dispatch via bindings::resolve and run_action(ActionId); removed the old normalize_strict_key + large match.
- Changed: command palette (src/tui/dialogs/command_palette.rs) to produce entries from the registry and to Invoke(ActionId) instead of synthesizing KeyEvents; PaletteCommand.hotkey is now owned String.
- Changed: help overlay (src/tui/components/help.rs) to build its rows from the registry and to return owned (String,String) labels.
- Added/Updated: tests covering registry resolution, six strict-mode behavior fixes, palette behavior, help overlay labels, and drift/guard assertions.
- Minor: src/tui/home/mod.rs now exposes the bindings submodule.

Behavior changes and fixes
- Six strict-mode fixes (notably Ctrl+T, Ctrl+N, Ctrl+D, Ctrl+R, Shift+P and strict diff using session-aware DiffView); strict-mode relocations are now honored consistently across dispatch, palette, and help.
- Non-strict bindings remain unchanged; pure navigation keys remain outside the registry.
- Command palette no longer misfires in strict mode because it invokes actions directly.

Benefits
- Single authoritative source for relocatable bindings reduces duplication and maintenance burden.
- Consistent behavior across input dispatch, command palette, and help overlay.
- Easier to add/move bindings (one-line change reflected everywhere).
- Removes brittle synthesized-key approach for palette actions, preventing strict-mode bugs.
- Improved test coverage for strict-mode and registry resolution.

Technical notes (concise)
- New public API surface in bindings.rs: ActionId, Chord, Context, HelpSection, HelpMeta, PaletteMeta, Binding, Ctx, BINDINGS, resolve, label, palette_id.
- PaletteAction enum simplified to include Invoke(ActionId); several synthesized-key and picker-specific variants removed.
- run_action(ActionId, ...) is now the centralized execution path; dispatcher resolves via bindings::resolve(key, strict, ctx).
- Tests: registry resolution table test, handle_key behavior tests for six fixes, strict-mode palette test, help-overlay test, and updated drift guards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->