### PR TITLE
fix(tui): keep the agent preview from clipping; single-source the preview geometry

### DIFF
--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -419,6 +419,37 @@ impl Session {
             .output();
     }
 
+    /// Resize the (detached) window to `cols`x`rows`. Best-effort: a missing
+    /// session or a tmux ENOENT is swallowed so a transient failure never
+    /// blocks a render.
+    ///
+    /// Used to keep a detached agent's pane sized to the visible preview area:
+    /// a full-screen agent is sized to whatever terminal it was last attached
+    /// from, so without this it renders taller than the preview window and the
+    /// bottom-anchored capture clips the top rows (worse when the info header
+    /// steals rows). Mirrors what live-send does through its worker.
+    ///
+    /// NOTE: tmux's `resize-window -x -y` silently flips the window-size option
+    /// to `manual`, so any later `attach-session` must call
+    /// [`reset_size_to_latest_client`](Self::reset_size_to_latest_client) first
+    /// or the window stays pinned at these preview dimensions.
+    pub fn resize_window(&self, cols: u16, rows: u16) {
+        if cols == 0 || rows == 0 || !self.exists() {
+            return;
+        }
+        let _ = Command::new("tmux")
+            .args([
+                "resize-window",
+                "-t",
+                &self.name,
+                "-x",
+                &cols.to_string(),
+                "-y",
+                &rows.to_string(),
+            ])
+            .output();
+    }
+
     /// Deliver `text` to `target` via tmux's load-buffer + paste-buffer.
     /// Buffer names are scoped by pid + a per-call counter so concurrent
     /// senders (and retries) cannot clobber each other. `-p` enables

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture, Event,
-    EventStream, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind,
+    EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind,
 };
 use futures_util::StreamExt;
 use ratatui::prelude::*;
