### PR TITLE
fix(web): repeat-delete on mobile soft-keyboard Backspace hold

### DIFF
--- a/web/src/hooks/useTerminal.lifecycle.test.ts
+++ b/web/src/hooks/useTerminal.lifecycle.test.ts
@@ -1493,3 +1493,162 @@ describe("useTerminal lifecycle", () => {
     }
   });
 });
+
+// Mobile soft-keyboard Backspace autorepeat handler (#1450). The hook
+// intercepts `beforeinput` on xterm's hidden textarea and emits one DEL
+// (0x7f) per `deleteContentBackward` tick, gated to coarse-pointer devices
+// without a fine pointer. jsdom lets us drive every branch deterministically:
+// matchMedia controls the gate, the FakeSocket's readyState the open guard.
+describe("useTerminal mobile backspace autorepeat", () => {
+  function stubPointer(coarse: boolean, anyFine: boolean): void {
+    vi.stubGlobal(
+      "matchMedia",
+      (q: string) =>
+        ({
+          matches:
+            q === "(pointer: coarse)"
+              ? coarse
+              : q === "(any-pointer: fine)"
+                ? anyFine
+                : false,
+        }) as MediaQueryList,
+    );
+  }
+
+  // Mount the hook, attach a container, and drive the socket to OPEN so the
+  // beforeinput handler's `ws.readyState === OPEN` guard passes. Returns the
+  // textarea xterm's mock created and the live FakeSocket.
+  async function mountOpen(): Promise<{
+    div: HTMLDivElement;
+    ws: FakeSocket;
+    ta: HTMLTextAreaElement;
+  }> {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    renderHook(() => {
+      const term = useTerminal("s-bksp", "ws", false, false);
+      if (term.containerRef && !term.containerRef.current) {
+        (
+          term.containerRef as unknown as { current: HTMLDivElement | null }
+        ).current = div;
+      }
+      return term;
+    });
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.(new Event("open"));
+    });
+    await flushAsync();
+    const ta = div.querySelector("textarea") as HTMLTextAreaElement;
+    return { div, ws, ta };
+  }
+
+  function fireDelete(
+    ta: HTMLTextAreaElement,
+    count: number,
+    opts: { inputType?: string; isComposing?: boolean } = {},
+  ): void {
+    const inputType = opts.inputType ?? "deleteContentBackward";
+    act(() => {
+      for (let i = 0; i < count; i++) {
+        const e = new InputEvent("beforeinput", {
+          inputType,
+          bubbles: true,
+          cancelable: true,
+        });
+        if (opts.isComposing) {
+          Object.defineProperty(e, "isComposing", { get: () => true });
+        }
+        ta.dispatchEvent(e);
+      }
+    });
+  }
+
+  function delBytes(ws: FakeSocket): number {
+    return ws.sent.filter(
+      (m) => typeof m !== "string" && m.length === 1 && m[0] === 0x7f,
+    ).length;
+  }
+
+  it("emits one DEL per tick on a coarse pointer", async () => {
+    stubPointer(true, false);
+    const { div, ws, ta } = await mountOpen();
+    try {
+      fireDelete(ta, 3);
+      expect(delBytes(ws)).toBe(3);
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("emits exactly one DEL for a single tick (no double-delete)", async () => {
+    stubPointer(true, false);
+    const { div, ws, ta } = await mountOpen();
+    try {
+      fireDelete(ta, 1);
+      expect(delBytes(ws)).toBe(1);
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("does nothing on a fine pointer", async () => {
+    stubPointer(false, false);
+    const { div, ws, ta } = await mountOpen();
+    try {
+      fireDelete(ta, 3);
+      expect(delBytes(ws)).toBe(0);
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("does nothing when a fine pointer is also present (iPad + keyboard)", async () => {
+    stubPointer(true, true);
+    const { div, ws, ta } = await mountOpen();
+    try {
+      fireDelete(ta, 3);
+      expect(delBytes(ws)).toBe(0);
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("ignores non-delete input types", async () => {
+    stubPointer(true, false);
+    const { div, ws, ta } = await mountOpen();
+    try {
+      fireDelete(ta, 3, { inputType: "insertText" });
+      expect(delBytes(ws)).toBe(0);
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("leaves composition deletes to xterm", async () => {
+    stubPointer(true, false);
+    const { div, ws, ta } = await mountOpen();
+    try {
+      fireDelete(ta, 3, { isComposing: true });
+      expect(delBytes(ws)).toBe(0);
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("does not send while the socket is not open", async () => {
+    stubPointer(true, false);
+    const { div, ws, ta } = await mountOpen();
+    try {
+      act(() => {
+        ws.readyState = FakeWebSocket.CLOSED;
+      });
+      fireDelete(ta, 3);
+      expect(delBytes(ws)).toBe(0);
+    } finally {
+      div.remove();
+    }
+  });
+});

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -262,6 +262,34 @@ export function useTerminal(
 
     term.open(termEl);
 
+    // Mobile soft-keyboard Backspace autorepeat arrives as a stream of
+    // `beforeinput` events (inputType "deleteContentBackward", with keydown
+    // surfacing as "Unidentified" / keyCode 229). xterm decodes only the
+    // first into a single onData, so holding Backspace deletes one character
+    // instead of repeat-deleting; the PTY sees one DEL rather than one per
+    // tick. Intercept on xterm's hidden textarea and emit one DEL per tick
+    // ourselves. preventDefault blocks the textarea mutation so xterm's
+    // input-diff decoder never fires its own onData for the same tick (no
+    // double-delete). Gated to coarse-pointer-without-fine-pointer: a
+    // hardware Backspace fires a recognized keydown that xterm preventDefaults,
+    // which per the UI Events spec suppresses the follow-on beforeinput, so
+    // this path only runs for soft keyboards. Mirrors the mobile-Enter
+    // interception in Composer.tsx. See #1450.
+    const xtermTextarea = termEl.querySelector("textarea");
+    const onBeforeInput = (e: InputEvent) => {
+      if (e.inputType !== "deleteContentBackward" || e.isComposing) return;
+      const coarse = window.matchMedia?.("(pointer: coarse)").matches;
+      const anyFine = window.matchMedia?.("(any-pointer: fine)").matches;
+      if (!coarse || anyFine) return;
+      const ws = wsRef.current;
+      if (ws?.readyState !== WebSocket.OPEN) return;
+      e.preventDefault();
+      ws.send(new TextEncoder().encode("\x7f"));
+    };
+    xtermTextarea?.addEventListener("beforeinput", onBeforeInput, {
+      capture: true,
+    });
+
     // Shift+Enter → bracketed paste containing a newline. Agents like
     // Claude Code treat pasted newlines as literal text (inserted, not
     // submitted). Bracketed paste passes cleanly through tmux without
@@ -1270,6 +1298,9 @@ export function useTerminal(
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
       viewport.removeEventListener("click", onClickCapture, true);
       viewport.removeEventListener("wheel", onWheelCapture, true);
+      xtermTextarea?.removeEventListener("beforeinput", onBeforeInput, {
+        capture: true,
+      });
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);

--- a/web/tests/backspace-autorepeat.spec.ts
+++ b/web/tests/backspace-autorepeat.spec.ts
@@ -63,7 +63,12 @@ test.describe("Mobile soft-keyboard Backspace autorepeat", () => {
     await page.goto("/");
     await openMobileSidebar(page);
     await clickSidebarSession(page, "pinch-test");
-    await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+    // Desktop renders two `.xterm` nodes (agent + paired); scope to the first
+    // to avoid a strict-mode locator violation.
+    await page
+      .locator(".xterm")
+      .first()
+      .waitFor({ state: "visible", timeout: 10_000 });
     await expect
       .poll(() => handle.wsMessages.length, { timeout: 5_000 })
       .toBeGreaterThan(0);
@@ -128,7 +133,12 @@ test.describe("Desktop Backspace path unchanged", () => {
     const handle = await mockTerminalApis(page);
     await page.goto("/");
     await clickSidebarSession(page, "pinch-test");
-    await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+    // Desktop renders two `.xterm` nodes (agent + paired); scope to the first
+    // to avoid a strict-mode locator violation.
+    await page
+      .locator(".xterm")
+      .first()
+      .waitFor({ state: "visible", timeout: 10_000 });
     await expect
       .poll(() => handle.wsMessages.length, { timeout: 5_000 })
       .toBeGreaterThan(0);

--- a/web/tests/backspace-autorepeat.spec.ts
+++ b/web/tests/backspace-autorepeat.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+
+// Mobile soft-keyboard Backspace autorepeat arrives as a stream of
+// `beforeinput` events (inputType "deleteContentBackward") rather than the
+// repeated `keydown` autorepeat desktop OSes deliver. xterm decodes only the
+// first into a single onData, so the PTY used to receive one DEL no matter how
+// long Backspace was held. useTerminal now intercepts `beforeinput` on the
+// hidden textarea and emits one DEL (0x7f) per tick, gated to coarse-pointer
+// devices. See #1450.
+
+// Count the lone 0x7f bytes our handler emits, ignoring the JSON control
+// messages (activate / resize) that share the WS.
+function delCount(handle: MockHandle, start: number) {
+  return handle.wsMessages
+    .slice(start)
+    .map((msg) => msg.toString("utf8"))
+    .filter((s) => s === "\x7f").length;
+}
+
+// Dispatch N `beforeinput` ticks on xterm's real hidden textarea, mirroring a
+// held soft-keyboard Backspace. `isComposing` lets the IME case opt in.
+async function fireDeleteBackward(
+  page: Page,
+  count: number,
+  isComposing = false,
+) {
+  await page.evaluate(
+    ({ count, isComposing }) => {
+      const ta = document.querySelector<HTMLTextAreaElement>(".xterm textarea");
+      if (!ta) throw new Error("xterm textarea not found");
+      ta.focus();
+      for (let i = 0; i < count; i++) {
+        const evt = new InputEvent("beforeinput", {
+          inputType: "deleteContentBackward",
+          bubbles: true,
+          cancelable: true,
+        });
+        // isComposing is readonly on the constructed event; force it for the
+        // IME path so the handler's `e.isComposing` guard is exercised.
+        if (isComposing) {
+          Object.defineProperty(evt, "isComposing", { get: () => true });
+        }
+        ta.dispatchEvent(evt);
+      }
+    },
+    { count, isComposing },
+  );
+}
+
+// Drop `defaultBrowserType` from the device profile: Playwright forbids it in
+// a describe-level test.use (it would force a new worker), and the project
+// already pins chromium. We only want the iPhone 13 viewport / touch / UA so
+// `(pointer: coarse)` matches.
+const { defaultBrowserType: _iphoneBrowser, ...iPhone13 } = devices["iPhone 13"];
+
+test.describe("Mobile soft-keyboard Backspace autorepeat", () => {
+  test.use(iPhone13);
+
+  async function openSession(page: Page, handle: MockHandle) {
+    await page.goto("/");
+    await openMobileSidebar(page);
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+    await expect
+      .poll(() => handle.wsMessages.length, { timeout: 5_000 })
+      .toBeGreaterThan(0);
+  }
+
+  test("holding Backspace sends one DEL per autorepeat tick", async ({
+    page,
+  }) => {
+    const handle = await mockTerminalApis(page);
+    await openSession(page, handle);
+
+    const start = handle.wsMessages.length;
+    await fireDeleteBackward(page, 5);
+
+    // Core bug: pre-fix this stream produced a single DEL (or none); post-fix
+    // each tick maps to one DEL.
+    await expect
+      .poll(() => delCount(handle, start), { timeout: 5_000 })
+      .toBe(5);
+  });
+
+  test("single Backspace tap sends exactly one DEL (no double-delete)", async ({
+    page,
+  }) => {
+    const handle = await mockTerminalApis(page);
+    await openSession(page, handle);
+
+    const start = handle.wsMessages.length;
+    await fireDeleteBackward(page, 1);
+
+    // Regression guard: if preventDefault failed to suppress xterm's own
+    // decode, a single tap would emit two DELs. Settle, then assert exactly 1.
+    await expect
+      .poll(() => delCount(handle, start), { timeout: 5_000 })
+      .toBe(1);
+    await page.waitForTimeout(200);
+    expect(delCount(handle, start)).toBe(1);
+  });
+
+  test("Backspace during IME composition is left to xterm", async ({
+    page,
+  }) => {
+    const handle = await mockTerminalApis(page);
+    await openSession(page, handle);
+
+    const start = handle.wsMessages.length;
+    await fireDeleteBackward(page, 3, true);
+
+    // isComposing ticks belong to xterm's composition path; our handler must
+    // not inject DELs.
+    await page.waitForTimeout(200);
+    expect(delCount(handle, start)).toBe(0);
+  });
+});
+
+test.describe("Desktop Backspace path unchanged", () => {
+  test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+
+  test("fine-pointer beforeinput does not trigger the mobile handler", async ({
+    page,
+  }) => {
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+    await expect
+      .poll(() => handle.wsMessages.length, { timeout: 5_000 })
+      .toBeGreaterThan(0);
+
+    const start = handle.wsMessages.length;
+    await fireDeleteBackward(page, 5);
+
+    // On a fine pointer the coarse-pointer gate is closed, so the handler is
+    // inert; the real desktop delete path runs through xterm's keydown decode.
+    await page.waitForTimeout(200);
+    expect(delCount(handle, start)).toBe(0);
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -38,6 +38,17 @@
       ]
     },
     {
+      "id": "terminal.mobile-backspace-autorepeat",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/backspace-autorepeat.spec.ts"
+      ],
+      "components": [
+        "web/src/hooks/useTerminal.ts"
+      ]
+    },
+    {
       "id": "auth.no-auth",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On mobile soft keyboards (iOS Safari, Android GBoard / Samsung Keyboard), holding the on-screen Backspace key in either terminal deleted only one character instead of repeat-deleting. The only way to clear a line was to mash the key.

All terminal input flows through a single `term.onData` callback in `web/src/hooks/useTerminal.ts`. On desktop, OS-level keydown autorepeat fires repeated `keydown` events that xterm.js decodes one by one, so `onData` runs N times. On mobile, holding Backspace delivers autorepeat as a stream of `beforeinput` events (`inputType: "deleteContentBackward"`, with `keydown` surfacing as `Unidentified` / `keyCode 229`); xterm decodes only the first into a single `onData`, so the PTY received one DEL no matter how long the key was held.

The fix intercepts `beforeinput` on xterm's hidden textarea, gated to coarse-pointer devices without a fine pointer, and emits one DEL (`0x7f`) per `deleteContentBackward` tick. Calling `preventDefault()` blocks the textarea mutation so xterm's input-diff decoder never emits its own DEL for the same tick (no double-delete). Composition ticks (`isComposing`) are left to xterm's IME path. A hardware Backspace fires a recognized `keydown` that xterm `preventDefault`s, which per the UI Events spec suppresses the follow-on `beforeinput`, so the new path runs only for soft keyboards. This mirrors the mobile-Enter interception already in `Composer.tsx`. Both the agent terminal and the paired right-panel terminal share `useTerminal`, so both are fixed.

Closes #1450

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] On a mobile device (or Chrome DevTools iPhone preset with touch emulation), open the dashboard and select a session.
- [x] Tap the agent terminal, type `hello world`.
- [x] Tap and hold Backspace for ~2s; confirm the line clears (repeat-delete) instead of deleting a single character.
- [x] Repeat in the right-panel paired terminal; confirm the same repeat-delete behavior.
- [x] On desktop with a physical keyboard, hold Backspace; confirm repeat-delete is unchanged and a single tap deletes exactly one character (no double-delete).

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

New mocked spec `web/tests/backspace-autorepeat.spec.ts` (iPhone 13 profile): a held-Backspace stream of N `deleteContentBackward` ticks sends N DELs (red pre-fix: 1), a single tap sends exactly one DEL (double-delete regression guard), IME-composition ticks are left to xterm, and the fine-pointer desktop path is unchanged. Verified red on the pre-fix tree and green post-fix.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (cross-checked with a multi-model design debate), and implementation were drafted by Claude under my direction. I made the design calls, reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed (High-level)

Fixed mobile soft-keyboard Backspace so holding the on-screen Backspace performs repeated deletes (matching desktop autorepeat). The change is limited to touch/coarse-pointer devices and preserves existing desktop, hardware Backspace, and IME behavior.

What was added or modified
- Updated web/src/hooks/useTerminal.ts to add a beforeinput listener on xterm’s hidden textarea that converts mobile beforeinput delete ticks into DEL bytes sent to the PTY.
- Added web/tests/backspace-autorepeat.spec.ts — Playwright mock tests (iPhone 13 profile) verifying held Backspace repeats, single tap sends one DEL, IME composition unaffected, and desktop/fine-pointer path unchanged.
- Added a coverage entry in web/tests/coverage-matrix.json for the new test surface.
- Added web/src/hooks/useTerminal.lifecycle.test.ts — unit tests stubbing matchMedia to validate coarse vs fine pointer behavior and socket states.

Nothing removed.

Technical details (brief)
- The handler listens for beforeinput events with inputType "deleteContentBackward" on devices detected as coarse-pointer without a fine pointer. It calls preventDefault() to stop the textarea mutation and emits a DEL (0x7f) per beforeinput tick over the existing WebSocket/term.onData path.
- IME/composition events (isComposing) are ignored by this handler so xterm’s composition handling remains intact.
- Hardware Backspace (keydown path) and desktop autorepeat are unchanged.
- Listener is cleaned up on effect teardown to avoid leaks; both agent and right-panel terminals are covered via the shared useTerminal hook.

Benefits
- Mobile users can hold Backspace to repeatedly delete characters, matching expected desktop behavior.
- Avoids double-delete regressions and preserves IME/composition correctness.
- Scoped to touch devices to prevent desktop regressions.
- Tests added to prevent future regressions and to validate behavior across mobile and desktop profiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->