### PR TITLE
chore: merge cockpit-main batch into main

### DIFF
--- a/cockpit-worker/test-shim/package-lock.json
+++ b/cockpit-worker/test-shim/package-lock.json
@@ -8,22 +8,22 @@
       "name": "aoe-cockpit-test-shim",
       "version": "0.0.1",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.21.0"
+        "@agentclientprotocol/sdk": "^0.22.0"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.21.0.tgz",
-      "integrity": "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.22.1.tgz",
+      "integrity": "sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/cockpit-worker/test-shim/package.json
+++ b/cockpit-worker/test-shim/package.json
@@ -5,6 +5,6 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.21.0"
+    "@agentclientprotocol/sdk": "^0.22.0"
   }
 }

--- a/cockpit-worker/test-shim/shim.mjs
+++ b/cockpit-worker/test-shim/shim.mjs
@@ -34,18 +34,57 @@ class ShimAgent {
     // assert the watchdog without waiting for CANCEL_ESCALATION_GRACE
     // to elapse.
     this._silentOrphanResolve = null;
+    this._installDeleteHandlerIfRequested();
   }
 
   async initialize(params) {
+    const agentCapabilities = {
+      loadSession: false,
+    };
+    // SHIM_DELETE_CAPABILITY=1 advertises sessionCapabilities.delete
+    // so the Rust client's session/delete dispatch path can be
+    // exercised end-to-end. Tests for #1404 toggle this; default off
+    // mirrors the negative-path adapters (aoe-agent, codex, opencode).
+    if (process.env.SHIM_DELETE_CAPABILITY === "1") {
+      agentCapabilities.sessionCapabilities = { delete: {} };
+    }
     return {
       protocolVersion: params.protocolVersion ?? acp.PROTOCOL_VERSION,
-      agentCapabilities: {
-        loadSession: false,
-      },
+      agentCapabilities,
       agentInfo: {
         name: "@agentclientprotocol/claude-agent-acp",
         version: "0.39.0",
       },
+    };
+  }
+
+  // Experimental session/delete handler installed only when
+  // SHIM_DELETE_CAPABILITY=1. Without the install, the SDK's request
+  // dispatcher returns -32601 method_not_found, which is the
+  // negative-path expectation aoe needs to test against (matches
+  // aoe-agent, codex, opencode behavior).
+  _installDeleteHandlerIfRequested() {
+    if (process.env.SHIM_DELETE_CAPABILITY !== "1") return;
+    // SHIM_DELETE_MODE controls the response shape so tests can drive
+    // the success / timeout / failure branches without spinning up
+    // distinct shim binaries. SHIM_DELETE_RECORD_FILE, when set,
+    // appends one line per call with the requested sessionId so tests
+    // assert the RPC actually fired.
+    this.unstable_deleteSession = async (params) => {
+      const mode = process.env.SHIM_DELETE_MODE ?? "success";
+      const recordFile = process.env.SHIM_DELETE_RECORD_FILE;
+      if (recordFile) {
+        const fs = await import("node:fs/promises");
+        await fs.appendFile(recordFile, `${params.sessionId}\n`);
+      }
+      if (mode === "slow") {
+        await new Promise((r) => setTimeout(r, 3000));
+        return {};
+      }
+      if (mode === "error") {
+        throw acp.RequestError.internalError({}, "shim deliberate failure");
+      }
+      return {};
     };
   }
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -295,6 +295,16 @@ An iPad with a Bluetooth keyboard (or any device that reports both
 the desktop Enter-to-send convention so hardware-keyboard typing
 feels natural. See #1129.
 
+### iOS Safari dictation
+
+Tapping the on-screen keyboard's mic icon to dictate into the composer
+commits each partial recognition exactly once. The composer detects
+WebKit's `insertReplacementText` burst, suspends its assistant-ui
+controlled-input flush for the duration so WebKit's dictation range
+pointer is not invalidated mid-utterance, then drains the final text
+into the composer state on blur (typically when you tap Send) or
+after a brief idle period. See #1431.
+
 ### Queued prompts (mid-turn + inactive session)
 
 The web composer keeps your messages around even when the session

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -239,6 +239,13 @@ state are always in sync.
 - **TUI status indicators**: a cockpit session that's healthy shows
   as Idle/Active in the TUI session list, since cockpit health is
   observed via the ACP event stream rather than tmux pane probing.
+- **`--auth=passphrase` daemons**: the local TUI attaches to a
+  same-host daemon without going through the passphrase exchange.
+  Loopback callers are treated as fs-trusted because the daemon's
+  serve files under `~/.agent-of-empires/serve.*` are already 0600,
+  so the filesystem permission boundary protects same-host access.
+  Remote callers proxied through a tunnel still hit the passphrase
+  wall as expected. See #1525.
 
 ### TUI cockpit view keybinds
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -455,6 +455,28 @@ Practical implications:
   `main`-branch case where there is no runner at all and every cockpit
   session takes the fresh-spawn branch on restart.
 
+## Session deletion
+
+When you delete a cockpit session, aoe opportunistically fires the
+experimental `session/delete` ACP request against the live worker
+(bounded by a 2-second timeout) whenever a stored ACP session id
+exists, and then proceeds with the existing kill path
+(`session/cancel` for in-flight prompts, then SIGTERM on the runner,
+then on-disk cleanup). aoe does not inspect the initialize-time
+capability flag: adapters that implement the method use the request
+to release adapter-side persisted state, for example
+`claude-agent-acp 0.37.0+` clearing the on-disk Claude session
+record so a recreated session id does not inherit prior transcripts.
+Adapters that do not implement the method (`aoe-agent`, `codex`,
+`opencode`, older `claude-agent-acp`) reply with JSON-RPC
+`-32601 method_not_found`; aoe logs that at `debug` and proceeds to
+SIGTERM. A wedged adapter is bounded by the 2-second timeout, so
+delete never stalls the UI. Outcomes are logged under
+`target = "cockpit.acp"` in `debug.log` with an `adapter=<agent_key>`
+field so operators can correlate behavior across adapters: success
+and `-32601` land at `debug`, timeout and other errors at `warn`. See
+[#1404](https://github.com/agent-of-empires/agent-of-empires/issues/1404).
+
 ## Conversation persistence
 
 Cockpit transcripts survive page reloads, session switches, and

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -801,10 +801,55 @@ The rate-limit banner offers a primary "Continue in another agent" CTA. Clicking
 
 After the switch, the modal fetches the context primer and pre-fills the composer with a framed recap of the prior conversation. If the user's last prompt is what triggered the rate-limit (it was published to the event log before the adapter rejected it), the primer endpoint surfaces it separately as `unprocessed_prompt`; the modal drops it into the composer as the user's pending request so they don't have to retype it. The composer is NOT auto-sent; review and submit manually.
 
+### Native binary launch failure
+
+When the cockpit banner shows an error of the form
+
+```text
+Claude Code native binary at /usr/lib/node_modules/.../claude exists but failed to launch.
+```
+
+the adapter found its bundled Claude Code native sub-binary on disk
+but `execve` was rejected by the kernel. Reinstalling
+`claude-agent-acp` does not help; the binary is already there.
+
+The common causes:
+
+1. **Architecture mismatch.** The binary's filename ends in a target
+   triple (`...-linux-arm64/claude`, `...-linux-x64/claude`, etc.).
+   If the host or sandbox container reports a different arch via
+   `uname -m`, the loader refuses the binary. Most often surfaces
+   inside a sandboxed cockpit session where the container image's
+   default arch differs from the host (e.g. an `arm64` host pulling
+   an `amd64` image without `--platform`).
+2. **Missing dynamic loader or old glibc.** Slim base images
+   sometimes ship without `/lib64/ld-linux-x86-64.so.2` or with a
+   glibc too old for the binary. `ldd <binary>` from inside the
+   container reports the gap.
+3. **Bind-mounted `node_modules` across arch.** If the host's npm
+   prefix is bind-mounted into the container (so the container reuses
+   the host install), an `arm64` host binary cannot launch in an
+   `amd64` container and vice versa.
+
+Use **Open agent log** on the red startup banner to see the verbatim
+adapter error from the dashboard, or run `aoe cockpit logs --session
+<id>` from a host terminal. To inspect the binary itself:
+
+```sh
+docker exec <container> file /usr/lib/node_modules/@agentclientprotocol/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk-*/claude
+docker exec <container> uname -m
+```
+
+If the file's arch line does not match `uname -m`, the fix is either
+re-pull the image with `--platform linux/<host-arch>` or install
+`claude-agent-acp` inside the container (rather than bind-mounting
+from the host).
+
 ### Cockpit feels "stuck" with no events
 
-- Check `aoe cockpit logs --follow` (when the worker supervisor lands)
-  to see worker stderr.
+- Check `aoe cockpit logs --session <id>` for the runner stderr drain;
+  the dashboard exposes the same content via the **Open agent log**
+  affordance on the red startup-error banner.
 - Check the dashboard's connection chrome at the top of the cockpit
   view; it shows reconnect status if the WebSocket is degraded.
 - The supervisor watchdog respawns the agent up to 3 times in 60s

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1768,11 +1768,24 @@ fn spawn_runner_detached(
     // container_workdir is reused from the SessionSandbox built upstream
     // so we don't redo `compute_volume_paths`.
     let sandbox_argv = match (&config.sandbox_info, session_sandbox) {
-        (Some(sandbox), Some(handle)) => Some(build_sandbox_docker_argv(
-            config,
-            sandbox,
-            handle.container_workdir.to_string_lossy().as_ref(),
-        )?),
+        (Some(sandbox), Some(handle)) => {
+            let argv = build_sandbox_docker_argv(
+                config,
+                sandbox,
+                handle.container_workdir.to_string_lossy().as_ref(),
+            )?;
+            info!(
+                target: "cockpit.acp.spawn",
+                session = %session_id,
+                container = %sandbox.container_name,
+                container_id = sandbox.container_id.as_deref().unwrap_or("?"),
+                image = %sandbox.image,
+                workdir = %handle.container_workdir.display(),
+                docker = %argv.docker_binary,
+                "docker wrap applied"
+            );
+            Some(argv)
+        }
         (Some(_), None) => {
             return Err(AcpError::Spawn(
                 "sandbox_info set but SessionSandbox handle missing; \
@@ -1780,7 +1793,14 @@ fn spawn_runner_detached(
                     .into(),
             ));
         }
-        (None, _) => None,
+        (None, _) => {
+            info!(
+                target: "cockpit.acp.spawn",
+                session = %session_id,
+                "docker wrap skipped (no sandbox_info)"
+            );
+            None
+        }
     };
 
     // Resolve the agent binary against PATH + known node-manager dirs so

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 
+use agent_client_protocol::schema::ErrorCode;
 use agent_client_protocol::schema::{
     CancelNotification, ClientCapabilities, ContentBlock, CreateTerminalRequest,
     CreateTerminalResponse, FileSystemCapabilities, InitializeRequest, KillTerminalRequest,
@@ -28,7 +29,10 @@ use agent_client_protocol::schema::{
     TerminalOutputRequest, TerminalOutputResponse, TextContent, WaitForTerminalExitRequest,
     WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
 };
-use agent_client_protocol::{Agent, ByteStreams, Client, ConnectionTo, Responder};
+use agent_client_protocol::{
+    Agent, ByteStreams, Client, ConnectionTo, JsonRpcRequest, JsonRpcResponse, Responder,
+};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -184,6 +188,61 @@ pub(crate) fn classify_rate_limit_from_message(message: &str) -> Option<RateLimi
     })
 }
 
+/// Experimental `session/delete` ACP request. Adapters advertising
+/// `sessionCapabilities.delete: {}` (claude-agent-acp >= 0.36) handle
+/// this by releasing adapter-side state for the session (e.g. clearing
+/// the persisted Claude session record on disk). Other adapters reply
+/// with `-32601 method_not_found` and the supervisor falls through to
+/// the existing SIGTERM path. The Rust ACP schema crate (0.12) does
+/// not yet expose `SessionCapabilities.delete`, so the request type is
+/// defined here against the wire format from the TypeScript SDK. See
+/// #1404.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[request(method = "session/delete", response = DeleteSessionResponse)]
+#[serde(rename_all = "camelCase")]
+struct DeleteSessionRequest {
+    session_id: agent_client_protocol::schema::SessionId,
+    /// Emit `_meta: {}` so adapters that validate against the strict
+    /// `unstable_session_delete` schema accept the request. Optional
+    /// in the TS schema, but a defensive default avoids `-32602
+    /// invalid_params` from future adapter validators.
+    #[serde(rename = "_meta")]
+    meta: serde_json::Value,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonRpcResponse)]
+struct DeleteSessionResponse {}
+
+/// Outcome of an experimental `session/delete` call. Every variant is
+/// non-fatal; the supervisor logs and proceeds to SIGTERM regardless.
+#[derive(Debug)]
+pub enum DeleteSessionOutcome {
+    /// Adapter accepted the request and returned a successful response.
+    Deleted,
+    /// Adapter returned JSON-RPC `-32601 method_not_found`. Expected on
+    /// adapters that don't advertise `sessionCapabilities.delete`
+    /// (`aoe-agent`, `codex`, `opencode`, older `claude-agent-acp`).
+    UnsupportedMethod,
+    /// The bounded wait elapsed before the adapter responded.
+    TimedOut,
+    /// Any other failure (non-`-32601` JSON-RPC error, transport drop,
+    /// dispatch channel closed). Carries the reason for the log line.
+    Failed(String),
+}
+
+/// Adapter error messages flow through here verbatim. Cap at this many
+/// bytes before logging so a chatty or malicious adapter cannot bloat
+/// `debug.log`. 256 leaves room for the prefix while preserving the
+/// JSON-RPC error code and a useful slice of the message.
+const ACP_DELETE_ERROR_MSG_MAX: usize = 256;
+
+/// Hard cap on the wait for `session/delete`. Adapters that succeed
+/// (claude-agent-acp clears a local file) complete in tens of ms; the
+/// timeout protects the delete path from a wedged adapter. Not a
+/// `CockpitConfig` field on purpose: this is best-effort experimental
+/// cleanup with no operator-visible failure mode.
+const ACP_SESSION_DELETE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Configuration for spawning an ACP agent.
 #[derive(Debug, Clone)]
 pub struct SpawnConfig {
@@ -236,6 +295,14 @@ enum ClientCmd {
     SetConfigOption {
         config_id: String,
         value: String,
+    },
+    /// Send the experimental `session/delete` RPC for the given ACP
+    /// session id and report the outcome via `respond_to`. Issued by
+    /// the supervisor before the existing shutdown path during cockpit
+    /// session deletion. See #1404.
+    DeleteSession {
+        acp_session_id: String,
+        respond_to: oneshot::Sender<DeleteSessionOutcome>,
     },
     Shutdown,
 }
@@ -1455,6 +1522,57 @@ impl AcpClient {
             .resolver
             .send(ApprovalResolutionMessage::Cancelled)
             .map_err(|_| AcpError::AgentExited)
+    }
+
+    /// Best-effort experimental `session/delete` RPC. Sent before
+    /// `shutdown` during cockpit session deletion so adapters that
+    /// persist session-side state (claude-agent-acp clears the on-disk
+    /// Claude session record) get a chance to clean up before SIGTERM.
+    ///
+    /// All outcomes are non-fatal. Adapters that don't implement the
+    /// method return `-32601 method_not_found` and surface as
+    /// `UnsupportedMethod`; the supervisor proceeds to the existing
+    /// kill path either way. Bounded by `ACP_SESSION_DELETE_TIMEOUT`
+    /// so a wedged adapter cannot stall delete. See #1404.
+    pub async fn delete_session(&self, acp_session_id: String) -> DeleteSessionOutcome {
+        let Some(cmd_tx) = self.cmd_tx.as_ref() else {
+            return DeleteSessionOutcome::Failed("client not running".into());
+        };
+        let (tx, rx) = oneshot::channel();
+        // Outer guard wraps BOTH the cmd_tx send AND the response wait.
+        // The mpsc send is `await`-able and can block if the connect
+        // task is wedged or the channel is saturated; without the
+        // guard a stalled worker would freeze the delete path
+        // indefinitely while the supervisor holds the per-instance
+        // lock at `sessions.rs:1361`. Wait slightly longer than the
+        // in-task `ACP_SESSION_DELETE_TIMEOUT` so the inner
+        // classification (Deleted/UnsupportedMethod/Failed) wins when
+        // the task is healthy.
+        let request = async {
+            if cmd_tx
+                .send(ClientCmd::DeleteSession {
+                    acp_session_id,
+                    respond_to: tx,
+                })
+                .await
+                .is_err()
+            {
+                return DeleteSessionOutcome::Failed("connect task gone".into());
+            }
+            match rx.await {
+                Ok(outcome) => outcome,
+                Err(_) => DeleteSessionOutcome::Failed("respond channel closed".into()),
+            }
+        };
+        match tokio::time::timeout(
+            ACP_SESSION_DELETE_TIMEOUT + std::time::Duration::from_millis(500),
+            request,
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(_) => DeleteSessionOutcome::TimedOut,
+        }
     }
 
     /// Shutdown the connection task and kill the subprocess.
@@ -3012,6 +3130,76 @@ fn extract_diff_from_locations(
     None
 }
 
+/// Dispatch the experimental `session/delete` RPC from the connect
+/// task's cmd_rx arm. The wait is detached via `tokio::spawn` so the
+/// cmd_rx select arm keeps polling other commands during the
+/// round-trip; the outcome is delivered to the caller via the
+/// `respond_to` oneshot. Bounded by `ACP_SESSION_DELETE_TIMEOUT` so a
+/// wedged adapter still resolves the oneshot in time for the caller's
+/// outer guard. See #1404.
+fn handle_delete_session_cmd(
+    connection: &ConnectionTo<Agent>,
+    acp_session_id: String,
+    respond_to: oneshot::Sender<DeleteSessionOutcome>,
+) {
+    let target = agent_client_protocol::schema::SessionId::from(acp_session_id);
+    // `block_task()` is documented as safe to await from a spawned
+    // task: it waits on the per-request oneshot the main connection
+    // task feeds via its inbound pump, so the dispatch loop keeps
+    // running while this future is parked. The spawn here keeps the
+    // cmd_rx select arm responsive to other commands during the
+    // round-trip, mirroring the pattern used by SetMode /
+    // SetConfigOption.
+    let sent = connection.send_request(DeleteSessionRequest {
+        session_id: target,
+        meta: serde_json::Value::Object(serde_json::Map::new()),
+    });
+    tokio::spawn(async move {
+        let outcome =
+            match tokio::time::timeout(ACP_SESSION_DELETE_TIMEOUT, sent.block_task()).await {
+                Ok(Ok(_resp)) => DeleteSessionOutcome::Deleted,
+                Ok(Err(err)) => {
+                    if err.code == ErrorCode::MethodNotFound {
+                        DeleteSessionOutcome::UnsupportedMethod
+                    } else {
+                        // Adapter error messages reach debug.log
+                        // verbatim. Run them through the existing
+                        // stderr secret scrubber so a leaked
+                        // `sk-...` / `Bearer ...` / GitHub PAT in
+                        // the adapter's own error string doesn't
+                        // land in operator logs, then cap length.
+                        let scrubbed = scrub_stderr_secrets(&err.message);
+                        DeleteSessionOutcome::Failed(format!(
+                            "acp error {}: {}",
+                            i32::from(err.code),
+                            truncate_for_log(&scrubbed, ACP_DELETE_ERROR_MSG_MAX)
+                        ))
+                    }
+                }
+                Err(_) => DeleteSessionOutcome::TimedOut,
+            };
+        let _ = respond_to.send(outcome);
+    });
+}
+
+/// Defensive truncation of adapter-provided strings before they land
+/// in `debug.log`. A malformed or malicious adapter could emit a
+/// multi-megabyte message; this caps the allocation while preserving
+/// a useful prefix and respecting UTF-8 boundaries.
+fn truncate_for_log(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = String::with_capacity(end + 3);
+    out.push_str(&s[..end]);
+    out.push_str("...");
+    out
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_connection_task<W, R>(
     transport: ByteStreams<W, R>,
@@ -4018,6 +4206,16 @@ async fn run_connection_task<W, R>(
                                                 }
                                             });
                                         }
+                                        Some(ClientCmd::DeleteSession {
+                                            acp_session_id: target_id,
+                                            respond_to,
+                                        }) => {
+                                            handle_delete_session_cmd(
+                                                &connection,
+                                                target_id,
+                                                respond_to,
+                                            );
+                                        }
                                         Some(ClientCmd::Prompt(rejected_text)) => {
                                             // Surface the dropped prompt
                                             // to the UI so the user can
@@ -4154,6 +4352,12 @@ async fn run_connection_task<W, R>(
                                 }
                             }
                         });
