### PR TITLE
fix(web): suppress iOS link callout on sidebar session rows

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -810,7 +810,7 @@ export const SessionRow = memo(function SessionRow({
         onTouchEnd={handleTouchEnd}
         onTouchMove={clearLongPress}
         onTouchCancel={clearLongPress}
-        className={`block w-full text-left py-2 cursor-pointer select-none transition-colors duration-75 ${
+        className={`block w-full text-left py-2 cursor-pointer select-none [-webkit-touch-callout:none] transition-colors duration-75 ${
           indented ? "pl-6 pr-3" : "px-3"
         } ${
           isActive

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -566,6 +566,17 @@
       ]
     },
     {
+      "id": "sidebar.ios-callout-suppression",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/ios-callout-suppression.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "sidebar.favorite-indicator",
       "kind": "deferred",
       "issue": "https://github.com/agent-of-empires/agent-of-empires/issues/986",

--- a/web/tests/ios-callout-suppression.spec.ts
+++ b/web/tests/ios-callout-suppression.spec.ts
@@ -1,0 +1,84 @@
+// Mocked-Playwright coverage for the iOS link-preview callout suppression
+// on sidebar session rows (#1451).
+//
+// On mobile Safari the session row, an <a href>, triggers iOS's native
+// link-preview action sheet on long-press, which preempts the app's own
+// 500ms rename/delete menu. The fix adds `-webkit-touch-callout: none` via
+// the arbitrary Tailwind class `[-webkit-touch-callout:none]` on the row.
+//
+// `-webkit-touch-callout` is a WebKit-only property, so chromium (the
+// engine these mocked specs run on) reports nothing for it via
+// getComputedStyle. We therefore assert the class token is present on the
+// row: that proves the suppression rule is wired onto the element. The
+// real callout-vs-menu behavior is a manual real-device check, noted in
+// the issue test plan.
+
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { openMobileSidebar } from "./helpers/sidebar";
+
+// iPhone 13 profile: pointer:coarse, hasTouch, mobile viewport.
+test.use({ ...devices["iPhone 13"] });
+
+function sessionResponse() {
+  return {
+    id: "s-1",
+    title: "demo-ws",
+    project_path: "/tmp/repo",
+    group_path: "/tmp/repo",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: "feature/demo",
+    main_repo_path: null,
+    is_sandboxed: false,
+    has_terminal: true,
+    profile: "default",
+    workspace_repos: [],
+  };
+}
+
+async function mockApis(page: Page) {
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: [sessionResponse()],
+        workspace_ordering: ["/tmp/repo::feature/demo"],
+      },
+    });
+  });
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: path === "docker/status" ? {} : [] }),
+    );
+  }
+}
+
+test.describe("Sidebar iOS callout suppression (#1451)", () => {
+  test("session row carries -webkit-touch-callout:none", async ({ page }) => {
+    await mockApis(page);
+    await page.goto("/");
+    await openMobileSidebar(page);
+
+    const row = page.getByTestId("sidebar-session-row").first();
+    await expect(row).toBeVisible();
+    await expect(row).toHaveClass(/\[-webkit-touch-callout:none\]/);
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On mobile Safari (iOS), long-pressing a session row in `WorkspaceSidebar` should open the app's rename / delete context menu after a 500ms hold. Instead, iOS popped its native link-preview action sheet (Copy Link / Open in Background / Share) first, because the row is rendered as an `<a href>` and iOS treats a long-press on a link as the universal link-callout gesture. That preempted the app's own menu, so the documented "hold to rename or delete" path was unreachable on touch.

The fix adds the arbitrary Tailwind class `[-webkit-touch-callout:none]` to the session-row `<a>` (`web/src/components/WorkspaceSidebar.tsx`). The existing `select-none` only suppresses text selection, not the iOS callout; `-webkit-touch-callout: none` is the property that disables it. The class keeps the styling cohesive with the rest of the row chain.

The three layered gestures are preserved: dnd-kit's `TouchSensor` lives on the wrapper `<div>` (150ms hold + 8px move) and is untouched, so drag-to-rearrange still works; the app's 500ms long-press handler on the `<a>` still fires; only Safari's link callout is suppressed.

I deliberately did not add the issue's optional "belt-and-braces" `e.preventDefault()` inside the 500ms `setTimeout`: by the time that timer fires the touchstart dispatch is already over, so the call would be a no-op for browser behavior. `handleTouchEnd` already calls `preventDefault()` after a fired long-press.

Closes #1451

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] On a real iPhone/iPad in Safari (and as an installed PWA), open the dashboard with at least one session in the sidebar, tap-and-hold a session row for ~1s, and confirm the app's Rename / Delete menu opens at the touch point with no Safari "Copy Link / Share" sheet flashing first.
- [ ] On the same device, drag a session row up two positions and confirm reorder still works and the menu does not appear mid-drag.
- [ ] On desktop, right-click a session row and confirm the Rename / Delete menu still opens (fix is iOS-only CSS).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (arbitrary Tailwind class over inline style for testability, dropping the no-op preventDefault), reviewed each commit, and will run the manual device test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes Made

- Modified:
  - web/src/components/WorkspaceSidebar.tsx — added the Tailwind arbitrary class `[-webkit-touch-callout:none]` to the per-session-row <a> to suppress iOS Safari's native link-preview callout on long-press.
- Added:
  - web/tests/ios-callout-suppression.spec.ts — a mocked Playwright test asserting the session row carries the Tailwind class token (iPhone 13 profile).
- Updated:
  - web/tests/coverage-matrix.json — added a coverage entry mapping the new test to WorkspaceSidebar.

## What Changed (high-level)

A single, scoped styling tweak prevents iOS Safari's long-press link action sheet from interrupting the app's 500ms Rename/Delete long-press menu for sidebar session rows. Drag-to-rearrange, desktop right-click, and existing selection/transition behaviors remain unchanged. Automated test coverage was added to ensure the class is present, and the coverage matrix was updated.

## Benefits

- Restores the intended mobile UX on iOS: the app's long-press context menu can appear without being preempted by Safari's native link menu.
- Minimal and low-risk: only a CSS token added to session-row anchors; no change to dnd-kit touch sensor or long-press logic.
- Testable and maintainable: Playwright spec ensures the class remains applied and coverage matrix keeps the component tracked.

## Technical details (concise)

- Uses Tailwind arbitrary class `[-webkit-touch-callout:none]` which emits `-webkit-touch-callout: none;` — a WebKit-only property that disables Safari's touch callout.
- dnd-kit TouchSensor on the wrapper <div> (150ms activation + 8px move tolerance) and the app's 500ms long-press handler on the <a> are preserved.
- No e.preventDefault() was added inside the 500ms timeout (ineffective by then); existing handleTouchEnd continues to call preventDefault() after a fired long-press.
- Playwright test verifies the presence of the class token (Chromium cannot reflect WebKit-only computed styles); manual real-device steps are recommended in the issue's test plan to confirm runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->