### PR TITLE
test(web): de-flake mouse-wheel and theme-passphrase Playwright specs

### DIFF
--- a/web/tests/live/settings-persistence-theme-passphrase.spec.ts
+++ b/web/tests/live/settings-persistence-theme-passphrase.spec.ts
@@ -110,14 +110,20 @@ async function bootDashboardAndNavigate(
   path: string,
 ): Promise<void> {
   await seedAuth(page, handle);
-  await page.goto(handle.baseUrl);
-  // Wait until at least one authenticated API call lands successfully.
-  // /api/about is served unconditionally once auth passes, so once it
-  // resolves the SPA's cookie+binding pair is known good.
-  await page.waitForResponse(
-    (res) => res.url().endsWith("/api/about") && res.status() === 200,
-    { timeout: 10_000 },
-  );
+  // Register the response listener BEFORE navigating: the SPA fires
+  // /api/about during bootstrap, which can resolve before `page.goto`
+  // settles. Attaching the wait afterwards races that and would miss the
+  // response, then time out. `Promise.all` attaches the listener first,
+  // then triggers the navigation. /api/about is served unconditionally
+  // once auth passes, so once it resolves the SPA's cookie+binding pair is
+  // known good.
+  await Promise.all([
+    page.waitForResponse(
+      (res) => res.url().endsWith("/api/about") && res.status() === 200,
+      { timeout: 10_000 },
+    ),
+    page.goto(handle.baseUrl),
+  ]);
   if (path !== "/") {
     await page.evaluate((target) => {
       window.history.pushState({}, "", target);
@@ -193,11 +199,16 @@ test("theme picker persists across reload + restart without passphrase prompt", 
     )
     .toBe("#282a36");
 
-  await page.reload();
-  await page.waitForResponse(
-    (res) => res.url().endsWith("/api/about") && res.status() === 200,
-    { timeout: 10_000 },
-  );
+  // Same register-before-navigate guard as the initial boot: the post-reload
+  // /api/about can resolve before `page.reload()` settles, so attach the
+  // listener first via `Promise.all`.
+  await Promise.all([
+    page.waitForResponse(
+      (res) => res.url().endsWith("/api/about") && res.status() === 200,
+      { timeout: 10_000 },
+    ),
+    page.reload(),
+  ]);
   const afterReload = await fetch(profileUrl, { headers: authHeaders(servePreauthed) }).then(
     (r) => r.json(),
   );

--- a/web/tests/wheel-scroll.spec.ts
+++ b/web/tests/wheel-scroll.spec.ts
@@ -42,7 +42,7 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     // resize/activate on connect). Until readyState is OPEN, sendWheel
     // silently drops messages.
     await expect
-      .poll(() => handle.wsMessages.length, { timeout: 5_000 })
+      .poll(() => handle.wsMessages.length, { timeout: 10_000 })
       .toBeGreaterThan(0);
   }
 
@@ -69,6 +69,33 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     );
   }
 
+  // Re-fire the wheel burst on every poll tick until the expected side
+  // effect lands. A single synthetic burst can arrive in a transient
+  // not-ready window (renderer init / socket-open timing under heavy CI
+  // parallelism), where the custom wheel handler never forwards it and the
+  // SGR bytes are silently dropped. Polling only the observation can't
+  // recover from a dropped burst, so it would wait out the full timeout and
+  // fail with "Received: 0". Re-firing recovers as soon as the handler is
+  // live. Only sound for monotonic effects: the wheel direction is fixed, so
+  // extra bursts can only push the observed value further past the threshold,
+  // never back across it.
+  async function fireUntil(
+    page: Page,
+    opts: { deltaY: number; ctrlKey?: boolean; times?: number },
+    predicate: () => boolean | Promise<boolean>,
+    timeout = 10_000,
+  ) {
+    await expect
+      .poll(
+        async () => {
+          await fireWheel(page, opts);
+          return await predicate();
+        },
+        { timeout },
+      )
+      .toBe(true);
+  }
+
   test("scroll down sends SGR wheel-down escape sequences", async ({
     page,
   }) => {
@@ -83,15 +110,11 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     // deltaY > 0 = scroll down. Fire enough events to exceed pxPerWheel
     // threshold (fontSize 14 * LINES_PER_WHEEL 2 = 28px per wheel tick).
     // deltaY=120 is a typical single mouse wheel notch on most browsers.
-    await fireWheel(page, { deltaY: 120, times: 3 });
-
-    // WebSocket message delivery from page to Playwright handler is async;
-    // poll so the assertion doesn't race the message capture. 5s gives
-    // enough headroom for CI runners under load (2s was tight enough
-    // to flake on heavy parallel runs).
-    await expect
-      .poll(() => countSeq(handle, WHEEL_DOWN_SEQ), { timeout: 10_000 })
-      .toBeGreaterThan(0);
+    await fireUntil(
+      page,
+      { deltaY: 120, times: 3 },
+      () => countSeq(handle, WHEEL_DOWN_SEQ) > 0,
+    );
     expect(countSeq(handle, WHEEL_UP_SEQ)).toBe(0);
   });
 
@@ -105,11 +128,11 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     handle.wsMessages.length = 0;
 
     // deltaY < 0 = scroll up
-    await fireWheel(page, { deltaY: -120, times: 3 });
-
-    await expect
-      .poll(() => countSeq(handle, WHEEL_UP_SEQ), { timeout: 10_000 })
-      .toBeGreaterThan(0);
+    await fireUntil(
+      page,
+      { deltaY: -120, times: 3 },
+      () => countSeq(handle, WHEEL_UP_SEQ) > 0,
+    );
     expect(countSeq(handle, WHEEL_DOWN_SEQ)).toBe(0);
   });
 
