### PR TITLE
fix(web): mobile right panel becomes a full-viewport picker (no keyboard collapse)

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -231,6 +231,12 @@ aoe serve --daemon
 - **Connected Devices** view in Settings > Security
 - **Push notifications** on Waiting / Idle / Error transitions, with per-session overrides ([guide](push-notifications.md))
 
+### Mobile layout
+
+On phones (below the `md` breakpoint) the dashboard shows a single full-viewport pane rather than the desktop side-by-side split. The right-panel button in the top bar opens a picker that swaps the main pane between three views: the **Agent terminal**, the **Diff** (changed files and review), and the **Paired terminal** (host or container shell). A back chip in the top-left of the diff and paired views returns you to the agent terminal.
+
+This replaces the earlier slide-in overlay, which left the paired terminal almost no room once the soft keyboard opened. Because each view now owns the whole viewport, the paired terminal handles the keyboard the same way the agent terminal does. The agent terminal and the paired shell stay alive in the background when you switch away, so their scrollback and focus are preserved. The desktop side-by-side split is unchanged.
+
 ### Sidebar sort
 
 By default the sidebar shows your manually-ordered list. Drag a row with a press-and-hold gesture to move it; the new order persists across browsers and devices via `workspace-ordering.json`.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,10 +59,8 @@ const CockpitView = lazy(() =>
   })),
 );
 import { RightPanel } from "./components/RightPanel";
-import { PairedShellPane } from "./components/PairedTerminal";
 import { MobileRightPanelPicker } from "./components/MobileRightPanelPicker";
-import { DiffFileList } from "./components/diff/DiffFileList";
-import { CommentsBanner } from "./components/diff/comments/CommentsBanner";
+import { MobileMainPane } from "./components/MobileMainPane";
 import { DiffFileViewer } from "./components/diff/DiffFileViewer";
 import { SettingsView } from "./components/SettingsView";
 import { ProjectsView } from "./components/ProjectsView";
@@ -811,158 +809,45 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       );
     }
 
-    const agentPane = activeSession?.cockpit_mode ? (
-      <Suspense fallback={<CockpitLoadingFallback />}>
-        <CockpitView
-          key={activeSessionId}
-          sessionId={activeSessionId!}
-          cockpitWorkerState={activeSession.cockpit_worker_state ?? "absent"}
-          tool={activeSession.tool}
-          archivedAt={activeSession.archived_at ?? null}
-          snoozedUntil={activeSession.snoozed_until ?? null}
-        />
-      </Suspense>
-    ) : (
-      <TerminalSessionStack
-        activeSessionId={activeSessionId!}
-        sessions={sessions.filter((session) => !session.cockpit_mode)}
-        cockpitMasterEnabled={!!serverAbout?.cockpit_master_enabled}
-        persistent={webSettings.persistentTerminals}
-        maxPersistentTerminals={webSettings.maxPersistentTerminals}
-      />
-    );
-
-    const diffViewerNode =
-      selectedFilePath && activeSessionId ? (
-        <DiffFileViewer
-          sessionId={activeSessionId}
-          filePath={selectedFilePath}
-          repoName={selectedRepoName}
-          revision={revision}
-          onClose={handleCloseFile}
-          commentsEnabled={commentsEnabled}
-          commentsStore={diffComments}
-        />
-      ) : null;
-
-    const diffListNode = (
-      <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-        {commentsEnabled && diffComments.count > 0 && (
-          <CommentsBanner
-            count={diffComments.count}
-            sendEnabled={commentSendEnabled}
-            sendDisabledReason={commentSendDisabledReason}
-            onSend={() => setSendDialogOpen(true)}
-            onDiscardAll={diffComments.clearComments}
-          />
-        )}
-        <DiffFileList
-          files={diffFiles}
-          perRepoBases={perRepoBases}
-          warning={warning}
-          selectedPath={selectedFilePath}
-          selectedRepoName={selectedRepoName}
-          loading={diffFilesLoading}
-          onSelectFile={handleSelectFile}
-          sessionId={activeSessionId}
-          repoPath={
-            activeSession?.main_repo_path ??
-            activeSession?.project_path ??
-            null
-          }
-          baseBranchOverride={activeSession?.base_branch_override ?? null}
-          onBaseBranchChanged={refreshDiffFiles}
-        />
-      </div>
-    );
-
-    const sendDialogNode = sendDialogOpen &&
-      commentsEnabled &&
-      activeSessionId && (
-        <SendCommentsDialog
-          sessionId={activeSessionId}
-          comments={diffComments.comments}
-          isMultiRepo={commentsIsMultiRepo}
-          sendEnabled={commentSendEnabled}
-          sendDisabledReason={commentSendDisabledReason}
-          introDraft={diffComments.introDraft}
-          outroDraft={diffComments.outroDraft}
-          clearAfterSend={diffComments.clearAfterSend}
-          onChangeIntro={diffComments.setIntroDraft}
-          onChangeOutro={diffComments.setOutroDraft}
-          onChangeClearAfterSend={diffComments.setClearAfterSend}
-          onClose={() => setSendDialogOpen(false)}
-          onSent={() => {
-            if (diffComments.clearAfterSend) {
-              diffComments.clearComments();
-              diffComments.setIntroDraft("");
-              diffComments.setOutroDraft("");
-            }
-            setSendDialogOpen(false);
-            // Close the diff viewer so the cockpit transcript is in
-            // view: the user just dispatched feedback and wants to
-            // see the agent's response. They can re-open any file
-            // from the right-panel list afterwards.
-            setSelectedFile(null);
-            toastBus.handler?.info("Comments sent to agent");
-          }}
-        />
-      );
-
     // Below the md breakpoint there is no room for the side-by-side split.
     // Render one full-viewport pane and let the picker choose which view
     // occupies it (#1452). The agent terminal (and the paired shell, once
     // first opened) stay mounted but hidden so their PTY, scrollback, and
     // focus survive view switches; the diff view has no xterm so it mounts
     // on demand. Inactive layers use visibility, never display:none, which
-    // would collapse xterm's measured geometry to zero.
+    // would collapse xterm's measured geometry to zero. The desktop branch
+    // below is left exactly as it was; only this mobile branch is new.
     if (singlePane) {
-      const layerClass = (active: boolean) =>
-        active
-          ? "absolute inset-0 flex flex-col min-h-0 overflow-hidden"
-          : "absolute inset-0 flex flex-col min-h-0 overflow-hidden invisible pointer-events-none";
-      const viewLabel = rightPanelView === "diff" ? "Diff" : "Paired terminal";
       return (
-        <div className="flex-1 flex flex-col min-h-0">
-          {rightPanelView !== "agent" && (
-            <div className="flex items-center gap-2 h-9 px-2 border-b border-surface-700/20 bg-surface-900 shrink-0">
-              <button
-                onClick={() => setRightPanelView("agent")}
-                data-testid="mobile-back-to-agent"
-                className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-text-secondary hover:text-text-primary hover:bg-surface-800 cursor-pointer transition-colors"
-              >
-                <span aria-hidden>&larr;</span> Agent
-              </button>
-              <span className="text-xs text-text-dim">{viewLabel}</span>
-            </div>
-          )}
-          <div className="relative flex-1 flex flex-col min-h-0 overflow-hidden">
-            <div
-              className={layerClass(rightPanelView === "agent")}
-              inert={rightPanelView !== "agent"}
-            >
-              {agentPane}
-            </div>
-            {pairedMounted && (
-              <div
-                className={layerClass(rightPanelView === "paired")}
-                inert={rightPanelView !== "paired"}
-              >
-                <PairedShellPane
-                  session={activeSession ?? null}
-                  sessionId={activeSessionId}
-                  fullViewport
-                />
-              </div>
-            )}
-            {rightPanelView === "diff" && (
-              <div className="absolute inset-0 z-10 flex flex-col min-h-0 overflow-hidden bg-surface-900">
-                {diffViewerNode ?? diffListNode}
-              </div>
-            )}
-          </div>
-          {sendDialogNode}
-        </div>
+        <MobileMainPane
+          view={rightPanelView}
+          onBackToAgent={() => setRightPanelView("agent")}
+          pairedMounted={pairedMounted}
+          activeSession={activeSession ?? null}
+          activeSessionId={activeSessionId}
+          sessions={sessions}
+          serverAbout={serverAbout}
+          webSettings={webSettings}
+          selectedFilePath={selectedFilePath}
+          selectedRepoName={selectedRepoName}
+          revision={revision}
+          diffFiles={diffFiles}
+          perRepoBases={perRepoBases}
+          warning={warning}
+          diffFilesLoading={diffFilesLoading}
+          onSelectFile={handleSelectFile}
+          onCloseFile={handleCloseFile}
+          onDiffRefresh={refreshDiffFiles}
+          commentsEnabled={commentsEnabled}
+          commentSendEnabled={commentSendEnabled}
+          commentSendDisabledReason={commentSendDisabledReason}
+          diffComments={diffComments}
+          commentsIsMultiRepo={commentsIsMultiRepo}
+          sendDialogOpen={sendDialogOpen}
+          onOpenSendDialog={() => setSendDialogOpen(true)}
+          onCloseSendDialog={() => setSendDialogOpen(false)}
+          onClearSelectedFile={() => setSelectedFile(null)}
+        />
       );
     }
 
@@ -980,10 +865,43 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                     : "flex-1 flex flex-col min-h-0 overflow-hidden"
                 }
               >
-                {agentPane}
+                {activeSession?.cockpit_mode ? (
+                  <Suspense fallback={<CockpitLoadingFallback />}>
+                    <CockpitView
+                      key={activeSessionId}
+                      sessionId={activeSessionId!}
+                      cockpitWorkerState={activeSession.cockpit_worker_state ?? "absent"}
+                      tool={activeSession.tool}
+                      archivedAt={activeSession.archived_at ?? null}
+                      snoozedUntil={activeSession.snoozed_until ?? null}
+                    />
+                  </Suspense>
+                ) : (
+                  <TerminalSessionStack
+                    activeSessionId={activeSessionId!}
+                    sessions={sessions.filter((session) => !session.cockpit_mode)}
+                    cockpitMasterEnabled={
+                      !!serverAbout?.cockpit_master_enabled
+                    }
+                    persistent={webSettings.persistentTerminals}
+                    maxPersistentTerminals={
+                      webSettings.maxPersistentTerminals
+                    }
+                  />
+                )}
               </div>
 
-              {diffViewerNode}
+              {selectedFilePath && activeSessionId && (
+                <DiffFileViewer
+                  sessionId={activeSessionId}
+                  filePath={selectedFilePath}
+                  repoName={selectedRepoName}
+                  revision={revision}
+                  onClose={handleCloseFile}
+                  commentsEnabled={commentsEnabled}
+                  commentsStore={diffComments}
+                />
+              )}
             </div>
           }
           right={
@@ -1007,7 +925,36 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             />
           }
         />
-        {sendDialogNode}
+        {sendDialogOpen && commentsEnabled && activeSessionId && (
+          <SendCommentsDialog
+            sessionId={activeSessionId}
+            comments={diffComments.comments}
+            isMultiRepo={commentsIsMultiRepo}
+            sendEnabled={commentSendEnabled}
+            sendDisabledReason={commentSendDisabledReason}
+            introDraft={diffComments.introDraft}
+            outroDraft={diffComments.outroDraft}
+            clearAfterSend={diffComments.clearAfterSend}
+            onChangeIntro={diffComments.setIntroDraft}
+            onChangeOutro={diffComments.setOutroDraft}
+            onChangeClearAfterSend={diffComments.setClearAfterSend}
+            onClose={() => setSendDialogOpen(false)}
+            onSent={() => {
+              if (diffComments.clearAfterSend) {
+                diffComments.clearComments();
+                diffComments.setIntroDraft("");
+                diffComments.setOutroDraft("");
+              }
+              setSendDialogOpen(false);
+              // Close the diff viewer so the cockpit transcript is in
+              // view: the user just dispatched feedback and wants to
+              // see the agent's response. They can re-open any file
+              // from the right-panel list afterwards.
+              setSelectedFile(null);
+              toastBus.handler?.info("Comments sent to agent");
+            }}
+          />
+        )}
       </div>
     );
   };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,8 @@ import { useCommandActions } from "./hooks/useCommandActions";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useMobileKeyboard } from "./hooks/useMobileKeyboard";
 import { useIsCoarsePointer } from "./hooks/useIsCoarsePointer";
+import { useIsWideViewport } from "./hooks/useIsWideViewport";
+import type { RightPanelView } from "./lib/rightPanelView";
 import {
   loginStatus,
   logout,
@@ -57,6 +59,10 @@ const CockpitView = lazy(() =>
   })),
 );
 import { RightPanel } from "./components/RightPanel";
+import { PairedShellPane } from "./components/PairedTerminal";
+import { MobileRightPanelPicker } from "./components/MobileRightPanelPicker";
+import { DiffFileList } from "./components/diff/DiffFileList";
+import { CommentsBanner } from "./components/diff/comments/CommentsBanner";
 import { DiffFileViewer } from "./components/diff/DiffFileViewer";
 import { SettingsView } from "./components/SettingsView";
 import { ProjectsView } from "./components/ProjectsView";
@@ -268,6 +274,20 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   useEffect(() => {
     safeSetItem(RIGHT_PANEL_COLLAPSED_KEY, diffCollapsed ? "1" : "0");
   }, [diffCollapsed]);
+  // Layout topology is width-driven so it stays aligned with the `md:`
+  // Tailwind classes the rest of the layout uses. At md and up the
+  // side-by-side ContentSplit renders; below md a single full-viewport
+  // pane shows one of agent / diff / paired, chosen via the picker (#1452).
+  const isMdUp = useIsWideViewport();
+  const singlePane = !isMdUp;
+  const [rightPanelView, setRightPanelView] =
+    useState<RightPanelView>("agent");
+  const [pickerOpen, setPickerOpen] = useState(false);
+  // The paired shell mounts lazily on first activation, then stays mounted
+  // (kept alive but hidden) so its PTY, scrollback, and focus survive view
+  // switches. Mounting it eagerly would spawn a shell for every mobile
+  // session the user never opens the shell on.
+  const [pairedMounted, setPairedMounted] = useState(false);
   const [showSessionWizard, setShowSessionWizard] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [showPalette, setShowPalette] = useState(false);
@@ -287,6 +307,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     (s) => s.id === activeSessionId,
   );
 
+  // Fetch the diff when the panel is actually showing: on desktop when the
+  // split is expanded, on mobile when the diff view is the active pane.
+  const diffPanelActive = isMdUp ? !diffCollapsed : rightPanelView === "diff";
   const {
     files: diffFiles,
     perRepoBases,
@@ -294,7 +317,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     loading: diffFilesLoading,
     revision,
     refresh: refreshDiffFiles,
-  } = useDiffFiles(activeSessionId, !diffCollapsed);
+  } = useDiffFiles(activeSessionId, diffPanelActive);
 
   // Diff-viewer comments (#928). Cockpit-only and session-scoped. The
   // banner lives in RightPanel while the inline UI lives inside
@@ -337,6 +360,32 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       setSelectedFile(null);
     }
   }, [activeSessionId, diffFiles, diffFilesLoading, selectedFilePath]);
