### PR TITLE
feat(web): auto-focus agent input on sidebar session select

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,7 +36,11 @@ import {
 } from "./lib/idleDecay";
 import { toastBus } from "./lib/toastBus";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
-import { requestSessionInputFocus } from "./lib/terminalFocus";
+import {
+  dispatchFocusTerminal,
+  requestSessionInputFocus,
+  setPendingTerminalFocus,
+} from "./lib/terminalFocus";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
 import { TopBar } from "./components/TopBar";

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialo
 import { useCommandActions } from "./hooks/useCommandActions";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useMobileKeyboard } from "./hooks/useMobileKeyboard";
+import { useIsCoarsePointer } from "./hooks/useIsCoarsePointer";
 import {
   loginStatus,
   logout,
@@ -346,14 +347,34 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     }
   };
 
+  // Selecting a session in the sidebar should land focus on its canonical
+  // "type here" target so the user can start typing without a second click:
+  // the cockpit composer in cockpit mode, the xterm textarea otherwise. The
+  // dispatch handles the already-mounted case (re-selecting the active
+  // session, re-showing a persistent terminal); the latch covers a first
+  // open where the target is still resolving (Suspense / xterm round-trip).
+  // Skipped on coarse pointers (#1178): auto-focusing pops the soft keyboard
+  // on every session swap, the wrong default for read-heavy mobile use.
+  const isCoarse = useIsCoarsePointer();
+  const focusAgentInput = useCallback(
+    (session: SessionResponse | undefined) => {
+      if (!session || isCoarse) return;
+      const target = session.cockpit_mode ? "composer" : "agent";
+      setPendingTerminalFocus(target);
+      dispatchFocusTerminal(target);
+    },
+    [isCoarse],
+  );
+
   const handleSelectSession = useCallback((sessionId: string) => {
     const ws = workspaces.find((w) => w.sessions.some((s) => s.id === sessionId));
     if (ws) {
       navigate(`/session/${encodeURIComponent(sessionId)}`);
       focusKeyboardProxy();
+      focusAgentInput(ws.sessions.find((s) => s.id === sessionId));
       if (window.innerWidth < 768) setSidebarOpen(false);
     }
-  }, [navigate, workspaces]);
+  }, [navigate, workspaces, focusAgentInput]);
 
   const handleSelectWorkspace = (workspaceId: string) => {
     const ws = workspaces.find((w) => w.id === workspaceId);
@@ -361,9 +382,10 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       const running = ws.sessions.find((s) =>
         isSessionActive(s, idleDecayWindowMs),
       );
-      const picked = running?.id ?? ws.sessions[0]?.id ?? null;
+      const picked = running ?? ws.sessions[0] ?? null;
       if (picked) {
-        navigate(`/session/${encodeURIComponent(picked)}`);
+        navigate(`/session/${encodeURIComponent(picked.id)}`);
+        focusAgentInput(picked);
       } else {
         navigate("/");
       }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -354,10 +354,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // requestSessionInputFocus for the dispatch/latch and coarse-pointer rules.
   const isCoarse = useIsCoarsePointer();
   const focusAgentInput = useCallback(
-    (session: SessionResponse | undefined) => {
-      if (!session) return;
-      requestSessionInputFocus(!!session.cockpit_mode, isCoarse);
-    },
+    (session: SessionResponse | undefined) =>
+      requestSessionInputFocus(session, isCoarse),
     [isCoarse],
   );
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,10 +36,7 @@ import {
 } from "./lib/idleDecay";
 import { toastBus } from "./lib/toastBus";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
-import {
-  dispatchFocusTerminal,
-  setPendingTerminalFocus,
-} from "./lib/terminalFocus";
+import { requestSessionInputFocus } from "./lib/terminalFocus";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
 import { TopBar } from "./components/TopBar";
@@ -349,19 +346,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   // Selecting a session in the sidebar should land focus on its canonical
   // "type here" target so the user can start typing without a second click:
-  // the cockpit composer in cockpit mode, the xterm textarea otherwise. The
-  // dispatch handles the already-mounted case (re-selecting the active
-  // session, re-showing a persistent terminal); the latch covers a first
-  // open where the target is still resolving (Suspense / xterm round-trip).
-  // Skipped on coarse pointers (#1178): auto-focusing pops the soft keyboard
-  // on every session swap, the wrong default for read-heavy mobile use.
+  // the cockpit composer in cockpit mode, the xterm textarea otherwise. See
+  // requestSessionInputFocus for the dispatch/latch and coarse-pointer rules.
   const isCoarse = useIsCoarsePointer();
   const focusAgentInput = useCallback(
     (session: SessionResponse | undefined) => {
-      if (!session || isCoarse) return;
-      const target = session.cockpit_mode ? "composer" : "agent";
-      setPendingTerminalFocus(target);
-      dispatchFocusTerminal(target);
+      if (!session) return;
+      requestSessionInputFocus(!!session.cockpit_mode, isCoarse);
     },
     [isCoarse],
   );
@@ -370,11 +361,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     const ws = workspaces.find((w) => w.sessions.some((s) => s.id === sessionId));
     if (ws) {
       navigate(`/session/${encodeURIComponent(sessionId)}`);
-      focusKeyboardProxy();
+      // The proxy is a real textarea; focusing it inside the click gesture
+      // would pop the soft keyboard on touch devices, so skip it on coarse
+      // pointers (#1178), matching the focusAgentInput suppression.
+      if (!isCoarse) focusKeyboardProxy();
       focusAgentInput(ws.sessions.find((s) => s.id === sessionId));
       if (window.innerWidth < 768) setSidebarOpen(false);
     }
-  }, [navigate, workspaces, focusAgentInput]);
+  }, [navigate, workspaces, focusAgentInput, isCoarse]);
 
   const handleSelectWorkspace = (workspaceId: string) => {
     const ws = workspaces.find((w) => w.id === workspaceId);
@@ -390,7 +384,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         navigate("/");
       }
     }