@@ -152,19 +175,20 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     await openSession(page, handle);
     handle.wsMessages.length = 0;
 
-    // Ctrl+wheel should zoom, not scroll
-    await fireWheel(page, { deltaY: -60, ctrlKey: true, times: 2 });
-
-    await expect
-      .poll(
-        () =>
-          page.evaluate(() => {
-            const raw = localStorage.getItem("aoe-web-settings");
-            return raw ? JSON.parse(raw).desktopFontSize : null;
-          }),
-        { timeout: 2_000 },
-      )
-      .toBeGreaterThan(14);
+    // Ctrl+wheel should zoom, not scroll. Re-fire until the zoom lands:
+    // extra ctrl+wheel bursts only zoom further in, never back, and never
+    // emit scroll sequences, so the scroll-count assertion below still holds.
+    await fireUntil(
+      page,
+      { deltaY: -60, ctrlKey: true, times: 2 },
+      async () => {
+        const size = await page.evaluate(() => {
+          const raw = localStorage.getItem("aoe-web-settings");
+          return raw ? JSON.parse(raw).desktopFontSize : null;
+        });
+        return typeof size === "number" && size > 14;
+      },
+    );
 
     // No SGR scroll sequences should have been sent
     const scrollCount =
@@ -192,19 +216,27 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
       page.getByRole("button", { name: "Back to live" }),
     ).toHaveCount(0);
 
-    await fireWheel(page, { deltaY: -120, times: 3 });
     const hasText = (needle: string) =>
       handle.wsMessages.some((m) => m.includes(Buffer.from(needle)));
 
-    await expect.poll(() => hasText('"type":"pause_output"')).toBe(true);
+    // Wheel-up enters scrollback (pause_output). Re-firing up only deepens
+    // scrollback, so the pause transition is monotonic and re-fire-safe.
+    await fireUntil(
+      page,
+      { deltaY: -120, times: 3 },
+      () => hasText('"type":"pause_output"'),
+    );
     expect(hasText('"type":"resume_output"')).toBe(false);
 