+
+  // Reset the mobile single-pane view to the agent terminal whenever the
+  // active session changes, and close the picker. Landing a freshly opened
+  // session on a stale "paired"/"diff" view would strand the user on a
+  // shell or empty file list before the new session's terminal is ready.
+  useEffect(() => {
+    setRightPanelView("agent");
+    setPickerOpen(false);
+    setPairedMounted(false);
+  }, [activeSessionId]);
+
+  // Mount the paired shell on first activation and keep it mounted after.
+  useEffect(() => {
+    if (rightPanelView === "paired") setPairedMounted(true);
+  }, [rightPanelView]);
+
+  // Refit the newly active terminal after a single-pane view switch: the
+  // layers keep their geometry while hidden (visibility, not display:none),
+  // but a resize nudge re-runs the xterm fit so the grid matches exactly.
+  useEffect(() => {
+    if (!singlePane) return;
+    const id = requestAnimationFrame(() =>
+      window.dispatchEvent(new Event("resize")),
+    );
+    return () => cancelAnimationFrame(id);
+  }, [singlePane, rightPanelView]);
 
   useEffect(() => {
     setSelectedFile(null);
@@ -484,7 +533,20 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     setShowSessionWizard(true);
   }, [sessions]);
 
-  const toggleDiff = useCallback(() => setDiffCollapsed((c) => !c), []);
+  // The right-panel control toggles the desktop split, but on mobile there
+  // is no split to collapse: it opens the view picker instead (#1452).
+  const toggleDiff = useCallback(() => {
+    if (isMdUp) {
+      setDiffCollapsed((c) => !c);
+    } else {
+      setPickerOpen((o) => !o);
+    }
+  }, [isMdUp]);
+
+  const handlePickView = useCallback((view: RightPanelView) => {
+    setRightPanelView(view);
+    setPickerOpen(false);
+  }, []);
 
   const handleSelectFile = useCallback(
     (path: string, repoName?: string) => {
@@ -541,7 +603,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   }, []);
 
   const openSidebar = useCallback(() => setSidebarOpen(true), []);
-  const openDiff = useCallback(() => setDiffCollapsed(false), []);
+  const openDiff = useCallback(() => {
+    if (isMdUp) {
+      setDiffCollapsed(false);
+    } else {
+      setPickerOpen(true);
+    }
+  }, [isMdUp]);
   useEdgeSwipe({
     edge: "left",
     enabled: !sidebarOpen,
@@ -566,10 +634,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   const handleToggleTerminalFocus = useCallback(() => {
     if (!activeSessionId) return;
-    // ContentSplit renders the right pane twice (desktop inline + mobile
-    // overlay); each instance mounts its own PairedTerminal. Probing by
-    // data-term attribute is robust against that duplication and against
-    // future panel reorderings.
+    // Probe by data-term attribute rather than a component ref: it is
+    // robust against panel reorderings and against the paired terminal
+    // living in either the desktop split or the mobile single pane.
     //
     // Semantic: VSCode-like "Cmd+` opens/focuses the terminal." So if the
     // user is NOT in the paired terminal, send them there; only flip back
@@ -589,6 +656,16 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     }
     const target = inPaired ? "agent" : "paired";
 
+    if (singlePane) {
+      // Below md there is one full-viewport pane. Promote the target view,
+      // then dispatch focus on the next frame: the inactive layer is inert
+      // until React commits the switch, and focus() on an inert subtree is
+      // a no-op.
+      setRightPanelView(target);
+      requestAnimationFrame(() => dispatchFocusTerminal(target));
+      return;
+    }
+
     if (target === "paired" && diffCollapsed) {
       // Right panel is collapsed; paired terminal is unmounted. Set the
       // pending intent so PairedTerminal grabs focus once it mounts and
@@ -606,7 +683,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       return;
     }
     dispatchFocusTerminal(target);
-  }, [activeSessionId, diffCollapsed, selectedFilePath]);
+  }, [activeSessionId, singlePane, diffCollapsed, selectedFilePath]);
 
   useKeyboardShortcuts(
     useCallback(
@@ -654,7 +731,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         onSettings: () => (showSettings ? handleCloseSettings() : navigate("/settings")),
         onPalette: () => setShowPalette((p) => !p),
         onToggleSidebar: () => setSidebarOpen((o) => !o),
-        onToggleRightPanel: () => setDiffCollapsed((c) => !c),
+        onToggleRightPanel: () => toggleDiff(),
         onToggleTerminalFocus: handleToggleTerminalFocus,
       }),
       [
@@ -731,6 +808,161 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       );
     }
 
+    const agentPane = activeSession?.cockpit_mode ? (
+      <Suspense fallback={<CockpitLoadingFallback />}>
+        <CockpitView
+          key={activeSessionId}
+          sessionId={activeSessionId!}
+          cockpitWorkerState={activeSession.cockpit_worker_state ?? "absent"}
+          tool={activeSession.tool}
+          archivedAt={activeSession.archived_at ?? null}
+          snoozedUntil={activeSession.snoozed_until ?? null}
+        />
+      </Suspense>
+    ) : (
+      <TerminalSessionStack
+        activeSessionId={activeSessionId!}
+        sessions={sessions.filter((session) => !session.cockpit_mode)}
+        cockpitMasterEnabled={!!serverAbout?.cockpit_master_enabled}
+        persistent={webSettings.persistentTerminals}
+        maxPersistentTerminals={webSettings.maxPersistentTerminals}
+      />
+    );
+
+    const diffViewerNode =
+      selectedFilePath && activeSessionId ? (
+        <DiffFileViewer
+          sessionId={activeSessionId}
+          filePath={selectedFilePath}
+          repoName={selectedRepoName}
+          revision={revision}
+          onClose={handleCloseFile}
+          commentsEnabled={commentsEnabled}
+          commentsStore={diffComments}
+        />
+      ) : null;
+
+    const diffListNode = (
+      <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        {commentsEnabled && diffComments.count > 0 && (
+          <CommentsBanner
+            count={diffComments.count}
+            sendEnabled={commentSendEnabled}
+            sendDisabledReason={commentSendDisabledReason}
+            onSend={() => setSendDialogOpen(true)}
+            onDiscardAll={diffComments.clearComments}
+          />
+        )}
+        <DiffFileList
+          files={diffFiles}
+          perRepoBases={perRepoBases}
+          warning={warning}
+          selectedPath={selectedFilePath}
+          selectedRepoName={selectedRepoName}
+          loading={diffFilesLoading}
+          onSelectFile={handleSelectFile}
+          sessionId={activeSessionId}
+          repoPath={
+            activeSession?.main_repo_path ??
+            activeSession?.project_path ??
+            null
+          }
+          baseBranchOverride={activeSession?.base_branch_override ?? null}
+          onBaseBranchChanged={refreshDiffFiles}
+        />
+      </div>
+    );
+
+    const sendDialogNode = sendDialogOpen &&
+      commentsEnabled &&
+      activeSessionId && (
+        <SendCommentsDialog
+          sessionId={activeSessionId}
+          comments={diffComments.comments}
+          isMultiRepo={commentsIsMultiRepo}
+          sendEnabled={commentSendEnabled}
+          sendDisabledReason={commentSendDisabledReason}
+          introDraft={diffComments.introDraft}
+          outroDraft={diffComments.outroDraft}
+          clearAfterSend={diffComments.clearAfterSend}
+          onChangeIntro={diffComments.setIntroDraft}
+          onChangeOutro={diffComments.setOutroDraft}
+          onChangeClearAfterSend={diffComments.setClearAfterSend}
+          onClose={() => setSendDialogOpen(false)}
+          onSent={() => {
+            if (diffComments.clearAfterSend) {
+              diffComments.clearComments();
+              diffComments.setIntroDraft("");
+              diffComments.setOutroDraft("");
+            }
+            setSendDialogOpen(false);
+            // Close the diff viewer so the cockpit transcript is in
+            // view: the user just dispatched feedback and wants to
+            // see the agent's response. They can re-open any file
+            // from the right-panel list afterwards.
+            setSelectedFile(null);
+            toastBus.handler?.info("Comments sent to agent");
+          }}
+        />
+      );
+
+    // Below the md breakpoint there is no room for the side-by-side split.
+    // Render one full-viewport pane and let the picker choose which view
+    // occupies it (#1452). The agent terminal (and the paired shell, once
+    // first opened) stay mounted but hidden so their PTY, scrollback, and
+    // focus survive view switches; the diff view has no xterm so it mounts
+    // on demand. Inactive layers use visibility, never display:none, which
+    // would collapse xterm's measured geometry to zero.
+    if (singlePane) {
+      const layerClass = (active: boolean) =>
+        active
+          ? "absolute inset-0 flex flex-col min-h-0 overflow-hidden"
+          : "absolute inset-0 flex flex-col min-h-0 overflow-hidden invisible pointer-events-none";
+      const viewLabel = rightPanelView === "diff" ? "Diff" : "Paired terminal";
+      return (
+        <div className="flex-1 flex flex-col min-h-0">
+          {rightPanelView !== "agent" && (
+            <div className="flex items-center gap-2 h-9 px-2 border-b border-surface-700/20 bg-surface-900 shrink-0">
+              <button
+                onClick={() => setRightPanelView("agent")}
+                data-testid="mobile-back-to-agent"
+                className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-text-secondary hover:text-text-primary hover:bg-surface-800 cursor-pointer transition-colors"
+              >
+                <span aria-hidden>&larr;</span> Agent
+              </button>
+              <span className="text-xs text-text-dim">{viewLabel}</span>
+            </div>
+          )}
+          <div className="relative flex-1 flex flex-col min-h-0 overflow-hidden">
+            <div
+              className={layerClass(rightPanelView === "agent")}
+              inert={rightPanelView !== "agent"}
+            >
+              {agentPane}
+            </div>
+            {pairedMounted && (
+              <div
+                className={layerClass(rightPanelView === "paired")}
+                inert={rightPanelView !== "paired"}
+              >
+                <PairedShellPane
+                  session={activeSession ?? null}
+                  sessionId={activeSessionId}
+                  fullViewport
+                />
+              </div>
+            )}
+            {rightPanelView === "diff" && (
+              <div className="absolute inset-0 z-10 flex flex-col min-h-0 overflow-hidden bg-surface-900">
+                {diffViewerNode ?? diffListNode}
+              </div>
+            )}
+          </div>
+          {sendDialogNode}
+        </div>
+      );
+    }
+
     return (
       <div className="flex-1 flex flex-col min-h-0">
         <ContentSplit
@@ -745,43 +977,10 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                     : "flex-1 flex flex-col min-h-0 overflow-hidden"
                 }
               >
-                {activeSession?.cockpit_mode ? (
-                  <Suspense fallback={<CockpitLoadingFallback />}>
-                    <CockpitView
-                      key={activeSessionId}
-                      sessionId={activeSessionId!}
-                      cockpitWorkerState={activeSession.cockpit_worker_state ?? "absent"}
-                      tool={activeSession.tool}
-                      archivedAt={activeSession.archived_at ?? null}
-                      snoozedUntil={activeSession.snoozed_until ?? null}
-                    />
-                  </Suspense>
-                ) : (
-                  <TerminalSessionStack
-                    activeSessionId={activeSessionId!}
-                    sessions={sessions.filter((session) => !session.cockpit_mode)}
-                    cockpitMasterEnabled={
-                      !!serverAbout?.cockpit_master_enabled
-                    }
-                    persistent={webSettings.persistentTerminals}
-                    maxPersistentTerminals={
-                      webSettings.maxPersistentTerminals
-                    }
-                  />
-                )}
+                {agentPane}
               </div>
 
-              {selectedFilePath && activeSessionId && (
-                <DiffFileViewer
-                  sessionId={activeSessionId}
-                  filePath={selectedFilePath}
-                  repoName={selectedRepoName}
-                  revision={revision}
-                  onClose={handleCloseFile}
-                  commentsEnabled={commentsEnabled}
-                  commentsStore={diffComments}
-                />
-              )}
+              {diffViewerNode}
             </div>
           }
           right={
@@ -805,36 +1004,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             />
           }
         />
-        {sendDialogOpen && commentsEnabled && activeSessionId && (
-          <SendCommentsDialog
-            sessionId={activeSessionId}
-            comments={diffComments.comments}
-            isMultiRepo={commentsIsMultiRepo}
-            sendEnabled={commentSendEnabled}
-            sendDisabledReason={commentSendDisabledReason}
-            introDraft={diffComments.introDraft}
-            outroDraft={diffComments.outroDraft}
-            clearAfterSend={diffComments.clearAfterSend}
-            onChangeIntro={diffComments.setIntroDraft}
-            onChangeOutro={diffComments.setOutroDraft}
-            onChangeClearAfterSend={diffComments.setClearAfterSend}
-            onClose={() => setSendDialogOpen(false)}
-            onSent={() => {
-              if (diffComments.clearAfterSend) {
-                diffComments.clearComments();
-                diffComments.setIntroDraft("");
-                diffComments.setOutroDraft("");
-              }
-              setSendDialogOpen(false);
-              // Close the diff viewer so the cockpit transcript is in
-              // view: the user just dispatched feedback and wants to
-              // see the agent's response. They can re-open any file
-              // from the right-panel list afterwards.
-              setSelectedFile(null);
-              toastBus.handler?.info("Comments sent to agent");
-            }}
-          />
-        )}
+        {sendDialogNode}
       </div>
     );
   };
@@ -853,9 +1023,17 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // the active session is cockpit so `h-dvh` plus the viewport meta's
   // `interactive-widget=resizes-content` shrink the container with the
   // keyboard and lift the composer back into view.
+  //
+  // Exception: when the single-pane paired shell is the active mobile view,
+  // an xterm.js terminal owns the viewport even on a cockpit session, so it
+  // needs the pin (plus the reservation in PairedTerminal) for the same
+  // reason the agent terminal does (#1452).
   const { isMobile, stableViewportHeight } = useMobileKeyboard();
+  const pairedFullViewport = singlePane && rightPanelView === "paired";
   const pinRootHeight =
-    isMobile && stableViewportHeight > 0 && !activeSession?.cockpit_mode;
+    isMobile &&
+    stableViewportHeight > 0 &&
+    (!activeSession?.cockpit_mode || pairedFullViewport);
   const rootStyle = pinRootHeight
     ? { height: `${stableViewportHeight}px` }
     : undefined;
@@ -969,6 +1147,15 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         onClose={() => setShowPalette(false)}
         actions={commandActions}
       />