@@ -548,6 +548,17 @@ impl App {
                 event = self.event_stream.as_mut().expect("event_stream missing").next() => {
                     match event {
                         Some(Ok(Event::Key(key))) => {
+                            // Only act on key-down / auto-repeat. Terminals that
+                            // report release events (Windows console always does;
+                            // kitty-protocol terminals do when enhancement flags are
+                            // on) would otherwise deliver a Release for every press
+                            // and double-fire every handler, so a toggle like `i`
+                            // (hide the info header) nets to zero and "won't hide".
+                            // The cockpit and remote-home loops already filter this;
+                            // the home loop has to as well.
+                            if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+                                continue;
+                            }
                             // Paste-burst detector for VoiceInk + Mosh ergonomics.
                             // Mosh strips bracketed-paste markers, so pasted
                             // dictation arrives as a stream of individual KeyEvents
@@ -580,6 +591,15 @@ impl App {
                                         self.event_stream.as_mut().expect("event_stream missing").next(),
                                     ).await;
                                     match next {
+                                        // Ignore key-release / non-press events mid-burst, same
+                                        // gate as the arm entry. On terminals that report releases
+                                        // they would otherwise be taken as burst chars (doubling the
+                                        // pasted text) or stashed as the deferred key.
+                                        Ok(Some(Ok(Event::Key(k))))
+                                            if !matches!(
+                                                k.kind,
+                                                KeyEventKind::Press | KeyEventKind::Repeat
+                                            ) => {}
                                         Ok(Some(Ok(Event::Key(k)))) if Self::is_burst_candidate(&k) => {
                                             if let Some(c) = Self::burst_char_for(&k) {
                                                 burst_str.push(c);
@@ -1912,6 +1932,14 @@ impl App {
             Some(inst) => inst.tmux_session()?,
             None => return Ok(()),
         };
+        // The non-live preview may have left the window pinned to manual
+        // sizing at the (smaller) preview dimensions. Restore `window-size
+        // latest` so the attaching client resizes it to the full terminal,
+        // and drop the preview-resize dedup so the next render re-asserts the
+        // preview geometry against the now-grown window instead of leaving the
+        // top clipped.
+        tmux_session.reset_size_to_latest_client();
+        self.home.clear_preview_pane_sync();
         let (attach_result, attached_status_updates) =
             self.with_attached_status_hooks(terminal, || tmux_session.attach())?;
 

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -74,6 +74,78 @@ pub fn terminal_info_height(instance: &Instance) -> u16 {
     base + sandbox_lines
 }
 
+/// The geometry of the preview body, computed once so every consumer agrees on
+/// where the output goes and how many rows it spans.
+///
+/// Historically the info-header / banner / output split was re-derived
+/// independently in the renderers (`Layout` + `Borders`), in `render_preview`
+/// (for the tmux pane size and the scroll clamp), and in the live `[offset/max]`
+/// footer. Each derivation drifted by a row at some point, which is the bug
+/// #1521, #1570, and #1604 each chased in turn. `PreviewLayout::compute` is the
+/// single definition; `output.height` is THE visible-row count. Anyone needing
+/// preview geometry calls this rather than re-counting rows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PreviewLayout {
+    /// The info-header rect, present iff the header is shown (header toggle on
+    /// and the viewport is not compact).
+    pub info: Option<Rect>,
+    /// The inner ` Output ` / ` Terminal Output ` banner row, present exactly
+    /// when `info` is (it visually separates the header from the body).
+    pub banner: Option<Rect>,
+    /// Where captured agent/terminal output paints. `output.height` is the
+    /// authoritative visible-row count for scrolling and pane sizing.
+    pub output: Rect,
+}
+
+impl PreviewLayout {
+    /// Split `area` (the preview block's inner rect) into header / banner /
+    /// output. With the header hidden (toggle off) or the viewport compact, the
+    /// output claims the whole `area` and there is no banner. Otherwise the
+    /// header takes the top `info_height` rows, a one-row banner follows, and
+    /// the output gets the rest, clamped so a pane shorter than that chrome
+    /// yields a zero-height output instead of underflowing.
+    pub(crate) fn compute(area: Rect, compact: bool, show_info: bool, info_height: u16) -> Self {
+        if compact || !show_info {
+            return Self {
+                info: None,
+                banner: None,
+                output: area,
+            };
+        }
+        let chrome = info_height.saturating_add(1).min(area.height);
+        let info_h = info_height.min(area.height);
+        let info = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: info_h,
+        };
+        // The banner row only exists when the pane had room for it on top of
+        // the header (i.e. `chrome` reached `info_height + 1`).
+        let banner = if chrome > info_h {
+            Some(Rect {
+                x: area.x,
+                y: area.y + info_h,
+                width: area.width,
+                height: 1,
+            })
+        } else {
+            None
+        };
+        let output = Rect {
+            x: area.x,
+            y: area.y + chrome,
+            width: area.width,
+            height: area.height - chrome,
+        };
+        Self {
+            info: Some(info),
+            banner,
+            output,
+        }
+    }
+}
+
 pub struct Preview;
 
 impl Preview {
@@ -89,24 +161,15 @@ impl Preview {
         compact: bool,
         show_info: bool,
     ) {
-        // Compact mode (narrow viewports) skips the info header entirely:
-        // the outer block title already carries the session name + status,
-        // and on a phone every row of vertical space matters. The user
-        // toggle `show_info` collapses the same chrome on a normal-width
-        // viewport so the output area can claim the rows the header would
-        // have taken. Symmetric with `render_with_cache` in the Agent view.
-        let render_info_section = !compact && show_info;
-        let output_area = if render_info_section {
-            let info_height = terminal_info_height(instance);
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(info_height), // Minimal info section
-                    Constraint::Min(1),              // Output section
-                ])
-                .split(area);
+        // One source of truth for the header / banner / output split. Compact
+        // viewports and the hidden-header toggle both collapse to "output owns
+        // the whole area" inside `PreviewLayout::compute`, symmetric with the
+        // Agent view's `render_with_cache`.
+        let layout =
+            PreviewLayout::compute(area, compact, show_info, terminal_info_height(instance));
 
-            // Minimal info for terminal view
+        if let Some(info_area) = layout.info {
+            // Minimal info for terminal view.
             let mut info_lines = vec![
                 Line::from(vec![
                     Span::styled("Title:   ", Style::default().fg(theme.dimmed)),
@@ -143,18 +206,12 @@ impl Preview {
                     ]));
                 }
             }
-            let paragraph = Paragraph::new(info_lines);
-            frame.render_widget(paragraph, chunks[0]);
-            chunks[1]
-        } else {
-            area
-        };
+            frame.render_widget(Paragraph::new(info_lines), info_area);
+        }
 
-        // Output section. With the info section hidden there's no inner
-        // ` Terminal Output ` banner, so the paragraph gets the full
-        // `output_area`; the visible height must match or `compute_scroll`
-        // clips the top row (and a fresh shell's cursor) in live mode.
-        let visible_height = output_visible_height(output_area.height, render_info_section);
+        // `output.height` is the authoritative visible-row count; no separate
+        // banner subtraction (that lives entirely in `PreviewLayout::compute`).
+        let visible_height = layout.output.height as usize;
         // Use the pre-parsed cache when the terminal is up; suppress
         // it otherwise so the "press Enter to start terminal" hint
         // can take the inner area instead of a stale capture.
@@ -165,13 +222,11 @@ impl Preview {
         };
         let line_count = parsed_output.map_or(0, |t| t.lines.len());
 
-        // Inner ` Terminal Output ` banner is paired with the info
-        // section: when the info section is hidden (compact or the user
-        // toggled it off), the outer block title already names the view
-        // and the scroll indicator is hoisted to that outer title by the
-        // caller, so we drop the inner banner here too. Drops one row of
-        // chrome and frees it for output.
-        let inner = if render_info_section {
+        // The inner ` Terminal Output ` banner is present exactly when the info
+        // section is (see `PreviewLayout`): with it hidden the outer block title
+        // already names the view and the scroll indicator is hoisted there by
+        // the caller, so the body claims the freed row.
+        if let Some(banner) = layout.banner {
             let mut block = Block::default()
                 .borders(Borders::TOP)
                 .border_style(Style::default().fg(theme.border))
@@ -186,13 +241,10 @@ impl Preview {
                         .style(Style::default().fg(theme.dimmed)),
                 );
             }
-            let inner = block.inner(output_area);
-            frame.render_widget(block, output_area);
-            inner
-        } else {
-            output_area
-        };
+            frame.render_widget(block, banner_block_area(layout.output, banner));
+        }
 
+        let inner = layout.output;
         if !terminal_running {
             let hint = Paragraph::new("Press Enter to start terminal")
                 .style(Style::default().fg(theme.dimmed))
@@ -232,42 +284,22 @@ impl Preview {
         compact: bool,
         show_info: bool,
     ) {
-        // When the user has hidden the info header (or the viewport is too
-        // narrow for it), the output gets the whole pane and skips the inner
-        // " Output " banner. The outer block already says "Preview", so an
-        // inner banner would just be redundant chrome.
-        if compact || !show_info {
-            Self::render_output_cached(
-                frame,
-                area,
-                instance,
-                cached_output,
-                scroll_offset,
-                theme,
-                true,
-            );
-            return;
+        // One source of truth for the split. With the header hidden or the
+        // viewport compact, `PreviewLayout::compute` returns `info: None` /
+        // `banner: None` and the output claims the whole pane (the outer block
+        // already says "Preview", so an inner banner would be redundant chrome).
+        let layout = PreviewLayout::compute(area, compact, show_info, agent_info_height(instance));
+        if let Some(info_area) = layout.info {
+            Self::render_info(frame, info_area, instance, theme, idle_decay_window);
         }
-
-        let info_height = agent_info_height(instance);
-
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(info_height), // Info section
-                Constraint::Min(1),              // Output section
-            ])
-            .split(area);
-
-        Self::render_info(frame, chunks[0], instance, theme, idle_decay_window);
         Self::render_output_cached(
             frame,
-            chunks[1],
+            layout.output,
+            layout.banner,
             instance,
             cached_output,
             scroll_offset,
             theme,
-            false,
         );
     }
 
@@ -369,18 +401,17 @@ impl Preview {
 
     fn render_output_cached(
         frame: &mut Frame,
-        area: Rect,
+        output: Rect,
+        banner: Option<Rect>,
         instance: &Instance,
         cached_output: CachedPreview<'_>,
         scroll_offset: u16,
         theme: &Theme,
-        compact: bool,
     ) {
-        // `compact` here doubles as the "skip the inner ` Output ` banner"
-        // flag (see the `inner` split below), so the banner is present
-        // exactly when `!compact`. Match the visible height to the actual
-        // paragraph area or the top row gets clipped when the banner is gone.
-        let visible_height = output_visible_height(area.height, !compact);
+        // `output.height` is the visible-row count straight from `PreviewLayout`;
+        // there is no banner subtraction here (the banner, when present, sits in
+        // its own row above `output`).
+        let visible_height = output.height as usize;
         // The error path below returns early, so by the time we use
         // `parsed_output` for the output Paragraph the error case has
         // been handled. Until then `parsed_output` is just the cached
@@ -388,12 +419,10 @@ impl Preview {
         let parsed_output = cached_output.text;
         let line_count = parsed_output.map_or(0, |t| t.lines.len());
 
-        // Compact mode skips the inner separator/title; the outer block
-        // already names the session and scroll indicator is omitted to
-        // free a row.
-        let inner = if compact {
-            area
-        } else {
+        // The inner ` Output ` banner is drawn only when `PreviewLayout` gave us
+        // a banner row (info header shown, non-compact). The outer block already
+        // names the session when it's hidden, so the body claims the freed row.
+        if let Some(banner) = banner {
             let mut block = Block::default()
                 .borders(Borders::TOP)
                 .border_style(Style::default().fg(theme.border))
@@ -408,10 +437,9 @@ impl Preview {
                         .style(Style::default().fg(theme.dimmed)),
                 );
             }
-            let inner = block.inner(area);
-            frame.render_widget(block, area);
-            inner
-        };
+            frame.render_widget(block, banner_block_area(output, banner));
+        }
+        let inner = output;
 
         if let Some(error) = &instance.last_error {
             let mut error_lines: Vec<Line> = vec![
@@ -458,21 +486,17 @@ impl Preview {
     }
 }
 
-/// Rows of captured output actually visible in the preview body.
-///
-/// The body drops one row for the inner ` Output ` / ` Terminal Output `
-/// banner ONLY when that banner is rendered (info section shown, non-compact).
-/// When the banner is hidden (compact viewport or the user toggled the info
-/// header off) the output paragraph claims the full area, so the visible
-/// height must equal the full area height. Subtracting one unconditionally
-/// makes `compute_scroll` walk one row too far past the bottom, clipping the
-/// top line of the capture, where a freshly started shell's prompt and cursor
-/// sit. That is the "first row is invisible in live mode" bug.
-pub(crate) fn output_visible_height(area_height: u16, has_banner: bool) -> usize {
-    if has_banner {
-        area_height.saturating_sub(1) as usize
-    } else {
-        area_height as usize
+/// The `Borders::TOP` block that draws the ` Output ` / ` Terminal Output `
+/// banner. It spans the banner row plus the whole output body so its single top
+/// border lands on the banner row and `block.inner()` coincides exactly with
+/// `output`. Built from `PreviewLayout`'s `output` + `banner` rects so the
+/// banner can never be sized independently of the body it caps.
+fn banner_block_area(output: Rect, banner: Rect) -> Rect {
+    Rect {
+        x: output.x,
+        y: banner.y,
+        width: output.width,
+        height: output.height.saturating_add(1),
     }
 }
 
@@ -604,36 +628,66 @@ mod tests {
         }
     }
 
-    // Regression for the "first row hidden in live mode" bug: with the info
-    // header toggled off there's no inner banner, so the output paragraph
-    // claims the full area and the visible height must equal the area height.
-    // Subtracting one (the pre-fix behavior) made `compute_scroll` walk one
-    // row past the bottom, clipping the top line where a fresh shell's cursor
-    // sits.
-    #[test]
-    fn output_visible_height_matches_area_when_banner_hidden() {
-        assert_eq!(output_visible_height(40, false), 40);
+    // Single source of truth for the preview split. These pin down the row
+    // arithmetic that #1521 / #1570 / #1604 each got wrong in a different
+    // derivation; now there is only one.
+    fn rect(x: u16, y: u16, w: u16, h: u16) -> Rect {
+        Rect {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
     }
 
     #[test]
-    fn output_visible_height_drops_banner_row_when_shown() {
-        assert_eq!(output_visible_height(40, true), 39);
+    fn layout_hidden_info_gives_output_the_whole_area() {
+        // Header toggled off (or compact): no header, no banner, output == area.
+        let area = rect(0, 0, 80, 40);
+        let l = PreviewLayout::compute(area, false, false, 7);
+        assert_eq!(l.info, None);
+        assert_eq!(l.banner, None);
+        assert_eq!(l.output, area);
+        // Compact forces the same regardless of the toggle.
+        assert_eq!(PreviewLayout::compute(area, true, true, 7).output, area);
     }
 
     #[test]
-    fn output_visible_height_saturates_at_zero() {
-        assert_eq!(output_visible_height(0, true), 0);
+    fn layout_shown_info_carves_header_plus_banner_once() {
+        let area = rect(2, 3, 80, 40);
+        let l = PreviewLayout::compute(area, false, true, 7);
+        // Header: top 7 rows.
+        assert_eq!(l.info, Some(rect(2, 3, 80, 7)));
+        // Banner: the single row just below the header.
+        assert_eq!(l.banner, Some(rect(2, 3 + 7, 80, 1)));
+        // Output: the rest, shifted down by header + banner (7 + 1).
+        assert_eq!(l.output, rect(2, 3 + 8, 80, 40 - 8));
+        // The banner block spans banner + output so its inner == output.
+        let block_area = banner_block_area(l.output, l.banner.unwrap());
+        assert_eq!(block_area, rect(2, 3 + 7, 80, 40 - 8 + 1));
     }
 
-    // The bug end to end: a captured screen exactly as tall as the pane,
-    // live-following (offset 0). With the banner hidden the scroll must be 0
-    // so row 0 (the cursor row) stays on screen; the pre-fix height-1 produced
-    // a scroll of 1 and pushed that row off the top.
+    #[test]
+    fn layout_clamps_when_pane_shorter_than_chrome() {
+        // Pane shorter than header + banner: output clamps to zero height and
+        // never underflows (the old panic-on-subtraction case).
+        let area = rect(0, 0, 80, 3);
+        let l = PreviewLayout::compute(area, false, true, 4);
+        assert_eq!(l.output.height, 0);
+        assert!(l.output.y <= area.y + area.height);
+    }
+
+    // End to end: a captured screen exactly as tall as the banner-less output,
+    // live-following (offset 0). The scroll must be 0 so the top row (a fresh
+    // shell's cursor) stays on screen. This is the #1604 "first row hidden"
+    // regression, now expressed against the single layout source.
     #[test]
     fn full_height_capture_does_not_scroll_when_banner_hidden() {
-        let height = 40u16;
-        let visible = output_visible_height(height, false);
-        assert_eq!(compute_scroll(height as usize, visible, 0), 0);
+        let area = rect(0, 0, 80, 40);
+        let l = PreviewLayout::compute(area, false, false, 7);
+        let visible = l.output.height as usize;
+        assert_eq!(visible, 40);
+        assert_eq!(compute_scroll(visible, visible, 0), 0);
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3914,6 +3914,10 @@ impl HomeView {
         self.live_send = None;
         self.live_send_worker = None;
         self.live_send_last_resize = None;
+        // Live mode just owned the pane's size; the non-live preview must
+        // re-assert its geometry on the next render now that the header is
+        // visible again (and so the agent reflows back to the previewed size).
+        self.preview_pane_synced = None;
         // Preview selections also work outside live mode now, but a
         // live-mode highlight pins to the live-resized pane coords,
         // and exiting reflows the preview back to its normal size.

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -424,6 +424,13 @@ pub struct HomeView {
     /// the current live-send session. Used to dedup the resize messages
     /// fired from the preview refresh path; cleared on live-send exit.
     pub(super) live_send_last_resize: Option<(u16, u16)>,
+    /// `(session_id, cols, rows)` of the last NON-live preview resize we sent
+    /// to the selected agent's pane, so the 250ms preview poll doesn't
+    /// SIGWINCH-storm it every tick. Invalidated (set to None) on attach and on
+    /// live-send enter/exit, where the window's real size changes out from
+    /// under us and the next render must re-assert the preview geometry. See
+    /// `refresh_preview_cache_if_needed`.
+    pub(super) preview_pane_synced: Option<(String, u16, u16)>,
     /// Pasted text captured at the home view that we couldn't immediately
     /// route (no session selected, cursor on a group header, etc.). Drained
     /// into the next compose dialog the user opens, so voice/dictation never
@@ -494,14 +501,13 @@ pub struct HomeView {
     /// every frame in info-expanded mode looked shifted up.
     pub(super) preview_pane_area: Rect,
     /// Rows of captured output the renderer actually paints into the preview
-    /// body: the pane height minus the inner ` Output ` / ` Terminal Output `
-    /// banner row when (and only when) that banner is shown. Computed in
-    /// `render_preview` via `preview::output_visible_height` and shared with
+    /// body. This is just `PreviewLayout::compute(..).output.height`: the
+    /// single split helper already accounts for the info header and the inner
+    /// ` Output ` / ` Terminal Output ` banner. Set in `render_preview` from the
+    /// same layout the renderer paints with, and shared with
     /// `clamp_scroll_to_capture` and the live-send `[offset/max]` banner so
     /// every consumer of "how many rows are visible" agrees with what's on
-    /// screen. Subtracting one unconditionally instead would let a phantom
-    /// scroll offset of 1 survive when content exactly fills a banner-less
-    /// pane, stalling live-follow one row early.
+    /// screen.
     pub(super) preview_visible_rows: usize,
     /// Outer rect of the preview pane (block + borders + content), captured
     /// during `render_preview`. The live-send preview-only fast path uses
@@ -782,6 +788,7 @@ impl HomeView {
             live_send: None,
             live_send_worker: None,
             live_send_last_resize: None,
+            preview_pane_synced: None,
             pending_paste: None,
             pending_attach_after_warning: None,
             pending_stop_session: None,
@@ -2218,6 +2225,14 @@ impl HomeView {
         }
     }
 
+    /// Forget the last non-live preview resize so the next render re-asserts the
+    /// preview geometry. Call whenever the agent window's real size changes out
+    /// from under the preview (an attach grows it to the client; entering or
+    /// leaving live mode hands the resize off and back).
+    pub(super) fn clear_preview_pane_sync(&mut self) {
+        self.preview_pane_synced = None;
+    }
+
     pub fn toggle_archived_section(&mut self) {
         self.archived_section_collapsed = !self.archived_section_collapsed;
         if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
@@ -2777,6 +2792,9 @@ impl HomeView {
         // issues its sync resize, even if the cached geometry from a
         // prior session happens to match the current preview_pane_area.
         self.live_send_last_resize = None;
+        // Live mode takes over the pane's size from here; drop the non-live
+        // preview dedup so exiting re-asserts the preview geometry cleanly.
+        self.preview_pane_synced = None;
         self.stamp_last_accessed(session_id);
         Ok(stale_sid)
     }
@@ -2799,8 +2817,7 @@ impl HomeView {
     /// `Paragraph` render then drop those rows on every frame, which
     /// the user perceives as content shifted up. The math is shared
     /// with the per-frame resize in `refresh_preview_cache_if_needed`
-    /// and friends; the helper that computes it lives in
-    /// `tui::home::render::split_off_info_section`.
+    /// and friends; the rect comes from `preview::PreviewLayout::compute`.
     pub fn finalize_live_send_resize(&mut self) {
         let Some(state) = self.live_send.as_ref() else {
             return;

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -62,33 +62,6 @@ fn compose_list_title(
 /// requested scroll.
 const CAPTURE_BUFFER: u16 = 20;
 
-/// Shrink `inner` to the OUTPUT sub-rect that sits below the info
-/// header AND below the inner ` Output ` / ` Terminal Output ` banner.
-///
-/// `info_height` is the row count of the rendered info header
-/// (computed by `preview::agent_info_height` for Agent view or
-/// `preview::terminal_info_height` for Terminal/Tool view). The
-/// banner is a single `Borders::TOP` row above the agent's actual
-/// output, so the OUTPUT pane is `info_height + 1` rows shorter than
-/// `inner`, not `info_height` as a naive split would suggest.
-///
-/// This matches what `render_with_cache` / `render_terminal_preview`
-/// actually paint into; live-send sizes the tmux pane to the returned
-/// rect so the agent's content lands pixel-aligned with the visible
-/// Paragraph instead of bleeding off the bottom row.
-fn split_off_info_section(inner: Rect, info_height: u16) -> Rect {
-    // `+ 1` for the inner banner row. Clamp so a tiny pane (smaller
-    // than the chrome it would draw) returns a zero-height rect rather
-    // than wrapping past zero.
-    let chrome = info_height.saturating_add(1).min(inner.height);
-    Rect {
-        x: inner.x,
-        y: inner.y + chrome,
-        width: inner.width,
-        height: inner.height - chrome,
-    }
-}
-
 /// Trim `text` to fit within `max_width` display cells, appending '…'
 /// if anything was dropped. Used by the live-send banners so a long
 /// session title never pushes the exit-chord hint off-screen on a
@@ -143,10 +116,11 @@ fn scroll_exceeds_cache(cache_captured_lines: usize, height: u16, scroll_offset:
 /// `MAX_PREVIEW_SCROLL`.
 ///
 /// `visible_height` is the rendered output-body height the caller already
-/// computed (via `preview::output_visible_height`), NOT the raw pane height.
-/// Re-deriving it here with a fixed `- 1` would over-count the max offset by a
-/// row whenever the inner banner is hidden, leaving a phantom offset that
-/// stalls live-follow one row early.
+/// computed (`PreviewLayout::compute(..).output.height`, shared via
+/// `preview_visible_rows`), NOT the raw pane height. Re-deriving it here with a
+/// fixed `- 1` would over-count the max offset by a row whenever the inner
+/// banner is hidden, leaving a phantom offset that stalls live-follow one row
+/// early.
 fn clamp_scroll_to_capture(
     scroll_offset: u16,
     captured_lines: usize,
@@ -1264,6 +1238,35 @@ impl HomeView {
     // pub(super) so unit tests in `super::tests` can exercise the
     // cache-preservation behavior added with the kill-switch fix
     // without standing up a full render pipeline.
+    /// Keep the live-send tmux pane sized to the preview's visible output area.
+    ///
+    /// No-op unless live-send is currently targeting `target`: without that gate,
+    /// viewing the Agent pane while live-on-Terminal would resize the *terminal*
+    /// pane (the worker is bound to it) to Agent-view dimensions, mis-fitting the
+    /// shell the user is typing into. Deduped against `live_send_last_resize`
+    /// (shared, since only one target is live at a time) so we only fire when the
+    /// user enters live mode or the preview pane is resized (terminal resize,
+    /// divider drag, layout flip). Each `refresh_*_cache_if_needed` calls this
+    /// with its own target so the three copies stay in lockstep.
+    fn resize_live_pane_if_target(
+        &mut self,
+        target: live_send::LiveSendTarget,
+        width: u16,
+        height: u16,
+    ) {
+        let targets_this_pane = self.live_send.as_ref().is_some_and(|s| s.target == target);
+        if !targets_this_pane || width == 0 || height == 0 {
+            return;
+        }
+        let next = (width, height);
+        if self.live_send_last_resize != Some(next) {
+            if let Some(worker) = &self.live_send_worker {
+                worker.resize(width, height);
+            }
+            self.live_send_last_resize = Some(next);
+        }
+    }
+
     pub(super) fn refresh_preview_cache_if_needed(&mut self, width: u16, height: u16) {
         // Outside live-send, captures fork a fresh `tmux capture-pane`
         // so we throttle to 250ms (4 Hz). Inside live-send, captures
@@ -1278,30 +1281,41 @@ impl HomeView {
         // vs. tmux writing bytes straight into your terminal.
         const PREVIEW_REFRESH_MS_IDLE: u128 = 250;
         let in_live = self.live_send.is_some();
-        // The per-frame resize only fires when live-send's target IS
-        // the agent pane this refresh is named after. Without the
-        // target gate, viewing Agent view while live-on-Terminal would
-        // resize the *terminal* pane (the worker is bound to it) to
-        // Agent-view dimensions, mis-fitting the shell that the user
-        // is actually typing into.
-        let resize_target_matches = self
-            .live_send
-            .as_ref()
-            .is_some_and(|s| matches!(s.target, live_send::LiveSendTarget::Agent));
+        // While in live-send mode, keep the agent's tmux pane sized to the
+        // preview's visible output area so it renders directly into view.
+        self.resize_live_pane_if_target(live_send::LiveSendTarget::Agent, width, height);
 
-        // While in live-send mode, keep the tmux pane geometry in sync
-        // with the preview's actual cell dimensions so the agent
-        // renders directly into the visible area (no wrap, no cropped
-        // UI). Deduped against live_send_last_resize so we only fire
-        // when the user first enters live mode or the preview pane is
-        // resized (terminal resize, divider drag, layout flip).
-        if resize_target_matches && width > 0 && height > 0 {
-            let next = (width, height);
-            if self.live_send_last_resize != Some(next) {
-                if let Some(worker) = &self.live_send_worker {
-                    worker.resize(width, height);
+        // Outside live-send nothing keeps the agent's pane sized to the
+        // preview's output area. A full-screen agent is sized to whatever
+        // terminal it was last attached from (usually the full window), so it
+        // renders taller than the preview and the bottom-anchored capture
+        // clips the top rows; opening the info header shrinks the area and
+        // clips even more. Resize the detached pane to the output geometry so
+        // the preview is WYSIWYG. Deduped per (session, w, h) so the 250ms poll
+        // doesn't SIGWINCH-storm the agent; the dedup is invalidated on attach
+        // and on live enter/exit, where the real window size changes under us.
+        // Live-send owns its own resize through the worker above, so skip there.
+        if !in_live && width > 0 && height > 0 {
+            if let Some(id) = self.selected_session.clone() {
+                let want = (id, width, height);
+                if self.preview_pane_synced.as_ref() != Some(&want) {
+                    // Only record the dedup once the pane actually exists and was
+                    // resized. If a Stopped session we're viewing is started later
+                    // without an attach in this instance to clear the dedup (e.g.
+                    // a peer or the web cockpit launches it), marking it synced now
+                    // would pin the preview to the pre-start size and keep clipping
+                    // until the next geometry change. Leaving it unset retries on
+                    // the next refresh; `exists()` is cache-backed, so the retry is
+                    // cheap.
+                    if let Some(session) = self
+                        .get_instance(&want.0)
+                        .and_then(|inst| inst.tmux_session().ok())
+                        .filter(|s| s.exists())
+                    {
+                        session.resize_window(width, height);
+                        self.preview_pane_synced = Some(want);
+                    }
                 }
-                self.live_send_last_resize = Some(next);
             }
         }
 
@@ -1407,23 +1421,10 @@ impl HomeView {
         const PREVIEW_REFRESH_MS: u128 = 250;
 
         // Symmetric with `refresh_preview_cache_if_needed`: when live-send
-        // is pointed at the host-terminal pane, keep the tmux pane sized
-        // to the visible output area on every render so a window resize
-        // or info-header toggle reflows the shell instead of waiting for
-        // the user to re-enter live mode.
-        let resize_target_matches = self
-            .live_send
-            .as_ref()
-            .is_some_and(|s| matches!(s.target, live_send::LiveSendTarget::Terminal));
-        if resize_target_matches && width > 0 && height > 0 {
-            let next = (width, height);
-            if self.live_send_last_resize != Some(next) {
-                if let Some(worker) = &self.live_send_worker {
-                    worker.resize(width, height);
-                }
-                self.live_send_last_resize = Some(next);
-            }
-        }
+        // is pointed at the host-terminal pane, keep its tmux pane sized to
+        // the visible output area so a window resize or info-header toggle
+        // reflows the shell instead of waiting for a live-mode re-enter.
+        self.resize_live_pane_if_target(live_send::LiveSendTarget::Terminal, width, height);
 
         let scroll_offset = self.preview_scroll_offset;
         let needs_refresh = match &self.selected_session {
@@ -1473,23 +1474,15 @@ impl HomeView {
     fn refresh_container_terminal_preview_cache_if_needed(&mut self, width: u16, height: u16) {
         const PREVIEW_REFRESH_MS: u128 = 250;
 
-        // Symmetric with `refresh_preview_cache_if_needed`: when
-        // live-send is pointed at the in-container shell, keep the
-        // tmux pane sized to the visible output area so a window
-        // resize or info-header toggle reflows immediately.
-        let resize_target_matches = self
-            .live_send
-            .as_ref()
-            .is_some_and(|s| matches!(s.target, live_send::LiveSendTarget::ContainerTerminal));
-        if resize_target_matches && width > 0 && height > 0 {
-            let next = (width, height);
-            if self.live_send_last_resize != Some(next) {
-                if let Some(worker) = &self.live_send_worker {
-                    worker.resize(width, height);
-                }
-                self.live_send_last_resize = Some(next);
-            }
-        }
+        // Symmetric with `refresh_preview_cache_if_needed`: when live-send
+        // is pointed at the in-container shell, keep its tmux pane sized to
+        // the visible output area so a window resize or info-header toggle
+        // reflows immediately.
+        self.resize_live_pane_if_target(
+            live_send::LiveSendTarget::ContainerTerminal,
+            width,
+            height,
+        );
 
         let scroll_offset = self.preview_scroll_offset;
         let needs_refresh = match &self.selected_session {
@@ -1708,9 +1701,9 @@ impl HomeView {
             // here so users still see how far back they've scrolled.
             // With borders::ALL the inner is area - 2; with the banner
             // hidden the output paragraph claims that full inner, so the
-            // visible height is `inner_height` (no extra row dropped). This
-            // mirrors `output_visible_height(.., has_banner = false)` in the
-            // preview renderers so the indicator count stays in lockstep.
+            // visible height is `inner_height` (no extra row dropped). That
+            // equals `PreviewLayout::compute(..).output.height` for the
+            // hidden-header case, which is what the renderers paint into.
             let scroll_indicator = if !self.show_preview_info {
                 let inner_height = area.height.saturating_sub(2);
                 let visible_height = inner_height as usize;
@@ -1745,9 +1738,10 @@ impl HomeView {
         self.preview_pane_area = inner;
         // Track the rows the output body actually paints into, shared with the
         // scroll clamp and the live banner so their math matches the renderer.
-        // Each view branch refines this after it resolves its real pane rect.
-        self.preview_visible_rows =
-            preview::output_visible_height(inner.height, !compact && self.show_preview_info);
+        // Each view branch refines this after it resolves its real pane rect to
+        // exactly `pane_area.height` (see below); the seed here is only used by
+        // the no-output paths (creating / no selection).
+        self.preview_visible_rows = inner.height as usize;
         frame.render_widget(block, area);
 
         match self.view_mode {
@@ -1762,37 +1756,29 @@ impl HomeView {
                 if is_creating {
                     self.render_creating_preview(frame, inner, theme);
                 } else {
-                    // Mirror the info-vs-output split in
-                    // `Preview::render_with_cache` so the cache + tmux pane
-                    // match the visible output area. Sizing to the full
-                    // `inner` while the user has the info header expanded
-                    // leaves the top `info_height` rows of the agent's
-                    // pane outside the displayed window, where they get
-                    // tail-clipped on every frame.
-                    //
-                    // After the info header, `render_output_cached` wraps
-                    // the output in a `Borders::TOP` block (the ` Output `
-                    // banner) which consumes one more row from the top.
-                    // The pane therefore shrinks by `info_h + 1` rows so
-                    // the tmux pane matches the visible Paragraph area
-                    // exactly; off by one and the agent's content scrolls
-                    // up by a row on every frame.
-                    let pane_area = if compact || !self.show_preview_info {
-                        inner
-                    } else {
-                        self.selected_session
-                            .as_ref()
-                            .and_then(|id| self.get_instance(id))
-                            .map(|inst| {
-                                split_off_info_section(inner, preview::agent_info_height(inst))
-                            })
-                            .unwrap_or(inner)
-                    };
+                    // Size the tmux pane + cache to the SAME output rect the
+                    // renderer paints into, via the one `PreviewLayout::compute`
+                    // that `render_with_cache` also uses. `layout.output` already
+                    // accounts for the info header and the ` Output ` banner row
+                    // (or claims the full `inner` when the header is hidden /
+                    // compact), so `output.height` is the exact visible body. No
+                    // second banner subtraction here, no parallel split to drift.
+                    let pane_area = self
+                        .selected_session
+                        .as_ref()
+                        .and_then(|id| self.get_instance(id))
+                        .map(|inst| {
+                            preview::PreviewLayout::compute(
+                                inner,
+                                compact,
+                                self.show_preview_info,
+                                preview::agent_info_height(inst),
+                            )
+                            .output
+                        })
+                        .unwrap_or(inner);
                     self.preview_pane_area = pane_area;
-                    self.preview_visible_rows = preview::output_visible_height(
-                        pane_area.height,
-                        !compact && self.show_preview_info,
-                    );
+                    self.preview_visible_rows = pane_area.height as usize;
                     // Refresh the raw `content` cache, then ensure the
                     // parsed `Text<'static>` cache reflects it. Doing
                     // the parse here (under `&mut self.preview_cache`)
@@ -1849,20 +1835,23 @@ impl HomeView {
                     // `inner.height - info_h - 1` rows are visible, and
                     // the top of the shell output gets clipped on every
                     // frame.
-                    let pane_area = if compact || !self.show_preview_info {
-                        inner
-                    } else {
-                        self.get_instance(&id)
-                            .map(|inst| {
-                                split_off_info_section(inner, preview::terminal_info_height(inst))
-                            })
-                            .unwrap_or(inner)
-                    };
+                    // Same single-source split as the Agent branch: the tmux
+                    // pane is sized to `PreviewLayout::compute(..).output`, which
+                    // `render_terminal_preview` also paints into.
+                    let pane_area = self
+                        .get_instance(&id)
+                        .map(|inst| {
+                            preview::PreviewLayout::compute(
+                                inner,
+                                compact,
+                                self.show_preview_info,
+                                preview::terminal_info_height(inst),
+                            )
+                            .output
+                        })
+                        .unwrap_or(inner);
                     self.preview_pane_area = pane_area;
-                    self.preview_visible_rows = preview::output_visible_height(
-                        pane_area.height,
-                        !compact && self.show_preview_info,
-                    );
+                    self.preview_visible_rows = pane_area.height as usize;
 
                     // Refresh the appropriate cache, then warm the
                     // matching `parsed_text` so the render call below
@@ -1931,20 +1920,23 @@ impl HomeView {
                 let selected_id = self.selected_session.clone();
 
                 if let Some(id) = selected_id {
-                    let pane_area = if compact || !self.show_preview_info {
-                        inner
-                    } else {
-                        self.get_instance(&id)
-                            .map(|inst| {
-                                split_off_info_section(inner, preview::terminal_info_height(inst))
-                            })
-                            .unwrap_or(inner)
-                    };
+                    // Same single-source split as the Agent branch: the tmux
+                    // pane is sized to `PreviewLayout::compute(..).output`, which
+                    // `render_terminal_preview` also paints into.
+                    let pane_area = self
+                        .get_instance(&id)
+                        .map(|inst| {
+                            preview::PreviewLayout::compute(
+                                inner,
+                                compact,
+                                self.show_preview_info,
+                                preview::terminal_info_height(inst),
+                            )
+                            .output
+                        })
+                        .unwrap_or(inner);
                     self.preview_pane_area = pane_area;
-                    self.preview_visible_rows = preview::output_visible_height(
-                        pane_area.height,
-                        !compact && self.show_preview_info,
-                    );
+                    self.preview_visible_rows = pane_area.height as usize;
 
                     self.refresh_tool_preview_cache_if_needed(
                         pane_area.width,
@@ -2449,45 +2441,12 @@ impl HomeView {
 mod tests {
     use super::*;
 
-    #[test]
-    fn split_off_info_section_subtracts_header_plus_banner() {
-        // The split must drop info_h ROWS for the info section AND one
-        // more row for the inner ` Output ` / ` Terminal Output ` banner
-        // that the renderer draws on top of the output area. Off by one
-        // here resurrects the "agent output scrolled up by a row" bug
-        // that lived before this helper existed.
-        let inner = Rect {
-            x: 2,
-            y: 3,
-            width: 80,
-            height: 30,
-        };
-        let out = split_off_info_section(inner, 4);
-        assert_eq!(out.x, 2);
-        assert_eq!(out.width, 80);
-        // y shifts down past 4 header rows + 1 banner row.
-        assert_eq!(out.y, 3 + 5);
-        // height shrinks by the same 5 rows.
-        assert_eq!(out.height, 30 - 5);
-    }
-
-    #[test]
-    fn split_off_info_section_clamps_when_pane_smaller_than_chrome() {
-        // A pane shorter than the chrome it would draw must return a
-        // zero-height rect rather than wrapping past zero. Without the
-        // clamp, a very narrow vertical layout (split panes, popped
-        // toasts) would panic on subtraction overflow during live mode.
-        let inner = Rect {
-            x: 0,
-            y: 0,
-            width: 80,
-            height: 3,
-        };
-        // Info header alone is 4 rows; combined chrome (5) exceeds
-        // inner.height (3). The helper should clamp to height 0.
-        let out = split_off_info_section(inner, 4);
-        assert_eq!(out.height, 0);
-    }
+    // The preview split geometry (header / banner / output rows) is now owned
+    // by `preview::PreviewLayout`; its tests live alongside it in
+    // `components/preview.rs`. The render-side regression is covered end to end
+    // by `preview_visible_rows_equal_output_area_with_info_shown` in
+    // `home/tests.rs`, which renders a real frame and asserts
+    // `preview_visible_rows == preview_pane_area.height`.
 
     #[test]
     fn truncate_to_width_passthrough_when_fits() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -150,6 +150,121 @@ fn test_initial_cursor_position() {
 
 #[test]
 #[serial]
+fn preview_info_follows_flag_and_never_auto_shows_in_live() {
+    // Info-header visibility is purely the persisted `show_preview_info` toggle
+    // (driven by `i` in the TUI). Live mode must NOT change it: if the user
+    // hid the header, it stays hidden when they go live, and a shown header
+    // stays shown. Nothing magically re-shows it.
+    use super::live_send::{LiveSendState, LiveSendTarget};
+    use crate::tui::styles::load_theme;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances()[0].id.clone();
+    env.view.select_session_by_id(&id);
+    env.view.view_mode = ViewMode::Agent;
+    let theme = load_theme("empire");
+
+    let render_to_string = |view: &mut HomeView| {
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                view.render(f, area, &theme, None, None);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    };
+
+    let live_state = || LiveSendState {
+        session_id: id.clone(),
+        title: "session0".to_string(),
+        tmux_name: "aoe_test_live".to_string(),
+        target: LiveSendTarget::Agent,
+        exit_chords: Vec::new(),
+    };
+
+    // Hidden via the toggle: gone outside live...
+    env.view.show_preview_info = false;
+    let hidden_not_live = render_to_string(&mut env.view);
+    assert!(
+        !hidden_not_live.contains("Profile:"),
+        "header must be hidden when the flag is off.\n{hidden_not_live}"
+    );
+    // ...and STILL gone after going live (the regression the user reported:
+    // it must never magically re-show).
+    env.view.live_send = Some(live_state());
+    let hidden_live = render_to_string(&mut env.view);
+    assert!(
+        !hidden_live.contains("Profile:"),
+        "a hidden header must not re-appear in live mode.\n{hidden_live}"
+    );
+
+    // Shown via the toggle: present both outside and inside live mode.
+    env.view.live_send = None;
+    env.view.show_preview_info = true;
+    let shown_not_live = render_to_string(&mut env.view);
+    assert!(
+        shown_not_live.contains("Profile:"),
+        "header must render when the flag is on.\n{shown_not_live}"
+    );
+    env.view.live_send = Some(live_state());
+    let shown_live = render_to_string(&mut env.view);
+    assert!(
+        shown_live.contains("Profile:"),
+        "a shown header stays shown in live mode (flag, not mode, governs it).\n{shown_live}"
+    );
+}
+
+#[test]
+#[serial]
+fn preview_visible_rows_equal_output_area_with_info_shown() {
+    // With the info header shown, the Agent branch sizes the pane to
+    // `PreviewLayout::compute(..).output` (header + banner removed once) and the
+    // renderer paints into the same rect. `preview_visible_rows` must equal
+    // `preview_pane_area.height`; the historical bugs all came from a second,
+    // drifting derivation of this number, now consolidated into one layout.
+    use crate::tui::styles::load_theme;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances()[0].id.clone();
+    env.view.select_session_by_id(&id);
+    env.view.view_mode = ViewMode::Agent;
+    env.view.show_preview_info = true;
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let theme = load_theme("empire");
+    terminal
+        .draw(|f| {
+            let area = f.area();
+            env.view.render(f, area, &theme, None, None);
+        })
+        .unwrap();
+
+    assert!(
+        env.view.preview_pane_area.height > 0,
+        "expected a non-empty output sub-rect at 120x40 (non-compact)"
+    );
+    assert_eq!(
+        env.view.preview_visible_rows, env.view.preview_pane_area.height as usize,
+        "visible rows must match the output area height, not be a row short"
+    );
+}
+
+#[test]
+#[serial]
 fn test_q_returns_quit_action() {
     let mut env = create_test_env_empty();
     let action = env.view.handle_key(key(KeyCode::Char('q')), None);


### PR DESCRIPTION
> _Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes two user-reported preview bugs and removes the root cause behind a string of recurring off-by-ones.

**Cut-off.** The agent terminal preview clipped its top rows when the info header was open (worse the taller the agent). Outside live mode nothing resized the agent's tmux pane to the preview's output area, so a full-screen agent (sized to whatever terminal it was last attached from) rendered taller than the window and the bottom-anchored capture dropped the top rows. Now the detached pane is resized to the output geometry (deduped per session and size), and attach resets `window-size` to `latest` so a later attach still grows to the full client.

**Info header that "won't hide".** Visibility now follows the `show_preview_info` toggle only; nothing auto-hides or re-shows it. Added a `KeyEventKind::Press | Repeat` guard to the home key loop (matching the cockpit and remote views) so a key-release event on terminals that report them cannot double-fire and bounce the toggle back on.

**The recurring smell.** The info / banner / output row split was derived independently in the renderers, in `render_preview`'s pane sizing, and in the scroll clamp; each drifted a row at some point (#1521, #1570, #1604). This consolidates the split into a single `PreviewLayout::compute` and removes the parallel `split_off_info_section` and `output_visible_height` helpers, which also fixes a banner-row double-subtract introduced by #1604. The repeated live-send resize dedup is now one helper too.

Follow-up tracked in #1620 (unify the four `refresh_*_cache_if_needed` methods), deliberately left out to keep this change focused and low-risk in a just-stabilized path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs affected)
- [ ] For UI changes: included screenshot or recording

Verified manually in tmux (info open and hidden, live mode, top row visible, toggle stays put). A GIF can be produced via the `needs-recording` CI label; I cannot attach one from the sandbox.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a new `tests/e2e/` spec, because: the behavior is covered deterministically by render-based regression tests using ratatui's `TestBackend` plus `PreviewLayout` unit tests (`preview_visible_rows_equal_output_area_with_info_shown`, verified to fail without the fix; `preview_info_follows_flag_and_never_auto_shows_in_live`; and the `PreviewLayout` split tests). Also verified end to end in tmux.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8, 1M context)

**Any Additional AI Details you'd like to share:**
Investigation, refactor, and tests were done with Claude Code via back-and-forth with @njbrake; direction and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR fixes two user-facing preview bugs and consolidates preview geometry into a single source of truth to eliminate recurring off-by-one/layout drift.

What changed (non-technical)
- Fixed preview clipping: detached tmux panes are resized to match the preview output area so top rows are no longer cut off when the info header is shown.
- Made info header visibility deterministic: the header strictly follows the user toggle and no longer auto-hides or re-shows; added a key-event guard to avoid accidental double-toggles from key-release events.
- Centralized layout math: header/banner/output splitting is computed by a single PreviewLayout so renderers and sizing logic no longer drift.

Added
- PreviewLayout (single authoritative layout computation)
- Session::resize_window() to resize detached tmux windows
- HomeView.preview_pane_synced cache and clear_preview_pane_sync() to deduplicate non-live resize assertions
- Unit tests for PreviewLayout and render-based regression tests covering clipping and header behavior

Removed
- output_visible_height() helper and its tests
- split_off_info_section() helper and its tests

Benefits
- Eliminates the preview clipping bug and keeps detached agent previews WYSIWYG
- Predictable, user-driven info-header behavior
- Fewer layout bugs and easier maintenance due to a single layout implementation
- Improved test coverage that guards regressions

---

Technical Details

- New pub(crate) struct PreviewLayout { info: Option<Rect>, banner: Option<Rect>, output: Rect } and PreviewLayout::compute(area, compact, show_info, info_height) centralize header/banner/output geometry; output.height is the authoritative visible-row count.
- src/tmux/session.rs: pub fn Session::resize_window(&self, cols: u16, rows: u16) — best-effort tmux resize-window call; guards against zero dimensions and missing sessions. Note: tmux resize-window sets window-size to manual; callers reset to latest client on attach.
- src/tui/app.rs: main key loop now only handles KeyEventKind::Press | KeyEventKind::Repeat for key processing and paste-burst detection to avoid release-event double-firing.
- src/tui/components/preview.rs: render paths now consume PreviewLayout output/banner rects; render_output_cached adjusted to draw a banner row correctly so inner content aligns with output rect.
- src/tui/home/mod.rs + render.rs + input.rs: HomeView gains preview_pane_synced: Option<(session_id, cols, rows)> to dedupe non-live pane resize assertions; clear_preview_pane_sync() resets it. Live-send and non-live resizing paths are refactored to centralized helpers that guard zero sizes, dedupe, and only act for the correct target; attach now resets tmux window-size to latest so subsequent attaches grow to client size.
- Tests: added/updated PreviewLayout unit tests and render-based regression tests (ratatui TestBackend) ensuring header toggle behavior and that preview_visible_rows equals output area when info is shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->