+                    }
+                    Some(ClientCmd::DeleteSession {
+                        acp_session_id: target_id,
+                        respond_to,
+                    }) => {
+                        handle_delete_session_cmd(&connection, target_id, respond_to);
                     }
                     Some(ClientCmd::SetConfigOption { config_id, value }) => {
                         info!(
@@ -4824,6 +5028,32 @@ mod tests {
         tx.send(Event::ThinkingStarted).await.unwrap();
         let event = client.next_event().await.expect("event delivered");
         assert!(matches!(event, Event::ThinkingStarted));
+    }
+
+    // truncate_for_log is the adapter-error sanitizer in the
+    // session/delete path: it caps a third-party-controlled string so
+    // a chatty adapter can't bloat debug.log, and must never panic on
+    // UTF-8 inputs. The cases below lock down the boundary semantics
+    // (no-op under cap, exact cap, multibyte cut) so a future change
+    // to the helper can't quietly regress the no-panic invariant.
+    #[test]
+    fn truncate_for_log_below_cap_returns_input() {
+        assert_eq!(truncate_for_log("hello", 64), "hello");
+    }
+
+    #[test]
+    fn truncate_for_log_at_exact_cap_returns_input() {
+        assert_eq!(truncate_for_log("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_for_log_cuts_on_utf8_boundary_without_panic() {
+        // "é" is two bytes (0xC3 0xA9). With max_bytes=5 the naive
+        // slice would land mid-codepoint; the helper must rewind to
+        // the previous char boundary (byte 4) before appending the
+        // ellipsis. "ééé" is 6 bytes total, so we expect "éé...".
+        let out = truncate_for_log("ééé", 5);
+        assert_eq!(out, "éé...");
     }
 
     // -------------------------------------------------------------------

--- a/src/cockpit/client/http.rs
+++ b/src/cockpit/client/http.rs
@@ -35,7 +35,12 @@ pub enum HttpError {
     SessionNotFound(String),
     #[error("daemon is read-only (started with --read-only); request refused")]
     ReadOnly,
-    #[error("authentication failed; check AOE_DAEMON_TOKEN or restart `aoe serve`")]
+    // The daemon may reject for several reasons: stale token, missing
+    // passphrase session, device binding mismatch. Pointing at
+    // `AOE_DAEMON_TOKEN` was misleading on `--auth=passphrase` and
+    // `--auth=none` daemons that never had a token in the first
+    // place. See #1525.
+    #[error("daemon rejected the request (401); restart `aoe serve` or check `--auth` mode")]
     Unauthorized,
     #[error("daemon returned HTTP {status}: {body}")]
     Server { status: StatusCode, body: String },
@@ -210,5 +215,24 @@ mod tests {
     fn auth_skips_bearer_when_no_token() {
         let client = HttpClient::new(endpoint("http://127.0.0.1:8080", None)).unwrap();
         assert!(client.endpoint().token.is_none());
+    }
+
+    // Regression test for #1525. The startup toast on a 401 from the
+    // cockpit endpoints folds in `HttpError::Unauthorized`'s Display.
+    // Previously that Display string hard-coded `AOE_DAEMON_TOKEN`,
+    // which made the toast actively misleading on `--auth=passphrase`
+    // and `--auth=none` daemons that never had a token. Pin the new
+    // wording so the env-var hint can't regress back in.
+    #[test]
+    fn unauthorized_display_omits_token_env_var() {
+        let rendered = HttpError::Unauthorized.to_string();
+        assert!(
+            !rendered.contains("AOE_DAEMON_TOKEN"),
+            "Unauthorized message must not pin diagnosis to a token env var that does not exist in passphrase or no-auth mode: {rendered}"
+        );
+        assert!(
+            rendered.contains("401"),
+            "Unauthorized message should still surface the underlying HTTP status: {rendered}"
+        );
     }
 }

--- a/src/cockpit/runner.rs
+++ b/src/cockpit/runner.rs
@@ -182,13 +182,22 @@ pub async fn run(args: CockpitRunnerArgs) -> Result<()> {
 
     // Drain agent stderr into the per-session log file. Without this the
     // child blocks once the stderr pipe fills (~64KB on Linux), looking
-    // like a wedged handshake.
+    // like a wedged handshake. The same lines also land on the daemon
+    // debug.log via tracing so they appear in the unified timeline; the
+    // direct file write is what gives `aoe cockpit logs --session <id>`
+    // and `GET /api/sessions/:id/cockpit/worker-log` something to read
+    // (init_runner_logging routes tracing to debug.log, not the
+    // per-session file). See #1449.
     if let Some(stderr) = agent_stderr {
         let label = args.session_id.clone();
+        let per_session_log = worker_registry::log_path_for(&args.session_id).ok();
         tokio::spawn(async move {
             let mut reader = BufReader::new(stderr).lines();
             while let Ok(Some(line)) = reader.next_line().await {
                 debug!(target: "cockpit.runner.agent.stderr", session = %label, "{line}");
+                if let Some(path) = per_session_log.as_ref() {
+                    append_agent_stderr_line(path, &line);
+                }
             }
         });
     }
@@ -670,8 +679,12 @@ fn init_runner_logging(session_id: &str) -> Result<()> {
     // --session <id>` and any external tail works. The actual tracing
     // output goes to the shared `debug.log` so daemon + every runner
     // appear in one timeline; runner spans add `session_id` for filtering.
+    // The agent stderr drainer at run() writes lines here directly so
+    // the per-session file is the cockpit's "what did the adapter say"
+    // surface (used by GET /cockpit/worker-log). See #1449.
     let per_session = worker_registry::log_path_for(session_id)?;
     open_log_file(&per_session)?;
+    write_runner_startup_marker(&per_session, session_id);
 
     // Same precedence as main.rs: env > [logging] in config.toml > info
     // baseline. The notify watcher on runtime_filter still takes over
@@ -699,6 +712,40 @@ fn init_runner_logging(session_id: &str) -> Result<()> {
         tracing::warn!(target: "log.runtime", "{}", w);
     }
     Ok(())
+}
+
+/// Write a one-line marker to the per-session log so the file is never
+/// empty after the runner has started. Best-effort.
+fn write_runner_startup_marker(path: &Path, session_id: &str) {
+    use std::io::Write;
+    let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    else {
+        return;
+    };
+    let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ");
+    let _ = writeln!(
+        f,
+        "[{ts}] runner.startup: cockpit runner up session={session_id}"
+    );
+}
+
+/// Append one line of agent stderr to the per-session log file with a
+/// timestamp prefix. Best-effort: a write failure is ignored so the
+/// runner does not crash when disk fills, lost permissions, etc.
+fn append_agent_stderr_line(path: &Path, line: &str) {
+    use std::io::Write;
+    let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    else {
+        return;
+    };
+    let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ");
+    let _ = writeln!(f, "[{ts}] agent.stderr: {line}");
 }
 
 fn open_log_file(path: &Path) -> Result<()> {

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -29,7 +29,7 @@ use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use super::acp_client::{AcpClient, AcpError, SpawnConfig};
+use super::acp_client::{AcpClient, AcpError, DeleteSessionOutcome, SpawnConfig};
 use super::agent_registry::{AgentRegistry, AgentSpec};
 use super::approvals::{ApprovalDecision, Nonce};
 use super::state::{CockpitSessionId, Event};
@@ -44,6 +44,96 @@ const RESTART_WINDOW: Duration = Duration::from_secs(60);
 /// Brief backoff before respawning an exited worker so we don't
 /// hot-loop when the agent process crashes immediately on startup.
 const RESPAWN_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Look up the stored ACP session id for `session_id` and, if present,
+/// fire the experimental `session/delete` RPC against the live worker.
+/// Logs the outcome at a level matched to its severity, tagging with
+/// the adapter kind so operators can tell `claude-agent-acp` apart
+/// from `aoe-agent` / `codex` / `opencode` / future adapters in
+/// debug.log without bouncing through the registry. All outcomes are
+/// non-fatal and the caller proceeds to shutdown + SIGTERM. See
+/// `AcpClient::delete_session` and #1404.
+async fn try_session_delete(client: &AcpClient, session_id: &str) {
+    // worker_registry::load reads from disk (sync I/O). Offload to
+    // the blocking pool so we don't park a Tokio worker thread on a
+    // delete path that the supervisor holds the per-instance API
+    // lock through.
+    let session_id_owned = session_id.to_string();
+    let loaded =
+        tokio::task::spawn_blocking(move || super::worker_registry::load(&session_id_owned)).await;
+    let record = match loaded {
+        Ok(Ok(rec)) => rec,
+        Ok(Err(e)) => {
+            // Registry read failed (disk error, malformed JSON, etc.).
+            // Skipping `session/delete` here means we lose adapter-side
+            // cleanup for a session that may have a stored ACP id, so
+            // surface at warn even though shutdown still proceeds.
+            warn!(
+                target: "cockpit.acp",
+                session = %session_id,
+                "skipping session/delete: worker_registry load failed: {e}"
+            );
+            return;
+        }
+        Err(e) => {
+            warn!(
+                target: "cockpit.acp",
+                session = %session_id,
+                "skipping session/delete: registry load task join failed: {e}"
+            );
+            return;
+        }
+    };
+    let (acp_id, adapter_kind) = match record {
+        Some(rec) => (rec.stored_acp_session_id, rec.agent_key),
+        None => (None, String::new()),
+    };
+    let Some(acp_id) = acp_id else {
+        debug!(
+            target: "cockpit.acp",
+            session = %session_id,
+            adapter = %adapter_kind,
+            "skipping session/delete: no stored ACP session id (pre-handshake or never assigned)"
+        );
+        return;
+    };
+    let started = Instant::now();
+    let outcome = client.delete_session(acp_id.clone()).await;
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    match &outcome {
+        DeleteSessionOutcome::Deleted => debug!(
+            target: "cockpit.acp",
+            session = %session_id,
+            adapter = %adapter_kind,
+            acp_session_id = %acp_id,
+            elapsed_ms,
+            "session/delete RPC succeeded"
+        ),
+        DeleteSessionOutcome::UnsupportedMethod => debug!(
+            target: "cockpit.acp",
+            session = %session_id,
+            adapter = %adapter_kind,
+            acp_session_id = %acp_id,
+            "adapter does not support session/delete; proceeding to SIGTERM"
+        ),
+        DeleteSessionOutcome::TimedOut => warn!(
+            target: "cockpit.acp",
+            session = %session_id,
+            adapter = %adapter_kind,
+            acp_session_id = %acp_id,
+            elapsed_ms,
+            "session/delete RPC timed out; proceeding to SIGTERM"
+        ),
+        DeleteSessionOutcome::Failed(msg) => warn!(
+            target: "cockpit.acp",
+            session = %session_id,
+            adapter = %adapter_kind,
+            acp_session_id = %acp_id,
+            elapsed_ms,
+            "session/delete RPC failed: {msg}; proceeding to SIGTERM"
+        ),
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum SupervisorError {
@@ -1452,6 +1542,16 @@ impl<S: BroadcastSink> Supervisor<S> {
         if let Some(handle) = workers.remove(session_id) {
             // Worker is alive — tear it down.
             drop(workers);
+            // Best-effort experimental `session/delete` RPC before
+            // SIGTERM. Adapters that advertise
+            // `sessionCapabilities.delete: {}` (claude-agent-acp >= 0.36)
+            // release adapter-side persisted state here. Other
+            // adapters return -32601 and we proceed to the existing
+            // kill path either way. Bounded by
+            // `ACP_SESSION_DELETE_TIMEOUT` inside `delete_session`
+            // (~2s) so a wedged adapter cannot stall the user's
+            // delete. See #1404.
+            try_session_delete(&handle.client, session_id).await;
             let _ = handle.client.shutdown().await;
             handle.drain_task.abort();
             // SIGTERM the runner (if there is one) so the agent

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -608,6 +608,138 @@ pub async fn cockpit_files(
     }
 }
 
+const WORKER_LOG_DEFAULT_TAIL: usize = 200;
+const WORKER_LOG_MAX_TAIL: usize = 2000;
+/// Cap the read size so a runaway log file can't pin the daemon. A 4 MiB
+/// window comfortably covers `WORKER_LOG_MAX_TAIL` lines worth of stderr
+/// while keeping memory predictable.
+const WORKER_LOG_MAX_READ_BYTES: u64 = 4 * 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+pub struct WorkerLogQuery {
+    /// Number of trailing lines to return. Clamped to
+    /// [1, `WORKER_LOG_MAX_TAIL`]; defaults to `WORKER_LOG_DEFAULT_TAIL`.
+    pub tail: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorkerLogResponse {
+    pub path: String,
+    pub exists: bool,
+    pub tail: String,
+    pub lines_returned: usize,
+    /// `true` when the file was larger than the read window and the
+    /// returned tail starts mid-stream rather than at the beginning of
+    /// the file.
+    pub truncated: bool,
+}
+
+/// Tail of the per-session cockpit runner log file. Surfaces the same
+/// stream `aoe cockpit logs --session <id>` reads, so a dashboard user
+/// (Funnel / no host terminal) can see the verbatim adapter error when
+/// the cockpit startup banner is otherwise opaque. Read-only; allowed
+/// in `--read-only` mode.
+pub async fn cockpit_worker_log(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    axum::extract::Query(q): axum::extract::Query<WorkerLogQuery>,
+) -> impl IntoResponse {
+    let instances = state.instances.read().await;
+    let session_known = instances.iter().any(|i| i.id == id);
+    drop(instances);
+    if !session_known {
+        return (StatusCode::NOT_FOUND, "session not found").into_response();
+    }
+
+    let log_path = match crate::cockpit::worker_registry::log_path_for(&id) {
+        Ok(p) => p,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, format!("invalid session id: {e}")).into_response();
+        }
+    };
+
+    let tail = q
+        .tail
+        .unwrap_or(WORKER_LOG_DEFAULT_TAIL)
+        .clamp(1, WORKER_LOG_MAX_TAIL);
+
+    let log_path_display = log_path.display().to_string();
+    let read_result = tokio::task::spawn_blocking(move || read_log_tail(&log_path, tail)).await;
+    match read_result {
+        Ok(Ok((lines, truncated, exists))) => {
+            let lines_returned = lines.len();
+            let body = lines.join("\n");
+            Json(WorkerLogResponse {
+                path: log_path_display,
+                exists,
+                tail: body,
+                lines_returned,
+                truncated,
+            })
+            .into_response()
+        }
+        Ok(Err(e)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("worker log read failed: {e}"),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("blocking task failed: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+pub(crate) fn read_log_tail(
+    path: &std::path::Path,
+    tail: usize,
+) -> std::io::Result<(Vec<String>, bool, bool)> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((Vec::new(), false, false));
+        }
+        Err(e) => return Err(e),
+    };
+    let len = file.metadata()?.len();
+    let read_from = len.saturating_sub(WORKER_LOG_MAX_READ_BYTES);
+    let truncated = len > WORKER_LOG_MAX_READ_BYTES;
+
+    // If the read window starts inside a line, the first line we parse
+    // is a partial line. If the previous byte is '\n' the first line is
+    // whole and we keep it. Probing one byte before `read_from` is the
+    // cheap way to tell them apart without re-reading the prefix.
+    let mut prev_byte = [0u8; 1];
+    let prev_is_newline = if truncated && read_from > 0 {
+        file.seek(SeekFrom::Start(read_from - 1))?;
+        file.read_exact(&mut prev_byte)?;
+        prev_byte[0] == b'\n'
+    } else {
+        false
+    };
+
+    file.seek(SeekFrom::Start(read_from))?;
+    let window_len = len - read_from;
+    let mut raw = Vec::with_capacity(window_len as usize);
+    // Bound the read with `take` so a concurrent append between
+    // `metadata()` and now cannot grow `raw` beyond the precomputed
+    // window. Keeps the 4 MiB cap a hard ceiling, not a target.
+    (&mut file).take(window_len).read_to_end(&mut raw)?;
+    // Lossy decode so a partial UTF-8 boundary at the window edge cannot
+    // 500 the endpoint; the tail is for human eyeballs, exact bytes are
+    // not required.
+    let buf = String::from_utf8_lossy(&raw);
+    let mut lines: Vec<String> = buf.lines().map(|l| l.to_string()).collect();
+    if truncated && !prev_is_newline && !lines.is_empty() {
+        lines.remove(0);
+    }
+    let total = lines.len();
+    let start = total.saturating_sub(tail);
+    Ok((lines[start..].to_vec(), truncated, true))
+}
+
 fn list_files(root: &std::path::Path, cap: usize) -> std::io::Result<(Vec<String>, bool)> {
     // Names we never want to recurse into. Top-level only — a deep
     // `node_modules` inside a sub-package would still show up via its
@@ -1218,5 +1350,80 @@ pub async fn set_cockpit_master(
             )
                 .into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn read_log_tail_missing_file_returns_empty_not_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.log");
+        let (lines, truncated, exists) = read_log_tail(&path, 100).unwrap();
+        assert!(lines.is_empty());
+        assert!(!truncated);
+        assert!(!exists);
+    }
+
+    #[test]
+    fn read_log_tail_returns_last_n_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.log");
+        let mut f = std::fs::File::create(&path).unwrap();
+        for i in 0..10 {
+            writeln!(f, "line {i}").unwrap();
+        }
+        drop(f);
+        let (lines, truncated, exists) = read_log_tail(&path, 3).unwrap();
+        assert_eq!(lines, vec!["line 7", "line 8", "line 9"]);
+        assert!(!truncated);
+        assert!(exists);
+    }
+
+    #[test]
+    fn read_log_tail_tail_larger_than_file_returns_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("short.log");
+        std::fs::write(&path, "only\nthree\nlines\n").unwrap();
+        let (lines, _, exists) = read_log_tail(&path, 999).unwrap();
+        assert_eq!(lines, vec!["only", "three", "lines"]);
+        assert!(exists);
+    }
+
+    #[test]
+    fn read_log_tail_keeps_first_line_when_window_starts_on_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("aligned.log");
+        let mut f = std::fs::File::create(&path).unwrap();
+        let big_line = "x".repeat((WORKER_LOG_MAX_READ_BYTES as usize) - 1);
+        writeln!(f, "{big_line}").unwrap();
+        writeln!(f, "first whole line").unwrap();
+        writeln!(f, "second whole line").unwrap();
+        drop(f);
+        let (lines, truncated, exists) = read_log_tail(&path, 10).unwrap();
+        assert!(truncated);
+        assert!(exists);
+        assert_eq!(lines.first().map(String::as_str), Some("first whole line"));
+        assert_eq!(lines.last().map(String::as_str), Some("second whole line"));
+    }
+
+    #[test]
+    fn read_log_tail_drops_partial_first_line_when_window_truncated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.log");
+        let mut f = std::fs::File::create(&path).unwrap();
+        let big_line = "x".repeat((WORKER_LOG_MAX_READ_BYTES as usize) + 64);
+        writeln!(f, "{big_line}").unwrap();
+        writeln!(f, "real first").unwrap();
+        writeln!(f, "real second").unwrap();
+        drop(f);
+        let (lines, truncated, exists) = read_log_tail(&path, 10).unwrap();
+        assert!(truncated);
+        assert!(exists);
+        assert_eq!(lines.last().map(String::as_str), Some("real second"));
+        assert!(!lines.iter().any(|l| l == &big_line));
     }
 }

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -24,8 +24,8 @@ mod system;
 pub use cockpit::{
     cockpit_cancel, cockpit_context_primer, cockpit_disable, cockpit_enable, cockpit_files,
     cockpit_force_end_turn, cockpit_prompt, cockpit_replay, cockpit_set_config_option,
-    cockpit_set_mode, list_cockpit_agents, resolve_approval, set_cockpit_master, shutdown_cockpit,
-    spawn_cockpit, switch_cockpit_agent,
+    cockpit_set_mode, cockpit_worker_log, list_cockpit_agents, resolve_approval,
+    set_cockpit_master, shutdown_cockpit, spawn_cockpit, switch_cockpit_agent,
 };
 
 #[cfg(feature = "serve")]

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -310,6 +310,46 @@ fn post_token_auth_action(
     }
 }
 
+/// Decision for the entry of `run_passphrase_wall`: a request landed on
+/// the wall because the daemon is running in `--auth=passphrase` mode
+/// (token gate disabled, passphrase login active). The wall normally
+/// requires a session cookie + device binding for `/api/*` and `/ws`,
+/// redirects to `/login` otherwise, and step-up-elevates writes to
+/// persistent-config surfaces. Two conditions bypass that entire
+/// gauntlet: a login-bootstrap path (so the SPA can load assets and
+/// post to `/api/login`) and a loopback caller (so the local TUI can
+/// attach without a passphrase exchange).
+#[derive(Debug, PartialEq, Eq)]
+enum PassphraseWallEntryAction {
+    /// Path is in the login-bootstrap allow-list. Skip the wall so
+    /// `/login`, `/api/login`, static assets, etc. stay reachable
+    /// even without a session.
+    BypassExempt,
+    /// Caller is on loopback. fs-perm boundary on
+    /// `~/.agent-of-empires/serve.*` already protects same-host
+    /// access, so layering the passphrase factor on top adds friction
+    /// without strengthening the trust boundary. Mirrors the token-
+    /// auth path's `is_local_trusted` carve-out from #1168 so the
+    /// local TUI works against an `--auth=passphrase` daemon. See
+    /// #1525.
+    BypassLoopback,
+    /// Run the full session + device-binding + elevation flow.
+    Continue,
+}
+
+/// Resolve the entry decision for `run_passphrase_wall`. Extracted so
+/// the bypass policy is table-testable without standing up the full
+/// axum middleware. See #1525.
+fn passphrase_wall_entry_action(path: &str, client_ip: IpAddr) -> PassphraseWallEntryAction {
+    if is_login_session_exempt(path) {
+        return PassphraseWallEntryAction::BypassExempt;
+    }
+    if is_local_trusted(client_ip) {
+        return PassphraseWallEntryAction::BypassLoopback;
+    }
+    PassphraseWallEntryAction::Continue
+}
+
 /// Whether a request path + method needs an elevated login session
 /// (step-up auth, 15-minute passphrase confirmation window).
 ///
@@ -447,6 +487,16 @@ pub struct AuthenticatedSession(pub String);
 /// inside the token-auth path, but skips every token-cookie
 /// operation since there is no token to refresh.
 ///
+/// Loopback callers bypass the wall entirely (see
+/// [`passphrase_wall_entry_action`] / [`is_local_trusted`]). This
+/// mirrors the token-auth path's #1168 carve-out so the local TUI can
+/// attach to a same-host `--auth=passphrase` daemon without going
+/// through a passphrase exchange. The fs-perm boundary on
+/// `~/.agent-of-empires/serve.*` already protects same-host access,
+/// and remote callers proxied through a tunnel come in with the real
+/// remote IP via `resolve_client_ip`, so they still hit the wall as
+/// expected. See #1525.
+///
 /// Rate-limit lockout is intentionally not consulted here: the only
 /// authentication attempt that can fail in this path is the passphrase
 /// POST itself, and `/api/login` enforces `check_locked` /
@@ -463,8 +513,18 @@ async fn run_passphrase_wall(
     let path = request.uri().path().to_string();
     let method = request.method().clone();
 
-    if is_login_session_exempt(&path) {
-        return next.run(request).await;
+    match passphrase_wall_entry_action(&path, client_ip) {
+        PassphraseWallEntryAction::BypassExempt => return next.run(request).await,
+        PassphraseWallEntryAction::BypassLoopback => {
+            tracing::info!(
+                target: "auth.passphrase",
+                ip = %client_ip,
+                path = %path,
+                "loopback bypass: skipping passphrase factor in passphrase-only mode"
+            );
+            return next.run(request).await;
+        }
+        PassphraseWallEntryAction::Continue => {}
     }
 
     let session_id = super::login::extract_login_session(&request);
@@ -1024,6 +1084,63 @@ mod tests {
         assert_eq!(
             post_token_auth_action(true, false, remote),
             PostTokenAuthAction::RequireLogin
+        );
+    }
+
+    // Per-row coverage of the passphrase-wall entry policy added in
+    // #1525: a loopback caller should bypass the wall outright so the
+    // local TUI can attach to an `--auth=passphrase` daemon without a
+    // session, while remote callers continue to fall through to the
+    // session check. The login-bootstrap allow-list still wins over
+    // both regardless of IP so the SPA can fetch assets and POST to
+    // `/api/login` even when the network would otherwise be remote.
+    #[test]
+    fn passphrase_wall_entry_action_matrix() {
+        let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+        let loopback_v6: IpAddr = "::1".parse().unwrap();
+        let remote: IpAddr = "100.64.0.5".parse().unwrap();
+
+        // Non-exempt path + loopback (IPv4 and IPv6): bypass the
+        // wall entirely. This is the #1525 fix: same-host TUI attach
+        // must not require a passphrase exchange.
+        assert_eq!(
+            passphrase_wall_entry_action("/api/sessions", loopback),
+            PassphraseWallEntryAction::BypassLoopback
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/sessions/abc/cockpit/ws", loopback),
+            PassphraseWallEntryAction::BypassLoopback
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/api/settings", loopback_v6),
+            PassphraseWallEntryAction::BypassLoopback
+        );
+
+        // Non-exempt path + remote: run the full session check. This
+        // is the case the passphrase wall was built for; the bypass
+        // must not leak through here.
+        assert_eq!(
+            passphrase_wall_entry_action("/api/sessions", remote),
+            PassphraseWallEntryAction::Continue
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/sessions/abc/cockpit/ws", remote),
+            PassphraseWallEntryAction::Continue
+        );
+
+        // Login-bootstrap allow-list wins regardless of IP, so the
+        // SPA can pull assets and POST to `/api/login` from any peer.
+        assert_eq!(
+            passphrase_wall_entry_action("/login", remote),
+            PassphraseWallEntryAction::BypassExempt
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/api/login", remote),
+            PassphraseWallEntryAction::BypassExempt
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/assets/index.css", loopback),
+            PassphraseWallEntryAction::BypassExempt
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1211,6 +1211,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/sessions/{id}/cockpit/files", get(api::cockpit_files))
         .route(
+            "/api/sessions/{id}/cockpit/worker-log",
+            get(api::cockpit_worker_log),
+        )
+        .route(
             "/api/sessions/{id}/cockpit/replay",
             get(api::cockpit_replay),
         )

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -214,13 +214,17 @@ fn cli_serve_daemon_writes_marker_to_debug_log_not_serve_log() {
 /// branch is locked in CI rather than relying on manual smoke tests.
 ///
 /// Flow:
-///   1. GET `/api/about` without a session  -> 401 `login_required`
-///      (proves the wall actually blocks API traffic).
+///   1. GET `/api/about` from a simulated non-loopback caller (loopback
+///      socket + `X-Forwarded-For: 10.0.0.5`, which `resolve_client_ip`
+///      trusts because the socket itself is loopback) -> 401
+///      `login_required`. Proves the wall still blocks remote API
+///      traffic after the #1525 loopback bypass landed.
 ///   2. POST `/api/login` with the correct passphrase + a fresh
 ///      device-binding secret -> 200 with `Set-Cookie: aoe_session=`.
 ///   3. GET `/api/about` carrying the session cookie + binding header
-///      -> 200, body has `"auth_mode":"passphrase"` (proves both the
-///      wall handoff and the `/api/about` mode-derivation surface).
+///      (no XFF so the caller is loopback) -> 200, body has
+///      `"auth_mode":"passphrase"`. Proves both the wall handoff and
+///      the `/api/about` mode-derivation surface.
 #[test]
 #[serial]
 fn cli_serve_auth_passphrase_login_round_trip() {
@@ -267,9 +271,14 @@ fn cli_serve_auth_passphrase_login_round_trip() {
             .build()
             .map_err(|e| format!("build client: {e}"))?;
 
-        // 1. Unauthenticated GET must come back with 401 + login_required body.
+        // 1. Unauthenticated GET from a simulated remote caller must
+        //    come back with 401 + login_required body. The daemon
+        //    binds loopback, so `resolve_client_ip` trusts XFF; we
+        //    pin a non-loopback last-hop IP so the #1525 loopback
+        //    bypass does not fire.
         let about_unauth = client
             .get(format!("{base}/api/about"))
+            .header("x-forwarded-for", "10.0.0.5")
             .send()
             .await
             .map_err(|e| format!("GET /api/about (unauth): {e}"))?;
@@ -349,6 +358,109 @@ fn cli_serve_auth_passphrase_login_round_trip() {
 
     // Always tear the daemon down before asserting, so a failed assert
     // doesn't leak a process that owns the test port.
+    let _ = h.run_cli(&["serve", "--stop"]);
+
+    if let Err(e) = result {
+        panic!("{e}");
+    }
+}
+
+/// Regression test for #1525. With `--auth=passphrase` the daemon used
+/// to route loopback callers through the passphrase wall, breaking the
+/// local TUI cockpit attach: it had no session cookie + device binding
+/// to present so `/api/sessions/{id}/cockpit/replay` and the cockpit ws
+/// upgrade always 401'd. The fix mirrors the token-auth path's #1168
+/// carve-out and treats loopback as fs-trusted.
+///
+/// Flow:
+///   1. Start `aoe serve --daemon --auth=passphrase`.
+///   2. GET `/api/about` from 127.0.0.1 with no session cookie, no
+///      device binding, no XFF -> 200 with `"auth_mode":"passphrase"`.
+///      Without the bypass this would 401 `login_required`.
+///   3. GET `/api/sessions` from 127.0.0.1 -> 200 (proves the bypass
+///      covers the cockpit REST surface, not just `/api/about`).
+#[test]
+#[serial]
+fn cli_serve_auth_passphrase_loopback_bypass() {
+    let h = TuiTestHarness::new("serve_auth_passphrase_loopback");
+    let port = pick_free_port();
+    let port_s = port.to_string();
+
+    let start = h.run_cli(&[
+        "serve",
+        "--daemon",
+        "--port",
+        &port_s,
+        "--auth",
+        "passphrase",
+        "--passphrase",
+        "e2e-pass",
+    ]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon --auth=passphrase failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {}",
+        port
+    );
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let result: Result<(), String> = rt.block_on(async {
+        let base = format!("http://127.0.0.1:{port}");
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|e| format!("build client: {e}"))?;
+
+        // No cookie, no device binding, no XFF: the loopback bypass
+        // (#1525) lets the request through. Pre-fix this would have
+        // returned 401 login_required.
+        let about = client
+            .get(format!("{base}/api/about"))
+            .send()
+            .await
+            .map_err(|e| format!("GET /api/about (loopback bypass): {e}"))?;
+        if !about.status().is_success() {
+            let s = about.status();
+            let b = about.text().await.unwrap_or_default();
+            return Err(format!(
+                "loopback /api/about should 200 under --auth=passphrase, got status={s} body={b}"
+            ));
+        }
+        let body: serde_json::Value = about
+            .json()
+            .await
+            .map_err(|e| format!("decode about body: {e}"))?;
+        if body.get("auth_mode").and_then(|v| v.as_str()) != Some("passphrase") {
+            return Err(format!(
+                "expected auth_mode=passphrase on loopback bypass, got {body}"
+            ));
+        }
+
+        // The cockpit REST surface lives under the same wall, so the
+        // bypass must extend to it. A successful 200 on `/api/sessions`
+        // from loopback without a session is what unblocks the local
+        // TUI cockpit attach in the issue report.
+        let sessions = client
+            .get(format!("{base}/api/sessions"))
+            .send()
+            .await
+            .map_err(|e| format!("GET /api/sessions (loopback bypass): {e}"))?;
+        if !sessions.status().is_success() {
+            let s = sessions.status();
+            let b = sessions.text().await.unwrap_or_default();
+            return Err(format!(
+                "loopback /api/sessions should 200 under --auth=passphrase, got status={s} body={b}"
+            ));
+        }
+
+        Ok(())
+    });
+
     let _ = h.run_cli(&["serve", "--stop"]);
 
     if let Err(e) = result {

--- a/tests/integration/cockpit_session_delete.rs
+++ b/tests/integration/cockpit_session_delete.rs
@@ -1,0 +1,185 @@
+//! Experimental `session/delete` RPC dispatch coverage. See #1404.
+//!
+//! Exercises the round-trip from `AcpClient::delete_session` through
+//! the Rust ACP client, the JSON-RPC layer, and the test-shim's
+//! `unstable_deleteSession` handler. Tests cover:
+//!
+//! - Adapter advertising `sessionCapabilities.delete: {}` succeeds and
+//!   the shim records the call (matches claude-agent-acp 0.37+).
+//! - Adapter NOT advertising the capability returns `-32601`, surfaced
+//!   as `DeleteSessionOutcome::Unsupported` (matches aoe-agent, codex,
+//!   opencode, older claude-agent-acp).
+//! - Adapter handler that exceeds the bounded timeout surfaces as
+//!   `TimedOut`; the call does not hang the caller.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use agent_of_empires::cockpit::acp_client::{AcpClient, DeleteSessionOutcome, SpawnConfig};
+use agent_of_empires::cockpit::agent_registry::AgentSpec;
+use agent_of_empires::cockpit::state::{CockpitSessionId, Event};
+
+use crate::common::{shim_path, shim_ready};
+
+fn spawn_config_with_shim_env(shim: PathBuf, env: Vec<(String, String)>) -> SpawnConfig {
+    SpawnConfig {
+        agent_key: "claude".into(),
+        spec: AgentSpec {
+            command: "node".into(),
+            args: vec![shim.to_string_lossy().to_string()],
+            description: "session/delete shim".into(),
+            env_allowlist: None,
+        },
+        cwd: std::env::temp_dir(),
+        additional_dirs: vec![],
+        provider_env: env,
+        socket_path: None,
+        stored_acp_session_id: None,
+        sandbox_info: None,
+        source_profile: None,
+    }
+}
+
+/// Drain events until a `Stopped` arrives or `deadline` elapses; returns
+/// the ACP session id assigned during the handshake so subsequent
+/// `delete_session` calls can target it.
+async fn drive_handshake_and_capture_session_id(
+    client: &mut AcpClient,
+    deadline: std::time::Instant,
+) -> Option<String> {
+    client
+        .send_prompt("hello")
+        .await
+        .expect("send_prompt should reach the shim");
+    let mut acp_session_id: Option<String> = None;
+    while std::time::Instant::now() < deadline {
+        let evt = match tokio::time::timeout(Duration::from_millis(200), client.next_event()).await
+        {
+            Ok(Some(evt)) => evt,
+            Ok(None) | Err(_) => continue,
+        };
+        if let Event::AcpSessionAssigned { acp_session_id: id } = &evt {
+            acp_session_id = Some(id.clone());
+        }
+        if matches!(evt, Event::Stopped { .. }) {
+            break;
+        }
+    }
+    acp_session_id
+}
+
+#[tokio::test]
+async fn session_delete_called_when_capability_advertised() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let record_path = temp.path().join("delete-calls.log");
+    let config = spawn_config_with_shim_env(
+        shim_path(),
+        vec![
+            ("SHIM_DELETE_CAPABILITY".into(), "1".into()),
+            (
+                "SHIM_DELETE_RECORD_FILE".into(),
+                record_path.to_string_lossy().to_string(),
+            ),
+        ],
+    );
+
+    let mut client = AcpClient::spawn(config, CockpitSessionId("delete-pos".into()))
+        .await
+        .expect("spawn shim");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let acp_id = drive_handshake_and_capture_session_id(&mut client, deadline)
+        .await
+        .expect("shim should assign an ACP session id during handshake");
+
+    let outcome = client.delete_session(acp_id.clone()).await;
+    let _ = client.shutdown().await;
+
+    assert!(
+        matches!(outcome, DeleteSessionOutcome::Deleted),
+        "expected Deleted; got {outcome:?}"
+    );
+    let recorded =
+        std::fs::read_to_string(&record_path).expect("record file should exist after delete RPC");
+    assert!(
+        recorded.lines().any(|line| line == acp_id),
+        "shim should have recorded the deleted session id {acp_id} (file contents: {recorded:?})"
+    );
+}
+
+#[tokio::test]
+async fn session_delete_unsupported_when_capability_absent() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+    // Without SHIM_DELETE_CAPABILITY the shim leaves
+    // unstable_deleteSession unset, so the SDK's dispatcher returns
+    // -32601 for `session/delete`. This is the steady-state shape for
+    // aoe-agent, codex, opencode.
+    let config = spawn_config_with_shim_env(shim_path(), vec![]);
+
+    let mut client = AcpClient::spawn(config, CockpitSessionId("delete-neg".into()))
+        .await
+        .expect("spawn shim");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let acp_id = drive_handshake_and_capture_session_id(&mut client, deadline)
+        .await
+        .expect("shim should assign an ACP session id during handshake");
+
+    let outcome = client.delete_session(acp_id).await;
+    let _ = client.shutdown().await;
+
+    assert!(
+        matches!(outcome, DeleteSessionOutcome::UnsupportedMethod),
+        "expected UnsupportedMethod; got {outcome:?}"
+    );
+}
+
+#[tokio::test]
+async fn session_delete_timeout_does_not_hang() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+    let config = spawn_config_with_shim_env(
+        shim_path(),
+        vec![
+            ("SHIM_DELETE_CAPABILITY".into(), "1".into()),
+            ("SHIM_DELETE_MODE".into(), "slow".into()),
+        ],
+    );
+
+    let mut client = AcpClient::spawn(config, CockpitSessionId("delete-slow".into()))
+        .await
+        .expect("spawn shim");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let acp_id = drive_handshake_and_capture_session_id(&mut client, deadline)
+        .await
+        .expect("shim should assign an ACP session id during handshake");
+
+    let started = std::time::Instant::now();
+    let outcome = client.delete_session(acp_id).await;
+    let elapsed = started.elapsed();
+    let _ = client.shutdown().await;
+
+    assert!(
+        matches!(outcome, DeleteSessionOutcome::TimedOut),
+        "expected TimedOut; got {outcome:?}"
+    );
+    // ACP_SESSION_DELETE_TIMEOUT is 2s; the outer guard adds 500ms.
+    // The shim's slow path sleeps 3s, so the wait must surface as
+    // TimedOut well before the 3s mark. Cap at 3.4s to keep the
+    // assertion robust against scheduler slack.
+    assert!(
+        elapsed < Duration::from_millis(3400),
+        "delete_session should bound the wait; took {:?}",
+        elapsed
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -30,6 +30,9 @@ mod worktree_integration;
 #[cfg(feature = "serve")]
 mod cockpit_acp_smoke;
 
+#[cfg(feature = "serve")]
+mod cockpit_session_delete;
+
 #[cfg(all(feature = "serve", debug_assertions))]
 mod cockpit_midturn_resume;
 

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -25,7 +25,7 @@ import { SoundSettings } from "./settings/SoundSettings";
 import { UpdateSettings } from "./settings/UpdateSettings";
 import { TmuxSettings } from "./settings/TmuxSettings";
 import { LoggingSettings } from "./settings/LoggingSettings";
-import { ProfileSelector } from "./settings/ProfileSelector";
+import { SettingsHeader } from "./settings/SettingsHeader";
 
 type TabId =
   | "session"
@@ -496,28 +496,13 @@ export function SettingsView({
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-surface-900">
-      {/* Header */}
-      <div className="h-12 bg-surface-850 border-b border-surface-700 flex items-center px-4 shrink-0">
-        <button
-          onClick={onClose}
-          className="text-brand-500 mr-3 cursor-pointer text-sm"
-        >
-          &larr; Back
-        </button>
-        <span className="text-sm font-semibold text-text-bright">Settings</span>
-        {saving && (
-          <span className="ml-2 text-xs text-text-dim">Saving...</span>
-        )}
-        {saveError && (
-          <span className="ml-2 text-xs text-red-400">{saveError}</span>
-        )}
-        <div className="flex-1 flex justify-center">
-          <ProfileSelector
-            selectedProfile={selectedProfile}
-            onSelect={setSelectedProfile}
-          />
-        </div>
-      </div>
+      <SettingsHeader
+        onClose={onClose}
+        saving={saving}
+        saveError={saveError}
+        selectedProfile={selectedProfile}
+        onSelectProfile={setSelectedProfile}
+      />
 
       {/* Mobile tabs (horizontal scroll) */}
       <div className="md:hidden border-b border-surface-700 bg-surface-850 overflow-x-auto">

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -54,9 +54,11 @@ import {
   setSessionSnooze,
 } from "../lib/api";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
+import { useClampedMenuPosition } from "../lib/menuPosition";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { reportError } from "../lib/toastBus";
 import {
+  repoGroupHasLiveWorkspace,
   resolveEffectiveSnoozedUntil,
   snoozeTimestampCloseEnough,
   triageMenuShape,
@@ -664,6 +666,8 @@ export const SessionRow = memo(function SessionRow({
     if (renaming) renameRef.current?.select();
   }, [renaming]);
 
+  useClampedMenuPosition(contextMenu, menuRef, setContextMenu);
+
   useEffect(() => {
     if (!contextMenu) return;
     const close = () => setContextMenu(null);
@@ -939,8 +943,12 @@ export const SessionRow = memo(function SessionRow({
         <div
           ref={menuRef}
           data-testid="sidebar-context-menu"
-          className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[180px]"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
+          className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[180px] overflow-y-auto"
+          style={{
+            left: contextMenu.x,
+            top: contextMenu.y,
+            maxHeight: "calc(100vh - 16px)",
+          }}
         >
           <button
             onClick={startRename}
@@ -1374,6 +1382,8 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
     if (renaming) renameRef.current?.select();
   }, [renaming]);
 
+  useClampedMenuPosition(contextMenu, menuRef, setContextMenu);
+
   useEffect(() => {
     if (!contextMenu) return;
     const close = () => setContextMenu(null);
@@ -1486,8 +1496,12 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
         <div
           ref={menuRef}
           data-testid="sidebar-group-context-menu"
-          className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[190px]"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
+          className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[190px] overflow-y-auto"
+          style={{
+            left: contextMenu.x,
+            top: contextMenu.y,
+            maxHeight: "calc(100vh - 16px)",
+          }}
         >
           <button
             onClick={() => {
@@ -1854,7 +1868,7 @@ export function WorkspaceSidebar({
             collisionDetection={closestCenter}
             onDragEnd={dragDisabled ? undefined : handleDragEnd}
           >
-            {filteredGroups.map((group) => {
+            {filteredGroups.filter(repoGroupHasLiveWorkspace).map((group) => {
               const showExpanded = q ? true : !group.collapsed;
               const hasActiveChild = group.workspaces.some(
                 (ws) => ws.id === displayedActiveId,

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -1538,7 +1538,7 @@ export function SnoozedWorkerStoppedBanner({
   );
 }
 
-function StartupErrorBanner({
+export function StartupErrorBanner({
   sessionId,
   message,
 }: {
@@ -1556,6 +1556,13 @@ function StartupErrorBanner({
   );
   const isProjectPathMissing = projectPathMissingMatch !== null;
   const missingPath = projectPathMissingMatch?.[1]?.trim() ?? null;
+  // The adapter found the bundled Claude Code native sub-binary at the
+  // global-npm path but `execve` failed. Usually arch/libc/loader
+  // mismatch inside a sandbox container, or a bind-mounted host
+  // node_modules whose binary doesn't match the container arch. See
+  // #1449.
+  const isNativeBinaryLaunchFail =
+    /native binary at .* exists but failed to launch/i.test(message);
   const [retryState, setRetryState] = useState<
     "idle" | "retrying" | "ok" | "failed"
   >("idle");
@@ -1668,6 +1675,42 @@ function StartupErrorBanner({
               </li>
             </ol>
           </>
+        ) : isNativeBinaryLaunchFail ? (
+          <>
+            The adapter is installed but its bundled Claude Code native
+            sub-binary couldn't launch. The binary exists on disk, the
+            kernel rejected the <code className="rounded bg-rose-900/60 px-1">execve</code>.
+            Reinstalling the adapter won't help; the binary is already
+            there. Likely causes:
+            <ul className="mt-1 list-disc space-y-0.5 pl-5">
+              <li>
+                Architecture mismatch (e.g. an{" "}
+                <code className="rounded bg-rose-900/60 px-1">arm64</code> binary
+                inside an <code className="rounded bg-rose-900/60 px-1">amd64</code>{" "}
+                sandbox container, or vice versa).
+              </li>
+              <li>
+                Container image missing the dynamic loader or a glibc
+                version old enough to refuse the binary.
+              </li>
+              <li>
+                Host{" "}
+                <code className="rounded bg-rose-900/60 px-1">node_modules</code>{" "}
+                bind-mounted into a container of a different arch.
+              </li>
+            </ul>
+            Open the agent log below for the verbatim adapter error, or
+            see{" "}
+            <a
+              href="https://agent-of-empires.com/docs/cockpit#native-binary-launch-failure"
+              target="_blank"
+              rel="noreferrer"
+              className="underline hover:text-rose-100"
+            >
+              the troubleshooting guide
+            </a>
+            .
+          </>
         ) : (
           <>
             Run <code className="rounded bg-rose-900/60 px-1">aoe cockpit doctor --fix</code>{" "}
@@ -1678,6 +1721,127 @@ function StartupErrorBanner({
           </>
         )}
       </div>
+      <AgentLogDisclosure sessionId={sessionId} />
+    </div>
+  );
+}
+
+/** Collapsible viewer for the per-session cockpit runner log.
+ *
+ *  Surfaces the same stream `aoe cockpit logs --session <id>` reads,
+ *  so a dashboard user without host terminal access (Tailscale Funnel,
+ *  remote setups) can see the verbatim adapter error when the startup
+ *  banner is otherwise opaque. See #1449.
+ */
+function AgentLogDisclosure({ sessionId }: { sessionId: string }) {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<
+    "idle" | "loading" | "ok" | "failed"
+  >("idle");
+  const [tail, setTail] = useState<string>("");
+  const [exists, setExists] = useState<boolean>(false);
+  const [truncated, setTruncated] = useState<boolean>(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
+
+  const fetchLog = async () => {
+    setState("loading");
+    setErrorText(null);
+    try {
+      const res = await fetch(
+        `/api/sessions/${encodeURIComponent(sessionId)}/cockpit/worker-log?tail=200`,
+      );
+      if (!res.ok) {
+        const detail = (await res.text().catch(() => "")).slice(0, 200);
+        setState("failed");
+        setErrorText(`Server returned ${res.status}. ${detail}`.trim());
+        return;
+      }
+      const body = (await res.json()) as {
+        path?: string;
+        exists?: boolean;
+        tail?: string;
+        truncated?: boolean;
+      };
+      setExists(Boolean(body.exists));
+      setTail(typeof body.tail === "string" ? body.tail : "");
+      setTruncated(Boolean(body.truncated));
+      setState("ok");
+    } catch (e) {
+      setState("failed");
+      setErrorText(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const handleToggle = () => {
+    const next = !open;
+    setOpen(next);
+    if (next && state === "idle") {
+      void fetchLog();
+    }
+  };
+
+  return (
+    <div className="mt-3 border-t border-rose-900/60 pt-2">
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={handleToggle}
+          data-testid="cockpit-agent-log-toggle"
+          aria-expanded={open}
+          className="text-xs font-medium text-rose-100 underline-offset-2 hover:underline"
+        >
+          {open ? "Hide agent log" : "Open agent log"}
+        </button>
+        {open && (
+          <button
+            type="button"
+            onClick={() => void fetchLog()}
+            disabled={state === "loading"}
+            data-testid="cockpit-agent-log-refresh"
+            className="rounded-md border border-rose-800/60 bg-rose-900/40 px-2 py-0.5 text-[10px] font-medium text-rose-100 hover:bg-rose-900/60 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {state === "loading" ? "Loading…" : "Refresh"}
+          </button>
+        )}
+      </div>
+      {open && (
+        <div className="mt-2" data-testid="cockpit-agent-log-body">
+          {state === "loading" && (
+            <div className="text-xs text-rose-200/80">Loading log…</div>
+          )}
+          {state === "failed" && errorText && (
+            <div className="text-xs text-rose-100/90">
+              Could not load log: {errorText}
+            </div>
+          )}
+          {state === "ok" && !exists && (
+            <div className="text-xs text-rose-200/80">
+              No log output yet. The worker may not have written anything
+              before exiting.
+            </div>
+          )}
+          {state === "ok" && exists && tail.length === 0 && (
+            <div className="text-xs text-rose-200/80">
+              Log file exists but is empty.
+            </div>
+          )}
+          {state === "ok" && exists && tail.length > 0 && (
+            <>
+              {truncated && (
+                <div className="mb-1 text-[10px] text-rose-200/70">
+                  Log is large; showing the tail.
+                </div>
+              )}
+              <pre
+                data-testid="cockpit-agent-log-pre"
+                className="max-h-64 overflow-auto whitespace-pre-wrap break-all rounded bg-rose-950/70 p-2 font-mono text-[11px] text-rose-100/90"
+              >
+                {tail}
+              </pre>
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/cockpit/Composer.dictation.test.ts
+++ b/web/src/components/cockpit/Composer.dictation.test.ts
@@ -1,0 +1,119 @@
+// State-machine tests for the cockpit composer's iOS-dictation burst
+// detector added in #1431. The pure helper lets the burst matrix be
+// exercised without mounting the composer + the WebKit dictation
+// engine; the imperative wiring (refs, timers, composerRuntime.setText)
+// is in the component and exercised by the live Playwright spec.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DICTATION_BURST_TIMEOUT_MS,
+  decideDictationAction,
+  type DictationBurstState,
+} from "./Composer";
+
+const inactive: DictationBurstState = { active: false };
+
+describe("decideDictationAction (#1431)", () => {
+  it("inactive + insertReplacementText -> enter burst, suppress upstream, arm timeout", () => {
+    const d = decideDictationAction(inactive, {
+      kind: "input",
+      inputType: "insertReplacementText",
+      nowMs: 1000,
+    });
+    expect(d.next).toEqual({ active: true, sinceMs: 1000 });
+    expect(d.suppressUpstreamChange).toBe(true);
+    expect(d.flushPending).toBe(false);
+    expect(d.armTimeoutMs).toBe(DICTATION_BURST_TIMEOUT_MS);
+  });
+
+  it("active + insertReplacementText -> stay in burst, suppress upstream, re-arm timeout", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, {
+      kind: "input",
+      inputType: "insertReplacementText",
+      nowMs: 1300,
+    });
+    expect(d.next).toEqual({ active: true, sinceMs: 1300 });
+    expect(d.suppressUpstreamChange).toBe(true);
+    expect(d.flushPending).toBe(false);
+    expect(d.armTimeoutMs).toBe(DICTATION_BURST_TIMEOUT_MS);
+  });
+
+  it("active + timeout -> exit burst, flush pending", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, {
+      kind: "timeout",
+      nowMs: 2300,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.suppressUpstreamChange).toBe(false);
+    expect(d.flushPending).toBe(true);
+    expect(d.armTimeoutMs).toBeNull();
+  });
+
+  it("active + blur -> exit burst, flush pending (Send tap fires blur first)", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, { kind: "blur" });
+    expect(d.next).toEqual({ active: false });
+    expect(d.suppressUpstreamChange).toBe(false);
+    expect(d.flushPending).toBe(true);
+    expect(d.armTimeoutMs).toBeNull();
+  });
+
+  it("active + non-replacement input -> exit burst, flush, do NOT suppress (let event through)", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, {
+      kind: "input",
+      inputType: "insertText",
+      nowMs: 1100,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.suppressUpstreamChange).toBe(false);
+    expect(d.flushPending).toBe(true);
+    expect(d.armTimeoutMs).toBeNull();
+  });
+
+  it("active + backspace -> exit burst, flush, do NOT suppress", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, {
+      kind: "input",
+      inputType: "deleteContentBackward",
+      nowMs: 1100,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.flushPending).toBe(true);
+    expect(d.suppressUpstreamChange).toBe(false);
+  });
+
+  it("inactive + regular insertText -> stay inactive, no-op", () => {
+    const d = decideDictationAction(inactive, {
+      kind: "input",
+      inputType: "insertText",
+      nowMs: 1000,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.suppressUpstreamChange).toBe(false);
+    expect(d.flushPending).toBe(false);
+    expect(d.armTimeoutMs).toBeNull();
+  });
+
+  it("inactive + blur -> stay inactive, no flush", () => {
+    const d = decideDictationAction(inactive, { kind: "blur" });
+    expect(d.next).toEqual({ active: false });
+    expect(d.flushPending).toBe(false);
+  });
+
+  it("inactive + timeout -> stay inactive, no flush (stale timer fired after blur)", () => {
+    const d = decideDictationAction(inactive, {
+      kind: "timeout",
+      nowMs: 5000,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.flushPending).toBe(false);
+  });
+
+  it("burst timeout is at least one second (must span typical breath pause)", () => {
+    expect(DICTATION_BURST_TIMEOUT_MS).toBeGreaterThanOrEqual(1000);
+  });
+});

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -32,6 +32,15 @@ import type { CockpitState } from "../../lib/cockpitTypes";
 import { getDraft, setDraft } from "../../lib/cockpitDrafts";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { useAgentProfile } from "../../lib/agentProfileContext";
+import { useDictationBurstGuard } from "./useDictationBurstGuard";
+
+export {
+  DICTATION_BURST_TIMEOUT_MS,
+  decideDictationAction,
+  type DictationBurstState,
+  type DictationDecision,
+  type DictationEvent,
+} from "./useDictationBurstGuard";
 
 /** Decision returned by {@link decideEnterAction} for an Enter
  *  keystroke on the cockpit composer textarea.
@@ -295,6 +304,17 @@ export function Composer({
 
   const composerRuntime = useComposerRuntime();
 
+  // iOS Safari native dictation (#1431): WebKit fires `beforeinput` /
+  // `input` with `inputType: "insertReplacementText"` per partial
+  // recognition and tracks a private range pointer into the textarea
+  // that is invalidated by any controlled-value re-render. The guard
+  // suspends assistant-ui's `setText` flush for the burst, buffers the
+  // textarea value, and drains it back into the runtime once the burst
+  // ends (1200 ms timeout, blur, or non-replacement input).
+  const dictationGuard = useDictationBurstGuard((text) => {
+    composerRuntime.setText(text);
+  });
+
   // Context-primer prefill: when the parent passes a `primerPrefill`
   // payload (after the user clicked "Resume with prior context" on the
   // banner), replace the composer text with the primer + focus the
@@ -505,15 +525,39 @@ export function Composer({
                 // let the keydown matrix handle the platforms that do
                 // fire a real Enter keydown. See #1174.
                 const ne = e.nativeEvent as InputEvent;
-                const action = decideBeforeInputAction(
+                const newlineAction = decideBeforeInputAction(
                   ne.inputType,
                   ne.isComposing,
                   { isMobile },
                 );
-                if (action === "default") return;
-                e.preventDefault();
-                e.stopPropagation();
-                insertNewlineAtCaret(taRef);
+                if (newlineAction === "newline") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  insertNewlineAtCaret(taRef);
+                  return;
+                }
+                // iOS native dictation burst detection (#1431). Driven
+                // from `beforeinput` rather than `input` so the burst
+                // flag is set before assistant-ui's onChange (composed
+                // by radix) gets a chance to run and call `setText`.
+                dictationGuard.observeInputType(ne.inputType, Date.now());
+              }}
+              onChange={(e) => {
+                // Suppress assistant-ui's controlled-input flush while
+                // an iOS dictation burst is active (#1431). Radix's
+                // `composeEventHandlers` (used by ComposerPrimitive.Input)
+                // skips the downstream handler when `defaultPrevented`
+                // is set on the SyntheticEvent.
+                if (dictationGuard.shouldSuppressUpstream(e.currentTarget.value)) {
+                  e.preventDefault();
+                }
+              }}
+              onBlur={() => {
+                // Tapping Send (or anywhere outside the textarea) blurs
+                // the iOS soft-keyboard-owned field; flush the dictation
+                // buffer first so the pending text lands in
+                // assistant-ui state before the Send click reads it.
+                dictationGuard.flushOnBlur();
               }}
               onKeyDown={(e) => {
                 // Three-way Enter dispatch. See decideEnterAction for

--- a/web/src/components/cockpit/__tests__/StartupErrorBanner.test.tsx
+++ b/web/src/components/cockpit/__tests__/StartupErrorBanner.test.tsx
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+//
+// Coverage for the cockpit StartupErrorBanner native-binary branch
+// and the Open-agent-log disclosure. The disclosure surfaces the
+// per-session worker log to dashboard users who don't have host
+// terminal access (Tailscale Funnel, remote setups). See #1449.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+
+import { StartupErrorBanner } from "../CockpitView";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const NATIVE_BINARY_MSG =
+  'agent spawn failed: ACP connection failed: Internal error: { "details": "Claude Code native binary at /usr/lib/node_modules/.../claude exists but failed to launch." }';
+
+describe("StartupErrorBanner native-binary branch", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          path: "/tmp/x.log",
+          exists: false,
+          tail: "",
+          lines_returned: 0,
+          truncated: false,
+        }),
+      }),
+    );
+  });
+
+  it("renders arch/loader remediation copy, not the doctor --fix fallback", () => {
+    const { container } = render(
+      <StartupErrorBanner sessionId="s-1" message={NATIVE_BINARY_MSG} />,
+    );
+    expect(container.textContent).toContain("Architecture mismatch");
+    expect(container.textContent).toContain("dynamic loader");
+    expect(container.textContent).toContain("bind-mounted into a container");
+    expect(container.textContent).not.toContain("aoe cockpit doctor --fix");
+  });
+
+  it("links the native-binary docs anchor", () => {
+    const { container } = render(
+      <StartupErrorBanner sessionId="s-1" message={NATIVE_BINARY_MSG} />,
+    );
+    const anchor = container.querySelector("a[href*='cockpit']");
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute("href")).toContain(
+      "native-binary-launch-failure",
+    );
+  });
+});
+
+describe("StartupErrorBanner fallback branch (unchanged)", () => {
+  it("still renders the doctor --fix copy on a generic failure", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ exists: false, tail: "" }),
+      }),
+    );
+    const { container } = render(
+      <StartupErrorBanner sessionId="s-1" message="some unknown failure" />,
+    );
+    expect(container.textContent).toContain("aoe cockpit doctor --fix");
+  });
+});
+
+describe("AgentLogDisclosure", () => {
+  it("does not fetch until the user clicks Open agent log", () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        path: "/tmp/x.log",
+        exists: true,
+        tail: "first line\nsecond line",
+        lines_returned: 2,
+        truncated: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    render(
+      <StartupErrorBanner sessionId="s-1" message={NATIVE_BINARY_MSG} />,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches the worker-log endpoint on first open and renders the tail", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        path: "/tmp/x.log",
+        exists: true,
+        tail: "ERROR cockpit.acp: spawn failed\nclaude execve: ENOEXEC",
+        lines_returned: 2,
+        truncated: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const { getByTestId } = render(
+      <StartupErrorBanner sessionId="abc-123" message={NATIVE_BINARY_MSG} />,
+    );
+    fireEvent.click(getByTestId("cockpit-agent-log-toggle"));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(fetchSpy.mock.calls[0]?.[0]).toContain(
+      "/api/sessions/abc-123/cockpit/worker-log?tail=200",
+    );
+    await waitFor(() => {
+      expect(getByTestId("cockpit-agent-log-pre").textContent).toContain(
+        "ENOEXEC",
+      );
+    });
+  });
+
+  it("renders 'No log output yet' when the endpoint reports exists=false", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        path: "/tmp/x.log",
+        exists: false,
+        tail: "",
+        lines_returned: 0,
+        truncated: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const { getByTestId, container } = render(
+      <StartupErrorBanner sessionId="s-1" message={NATIVE_BINARY_MSG} />,
+    );
+    fireEvent.click(getByTestId("cockpit-agent-log-toggle"));
+    await waitFor(() => {
+      expect(container.textContent).toContain("No log output yet");
+    });
+  });
+
+  it("shows an error message when the fetch fails", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "boom",
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const { getByTestId, container } = render(
+      <StartupErrorBanner sessionId="s-1" message={NATIVE_BINARY_MSG} />,
+    );
+    fireEvent.click(getByTestId("cockpit-agent-log-toggle"));
+    await waitFor(() => {
+      expect(container.textContent).toContain("Could not load log");
+      expect(container.textContent).toContain("500");
+    });
+  });
+
+  it("renders 'log file exists but is empty' when tail is empty and exists=true", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        path: "/tmp/x.log",
+        exists: true,
+        tail: "",
+        lines_returned: 0,
+        truncated: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const { getByTestId, container } = render(
+      <StartupErrorBanner sessionId="s-1" message={NATIVE_BINARY_MSG} />,
+    );
+    fireEvent.click(getByTestId("cockpit-agent-log-toggle"));
+    await waitFor(() => {
+      expect(container.textContent).toContain("Log file exists but is empty");
+    });
+  });
+
+  it("renders the truncated-log hint when the response sets truncated=true", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        path: "/tmp/x.log",
+        exists: true,
+        tail: "tail content",
+        lines_returned: 1,
+        truncated: true,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const { getByTestId, container } = render(
+      <StartupErrorBanner sessionId="s-1" message={NATIVE_BINARY_MSG} />,
+    );
+    fireEvent.click(getByTestId("cockpit-agent-log-toggle"));
+    await waitFor(() => {
+      expect(container.textContent).toContain("Log is large; showing the tail");
+    });
+  });
+
+  it("hides the body when the toggle is clicked a second time", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        path: "/tmp/x.log",
+        exists: true,
+        tail: "abc",
+        lines_returned: 1,
+        truncated: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const { getByTestId, queryByTestId } = render(
+      <StartupErrorBanner sessionId="s-1" message={NATIVE_BINARY_MSG} />,
+    );
+    const toggle = getByTestId("cockpit-agent-log-toggle");
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(queryByTestId("cockpit-agent-log-pre")).not.toBeNull();
+    });
+    fireEvent.click(toggle);
+    expect(queryByTestId("cockpit-agent-log-pre")).toBeNull();
+  });
+
+  it("re-fetches when the Refresh button is clicked", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        path: "/tmp/x.log",
+        exists: true,
+        tail: "tail",
+        lines_returned: 1,
+        truncated: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const { getByTestId } = render(
+      <StartupErrorBanner sessionId="s-1" message={NATIVE_BINARY_MSG} />,
+    );
+    fireEvent.click(getByTestId("cockpit-agent-log-toggle"));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(getByTestId("cockpit-agent-log-refresh"));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/web/src/components/cockpit/useDictationBurstGuard.test.ts
+++ b/web/src/components/cockpit/useDictationBurstGuard.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+//
+// Imperative-side tests for useDictationBurstGuard, the iOS-Safari
+// dictation glue extracted from Composer.tsx (#1431). The pure
+// decideDictationAction matrix is covered separately by
+// Composer.dictation.test.ts; this file covers the hook wiring (refs,
+// burst timer, setText sink, unmount cleanup) without mounting the
+// whole composer + assistant-ui runtime.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import {
+  DICTATION_BURST_TIMEOUT_MS,
+  useDictationBurstGuard,
+} from "./useDictationBurstGuard";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function renderGuard() {
+  const setText = vi.fn<(s: string) => void>();
+  const { result, unmount, rerender } = renderHook(() =>
+    useDictationBurstGuard(setText),
+  );
+  return { setText, result, unmount, rerender };
+}
+
+describe("useDictationBurstGuard (#1431)", () => {
+  it("non-replacement input outside a burst is a no-op", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertText", 1000);
+    });
+    expect(result.current.shouldSuppressUpstream("hello")).toBe(false);
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("insertReplacementText enters a burst and suppresses upstream change", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    expect(result.current.shouldSuppressUpstream("open the")).toBe(true);
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("buffers the latest textarea value across consecutive replacements", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    expect(result.current.shouldSuppressUpstream("open")).toBe(true);
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1100);
+    });
+    expect(result.current.shouldSuppressUpstream("open the")).toBe(true);
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1300);
+    });
+    expect(result.current.shouldSuppressUpstream("open the diff viewer")).toBe(
+      true,
+    );
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("flushes the buffered text into setText after the burst timeout fires", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("open the diff viewer");
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 5);
+    });
+    expect(setText).toHaveBeenCalledTimes(1);
+    expect(setText).toHaveBeenCalledWith("open the diff viewer");
+    expect(result.current.shouldSuppressUpstream("any")).toBe(false);
+  });
+
+  it("re-arms the burst timer on each replacement so a long utterance does not flush mid-stream", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("open");
+    // Half-window passes, then another partial fires; the original
+    // timer must be cancelled and replaced.
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS - 100);
+    });
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 2000);
+    });
+    result.current.shouldSuppressUpstream("open the");
+    // Original 1200 ms window has now elapsed since the first event,
+    // but the second event reset it; nothing should have flushed yet.
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(setText).not.toHaveBeenCalled();
+    // Once a full window passes since the second event, the flush fires.
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS);
+    });
+    expect(setText).toHaveBeenCalledExactlyOnceWith("open the");
+  });
+
+  it("blur during an active burst flushes the buffer and clears the timer", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("hello");
+    act(() => {
+      result.current.flushOnBlur();
+    });
+    expect(setText).toHaveBeenCalledExactlyOnceWith("hello");
+    // The timer should be cleared by the flush; advancing past it must
+    // not double-fire setText.
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 100);
+    });
+    expect(setText).toHaveBeenCalledTimes(1);
+  });
+
+  it("blur outside a burst is a no-op", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.flushOnBlur();
+    });
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("non-replacement input during a burst flushes, exits the burst, and stops suppressing", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("hello");
+    act(() => {
+      result.current.observeInputType("insertText", 1500);
+    });
+    expect(setText).toHaveBeenCalledExactlyOnceWith("hello");
+    expect(result.current.shouldSuppressUpstream("hello!")).toBe(false);
+  });
+
+  it("does not call setText when the burst ends with an empty buffer (no shouldSuppressUpstream call between burst start and end)", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    // Never captured a textarea value via shouldSuppressUpstream; the
+    // buffer ref stays null and the flush path skips setText.
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 5);
+    });
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("unmount clears any armed timer to avoid a setText on an unmounted parent", () => {
+    const { setText, result, unmount } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("hello");
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 100);
+    });
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("re-rendering the hook with the same setText reuses the burst state (refs survive re-render)", () => {
+    let calls = 0;
+    const setText = vi.fn<(s: string) => void>(() => {
+      calls += 1;
+    });
+    const { result, rerender } = renderHook(() =>
+      useDictationBurstGuard(setText),
+    );
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("hello");
+    rerender();
+    // After the rerender the same burst is still active.
+    expect(result.current.shouldSuppressUpstream("hello world")).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 5);
+    });
+    expect(setText).toHaveBeenCalledExactlyOnceWith("hello world");
+    expect(calls).toBe(1);
+  });
+});

--- a/web/src/components/cockpit/useDictationBurstGuard.ts
+++ b/web/src/components/cockpit/useDictationBurstGuard.ts
@@ -1,0 +1,219 @@
+// Hook + pure state machine for the iOS-Safari native-mic dictation
+// path on the cockpit composer (#1431).
+//
+// WebKit fires `beforeinput` / `input` with `inputType:
+// "insertReplacementText"` per partial recognition. It tracks a
+// private NSAttributedString range pointer into the textarea's text
+// storage so the next partial replaces the prior one; any JS write to
+// `textarea.value` via the property setter invalidates that pointer,
+// after which the next partial appends instead of replacing.
+// assistant-ui's `ComposerPrimitive.Input` is fully controlled and
+// re-renders on every `setText`, so without this guard the
+// controlled-value reconciler re-writes the DOM value on every partial
+// and dictation duplicates.
+//
+// The guard detects the burst via the `insertReplacementText`
+// inputType, suspends the assistant-ui flush for its duration, buffers
+// the textarea value in a ref, and drains the buffer into `setText`
+// once when the burst ends (1200 ms timeout, blur, or non-replacement
+// input event).
+
+import { useEffect, useRef } from "react";
+
+/** Dictation burst state for the iOS-Safari native-mic input path
+ *  (#1431). Tracks whether we are currently inside a sequence of
+ *  `inputType: "insertReplacementText"` events. */
+export type DictationBurstState =
+  | { active: false }
+  | { active: true; sinceMs: number };
+
+/** Event the composer feeds into {@link decideDictationAction}. The
+ *  helper only needs the discriminator + the current monotonic clock
+ *  reading; the imperative wiring lives in the hook below. */
+export type DictationEvent =
+  | { kind: "input"; inputType: string; nowMs: number }
+  | { kind: "timeout"; nowMs: number }
+  | { kind: "blur" };
+
+/** Decision returned by {@link decideDictationAction}. The hook
+ *  applies the actions imperatively (refs, timers, `setText`); the
+ *  helper itself is pure so the burst-state matrix can be tested
+ *  without mounting the composer + the WebKit dictation engine. */
+export interface DictationDecision {
+  /** Next burst state to commit. */
+  next: DictationBurstState;
+  /** Caller should `preventDefault()` on the React `onChange` so that
+   *  radix's `composeEventHandlers` skips assistant-ui's downstream
+   *  `setText` flush, which would otherwise re-render the textarea's
+   *  controlled `value` prop and invalidate WebKit's dictation range
+   *  pointer. */
+  suppressUpstreamChange: boolean;
+  /** Caller should flush the buffered textarea value into `setText`
+   *  before clearing the burst. Set only on the transition from
+   *  `active` to inactive. */
+  flushPending: boolean;
+  /** Caller should (re)arm the burst timeout for this many ms from
+   *  now. Set only when entering or extending a burst. */
+  armTimeoutMs: number | null;
+}
+
+/** Window (ms) after the last `insertReplacementText` event before we
+ *  consider an iOS dictation burst finished and flush the buffered
+ *  text into assistant-ui state. Long enough to span a breath pause
+ *  between phrases in continuous dictation, short enough that the
+ *  user does not perceive lag between releasing the mic and the
+ *  composer state catching up. */
+export const DICTATION_BURST_TIMEOUT_MS = 1200;
+
+/** Pure decision helper for the iOS-dictation burst state machine
+ *  (#1431). The hook below mirrors this state in refs and applies the
+ *  returned actions; tests exercise the matrix directly. */
+export function decideDictationAction(
+  prev: DictationBurstState,
+  ev: DictationEvent,
+): DictationDecision {
+  if (ev.kind === "blur") {
+    if (!prev.active) {
+      return {
+        next: { active: false },
+        suppressUpstreamChange: false,
+        flushPending: false,
+        armTimeoutMs: null,
+      };
+    }
+    return {
+      next: { active: false },
+      suppressUpstreamChange: false,
+      flushPending: true,
+      armTimeoutMs: null,
+    };
+  }
+  if (ev.kind === "timeout") {
+    if (!prev.active) {
+      return {
+        next: { active: false },
+        suppressUpstreamChange: false,
+        flushPending: false,
+        armTimeoutMs: null,
+      };
+    }
+    return {
+      next: { active: false },
+      suppressUpstreamChange: false,
+      flushPending: true,
+      armTimeoutMs: null,
+    };
+  }
+  if (ev.inputType === "insertReplacementText") {
+    return {
+      next: { active: true, sinceMs: ev.nowMs },
+      suppressUpstreamChange: true,
+      flushPending: false,
+      armTimeoutMs: DICTATION_BURST_TIMEOUT_MS,
+    };
+  }
+  if (prev.active) {
+    return {
+      next: { active: false },
+      suppressUpstreamChange: false,
+      flushPending: true,
+      armTimeoutMs: null,
+    };
+  }
+  return {
+    next: { active: false },
+    suppressUpstreamChange: false,
+    flushPending: false,
+    armTimeoutMs: null,
+  };
+}
+
+/** Imperative side of the dictation-burst guard. The component calls
+ *  the returned handlers from `onBeforeInput`, `onChange`, and
+ *  `onBlur`; the hook owns the burst state ref, the buffered text
+ *  ref, and the burst-timeout timer. */
+export interface DictationGuard {
+  /** Call from `onBeforeInput` with the native input event's
+   *  `inputType` and the current clock reading. Updates the burst
+   *  state, (re)arms or clears the burst timer, and flushes the
+   *  buffered text into `setText` if the burst is ending due to a
+   *  non-replacement input event. */
+  observeInputType: (inputType: string, nowMs: number) => void;
+  /** Call from `onChange` with the latest textarea value. Returns
+   *  `true` when the caller should `preventDefault()` on the
+   *  SyntheticEvent so that radix's `composeEventHandlers` skips the
+   *  downstream assistant-ui flush. */
+  shouldSuppressUpstream: (value: string) => boolean;
+  /** Call from `onBlur`. Flushes any pending burst into `setText`
+   *  before the focus shift can reach a Send-button click handler
+   *  that reads `composerRuntime.getState().text`. */
+  flushOnBlur: () => void;
+}
+
+/** Builds a {@link DictationGuard} bound to a single `setText` sink.
+ *  The hook owns three refs (state, buffered text, timer handle) and
+ *  one cleanup effect that clears the timer on unmount. */
+export function useDictationBurstGuard(
+  setText: (text: string) => void,
+): DictationGuard {
+  const stateRef = useRef<DictationBurstState>({ active: false });
+  const bufferRef = useRef<string | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const flush = () => {
+    const buffered = bufferRef.current;
+    stateRef.current = { active: false };
+    bufferRef.current = null;
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (buffered !== null) {
+      setText(buffered);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    observeInputType(inputType, nowMs) {
+      const decision = decideDictationAction(stateRef.current, {
+        kind: "input",
+        inputType,
+        nowMs,
+      });
+      if (decision.flushPending) {
+        flush();
+      }
+      stateRef.current = decision.next;
+      if (decision.armTimeoutMs !== null) {
+        if (timerRef.current !== null) {
+          window.clearTimeout(timerRef.current);
+        }
+        timerRef.current = window.setTimeout(flush, decision.armTimeoutMs);
+      }
+    },
+    shouldSuppressUpstream(value) {
+      if (stateRef.current.active) {
+        bufferRef.current = value;
+        return true;
+      }
+      return false;
+    },
+    flushOnBlur() {
+      const decision = decideDictationAction(stateRef.current, {
+        kind: "blur",
+      });
+      if (decision.flushPending) {
+        flush();
+      }
+    },
+  };
+}

--- a/web/src/components/settings/ProfileSelector.tsx
+++ b/web/src/components/settings/ProfileSelector.tsx
@@ -107,12 +107,12 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
 
   return (
     <div className="relative" ref={panelRef}>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-nowrap">
         <label className="text-sm font-medium text-text-secondary shrink-0">Profile</label>
         <select
           value={selectedProfile}
           onChange={(e) => onSelect(e.target.value)}
-          className="bg-surface-900 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary focus:border-brand-600 focus:outline-none w-40"
+          className="bg-surface-900 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary focus:border-brand-600 focus:outline-none w-32 sm:w-40 shrink"
         >
           {profiles.map((p) => (
             <option key={p.name} value={p.name}>

--- a/web/src/components/settings/SettingsHeader.tsx
+++ b/web/src/components/settings/SettingsHeader.tsx
@@ -1,0 +1,53 @@
+import { ProfileSelector } from "./ProfileSelector";
+
+interface Props {
+  onClose: () => void;
+  saving: boolean;
+  saveError: string | null;
+  selectedProfile: string;
+  onSelectProfile: (profile: string) => void;
+}
+
+// Settings header. ProfileSelector wraps onto its own row on mobile via
+// `basis-full` so the Back affordance and title keep their space; on md+
+// the wrapper switches to `basis-auto ml-auto` for a single-row layout
+// with the picker aligned right.
+export function SettingsHeader({
+  onClose,
+  saving,
+  saveError,
+  selectedProfile,
+  onSelectProfile,
+}: Props) {
+  return (
+    <div
+      data-testid="settings-header"
+      className="bg-surface-850 border-b border-surface-700 shrink-0 flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2 md:flex-nowrap md:h-12 md:py-0"
+    >
+      <button
+        onClick={onClose}
+        className="text-brand-500 cursor-pointer text-sm shrink-0"
+      >
+        &larr; Back
+      </button>
+      <span className="text-xs font-mono text-text-bright shrink-0">Settings</span>
+      {saving && (
+        <span className="text-[11px] font-mono text-text-dim shrink-0">Saving...</span>
+      )}
+      {saveError && (
+        <span
+          data-testid="settings-header-save-error"
+          className="text-[11px] font-mono text-status-error truncate min-w-0"
+        >
+          {saveError}
+        </span>
+      )}
+      <div className="basis-full flex justify-center overflow-x-auto md:basis-auto md:ml-auto md:overflow-visible md:justify-end shrink-0">
+        <ProfileSelector
+          selectedProfile={selectedProfile}
+          onSelect={onSelectProfile}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/__tests__/SettingsHeader.test.tsx
+++ b/web/src/components/settings/__tests__/SettingsHeader.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+//
+// Contract test for the SettingsHeader extracted from SettingsView so the
+// header's transient render branches (`saving`, `saveError`) get hit by
+// vitest. The end-to-end layout assertions (two-row mobile, single-row
+// desktop) live in `web/tests/mobile-settings-header.spec.ts`; this file
+// covers the conditional render branches and the back-button click path.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("../../../lib/api", () => ({
+  fetchProfiles: vi.fn().mockResolvedValue([{ name: "default", is_default: true }]),
+  createProfile: vi.fn(),
+  renameProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+}));
+
+import { SettingsHeader } from "../SettingsHeader";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SettingsHeader", () => {
+  const baseProps = {
+    onClose: () => {},
+    saving: false,
+    saveError: null as string | null,
+    selectedProfile: "default",
+    onSelectProfile: () => {},
+  };
+
+  it("renders Back button and Settings title", () => {
+    render(<SettingsHeader {...baseProps} />);
+    expect(screen.getByRole("button", { name: /Back/ })).toBeTruthy();
+    expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("does not render Saving... indicator when saving is false", () => {
+    render(<SettingsHeader {...baseProps} saving={false} />);
+    expect(screen.queryByText("Saving...")).toBeNull();
+  });
+
+  it("renders Saving... indicator when saving is true", () => {
+    render(<SettingsHeader {...baseProps} saving={true} />);
+    expect(screen.getByText("Saving...")).toBeTruthy();
+  });
+
+  it("does not render saveError span when saveError is null", () => {
+    render(<SettingsHeader {...baseProps} saveError={null} />);
+    expect(screen.queryByTestId("settings-header-save-error")).toBeNull();
+  });
+
+  it("renders saveError message when saveError is set", () => {
+    render(
+      <SettingsHeader {...baseProps} saveError="Save failed: network error" />,
+    );
+    const errorSpan = screen.getByTestId("settings-header-save-error");
+    expect(errorSpan.textContent).toBe("Save failed: network error");
+  });
+
+  it("renders both Saving... and saveError together when both are set", () => {
+    // The header allows saveError to surface while a subsequent save is in
+    // flight; both branches should render side by side.
+    render(
+      <SettingsHeader
+        {...baseProps}
+        saving={true}
+        saveError="Save failed: network error"
+      />,
+    );
+    expect(screen.getByText("Saving...")).toBeTruthy();
+    expect(screen.getByText("Save failed: network error")).toBeTruthy();
+  });
+
+  it("calls onClose when the Back button is clicked", () => {
+    const onClose = vi.fn();
+    render(<SettingsHeader {...baseProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /Back/ }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/__tests__/menuPosition.test.ts
+++ b/web/src/lib/__tests__/menuPosition.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { clampMenuPosition, useClampedMenuPosition } from "../menuPosition";
+
+describe("clampMenuPosition", () => {
+  const VW = 1000;
+  const VH = 800;
+
+  it("returns the anchor unchanged when the menu fits at the cursor", () => {
+    const out = clampMenuPosition({
+      x: 100,
+      y: 100,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out).toEqual({ x: 100, y: 100 });
+  });
+
+  it("clamps top when the menu would overflow the bottom edge", () => {
+    const out = clampMenuPosition({
+      x: 100,
+      y: 750,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out.y).toBe(VH - 300 - 8);
+    expect(out.x).toBe(100);
+  });
+
+  it("clamps left when the menu would overflow the right edge", () => {
+    const out = clampMenuPosition({
+      x: 950,
+      y: 100,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out.x).toBe(VW - 200 - 8);
+    expect(out.y).toBe(100);
+  });
+
+  it("clamps both axes when the menu would overflow the bottom-right corner", () => {
+    const out = clampMenuPosition({
+      x: 950,
+      y: 750,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out).toEqual({ x: VW - 200 - 8, y: VH - 300 - 8 });
+  });
+
+  it("collapses to the margin when the menu is taller than the viewport", () => {
+    const out = clampMenuPosition({
+      x: 50,
+      y: 50,
+      menuWidth: 200,
+      menuHeight: 5000,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out.y).toBe(8);
+  });
+
+  it("honors a custom margin", () => {
+    const out = clampMenuPosition({
+      x: 950,
+      y: 100,
+      menuWidth: 200,
+      menuHeight: 100,
+      viewportWidth: VW,
+      viewportHeight: VH,
+      margin: 16,
+    });
+    expect(out.x).toBe(VW - 200 - 16);
+  });
+
+  it("clamps negative anchors up to the margin", () => {
+    const out = clampMenuPosition({
+      x: -50,
+      y: -30,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out).toEqual({ x: 8, y: 8 });
+  });
+});
+
+describe("useClampedMenuPosition", () => {
+  function setupHook(opts: {
+    anchor: { x: number; y: number } | null;
+    menuRect: { width: number; height: number };
+    viewport: { width: number; height: number };
+  }) {
+    const setContextMenu = vi.fn<(next: { x: number; y: number }) => void>();
+    const menu = document.createElement("div");
+    menu.getBoundingClientRect = () =>
+      ({
+        width: opts.menuRect.width,
+        height: opts.menuRect.height,
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: opts.menuRect.width,
+        bottom: opts.menuRect.height,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: opts.viewport.width,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: opts.viewport.height,
+    });
+    const { rerender } = renderHook(
+      ({ ctx }: { ctx: { x: number; y: number } | null }) => {
+        const ref = useRef<HTMLDivElement | null>(menu);
+        useClampedMenuPosition(ctx, ref, setContextMenu);
+      },
+      { initialProps: { ctx: opts.anchor } },
+    );
+    return { setContextMenu, rerender };
+  }
+
+  it("no-ops when the menu fits at the anchor", () => {
+    const { setContextMenu } = setupHook({
+      anchor: { x: 100, y: 100 },
+      menuRect: { width: 180, height: 240 },
+      viewport: { width: 1280, height: 720 },
+    });
+    expect(setContextMenu).not.toHaveBeenCalled();
+  });
+
+  it("flips the menu upward when the anchor overflows the bottom edge", () => {
+    const { setContextMenu } = setupHook({
+      anchor: { x: 100, y: 700 },
+      menuRect: { width: 180, height: 240 },
+      viewport: { width: 1280, height: 720 },
+    });
+    expect(setContextMenu).toHaveBeenCalledWith({ x: 100, y: 472 });
+  });
+
+  it("clamps the menu left when the anchor overflows the right edge", () => {
+    const { setContextMenu } = setupHook({
+      anchor: { x: 1270, y: 100 },
+      menuRect: { width: 180, height: 240 },
+      viewport: { width: 1280, height: 720 },
+    });
+    expect(setContextMenu).toHaveBeenCalledWith({ x: 1092, y: 100 });
+  });
+
+  it("does not call setContextMenu when contextMenu is null", () => {
+    const { setContextMenu } = setupHook({
+      anchor: null,
+      menuRect: { width: 180, height: 240 },
+      viewport: { width: 1280, height: 720 },
+    });
+    expect(setContextMenu).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it } from "vitest";
-import type { SessionResponse, Workspace } from "../types";
+import type { RepoGroup, SessionResponse, Workspace } from "../types";
 import {
   SIDEBAR_SORT_MODE_KEY,
   compareWorkspacesByLastActivityDesc,
   loadSidebarSortMode,
+  repoGroupHasLiveWorkspace,
   repoGroupLastActivityMs,
   resolveEffectiveSnoozedUntil,
   saveSidebarSortMode,
@@ -582,5 +583,73 @@ describe("loadSidebarSortMode / saveSidebarSortMode", () => {
     saveSidebarSortMode("lastActivity");
     saveSidebarSortMode("manual");
     expect(loadSidebarSortMode()).toBe("manual");
+  });
+});
+
+function repoGroup(id: string, workspaces: Workspace[]): RepoGroup {
+  return {
+    id,
+    repoPath: id,
+    displayName: id,
+    defaultDisplayName: id,
+    alias: null,
+    color: null,
+    remoteOwner: null,
+    workspaces,
+    status: "idle",
+    collapsed: false,
+  };
+}
+
+describe("repoGroupHasLiveWorkspace", () => {
+  it("returns true when at least one workspace is live", () => {
+    const g = repoGroup("repo-a", [
+      workspace("w-live", [session({})]),
+      workspace("w-archived", [
+        session({ id: "s-arch", archived_at: "2026-01-01T00:00:00Z" }),
+      ]),
+    ]);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(true);
+  });
+
+  it("returns false when every workspace is sunk", () => {
+    const g = repoGroup("repo-sunk", [
+      workspace("w-archived", [
+        session({ id: "s1", archived_at: "2026-01-01T00:00:00Z" }),
+      ]),
+      workspace("w-snoozed", [
+        session({ id: "s2", snoozed_until: "2099-01-01T00:00:00Z" }),
+      ]),
+    ]);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(false);
+  });
+
+  it("returns false for an empty workspace list", () => {
+    const g = repoGroup("repo-empty", []);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(false);
+  });
+
+  it("flips back to live when a sunk session is unsnoozed/unarchived", () => {
+    const g = repoGroup("repo-flip", [
+      workspace("w", [
+        session({ id: "s", archived_at: "2026-01-01T00:00:00Z" }),
+      ]),
+    ]);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(false);
+    const revived: RepoGroup = {
+      ...g,
+      workspaces: [workspace("w", [session({ id: "s" })])],
+    };
+    expect(repoGroupHasLiveWorkspace(revived)).toBe(true);
+  });
+
+  it("treats a multi-session workspace with one live session as live", () => {
+    const g = repoGroup("repo-mixed", [
+      workspace("w-mixed", [
+        session({ id: "s-live" }),
+        session({ id: "s-arch", archived_at: "2026-01-01T00:00:00Z" }),
+      ]),
+    ]);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(true);
   });
 });

--- a/web/src/lib/menuPosition.ts
+++ b/web/src/lib/menuPosition.ts
@@ -1,0 +1,75 @@
+import { useLayoutEffect, type RefObject } from "react";
+
+export interface ClampMenuArgs {
+  x: number;
+  y: number;
+  menuWidth: number;
+  menuHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  margin?: number;
+}
+
+/** Clamp a `position: fixed` floating menu's top-left so the menu fits
+ *  inside the viewport with at least `margin` pixels of breathing room
+ *  on every side. Used by the sidebar's right-click / long-press
+ *  context menus so opening one near the bottom or right edge does not
+ *  push items off-screen. When the menu is taller or wider than the
+ *  viewport (minus margins) the position collapses to `margin` rather
+ *  than going negative; the menu's own stylesheet caps `max-height`
+ *  with `overflow-y: auto` to make the tail scrollable. See #1601. */
+export function clampMenuPosition({
+  x,
+  y,
+  menuWidth,
+  menuHeight,
+  viewportWidth,
+  viewportHeight,
+  margin = 8,
+}: ClampMenuArgs): { x: number; y: number } {
+  const maxX = Math.max(margin, viewportWidth - menuWidth - margin);
+  const maxY = Math.max(margin, viewportHeight - menuHeight - margin);
+  const nextX = Math.min(Math.max(x, margin), maxX);
+  const nextY = Math.min(Math.max(y, margin), maxY);
+  return { x: nextX, y: nextY };
+}
+
+/** React hook: keep a floating context menu inside the viewport.
+ *
+ *  On every state transition of `contextMenu`, measure `menuRef` after
+ *  layout, call `clampMenuPosition`, and forward the clamped position
+ *  through `setContextMenu` if it differs. Wires a `ResizeObserver`
+ *  while the menu is open so a deferred layout shift (web fonts
+ *  loading, icon images decoding) re-runs the clamp instead of leaking
+ *  items off the bottom edge. Guarded with a `typeof` check so the
+ *  jsdom-based Vitest suites that lack `ResizeObserver` still execute
+ *  the layout effect cleanly. See #1601. */
+export function useClampedMenuPosition(
+  contextMenu: { x: number; y: number } | null,
+  menuRef: RefObject<HTMLElement | null>,
+  setContextMenu: (next: { x: number; y: number }) => void,
+): void {
+  useLayoutEffect(() => {
+    if (!contextMenu || !menuRef.current) return;
+    const menu = menuRef.current;
+    const clamp = () => {
+      const rect = menu.getBoundingClientRect();
+      const next = clampMenuPosition({
+        x: contextMenu.x,
+        y: contextMenu.y,
+        menuWidth: rect.width,
+        menuHeight: rect.height,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      });
+      if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+        setContextMenu(next);
+      }
+    };
+    clamp();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(clamp);
+    ro.observe(menu);
+    return () => ro.disconnect();
+  }, [contextMenu, menuRef, setContextMenu]);
+}

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -1,4 +1,4 @@
-import type { Workspace } from "./types";
+import type { RepoGroup, Workspace } from "./types";
 import { safeGetItem, safeSetItem } from "./safeStorage";
 
 export type SidebarSortMode = "manual" | "lastActivity";
@@ -71,6 +71,17 @@ export function workspaceIsSunk(ws: Workspace): boolean {
   return ws.sessions.every(
     (s) => s.archived_at != null || s.snoozed_until != null,
   );
+}
+
+/** True when a repo group still has at least one workspace that is
+ *  not sunk (archived or actively snoozed across all sessions). The
+ *  sidebar uses this to hide the group's header when every workspace
+ *  has dropped into the global "Snoozed & archived" footer, so the
+ *  live list does not show an orphan header with no rows. The footer
+ *  itself scans the unfiltered group list, so sunk sessions are not
+ *  lost. See #1600. */
+export function repoGroupHasLiveWorkspace(group: RepoGroup): boolean {
+  return group.workspaces.some((ws) => !workspaceIsSunk(ws));
 }
 
 /** Triage tier for a workspace: 0 = pinned (top of every sort), 1 =

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1929,6 +1929,32 @@
       ]
     },
     {
+      "id": "triage.empty-group-hide",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/lib/__tests__/sidebarSort.test.ts",
+        "tests/live/triage-archive.spec.ts"
+      ],
+      "components": [
+        "web/src/lib/sidebarSort.ts",
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.context-menu-clamp",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/lib/__tests__/menuPosition.test.ts",
+        "tests/sidebar-context-menu-clamp.spec.ts"
+      ],
+      "components": [
+        "web/src/lib/menuPosition.ts",
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "triage.session-row-chips",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1704,6 +1704,28 @@
       ]
     },
     {
+      "id": "cockpit.story.composer-ios-dictation",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/composer-ios-dictation.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
+      "id": "cockpit.composer-ios-dictation-state-machine",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/Composer.dictation.test.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
       "id": "cockpit.story.composer-streamed-response",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1006,6 +1006,31 @@
       ]
     },
     {
+      "id": "cockpit.startup-error-banner",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/components/cockpit/__tests__/StartupErrorBanner.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx"
+      ]
+    },
+    {
+      "id": "cockpit.startup-error-banner-live",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-worker-log.spec.ts",
+        "tests/live/cockpit-stories/startup-error-banner-native-binary.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx",
+        "src/server/api/cockpit.rs",
+        "src/cockpit/acp_client.rs"
+      ]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -93,6 +93,30 @@
       ]
     },
     {
+      "id": "settings.mobile-header",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/mobile-settings-header.spec.ts"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/SettingsHeader.tsx",
+        "web/src/components/settings/ProfileSelector.tsx"
+      ]
+    },
+    {
+      "id": "settings.header-branches",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": [
+        "src/components/settings/__tests__/SettingsHeader.test.tsx"
+      ],
+      "components": [
+        "web/src/components/settings/SettingsHeader.tsx"
+      ]
+    },
+    {
       "id": "settings.theme-persistence-passphrase",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -456,6 +456,105 @@
       ]
     },
     {
+      "id": "sidebar.reorder-stationary-click",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-stationary-click-navigates.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-tiny-drag-noop",
+      "kind": "mocked-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/sidebar-reorder-tiny-drag-noop.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-click-after-drag-suppressed",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/sidebar-reorder-click-after-drag-suppressed.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-cross-group-noop",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-cross-group-noop.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-read-only",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-read-only.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-mobile-tap-navigates",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-mobile-tap-navigates.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-mobile-flick-scrolls",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-mobile-flick-scrolls.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-mobile-press-hold",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/sidebar-reorder-mobile-press-hold-reorders.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "story.sidebar-reorder-reload-persists",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/sidebar-reorder-reload-persists.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "sidebar.client-side-navigation",
       "kind": "mocked-playwright",
       "risk": "medium",
@@ -1296,6 +1395,54 @@
       ],
       "components": [
         "web/src/components/settings/ThemeSettings.tsx"
+      ]
+    },
+    {
+      "id": "story.settings-theme-custom",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/settings-theme-custom.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/ThemeSettings.tsx",
+        "web/src/lib/theme.ts"
+      ]
+    },
+    {
+      "id": "story.settings-theme-custom-malformed",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/settings-theme-custom-malformed.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/ThemeSettings.tsx"
+      ]
+    },
+    {
+      "id": "story.settings-theme-color-mode",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/settings-theme-color-mode.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/ThemeSettings.tsx",
+        "web/src/hooks/useResolvedTheme.ts"
+      ]
+    },
+    {
+      "id": "story.settings-theme-failure-revert",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/settings-theme-failure-revert.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/ThemeSettings.tsx",
+        "web/src/components/SettingsView.tsx",
+        "web/src/hooks/useResolvedTheme.ts"
       ]
     },
     {

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -150,8 +150,10 @@ function sendResult(id, result) {
   send({ jsonrpc: "2.0", id, result });
 }
 
-function sendError(id, code, message) {
-  send({ jsonrpc: "2.0", id, error: { code, message } });
+function sendError(id, code, message, data) {
+  const error = { code, message };
+  if (data !== undefined) error.data = data;
+  send({ jsonrpc: "2.0", id, error });
 }
 
 function sendNotification(method, params) {
@@ -324,6 +326,26 @@ async function handleRequest(msg) {
       // ignore log errors
     }
   }
+  // Script-controlled failure injection: lets specs simulate "adapter
+  // returns a JSON-RPC error on method X" without needing a hand-rolled
+  // ACP server per failure mode. Shape: script.failOn = { method:
+  // "session/new", code: -32603, message: "Internal error", data: {...} }.
+  // Single-shot by default; set `repeat: true` to keep failing on every
+  // call. See web/tests/live/cockpit-stories/startup-error-banner-native-binary.spec.ts.
+  if (script.failOn && script.failOn.method === method) {
+    const f = script.failOn;
+    sendError(
+      id,
+      typeof f.code === "number" ? f.code : -32603,
+      typeof f.message === "string" ? f.message : "Internal error",
+      f.data,
+    );
+    if (!f.repeat) {
+      script.failOn = null;
+    }
+    return;
+  }
+
   switch (method) {
     case "initialize":
       sendResult(id, INITIALIZE_RESULT);

--- a/web/tests/helpers/sidebar.ts
+++ b/web/tests/helpers/sidebar.ts
@@ -1,4 +1,8 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
 import type { Page } from "@playwright/test";
+import { resolveAoeBinary } from "./aoeServe";
 
 export async function clickSidebarSession(page: Page, title: string) {
   // Sidebar session rows are anchor tags (see WorkspaceSidebar.tsx). The
@@ -66,3 +70,98 @@ export async function openMobileSidebar(page: Page) {
     { timeout: 5_000 },
   );
 }
+
+/**
+ * Read the visible session-row titles in the sidebar, in DOM order.
+ *
+ * Scopes to the `.truncate` label span inside each row so a Wakeup or
+ * Plan chip on the same row can't be confused with the workspace
+ * title. Hoisted from `tests/live/workspace-ordering.spec.ts` so the
+ * reorder story specs can share the same accessor without redefining
+ * it per file.
+ */
+export async function readVisibleSessionTitles(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const rows = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        "[data-testid='sidebar-session-row']",
+      ),
+    );
+    return rows
+      .map(
+        (r) =>
+          r.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
+      )
+      .filter(Boolean);
+  });
+}
+
+/**
+ * Build a `seedFn` for `spawnAoeServe` that git-inits a project dir
+ * under the isolated HOME, then runs `aoe add` once per supplied
+ * title. The arrival order matters: the server prepends new workspace
+ * ids newest-first, so the seeded sidebar order in arrival sequence
+ * is `titles[-1]` at the top down to `titles[0]` at the bottom.
+ *
+ * Optional `subdir` lets callers seed multiple repos by pointing each
+ * `seedSessionsInRepo` call at a different directory; the cross-group
+ * reorder story chains two calls for that reason.
+ */
+export function seedSessionsInRepo(opts: {
+  titles: string[];
+  subdir?: string;
+  tool?: string;
+}): (seedEnv: {
+  home: string;
+  shimBin: string;
+  env: NodeJS.ProcessEnv;
+}) => void {
+  return ({ home, env }) => {
+    const binary = resolveAoeBinary();
+    const projectDir = join(home, opts.subdir ?? "repo");
+    mkdirSync(projectDir, { recursive: true });
+    spawnSync("git", ["init", "-q"], { cwd: projectDir });
+    spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+      cwd: projectDir,
+      env: {
+        ...env,
+        GIT_AUTHOR_NAME: "t",
+        GIT_AUTHOR_EMAIL: "t@t",
+        GIT_COMMITTER_NAME: "t",
+        GIT_COMMITTER_EMAIL: "t@t",
+      },
+    });
+    for (const title of opts.titles) {
+      const res = spawnSync(
+        binary,
+        ["add", projectDir, "-t", title, "-c", opts.tool ?? "claude"],
+        { env },
+      );
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed for ${title}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    }
+  };
+}
+
+/**
+ * Chain multiple repo seeds into a single `seedFn`. Cross-group
+ * reorder stories need at least two repos so dnd-kit's per-group
+ * SortableContext renders multiple drag boundaries; this helper runs
+ * each repo's `seedSessionsInRepo` in sequence under the same env.
+ */
+export function seedRepos(
+  repos: Array<{ titles: string[]; subdir: string; tool?: string }>,
+): (seedEnv: {
+  home: string;
+  shimBin: string;
+  env: NodeJS.ProcessEnv;
+}) => void {
+  const fns = repos.map((r) => seedSessionsInRepo(r));
+  return (seedEnv) => {
+    for (const fn of fns) fn(seedEnv);
+  };
+}
+

--- a/web/tests/helpers/sidebarMocks.ts
+++ b/web/tests/helpers/sidebarMocks.ts
@@ -1,0 +1,175 @@
+// Shared mocked-Playwright setup for the sidebar-reorder story specs
+// under `web/tests/sidebar-reorder-*.spec.ts` (#1419). The drag-to-
+// reorder UI sits on top of dnd-kit and a handful of REST endpoints;
+// the per-test specifics are just the input gesture + the assertion.
+// Extracted from `sidebar-drag-reorder.spec.ts` and trimmed to what
+// the story specs actually need.
+
+import type { Page, Route } from "@playwright/test";
+
+export interface MockSessionInput {
+  id: string;
+  title: string;
+  project_path: string;
+  branch: string | null;
+  /** ISO 8601 timestamp; controls newest-first default ordering. */
+  created_at?: string;
+}
+
+type MockSession = Required<MockSessionInput>;
+
+function fillCreatedAt(s: MockSessionInput, fallbackIndex: number): MockSession {
+  return {
+    ...s,
+    // Stagger fallback timestamps a day apart so a list seeded in
+    // arrival order has a deterministic newest-first sort if anything
+    // ever falls back to created_at.
+    created_at:
+      s.created_at ??
+      new Date(Date.UTC(2025, 0, 1 + fallbackIndex)).toISOString(),
+  };
+}
+
+function sessionResponse(s: MockSession) {
+  return {
+    id: s.id,
+    title: s.title,
+    project_path: s.project_path,
+    group_path: s.project_path,
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: s.created_at,
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: s.branch,
+    main_repo_path: null,
+    is_sandboxed: false,
+    has_terminal: true,
+    profile: "default",
+    workspace_repos: [],
+  };
+}
+
+/** Workspace id format used by the server: `<project_path>::<branch>`
+ *  for branched sessions, `<project_path>::__session__::<id>` for
+ *  ones without a branch. Mirrors `useWorkspaces.ts:31`. */
+export function workspaceId(s: { project_path: string; branch: string | null; id: string }): string {
+  return s.branch
+    ? `${s.project_path}::${s.branch}`
+    : `${s.project_path}::__session__::${s.id}`;
+}
+
+export interface SidebarMockHandle {
+  /** Recorded `PUT /api/workspace-ordering` bodies in arrival order. */
+  puts: Array<{ order?: string[] }>;
+  /** Override the fulfill response for the next PUT (used by the
+   *  failure-mode story). Reset after each call. */
+  nextPutResponse: { status?: number; body?: string } | null;
+  /** Override the read_only flag from `/api/about` (used by the
+   *  read-only story). */
+  readOnly: boolean;
+}
+
+export interface SidebarMockOptions {
+  sessions: MockSessionInput[];
+  /** Server-supplied workspace ordering (the full list, with each id
+   *  composed via `workspaceId`). Defaults to the input order. */
+  ordering?: string[];
+  /** Add `read_only: true` to the `/api/about` response. */
+  readOnly?: boolean;
+}
+
+/** Install routes for the surface the sidebar uses. Returns a handle
+ *  the test can read for captured PUT bodies and tweak the next PUT's
+ *  fulfill (for the failure-mode story). */
+export async function installSidebarMocks(
+  page: Page,
+  opts: SidebarMockOptions,
+): Promise<SidebarMockHandle> {
+  const filled = opts.sessions.map((s, i) => fillCreatedAt(s, i));
+  const handle: SidebarMockHandle = {
+    puts: [],
+    nextPutResponse: null,
+    readOnly: !!opts.readOnly,
+  };
+
+  const ordering = opts.ordering ?? filled.map((s) => workspaceId(s));
+
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: { sessions: filled.map(sessionResponse), workspace_ordering: ordering },
+    });
+  });
+  await page.route("**/api/workspace-ordering", (r: Route) => {
+    if (r.request().method() === "PUT") {
+      const body = r.request().postDataJSON() as { order?: string[] };
+      handle.puts.push(body ?? {});
+      const override = handle.nextPutResponse;
+      handle.nextPutResponse = null;
+      if (override) return r.fulfill(override);
+    }
+    return r.fulfill({ json: { order: [] } });
+  });
+  await page.route("**/api/about", (r) =>
+    r.fulfill({
+      json: {
+        read_only: handle.readOnly,
+        auth_mode: "none",
+        behind_tunnel: false,
+        profile: "default",
+      },
+    }),
+  );
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: [] }),
+    );
+  }
+  await page.route("**/api/docker/status", (r) =>
+    r.fulfill({ json: {} }),
+  );
+
+  return handle;
+}
+
+/** Standard three sessions in one repo, used by the activation /
+ *  suppression / mobile stories. Title -> branch -> id are aligned so
+ *  the test reads naturally. */
+export function threeSessionsInOneRepo(): MockSessionInput[] {
+  return [
+    {
+      id: "s-a",
+      title: "alpha",
+      project_path: "/tmp/repo",
+      branch: "feature/a",
+      created_at: "2025-03-01T00:00:00Z",
+    },
+    {
+      id: "s-b",
+      title: "beta",
+      project_path: "/tmp/repo",
+      branch: "feature/b",
+      created_at: "2025-02-01T00:00:00Z",
+    },
+    {
+      id: "s-c",
+      title: "gamma",
+      project_path: "/tmp/repo",
+      branch: "feature/c",
+      created_at: "2025-01-01T00:00:00Z",
+    },
+  ];
+}

--- a/web/tests/helpers/theme.ts
+++ b/web/tests/helpers/theme.ts
@@ -1,0 +1,117 @@
+// Shared helpers for theme-switching story specs (#1405).
+//
+// Two domains:
+//
+//   - `seedCustomTheme(home, name, body)` writes a TOML file into the
+//     isolated $HOME so that an `aoe serve` boot picks it up via
+//     `discover_custom_themes` (src/tui/styles/mod.rs:86). The themes
+//     directory lives at `${appDir}/themes/`, where `appDir` is
+//     `${home}/.agent-of-empires-dev` (macOS/Windows) or
+//     `${xdg}/agent-of-empires-dev/` (Linux). `appDirFor` in
+//     `aoeServe.ts` already mirrors that resolution.
+//
+//   - `readThemeFromDocument(page)` snapshots the four observable
+//     side-effects of `applyResolvedTheme` (web/src/lib/theme.ts:47):
+//     `dataset.theme`, `dataset.themeAppearance`, the `color-scheme`
+//     style, and one representative CSS variable. Used by the failure
+//     and color-mode stories to assert a precise "did NOT paint" state.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Page } from "@playwright/test";
+import { appDirFor, resolveAoeBinary } from "./aoeServe";
+
+const MINIMAL_THEME_TOML = `appearance = "dark"
+
+background = "#11131c"
+border = "#2b2f3f"
+terminal_border = "#5fd7ff"
+selection = "#2b2f3f"
+session_selection = "#3c4154"
+title = "#c4b5fd"
+text = "#e6e8ee"
+dimmed = "#7a829a"
+hint = "#7a829a"
+running = "#5fd7af"
+waiting = "#ffd178"
+fresh_idle = "#ff8a5b"
+idle = "#7a829a"
+error = "#ff6b6b"
+terminal_active = "#5fd7ff"
+group = "#5fd7ff"
+search = "#fff59d"
+accent = "#c4b5fd"
+diff_add = "#5fd7af"
+diff_delete = "#ff6b6b"
+diff_modified = "#ffd178"
+diff_header = "#c4b5fd"
+help_key = "#c4b5fd"
+branch = "#5fd7ff"
+sandbox = "#c4b5fd"
+
+[syntax]
+shiki_theme = "github-dark"
+`;
+
+/** Body of a valid custom-theme TOML file. Custom themes deserialize as
+ *  the full `Theme` struct (TUI palette + syntax sub-table); a partial
+ *  body fails to parse and ends up filtered out by `load_custom_theme`. */
+export const VALID_CUSTOM_THEME_TOML = MINIMAL_THEME_TOML;
+
+/** Intentionally malformed TOML. Anything that doesn't satisfy the
+ *  `Theme` struct deserializer counts; this body trips a parse error,
+ *  so `load_custom_theme` returns `None` and the name is still listed
+ *  by `discover_custom_themes` (the discovery scan only looks at the
+ *  file stem, see src/tui/styles/mod.rs:97-108). */
+export const MALFORMED_CUSTOM_THEME_TOML = `appearance = "dark"
+this-is-not = "valid theme schema"
+[syntax
+shiki_theme = "missing closing bracket"
+`;
+
+export function customThemesDir(home: string, xdg: string): string {
+  const appDir = appDirFor(home, xdg, resolveAoeBinary());
+  return join(appDir, "themes");
+}
+
+/** Seed a `<name>.toml` file under the isolated app dir's `themes/`
+ *  directory. Caller passes both `home` and the per-test XDG path; the
+ *  resolution mirrors `appDirFor` so the same binary that the spec
+ *  resolves will discover the file on boot. */
+export function seedCustomTheme(
+  home: string,
+  xdg: string,
+  name: string,
+  body: string,
+): string {
+  const dir = customThemesDir(home, xdg);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${name}.toml`);
+  writeFileSync(path, body);
+  return path;
+}
+
+export interface ThemeDocumentSnapshot {
+  datasetTheme: string | undefined;
+  datasetAppearance: string | undefined;
+  colorScheme: string;
+  surface900: string;
+}
+
+/** Snapshot the observable side-effects of `applyResolvedTheme` on the
+ *  root element. Returning a strict shape (rather than asserting inline)
+ *  lets the failure-mode specs compare a single object against a
+ *  pre-change baseline without re-reading per-property. */
+export async function readThemeFromDocument(
+  page: Page,
+): Promise<ThemeDocumentSnapshot> {
+  return await page.evaluate(() => {
+    const root = document.documentElement;
+    return {
+      datasetTheme: root.dataset.theme,
+      datasetAppearance: root.dataset.themeAppearance,
+      colorScheme: root.style.colorScheme,
+      surface900: root.style.getPropertyValue("--color-surface-900").trim(),
+    };
+  });
+}

--- a/web/tests/live/cockpit-stories/composer-ios-dictation.spec.ts
+++ b/web/tests/live/cockpit-stories/composer-ios-dictation.spec.ts
@@ -1,0 +1,222 @@
+// User story: iOS Safari native dictation into the cockpit composer
+// commits each partial recognition exactly once instead of re-appending
+// the prior partial on every event (#1431).
+//
+// The bug shape on real iOS: WebKit fires `beforeinput` + `input` with
+// `inputType: "insertReplacementText"` per partial. WebKit tracks a
+// private range pointer into the textarea's text storage, and any JS
+// write to `textarea.value` via the property setter invalidates that
+// pointer, so the next partial appends instead of replacing. The fix
+// detects the burst, suppresses assistant-ui's controlled-input flush
+// for the duration, buffers the textarea value, and drains the buffer
+// into `composerRuntime.setText` once at burst end (timeout, blur, or
+// a non-replacement input event).
+//
+// Chromium does not reproduce the WebKit pointer-reset itself, so this
+// spec exercises the new code path end-to-end and asserts the
+// observable invariants:
+//   - During the burst, assistant-ui state stays frozen (the localStorage
+//     draft, which mirrors composerRuntime state with a 250 ms debounce,
+//     does NOT update per replacement event).
+//   - After blur, the buffered text flushes into composerRuntime state,
+//     and the draft picks up the final dictated phrase exactly once.
+//   - The textarea still displays the final phrase exactly once with no
+//     duplication artifacts.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+
+base(
+  "iOS dictation commits each partial exactly once, syncs on blur",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-ios-dictation" }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find((s) => s.title === "story-ios-dictation");
+      if (!seeded) throw new Error("seeded session 'story-ios-dictation' missing");
+      const sessionId = seeded.id;
+
+      await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+      await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+      await waitForCockpitView(page);
+
+      const composer = page.getByRole("textbox", { name: /Send a message/i });
+      await composer.click();
+      await expect(composer).toBeFocused();
+
+      // Simulate the WebKit dictation emission shape. Each partial:
+      //   1. dispatch a cancelable `beforeinput` with
+      //      `inputType: "insertReplacementText"` so the composer's
+      //      `onBeforeInput` flips the burst flag.
+      //   2. set `textarea.value` via the native property setter, the
+      //      way WebKit would after the replacement is committed.
+      //   3. dispatch a non-cancelable `input` with the same inputType
+      //      so React's `onChange` runs and the composer's interceptor
+      //      can preventDefault on the composed assistant-ui handler.
+      const partials = [
+        "open",
+        "open the",
+        "open the diff",
+        "open the diff viewer",
+      ];
+      for (const partial of partials) {
+        await composer.evaluate((el, text) => {
+          const ta = el as HTMLTextAreaElement;
+          const beforeEvent = new InputEvent("beforeinput", {
+            bubbles: true,
+            cancelable: true,
+            inputType: "insertReplacementText",
+            data: text,
+          });
+          ta.dispatchEvent(beforeEvent);
+          const setter = Object.getOwnPropertyDescriptor(
+            HTMLTextAreaElement.prototype,
+            "value",
+          )?.set;
+          setter?.call(ta, text);
+          const inputEvent = new InputEvent("input", {
+            bubbles: true,
+            cancelable: false,
+            inputType: "insertReplacementText",
+            data: text,
+          });
+          ta.dispatchEvent(inputEvent);
+        }, partial);
+      }
+
+      // While the burst is active the composer should be holding the
+      // latest textarea value in its ref, NOT pushing it through
+      // composerRuntime. The localStorage draft mirrors composerRuntime
+      // state, so it should still be empty (or null) immediately after
+      // the burst events.
+      const draftKey = `cockpit:draft:${sessionId}`;
+      const draftMid = await page.evaluate(
+        (k) => localStorage.getItem(k),
+        draftKey,
+      );
+      expect(draftMid ?? "").toBe("");
+
+      // Textarea displays the final dictated phrase exactly once, no
+      // duplication artifacts from the simulated replacement chain.
+      await expect(composer).toHaveValue("open the diff viewer");
+
+      // Blur flushes the buffer into composerRuntime. The draft
+      // subscriber then writes the final phrase to localStorage on its
+      // 250 ms debounce.
+      await composer.blur();
+
+      await expect
+        .poll(
+          async () =>
+            await page.evaluate((k) => localStorage.getItem(k), draftKey),
+          { timeout: 5_000 },
+        )
+        .toBe("open the diff viewer");
+
+      await expect(composer).toHaveValue("open the diff viewer");
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "regular typing after dictation is unaffected",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-ios-dictation-then-type" }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find(
+        (s) => s.title === "story-ios-dictation-then-type",
+      );
+      if (!seeded)
+        throw new Error("seeded session 'story-ios-dictation-then-type' missing");
+      const sessionId = seeded.id;
+
+      await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+      await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+      await waitForCockpitView(page);
+
+      const composer = page.getByRole("textbox", { name: /Send a message/i });
+      await composer.click();
+
+      // One dictation burst, then a real keystroke. The keystroke fires
+      // `beforeinput` + `input` with `inputType: "insertText"`, which
+      // should end the burst and let the keystroke flow normally to
+      // assistant-ui state. The final composer state must include both
+      // the dictated text and the appended keystroke text.
+      await composer.evaluate((el) => {
+        const ta = el as HTMLTextAreaElement;
+        ta.dispatchEvent(
+          new InputEvent("beforeinput", {
+            bubbles: true,
+            cancelable: true,
+            inputType: "insertReplacementText",
+            data: "hello",
+          }),
+        );
+        const setter = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          "value",
+        )?.set;
+        setter?.call(ta, "hello");
+        ta.dispatchEvent(
+          new InputEvent("input", {
+            bubbles: true,
+            cancelable: false,
+            inputType: "insertReplacementText",
+            data: "hello",
+          }),
+        );
+      });
+
+      // Place the caret at end so the appended keystroke lands after
+      // the dictated text, mirroring what a real user would do.
+      await composer.evaluate((el) => {
+        const ta = el as HTMLTextAreaElement;
+        ta.setSelectionRange(ta.value.length, ta.value.length);
+      });
+
+      // Type a single character via Playwright; this simulates a real
+      // keyboard keystroke and exercises the burst-end-on-non-replacement
+      // branch of the state machine.
+      await composer.pressSequentially("!");
+
+      await expect(composer).toHaveValue("hello!");
+
+      await composer.blur();
+
+      const draftKey = `cockpit:draft:${sessionId}`;
+      await expect
+        .poll(
+          async () =>
+            await page.evaluate((k) => localStorage.getItem(k), draftKey),
+          { timeout: 5_000 },
+        )
+        .toBe("hello!");
+    } finally {
+      await serve.stop();
+    }
+  },
+);

--- a/web/tests/live/cockpit-stories/settings-theme-color-mode.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-theme-color-mode.spec.ts
@@ -1,0 +1,117 @@
+// Color-mode field PATCHes but does NOT dispatch the theme repaint
+// event (#1405).
+//
+// ThemeSettings.tsx:34 early-returns from `save()` for any field other
+// than `name`, so only theme.name selections drive the dashboard
+// repaint. Color mode is a TUI-only setting (palette downsample for
+// 256-color terminals); a refactor that drops the early-return would
+// wastefully re-fetch /api/themes/<name> and dispatch
+// aoe:theme-picker-changed on every color-mode toggle, repainting the
+// dashboard on a TUI-only setting.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import { settingsSelectByLabel } from "../../helpers/cockpit";
+
+base("color-mode change PATCHes but does not dispatch theme-picker-changed", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    // Capture both theme events before the SPA mounts so any dispatch
+    // is observable. addInitScript runs before any document script in
+    // each page (and survives reloads).
+    await page.addInitScript(() => {
+      const w = window as unknown as {
+        __pickerFired?: number;
+        __changedFired?: number;
+      };
+      w.__pickerFired = 0;
+      w.__changedFired = 0;
+      window.addEventListener("aoe:theme-picker-changed", () => {
+        w.__pickerFired = (w.__pickerFired ?? 0) + 1;
+      });
+      window.addEventListener("aoe:theme-changed", () => {
+        w.__changedFired = (w.__changedFired ?? 0) + 1;
+      });
+    });
+
+    await page.goto(`${serve.baseUrl}/settings/theme`);
+    await expect(page.getByRole("heading", { name: "Theme" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const colorMode = settingsSelectByLabel(page, "Color mode");
+    await expect(colorMode).toBeVisible({ timeout: 10_000 });
+
+    // useResolvedTheme fires aoe:theme-changed once on mount when its
+    // /api/theme/current resolves. Reset both counters AFTER mount so
+    // the assertion below targets only events the color-mode pick
+    // triggers.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () =>
+              (window as unknown as { __changedFired?: number })
+                .__changedFired ?? 0,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(0);
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __pickerFired?: number;
+        __changedFired?: number;
+      };
+      w.__pickerFired = 0;
+      w.__changedFired = 0;
+    });
+
+    const before = await page.evaluate(
+      () => document.documentElement.dataset.theme,
+    );
+    const initialMode = await colorMode.inputValue();
+    const nextMode = initialMode === "palette" ? "truecolor" : "palette";
+
+    await colorMode.selectOption(nextMode);
+    await expect(colorMode).toHaveValue(nextMode);
+
+    // The PATCH lands; this poll reads the persisted value back via
+    // GET /api/profiles/<name>/settings so a regression that drops the
+    // write surfaces here, not as a missing event later.
+    const profiles: Array<{ name: string; is_default?: boolean }> = await fetch(
+      `${serve.baseUrl}/api/profiles`,
+    ).then((r) => r.json());
+    const defaultProfile =
+      profiles.find((p) => p.is_default)?.name ?? profiles[0]?.name ?? "main";
+    const profileUrl = `${serve.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
+    await expect(async () => {
+      const after = await fetch(profileUrl).then((r) => r.json());
+      expect(after?.theme?.color_mode).toBe(nextMode);
+    }).toPass({ timeout: 5_000 });
+
+    // The contract is "neither event fires for a color-mode change."
+    // A fixed 500ms wait is enough; the dispatch would have happened
+    // synchronously inside save().
+    await page.waitForTimeout(500);
+    const fired = await page.evaluate(() => ({
+      picker:
+        (window as unknown as { __pickerFired?: number }).__pickerFired ?? 0,
+      changed:
+        (window as unknown as { __changedFired?: number }).__changedFired ?? 0,
+    }));
+    expect(fired.picker).toBe(0);
+    expect(fired.changed).toBe(0);
+
+    const after = await page.evaluate(
+      () => document.documentElement.dataset.theme,
+    );
+    expect(after).toBe(before);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/settings-theme-custom-malformed.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-theme-custom-malformed.spec.ts
@@ -1,0 +1,72 @@
+// User story: a malformed custom theme TOML in `${appDir}/themes/`
+// does NOT break the settings dropdown; builtins still load and can be
+// picked (#1405).
+//
+// `discover_custom_themes` (src/tui/styles/mod.rs:86) scans by file
+// stem and surfaces the malformed name in /api/themes alongside the
+// builtins; `load_custom_theme` (mod.rs:124) returns None on parse
+// failure, so a user who selects the malformed entry gets the default
+// fallback palette. The user-observable contract this spec locks is
+// narrower: dropping a bad TOML in the dir must not 500 the settings
+// page or wipe the builtin list. Without this, a regression that
+// propagates the parse error up through `available_themes` would block
+// the entire theme picker.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import { openSettingsTab, settingsSelectByLabel } from "../../helpers/cockpit";
+import {
+  MALFORMED_CUSTOM_THEME_TOML,
+  seedCustomTheme,
+} from "../../helpers/theme";
+
+const MALFORMED_NAME = "aoe-story-malformed";
+const SWITCH_TO = "dracula";
+
+base("malformed custom theme TOML does not break the dropdown", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, xdg }) => {
+      seedCustomTheme(home, xdg, MALFORMED_NAME, MALFORMED_CUSTOM_THEME_TOML);
+    },
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings`);
+    await openSettingsTab(page, "Theme");
+
+    const themeSelect = settingsSelectByLabel(page, "Theme");
+    await expect(themeSelect).toBeVisible({ timeout: 10_000 });
+
+    // Dropdown still populates: builtins are there and can be picked.
+    // We assert dracula specifically because the rest of the suite
+    // uses it as the switch-target; if the builtin set ever changes,
+    // pick any non-default builtin instead.
+    await expect
+      .poll(
+        async () =>
+          await themeSelect.evaluate((sel: HTMLSelectElement, target) =>
+            Array.from(sel.options).some((o) => o.value === target),
+          SWITCH_TO),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    // Switching to a builtin lands. The PATCH succeeds (the server
+    // does not validate names server-side; it would simply resolve
+    // through `resolve_theme`).
+    await themeSelect.selectOption(SWITCH_TO);
+    await expect(themeSelect).toHaveValue(SWITCH_TO);
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(() => document.documentElement.dataset.theme),
+        { timeout: 10_000 },
+      )
+      .toBe(SWITCH_TO);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/settings-theme-custom.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-theme-custom.spec.ts
@@ -1,0 +1,79 @@
+// User story: a custom theme file in `${appDir}/themes/` is offered in
+// the settings dropdown and, when picked, applies its palette to the
+// dashboard (#1405).
+//
+// `discover_custom_themes` (src/tui/styles/mod.rs:86) scans the dir at
+// daemon startup; `GET /api/themes` returns the merged builtin + custom
+// list. Without this spec, a regression that drops the directory scan
+// (or renames the dir, or stops invoking it from `available_themes`)
+// would ship green: the existing settings-theme-select spec only
+// exercises builtins.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import { openSettingsTab, settingsSelectByLabel } from "../../helpers/cockpit";
+import {
+  VALID_CUSTOM_THEME_TOML,
+  seedCustomTheme,
+} from "../../helpers/theme";
+
+const CUSTOM_NAME = "aoe-story-custom";
+
+base("custom theme TOML appears in the dropdown and applies on pick", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, xdg }) => {
+      seedCustomTheme(home, xdg, CUSTOM_NAME, VALID_CUSTOM_THEME_TOML);
+    },
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings`);
+    await openSettingsTab(page, "Theme");
+
+    const themeSelect = settingsSelectByLabel(page, "Theme");
+    await expect(themeSelect).toBeVisible({ timeout: 10_000 });
+
+    // The dropdown populates from /api/themes; poll for the custom
+    // entry rather than reading once. A non-zero option count alone is
+    // not enough since builtins always populate first.
+    await expect
+      .poll(
+        async () =>
+          await themeSelect.evaluate((sel: HTMLSelectElement, target) =>
+            Array.from(sel.options).some((o) => o.value === target),
+          CUSTOM_NAME),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    await themeSelect.selectOption(CUSTOM_NAME);
+    await expect(themeSelect).toHaveValue(CUSTOM_NAME);
+
+    // applyResolvedTheme runs once the PATCH resolves and the picker
+    // refetches /api/themes/<custom>. The resolved payload's `name`
+    // matches the custom file's stem, so dataset.theme lands on it.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(() => document.documentElement.dataset.theme),
+        { timeout: 10_000 },
+      )
+      .toBe(CUSTOM_NAME);
+
+    // The custom TOML declares `background = "#11131c"`; the web
+    // projection maps theme.background to --color-surface-900. If a
+    // future refactor stops projecting custom theme palettes, this
+    // would fall back to whatever default the server resolves.
+    const surface = await page.evaluate(() =>
+      document.documentElement.style
+        .getPropertyValue("--color-surface-900")
+        .trim(),
+    );
+    expect(surface.toLowerCase()).toBe("#11131c");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/settings-theme-failure-revert.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-theme-failure-revert.spec.ts
@@ -1,0 +1,119 @@
+// A failed PATCH must NOT silently change dataset.theme or fire the
+// repaint event (#1405, originally tracked in #1510).
+//
+// Before the fix, ThemeSettings.save() dispatched
+// aoe:theme-picker-changed immediately, then awaited the PATCH; the
+// dashboard repainted to the user's pick even when the server
+// rejected the write. On reload the page snapped back to the
+// persisted value and the user saw a silent revert. The fix at
+// ThemeSettings.tsx:34-37 gates the dispatch on `await result === true`.
+//
+// This spec spawns a real `aoe serve`, then intercepts
+// `PATCH /api/profiles/<name>/settings` from the browser side via
+// `page.route()` so the response is a 500 even though the rest of
+// the surface is real. Locks: dataset.theme does NOT change, and the
+// aoe:theme-picker-changed event never fires.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import { settingsSelectByLabel } from "../../helpers/cockpit";
+
+base("PATCH 500 does not silently change dataset.theme or dispatch picker event", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.addInitScript(() => {
+      const w = window as unknown as { __pickerFired?: number };
+      w.__pickerFired = 0;
+      window.addEventListener("aoe:theme-picker-changed", () => {
+        w.__pickerFired = (w.__pickerFired ?? 0) + 1;
+      });
+    });
+
+    // Reject the settings PATCH at the browser boundary. The rest of
+    // the surface (themes list, current theme, GETs against the
+    // profile) stays on the real serve so the rendering paths behave
+    // like production. Only the write path 500s.
+    await page.route(/.*\/api\/profiles\/[^/]+\/settings$/, (route) => {
+      if (route.request().method() === "PATCH") {
+        return route.fulfill({ status: 500, body: "boom" });
+      }
+      return route.continue();
+    });
+
+    await page.goto(`${serve.baseUrl}/settings/theme`);
+    await expect(page.getByRole("heading", { name: "Theme" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const themeSelect = settingsSelectByLabel(page, "Theme");
+    await expect(themeSelect).toBeVisible({ timeout: 10_000 });
+    await expect
+      .poll(async () => themeSelect.locator("option").count(), {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(1);
+
+    // useResolvedTheme's mount-time apply runs before we pick. Wait
+    // for it to settle, then take the baseline and reset the picker
+    // counter so the assertion below targets only the pick attempt.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () => document.documentElement.dataset.theme ?? "",
+          ),
+        { timeout: 5_000 },
+      )
+      .not.toBe("");
+    await page.evaluate(() => {
+      (window as unknown as { __pickerFired?: number }).__pickerFired = 0;
+    });
+    const datasetBefore = await page.evaluate(
+      () => document.documentElement.dataset.theme,
+    );
+    const surfaceBefore = await page.evaluate(() =>
+      document.documentElement.style
+        .getPropertyValue("--color-surface-900")
+        .trim(),
+    );
+
+    const currentValue = await themeSelect.inputValue();
+    const optionValues = await themeSelect
+      .locator("option")
+      .evaluateAll((els) => (els as HTMLOptionElement[]).map((o) => o.value));
+    const next = optionValues.find((v) => v && v !== currentValue);
+    expect(next, "themes list must include at least two options").toBeDefined();
+
+    await themeSelect.selectOption(next!);
+
+    // Wait long enough that the PATCH round-trip would have settled.
+    // The save() awaits the PATCH; on the 500 it returns false and
+    // never dispatches the picker event. A short fixed wait is
+    // enough here since the contract is "never fires".
+    await page.waitForTimeout(600);
+
+    const picker = await page.evaluate(
+      () =>
+        (window as unknown as { __pickerFired?: number }).__pickerFired ?? 0,
+    );
+    expect(picker).toBe(0);
+
+    const datasetAfter = await page.evaluate(
+      () => document.documentElement.dataset.theme,
+    );
+    const surfaceAfter = await page.evaluate(() =>
+      document.documentElement.style
+        .getPropertyValue("--color-surface-900")
+        .trim(),
+    );
+    expect(datasetAfter).toBe(datasetBefore);
+    expect(surfaceAfter).toBe(surfaceBefore);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/sidebar-reorder-reload-persists.spec.ts
+++ b/web/tests/live/cockpit-stories/sidebar-reorder-reload-persists.spec.ts
@@ -1,0 +1,91 @@
+// User story: a sidebar drag-reorder survives a full page reload
+// (#1419). The live `workspace-ordering.spec.ts` round-trips one drag
+// and confirms `GET /api/sessions` returns the merged ordering, but
+// it does not refresh the page; a regression in the bootstrap path
+// that re-derives ordering from `created_at` instead of honoring the
+// server-supplied `workspace_ordering` would ship green there.
+//
+// This spec drags the bottom row to the top, awaits the PUT round-
+// trip, reloads the page, and asserts the new order paints from the
+// initial `GET /api/sessions` response (not after a delayed
+// client-side sort).
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions } from "../../helpers/aoeServe";
+import {
+  readVisibleSessionTitles,
+  seedSessionsInRepo,
+} from "../../helpers/sidebar";
+
+base("sidebar reorder persists across a full page reload", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionsInRepo({ titles: ["alpha", "beta", "gamma"] }),
+  });
+
+  try {
+    const seeded = await listSessions(serve.baseUrl);
+    expect(seeded).toHaveLength(3);
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto(`${serve.baseUrl}/`);
+
+    await expect
+      .poll(() => readVisibleSessionTitles(page), { timeout: 8_000 })
+      .toEqual(expect.arrayContaining(["alpha", "beta", "gamma"]));
+    const initial = await readVisibleSessionTitles(page);
+    expect(initial).toHaveLength(3);
+
+    const wrappers = page.locator(
+      "[aria-roledescription='Press and hold to reorder']",
+    );
+    await expect(wrappers).toHaveCount(3);
+
+    // Wait for the PUT so we know the server persisted before the
+    // reload. The route-attach captures it without altering response.
+    const putWait = page.waitForResponse(
+      (r) =>
+        r.url().endsWith("/api/workspace-ordering") &&
+        r.request().method() === "PUT" &&
+        r.status() < 400,
+      { timeout: 8_000 },
+    );
+
+    const sourceBox = await wrappers.nth(2).boundingBox();
+    const targetBox = await wrappers.nth(0).boundingBox();
+    if (!sourceBox || !targetBox) throw new Error("row box missing");
+
+    await page.mouse.move(
+      sourceBox.x + sourceBox.width - 4,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.waitForTimeout(250);
+    await page.mouse.move(
+      targetBox.x + targetBox.width / 2,
+      targetBox.y + targetBox.height / 2,
+      { steps: 12 },
+    );
+    await page.mouse.up();
+
+    await putWait;
+
+    const expectedAfter = [initial[2], initial[0], initial[1]];
+    await expect
+      .poll(() => readVisibleSessionTitles(page), { timeout: 4_000 })
+      .toEqual(expectedAfter);
+
+    // Reload the whole page. The new visual order must come from the
+    // initial server response, not from a delayed PUT or sort. Poll
+    // because the very first paint can briefly show the bootstrap
+    // shell before sessions land.
+    await page.reload();
+    await expect
+      .poll(() => readVisibleSessionTitles(page), { timeout: 8_000 })
+      .toEqual(expectedAfter);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/startup-error-banner-native-binary.spec.ts
+++ b/web/tests/live/cockpit-stories/startup-error-banner-native-binary.spec.ts
@@ -1,0 +1,131 @@
+// User story: the red "Cockpit agent failed to start" banner shows
+// the new native-binary-launch-failure remediation and exposes an
+// Open agent log affordance that round-trips the worker-log endpoint.
+//
+// The fake ACP agent's `failOn` script field rejects `session/new`
+// with a JSON-RPC error whose `data.details` matches the native-binary
+// regex; cockpit's spawn path turns that into an AgentStartupError
+// event the React banner reads. See #1449.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+const NATIVE_BINARY_DETAILS =
+  "Claude Code native binary at /usr/lib/node_modules/@agentclientprotocol/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64/claude exists but failed to launch.";
+
+const SCRIPT = {
+  failOn: {
+    method: "session/new",
+    code: -32603,
+    message: "Internal error",
+    data: { details: NATIVE_BINARY_DETAILS },
+  },
+};
+
+interface ReplayFrameEvent {
+  AgentStartupError?: { message?: string };
+}
+
+async function pollForStartupError(
+  baseUrl: string,
+  sessionId: string,
+  timeoutMs = 20_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = await fetch(
+      `${baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+    );
+    if (res.ok) {
+      const body = (await res.json()) as {
+        frames?: Array<{ event?: ReplayFrameEvent }>;
+      };
+      for (const f of body.frames ?? []) {
+        const msg = f.event?.AgentStartupError?.message;
+        if (typeof msg === "string" && msg.length > 0) return msg;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error("never observed AgentStartupError on replay");
+}
+
+base("startup banner: native-binary branch + agent-log disclosure", async ({ page }, testInfo) => {
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-native-binary-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-native-binary" }),
+    });
+
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-native-binary");
+    if (!seeded) throw new Error("seeded session 'story-native-binary' missing");
+    const sessionId = seeded.id;
+
+    // Bypass enableCockpitAndWait: it throws when an AgentStartupError
+    // shows up on replay, which is exactly the state this spec is
+    // trying to land in. Hit the enable endpoint directly and then
+    // poll for the typed error event ourselves.
+    const enableRes = await fetch(
+      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
+      { method: "POST" },
+    );
+    expect(enableRes.ok).toBe(true);
+    const msg = await pollForStartupError(serve.baseUrl, sessionId);
+    expect(msg).toContain("native binary");
+    expect(msg).toContain("failed to launch");
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+
+    // Banner is in the cockpit chrome above the composer. Match on the
+    // header text plus a piece of the new remediation copy so a future
+    // rewording of either alone surfaces here.
+    const banner = page.getByText("Cockpit agent failed to start");
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/Architecture mismatch/i)).toBeVisible();
+    await expect(page.getByText(/aoe cockpit doctor --fix/)).toHaveCount(0);
+
+    const toggle = page.getByTestId("cockpit-agent-log-toggle");
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    // Disclosure can terminate in any of: populated <pre>, "No log
+    // output yet", "Log file exists but is empty", or an error
+    // message. All confirm the endpoint round-tripped. The <pre> is
+    // nested inside <div cockpit-agent-log-body>, so asserting on the
+    // body alone covers every terminal state without strict-mode
+    // multi-match ambiguity.
+    const body = page.getByTestId("cockpit-agent-log-body");
+    await expect(body).toBeVisible({ timeout: 10_000 });
+    await expect(body).toHaveText(
+      /Loading log|Could not load log|No log output yet|Log file exists but is empty|.+/,
+    );
+
+    // Refresh re-issues the GET. Body remains the canonical container.
+    await page.getByTestId("cockpit-agent-log-refresh").click();
+    await expect(body).toBeVisible({ timeout: 5_000 });
+  } finally {
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/web/tests/live/cockpit-worker-log.spec.ts
+++ b/web/tests/live/cockpit-worker-log.spec.ts
@@ -1,0 +1,143 @@
+// Live coverage for GET /api/sessions/:id/cockpit/worker-log.
+//
+// Endpoint surfaces the per-session runner stderr drain (same content
+// `aoe cockpit logs --session <id>` reads) so a dashboard user without
+// host terminal access can see verbatim adapter errors. See #1449.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+import { enableCockpitAndWait } from "../helpers/cockpit";
+
+interface WorkerLogResponse {
+  path: string;
+  exists: boolean;
+  tail: string;
+  lines_returned: number;
+  truncated: boolean;
+}
+
+base("worker-log returns exists=false before the runner writes anything", async ({}, testInfo) => {
+  const title = "worker-log-empty";
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === title);
+    if (!seeded) throw new Error(`seeded session '${title}' missing`);
+    const sessionId = seeded.id;
+
+    const res = await fetch(
+      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/worker-log?tail=200`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as WorkerLogResponse;
+    expect(body.exists).toBe(false);
+    expect(body.tail).toBe("");
+    expect(body.lines_returned).toBe(0);
+    expect(body.truncated).toBe(false);
+    expect(body.path).toMatch(/cockpit-workers/);
+  } finally {
+    await serve.stop();
+  }
+});
+
+base("worker-log returns the runner tail after cockpit spawns", async ({}, testInfo) => {
+  const title = "worker-log-populated";
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === title);
+    if (!seeded) throw new Error(`seeded session '${title}' missing`);
+    const sessionId = seeded.id;
+
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    // The runner emits a handful of `tracing` lines during init
+    // (`cockpit.runner`, `cockpit.acp.spawn`, etc.) before quiescing.
+    // Poll briefly until the tail is non-empty so the assertion does
+    // not race the post-handshake log flush.
+    const deadline = Date.now() + 10_000;
+    let body: WorkerLogResponse | null = null;
+    while (Date.now() < deadline) {
+      const res = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/worker-log?tail=200`,
+      );
+      expect(res.status).toBe(200);
+      body = (await res.json()) as WorkerLogResponse;
+      if (body.exists && body.lines_returned > 0) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    expect(body, "worker-log never reported a populated tail").not.toBeNull();
+    expect(body!.exists).toBe(true);
+    expect(body!.lines_returned).toBeGreaterThan(0);
+    expect(body!.tail.length).toBeGreaterThan(0);
+  } finally {
+    await serve.stop();
+  }
+});
+
+base("worker-log clamps an oversized tail request to the server max", async ({}, testInfo) => {
+  const title = "worker-log-clamp";
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === title);
+    if (!seeded) throw new Error(`seeded session '${title}' missing`);
+    const sessionId = seeded.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    const res = await fetch(
+      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/worker-log?tail=999999`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as WorkerLogResponse;
+    // Hard ceiling enforced server-side. The fact the request did not
+    // 4xx is the contract: clamping is silent.
+    expect(body.lines_returned).toBeLessThanOrEqual(2000);
+  } finally {
+    await serve.stop();
+  }
+});
+
+base("worker-log returns 404 for an unknown session id", async ({}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "worker-log-404" }),
+  });
+
+  try {
+    const res = await fetch(
+      `${serve.baseUrl}/api/sessions/does-not-exist-9d34/cockpit/worker-log`,
+    );
+    expect(res.status).toBe(404);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/settings-persistence-theme-passphrase.spec.ts
+++ b/web/tests/live/settings-persistence-theme-passphrase.spec.ts
@@ -110,14 +110,20 @@ async function bootDashboardAndNavigate(
   path: string,
 ): Promise<void> {
   await seedAuth(page, handle);
-  await page.goto(handle.baseUrl);
-  // Wait until at least one authenticated API call lands successfully.
-  // /api/about is served unconditionally once auth passes, so once it
-  // resolves the SPA's cookie+binding pair is known good.
-  await page.waitForResponse(
-    (res) => res.url().endsWith("/api/about") && res.status() === 200,
-    { timeout: 10_000 },
-  );
+  // Register the response listener BEFORE navigating: the SPA fires
+  // /api/about during bootstrap, which can resolve before `page.goto`
+  // settles. Attaching the wait afterwards races that and would miss the
+  // response, then time out. `Promise.all` attaches the listener first,
+  // then triggers the navigation. /api/about is served unconditionally
+  // once auth passes, so once it resolves the SPA's cookie+binding pair is
+  // known good.
+  await Promise.all([
+    page.waitForResponse(
+      (res) => res.url().endsWith("/api/about") && res.status() === 200,
+      { timeout: 10_000 },
+    ),
+    page.goto(handle.baseUrl),
+  ]);
   if (path !== "/") {
     await page.evaluate((target) => {
       window.history.pushState({}, "", target);
@@ -193,11 +199,16 @@ test("theme picker persists across reload + restart without passphrase prompt", 
     )
     .toBe("#282a36");
 
-  await page.reload();
-  await page.waitForResponse(
-    (res) => res.url().endsWith("/api/about") && res.status() === 200,
-    { timeout: 10_000 },
-  );
+  // Same register-before-navigate guard as the initial boot: the post-reload
+  // /api/about can resolve before `page.reload()` settles, so attach the
+  // listener first via `Promise.all`.
+  await Promise.all([
+    page.waitForResponse(
+      (res) => res.url().endsWith("/api/about") && res.status() === 200,
+      { timeout: 10_000 },
+    ),
+    page.reload(),
+  ]);
   const afterReload = await fetch(profileUrl, { headers: authHeaders(servePreauthed) }).then(
     (r) => r.json(),
   );

--- a/web/tests/live/triage-archive.spec.ts
+++ b/web/tests/live/triage-archive.spec.ts
@@ -65,6 +65,14 @@ base.describe("sidebar archive via context menu (#1581)", () => {
       const sunkSection = page.locator("[data-testid='sidebar-sunk-section']");
       await expect(sunkSection).toBeVisible({ timeout: 5_000 });
 
+      // Regression for #1600: with every workspace in the repo group
+      // sunk, the orphan group header must disappear from the live
+      // list. The sole live session in this project was just archived,
+      // so no repo group header should remain.
+      await expect(
+        page.locator("[data-testid='sidebar-group-header']"),
+      ).toHaveCount(0);
+
       // Default collapsed: the archived row is not visible until the
       // footer is expanded.
       const archivedRowInFooter = sunkSection.locator(
@@ -155,6 +163,12 @@ base.describe("sidebar archive via context menu (#1581)", () => {
           { timeout: 5_000 },
         )
         .toBeNull();
+
+      // Regression for #1600: once the row is back in the live tier
+      // the repo group header reappears.
+      await expect(
+        page.locator("[data-testid='sidebar-group-header']"),
+      ).toHaveCount(1, { timeout: 5_000 });
     } finally {
       await serve.stop();
     }

--- a/web/tests/live/workspace-ordering.spec.ts
+++ b/web/tests/live/workspace-ordering.spec.ts
@@ -18,65 +18,12 @@
 // so the hold has to outlast the activation window without moving more
 // than 8px.
 
-import { spawnSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
-import { join } from "node:path";
 import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions } from "../helpers/aoeServe";
 import {
-  spawnAoeServe,
-  listSessions,
-  resolveAoeBinary,
-} from "../helpers/aoeServe";
-
-function seedThreeSessionsInOneRepo(titles: [string, string, string]) {
-  return ({ home, env }: { home: string; shimBin: string; env: NodeJS.ProcessEnv }) => {
-    const binary = resolveAoeBinary();
-    const projectDir = join(home, "repo");
-    mkdirSync(projectDir, { recursive: true });
-    spawnSync("git", ["init", "-q"], { cwd: projectDir });
-    spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
-      cwd: projectDir,
-      env: {
-        ...env,
-        GIT_AUTHOR_NAME: "t",
-        GIT_AUTHOR_EMAIL: "t@t",
-        GIT_COMMITTER_NAME: "t",
-        GIT_COMMITTER_EMAIL: "t@t",
-      },
-    });
-    for (const title of titles) {
-      const res = spawnSync(
-        binary,
-        ["add", projectDir, "-t", title, "-c", "claude"],
-        { env },
-      );
-      if (res.status !== 0) {
-        throw new Error(
-          `aoe add failed for ${title}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
-        );
-      }
-    }
-  };
-}
-
-async function readVisibleSessionTitles(page: import("@playwright/test").Page): Promise<string[]> {
-  return page.evaluate(() => {
-    const rows = Array.from(
-      document.querySelectorAll<HTMLElement>(
-        "[data-testid='sidebar-session-row']",
-      ),
-    );
-    // Scope to the label span specifically (see WorkspaceSidebar.tsx:587).
-    // A bare `[title]` selector can pick up a Wakeup or Plan chip if either
-    // ever renders on the row.
-    return rows
-      .map(
-        (r) =>
-          r.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
-      )
-      .filter(Boolean);
-  });
-}
+  readVisibleSessionTitles,
+  seedSessionsInRepo,
+} from "../helpers/sidebar";
 
 base.describe("workspace ordering live round-trip (#1220)", () => {
   base("press-and-hold drag reorders and round-trips PUT /api/workspace-ordering", async ({ page }, testInfo) => {
@@ -89,7 +36,7 @@ base.describe("workspace ordering live round-trip (#1220)", () => {
       authMode: "none",
       workerIndex: testInfo.workerIndex,
       parallelIndex: testInfo.parallelIndex,
-      seedFn: seedThreeSessionsInOneRepo(["alpha", "beta", "gamma"]),
+      seedFn: seedSessionsInRepo({ titles: ["alpha", "beta", "gamma"] }),
     });
 
     try {

--- a/web/tests/mobile-settings-header.spec.ts
+++ b/web/tests/mobile-settings-header.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "./helpers/mockedTest";
+import { devices } from "@playwright/test";
+
+// Anti-regression for #1430. The old header crammed Back + "Settings" title
+// + ProfileSelector into one h-12 row; ProfileSelector was wrapped in a
+// `flex-1 justify-center` div that squeezed the back affordance and title
+// down to the left edge at mobile widths. The fix makes the header use
+// flex-wrap so the ProfileSelector drops onto a second row below md, and
+// keeps a single-row layout (selector on the right) on md+.
+
+test.use({ ...devices["iPhone 13"] });
+
+test.describe("Mobile settings header (iPhone 13)", () => {
+  test("Back button and title sit on a row above the ProfileSelector", async ({ page }) => {
+    await page.goto("/settings");
+
+    const backBtn = page.getByRole("button", { name: /Back/ });
+    const profileLabel = page.getByText("Profile", { exact: true });
+
+    await expect(backBtn).toBeVisible();
+    await expect(profileLabel).toBeVisible();
+
+    const backBox = await backBtn.boundingBox();
+    const profileBox = await profileLabel.boundingBox();
+    expect(backBox).not.toBeNull();
+    expect(profileBox).not.toBeNull();
+    // ProfileSelector must wrap onto its own row, i.e. start at or below
+    // the bottom of the Back button (mobile two-row layout).
+    expect(profileBox!.y).toBeGreaterThanOrEqual(backBox!.y + backBox!.height - 1);
+  });
+
+  test("'Settings' title keeps clear separation from the Back button", async ({ page }) => {
+    await page.goto("/settings");
+    const backBtn = page.getByRole("button", { name: /Back/ });
+    const title = page.getByText("Settings", { exact: true }).first();
+    const backBox = await backBtn.boundingBox();
+    const titleBox = await title.boundingBox();
+    expect(backBox).not.toBeNull();
+    expect(titleBox).not.toBeNull();
+    // gap-x-3 on the header (12px); allow a small fudge for sub-pixel
+    // layout, anything above 6px proves the cramped-against-left-edge
+    // regression is gone.
+    expect(titleBox!.x - (backBox!.x + backBox!.width)).toBeGreaterThan(6);
+  });
+
+  test("settings header does not overflow horizontally at iPhone 13 width", async ({ page }) => {
+    await page.goto("/settings");
+    const header = page.getByTestId("settings-header");
+    await expect(header).toBeVisible();
+    const overflow = await header.evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+  });
+});
+
+test.describe("Mobile settings header (narrow 320px)", () => {
+  test.use({ viewport: { width: 320, height: 568 } });
+
+  test("header stays within viewport at 320px (5.4\" Android narrow case)", async ({ page }) => {
+    await page.goto("/settings");
+    const header = page.getByTestId("settings-header");
+    await expect(header).toBeVisible();
+    const headerBox = await header.boundingBox();
+    expect(headerBox).not.toBeNull();
+    // Header element must fit within the viewport width. Overflow inside
+    // the ProfileSelector row is allowed via overflow-x-auto, but the
+    // header container itself must not push past the viewport edge.
+    expect(headerBox!.width).toBeLessThanOrEqual(320);
+  });
+});

--- a/web/tests/sidebar-context-menu-clamp.spec.ts
+++ b/web/tests/sidebar-context-menu-clamp.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+
+// Regression for #1601: the session-row and repo-group context menus
+// must clamp inside the viewport when opened near the bottom or right
+// edge, so every menu item stays reachable.
+
+interface MockSession {
+  id: string;
+  title: string;
+  project_path: string;
+}
+
+async function mockApis(page: Page, sessions: MockSession[]) {
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: sessions.map((s) => ({
+          id: s.id,
+          title: s.title,
+          project_path: s.project_path,
+          group_path: s.project_path,
+          tool: "claude",
+          status: "Idle",
+          yolo_mode: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: null,
+          last_error: null,
+          branch: null,
+          main_repo_path: null,
+          is_sandboxed: false,
+          has_terminal: true,
+          profile: "default",
+          workspace_repos: [],
+        })),
+        workspace_ordering: [],
+      },
+    });
+  });
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: path === "docker/status" ? {} : [] }),
+    );
+  }
+}
+
+async function menuFitsViewport(page: Page, locator: string) {
+  // Web fonts and icons can grow the menu after first paint, so the
+  // component reclamps via ResizeObserver. Wait for fonts to settle
+  // before sampling the bounding box so this test does not race the
+  // late layout. See #1601.
+  await page.evaluate(() => document.fonts?.ready);
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+  await expect
+    .poll(
+      async () => {
+        const box = await page.locator(locator).boundingBox();
+        if (!box) return null;
+        return (
+          box.x >= 0 &&
+          box.y >= 0 &&
+          box.x + box.width <= viewport!.width &&
+          box.y + box.height <= viewport!.height
+        );
+      },
+      { timeout: 5_000 },
+    )
+    .toBe(true);
+}
+
+test.describe("Sidebar context-menu viewport clamp (#1601)", () => {
+  test("right-click on the bottom session row keeps the menu inside the viewport", async ({
+    page,
+  }) => {
+    await mockApis(page, [
+      { id: "s-1", title: "Mongols", project_path: "/tmp/repo-a" },
+      { id: "s-2", title: "Goths", project_path: "/tmp/repo-b" },
+      { id: "s-3", title: "Persians", project_path: "/tmp/repo-c" },
+    ]);
+    await page.setViewportSize({ width: 900, height: 360 });
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const rows = page.locator("[data-testid='sidebar-session-row']");
+    await expect(rows).toHaveCount(3);
+    const lastRow = rows.last();
+    await lastRow.scrollIntoViewIfNeeded();
+    await lastRow.click({ button: "right" });
+
+    const menu = page.locator("[data-testid='sidebar-context-menu']");
+    await expect(menu).toBeVisible();
+    await menuFitsViewport(page, "[data-testid='sidebar-context-menu']");
+  });
+
+  test("right-click on a repo group header near the bottom clamps the menu", async ({
+    page,
+  }) => {
+    await mockApis(page, [
+      { id: "s-1", title: "Mongols", project_path: "/tmp/repo-a" },
+      { id: "s-2", title: "Goths", project_path: "/tmp/repo-b" },
+      { id: "s-3", title: "Persians", project_path: "/tmp/repo-c" },
+    ]);
+    await page.setViewportSize({ width: 900, height: 360 });
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const headers = page.locator("[data-testid='sidebar-group-header']");
+    await expect(headers).toHaveCount(3);
+    const lastHeader = headers.last();
+    await lastHeader.scrollIntoViewIfNeeded();
+    await lastHeader.click({ button: "right" });
+
+    const menu = page.locator("[data-testid='sidebar-group-context-menu']");
+    await expect(menu).toBeVisible();
+    await menuFitsViewport(page, "[data-testid='sidebar-group-context-menu']");
+  });
+});

--- a/web/tests/sidebar-reorder-click-after-drag-suppressed.spec.ts
+++ b/web/tests/sidebar-reorder-click-after-drag-suppressed.spec.ts
@@ -1,0 +1,56 @@
+// `useSuppressClickAfterDrag` (WorkspaceSidebar.tsx:274-290,
+// 356-371) swallows the synthetic click Chromium dispatches ~250ms
+// after `mouseup` on a drag. Without that, the dropped-on row would
+// receive a click and navigate, defeating the whole drag.
+//
+// This story drags gamma onto alpha's position and asserts that the
+// URL does NOT change to /session/s-a (alpha's id) even though the
+// click would have landed there.
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test("click-after-drag suppression keeps the URL on the source row", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  // Start at "/" (no active session). The synthetic click after the
+  // drag release would try to land on alpha's row (the drop target);
+  // if the suppressor lets it through, the URL flips to /session/s-a.
+  // The contract is "URL stays at /".
+  await page.goto("/");
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(3);
+
+  const sourceBox = await wrappers.nth(2).boundingBox();
+  const targetBox = await wrappers.nth(0).boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("row box missing");
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width - 4,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.waitForTimeout(250);
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 12 },
+  );
+  await page.mouse.up();
+
+  // The drag fires one PUT. After release, the synthetic click would
+  // try to activate alpha (the row under the cursor); the suppressor
+  // swallows it so the URL stays on /.
+  await expect.poll(() => handle.puts.length, { timeout: 3_000 }).toBe(1);
+  await page.waitForTimeout(400);
+  expect(new URL(page.url()).pathname).toBe("/");
+});

--- a/web/tests/sidebar-reorder-cross-group-noop.spec.ts
+++ b/web/tests/sidebar-reorder-cross-group-noop.spec.ts
@@ -1,0 +1,73 @@
+// Drag is constrained to within one repo group: each repo's
+// `SortableContext` lives behind a separate boundary, so an `over.id`
+// that points into a different group's workspace list never matches
+// the active group's reorder logic (WorkspaceSidebar.tsx:1639-1664).
+//
+// Seeds two repos with three workspaces each, drags a row from group
+// A onto a row in group B, and asserts:
+//   - both groups' visual orders are unchanged
+//   - zero PUTs flew (handleDragEnd short-circuits at the `over.id`
+//     check, no `onReorderWorkspaces` call)
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  workspaceId,
+  type MockSessionInput,
+} from "./helpers/sidebarMocks";
+
+test("dragging a row onto a different repo group is a no-op", async ({ page }) => {
+  const repoA = "/tmp/repo-a";
+  const repoB = "/tmp/repo-b";
+  const sessions: MockSessionInput[] = [
+    { id: "a1", title: "alpha-a", project_path: repoA, branch: "feat/1" },
+    { id: "a2", title: "beta-a", project_path: repoA, branch: "feat/2" },
+    { id: "b1", title: "alpha-b", project_path: repoB, branch: "feat/1" },
+    { id: "b2", title: "beta-b", project_path: repoB, branch: "feat/2" },
+  ];
+  const handle = await installSidebarMocks(page, {
+    sessions,
+    ordering: sessions.map((s) => workspaceId(s)),
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(4);
+
+  // First two wrappers belong to repo A, next two to repo B (the
+  // server-supplied ordering controls the render order). Drag the
+  // last A row onto the first B row.
+  const sourceBox = await wrappers.nth(1).boundingBox();
+  const targetBox = await wrappers.nth(2).boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("row box missing");
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width - 4,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.waitForTimeout(250);
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 12 },
+  );
+  await page.mouse.up();
+
+  // Wait a frame so handleDragEnd has had a chance to fire on a
+  // regression that doesn't short-circuit cross-group.
+  await page.waitForTimeout(300);
+
+  const afterOrder = await wrappers.evaluateAll((els) =>
+    els.map(
+      (el) =>
+        el.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
+    ),
+  );
+  expect(afterOrder).toEqual(["alpha-a", "beta-a", "alpha-b", "beta-b"]);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-mobile-flick-scrolls.spec.ts
+++ b/web/tests/sidebar-reorder-mobile-flick-scrolls.spec.ts
@@ -1,0 +1,77 @@
+// A fast vertical scroll-flick on the sidebar must NOT reorder a
+// row. TouchSensor `{ delay: 150, tolerance: 8 }` only promotes after
+// 150ms with movement under 8px; a flick that exceeds tolerance
+// before the delay elapses cancels the activation, so no drag starts
+// and no PUT fires (WorkspaceSidebar.tsx:1631, #1419).
+//
+// Real Playwright `page.touchscreen.tap` is single-finger and only
+// supports tap. To synthesize a multi-frame touchmove sequence we
+// dispatch raw TouchEvents from `page.evaluate`, per the AGENTS.md
+// "Legacy mobile/touch recipe".
+
+import { devices } from "@playwright/test";
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test.use({ ...devices["iPhone 13"] });
+
+test("touch flick on the sidebar does not reorder rows", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Toggle sidebar" }).click();
+
+  const rows = page.getByTestId("sidebar-session-row");
+  await expect(rows).toHaveCount(3);
+  await page.waitForFunction(
+    () => {
+      const r = document
+        .querySelector('[data-testid="sidebar-session-row"]')
+        ?.getBoundingClientRect();
+      return !!r && r.x >= 0 && r.width > 0;
+    },
+    null,
+    { timeout: 5_000 },
+  );
+
+  const box = await rows.nth(0).boundingBox();
+  if (!box) throw new Error("row box missing");
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+
+  // touchStart, then three quick vertical touchMoves well past the
+  // 8px tolerance, then touchEnd, all within ~60ms total wall time.
+  // The TouchSensor sees movement BEFORE the 150ms activation delay
+  // elapses and cancels activation. Driven via CDP so the events
+  // carry through to dnd-kit's document-level listeners the same way
+  // the press-hold recipe does.
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [{ x: cx, y: cy, id: 1 }],
+  });
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x: cx, y: cy + 40, id: 1 }],
+  });
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x: cx, y: cy + 120, id: 1 }],
+  });
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x: cx, y: cy + 240, id: 1 }],
+  });
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [],
+  });
+
+  await page.waitForTimeout(300);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-mobile-press-hold-reorders.spec.ts
+++ b/web/tests/sidebar-reorder-mobile-press-hold-reorders.spec.ts
@@ -1,0 +1,83 @@
+// A press-and-hold past the 150ms TouchSensor delay, followed by a
+// drag past 8px tolerance, DOES reorder on mobile
+// (WorkspaceSidebar.tsx:1631). Locks the activation path so the
+// mobile drag affordance does not silently break when the dnd-kit
+// dependency or its activation constraints change (#1419).
+//
+// Synthesizes TouchEvents from `page.evaluate` per the AGENTS.md
+// "Legacy mobile/touch recipe"; `page.touchscreen.tap` is single-
+// finger and does not satisfy the delay sensor cleanly.
+
+import { devices } from "@playwright/test";
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+  workspaceId,
+} from "./helpers/sidebarMocks";
+
+test.use({ ...devices["iPhone 13"] });
+
+test("touch press-and-hold drag reorders the row and PUTs the new order", async ({ page }) => {
+  const sessions = threeSessionsInOneRepo();
+  const handle = await installSidebarMocks(page, { sessions });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Toggle sidebar" }).click();
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(3);
+  await page.waitForFunction(
+    () => {
+      const r = document
+        .querySelector("[aria-roledescription='Press and hold to reorder']")
+        ?.getBoundingClientRect();
+      return !!r && r.x >= 0 && r.width > 0;
+    },
+    null,
+    { timeout: 5_000 },
+  );
+
+  const sourceBox = await wrappers.nth(2).boundingBox();
+  const targetBox = await wrappers.nth(0).boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("row box missing");
+  const sx = sourceBox.x + sourceBox.width / 2;
+  const sy = sourceBox.y + sourceBox.height / 2;
+  const tx = targetBox.x + targetBox.width / 2;
+  const ty = targetBox.y + targetBox.height / 2;
+
+  // Drive real touch events through the Chrome DevTools Protocol.
+  // Playwright's `page.touchscreen` only exposes `tap`; raw
+  // `Input.dispatchTouchEvent` lets the test hold past the 150ms
+  // delay, then walk the touch across the sidebar one frame at a
+  // time so dnd-kit's TouchSensor activates and its collision
+  // detector resolves to the target row.
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [{ x: sx, y: sy, id: 1 }],
+  });
+  await page.waitForTimeout(220);
+  const frames = 8;
+  for (let i = 1; i <= frames; i++) {
+    const t = i / frames;
+    const x = sx + (tx - sx) * t;
+    const y = sy + (ty - sy) * t;
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [{ x, y, id: 1 }],
+    });
+    await page.waitForTimeout(20);
+  }
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [],
+  });
+
+  // One PUT body with gamma's id at the top of the flat order.
+  await expect.poll(() => handle.puts.length, { timeout: 4_000 }).toBe(1);
+  const sent = handle.puts[0]?.order ?? [];
+  expect(sent[0]).toBe(workspaceId(sessions[2]!));
+});

--- a/web/tests/sidebar-reorder-mobile-tap-navigates.spec.ts
+++ b/web/tests/sidebar-reorder-mobile-tap-navigates.spec.ts
@@ -1,0 +1,49 @@
+// On mobile a tap on a row must navigate, not reorder. dnd-kit's
+// TouchSensor has `{ delay: 150, tolerance: 8 }` activation
+// (WorkspaceSidebar.tsx:1631): a quick tap never crosses the 150ms
+// delay, so the sensor never promotes and the inner Link's click
+// runs as if the wrapper were not draggable (#1419).
+
+import { devices } from "@playwright/test";
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test.use({ ...devices["iPhone 13"] });
+
+test("touch tap on a row navigates", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.goto("/");
+  // On mobile the sidebar is initially closed; open it via the
+  // toggle so the rows have a visible bounding box. The dashboard
+  // exposes the toggle with accessible name "Toggle sidebar".
+  await page.getByRole("button", { name: "Toggle sidebar" }).click();
+
+  const rows = page.getByTestId("sidebar-session-row");
+  await expect(rows).toHaveCount(3);
+  await page.waitForFunction(
+    () => {
+      const r = document
+        .querySelector('[data-testid="sidebar-session-row"]')
+        ?.getBoundingClientRect();
+      return !!r && r.x >= 0 && r.width > 0;
+    },
+    null,
+    { timeout: 5_000 },
+  );
+
+  const box = await rows.nth(1).boundingBox();
+  if (!box) throw new Error("row box missing");
+  await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2);
+
+  await expect(page).toHaveURL(/\/session\/s-b$/, { timeout: 5_000 });
+
+  // No PUT fired; the gesture never started a drag.
+  await page.waitForTimeout(200);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-read-only.spec.ts
+++ b/web/tests/sidebar-reorder-read-only.spec.ts
@@ -1,0 +1,62 @@
+// Read-only viewers cannot drag rows: `useSortable({ disabled })` is
+// fed `dragOff = !!props.readOnly || !!props.dragDisabled`
+// (WorkspaceSidebar.tsx:389-391), `listeners` are not spread onto the
+// wrapper, and `aria-roledescription` is omitted (line 423-425). The
+// onDragEnd callback is also gated at the DndContext level
+// (line 1855). A press-and-hold attempt must produce no visual lift
+// and no PUT (#1419).
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test("read-only viewer cannot drag sidebar rows", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+    readOnly: true,
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  // The drag-enabled wrapper carries
+  // `aria-roledescription="Press and hold to reorder"`. In read-only
+  // mode the attribute is omitted; the row should not match at all.
+  const dragWrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect.poll(() => dragWrappers.count(), { timeout: 5_000 }).toBe(0);
+
+  // Locate the row a different way and attempt a drag anyway. If a
+  // future regression re-enables listeners on the wrapper, this
+  // gesture would surface as a PUT body or a visual ring.
+  const rows = page.getByTestId("sidebar-session-row");
+  await expect(rows).toHaveCount(3);
+  const sourceBox = await rows.nth(2).boundingBox();
+  const targetBox = await rows.nth(0).boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("row box missing");
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width - 4,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.waitForTimeout(250);
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 12 },
+  );
+
+  // Visual feedback contract: no row gains the active-drag ring class.
+  // The check runs mid-gesture so a regression that wires listeners
+  // back up would still show the lift.
+  const ringedCount = await page.locator(".ring-2.ring-brand-500").count();
+  expect(ringedCount).toBe(0);
+
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-stationary-click-navigates.spec.ts
+++ b/web/tests/sidebar-reorder-stationary-click-navigates.spec.ts
@@ -1,0 +1,38 @@
+// dnd-kit MouseSensor has `{ distance: 8 }` activation
+// (WorkspaceSidebar.tsx:1630). A press-and-release on a row WITHOUT
+// movement must not trigger reorder; it must navigate to the session
+// instead. Locks the desktop activation threshold from drifting
+// silently (#1419).
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test("stationary click on a row navigates without reordering", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(3);
+
+  const box = await wrappers.nth(1).boundingBox();
+  if (!box) throw new Error("row box missing");
+  await page.mouse.move(box.x + box.width - 4, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.up();
+
+  // The Link inside SessionRow resolves to `/session/<id>`; the URL
+  // change is the user-observable contract here.
+  await expect(page).toHaveURL(/\/session\/s-b$/, { timeout: 5_000 });
+
+  await page.waitForTimeout(200);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-tiny-drag-noop.spec.ts
+++ b/web/tests/sidebar-reorder-tiny-drag-noop.spec.ts
@@ -1,0 +1,57 @@
+// dnd-kit MouseSensor `{ distance: 8 }` rejects micro-movements
+// (WorkspaceSidebar.tsx:1630). Moving only 4px between mouse-down and
+// mouse-up must not start a drag; the order stays put and no PUT
+// flies. Locks the 8px threshold from drifting (#1419).
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test("4px movement does not start a drag", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(3);
+
+  // Snapshot the visible order via the inner link text.
+  const beforeOrder = await wrappers.evaluateAll((els) =>
+    els.map(
+      (el) =>
+        el.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
+    ),
+  );
+  expect(beforeOrder).toEqual(["alpha", "beta", "gamma"]);
+
+  const box = await wrappers.nth(2).boundingBox();
+  if (!box) throw new Error("row box missing");
+  await page.mouse.move(box.x + box.width - 4, box.y + box.height / 2);
+  await page.mouse.down();
+  // 4px below the activation threshold; sensor should not promote.
+  await page.mouse.move(
+    box.x + box.width - 4,
+    box.y + box.height / 2 + 4,
+  );
+  await page.mouse.up();
+
+  // Give the sensor a tick; a regression that drops the threshold
+  // check would still fire onDragEnd inside this window.
+  await page.waitForTimeout(200);
+
+  const afterOrder = await wrappers.evaluateAll((els) =>
+    els.map(
+      (el) =>
+        el.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
+    ),
+  );
+  expect(afterOrder).toEqual(beforeOrder);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/wheel-scroll.spec.ts
+++ b/web/tests/wheel-scroll.spec.ts
@@ -90,7 +90,7 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     // enough headroom for CI runners under load (2s was tight enough
     // to flake on heavy parallel runs).
     await expect
-      .poll(() => countSeq(handle, WHEEL_DOWN_SEQ), { timeout: 5_000 })
+      .poll(() => countSeq(handle, WHEEL_DOWN_SEQ), { timeout: 10_000 })
       .toBeGreaterThan(0);
     expect(countSeq(handle, WHEEL_UP_SEQ)).toBe(0);
   });
@@ -108,7 +108,7 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     await fireWheel(page, { deltaY: -120, times: 3 });
 
     await expect
-      .poll(() => countSeq(handle, WHEEL_UP_SEQ), { timeout: 5_000 })
+      .poll(() => countSeq(handle, WHEEL_UP_SEQ), { timeout: 10_000 })
       .toBeGreaterThan(0);
     expect(countSeq(handle, WHEEL_DOWN_SEQ)).toBe(0);
   });

--- a/web/tests/wheel-scroll.spec.ts
+++ b/web/tests/wheel-scroll.spec.ts
@@ -42,7 +42,7 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     // resize/activate on connect). Until readyState is OPEN, sendWheel
     // silently drops messages.
     await expect
-      .poll(() => handle.wsMessages.length, { timeout: 5_000 })
+      .poll(() => handle.wsMessages.length, { timeout: 10_000 })
       .toBeGreaterThan(0);
   }
 
@@ -69,6 +69,33 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     );
   }
 
+  // Re-fire the wheel burst on every poll tick until the expected side
+  // effect lands. A single synthetic burst can arrive in a transient
+  // not-ready window (renderer init / socket-open timing under heavy CI
+  // parallelism), where the custom wheel handler never forwards it and the
+  // SGR bytes are silently dropped. Polling only the observation can't
+  // recover from a dropped burst, so it would wait out the full timeout and
+  // fail with "Received: 0". Re-firing recovers as soon as the handler is
+  // live. Only sound for monotonic effects: the wheel direction is fixed, so
+  // extra bursts can only push the observed value further past the threshold,
+  // never back across it.
+  async function fireUntil(
+    page: Page,
+    opts: { deltaY: number; ctrlKey?: boolean; times?: number },
+    predicate: () => boolean | Promise<boolean>,
+    timeout = 10_000,
+  ) {
+    await expect
+      .poll(
+        async () => {
+          await fireWheel(page, opts);
+          return await predicate();
+        },
+        { timeout },
+      )
+      .toBe(true);
+  }
+
   test("scroll down sends SGR wheel-down escape sequences", async ({
     page,
   }) => {
@@ -83,15 +110,11 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     // deltaY > 0 = scroll down. Fire enough events to exceed pxPerWheel
     // threshold (fontSize 14 * LINES_PER_WHEEL 2 = 28px per wheel tick).
     // deltaY=120 is a typical single mouse wheel notch on most browsers.
-    await fireWheel(page, { deltaY: 120, times: 3 });
-
-    // WebSocket message delivery from page to Playwright handler is async;
-    // poll so the assertion doesn't race the message capture. 5s gives
-    // enough headroom for CI runners under load (2s was tight enough
-    // to flake on heavy parallel runs).
-    await expect
-      .poll(() => countSeq(handle, WHEEL_DOWN_SEQ), { timeout: 10_000 })
-      .toBeGreaterThan(0);
+    await fireUntil(
+      page,
+      { deltaY: 120, times: 3 },
+      () => countSeq(handle, WHEEL_DOWN_SEQ) > 0,
+    );
     expect(countSeq(handle, WHEEL_UP_SEQ)).toBe(0);
   });
 
@@ -105,11 +128,11 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     handle.wsMessages.length = 0;
 
     // deltaY < 0 = scroll up
-    await fireWheel(page, { deltaY: -120, times: 3 });
-
-    await expect
-      .poll(() => countSeq(handle, WHEEL_UP_SEQ), { timeout: 10_000 })
-      .toBeGreaterThan(0);
+    await fireUntil(
+      page,
+      { deltaY: -120, times: 3 },
+      () => countSeq(handle, WHEEL_UP_SEQ) > 0,
+    );
     expect(countSeq(handle, WHEEL_DOWN_SEQ)).toBe(0);
   });
 
@@ -152,19 +175,20 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     await openSession(page, handle);
     handle.wsMessages.length = 0;
 
-    // Ctrl+wheel should zoom, not scroll
-    await fireWheel(page, { deltaY: -60, ctrlKey: true, times: 2 });
-
-    await expect
-      .poll(
-        () =>
-          page.evaluate(() => {
-            const raw = localStorage.getItem("aoe-web-settings");
-            return raw ? JSON.parse(raw).desktopFontSize : null;
-          }),
-        { timeout: 2_000 },
-      )
-      .toBeGreaterThan(14);
+    // Ctrl+wheel should zoom, not scroll. Re-fire until the zoom lands:
+    // extra ctrl+wheel bursts only zoom further in, never back, and never
+    // emit scroll sequences, so the scroll-count assertion below still holds.
+    await fireUntil(
+      page,
+      { deltaY: -60, ctrlKey: true, times: 2 },
+      async () => {
+        const size = await page.evaluate(() => {
+          const raw = localStorage.getItem("aoe-web-settings");
+          return raw ? JSON.parse(raw).desktopFontSize : null;
+        });
+        return typeof size === "number" && size > 14;
+      },
+    );
 
     // No SGR scroll sequences should have been sent
     const scrollCount =
@@ -192,19 +216,27 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
       page.getByRole("button", { name: "Back to live" }),
     ).toHaveCount(0);
 
-    await fireWheel(page, { deltaY: -120, times: 3 });
     const hasText = (needle: string) =>
       handle.wsMessages.some((m) => m.includes(Buffer.from(needle)));
 
-    await expect.poll(() => hasText('"type":"pause_output"')).toBe(true);
+    // Wheel-up enters scrollback (pause_output). Re-firing up only deepens
+    // scrollback, so the pause transition is monotonic and re-fire-safe.
+    await fireUntil(
+      page,
+      { deltaY: -120, times: 3 },
+      () => hasText('"type":"pause_output"'),
+    );
     expect(hasText('"type":"resume_output"')).toBe(false);
 
-    // Scroll back down enough wheel ticks to zero the depth. The client
-    // emitted N wheel-UPs; N wheel-DOWNs should be enough. (deltaY=120
-    // with fontSize 14 gives ~4 wheels per fireWheel call; use times: 5
-    // to overshoot and guarantee the transition.)
-    await fireWheel(page, { deltaY: 120, times: 5 });
-    await expect.poll(() => hasText('"type":"resume_output"')).toBe(true);
+    // Scroll back down to zero the depth; on desktop tmux auto-exits
+    // copy-mode and the client emits resume_output. Re-fire down until that
+    // lands: each burst drives depth toward 0 and stops at 0, so re-firing
+    // can only reach (never overshoot past) the resume transition.
+    await fireUntil(
+      page,
+      { deltaY: 120, times: 5 },
+      () => hasText('"type":"resume_output"'),
+    );
 
     // Still no button on desktop at any point.
     await expect(


### PR DESCRIPTION
## Description

Batched merge of the `cockpit-main` integration branch into `main`. Branch protection on `main` requires a human approval; autonomous PRs land on `cockpit-main` first, then ship up in periodic batches like this one.

This batch contains 8 commits:

- `f351fed9` test(web): de-flake mouse-wheel and theme-passphrase Playwright specs
- `91278540` fix(cockpit): surface sandbox spawn failures with actionable diagnostics
- `962ea2f4` feat(cockpit): call experimental session/delete RPC before SIGTERM
- `0fcfa602` fix(cockpit): stop iOS dictation duplicating dictated text in web composer
- `49bc9f94` fix(server): bypass passphrase wall for loopback callers (#1596)
- `b0c306c4` test(web): theme switching and sidebar reorder user-story specs (#1405, #1419)
- `62fd6141` fix(web): stack settings header into two rows on mobile (#1595)
- `06bc6c9d` fix(web): hide empty repo group header and clamp sidebar context menu to viewport

Each commit already passed CI and review on its own PR into `cockpit-main`. No new code here; this is the gate-through to `main`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: tests landed with the individual PRs in this batch

**TUI / CLI (e2e test)**
- [x] N/A: tests landed with the individual PRs in this batch

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (Claude Code)

**Any Additional AI Details you'd like to share:**

Batch integration PR assembled by an AI agent. Underlying commits authored across prior reviewed PRs.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->