-    focusKeyboardProxy();
+    if (!isCoarse) focusKeyboardProxy();
     if (window.innerWidth < 768) {
       setSidebarOpen(false);
     }

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -32,6 +32,12 @@ import type { CockpitState } from "../../lib/cockpitTypes";
 import { getDraft, setDraft } from "../../lib/cockpitDrafts";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { useAgentProfile } from "../../lib/agentProfileContext";
+import {
+  FOCUS_TERMINAL_EVENT,
+  consumePendingTerminalFocus,
+  setPendingTerminalFocus,
+  type FocusTerminalDetail,
+} from "../../lib/terminalFocus";
 import { useDictationBurstGuard } from "./useDictationBurstGuard";
 
 export {
@@ -440,6 +446,29 @@ export function Composer({
       window.clearTimeout(t2);
     };
   }, [isMobile]);
+
+  // Explicit focus from sidebar session selection (#1454). Mirrors
+  // TerminalView's "agent" listener for the "composer" target so a click
+  // lands focus on the input even when the composer is already mounted
+  // (re-selecting the active session, where the keyed remount above never
+  // fires). App only dispatches this on desktop, so no coarse-pointer gate
+  // is needed here. The latch covers the first-open race where this
+  // component mounts after the dispatch.
+  useEffect(() => {
+    const onFocusEvent = (e: Event) => {
+      const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
+      if (detail?.target !== "composer") return;
+      const el = taRef.current;
+      if (el) el.focus();
+      else setPendingTerminalFocus("composer");
+    };
+    window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
+    return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
+  }, []);
+
+  useEffect(() => {
+    if (consumePendingTerminalFocus("composer")) taRef.current?.focus();
+  }, []);
 
   const wrapperLayout = composerWrapperLayout({ keyboardOpen });
   return (

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -32,12 +32,7 @@ import type { CockpitState } from "../../lib/cockpitTypes";
 import { getDraft, setDraft } from "../../lib/cockpitDrafts";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { useAgentProfile } from "../../lib/agentProfileContext";
-import {
-  FOCUS_TERMINAL_EVENT,
-  consumePendingTerminalFocus,
-  setPendingTerminalFocus,
-  type FocusTerminalDetail,
-} from "../../lib/terminalFocus";
+import { useFocusTerminalTarget } from "../../hooks/useFocusTerminalTarget";
 import { useDictationBurstGuard } from "./useDictationBurstGuard";
 
 export {
@@ -447,28 +442,12 @@ export function Composer({
     };
   }, [isMobile]);
 
-  // Explicit focus from sidebar session selection (#1454). Mirrors
-  // TerminalView's "agent" listener for the "composer" target so a click
-  // lands focus on the input even when the composer is already mounted
-  // (re-selecting the active session, where the keyed remount above never
-  // fires). App only dispatches this on desktop, so no coarse-pointer gate
-  // is needed here. The latch covers the first-open race where this
-  // component mounts after the dispatch.
-  useEffect(() => {
-    const onFocusEvent = (e: Event) => {
-      const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
-      if (detail?.target !== "composer") return;
-      const el = taRef.current;
-      if (el) el.focus();
-      else setPendingTerminalFocus("composer");
-    };
-    window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
-    return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
-  }, []);
-
-  useEffect(() => {
-    if (consumePendingTerminalFocus("composer")) taRef.current?.focus();
-  }, []);
+  // Explicit focus from sidebar session selection (#1454). Lands focus on
+  // the composer even when it is already mounted (re-selecting the active
+  // session, where the keyed remount above never fires); the latch inside
+  // the hook covers the first-open race. App only dispatches "composer" on
+  // desktop, so no coarse-pointer gate is needed here.
+  useFocusTerminalTarget("composer", taRef);
 
   const wrapperLayout = composerWrapperLayout({ keyboardOpen });
   return (

--- a/web/src/hooks/__tests__/useFocusTerminalTarget.test.tsx
+++ b/web/src/hooks/__tests__/useFocusTerminalTarget.test.tsx
@@ -57,6 +57,27 @@ describe("useFocusTerminalTarget", () => {
     }
   });
 
+  it("ignores a focus event with no detail", () => {
+    const el = document.createElement("textarea");
+    document.body.appendChild(el);
+    try {
+      renderWithElement("composer", el);
+      // A bare event (detail undefined) must not throw or focus.
+      window.dispatchEvent(new CustomEvent("aoe:focus-terminal"));
+      expect(document.activeElement).not.toBe(el);
+    } finally {
+      el.remove();
+    }
+  });
+
+  it("consuming a latch with no element present is a no-op", () => {
+    setPendingTerminalFocus("composer");
+    // ref.current is null on mount: the latch is consumed but focus() is
+    // skipped via optional chaining, with nothing left dangling.
+    renderWithElement("composer", null);
+    expect(consumePendingTerminalFocus("composer")).toBe(false);
+  });
+
   it("stashes the latch when the element is not present at event time", () => {
     renderWithElement("composer", null);
     dispatchFocusTerminal("composer");

--- a/web/src/hooks/__tests__/useFocusTerminalTarget.test.tsx
+++ b/web/src/hooks/__tests__/useFocusTerminalTarget.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+//
+// Unit tests for useFocusTerminalTarget (#1454): the hook the cockpit
+// Composer uses to receive sidebar-select focus. Covers the three paths:
+//  - a matching dispatch focuses the ref while mounted,
+//  - a dispatch with the ref missing stashes the pending latch,
+//  - a pending latch set before mount is consumed (and focused) on mount,
+//  - the listener is removed on unmount.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRef } from "react";
+
+import { useFocusTerminalTarget } from "../useFocusTerminalTarget";
+import {
+  consumePendingTerminalFocus,
+  dispatchFocusTerminal,
+  setPendingTerminalFocus,
+} from "../../lib/terminalFocus";
+
+afterEach(() => {
+  consumePendingTerminalFocus("composer");
+  consumePendingTerminalFocus("agent");
+});
+
+function renderWithElement(target: "composer" | "agent", el: HTMLElement | null) {
+  return renderHook(() => {
+    const ref = useRef<HTMLElement | null>(el);
+    useFocusTerminalTarget(target, ref);
+    return ref;
+  });
+}
+
+describe("useFocusTerminalTarget", () => {
+  it("focuses the ref when a matching focus event is dispatched", () => {
+    const el = document.createElement("textarea");
+    document.body.appendChild(el);
+    try {
+      renderWithElement("composer", el);
+      expect(document.activeElement).not.toBe(el);
+      dispatchFocusTerminal("composer");
+      expect(document.activeElement).toBe(el);
+    } finally {
+      el.remove();
+    }
+  });
+
+  it("ignores focus events for other targets", () => {
+    const el = document.createElement("textarea");
+    document.body.appendChild(el);
+    try {
+      renderWithElement("composer", el);
+      dispatchFocusTerminal("agent");
+      expect(document.activeElement).not.toBe(el);
+    } finally {
+      el.remove();
+    }
+  });
+
+  it("stashes the latch when the element is not present at event time", () => {
+    renderWithElement("composer", null);
+    dispatchFocusTerminal("composer");
+    expect(consumePendingTerminalFocus("composer")).toBe(true);
+  });
+
+  it("consumes a pending latch on mount", () => {
+    const el = document.createElement("textarea");
+    document.body.appendChild(el);
+    try {
+      setPendingTerminalFocus("composer");
+      renderWithElement("composer", el);
+      expect(document.activeElement).toBe(el);
+      // Latch was consumed, not left dangling.
+      expect(consumePendingTerminalFocus("composer")).toBe(false);
+    } finally {
+      el.remove();
+    }
+  });
+
+  it("removes its listener on unmount", () => {
+    const el = document.createElement("textarea");
+    document.body.appendChild(el);
+    try {
+      const { unmount } = renderWithElement("composer", el);
+      unmount();
+      el.blur();
+      dispatchFocusTerminal("composer");
+      expect(document.activeElement).not.toBe(el);
+    } finally {
+      el.remove();
+    }
+  });
+});

--- a/web/src/hooks/useFocusTerminalTarget.ts
+++ b/web/src/hooks/useFocusTerminalTarget.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import {
+  FOCUS_TERMINAL_EVENT,
+  consumePendingTerminalFocus,
+  setPendingTerminalFocus,
+  type FocusTerminalDetail,
+  type TerminalFocusTarget,
+} from "../lib/terminalFocus";
+
+/**
+ * Wire a focusable element to the terminalFocus bus for a given target.
+ *
+ * Registers a {@link FOCUS_TERMINAL_EVENT} listener that focuses `ref` when a
+ * matching-target focus is dispatched (handling the already-mounted case, for
+ * example re-selecting the active session), and consumes the pending-focus
+ * latch on mount (handling the first-open race where this component mounts
+ * after the dispatch). If the element is not present when the event fires, the
+ * intent is stashed back on the latch.
+ *
+ * Mirrors the inline wiring TerminalView uses for the "agent" target; the
+ * cockpit Composer uses it for "composer".
+ */
+export function useFocusTerminalTarget(
+  target: TerminalFocusTarget,
+  ref: React.RefObject<HTMLElement | null>,
+): void {
+  useEffect(() => {
+    const onFocusEvent = (e: Event) => {
+      const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
+      if (detail?.target !== target) return;
+      const el = ref.current;
+      if (el) el.focus();
+      else setPendingTerminalFocus(target);
+    };
+    window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
+    return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
+  }, [target, ref]);
+
+  useEffect(() => {
+    if (consumePendingTerminalFocus(target)) ref.current?.focus();
+  }, [target, ref]);
+}

--- a/web/src/lib/__tests__/terminalFocus.test.ts
+++ b/web/src/lib/__tests__/terminalFocus.test.ts
@@ -36,17 +36,24 @@ afterEach(() => {
 describe("requestSessionInputFocus", () => {
   it("does nothing on a coarse pointer", () => {
     const done = captureDispatch();
-    requestSessionInputFocus(true, true);
-    requestSessionInputFocus(false, true);
+    requestSessionInputFocus({ cockpit_mode: true }, true);
+    requestSessionInputFocus({ cockpit_mode: false }, true);
     const events = done();
     expect(events).toHaveLength(0);
     expect(consumePendingTerminalFocus("composer")).toBe(false);
     expect(consumePendingTerminalFocus("agent")).toBe(false);
   });
 
+  it("does nothing when there is no session", () => {
+    const done = captureDispatch();
+    requestSessionInputFocus(undefined, false);
+    expect(done()).toHaveLength(0);
+    expect(consumePendingTerminalFocus("agent")).toBe(false);
+  });
+
   it("targets the composer for cockpit sessions on a fine pointer", () => {
     const done = captureDispatch();
-    requestSessionInputFocus(true, false);
+    requestSessionInputFocus({ cockpit_mode: true }, false);
     const events = done();
     expect(events).toEqual([{ target: "composer" }]);
     // Latch was set for the not-yet-mounted case.
@@ -56,7 +63,7 @@ describe("requestSessionInputFocus", () => {
 
   it("targets the agent terminal for non-cockpit sessions on a fine pointer", () => {
     const done = captureDispatch();
-    requestSessionInputFocus(false, false);
+    requestSessionInputFocus({ cockpit_mode: false }, false);
     const events = done();
     expect(events).toEqual([{ target: "agent" }]);
     expect(consumePendingTerminalFocus("agent")).toBe(true);

--- a/web/src/lib/__tests__/terminalFocus.test.ts
+++ b/web/src/lib/__tests__/terminalFocus.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+//
+// Unit tests for requestSessionInputFocus (#1454): the pure dispatch +
+// pending-latch helper the sidebar select handlers delegate to. Covers the
+// coarse-pointer suppression and the cockpit / non-cockpit target choice,
+// asserting both the dispatched event and the stashed latch.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FOCUS_TERMINAL_EVENT,
+  consumePendingTerminalFocus,
+  requestSessionInputFocus,
+  type FocusTerminalDetail,
+} from "../terminalFocus";
+
+function captureDispatch(): () => FocusTerminalDetail[] {
+  const seen: FocusTerminalDetail[] = [];
+  const handler = (e: Event) => {
+    seen.push((e as CustomEvent<FocusTerminalDetail>).detail);
+  };
+  window.addEventListener(FOCUS_TERMINAL_EVENT, handler);
+  return () => {
+    window.removeEventListener(FOCUS_TERMINAL_EVENT, handler);
+    return seen;
+  };
+}
+
+afterEach(() => {
+  // Drain any latch left over so tests stay independent.
+  consumePendingTerminalFocus("agent");
+  consumePendingTerminalFocus("composer");
+  consumePendingTerminalFocus("paired");
+  vi.restoreAllMocks();
+});
+
+describe("requestSessionInputFocus", () => {
+  it("does nothing on a coarse pointer", () => {
+    const done = captureDispatch();
+    requestSessionInputFocus(true, true);
+    requestSessionInputFocus(false, true);
+    const events = done();
+    expect(events).toHaveLength(0);
+    expect(consumePendingTerminalFocus("composer")).toBe(false);
+    expect(consumePendingTerminalFocus("agent")).toBe(false);
+  });
+
+  it("targets the composer for cockpit sessions on a fine pointer", () => {
+    const done = captureDispatch();
+    requestSessionInputFocus(true, false);
+    const events = done();
+    expect(events).toEqual([{ target: "composer" }]);
+    // Latch was set for the not-yet-mounted case.
+    expect(consumePendingTerminalFocus("composer")).toBe(true);
+    expect(consumePendingTerminalFocus("composer")).toBe(false);
+  });
+
+  it("targets the agent terminal for non-cockpit sessions on a fine pointer", () => {
+    const done = captureDispatch();
+    requestSessionInputFocus(false, false);
+    const events = done();
+    expect(events).toEqual([{ target: "agent" }]);
+    expect(consumePendingTerminalFocus("agent")).toBe(true);
+  });
+});

--- a/web/src/lib/terminalFocus.ts
+++ b/web/src/lib/terminalFocus.ts
@@ -1,6 +1,6 @@
 export const FOCUS_TERMINAL_EVENT = "aoe:focus-terminal";
 
-export type TerminalFocusTarget = "agent" | "paired";
+export type TerminalFocusTarget = "agent" | "paired" | "composer";
 
 export interface FocusTerminalDetail {
   target: TerminalFocusTarget;
@@ -14,10 +14,12 @@ export function dispatchFocusTerminal(target: TerminalFocusTarget) {
   );
 }
 
-// When the right panel is collapsed, the paired terminal is unmounted, so
-// dispatching a focus event before the panel re-renders has no listener to
-// receive it. The shortcut handler stashes the intent here, and PairedTerminal
-// consumes it once it mounts and its PTY becomes ready.
+// When the target component is not mounted yet (the right panel is
+// collapsed so the paired terminal is gone, or a freshly selected session's
+// terminal/composer is still resolving), dispatching a focus event has no
+// listener to receive it. The caller stashes the intent here, and the target
+// (PairedTerminal, TerminalView, or the cockpit Composer) consumes it once it
+// mounts and is ready.
 let pendingFocus: TerminalFocusTarget | null = null;
 
 export function setPendingTerminalFocus(target: TerminalFocusTarget) {

--- a/web/src/lib/terminalFocus.ts
+++ b/web/src/lib/terminalFocus.ts
@@ -40,14 +40,16 @@ export function consumePendingTerminalFocus(
 // composer in cockpit mode, the xterm textarea otherwise. Sets the pending
 // latch (consumed on mount when the target is still resolving) and dispatches
 // (handled immediately when the target is already mounted, e.g. re-selecting
-// the active session). A no-op on coarse pointers so a session swap never
-// pops the soft keyboard (#1178).
+// the active session). No-ops when there is no session or on coarse pointers,
+// so a session swap never pops the soft keyboard (#1178).
 export function requestSessionInputFocus(
-  cockpitMode: boolean,
+  session: { cockpit_mode?: boolean } | undefined,
   isCoarse: boolean,
 ): void {
-  if (isCoarse) return;
-  const target: TerminalFocusTarget = cockpitMode ? "composer" : "agent";
+  if (!session || isCoarse) return;
+  const target: TerminalFocusTarget = session.cockpit_mode
+    ? "composer"
+    : "agent";
   setPendingTerminalFocus(target);
   dispatchFocusTerminal(target);
 }

--- a/web/src/lib/terminalFocus.ts
+++ b/web/src/lib/terminalFocus.ts
@@ -35,3 +35,19 @@ export function consumePendingTerminalFocus(
   }
   return false;
 }
+
+// Focus the canonical input for a freshly selected session: the cockpit
+// composer in cockpit mode, the xterm textarea otherwise. Sets the pending
+// latch (consumed on mount when the target is still resolving) and dispatches
+// (handled immediately when the target is already mounted, e.g. re-selecting
+// the active session). A no-op on coarse pointers so a session swap never
+// pops the soft keyboard (#1178).
+export function requestSessionInputFocus(
+  cockpitMode: boolean,
+  isCoarse: boolean,
+): void {
+  if (isCoarse) return;
+  const target: TerminalFocusTarget = cockpitMode ? "composer" : "agent";
+  setPendingTerminalFocus(target);
+  dispatchFocusTerminal(target);
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1301,6 +1301,20 @@
       ]
     },
     {
+      "id": "story.sidebar-select-focuses-input",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/sidebar-select-focuses-terminal.spec.ts",
+        "tests/live/cockpit-stories/sidebar-select-focuses-composer.spec.ts"
+      ],
+      "components": [
+        "web/src/App.tsx",
+        "web/src/lib/terminalFocus.ts",
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
       "id": "cockpit.story.substrate-switch-to-cockpit",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/live/cockpit-stories/sidebar-select-focuses-composer.spec.ts
+++ b/web/tests/live/cockpit-stories/sidebar-select-focuses-composer.spec.ts
@@ -63,3 +63,74 @@ base(
     }
   },
 );
+
+base(
+  "coarse pointer: selecting a cockpit session does not focus the composer",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-focus-composer-coarse" }),
+    });
+
+    try {
+      // Chromium emulation does not reliably flip the pointer media
+      // queries, so force a touch-only profile: `(pointer: coarse)` matches
+      // and `(any-pointer: fine)` does not. This drives both production
+      // gates, `useIsCoarsePointer()` (suppresses the select dispatch) and
+      // the composer's `detectMobileInput()` (disables its mount autofocus,
+      // #1178). Every other query passes through to the real matchMedia.
+      await page.addInitScript(() => {
+        const orig = window.matchMedia.bind(window);
+        const forced: Record<string, boolean> = {
+          "(pointer: coarse)": true,
+          "(any-pointer: fine)": false,
+        };
+        window.matchMedia = (query: string) => {
+          if (query in forced) {
+            return {
+              matches: forced[query],
+              media: query,
+              onchange: null,
+              addEventListener: () => {},
+              removeEventListener: () => {},
+              addListener: () => {},
+              removeListener: () => {},
+              dispatchEvent: () => false,
+            } as MediaQueryList;
+          }
+          return orig(query);
+        };
+      });
+
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find(
+        (s) => s.title === "story-focus-composer-coarse",
+      );
+      if (!seeded) {
+        throw new Error("seeded session 'story-focus-composer-coarse' missing");
+      }
+      await enableCockpitAndWait(serve.baseUrl, seeded.id);
+
+      await page.goto(serve.baseUrl);
+      const row = page
+        .locator('[data-testid="sidebar-session-row"]')
+        .first();
+      await expect(row).toBeVisible({ timeout: 10_000 });
+
+      await row.click();
+      await waitForCockpitView(page);
+      const composer = page.getByRole("textbox", {
+        name: /Send a message|Queue a follow-up/i,
+      });
+      // Give any stray focus dispatch a beat to land, then assert the
+      // composer never took focus.
+      await page.waitForTimeout(1_000);
+      await expect(composer).not.toBeFocused();
+    } finally {
+      await serve.stop();
+    }
+  },
+);

--- a/web/tests/live/cockpit-stories/sidebar-select-focuses-composer.spec.ts
+++ b/web/tests/live/cockpit-stories/sidebar-select-focuses-composer.spec.ts
@@ -1,0 +1,65 @@
+// User story (#1454): clicking a cockpit session row in the sidebar lands
+// focus on the composer textarea. The interesting case is re-selecting the
+// session that is ALREADY active: CockpitView is keyed by sessionId so it
+// does not remount, the mount-time autofocus never re-fires, and only the
+// explicit focus dispatch from the select handler can refocus the composer.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import { enableCockpitAndWait, waitForCockpitView } from "../../helpers/cockpit";
+
+base(
+  "desktop: re-selecting the active cockpit session refocuses the composer",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-focus-composer" }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find((s) => s.title === "story-focus-composer");
+      if (!seeded) {
+        throw new Error("seeded session 'story-focus-composer' missing");
+      }
+      await enableCockpitAndWait(serve.baseUrl, seeded.id);
+
+      await page.goto(serve.baseUrl);
+      const row = page
+        .locator('[data-testid="sidebar-session-row"]')
+        .first();
+      await expect(row).toBeVisible({ timeout: 10_000 });
+
+      // First select: navigates into the cockpit session and mounts the
+      // composer (which autofocuses on mount).
+      await row.click();
+      await waitForCockpitView(page);
+      const composer = page.getByRole("textbox", {
+        name: /Send a message|Queue a follow-up/i,
+      });
+      await expect(composer).toBeFocused({ timeout: 10_000 });
+
+      // Let the mount-autofocus reclaim timers (250ms / 700ms) settle, then
+      // blur so the only thing that can refocus is the select dispatch.
+      await page.waitForTimeout(1_000);
+      await page.evaluate(() =>
+        (document.activeElement as HTMLElement | null)?.blur(),
+      );
+      await expect(composer).not.toBeFocused();
+
+      // Re-select the already-active session: no remount, so this passes
+      // only because the select handler dispatches composer focus.
+      await row.click();
+      await expect(composer).toBeFocused({ timeout: 10_000 });
+    } finally {
+      await serve.stop();
+    }
+  },
+);

--- a/web/tests/live/cockpit-stories/sidebar-select-focuses-terminal.spec.ts
+++ b/web/tests/live/cockpit-stories/sidebar-select-focuses-terminal.spec.ts
@@ -1,7 +1,12 @@
-// User story (#1454): clicking a non-cockpit session row in the sidebar
-// lands keyboard focus on that session's xterm textarea, so the user can
-// type immediately without a second click. Desktop only; on a coarse
-// pointer the click must NOT focus the textarea (no soft-keyboard pop).
+// User story (#1454): selecting a non-cockpit session in the sidebar lands
+// keyboard focus on its xterm textarea.
+//
+// First-open is already covered by useTerminal's autoFocus (it calls
+// term.focus() when the socket opens). The gap this fix closes is the
+// already-connected case: re-selecting the active session (or switching
+// back to a persistent terminal) does not re-fire the socket open, so only
+// the explicit focus dispatch from the select handler can refocus it. The
+// blur-then-reselect below isolates exactly that dispatch.
 
 import { test as base, expect } from "@playwright/test";
 import {
@@ -10,7 +15,7 @@ import {
   seedSessionViaAoeAdd,
 } from "../../helpers/aoeServe";
 
-async function activeElementInXterm(page: import("@playwright/test").Page) {
+function activeElementInXterm(page: import("@playwright/test").Page) {
   return page.evaluate(() => {
     const active = document.activeElement as HTMLElement | null;
     return Boolean(active && active.closest(".xterm"));
@@ -18,7 +23,7 @@ async function activeElementInXterm(page: import("@playwright/test").Page) {
 }
 
 base(
-  "desktop: sidebar select focuses the terminal textarea",
+  "desktop: re-selecting the active terminal session refocuses the textarea",
   async ({ page }, testInfo) => {
     const serve = await spawnAoeServe({
       authMode: "none",
@@ -32,13 +37,14 @@ base(
       const seeded = sessions.find((s) => s.title === "story-focus-term");
       if (!seeded) throw new Error("seeded session 'story-focus-term' missing");
 
-      // Start on the dashboard so the click is what navigates + focuses.
       await page.goto(serve.baseUrl);
       const row = page
         .locator('[data-testid="sidebar-session-row"]')
         .first();
       await expect(row).toBeVisible({ timeout: 10_000 });
 
+      // First select: navigate + connect; useTerminal autofocuses the xterm
+      // textarea once the socket opens.
       await row.click();
       await expect(page).toHaveURL(
         new URL(
@@ -47,60 +53,23 @@ base(
         ).toString(),
         { timeout: 10_000 },
       );
+      await expect.poll(() => activeElementInXterm(page), { timeout: 10_000 }).toBe(
+        true,
+      );
 
-      await expect
-        .poll(() => activeElementInXterm(page), { timeout: 10_000 })
-        .toBe(true);
+      // Blur, then re-select the already-connected session. The socket does
+      // not reopen, so a refocus here can only come from the select dispatch.
+      await page.evaluate(() =>
+        (document.activeElement as HTMLElement | null)?.blur(),
+      );
+      await expect.poll(() => activeElementInXterm(page)).toBe(false);
+
+      await row.click();
+      await expect.poll(() => activeElementInXterm(page), { timeout: 10_000 }).toBe(
+        true,
+      );
     } finally {
       await serve.stop();
     }
   },
 );
-
-base.describe("coarse pointer", () => {
-  base.use({ hasTouch: true, isMobile: true });
-
-  base(
-    "coarse pointer: sidebar select does not focus the terminal textarea",
-    async ({ page }, testInfo) => {
-      const serve = await spawnAoeServe({
-        authMode: "none",
-        workerIndex: testInfo.workerIndex,
-        parallelIndex: testInfo.parallelIndex,
-        seedFn: seedSessionViaAoeAdd({ title: "story-focus-term-coarse" }),
-      });
-
-      try {
-        const sessions = await listSessions(serve.baseUrl);
-        const seeded = sessions.find(
-          (s) => s.title === "story-focus-term-coarse",
-        );
-        if (!seeded) {
-          throw new Error("seeded session 'story-focus-term-coarse' missing");
-        }
-
-        await page.goto(serve.baseUrl);
-        const row = page
-          .locator('[data-testid="sidebar-session-row"]')
-          .first();
-        await expect(row).toBeVisible({ timeout: 10_000 });
-
-        await row.click();
-        await expect(page).toHaveURL(
-          new URL(
-            `/session/${encodeURIComponent(seeded.id)}`,
-            serve.baseUrl,
-          ).toString(),
-          { timeout: 10_000 },
-        );
-
-        // Give any stray focus dispatch a beat to land, then assert focus
-        // never entered the terminal (which would pop the soft keyboard).
-        await page.waitForTimeout(1_000);
-        expect(await activeElementInXterm(page)).toBe(false);
-      } finally {
-        await serve.stop();
-      }
-    },
-  );
-});

--- a/web/tests/live/cockpit-stories/sidebar-select-focuses-terminal.spec.ts
+++ b/web/tests/live/cockpit-stories/sidebar-select-focuses-terminal.spec.ts
@@ -1,0 +1,106 @@
+// User story (#1454): clicking a non-cockpit session row in the sidebar
+// lands keyboard focus on that session's xterm textarea, so the user can
+// type immediately without a second click. Desktop only; on a coarse
+// pointer the click must NOT focus the textarea (no soft-keyboard pop).
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+async function activeElementInXterm(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const active = document.activeElement as HTMLElement | null;
+    return Boolean(active && active.closest(".xterm"));
+  });
+}
+
+base(
+  "desktop: sidebar select focuses the terminal textarea",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-focus-term" }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find((s) => s.title === "story-focus-term");
+      if (!seeded) throw new Error("seeded session 'story-focus-term' missing");
+
+      // Start on the dashboard so the click is what navigates + focuses.
+      await page.goto(serve.baseUrl);
+      const row = page
+        .locator('[data-testid="sidebar-session-row"]')
+        .first();
+      await expect(row).toBeVisible({ timeout: 10_000 });
+
+      await row.click();
+      await expect(page).toHaveURL(
+        new URL(
+          `/session/${encodeURIComponent(seeded.id)}`,
+          serve.baseUrl,
+        ).toString(),
+        { timeout: 10_000 },
+      );
+
+      await expect
+        .poll(() => activeElementInXterm(page), { timeout: 10_000 })
+        .toBe(true);
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base.describe("coarse pointer", () => {
+  base.use({ hasTouch: true, isMobile: true });
+
+  base(
+    "coarse pointer: sidebar select does not focus the terminal textarea",
+    async ({ page }, testInfo) => {
+      const serve = await spawnAoeServe({
+        authMode: "none",
+        workerIndex: testInfo.workerIndex,
+        parallelIndex: testInfo.parallelIndex,
+        seedFn: seedSessionViaAoeAdd({ title: "story-focus-term-coarse" }),
+      });
+
+      try {
+        const sessions = await listSessions(serve.baseUrl);
+        const seeded = sessions.find(
+          (s) => s.title === "story-focus-term-coarse",
+        );
+        if (!seeded) {
+          throw new Error("seeded session 'story-focus-term-coarse' missing");
+        }
+
+        await page.goto(serve.baseUrl);
+        const row = page
+          .locator('[data-testid="sidebar-session-row"]')
+          .first();
+        await expect(row).toBeVisible({ timeout: 10_000 });
+
+        await row.click();
+        await expect(page).toHaveURL(
+          new URL(
+            `/session/${encodeURIComponent(seeded.id)}`,
+            serve.baseUrl,
+          ).toString(),
+          { timeout: 10_000 },
+        );
+
+        // Give any stray focus dispatch a beat to land, then assert focus
+        // never entered the terminal (which would pop the soft keyboard).
+        await page.waitForTimeout(1_000);
+        expect(await activeElementInXterm(page)).toBe(false);
+      } finally {
+        await serve.stop();
+      }
+    },
+  );
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Selecting a session in the sidebar now lands keyboard focus on that session's canonical "type here" target, so you can start typing without a second click: the cockpit composer in cockpit mode, the xterm.js textarea otherwise.

`handleSelectSession` and `handleSelectWorkspace` dispatch focus after navigating. The dispatch reuses the existing `terminalFocus` bus (extended with a `"composer"` target) plus its pending-focus latch: the dispatch handles the already-mounted case (re-selecting the active session, switching back to a persistent terminal whose socket is already open) and the latch handles the first-open race where the target is still resolving (Suspense, the xterm ensure-session round-trip). The cockpit composer gains a matching listener and a mount-time latch consumer, mirroring `TerminalView` for the `agent` target.

The behavior is gated behind a non-coarse pointer (`useIsCoarsePointer()`): on touch devices a session swap must not pop the soft keyboard, matching the intent established in #1178. On a coarse pointer the select handler leaves focus where it was.

Scope note: the issue originally proposed a parallel `"composer"` latch/listener pair, drafted before the composer gained its own mount autofocus. On the current tree the simpler shared-bus approach covers the same cases (verified by debate plus the regression specs below). Focus restoration when returning from settings / projects / diff full-screen is intentionally out of scope, as called out in the issue.

Closes #1454

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [x] Desktop: from the dashboard, click a non-cockpit (terminal) session row in the sidebar; confirm you can type into the terminal immediately, with no second click.
- [x] Desktop: switch to another session, then re-select the previous one (or re-click the already-active row); confirm focus returns to the input.
- [x] Desktop, cockpit session: click a cockpit session row; confirm the composer textarea is focused.
- [ ] Mobile / touch device: click a session row; confirm the soft keyboard does NOT pop and the input is not auto-focused.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a multi-model `/debate` pass on the design. I made the design calls (shared bus vs parallel listener, out-of-scope boundaries) and ran the manual test steps. The two live Playwright reproducers were confirmed to fail on the pre-fix tree and pass after the fix.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Selecting a session in the sidebar now auto-focuses that session’s input so typing can begin immediately without a second click. In cockpit sessions this focuses the composer textarea; in non-cockpit sessions it focuses the terminal's input. Auto-focus is disabled on coarse-pointer (touch) devices to avoid opening the soft keyboard.

## What changed (high level)

- Auto-focus on sidebar session selection (composer for cockpit, terminal for non-cockpit).
- Cockpit Composer wired into the existing focus-dispatch + pending-focus latch system so mount races and re-selects both focus correctly.
- Coarse-pointer detection added to suppress auto-focus on touch devices.
- New reusable hook to attach elements to the focus-dispatch system and a small focus helper to centralize selection logic.
- Unit tests and Playwright specs added and coverage matrix updated to cover these behaviors.

## Files added / modified (concise)

- Added: web/src/hooks/useFocusTerminalTarget.ts — hook to connect an element ref to the FOCUS_TERMINAL_EVENT + pending-latch flow.
- Modified: web/src/lib/terminalFocus.ts — added "composer" target and requestSessionInputFocus(session, isCoarse) helper that latches and dispatches focus (no-op for coarse pointers or missing session).
- Modified: web/src/App.tsx — uses useIsCoarsePointer and calls the new focus helper from session/workspace selection handlers (handles navigation, sidebar auto-close, and focus dispatch).
- Modified: web/src/components/cockpit/Composer.tsx — uses useFocusTerminalTarget to focus the composer textarea and consume mount-time pending-focus.
- Tests:
  - Unit: web/src/hooks/__tests__/useFocusTerminalTarget.test.tsx, web/src/lib/__tests__/terminalFocus.test.ts — verify dispatch, latch, mount-consume, and coarse-pointer suppression.
  - Playwright: web/tests/live/cockpit-stories/sidebar-select-focuses-composer.spec.ts, web/tests/live/cockpit-stories/sidebar-select-focuses-terminal.spec.ts — live UI verification for desktop and coarse-pointer scenarios.
- CI metadata: web/tests/coverage-matrix.json — added coverage entry for the new story.

## Benefits

- Better UX: users can start typing immediately after switching sessions without an extra click.
- Consistent behavior across cockpit and terminal modes.
- Mobile-friendly: avoids popping the soft keyboard on touch-first devices.
- Robust against mount races and supports re-select refocus.
- Covered by unit and end-to-end tests.

## Technical notes (concise)

- TerminalFocusTarget now includes "composer"; requestSessionInputFocus(session, isCoarse) chooses "composer" vs "agent", returns early for coarse pointers or missing session, sets pending focus, and dispatches FOCUS_TERMINAL_EVENT.
- useFocusTerminalTarget(target, ref) registers a window listener to focus the ref when matching events arrive, stashes pending focus if the element is absent at dispatch time, and consumes the pending latch on mount (symmetric to TerminalView).
- App selection handlers set the pending-focus latch and call the new helper after navigation so both already-mounted and first-open (mount race) cases are handled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->