### PR TITLE
feat(tui): footer indicator when another aoe TUI is watching

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -454,42 +454,77 @@ pub fn collect_startup_config_warnings(profile: &str) -> Option<String> {
     }
 }
 
-// ── TUI heartbeat ──────────────────────────────────────────────────────────
+// ── TUI presence ────────────────────────────────────────────────────────────
+//
+// Each running TUI process drops a `<pid>` file under `tui-presence/` and
+// refreshes its mtime on the heartbeat tick. This lets us (a) tell the push
+// consumer whether *any* TUI is watching, and (b) count how many TUIs are
+// alive so the footer can surface "another instance is watching" when two
+// `aoe` TUIs run at once (the launcher TUI isn't tmux-backed, so there's no
+// tmux client list to read). A presence file is considered live while its
+// mtime is fresh; stale ones (crash without cleanup) are swept on read.
 
-const TUI_HEARTBEAT_FILE: &str = "tui.active";
+const TUI_PRESENCE_DIR: &str = "tui-presence";
 
-/// Write (or touch) the TUI heartbeat file so the push consumer knows the
-/// TUI is currently running. Called periodically from the TUI event loop.
+fn presence_dir() -> Option<std::path::PathBuf> {
+    get_app_dir().ok().map(|d| d.join(TUI_PRESENCE_DIR))
+}
+
+fn own_presence_file() -> Option<std::path::PathBuf> {
+    presence_dir().map(|d| d.join(std::process::id().to_string()))
+}
+
+/// Write (or touch) this process's presence file so the push consumer knows
+/// a TUI is running and other TUIs can count us. Called periodically from the
+/// TUI event loop.
 pub fn write_tui_heartbeat() {
-    if let Ok(dir) = get_app_dir() {
-        let _ = fs::write(dir.join(TUI_HEARTBEAT_FILE), b"");
+    if let Some(dir) = presence_dir() {
+        let _ = fs::create_dir_all(&dir);
+        let _ = fs::write(dir.join(std::process::id().to_string()), b"");
     }
 }
 
-/// Remove the heartbeat file on TUI exit.
+/// Remove this process's presence file on TUI exit.
 pub fn clear_tui_heartbeat() {
-    if let Ok(dir) = get_app_dir() {
-        let _ = fs::remove_file(dir.join(TUI_HEARTBEAT_FILE));
+    if let Some(file) = own_presence_file() {
+        let _ = fs::remove_file(file);
     }
 }
 
-/// Returns true if the TUI heartbeat file was modified within `threshold`.
+/// Count TUI presence files whose mtime is fresh within `threshold`, sweeping
+/// any stale entries left behind by crashed processes. Returns the number of
+/// live TUIs (including this process, if its file is fresh).
+pub fn count_active_tuis(threshold: Duration) -> usize {
+    let dir = match presence_dir() {
+        Some(d) => d,
+        None => return 0,
+    };
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut live = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let fresh = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .map(|t| t.elapsed().unwrap_or(Duration::MAX) < threshold)
+            .unwrap_or(false);
+        if fresh {
+            live += 1;
+        } else {
+            let _ = fs::remove_file(&path);
+        }
+    }
+    live
+}
+
+/// Returns true if any TUI presence file was modified within `threshold`.
 /// Used by the push consumer to suppress notifications when the user is
-/// actively watching the TUI.
+/// actively watching a TUI.
 pub fn is_tui_active(threshold: Duration) -> bool {
-    let dir = match get_app_dir() {
-        Ok(d) => d,
-        Err(_) => return false,
-    };
-    let meta = match fs::metadata(dir.join(TUI_HEARTBEAT_FILE)) {
-        Ok(m) => m,
-        Err(_) => return false,
-    };
-    let modified = match meta.modified() {
-        Ok(t) => t,
-        Err(_) => return false,
-    };
-    modified.elapsed().unwrap_or(Duration::MAX) < threshold
+    count_active_tuis(threshold) > 0
 }
 
 #[cfg(test)]
@@ -511,6 +546,34 @@ mod tests {
         let dir = temp_home.path().join(APP_DIR_NAME_OTHER);
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_tui_presence_counts_and_sweeps() {
+        let temp = isolate_app_dir();
+        let pdir = app_dir(&temp).join(TUI_PRESENCE_DIR);
+
+        // Our own heartbeat counts as one live TUI.
+        write_tui_heartbeat();
+        assert_eq!(count_active_tuis(Duration::from_secs(30)), 1);
+        assert!(is_tui_active(Duration::from_secs(30)));
+
+        // A second instance's presence file bumps the count to two.
+        fs::write(pdir.join("999999"), b"").unwrap();
+        assert_eq!(count_active_tuis(Duration::from_secs(30)), 2);
+
+        // A zero threshold makes every file stale; they're swept and the
+        // directory is left empty.
+        assert_eq!(count_active_tuis(Duration::ZERO), 0);
+        assert!(!is_tui_active(Duration::from_secs(30)));
+        assert_eq!(fs::read_dir(&pdir).unwrap().count(), 0);
+
+        // Exit cleanup removes only our own file.
+        write_tui_heartbeat();
+        fs::write(pdir.join("999999"), b"").unwrap();
+        clear_tui_heartbeat();
+        assert_eq!(count_active_tuis(Duration::from_secs(30)), 1);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -511,6 +511,7 @@ impl App {
         let mut last_disk_refresh = std::time::Instant::now();
         let mut last_spinner_redraw = std::time::Instant::now();
         let mut last_heartbeat = std::time::Instant::now();
+        let mut last_presence_refresh = std::time::Instant::now();
         // Throttle for how often the periodic block re-reads settings;
         // without this, the inner guards would re-fire on every loop
         // iteration once any time has passed, hitting the config file at
@@ -521,10 +522,21 @@ impl App {
         // Fastest spinner (breathe) changes every 180ms; 120ms ensures smooth animation
         const SPINNER_REDRAW_INTERVAL: Duration = Duration::from_millis(120);
         const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+        // How often to recount live TUIs for the footer indicator. Cheap dir
+        // listing (a handful of entries), so a tight-ish cadence keeps the
+        // "another instance appeared/left" signal responsive without disk I/O
+        // on the hot render path.
+        const PRESENCE_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
+        // A presence file counts as live while its mtime is within this window.
+        // Larger than HEARTBEAT_INTERVAL so a couple of missed beats (busy loop,
+        // brief stall) don't drop an instance; matches the push consumer.
+        const PRESENCE_FRESH_WINDOW: Duration = Duration::from_secs(30);
 
         // Signal that the TUI is active so the web push consumer can
-        // suppress notifications while the user is watching the dashboard.
+        // suppress notifications while the user is watching the dashboard, and
+        // so other TUIs can count this instance.
         crate::session::write_tui_heartbeat();
+        self.home.active_tui_count = crate::session::count_active_tuis(PRESENCE_FRESH_WINDOW);
 
         loop {
             // Force full redraw if needed (e.g., after returning from tmux).
@@ -1060,6 +1072,15 @@ impl App {
             if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
                 crate::session::write_tui_heartbeat();
                 last_heartbeat = std::time::Instant::now();
+            }
+
+            if last_presence_refresh.elapsed() >= PRESENCE_REFRESH_INTERVAL {
+                last_presence_refresh = std::time::Instant::now();
+                let count = crate::session::count_active_tuis(PRESENCE_FRESH_WINDOW);
+                if count != self.home.active_tui_count {
+                    self.home.active_tui_count = count;
+                    refresh_needed = true;
+                }
             }
 
             // Periodic update re-check (#1471). The startup spawn only fires

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -555,6 +555,12 @@ pub struct HomeView {
     // dictation / stray keystrokes triggering destructive actions).
     pub(super) strict_hotkeys: bool,
 
+    // Number of live `aoe` TUI processes (including this one), refreshed on a
+    // throttle from the app loop. The footer surfaces it when >1 so the user
+    // knows another instance is attached (the two clash over agent pane sizes
+    // since tmux reflows to the smallest attached client).
+    pub(super) active_tui_count: usize,
+
     // Settings view
     pub(super) settings_view: Option<SettingsView>,
     /// Flag to indicate we're confirming settings close (unsaved changes)
@@ -826,6 +832,7 @@ impl HomeView {
             status_hook_config,
             status_hook_configs,
             strict_hotkeys,
+            active_tui_count: 1,
             idle_decay_window,
             settings_view: None,
             settings_close_confirm: false,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2291,6 +2291,21 @@ impl HomeView {
             }
         }
 
+        // Other-TUI indicator: shown only when more than one `aoe` TUI is
+        // alive. Two TUIs watching the same agent sessions clash over pane
+        // sizes (tmux reflows to the smallest attached client), so surface the
+        // count as a heads-up. The value is recomputed on a throttle in the
+        // app loop, not per frame.
+        if self.active_tui_count > 1 {
+            groups.push((
+                0,
+                vec![Span::styled(
+                    format!(" \u{25C9} {} watching ", self.active_tui_count),
+                    Style::default().fg(theme.accent).bold(),
+                )],
+            ));
+        }
+
         // Pending-paste indicator: text was captured at the home view but
         // couldn't be routed yet (no runnable session selected). Surface a
         // high-priority hint so the user knows the paste/dictation didn't


### PR DESCRIPTION
## Description

The launcher TUI isn't tmux-backed, so two `aoe` TUIs running at once (one inside tmux, one outside) have no shared tmux client list to read. They still clash over agent pane sizes, since tmux reflows panes to the smallest attached client, so it helps to know another instance is watching.

This reworks the single-file `tui.active` heartbeat into a per-PID presence directory so it can count instances. Each TUI drops `tui-presence/<pid>` and refreshes its mtime on the existing heartbeat tick; `count_active_tuis` lists the dir, counts fresh entries (within a 30s window), and sweeps stale ones left by crashes. `is_tui_active` (push consumer) now just asks whether the count is > 0, so its behavior is unchanged. The app loop recounts on a 3s throttle off the render path and caches the value on HomeView; the footer shows `◉ N watching` next to the serve indicator only when more than one TUI is alive.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs affected)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the footer indicator only appears with a second live `aoe` process, which needs a multi-process harness; the presence counting and stale-sweep logic is covered by a unit test (`test_tui_presence_counts_and_sweeps` in `src/session/mod.rs`). Happy to add an e2e if reviewers want one.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implemented via Claude Code; reasoning and decisions are the author's.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR replaces the single-file TUI heartbeat mechanism with a multi-file presence tracking system, enabling the application to detect and display when multiple TUI instances are running.

## What Changed

**Session/Presence Tracking:**
- Replaced single `tui.active` file with a `tui-presence/` directory that maintains one file per running process (named by PID)
- Each TUI instance continuously refreshes its presence file during the heartbeat tick
- The presence system automatically detects and removes stale files from crashed processes
- Added new `count_active_tuis()` function to count active TUI instances and clean up stale entries

**TUI Application Loop:**
- Added periodic presence refresh logic that re-counts active TUI instances every 3 seconds
- Caches the active TUI count on the HomeView and triggers UI updates when the count changes

**UI Display:**
- HomeView now tracks the count of active TUI instances
- Footer now displays `◉ N watching` indicator (in accent color) when more than one TUI is detected

## Benefits

- **Better visibility**: Users can now see when other TUI instances are watching the same application
- **Automatic cleanup**: Stale presence files from crashed processes are automatically removed
- **Efficient tracking**: Per-process files are more reliable than a single shared file for detecting active instances
- **Non-intrusive display**: The indicator only appears when multiple TUIs are active, keeping the UI clean in single-instance scenarios

## Technical Details

The implementation uses a time-based freshness threshold (30-second window) to determine if a process is truly active. During counting, any presence file with stale modification time is removed. The main app loop throttles the recounting operation to 3 seconds off the render path, avoiding performance impacts. Tests validate the presence counting and sweeping behavior, including proper cleanup on process exit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->