### PR TITLE
fix(tui): remove FORCE_COLOR override from agent launch env

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1760,7 +1760,7 @@ impl Instance {
             }) {
             Ok(_handle) => {}
             Err(e) => {
-                tracing::error!(target: "session.store", 
+                tracing::error!(target: "session.store",
                     session = %instance_id_for_log,
                     error = %e,
                     "Failed to spawn finalize-tmux thread"
@@ -2780,17 +2780,16 @@ fn format_env_var_prefix(key: &str, value: &str, cmd: &str) -> String {
 ///
 /// Some terminal agents inherit the parent tmux env, which can carry
 /// `NO_COLOR=1` and silently disable their terminal palettes even though the
-/// web renderer handles ANSI fine. Unsetting `NO_COLOR` and forcing
-/// `TERM=xterm-256color`, `FORCE_COLOR=1`, and
-/// `COLORTERM=truecolor` at launch keeps color on without leaking the override
-/// to other agents.
+/// web renderer handles ANSI fine. Unsetting `NO_COLOR` and advertising
+/// `TERM=xterm-256color` plus `COLORTERM=truecolor` at launch keeps color on
+/// without pinning tools to a specific `FORCE_COLOR` depth.
 fn apply_agent_launch_env(cmd: &mut String, agent: Option<&'static crate::agents::AgentDef>) {
     if !matches!(agent.map(|a| a.name), Some("antigravity" | "codex")) {
         return;
     }
 
     *cmd = format!(
-        "env -u NO_COLOR TERM=xterm-256color FORCE_COLOR=1 COLORTERM=truecolor {}",
+        "env -u NO_COLOR TERM=xterm-256color COLORTERM=truecolor {}",
         cmd
     );
 }
@@ -4556,7 +4555,6 @@ mod tests {
 
         assert!(cmd_str.contains("env -u NO_COLOR"));
         assert!(cmd_str.contains("TERM=xterm-256color"));
-        assert!(cmd_str.contains("FORCE_COLOR=1"));
         assert!(cmd_str.contains("COLORTERM=truecolor"));
         assert!(cmd_str.contains("agy"));
     }
@@ -4571,7 +4569,6 @@ mod tests {
 
         assert!(cmd_str.contains("env -u NO_COLOR"));
         assert!(cmd_str.contains("TERM=xterm-256color"));
-        assert!(cmd_str.contains("FORCE_COLOR=1"));
         assert!(cmd_str.contains("COLORTERM=truecolor"));
         assert!(cmd_str.contains("agy --some-flag"));
     }
@@ -4585,7 +4582,6 @@ mod tests {
 
         assert!(cmd_str.contains("env -u NO_COLOR"));
         assert!(cmd_str.contains("TERM=xterm-256color"));
-        assert!(cmd_str.contains("FORCE_COLOR=1"));
         assert!(cmd_str.contains("COLORTERM=truecolor"));
         assert!(cmd_str.contains("codex"));
     }
@@ -4599,7 +4595,6 @@ mod tests {
 
         assert!(!cmd_str.contains("env -u NO_COLOR"));
         assert!(!cmd_str.contains("TERM=xterm-256color"));
-        assert!(!cmd_str.contains("FORCE_COLOR=1"));
         assert!(!cmd_str.contains("COLORTERM=truecolor"));
     }
 


### PR DESCRIPTION
## Description
Setting `FORCE_COLOR=1` would force Codex to use basic ANSI 16-color output, which is not what most modern terminals expect.
```
FORCE_COLOR=3 => truecolor
FORCE_COLOR=2 => ANSI 256
FORCE_COLOR=1 => ANSI 16
```
FORCE_COLOR should be inherited from the parent terminal environment instead of being hardcoded to `FORCE_COLOR=1`.

ScreenShot:
The left side was launched with command `aoe add --scratch --cmd codex --launch`.
The right side was launched with command `tmux new-session codex`.
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/16aabc83-c294-4bfe-b38a-b1a39cdb1c98" />

Source code references:
- [agent-of-empires/src/session/instance.rs](https://github.com/agent-of-empires/agent-of-empires/blob/777e31a95f2faeb404201a8f239d497ec74377e8/src/session/instance.rs#L2787-L2796)
- [supports-color/src/lib.rs](https://github.com/zkat/supports-color/blob/26ad8d206ad01ba7d6b4ad10d52f8f584aa68ec6/src/lib.rs#L69-L80)
- [codex/codex-rs/tui/src/terminal_palette.rs](https://github.com/openai/codex/blob/251b2412b2350ba850c92f395a54ba9b666f0c54/codex-rs/tui/src/terminal_palette.rs#L12-L19)

Related PR: #1478 #1382 

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
Codex

**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary of Changes

This PR removes an environment variable override that was forcing color output settings when launching AI agents in the terminal user interface. Previously, the system was hardcoding `FORCE_COLOR=1` when spawning agents, which restricted color output to a limited 16-color palette. This change allows the agent to respect the terminal's native color capabilities instead.

### What Changed

**Removed:**
- The hardcoded `FORCE_COLOR=1` environment variable override for agent launches

**Added:**
- Explicit setting of `TERM=xterm-256color` and `COLORTERM=truecolor` to properly communicate terminal capabilities
- Unsetting of `NO_COLOR` to ensure color display is enabled

**Updated:**
- Unit tests were modified to remove assertions checking for `FORCE_COLOR=1`
- Tests now verify the new environment variable configuration
- Minor formatting adjustment to error logging in the tmux thread handler

### File Changed
- `src/session/instance.rs` (+5/-10 lines)

### Benefits

- **Better terminal color support**: Modern terminals now render colors correctly, using up to 256 colors or truecolor depending on the terminal's capabilities, instead of being limited to 16 colors
- **Respects terminal preferences**: The agent now inherits color settings from the parent terminal environment rather than forcing a specific configuration
- **Improved visual quality**: The Codex and Antigravity agents will display with proper color differentiation and improved aesthetics in the terminal interface

### Technical Details

The change modifies the `apply_agent_launch_env` function for color-sensitive agents (`codex` and `antigravity`). Instead of forcing `FORCE_COLOR=1` (which maps to ANSI 16-color output), the environment now properly indicates 256-color (`TERM=xterm-256color`) and truecolor (`COLORTERM=truecolor`) support, allowing libraries like `supports-color` to automatically select the appropriate color palette based on actual terminal capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->