+
+      {activeWorkspace && activeSession && (
+        <MobileRightPanelPicker
+          open={pickerOpen && singlePane}
+          active={rightPanelView}
+          onSelect={handlePickView}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
 
       <textarea
         ref={keyboardProxyRef}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -660,8 +660,11 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       // Below md there is one full-viewport pane. Promote the target view,
       // then dispatch focus on the next frame: the inactive layer is inert
       // until React commits the switch, and focus() on an inert subtree is
-      // a no-op.
+      // a no-op. The paired shell mounts lazily on first activation, so its
+      // PTY may not be ready when the dispatch fires; latch the intent too,
+      // and PairedTerminal grabs focus once ready.
       setRightPanelView(target);
+      if (target === "paired") setPendingTerminalFocus("paired");
       requestAnimationFrame(() => dispatchFocusTerminal(target));
       return;
     }

--- a/web/src/components/ContentSplit.tsx
+++ b/web/src/components/ContentSplit.tsx
@@ -97,34 +97,14 @@ export function ContentSplit({
             className="hidden md:block w-1 cursor-col-resize shrink-0 bg-surface-800 hover:bg-brand-600/50 transition-colors duration-75"
           />
 
-          {/* Right pane: inline on desktop, overlay on mobile */}
+          {/* Right pane (inline). ContentSplit only renders at the md
+              breakpoint and up; below md the mobile picker promotes the
+              chosen view into the single full-viewport pane instead (#1452). */}
           <div
             style={{ width: diffWidth }}
-            className="hidden md:flex shrink-0 flex-col min-h-0 overflow-hidden"
+            className="flex shrink-0 flex-col min-h-0 overflow-hidden"
           >
             {right}
-          </div>
-
-          {/* Mobile: slide-in panel from right with backdrop (mirrors left sidebar pattern) */}
-          <div
-            className="md:hidden fixed top-12 inset-x-0 bottom-0 bg-black/50 z-30"
-            onClick={onToggleCollapse}
-          />
-          <div className="md:hidden fixed top-12 bottom-0 right-0 z-40 w-[85vw] max-w-sm flex flex-col bg-surface-900">
-            <div className="h-10 flex items-center px-3 border-b border-surface-700/20 shrink-0">
-              <span className="text-sm text-text-muted flex-1">
-                Diff & Shell
-              </span>
-              <button
-                onClick={onToggleCollapse}
-                className="w-8 h-8 flex items-center justify-center text-text-dim hover:text-text-secondary hover:bg-surface-800 cursor-pointer rounded-md transition-colors"
-              >
-                &times;
-              </button>
-            </div>
-            <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-              {right}
-            </div>
           </div>
         </>
       )}

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -1,0 +1,212 @@
+import { lazy, Suspense } from "react";
+
+import { TerminalSessionStack } from "./TerminalSessionStack";
+import { PairedShellPane } from "./PairedTerminal";
+import { DiffFileList } from "./diff/DiffFileList";
+import { DiffFileViewer } from "./diff/DiffFileViewer";
+import { CommentsBanner } from "./diff/comments/CommentsBanner";
+import { SendCommentsDialog } from "./diff/comments/SendCommentsDialog";
+import type { RightPanelView } from "../lib/rightPanelView";
+import type { ServerAbout } from "../lib/api";
+import type { RepoBase, RichDiffFile, SessionResponse } from "../lib/types";
+import type { useDiffComments } from "../hooks/useDiffComments";
+
+const CockpitView = lazy(() =>
+  import("./cockpit/CockpitView").then((m) => ({ default: m.CockpitView })),
+);
+
+interface Props {
+  view: RightPanelView;
+  onBackToAgent: () => void;
+  pairedMounted: boolean;
+  activeSession: SessionResponse | null;
+  activeSessionId: string | null;
+  sessions: SessionResponse[];
+  serverAbout: ServerAbout | null;
+  webSettings: { persistentTerminals: boolean; maxPersistentTerminals: number };
+  selectedFilePath: string | null;
+  selectedRepoName: string | undefined;
+  revision: number;
+  diffFiles: RichDiffFile[];
+  perRepoBases: RepoBase[];
+  warning: string | null;
+  diffFilesLoading: boolean;
+  onSelectFile: (path: string, repoName?: string) => void;
+  onCloseFile: () => void;
+  onDiffRefresh: () => void;
+  commentsEnabled: boolean;
+  commentSendEnabled: boolean;
+  commentSendDisabledReason?: string;
+  diffComments: ReturnType<typeof useDiffComments>;
+  commentsIsMultiRepo: boolean;
+  sendDialogOpen: boolean;
+  onOpenSendDialog: () => void;
+  onCloseSendDialog: () => void;
+  onClearSelectedFile: () => void;
+}
+
+function layerClass(active: boolean): string {
+  const base = "absolute inset-0 flex flex-col min-h-0 overflow-hidden";
+  return active ? base : `${base} invisible pointer-events-none`;
+}
+
+/** The single full-viewport pane shown below the `md` breakpoint (#1452).
+ *  The picker promotes one of agent / diff / paired into it. The agent
+ *  terminal and the paired shell (once first opened) stay mounted but
+ *  hidden via `visibility` so their PTY, scrollback, and focus survive
+ *  view switches; `display:none` would collapse xterm geometry to zero. */
+export function MobileMainPane({
+  view,
+  onBackToAgent,
+  pairedMounted,
+  activeSession,
+  activeSessionId,
+  sessions,
+  serverAbout,
+  webSettings,
+  selectedFilePath,
+  selectedRepoName,
+  revision,
+  diffFiles,
+  perRepoBases,
+  warning,
+  diffFilesLoading,
+  onSelectFile,
+  onCloseFile,
+  onDiffRefresh,
+  commentsEnabled,
+  commentSendEnabled,
+  commentSendDisabledReason,
+  diffComments,
+  commentsIsMultiRepo,
+  sendDialogOpen,
+  onOpenSendDialog,
+  onCloseSendDialog,
+  onClearSelectedFile,
+}: Props) {
+  const viewLabel = view === "diff" ? "Diff" : "Paired terminal";
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      {view !== "agent" && (
+        <div className="flex items-center gap-2 h-9 px-2 border-b border-surface-700/20 bg-surface-900 shrink-0">
+          <button
+            onClick={onBackToAgent}
+            data-testid="mobile-back-to-agent"
+            className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-text-secondary hover:text-text-primary hover:bg-surface-800 cursor-pointer transition-colors"
+          >
+            <span aria-hidden>&larr;</span> Agent
+          </button>
+          <span className="text-xs text-text-dim">{viewLabel}</span>
+        </div>
+      )}
+      <div className="relative flex-1 flex flex-col min-h-0 overflow-hidden">
+        <div className={layerClass(view === "agent")} inert={view !== "agent"}>
+          {activeSession?.cockpit_mode ? (
+            <Suspense fallback={null}>
+              <CockpitView
+                key={activeSessionId}
+                sessionId={activeSessionId!}
+                cockpitWorkerState={activeSession.cockpit_worker_state ?? "absent"}
+                tool={activeSession.tool}
+                archivedAt={activeSession.archived_at ?? null}
+                snoozedUntil={activeSession.snoozed_until ?? null}
+              />
+            </Suspense>
+          ) : (
+            <TerminalSessionStack
+              activeSessionId={activeSessionId!}
+              sessions={sessions.filter((session) => !session.cockpit_mode)}
+              cockpitMasterEnabled={!!serverAbout?.cockpit_master_enabled}
+              persistent={webSettings.persistentTerminals}
+              maxPersistentTerminals={webSettings.maxPersistentTerminals}
+            />
+          )}
+        </div>
+
+        {pairedMounted && (
+          <div
+            className={layerClass(view === "paired")}
+            inert={view !== "paired"}
+          >
+            <PairedShellPane
+              session={activeSession}
+              sessionId={activeSessionId}
+              fullViewport
+            />
+          </div>
+        )}
+
+        {view === "diff" && (
+          <div className="absolute inset-0 z-10 flex flex-col min-h-0 overflow-hidden bg-surface-900">
+            {selectedFilePath && activeSessionId ? (
+              <DiffFileViewer
+                sessionId={activeSessionId}
+                filePath={selectedFilePath}
+                repoName={selectedRepoName}
+                revision={revision}
+                onClose={onCloseFile}
+                commentsEnabled={commentsEnabled}
+                commentsStore={diffComments}
+              />
+            ) : (
+              <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+                {commentsEnabled && diffComments.count > 0 && (
+                  <CommentsBanner
+                    count={diffComments.count}
+                    sendEnabled={commentSendEnabled}
+                    sendDisabledReason={commentSendDisabledReason}
+                    onSend={onOpenSendDialog}
+                    onDiscardAll={diffComments.clearComments}
+                  />
+                )}
+                <DiffFileList
+                  files={diffFiles}
+                  perRepoBases={perRepoBases}
+                  warning={warning}
+                  selectedPath={selectedFilePath}
+                  selectedRepoName={selectedRepoName}
+                  loading={diffFilesLoading}
+                  onSelectFile={onSelectFile}
+                  sessionId={activeSessionId}
+                  repoPath={
+                    activeSession?.main_repo_path ??
+                    activeSession?.project_path ??
+                    null
+                  }
+                  baseBranchOverride={activeSession?.base_branch_override ?? null}
+                  onBaseBranchChanged={onDiffRefresh}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      {sendDialogOpen && commentsEnabled && activeSessionId && (
+        <SendCommentsDialog
+          sessionId={activeSessionId}
+          comments={diffComments.comments}
+          isMultiRepo={commentsIsMultiRepo}
+          sendEnabled={commentSendEnabled}
+          sendDisabledReason={commentSendDisabledReason}
+          introDraft={diffComments.introDraft}
+          outroDraft={diffComments.outroDraft}
+          clearAfterSend={diffComments.clearAfterSend}
+          onChangeIntro={diffComments.setIntroDraft}
+          onChangeOutro={diffComments.setOutroDraft}
+          onChangeClearAfterSend={diffComments.setClearAfterSend}
+          onClose={onCloseSendDialog}
+          onSent={() => {
+            if (diffComments.clearAfterSend) {
+              diffComments.clearComments();
+              diffComments.setIntroDraft("");
+              diffComments.setOutroDraft("");
+            }
+            onCloseSendDialog();
+            onClearSelectedFile();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/MobileRightPanelPicker.tsx
+++ b/web/src/components/MobileRightPanelPicker.tsx
@@ -1,0 +1,74 @@
+import type { RightPanelView } from "../lib/rightPanelView";
+
+interface Entry {
+  view: RightPanelView;
+  label: string;
+  hint: string;
+}
+
+const ENTRIES: Entry[] = [
+  { view: "agent", label: "Agent terminal", hint: "The session's main view" },
+  { view: "diff", label: "Diff", hint: "Changed files and review" },
+  { view: "paired", label: "Paired terminal", hint: "Host or container shell" },
+];
+
+interface Props {
+  open: boolean;
+  active: RightPanelView;
+  onSelect: (view: RightPanelView) => void;
+  onClose: () => void;
+}
+
+/** Mobile-only bottom sheet that promotes the chosen view into the single
+ *  full-viewport main pane (#1452). Replaces the old slide-in right-panel
+ *  overlay, which collapsed the paired terminal to zero height under the
+ *  soft keyboard. */
+export function MobileRightPanelPicker({
+  open,
+  active,
+  onSelect,
+  onClose,
+}: Props) {
+  if (!open) return null;
+  return (
+    <div className="md:hidden fixed inset-0 z-50 flex flex-col justify-end">
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        data-testid="mobile-right-panel-picker-backdrop"
+      />
+      <div
+        className="relative bg-surface-900 border-t border-surface-700/20 rounded-t-xl pb-[env(safe-area-inset-bottom)]"
+        role="dialog"
+        aria-label="Select view"
+        data-testid="mobile-right-panel-picker"
+      >
+        <div className="flex justify-center py-2">
+          <div className="w-9 h-1 rounded-full bg-surface-500/40" />
+        </div>
+        <ul className="px-2 pb-2">
+          {ENTRIES.map((entry) => {
+            const isActive = entry.view === active;
+            return (
+              <li key={entry.view}>
+                <button
+                  onClick={() => onSelect(entry.view)}
+                  aria-current={isActive ? "true" : undefined}
+                  data-testid={`mobile-right-panel-pick-${entry.view}`}
+                  className={`w-full flex flex-col items-start gap-0.5 px-3 py-3 rounded-lg text-left cursor-pointer transition-colors ${
+                    isActive
+                      ? "bg-brand-600/10 text-brand-500"
+                      : "text-text-secondary hover:bg-surface-800"
+                  }`}
+                >
+                  <span className="text-sm font-medium">{entry.label}</span>
+                  <span className="text-xs text-text-dim">{entry.hint}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/MobileRightPanelPicker.tsx
+++ b/web/src/components/MobileRightPanelPicker.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import type { RightPanelView } from "../lib/rightPanelView";
 
 interface Entry {
@@ -29,6 +30,16 @@ export function MobileRightPanelPicker({
   onSelect,
   onClose,
 }: Props) {
+  // Close on Escape, matching the other dismissible overlays.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
   if (!open) return null;
   return (
     <div className="md:hidden fixed inset-0 z-50 flex flex-col justify-end">
@@ -40,6 +51,7 @@ export function MobileRightPanelPicker({
       <div
         className="relative bg-surface-900 border-t border-surface-700/20 rounded-t-xl pb-[env(safe-area-inset-bottom)]"
         role="dialog"
+        aria-modal="true"
         aria-label="Select view"
         data-testid="mobile-right-panel-picker"
       >

--- a/web/src/components/MobileRightPanelPicker.tsx
+++ b/web/src/components/MobileRightPanelPicker.tsx
@@ -49,7 +49,7 @@ export function MobileRightPanelPicker({
         data-testid="mobile-right-panel-picker-backdrop"
       />
       <div
-        className="relative bg-surface-900 border-t border-surface-700/20 rounded-t-xl pb-[env(safe-area-inset-bottom)]"
+        className="relative bg-surface-900 border-t border-surface-700/20 rounded-t-lg pb-[env(safe-area-inset-bottom)]"
         role="dialog"
         aria-modal="true"
         aria-label="Select view"
@@ -67,7 +67,7 @@ export function MobileRightPanelPicker({
                   onClick={() => onSelect(entry.view)}
                   aria-current={isActive ? "true" : undefined}
                   data-testid={`mobile-right-panel-pick-${entry.view}`}
-                  className={`w-full flex flex-col items-start gap-0.5 px-3 py-3 rounded-lg text-left cursor-pointer transition-colors ${
+                  className={`w-full flex flex-col items-start gap-0.5 px-3 py-2 rounded-lg text-left cursor-pointer transition-colors ${
                     isActive
                       ? "bg-brand-600/10 text-brand-500"
                       : "text-text-secondary hover:bg-surface-800"

--- a/web/src/components/PairedTerminal.tsx
+++ b/web/src/components/PairedTerminal.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useTerminal } from "../hooks/useTerminal";
+import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
+import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
+import { BackToLiveButton } from "./BackToLiveButton";
+import { KeyboardFab } from "./KeyboardFab";
+import { ensureTerminal } from "../lib/api";
+import type { SessionResponse } from "../lib/types";
+import {
+  FOCUS_TERMINAL_EVENT,
+  consumePendingTerminalFocus,
+  setPendingTerminalFocus,
+  type FocusTerminalDetail,
+} from "../lib/terminalFocus";
+import "@xterm/xterm/css/xterm.css";
+
+type ShellMode = "host" | "container";
+
+/** The paired (side-shell) xterm.js terminal.
+ *
+ *  `fullViewport` switches the keyboard-padding posture. In the desktop
+ *  split this terminal owns only half of an already-capped panel, so it
+ *  pads by the live `keyboardHeight` (and on desktop that is always 0).
+ *  When promoted to the single full-viewport mobile pane it owns the
+ *  whole viewport, so it pads by the latched `reservedKeyboardHeight`,
+ *  the same sticky reservation the agent `TerminalView` uses; padding by
+ *  the live height there would collapse the grid on every keyboard
+ *  show/hide. See #1452. */
+function PairedTerminal({
+  sessionId,
+  mode,
+  fullViewport = false,
+}: {
+  sessionId: string;
+  mode: ShellMode;
+  fullViewport?: boolean;
+}) {
+  const [ready, setReady] = useState(false);
+  const wsPath =
+    mode === "container" ? "container-terminal/ws" : "terminal/ws";
+  const {
+    containerRef,
+    termRef,
+    state,
+    manualReconnect,
+    sendData,
+    activate,
+    exitScrollback,
+    ctrlActiveRef,
+    clearCtrlRef,
+    maxRetries,
+  } = useTerminal(ready ? sessionId : null, wsPath, false);
+  const { isMobile, keyboardOpen, keyboardHeight, reservedKeyboardHeight } =
+    useMobileKeyboard();
+  const [ctrlActive, setCtrlActive] = useState(false);
+  const [termFocused, setTermFocused] = useState(false);
+
+  // See TerminalView.tsx for why these syncs live in effects rather
+  // than running during render.
+  useEffect(() => {
+    ctrlActiveRef.current = ctrlActive;
+  });
+  useEffect(() => {
+    clearCtrlRef.current = () => setCtrlActive(false);
+  }, [clearCtrlRef]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setReady(false);
+    ensureTerminal(sessionId, mode === "container").then((ok) => {
+      if (!cancelled && ok) setReady(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, mode]);
+
+  // Dispatch a window resize after keyboard transitions so anything else
+  // watching layout is nudged; the hook's ResizeObserver already refits
+  // the terminal grid automatically.
+  useLayoutEffect(() => {
+    const t = setTimeout(() => {
+      window.dispatchEvent(new Event("resize"));
+    }, 150);
+    return () => clearTimeout(t);
+  }, [keyboardHeight, keyboardOpen]);
+
+  const toggleKeyboard = useCallback(() => {
+    const term = termRef.current;
+    if (!term?.element) return;
+    const ta = term.element.querySelector("textarea");
+    if (keyboardOpen) {
+      ta?.blur();
+    } else if (ta instanceof HTMLElement) {
+      ta.focus();
+    }
+    activate();
+  }, [termRef, keyboardOpen, activate]);
+
+  // Returns true if focus was applied. Callers can fall back to the pending
+  // latch when the textarea isn't in the DOM yet (PTY still booting).
+  const focusSelf = useCallback(() => {
+    const ta = termRef.current?.element?.querySelector("textarea");
+    if (ta instanceof HTMLElement) {
+      ta.focus();
+      return true;
+    }
+    return false;
+  }, [termRef]);
+
+  // Cmd+` shortcut focuses this terminal when "paired" is the dispatched
+  // target. The component might be mounted but its PTY not yet ready (the
+  // initial ensureTerminal round-trip), in which case focusSelf() can't
+  // find a textarea, so we latch the intent for the ready-effect below.
+  // While the right panel is collapsed this component is unmounted entirely;
+  // App.tsx sets the latch directly in that case.
+  useEffect(() => {
+    const onFocusEvent = (e: Event) => {
+      const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
+      if (detail?.target !== "paired") return;
+      if (!focusSelf()) setPendingTerminalFocus("paired");
+    };
+    window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
+    return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
+  }, [focusSelf]);
+
+  useEffect(() => {
+    if (!ready) return;
+    if (consumePendingTerminalFocus("paired")) focusSelf();
+  }, [ready, focusSelf]);
+
+  if (!ready) {
+    return (
+      <div className="flex-1 flex items-center justify-center bg-surface-950 text-text-dim">
+        <span className="text-xs">Starting terminal...</span>
+      </div>
+    );
+  }
+
+  const appliedKeyboardPadding = fullViewport
+    ? reservedKeyboardHeight
+    : keyboardHeight;
+  const rootStyle = {
+    paddingBottom:
+      appliedKeyboardPadding > 0 ? appliedKeyboardPadding : undefined,
+  } as const;
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 overflow-hidden md:bg-surface-800" style={rootStyle}>
+      {!state.connected && state.reconnecting && (
+        <div className="bg-status-waiting/15 border-b border-status-waiting/30 px-3 py-1 shrink-0">
+          <span className="text-xs text-status-waiting">
+            Reconnecting... ({state.retryCount}/{maxRetries})
+          </span>
+        </div>
+      )}
+      {!state.connected && !state.reconnecting && state.retryCount >= maxRetries && (
+        <div className="bg-status-error/10 border-b border-status-error/30 px-3 py-1 flex items-center gap-2 shrink-0">
+          <span className="text-xs text-status-error">Disconnected</span>
+          <button
+            onClick={manualReconnect}
+            className="text-xs text-brand-500 cursor-pointer underline"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+      <div
+        data-term="paired"
+        className={`flex-1 overflow-hidden bg-surface-950 relative md:rounded-lg term-panel${termFocused ? " term-focused" : ""}`}
+        onFocus={() => setTermFocused(true)}
+        onBlur={() => setTermFocused(false)}
+      >
+        <div
+          ref={containerRef}
+          className="absolute inset-0"
+          onPointerDown={activate}
+        />
+
+        {isMobile && state.isInScrollback && (
+          <BackToLiveButton onClick={exitScrollback} topOffset="top-2" />
+        )}
+
+        {isMobile && state.connected && (
+          <KeyboardFab keyboardOpen={keyboardOpen} onToggle={toggleKeyboard} />
+        )}
+      </div>
+      {isMobile && state.connected && (
+        <MobileTerminalToolbar
+          sendData={sendData}
+          termRef={termRef}
+          keyboardOpen={keyboardOpen}
+          ctrlActive={ctrlActive}
+          onCtrlToggle={() => setCtrlActive((v) => !v)}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Host/container shell switch plus the paired terminal. Used both in the
+ *  desktop right-panel split (`fullViewport={false}`) and as the promoted
+ *  single full-viewport mobile pane (`fullViewport`). */
+export function PairedShellPane({
+  session,
+  sessionId,
+  fullViewport = false,
+}: {
+  session: SessionResponse | null;
+  sessionId: string | null;
+  fullViewport?: boolean;
+}) {
+  const [shellMode, setShellMode] = useState<ShellMode>("host");
+  const isSandboxed = session?.is_sandboxed ?? false;
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+      <div className="flex items-center gap-1 px-2 py-1 bg-surface-900 border-b border-surface-700/20 shrink-0">
+        <span className="text-xs text-text-dim mr-1">Shell</span>
+        <button
+          onClick={() => setShellMode("host")}
+          className={`text-[12px] px-2 py-0.5 rounded cursor-pointer transition-colors ${
+            shellMode === "host"
+              ? "text-brand-500 bg-brand-600/10"
+              : "text-text-dim hover:text-text-muted"
+          }`}
+        >
+          Host
+        </button>
+        {isSandboxed && (
+          <button
+            onClick={() => setShellMode("container")}
+            className={`text-[12px] px-2 py-0.5 rounded cursor-pointer transition-colors ${
+              shellMode === "container"
+                ? "text-brand-500 bg-brand-600/10"
+                : "text-text-dim hover:text-text-muted"
+            }`}
+          >
+            Container
+          </button>
+        )}
+      </div>
+
+      {sessionId ? (
+        <PairedTerminal
+          key={`${sessionId}-${shellMode}`}
+          sessionId={sessionId}
+          mode={shellMode}
+          fullViewport={fullViewport}
+        />
+      ) : (
+        <div className="flex-1 flex items-center justify-center bg-surface-950 text-text-dim">
+          <p className="text-xs">Select a session</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/PairedTerminal.tsx
+++ b/web/src/components/PairedTerminal.tsx
@@ -53,6 +53,8 @@ function PairedTerminal({
     useMobileKeyboard();
   const [ctrlActive, setCtrlActive] = useState(false);
   const [termFocused, setTermFocused] = useState(false);
+  const [bootError, setBootError] = useState(false);
+  const [bootAttempt, setBootAttempt] = useState(0);
 
   // See TerminalView.tsx for why these syncs live in effects rather
   // than running during render.
@@ -66,13 +68,20 @@ function PairedTerminal({
   useEffect(() => {
     let cancelled = false;
     setReady(false);
-    ensureTerminal(sessionId, mode === "container").then((ok) => {
-      if (!cancelled && ok) setReady(true);
-    });
+    setBootError(false);
+    void ensureTerminal(sessionId, mode === "container")
+      .then((ok) => {
+        if (cancelled) return;
+        if (ok) setReady(true);
+        else setBootError(true);
+      })
+      .catch(() => {
+        if (!cancelled) setBootError(true);
+      });
     return () => {
       cancelled = true;
     };
-  }, [sessionId, mode]);
+  }, [sessionId, mode, bootAttempt]);
 
   // Dispatch a window resize after keyboard transitions so anything else
   // watching layout is nudged; the hook's ResizeObserver already refits
@@ -127,6 +136,22 @@ function PairedTerminal({
     if (!ready) return;
     if (consumePendingTerminalFocus("paired")) focusSelf();
   }, [ready, focusSelf]);
+
+  if (bootError) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-2 bg-surface-950 text-text-dim">
+        <span className="text-xs text-status-error">
+          Couldn't start the terminal.
+        </span>
+        <button
+          onClick={() => setBootAttempt((n) => n + 1)}
+          className="text-xs text-brand-500 cursor-pointer underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
 
   if (!ready) {
     return (

--- a/web/src/components/PairedTerminal.tsx
+++ b/web/src/components/PairedTerminal.tsx
@@ -22,10 +22,9 @@ type ShellMode = "host" | "container";
  *  split this terminal owns only half of an already-capped panel, so it
  *  pads by the live `keyboardHeight` (and on desktop that is always 0).
  *  When promoted to the single full-viewport mobile pane it owns the
- *  whole viewport, so it pads by the latched `reservedKeyboardHeight`,
- *  the same sticky reservation the agent `TerminalView` uses; padding by
- *  the live height there would collapse the grid on every keyboard
- *  show/hide. See #1452. */
+ *  whole viewport, so it pads by `keyboardOcclusion`, the same value the
+ *  agent `TerminalView` uses; padding by the live height there would
+ *  collapse the grid on every keyboard show/hide. See #1452. */
 function PairedTerminal({
   sessionId,
   mode,
@@ -50,7 +49,7 @@ function PairedTerminal({
     clearCtrlRef,
     maxRetries,
   } = useTerminal(ready ? sessionId : null, wsPath, false);
-  const { isMobile, keyboardOpen, keyboardHeight, reservedKeyboardHeight } =
+  const { isMobile, keyboardOpen, keyboardHeight, keyboardOcclusion } =
     useMobileKeyboard();
   const [ctrlActive, setCtrlActive] = useState(false);
   const [termFocused, setTermFocused] = useState(false);
@@ -138,7 +137,7 @@ function PairedTerminal({
   }
 
   const appliedKeyboardPadding = fullViewport
-    ? reservedKeyboardHeight
+    ? keyboardOcclusion
     : keyboardHeight;
   const rootStyle = {
     paddingBottom:

--- a/web/src/components/PairedTerminal.tsx
+++ b/web/src/components/PairedTerminal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import { useTerminal } from "../hooks/useTerminal";
 import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
 import { MobileTerminalToolbar } from "./MobileTerminalToolbar";

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -1,21 +1,9 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { DiffFileList } from "./diff/DiffFileList";
 import { CommentsBanner } from "./diff/comments/CommentsBanner";
-import { useTerminal } from "../hooks/useTerminal";
-import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
-import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
-import { BackToLiveButton } from "./BackToLiveButton";
-import { KeyboardFab } from "./KeyboardFab";
-import { ensureTerminal } from "../lib/api";
+import { PairedShellPane } from "./PairedTerminal";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import type { RepoBase, RichDiffFile, SessionResponse } from "../lib/types";
-import {
-  FOCUS_TERMINAL_EVENT,
-  consumePendingTerminalFocus,
-  setPendingTerminalFocus,
-  type FocusTerminalDetail,
-} from "../lib/terminalFocus";
-import "@xterm/xterm/css/xterm.css";
 
 const VSPLIT_STORAGE_KEY = "aoe-right-vsplit";
 const DEFAULT_TOP_RATIO = 0.5;
@@ -53,178 +41,6 @@ interface Props {
   onDiscardAllComments: () => void;
 }
 
-type ShellMode = "host" | "container";
-
-function PairedTerminal({
-  sessionId,
-  mode,
-}: {
-  sessionId: string;
-  mode: ShellMode;
-}) {
-  const [ready, setReady] = useState(false);
-  const wsPath =
-    mode === "container" ? "container-terminal/ws" : "terminal/ws";
-  const {
-    containerRef,
-    termRef,
-    state,
-    manualReconnect,
-    sendData,
-    activate,
-    exitScrollback,
-    ctrlActiveRef,
-    clearCtrlRef,
-    maxRetries,
-  } = useTerminal(ready ? sessionId : null, wsPath, false);
-  // PairedTerminal intentionally uses the live keyboardHeight, not the
-  // sticky reservation that TerminalView uses. The slide-in only gives
-  // this pane ~half a viewport tall, and applying a ~340px reservation
-  // there collapses data-term="paired" to 0 height. Side-shell use is
-  // sporadic so the original kb-cycle behavior is acceptable here.
-  const { isMobile, keyboardOpen, keyboardHeight } = useMobileKeyboard();
-  const [ctrlActive, setCtrlActive] = useState(false);
-  const [termFocused, setTermFocused] = useState(false);
-
-  // See TerminalView.tsx for why these syncs live in effects rather
-  // than running during render.
-  useEffect(() => {
-    ctrlActiveRef.current = ctrlActive;
-  });
-  useEffect(() => {
-    clearCtrlRef.current = () => setCtrlActive(false);
-  }, [clearCtrlRef]);
-
-  useEffect(() => {
-    let cancelled = false;
-    setReady(false);
-    ensureTerminal(sessionId, mode === "container").then((ok) => {
-      if (!cancelled && ok) setReady(true);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionId, mode]);
-
-  // Dispatch a window resize after keyboard transitions so anything else
-  // watching layout is nudged; the hook's ResizeObserver already refits
-  // the terminal grid automatically.
-  useLayoutEffect(() => {
-    const t = setTimeout(() => {
-      window.dispatchEvent(new Event("resize"));
-    }, 150);
-    return () => clearTimeout(t);
-  }, [keyboardHeight, keyboardOpen]);
-
-  const toggleKeyboard = useCallback(() => {
-    const term = termRef.current;
-    if (!term?.element) return;
-    const ta = term.element.querySelector("textarea");
-    if (keyboardOpen) {
-      ta?.blur();
-    } else if (ta instanceof HTMLElement) {
-      ta.focus();
-    }
-    activate();
-  }, [termRef, keyboardOpen, activate]);
-
-  // Returns true if focus was applied. Callers can fall back to the pending
-  // latch when the textarea isn't in the DOM yet (PTY still booting).
-  const focusSelf = useCallback(() => {
-    const ta = termRef.current?.element?.querySelector("textarea");
-    if (ta instanceof HTMLElement) {
-      ta.focus();
-      return true;
-    }
-    return false;
-  }, [termRef]);
-
-  // Cmd+` shortcut focuses this terminal when "paired" is the dispatched
-  // target. The component might be mounted but its PTY not yet ready (the
-  // initial ensureTerminal round-trip), in which case focusSelf() can't
-  // find a textarea, so we latch the intent for the ready-effect below.
-  // While the right panel is collapsed this component is unmounted entirely;
-  // App.tsx sets the latch directly in that case.
-  useEffect(() => {
-    const onFocusEvent = (e: Event) => {
-      const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
-      if (detail?.target !== "paired") return;
-      if (!focusSelf()) setPendingTerminalFocus("paired");
-    };
-    window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
-    return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
-  }, [focusSelf]);
-
-  useEffect(() => {
-    if (!ready) return;
-    if (consumePendingTerminalFocus("paired")) focusSelf();
-  }, [ready, focusSelf]);
-
-  if (!ready) {
-    return (
-      <div className="flex-1 flex items-center justify-center bg-surface-950 text-text-dim">
-        <span className="text-xs">Starting terminal...</span>
-      </div>
-    );
-  }
-
-  const rootStyle = {
-    paddingBottom: keyboardHeight > 0 ? keyboardHeight : undefined,
-  } as const;
-
-  return (
-    <div className="flex-1 flex flex-col min-h-0 overflow-hidden md:bg-surface-800" style={rootStyle}>
-      {!state.connected && state.reconnecting && (
-        <div className="bg-status-waiting/15 border-b border-status-waiting/30 px-3 py-1 shrink-0">
-          <span className="text-xs text-status-waiting">
-            Reconnecting... ({state.retryCount}/{maxRetries})
-          </span>
-        </div>
-      )}
-      {!state.connected && !state.reconnecting && state.retryCount >= maxRetries && (
-        <div className="bg-status-error/10 border-b border-status-error/30 px-3 py-1 flex items-center gap-2 shrink-0">
-          <span className="text-xs text-status-error">Disconnected</span>
-          <button
-            onClick={manualReconnect}
-            className="text-xs text-brand-500 cursor-pointer underline"
-          >
-            Retry
-          </button>
-        </div>
-      )}
-      <div
-        data-term="paired"
-        className={`flex-1 overflow-hidden bg-surface-950 relative md:rounded-lg term-panel${termFocused ? " term-focused" : ""}`}
-        onFocus={() => setTermFocused(true)}
-        onBlur={() => setTermFocused(false)}
-      >
-        <div
-          ref={containerRef}
-          className="absolute inset-0"
-          onPointerDown={activate}
-        />
-
-        {isMobile && state.isInScrollback && (
-          <BackToLiveButton onClick={exitScrollback} topOffset="top-2" />
-        )}
-
-        {isMobile && state.connected && (
-          <KeyboardFab keyboardOpen={keyboardOpen} onToggle={toggleKeyboard} />
-        )}
-      </div>
-      {isMobile && state.connected && (
-        <MobileTerminalToolbar
-          sendData={sendData}
-          termRef={termRef}
-          keyboardOpen={keyboardOpen}
-          ctrlActive={ctrlActive}
-          onCtrlToggle={() => setCtrlActive((v) => !v)}
-        />
-      )}
-    </div>
-  );
-}
-
 export function RightPanel({
   session,
   sessionId,
@@ -243,9 +59,6 @@ export function RightPanel({
   onOpenSendDialog,
   onDiscardAllComments,
 }: Props) {
-  const [shellMode, setShellMode] = useState<ShellMode>("host");
-  const isSandboxed = session?.is_sandboxed ?? false;
-
   const [topRatio, setTopRatio] = useState(loadSavedRatio);
   const containerRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
@@ -363,43 +176,7 @@ export function RightPanel({
       <div
         style={{ flexBasis: `${(1 - topRatio) * 100}%` }}
         className="flex flex-col min-h-0">
-        <div className="flex items-center gap-1 px-2 py-1 bg-surface-900 border-b border-surface-700/20 shrink-0">
-          <span className="text-xs text-text-dim mr-1">Shell</span>
-          <button
-            onClick={() => setShellMode("host")}
-            className={`text-[12px] px-2 py-0.5 rounded cursor-pointer transition-colors ${
-              shellMode === "host"
-                ? "text-brand-500 bg-brand-600/10"
-                : "text-text-dim hover:text-text-muted"
-            }`}
-          >
-            Host
-          </button>
-          {isSandboxed && (
-            <button
-              onClick={() => setShellMode("container")}
-              className={`text-[12px] px-2 py-0.5 rounded cursor-pointer transition-colors ${
-                shellMode === "container"
-                  ? "text-brand-500 bg-brand-600/10"
-                  : "text-text-dim hover:text-text-muted"
-              }`}
-            >
-              Container
-            </button>
-          )}
-        </div>
-
-        {sessionId ? (
-          <PairedTerminal
-            key={`${sessionId}-${shellMode}`}
-            sessionId={sessionId}
-            mode={shellMode}
-          />
-        ) : (
-          <div className="flex-1 flex items-center justify-center bg-surface-950 text-text-dim">
-            <p className="text-xs">Select a session</p>
-          </div>
-        )}
+        <PairedShellPane session={session} sessionId={sessionId} />
       </div>
     </div>
   );

--- a/web/src/components/__tests__/MobileMainPane.test.tsx
+++ b/web/src/components/__tests__/MobileMainPane.test.tsx
@@ -28,7 +28,11 @@ vi.mock("../diff/comments/CommentsBanner", () => ({
   CommentsBanner: () => <div data-testid="comments-banner" />,
 }));
 vi.mock("../diff/comments/SendCommentsDialog", () => ({
-  SendCommentsDialog: () => <div data-testid="send-dialog" />,
+  SendCommentsDialog: ({ onSent }: { onSent: () => void }) => (
+    <button data-testid="send-dialog" onClick={onSent}>
+      send
+    </button>
+  ),
 }));
 vi.mock("../cockpit/CockpitView", () => ({
   CockpitView: () => <div data-testid="cockpit-view" />,
@@ -58,17 +62,24 @@ function session(overrides: Partial<SessionResponse> = {}): SessionResponse {
   } as SessionResponse;
 }
 
-const diffComments = {
-  count: 0,
-  comments: [],
-  introDraft: "",
-  outroDraft: "",
-  clearAfterSend: true,
-  setIntroDraft: vi.fn(),
-  setOutroDraft: vi.fn(),
-  setClearAfterSend: vi.fn(),
-  clearComments: vi.fn(),
-} as unknown as ReturnType<typeof useDiffComments>;
+function makeStore(
+  overrides: Partial<ReturnType<typeof useDiffComments>> = {},
+): ReturnType<typeof useDiffComments> {
+  return {
+    count: 0,
+    comments: [],
+    introDraft: "",
+    outroDraft: "",
+    clearAfterSend: true,
+    setIntroDraft: vi.fn(),
+    setOutroDraft: vi.fn(),
+    setClearAfterSend: vi.fn(),
+    clearComments: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useDiffComments>;
+}
+
+const diffComments = makeStore();
 
 function setup(overrides: Partial<Parameters<typeof MobileMainPane>[0]> = {}) {
   const onBackToAgent = vi.fn();
@@ -165,5 +176,39 @@ describe("MobileMainPane", () => {
       sendDialogOpen: true,
     });
     expect(screen.getByTestId("send-dialog")).toBeDefined();
+  });
+
+  it("on send: clears comments + drafts, closes the dialog and the open file", () => {
+    const onCloseSendDialog = vi.fn();
+    const onClearSelectedFile = vi.fn();
+    const store = makeStore({ clearAfterSend: true });
+    setup({
+      view: "diff",
+      commentsEnabled: true,
+      sendDialogOpen: true,
+      diffComments: store,
+      onCloseSendDialog,
+      onClearSelectedFile,
+    });
+    fireEvent.click(screen.getByTestId("send-dialog"));
+    expect(store.clearComments).toHaveBeenCalled();
+    expect(store.setIntroDraft).toHaveBeenCalledWith("");
+    expect(onCloseSendDialog).toHaveBeenCalled();
+    expect(onClearSelectedFile).toHaveBeenCalled();
+  });
+
+  it("on send with clearAfterSend off: keeps comments but still closes", () => {
+    const onCloseSendDialog = vi.fn();
+    const store = makeStore({ clearAfterSend: false });
+    setup({
+      view: "diff",
+      commentsEnabled: true,
+      sendDialogOpen: true,
+      diffComments: store,
+      onCloseSendDialog,
+    });
+    fireEvent.click(screen.getByTestId("send-dialog"));
+    expect(store.clearComments).not.toHaveBeenCalled();
+    expect(onCloseSendDialog).toHaveBeenCalled();
   });
 });

--- a/web/src/components/__tests__/MobileMainPane.test.tsx
+++ b/web/src/components/__tests__/MobileMainPane.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+//
+// Covers the mobile single-pane container (#1452): the back header, the
+// agent / paired / diff layers with their inert + visibility toggling, the
+// cockpit vs terminal agent branch, the diff list vs viewer branch, and the
+// send-comments dialog. Heavy children are stubbed; this asserts the
+// container's own branching, which the Playwright suite then exercises live.
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import type { SessionResponse } from "../../lib/types";
+import type { useDiffComments } from "../../hooks/useDiffComments";
+
+vi.mock("../TerminalSessionStack", () => ({
+  TerminalSessionStack: () => <div data-testid="agent-terminal" />,
+}));
+vi.mock("../PairedTerminal", () => ({
+  PairedShellPane: () => <div data-testid="paired-shell" />,
+}));
+vi.mock("../diff/DiffFileList", () => ({
+  DiffFileList: () => <div data-testid="diff-list" />,
+}));
+vi.mock("../diff/DiffFileViewer", () => ({
+  DiffFileViewer: () => <div data-testid="diff-viewer" />,
+}));
+vi.mock("../diff/comments/CommentsBanner", () => ({
+  CommentsBanner: () => <div data-testid="comments-banner" />,
+}));
+vi.mock("../diff/comments/SendCommentsDialog", () => ({
+  SendCommentsDialog: () => <div data-testid="send-dialog" />,
+}));
+vi.mock("../cockpit/CockpitView", () => ({
+  CockpitView: () => <div data-testid="cockpit-view" />,
+}));
+
+import { MobileMainPane } from "../MobileMainPane";
+
+function session(overrides: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: "s1",
+    title: "t",
+    project_path: "/tmp/t",
+    group_path: "/tmp",
+    tool: "claude",
+    status: "Running",
+    yolo_mode: false,
+    created_at: new Date().toISOString(),
+    last_accessed_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    has_terminal: true,
+    profile: "default",
+    workspace_repos: [],
+    ...overrides,
+  } as SessionResponse;
+}
+
+const diffComments = {
+  count: 0,
+  comments: [],
+  introDraft: "",
+  outroDraft: "",
+  clearAfterSend: true,
+  setIntroDraft: vi.fn(),
+  setOutroDraft: vi.fn(),
+  setClearAfterSend: vi.fn(),
+  clearComments: vi.fn(),
+} as unknown as ReturnType<typeof useDiffComments>;
+
+function setup(overrides: Partial<Parameters<typeof MobileMainPane>[0]> = {}) {
+  const onBackToAgent = vi.fn();
+  const props: Parameters<typeof MobileMainPane>[0] = {
+    view: "agent",
+    onBackToAgent,
+    pairedMounted: false,
+    activeSession: session(),
+    activeSessionId: "s1",
+    sessions: [session()],
+    serverAbout: null,
+    webSettings: { persistentTerminals: false, maxPersistentTerminals: 3 },
+    selectedFilePath: null,
+    selectedRepoName: undefined,
+    revision: 0,
+    diffFiles: [],
+    perRepoBases: [],
+    warning: null,
+    diffFilesLoading: false,
+    onSelectFile: vi.fn(),
+    onCloseFile: vi.fn(),
+    onDiffRefresh: vi.fn(),
+    commentsEnabled: false,
+    commentSendEnabled: false,
+    commentSendDisabledReason: undefined,
+    diffComments,
+    commentsIsMultiRepo: false,
+    sendDialogOpen: false,
+    onOpenSendDialog: vi.fn(),
+    onCloseSendDialog: vi.fn(),
+    onClearSelectedFile: vi.fn(),
+    ...overrides,
+  };
+  render(<MobileMainPane {...props} />);
+  return { onBackToAgent };
+}
+
+describe("MobileMainPane", () => {
+  it("shows the agent terminal and no back header in agent view", () => {
+    setup({ view: "agent" });
+    expect(screen.getByTestId("agent-terminal")).toBeDefined();
+    expect(screen.queryByTestId("mobile-back-to-agent")).toBeNull();
+  });
+
+  it("renders the cockpit view for cockpit sessions", async () => {
+    setup({ view: "agent", activeSession: session({ cockpit_mode: true }) });
+    // CockpitView is lazy-loaded behind Suspense, so await its resolution.
+    expect(await screen.findByTestId("cockpit-view")).toBeDefined();
+  });
+
+  it("shows the back header and returns to agent on click", () => {
+    const { onBackToAgent } = setup({ view: "paired", pairedMounted: true });
+    fireEvent.click(screen.getByTestId("mobile-back-to-agent"));
+    expect(onBackToAgent).toHaveBeenCalled();
+  });
+
+  it("mounts the paired shell only once activated", () => {
+    setup({ view: "agent", pairedMounted: false });
+    expect(screen.queryByTestId("paired-shell")).toBeNull();
+  });
+
+  it("keeps the paired shell mounted after first activation", () => {
+    setup({ view: "agent", pairedMounted: true });
+    expect(screen.getByTestId("paired-shell")).toBeDefined();
+  });
+
+  it("shows the diff file list in diff view", () => {
+    setup({ view: "diff" });
+    expect(screen.getByTestId("diff-list")).toBeDefined();
+    expect(screen.getByText("Diff")).toBeDefined();
+  });
+
+  it("shows the diff viewer when a file is selected", () => {
+    setup({ view: "diff", selectedFilePath: "src/foo.ts" });
+    expect(screen.getByTestId("diff-viewer")).toBeDefined();
+    expect(screen.queryByTestId("diff-list")).toBeNull();
+  });
+
+  it("shows the comments banner when there are comments", () => {
+    setup({
+      view: "diff",
+      commentsEnabled: true,
+      diffComments: { ...diffComments, count: 2 } as ReturnType<
+        typeof useDiffComments
+      >,
+    });
+    expect(screen.getByTestId("comments-banner")).toBeDefined();
+  });
+
+  it("renders the send dialog when open", () => {
+    setup({
+      view: "diff",
+      commentsEnabled: true,
+      sendDialogOpen: true,
+    });
+    expect(screen.getByTestId("send-dialog")).toBeDefined();
+  });
+});

--- a/web/src/components/__tests__/MobileRightPanelPicker.test.tsx
+++ b/web/src/components/__tests__/MobileRightPanelPicker.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { MobileRightPanelPicker } from "../MobileRightPanelPicker";
+
+function setup(overrides: Partial<Parameters<typeof MobileRightPanelPicker>[0]> = {}) {
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <MobileRightPanelPicker
+      open
+      active="agent"
+      onSelect={onSelect}
+      onClose={onClose}
+      {...overrides}
+    />,
+  );
+  return { onSelect, onClose };
+}
+
+describe("MobileRightPanelPicker", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <MobileRightPanelPicker
+        open={false}
+        active="agent"
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the three view entries with the active one marked", () => {
+    setup({ active: "paired" });
+    expect(screen.getByTestId("mobile-right-panel-picker")).toBeDefined();
+    expect(screen.getByTestId("mobile-right-panel-pick-agent")).toBeDefined();
+    expect(screen.getByTestId("mobile-right-panel-pick-diff")).toBeDefined();
+    const paired = screen.getByTestId("mobile-right-panel-pick-paired");
+    expect(paired.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("calls onSelect with the chosen view", () => {
+    const { onSelect } = setup();
+    fireEvent.click(screen.getByTestId("mobile-right-panel-pick-diff"));
+    expect(onSelect).toHaveBeenCalledWith("diff");
+  });
+
+  it("closes on backdrop click", () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByTestId("mobile-right-panel-picker-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", () => {
+    const { onClose } = setup();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores non-Escape keys", () => {
+    const { onClose } = setup();
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/__tests__/PairedTerminal.test.tsx
+++ b/web/src/components/__tests__/PairedTerminal.test.tsx
@@ -2,14 +2,19 @@
 //
 // Covers PairedShellPane / PairedTerminal render branches: the loading
 // placeholder, the connected/reconnecting/disconnected banners, mobile
-// chrome, the host/container shell switch, and the fullViewport keyboard
-// padding. The live PTY path is exercised by the Playwright suites; this
-// drives the conditional JSX deterministically with a mocked useTerminal.
+// chrome, the host/container shell switch, the fullViewport keyboard
+// padding, and the focus/keyboard interaction handlers. The live PTY path
+// is exercised by the Playwright suites; this drives the conditional JSX
+// and the focus latch deterministically with a mocked useTerminal.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import type { SessionResponse } from "../../lib/types";
+import {
+  FOCUS_TERMINAL_EVENT,
+  setPendingTerminalFocus,
+} from "../../lib/terminalFocus";
 
 const ensureTerminal = vi.fn();
 const manualReconnect = vi.fn();
@@ -30,6 +35,9 @@ const mockKeyboard = vi.hoisted(() => ({
     reservedKeyboardHeight: 0,
   },
 }));
+// A real xterm-like element holding a textarea so focusSelf / toggleKeyboard
+// run their actual focus/blur paths rather than the null guard.
+const termEl = vi.hoisted(() => ({ current: null as HTMLElement | null }));
 
 vi.mock("../../lib/api", () => ({
   ensureSession: vi.fn(),
@@ -39,7 +47,7 @@ vi.mock("../../lib/api", () => ({
 vi.mock("../../hooks/useTerminal", () => ({
   useTerminal: () => ({
     containerRef: { current: null },
-    termRef: { current: null },
+    termRef: { current: termEl.current ? { element: termEl.current } : null },
     state: mockState.current,
     manualReconnect,
     sendData: vi.fn(),
@@ -57,9 +65,6 @@ vi.mock("../../hooks/useMobileKeyboard", () => ({
 
 vi.mock("../MobileTerminalToolbar", () => ({
   MobileTerminalToolbar: () => <div data-testid="mobile-toolbar" />,
-}));
-vi.mock("../KeyboardFab", () => ({
-  KeyboardFab: () => <button data-testid="keyboard-fab" />,
 }));
 vi.mock("../BackToLiveButton", () => ({
   BackToLiveButton: () => <button data-testid="back-to-live" />,
@@ -89,8 +94,16 @@ function session(overrides: Partial<SessionResponse> = {}): SessionResponse {
   } as SessionResponse;
 }
 
+function makeTermElement() {
+  const el = document.createElement("div");
+  const ta = document.createElement("textarea");
+  el.appendChild(ta);
+  return el;
+}
+
 beforeEach(() => {
   ensureTerminal.mockResolvedValue(true);
+  termEl.current = makeTermElement();
   mockState.current = {
     connected: true,
     reconnecting: false,
@@ -109,6 +122,15 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+async function renderReady(props: Partial<Parameters<typeof PairedShellPane>[0]> = {}) {
+  render(
+    <PairedShellPane session={session()} sessionId="sess-1" {...props} />,
+  );
+  await waitFor(() =>
+    expect(document.querySelector('[data-term="paired"]')).not.toBeNull(),
+  );
+}
+
 describe("PairedShellPane", () => {
   it("shows the placeholder while ensureTerminal is pending", () => {
     ensureTerminal.mockReturnValue(new Promise(() => {}));
@@ -122,19 +144,100 @@ describe("PairedShellPane", () => {
   });
 
   it("renders the terminal surface once ready", async () => {
-    render(<PairedShellPane session={session()} sessionId="sess-1" />);
-    await waitFor(() =>
-      expect(document.querySelector('[data-term="paired"]')).not.toBeNull(),
-    );
+    await renderReady();
+    expect(document.querySelector('[data-term="paired"]')).not.toBeNull();
   });
 
   it("renders mobile chrome and scrollback affordance", async () => {
     mockKeyboard.current.isMobile = true;
     mockState.current.isInScrollback = true;
-    render(<PairedShellPane session={session()} sessionId="sess-1" />);
-    await screen.findByTestId("keyboard-fab");
+    await renderReady();
     expect(screen.getByTestId("mobile-toolbar")).toBeDefined();
     expect(screen.getByTestId("back-to-live")).toBeDefined();
+  });
+
+  it("focuses the textarea when the FAB opens the keyboard", async () => {
+    mockKeyboard.current.isMobile = true;
+    await renderReady();
+    const ta = termEl.current!.querySelector("textarea") as HTMLTextAreaElement;
+    const focusSpy = vi.spyOn(ta, "focus");
+    fireEvent.click(screen.getByRole("button", { name: /Open keyboard/i }));
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("blurs the textarea when the FAB closes the keyboard", async () => {
+    mockKeyboard.current.isMobile = true;
+    mockKeyboard.current.keyboardOpen = true;
+    await renderReady();
+    const ta = termEl.current!.querySelector("textarea") as HTMLTextAreaElement;
+    const blurSpy = vi.spyOn(ta, "blur");
+    fireEvent.click(screen.getByRole("button", { name: /Close keyboard/i }));
+    expect(blurSpy).toHaveBeenCalled();
+  });
+
+  it("ignores focus events aimed at the agent terminal", async () => {
+    await renderReady();
+    const ta = termEl.current!.querySelector("textarea") as HTMLTextAreaElement;
+    const focusSpy = vi.spyOn(ta, "focus");
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(FOCUS_TERMINAL_EVENT, { detail: { target: "agent" } }),
+      );
+    });
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+
+  it("no-ops the keyboard toggle when the terminal element is absent", async () => {
+    mockKeyboard.current.isMobile = true;
+    termEl.current = null;
+    await renderReady();
+    // FAB present but termRef has no element; toggling must not throw.
+    fireEvent.click(screen.getByRole("button", { name: /Open keyboard/i }));
+    expect(document.querySelector('[data-term="paired"]')).not.toBeNull();
+  });
+
+  it("latches focus when the textarea is not in the DOM yet", async () => {
+    // Element present but without a textarea: focusSelf returns false and
+    // the paired focus intent is latched instead.
+    termEl.current = document.createElement("div");
+    await renderReady();
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(FOCUS_TERMINAL_EVENT, { detail: { target: "paired" } }),
+      );
+    });
+    expect(document.querySelector('[data-term="paired"]')).not.toBeNull();
+  });
+
+  it("focuses itself on a paired focus event", async () => {
+    await renderReady();
+    const ta = termEl.current!.querySelector("textarea") as HTMLTextAreaElement;
+    const focusSpy = vi.spyOn(ta, "focus");
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(FOCUS_TERMINAL_EVENT, { detail: { target: "paired" } }),
+      );
+    });
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("consumes a pending paired focus latch once ready", async () => {
+    setPendingTerminalFocus("paired");
+    const focusedBefore = makeTermElement();
+    termEl.current = focusedBefore;
+    const ta = focusedBefore.querySelector("textarea") as HTMLTextAreaElement;
+    const focusSpy = vi.spyOn(ta, "focus");
+    await renderReady();
+    await waitFor(() => expect(focusSpy).toHaveBeenCalled());
+  });
+
+  it("tracks focus on the terminal surface", async () => {
+    await renderReady();
+    const panel = document.querySelector('[data-term="paired"]') as HTMLElement;
+    fireEvent.focus(panel);
+    expect(panel.className).toMatch(/term-focused/);
+    fireEvent.blur(panel);
+    expect(panel.className).not.toMatch(/term-focused/);
   });
 
   it("shows the reconnecting banner", async () => {
@@ -144,8 +247,8 @@ describe("PairedShellPane", () => {
       retryCount: 2,
       isInScrollback: false,
     };
-    render(<PairedShellPane session={session()} sessionId="sess-1" />);
-    await screen.findByText(/Reconnecting/i);
+    await renderReady();
+    expect(screen.getByText(/Reconnecting/i)).toBeDefined();
   });
 
   it("shows the disconnected banner with a working Retry", async () => {
@@ -155,9 +258,8 @@ describe("PairedShellPane", () => {
       retryCount: 7,
       isInScrollback: false,
     };
-    render(<PairedShellPane session={session()} sessionId="sess-1" />);
-    const retry = await screen.findByRole("button", { name: /Retry/i });
-    fireEvent.click(retry);
+    await renderReady();
+    fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
     expect(manualReconnect).toHaveBeenCalled();
   });
 
@@ -177,12 +279,7 @@ describe("PairedShellPane", () => {
 
   it("reserves keyboard padding in fullViewport mode", async () => {
     mockKeyboard.current.reservedKeyboardHeight = 320;
-    render(
-      <PairedShellPane session={session()} sessionId="sess-1" fullViewport />,
-    );
-    await waitFor(() =>
-      expect(document.querySelector('[data-term="paired"]')).not.toBeNull(),
-    );
+    await renderReady({ fullViewport: true });
     const root = document.querySelector('[data-term="paired"]')
       ?.parentElement as HTMLElement;
     expect(root.style.paddingBottom).toBe("320px");

--- a/web/src/components/__tests__/PairedTerminal.test.tsx
+++ b/web/src/components/__tests__/PairedTerminal.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+//
+// Covers PairedShellPane / PairedTerminal render branches: the loading
+// placeholder, the connected/reconnecting/disconnected banners, mobile
+// chrome, the host/container shell switch, and the fullViewport keyboard
+// padding. The live PTY path is exercised by the Playwright suites; this
+// drives the conditional JSX deterministically with a mocked useTerminal.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import type { SessionResponse } from "../../lib/types";
+
+const ensureTerminal = vi.fn();
+const manualReconnect = vi.fn();
+
+const mockState = vi.hoisted(() => ({
+  current: {
+    connected: true,
+    reconnecting: false,
+    retryCount: 0,
+    isInScrollback: false,
+  },
+}));
+const mockKeyboard = vi.hoisted(() => ({
+  current: {
+    isMobile: false,
+    keyboardOpen: false,
+    keyboardHeight: 0,
+    reservedKeyboardHeight: 0,
+  },
+}));
+
+vi.mock("../../lib/api", () => ({
+  ensureSession: vi.fn(),
+  ensureTerminal: (id: string, container: boolean) => ensureTerminal(id, container),
+}));
+
+vi.mock("../../hooks/useTerminal", () => ({
+  useTerminal: () => ({
+    containerRef: { current: null },
+    termRef: { current: null },
+    state: mockState.current,
+    manualReconnect,
+    sendData: vi.fn(),
+    activate: vi.fn(),
+    exitScrollback: vi.fn(),
+    ctrlActiveRef: { current: false },
+    clearCtrlRef: { current: null },
+    maxRetries: 7,
+  }),
+}));
+
+vi.mock("../../hooks/useMobileKeyboard", () => ({
+  useMobileKeyboard: () => mockKeyboard.current,
+}));
+
+vi.mock("../MobileTerminalToolbar", () => ({
+  MobileTerminalToolbar: () => <div data-testid="mobile-toolbar" />,
+}));
+vi.mock("../KeyboardFab", () => ({
+  KeyboardFab: () => <button data-testid="keyboard-fab" />,
+}));
+vi.mock("../BackToLiveButton", () => ({
+  BackToLiveButton: () => <button data-testid="back-to-live" />,
+}));
+
+import { PairedShellPane } from "../PairedTerminal";
+
+function session(overrides: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: "sess-1",
+    title: "t",
+    project_path: "/tmp/t",
+    group_path: "/tmp",
+    tool: "claude",
+    status: "Running",
+    yolo_mode: false,
+    created_at: new Date().toISOString(),
+    last_accessed_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    has_terminal: true,
+    profile: "default",
+    workspace_repos: [],
+    ...overrides,
+  } as SessionResponse;
+}
+
+beforeEach(() => {
+  ensureTerminal.mockResolvedValue(true);
+  mockState.current = {
+    connected: true,
+    reconnecting: false,
+    retryCount: 0,
+    isInScrollback: false,
+  };
+  mockKeyboard.current = {
+    isMobile: false,
+    keyboardOpen: false,
+    keyboardHeight: 0,
+    reservedKeyboardHeight: 0,
+  };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PairedShellPane", () => {
+  it("shows the placeholder while ensureTerminal is pending", () => {
+    ensureTerminal.mockReturnValue(new Promise(() => {}));
+    render(<PairedShellPane session={session()} sessionId="sess-1" />);
+    expect(screen.getByText(/Starting terminal/i)).toBeDefined();
+  });
+
+  it("renders 'Select a session' when sessionId is null", () => {
+    render(<PairedShellPane session={null} sessionId={null} />);
+    expect(screen.getByText(/Select a session/i)).toBeDefined();
+  });
+
+  it("renders the terminal surface once ready", async () => {
+    render(<PairedShellPane session={session()} sessionId="sess-1" />);
+    await waitFor(() =>
+      expect(document.querySelector('[data-term="paired"]')).not.toBeNull(),
+    );
+  });
+
+  it("renders mobile chrome and scrollback affordance", async () => {
+    mockKeyboard.current.isMobile = true;
+    mockState.current.isInScrollback = true;
+    render(<PairedShellPane session={session()} sessionId="sess-1" />);
+    await screen.findByTestId("keyboard-fab");
+    expect(screen.getByTestId("mobile-toolbar")).toBeDefined();
+    expect(screen.getByTestId("back-to-live")).toBeDefined();
+  });
+
+  it("shows the reconnecting banner", async () => {
+    mockState.current = {
+      connected: false,
+      reconnecting: true,
+      retryCount: 2,
+      isInScrollback: false,
+    };
+    render(<PairedShellPane session={session()} sessionId="sess-1" />);
+    await screen.findByText(/Reconnecting/i);
+  });
+
+  it("shows the disconnected banner with a working Retry", async () => {
+    mockState.current = {
+      connected: false,
+      reconnecting: false,
+      retryCount: 7,
+      isInScrollback: false,
+    };
+    render(<PairedShellPane session={session()} sessionId="sess-1" />);
+    const retry = await screen.findByRole("button", { name: /Retry/i });
+    fireEvent.click(retry);
+    expect(manualReconnect).toHaveBeenCalled();
+  });
+
+  it("offers the Container switch for sandboxed sessions and re-ensures on switch", async () => {
+    render(
+      <PairedShellPane
+        session={session({ is_sandboxed: true })}
+        sessionId="sess-1"
+      />,
+    );
+    await waitFor(() =>
+      expect(document.querySelector('[data-term="paired"]')).not.toBeNull(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Container$/ }));
+    await waitFor(() => expect(ensureTerminal).toHaveBeenCalledWith("sess-1", true));
+  });
+
+  it("reserves keyboard padding in fullViewport mode", async () => {
+    mockKeyboard.current.reservedKeyboardHeight = 320;
+    render(
+      <PairedShellPane session={session()} sessionId="sess-1" fullViewport />,
+    );
+    await waitFor(() =>
+      expect(document.querySelector('[data-term="paired"]')).not.toBeNull(),
+    );
+    const root = document.querySelector('[data-term="paired"]')
+      ?.parentElement as HTMLElement;
+    expect(root.style.paddingBottom).toBe("320px");
+  });
+});

--- a/web/src/components/__tests__/PairedTerminal.test.tsx
+++ b/web/src/components/__tests__/PairedTerminal.test.tsx
@@ -32,7 +32,7 @@ const mockKeyboard = vi.hoisted(() => ({
     isMobile: false,
     keyboardOpen: false,
     keyboardHeight: 0,
-    reservedKeyboardHeight: 0,
+    keyboardOcclusion: 0,
   },
 }));
 // A real xterm-like element holding a textarea so focusSelf / toggleKeyboard
@@ -114,7 +114,7 @@ beforeEach(() => {
     isMobile: false,
     keyboardOpen: false,
     keyboardHeight: 0,
-    reservedKeyboardHeight: 0,
+    keyboardOcclusion: 0,
   };
 });
 
@@ -278,7 +278,7 @@ describe("PairedShellPane", () => {
   });
 
   it("reserves keyboard padding in fullViewport mode", async () => {
-    mockKeyboard.current.reservedKeyboardHeight = 320;
+    mockKeyboard.current.keyboardOcclusion = 320;
     await renderReady({ fullViewport: true });
     const root = document.querySelector('[data-term="paired"]')
       ?.parentElement as HTMLElement;

--- a/web/src/components/__tests__/PairedTerminal.test.tsx
+++ b/web/src/components/__tests__/PairedTerminal.test.tsx
@@ -148,6 +148,24 @@ describe("PairedShellPane", () => {
     expect(document.querySelector('[data-term="paired"]')).not.toBeNull();
   });
 
+  it("shows an error with Retry when bootstrap fails, then recovers", async () => {
+    ensureTerminal.mockResolvedValueOnce(false);
+    render(<PairedShellPane session={session()} sessionId="sess-1" />);
+    await screen.findByText(/Couldn't start the terminal/i);
+    // Retry re-runs ensureTerminal (now succeeding) and the terminal mounts.
+    ensureTerminal.mockResolvedValue(true);
+    fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
+    await waitFor(() =>
+      expect(document.querySelector('[data-term="paired"]')).not.toBeNull(),
+    );
+  });
+
+  it("shows the error state when ensureTerminal rejects", async () => {
+    ensureTerminal.mockRejectedValueOnce(new Error("boom"));
+    render(<PairedShellPane session={session()} sessionId="sess-1" />);
+    await screen.findByText(/Couldn't start the terminal/i);
+  });
+
   it("renders mobile chrome and scrollback affordance", async () => {
     mockKeyboard.current.isMobile = true;
     mockState.current.isInScrollback = true;

--- a/web/src/hooks/__tests__/useIsWideViewport.test.tsx
+++ b/web/src/hooks/__tests__/useIsWideViewport.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useIsWideViewport } from "../useIsWideViewport";
+
+type Listener = () => void;
+
+function stubMatchMedia(initialMatches: boolean) {
+  let matches = initialMatches;
+  const listeners = new Set<Listener>();
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: "(min-width: 768px)",
+    addEventListener: (_: string, cb: Listener) => listeners.add(cb),
+    removeEventListener: (_: string, cb: Listener) => listeners.delete(cb),
+  };
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  return {
+    set(next: boolean) {
+      matches = next;
+      listeners.forEach((cb) => cb());
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useIsWideViewport", () => {
+  it("reflects the initial match state", () => {
+    stubMatchMedia(true);
+    const { result } = renderHook(() => useIsWideViewport());
+    expect(result.current).toBe(true);
+  });
+
+  it("starts false below the breakpoint", () => {
+    stubMatchMedia(false);
+    const { result } = renderHook(() => useIsWideViewport());
+    expect(result.current).toBe(false);
+  });
+
+  it("updates when the media query changes and cleans up on unmount", () => {
+    const ctl = stubMatchMedia(false);
+    const { result, unmount } = renderHook(() => useIsWideViewport());
+    expect(result.current).toBe(false);
+
+    act(() => ctl.set(true));
+    expect(result.current).toBe(true);
+
+    expect(ctl.listenerCount()).toBe(1);
+    unmount();
+    expect(ctl.listenerCount()).toBe(0);
+  });
+});

--- a/web/src/hooks/useIsWideViewport.ts
+++ b/web/src/hooks/useIsWideViewport.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+/** Tracks whether the viewport is at least Tailwind's `md` breakpoint
+ *  (768px) wide. Reactive to `(min-width: 768px)` matchMedia changes,
+ *  SSR-safe via a `typeof window` guard on the initial read.
+ *
+ *  Layout topology (side-by-side split vs single-pane picker) is driven
+ *  by width so it stays aligned with the `md:` Tailwind classes the rest
+ *  of the layout uses; pointer type (`useIsCoarsePointer` /
+ *  `useMobileKeyboard`) governs touch affordances and keyboard padding,
+ *  not which panes exist. Gating layout on pointer type instead would
+ *  force a touch laptop into the mobile UI and squash a narrow desktop
+ *  window into a cramped split. */
+export function useIsWideViewport(): boolean {
+  const [isWide, setIsWide] = useState(() =>
+    typeof window !== "undefined" &&
+    Boolean(window.matchMedia?.("(min-width: 768px)").matches),
+  );
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(min-width: 768px)");
+    const onChange = () => setIsWide(mql.matches);
+    mql.addEventListener?.("change", onChange);
+    return () => mql.removeEventListener?.("change", onChange);
+  }, []);
+  return isWide;
+}

--- a/web/src/lib/rightPanelView.ts
+++ b/web/src/lib/rightPanelView.ts
@@ -1,0 +1,4 @@
+/** Which view occupies the single full-viewport main pane on mobile
+ *  (below the `md` breakpoint). Desktop ignores this and renders the
+ *  side-by-side ContentSplit. See #1452. */
+export type RightPanelView = "agent" | "diff" | "paired";

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -716,9 +716,27 @@
       ],
       "components": [
         "web/src/components/MobileRightPanelPicker.tsx",
+        "web/src/components/MobileMainPane.tsx",
         "web/src/components/PairedTerminal.tsx",
         "web/src/components/ContentSplit.tsx",
         "web/src/components/RightPanel.tsx"
+      ]
+    },
+    {
+      "id": "right-panel.mobile-picker-units",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/components/__tests__/MobileMainPane.test.tsx",
+        "src/components/__tests__/MobileRightPanelPicker.test.tsx",
+        "src/components/__tests__/PairedTerminal.test.tsx",
+        "src/hooks/__tests__/useIsWideViewport.test.tsx"
+      ],
+      "components": [
+        "web/src/components/MobileMainPane.tsx",
+        "web/src/components/MobileRightPanelPicker.tsx",
+        "web/src/components/PairedTerminal.tsx",
+        "web/src/hooks/useIsWideViewport.ts"
       ]
     },
     {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -708,6 +708,20 @@
       ]
     },
     {
+      "id": "right-panel.mobile-picker",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/mobile-right-panel-picker.spec.ts"
+      ],
+      "components": [
+        "web/src/components/MobileRightPanelPicker.tsx",
+        "web/src/components/PairedTerminal.tsx",
+        "web/src/components/ContentSplit.tsx",
+        "web/src/components/RightPanel.tsx"
+      ]
+    },
+    {
       "id": "right-panel.diff-line-visibility",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/mobile-right-panel-picker.spec.ts
+++ b/web/tests/mobile-right-panel-picker.spec.ts
@@ -110,8 +110,12 @@ test.describe("Mobile right panel picker (#1452)", () => {
     const back = page.getByTestId("mobile-back-to-agent");
     await expect(back).toBeVisible();
 
-    // Tap the file row to promote the diff viewer in place.
-    await page.locator('button:has-text("foo.ts")').first().click();
+    // Tap the file row to promote the diff viewer in place; the viewer
+    // replaces the file list in the same pane, so the row disappears.
+    const row = page.locator('button[data-index="0"]').first();
+    await row.hover();
+    await row.click();
+    await expect(page.locator('button[data-index="0"]')).toHaveCount(0);
     await expect(back).toBeVisible();
 
     await back.click();

--- a/web/tests/mobile-right-panel-picker.spec.ts
+++ b/web/tests/mobile-right-panel-picker.spec.ts
@@ -161,3 +161,81 @@ test.describe("Desktop right panel split is unchanged (#1452)", () => {
     await expect(page.getByTestId("mobile-right-panel-picker")).toHaveCount(0);
   });
 });
+
+async function setupCockpitSession(page: Page) {
+  await mockTerminalApis(page);
+  // Override the session as a running cockpit session and stub the cockpit
+  // panel endpoints; the paired shell still uses the terminal WS, which
+  // mockTerminalApis already routes.
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: [
+          {
+            id: "pinch-test",
+            title: "cockpit-mobile",
+            project_path: "/tmp/cockpit-mobile",
+            group_path: "/tmp",
+            tool: "claude",
+            status: "Running",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+            workspace_repos: [],
+            cockpit_mode: true,
+            cockpit_worker_state: "running",
+          },
+        ],
+        workspace_ordering: [],
+      },
+    });
+  });
+  await page.route("**/api/sessions/*/cockpit/**", (r) =>
+    r.fulfill({ json: {} }),
+  );
+  await page.goto("/");
+  await page.waitForTimeout(300);
+  await openMobileSidebar(page);
+  await clickSidebarSession(page, "cockpit-mobile");
+  // Cockpit sessions render no xterm in the agent view; wait for the
+  // right-panel toggle, which only appears once a session is active.
+  await page
+    .getByRole("button", { name: "Toggle diff panel" })
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+test.describe("Mobile picker on a cockpit session (#1452)", () => {
+  test("promotes the paired shell over a cockpit session and survives the keyboard", async ({
+    page,
+  }) => {
+    await setupCockpitSession(page);
+    await openPicker(page);
+
+    await page.getByTestId("mobile-right-panel-pick-paired").click();
+    await expect(page.getByTestId("mobile-right-panel-picker")).toHaveCount(0);
+    const paired = page.locator('[data-term="paired"]');
+    await paired.waitFor({ state: "visible", timeout: 10_000 });
+
+    // The root is pinned for the paired view even on a cockpit session, so
+    // the terminal stays tall under the keyboard rather than collapsing.
+    await simulateKeyboardOpen(page, 300);
+    await page.waitForTimeout(400);
+    const box = await paired.boundingBox();
+    expect(box, "paired terminal should have a bounding box").not.toBeNull();
+    expect(
+      box!.height,
+      `paired terminal collapsed to ${box!.height}px on a cockpit session`,
+    ).toBeGreaterThan(150);
+
+    // Back to the cockpit agent view.
+    await page.getByTestId("mobile-back-to-agent").click();
+    await expect(page.getByTestId("mobile-back-to-agent")).toHaveCount(0);
+  });
+});

--- a/web/tests/mobile-right-panel-picker.spec.ts
+++ b/web/tests/mobile-right-panel-picker.spec.ts
@@ -74,16 +74,44 @@ test.describe("Mobile right panel picker (#1452)", () => {
     ).toBeGreaterThan(150);
   });
 
-  test("picker promotes the diff view and the back chip returns to the agent", async ({
+  test("picker promotes the diff view, opens a file, and the back chip returns to the agent", async ({
     page,
   }) => {
-    await setupAndOpenSession(page);
-    await openPicker(page);
+    await mockTerminalApis(page);
+    // Seed one changed file so the diff list has a row to tap; tapping it
+    // promotes the full-screen file viewer into the same pane.
+    await page.route("**/api/sessions/*/diff/files", (r) =>
+      r.fulfill({
+        json: {
+          files: [
+            {
+              path: "src/foo.ts",
+              old_path: null,
+              status: "modified",
+              additions: 2,
+              deletions: 1,
+            },
+          ],
+          per_repo_bases: [{ base_branch: "main" }],
+          warning: null,
+        },
+      }),
+    );
+    await page.goto("/");
+    await page.waitForTimeout(300);
+    await openMobileSidebar(page);
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator(".xterm").first().waitFor({ state: "visible", timeout: 10_000 });
 
+    await openPicker(page);
     await page.getByTestId("mobile-right-panel-pick-diff").click();
     await expect(page.getByTestId("mobile-right-panel-picker")).toHaveCount(0);
     // The non-agent views carry a persistent back affordance.
     const back = page.getByTestId("mobile-back-to-agent");
+    await expect(back).toBeVisible();
+
+    // Tap the file row to promote the diff viewer in place.
+    await page.locator('button:has-text("foo.ts")').first().click();
     await expect(back).toBeVisible();
 
     await back.click();

--- a/web/tests/mobile-right-panel-picker.spec.ts
+++ b/web/tests/mobile-right-panel-picker.spec.ts
@@ -35,7 +35,6 @@ async function setupAndOpenSession(page: Page) {
   await page.goto("/");
   await seedSettings(page, { mobileFontSize: 10 });
   await page.reload();
-  await page.waitForTimeout(300);
   await openMobileSidebar(page);
   await clickSidebarSession(page, "pinch-test");
   await page.locator(".xterm").first().waitFor({ state: "visible", timeout: 10_000 });
@@ -65,13 +64,13 @@ test.describe("Mobile right panel picker (#1452)", () => {
     // The bug: keyboard padding collapsed the paired terminal to ~0px.
     // Now it owns the viewport, so it stays comfortably tall.
     await simulateKeyboardOpen(page, 300);
-    await page.waitForTimeout(400);
-    const box = await paired.boundingBox();
-    expect(box, "paired terminal should have a bounding box").not.toBeNull();
-    expect(
-      box!.height,
-      `paired terminal collapsed to ${box!.height}px under the keyboard`,
-    ).toBeGreaterThan(150);
+    // Poll the height rather than sleeping a fixed time: the layout settles
+    // a frame or two after the visualViewport resize.
+    await expect
+      .poll(async () => (await paired.boundingBox())?.height ?? 0, {
+        message: "paired terminal collapsed under the keyboard",
+      })
+      .toBeGreaterThan(150);
   });
 
   test("picker promotes the diff view, opens a file, and the back chip returns to the agent", async ({
@@ -98,7 +97,6 @@ test.describe("Mobile right panel picker (#1452)", () => {
       }),
     );
     await page.goto("/");
-    await page.waitForTimeout(300);
     await openMobileSidebar(page);
     await clickSidebarSession(page, "pinch-test");
     await page.locator(".xterm").first().waitFor({ state: "visible", timeout: 10_000 });
@@ -151,7 +149,6 @@ test.describe("Desktop right panel split is unchanged (#1452)", () => {
   }) => {
     await mockTerminalApis(page);
     await page.goto("/");
-    await page.waitForTimeout(300);
     await clickSidebarSession(page, "pinch-test");
     await page.locator(".xterm").first().waitFor({ state: "visible", timeout: 10_000 });
 
@@ -201,7 +198,6 @@ async function setupCockpitSession(page: Page) {
     r.fulfill({ json: {} }),
   );
   await page.goto("/");
-  await page.waitForTimeout(300);
   await openMobileSidebar(page);
   await clickSidebarSession(page, "cockpit-mobile");
   // Cockpit sessions render no xterm in the agent view; wait for the
@@ -226,13 +222,11 @@ test.describe("Mobile picker on a cockpit session (#1452)", () => {
     // The root is pinned for the paired view even on a cockpit session, so
     // the terminal stays tall under the keyboard rather than collapsing.
     await simulateKeyboardOpen(page, 300);
-    await page.waitForTimeout(400);
-    const box = await paired.boundingBox();
-    expect(box, "paired terminal should have a bounding box").not.toBeNull();
-    expect(
-      box!.height,
-      `paired terminal collapsed to ${box!.height}px on a cockpit session`,
-    ).toBeGreaterThan(150);
+    await expect
+      .poll(async () => (await paired.boundingBox())?.height ?? 0, {
+        message: "paired terminal collapsed on a cockpit session",
+      })
+      .toBeGreaterThan(150);
 
     // Back to the cockpit agent view.
     await page.getByTestId("mobile-back-to-agent").click();

--- a/web/tests/mobile-right-panel-picker.spec.ts
+++ b/web/tests/mobile-right-panel-picker.spec.ts
@@ -1,0 +1,131 @@
+// Regression for #1452: on mobile the right panel used to be an 85vw
+// slide-in overlay pinned to bottom-0. When the soft keyboard opened
+// against the paired terminal inside it, the live keyboardHeight padding
+// collapsed the terminal to near-zero height. The fix replaces the overlay
+// with a picker that promotes the chosen view into the single full-viewport
+// main pane, so the paired terminal owns the viewport and stays tall under
+// the keyboard (the same posture the agent terminal already uses).
+
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+import { mockTerminalApis, seedSettings } from "./helpers/terminal-mocks";
+
+// iPhone 13: width 390 (< md), pointer:coarse, hasTouch, WebKit UA.
+test.use({ ...devices["iPhone 13"] });
+
+// Override visualViewport to model the iOS soft keyboard occluding the
+// bottom of the layout viewport.
+async function simulateKeyboardOpen(page: Page, keyboardPx: number) {
+  await page.evaluate((keyboardPx) => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const newVvH = window.innerHeight - keyboardPx;
+    Object.defineProperty(vv, "height", {
+      get: () => newVvH,
+      configurable: true,
+    });
+    Object.defineProperty(vv, "offsetTop", { get: () => 0, configurable: true });
+    vv.dispatchEvent(new Event("resize"));
+  }, keyboardPx);
+}
+
+async function setupAndOpenSession(page: Page) {
+  await mockTerminalApis(page);
+  await page.goto("/");
+  await seedSettings(page, { mobileFontSize: 10 });
+  await page.reload();
+  await page.waitForTimeout(300);
+  await openMobileSidebar(page);
+  await clickSidebarSession(page, "pinch-test");
+  await page.locator(".xterm").first().waitFor({ state: "visible", timeout: 10_000 });
+}
+
+async function openPicker(page: Page) {
+  await page.getByRole("button", { name: "Toggle diff panel" }).click();
+  await page.getByTestId("mobile-right-panel-picker").waitFor({
+    state: "visible",
+    timeout: 5_000,
+  });
+}
+
+test.describe("Mobile right panel picker (#1452)", () => {
+  test("picker promotes the paired terminal and it survives the keyboard", async ({
+    page,
+  }) => {
+    await setupAndOpenSession(page);
+    await openPicker(page);
+
+    await page.getByTestId("mobile-right-panel-pick-paired").click();
+    // Picker closes; the paired shell mounts at full viewport.
+    await expect(page.getByTestId("mobile-right-panel-picker")).toHaveCount(0);
+    const paired = page.locator('[data-term="paired"]');
+    await paired.waitFor({ state: "visible", timeout: 10_000 });
+
+    // The bug: keyboard padding collapsed the paired terminal to ~0px.
+    // Now it owns the viewport, so it stays comfortably tall.
+    await simulateKeyboardOpen(page, 300);
+    await page.waitForTimeout(400);
+    const box = await paired.boundingBox();
+    expect(box, "paired terminal should have a bounding box").not.toBeNull();
+    expect(
+      box!.height,
+      `paired terminal collapsed to ${box!.height}px under the keyboard`,
+    ).toBeGreaterThan(150);
+  });
+
+  test("picker promotes the diff view and the back chip returns to the agent", async ({
+    page,
+  }) => {
+    await setupAndOpenSession(page);
+    await openPicker(page);
+
+    await page.getByTestId("mobile-right-panel-pick-diff").click();
+    await expect(page.getByTestId("mobile-right-panel-picker")).toHaveCount(0);
+    // The non-agent views carry a persistent back affordance.
+    const back = page.getByTestId("mobile-back-to-agent");
+    await expect(back).toBeVisible();
+
+    await back.click();
+    await expect(page.getByTestId("mobile-back-to-agent")).toHaveCount(0);
+    await expect(page.locator(".xterm").first()).toBeVisible();
+  });
+
+  test("agent and paired terminals stay mounted across view switches", async ({
+    page,
+  }) => {
+    await setupAndOpenSession(page);
+
+    await openPicker(page);
+    await page.getByTestId("mobile-right-panel-pick-paired").click();
+    await page.locator('[data-term="paired"]').waitFor({
+      state: "visible",
+      timeout: 10_000,
+    });
+
+    // Back to the agent: the paired shell is kept alive (hidden), not
+    // unmounted, so its PTY and scrollback survive the switch.
+    await page.getByTestId("mobile-back-to-agent").click();
+    await expect(page.locator('[data-term="paired"]')).toHaveCount(1);
+    await expect(page.locator(".xterm").first()).toBeVisible();
+  });
+});
+
+test.describe("Desktop right panel split is unchanged (#1452)", () => {
+  test.use({ viewport: { width: 1400, height: 900 }, hasTouch: false });
+
+  test("renders the side-by-side split, not the mobile picker", async ({
+    page,
+  }) => {
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await page.waitForTimeout(300);
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator(".xterm").first().waitFor({ state: "visible", timeout: 10_000 });
+
+    // The desktop split renders the resize handle and never the picker.
+    await expect(page.getByTestId("content-split-resize-handle")).toBeVisible();
+    await page.getByRole("button", { name: "Toggle diff panel" }).click();
+    await expect(page.getByTestId("mobile-right-panel-picker")).toHaveCount(0);
+  });
+});

--- a/web/tests/terminal-focus-shortcut.spec.ts
+++ b/web/tests/terminal-focus-shortcut.spec.ts
@@ -41,9 +41,9 @@ async function focusKind(page: Page, kind: "agent" | "paired") {
       .focus();
     return;
   }
-  // Pick the visible paired panel: on desktop the inline copy
-  // (md:flex), on mobile the slide-in (md:hidden by default desktop).
-  // Filter by visibility so we hit whichever the user would actually use.
+  // The paired panel renders once (the inline desktop split copy); on
+  // mobile it is promoted into the single pane. Filter by visibility to
+  // hit whichever instance the user would actually use.
   const visiblePaired = page.locator('[data-term="paired"]:visible').first();
   await visiblePaired.locator("textarea").focus();
 }
@@ -69,7 +69,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
     await mockTerminalApis(page);
     await page.goto("/");
     await openSession(page);
-    await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
+    await expect(page.locator('[data-term="paired"]')).toHaveCount(1);
 
     await focusKind(page, "agent");
     await expect.poll(() => focusedKind(page)).toBe("agent");
@@ -112,7 +112,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
 
     await focusKind(page, "agent");
     await page.keyboard.press("ControlOrMeta+`");
-    await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
+    await expect(page.locator('[data-term="paired"]')).toHaveCount(1);
     await expect.poll(() => focusedKind(page)).toBe("paired");
     await shot(page, "05-expanded-paired-focused.png");
   });
@@ -262,17 +262,14 @@ test.describe("Cmd/Ctrl+` mobile", () => {
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
     await openSession(page);
 
-    // Right panel starts collapsed on mobile; expand it via the existing
-    // shortcut so the slide-in mounts.
-    await page.keyboard.press("ControlOrMeta+Alt+b");
-    await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
-
-    // Focus the visible paired (mobile slide-in). On a mobile viewport
-    // the desktop-inline copy has md:flex hidden, so :visible filters to
-    // the slide-in instance.
-    await focusKind(page, "paired");
+    // Single full-viewport pane on mobile (#1452). Cmd+` promotes and
+    // focuses the paired shell, mounting it lazily; there is exactly one
+    // paired instance, no slide-in copy.
+    await page.keyboard.press("ControlOrMeta+`");
+    await expect(page.locator('[data-term="paired"]')).toHaveCount(1);
     await expect.poll(() => focusedKind(page)).toBe("paired");
 
+    // Pressing again returns to the agent terminal.
     await page.keyboard.press("ControlOrMeta+`");
     await expect.poll(() => focusedKind(page)).toBe("agent");
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On mobile, the right panel (diff file list plus the paired shell terminal) was rendered as an `85vw` slide-in overlay pinned to `bottom-0`. When the soft keyboard opened against the paired terminal inside that overlay, `PairedTerminal` padded itself by the live `keyboardHeight`. That padding came out of a container whose height was already capped by the overlay, so `data-term="paired"` collapsed to near-zero pixels and the keyboard sat over an empty sliver.

This drops the slide-in model on mobile. Below the `md` breakpoint the dashboard now shows a single full-viewport pane, and the right-panel button opens a picker that promotes the chosen view (Agent terminal, Diff, or Paired terminal) into that pane. Because each view owns the whole viewport, the paired terminal inherits the same posture the agent terminal already uses: the App root pins to the latched `stableViewportHeight` and the terminal pads by the latched `reservedKeyboardHeight` (sticky, not live), which keeps it stable across the keyboard cycle. A back chip in the diff and paired views returns to the agent terminal.

The topology switch is width-driven (`useIsWideViewport`, the same 768px boundary the old overlay used), so it stays aligned with the `md:` Tailwind classes; pointer type still governs keyboard padding and touch affordances only. The agent terminal, and the paired shell once first opened, stay mounted but hidden via `visibility` (never `display:none`, which would collapse xterm's measured geometry to zero), so their PTY, scrollback, and focus survive view switches. The paired shell mounts lazily on first activation so we do not spawn a shell for every mobile session. The desktop side-by-side `ContentSplit` is unchanged.

The fix shape (drop the overlay, promote a single view, reuse the agent terminal's keyboard posture) was reviewed with a multi-model design debate before implementation; the width-based gating and the `visibility`-not-`display:none` keep-alive came out of that.

Closes #1452

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

Behavioral steps for a human verifier (on a phone or a 390x844 mobile preset with touch emulation):

- [ ] Open a session, tap the right-panel button in the top bar, confirm a picker appears (Agent terminal / Diff / Paired terminal) instead of a slide-in overlay.
- [ ] Pick "Paired terminal", confirm it fills the screen and the agent terminal is no longer shown.
- [ ] Tap into the paired terminal to open the soft keyboard; confirm the terminal stays visible above the keyboard (does not collapse to a sliver).
- [ ] Pick "Diff" from the picker, tap a changed file, confirm the diff opens full-screen.
- [ ] Tap the back chip (top-left); confirm you return to the agent terminal with its scrollback and input intact.
- [ ] Press Cmd/Ctrl+` ; confirm focus toggles between the agent terminal and the paired shell, promoting the paired view when needed.
- [ ] On a desktop-width window, confirm the right panel still renders as the side-by-side split with the draggable divider (unchanged).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added `web/tests/mobile-right-panel-picker.spec.ts` (mocked iPhone 13): drives the picker, promotes the paired terminal, simulates the soft keyboard, and asserts `data-term="paired"` stays > 150px tall (it collapsed to ~0 before). Also covers the diff view, the back-to-agent chip, terminal keep-alive across switches, and that the desktop split is unchanged. Updated `terminal-focus-shortcut.spec.ts` for the single paired instance and the picker-based mobile Cmd+` flow. Added the `right-panel.mobile-picker` matrix entry. This is a mobile-viewport / keyboard / touch behavior, which `AGENTS.md` routes to mocked Playwright; the paired terminal's backend round-trip is already covered by the existing live right-panel specs.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the multi-model design debate, plan, and implementation were drafted by Claude under my direction. I made the design calls (drop the overlay, width-based gating, keep-alive via visibility), reviewed each commit, and ran the manual mobile test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a mobile-only bug where the Paired terminal collapsed to near-zero height when the soft keyboard opened by replacing the mobile slide-in right-panel with a single full-viewport pane and a bottom-sheet picker that promotes the selected view to own the viewport. Desktop side-by-side split behavior is unchanged.

What changed (high-level)
- Mobile UX: removed the fixed bottom-anchored slide-in overlay and added MobileRightPanelPicker (bottom-sheet). On small screens the picker (Agent / Diff / Paired) promotes the chosen view into a MobileMainPane full-viewport.
- Views: Agent terminal, Diff viewer, and Paired terminal can be promoted. Promoted non-agent views show a back-to-Agent chip.
- Mounting/visibility: Agent and Paired terminals are kept mounted when hidden (visibility/inert, not display:none) so PTY, scrollback, and focus survive view switches; Paired shell mounts lazily on first activation.
- Desktop: ContentSplit and desktop split/drag behavior unchanged.

Added
- MobileRightPanelPicker component (mobile picker UI).
- PairedTerminal and PairedShellPane with robust mobile keyboard handling and focus-intent latching.
- MobileMainPane to host promoted full-viewport views.
- useIsWideViewport hook and RightPanelView type.
- Playwright mobile tests (mocked iPhone 13), Vitest unit tests for new components/hooks, and coverage-matrix entries.
- Documentation updated describing the mobile single-pane UX.

Modified / Removed
- App.tsx: responsive right-panel state and mobile render path, picker wiring, lazy paired mounting, focus routing, and diff fetch gating.
- RightPanel.tsx: removed in-file paired-terminal and delegates to PairedShellPane.
- ContentSplit.tsx: removed mobile slide-in overlay/backdrop and simplified right-pane rendering.
- Tests updated to reflect single-viewport mobile behavior and updated focus semantics.

Benefits
- Prevents keyboard-induced terminal collapse by ensuring promoted terminals own the viewport and reserve keyboard space (sticky reservation), avoiding padding inside height-capped overlays.
- Preserves terminal state (scrollback, PTY connection, focus) across view switches.
- Keeps desktop UX intact and reduces initial load by lazy-mounting the paired shell.
- Adds automated mobile and unit tests to protect against regressions.

Technical summary (concise)
- Breakpoint: md (min-width: 768px) still gates split vs single-pane via useIsWideViewport.
- Mobile state: pickerOpen + rightPanelView ("agent" | "diff" | "paired") control promotion into MobileMainPane.
- Keyboard handling: promoted terminals use a latched stableViewportHeight + reservedKeyboardHeight (keyboardOcclusion) posture (sticky reservation vs live bottom-padding).
- Visibility: inactive panes hidden via visibility/inert (not display:none) so xterm geometry and focus survive; PairedTerminal supports pending focus latches until its textarea mounts.
- Implementation notes: Escape-to-close picker, Escape key handling added; view switches dispatch a resize nudge to refit xterm; paired terminal boot error shows Retry to recover; Playwright tests simulate visualViewport occlusion and poll for stable heights for robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->