-    // Scroll back down enough wheel ticks to zero the depth. The client
-    // emitted N wheel-UPs; N wheel-DOWNs should be enough. (deltaY=120
-    // with fontSize 14 gives ~4 wheels per fireWheel call; use times: 5
-    // to overshoot and guarantee the transition.)
-    await fireWheel(page, { deltaY: 120, times: 5 });
-    await expect.poll(() => hasText('"type":"resume_output"')).toBe(true);
+    // Scroll back down to zero the depth; on desktop tmux auto-exits
+    // copy-mode and the client emits resume_output. Re-fire down until that
+    // lands: each burst drives depth toward 0 and stops at 0, so re-firing
+    // can only reach (never overshoot past) the resume transition.
+    await fireUntil(
+      page,
+      { deltaY: 120, times: 5 },
+      () => hasText('"type":"resume_output"'),
+    );
 
     // Still no button on desktop at any point.
     await expect(


### PR DESCRIPTION
> Note: This PR was created with AI assistance (Claude Code).

## Description

Fixes two systemic Playwright flakes surfaced repeatedly across recent CI runs. Test-only; no product code changes.

**1. Mouse-wheel scroll (`web/tests/wheel-scroll.spec.ts`)** intermittently failed with `expect(...).toBeGreaterThan(0)` got `Received: 0`.

Root cause: a single synthetic wheel burst could land in a transient not-ready window (renderer init / socket-open timing under heavy CI parallelism) where the terminal's custom wheel handler never forwarded it, so `sendWheel` bailed and the SGR bytes were silently dropped. The poll only watched the observation and never re-fired, so a dropped burst waited out the full timeout. Confirmed not capture lag: a 10s-timeout run still failed on retry1, far past any page-to-Playwright message delay.

Fix: a `fireUntil` helper re-fires the burst on every poll tick until the expected side effect appears. Applied to all four firing+assert pairs. Each is monotonic (fixed scroll direction, zoom-in only, scrollback depth toward 0), so extra bursts can only push the observed value further past the threshold, never back across it.

**2. Live theme-passphrase persistence (`web/tests/live/settings-persistence-theme-passphrase.spec.ts`)** intermittently timed out on `page.waitForResponse` for `/api/about`.

Root cause: the SPA fires `/api/about` during bootstrap, which can resolve before `page.goto` / `page.reload` settles, so a listener attached afterwards misses the response and waits out the timeout.

Fix: register the response listener before navigating via `Promise.all([waitForResponse, navigate])`, at both navigation sites.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A: test-only)
- [ ] For UI changes: included screenshot or recording (N/A: no UI change)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/`

No `coverage-matrix.json` change: this PR only hardens existing specs and changes no user-facing dashboard flow.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## Testing performed

- `tsc --noEmit`: clean on both files.
- Wheel suite stress: 40/40 (repeat-each=8 @ 6 workers), then 100/100 (repeat-each=20 @ 8 oversubscribed workers), reproducing CI contention. Green; was flaky before.
- Live spec: standard register-before-navigate change; relies on CI (needs cargo `aoe` + tmux locally).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** CI history mined for flaky Playwright failures; root causes diagnosed and fixes implemented with AI assistance. Stress-validated locally.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Summary

This PR fixes two intermittent test failures in the Playwright test suite. No product code is affected—only test files were modified.

**What Changed:**
- **Mouse-wheel scroll tests** (`web/tests/wheel-scroll.spec.ts`): Added logic to retry sending wheel input until the terminal acknowledges it, preventing bursts from being silently dropped during initialization.
- **Theme-passphrase persistence test** (`web/tests/live/settings-persistence-theme-passphrase.spec.ts`): Reordered test setup to listen for API responses before navigating, preventing missed responses that occur during app bootstrap.

**What Was Added:**
- A `fireUntil` helper function that repeatedly dispatches wheel events until the expected behavior is observed.
- Promise-based synchronization patterns that attach response listeners before page navigation.
- Increased timeout for WebSocket readiness checks (5s → 10s).

**What Was Removed:**
- Single-dispatch wheel event patterns that were unreliable during transient initialization windows.
- Sequential navigate-then-wait patterns that could miss responses.

## Benefits

These changes eliminate race conditions that caused intermittent CI failures:
- Tests are now more robust to timing variations in renderer initialization and network requests.
- Wheel-scroll tests can tolerate synthetic bursts landing before the handler is ready.
- Theme-passphrase test reliably captures API responses regardless of bootstrap timing.
- No impact on application functionality—only test reliability improved.

## Technical Details

**Mouse-wheel scroll fix (root cause):**
A synthetic wheel burst could land during a transient window where the terminal's custom wheel handler wasn't yet ready (renderer init / socket-open timing), causing SGR bytes to be dropped. The `fireUntil` helper addresses this by re-dispatching the event on each poll tick until the expected side effect (SGR escape sequences) is observed.

**Theme-passphrase persistence fix (root cause):**
The SPA fires `/api/about` during bootstrap, which can resolve before a response listener is attached after navigation, causing the wait to hang indefinitely. The fix uses `Promise.all` to attach the response listener before calling `page.goto()` or `page.reload()`, ensuring no responses are missed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->