### PR TITLE
fix(tui): run session stop on a background thread

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod recovery;
 pub mod repo_config;
 pub mod scratch;
 pub(crate) mod serde_helpers;
+pub mod stop;
 mod storage;
 
 pub use crate::sound::{SoundConfig, SoundConfigOverride};

--- a/src/session/stop.rs
+++ b/src/session/stop.rs
@@ -1,0 +1,78 @@
+//! Shared session stop logic.
+//!
+//! Stopping a session kills its tmux pane and, for sandboxed sessions, stops
+//! (but does not remove) the Docker container so it can be restarted on
+//! re-attach. `container.stop()` can block for up to the Docker stop grace
+//! period (~10s), so the TUI runs this off the UI thread via `StopPoller`.
+
+use crate::session::Instance;
+
+pub struct StopRequest {
+    pub session_id: String,
+    pub instance: Instance,
+}
+
+#[derive(Debug)]
+pub struct StopResult {
+    pub session_id: String,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+pub fn perform_stop(request: &StopRequest) -> StopResult {
+    match request.instance.stop() {
+        Ok(()) => {
+            crate::tmux::refresh_session_cache();
+            StopResult {
+                session_id: request.session_id.clone(),
+                success: true,
+                error: None,
+            }
+        }
+        Err(e) => {
+            tracing::error!(target: "session.stop", session_id = %request.session_id, error = %e, "perform_stop failed");
+            StopResult {
+                session_id: request.session_id.clone(),
+                success: false,
+                error: Some(e.to_string()),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_instance() -> Instance {
+        Instance::new("Test Session", "/tmp/test-project")
+    }
+
+    #[test]
+    fn test_stop_result_success_for_session_without_tmux_or_sandbox() {
+        let instance = create_test_instance();
+        let request = StopRequest {
+            session_id: instance.id.clone(),
+            instance,
+        };
+
+        let result = perform_stop(&request);
+
+        assert!(result.success);
+        assert!(result.error.is_none());
+        assert_eq!(result.session_id, request.session_id);
+    }
+
+    #[test]
+    fn test_stop_result_preserves_session_id() {
+        let instance = create_test_instance();
+        let custom_id = "custom-session-id-123".to_string();
+        let request = StopRequest {
+            session_id: custom_id.clone(),
+            instance,
+        };
+
+        let result = perform_stop(&request);
+        assert_eq!(result.session_id, custom_id);
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1050,6 +1050,11 @@ impl App {
                 needs_full_refresh = true;
             }
 
+            if self.home.apply_stop_results() {
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
+
             if self.home.apply_session_id_updates() {
                 refresh_needed = true;
                 needs_full_refresh = true;
@@ -1681,28 +1686,21 @@ impl App {
             }
             Action::StopSession(id) => {
                 if let Some(inst) = self.home.get_instance(&id) {
-                    let inst_clone = inst.clone();
-                    // Set Stopped immediately so the status poller won't
-                    // override to Error while stop() blocks (docker stop
-                    // can take up to 10s).
+                    // Run the stop on a background thread: `inst.stop()` calls
+                    // `docker stop` for sandboxed sessions, which can block for
+                    // the container's grace period (~10s) and would otherwise
+                    // freeze the TUI (issue #1496). Set Stopped immediately so
+                    // the status poller won't override to Error while the stop
+                    // is in flight; the result is applied in the main loop via
+                    // `apply_stop_results`.
+                    let request = crate::tui::stop_poller::StopRequest {
+                        session_id: id.clone(),
+                        instance: inst.clone(),
+                    };
                     self.home
                         .set_instance_status(&id, crate::session::Status::Stopped);
-                    match inst_clone.stop() {
-                        Ok(()) => {
-                            crate::tmux::refresh_session_cache();
-                            self.home.reload()?;
-                            self.home
-                                .set_instance_status(&id, crate::session::Status::Stopped);
-                            self.home.save()?;
-                        }
-                        Err(e) => {
-                            tracing::error!(target: "tui.input", "Failed to stop session: {}", e);
-                            self.home.set_instance_error(&id, Some(e.to_string()));
-                            self.home
-                                .set_instance_status(&id, crate::session::Status::Error);
-                            self.home.save()?;
-                        }
-                    }
+                    self.home.save()?;
+                    self.home.stop_poller.request_stop(request);
                 }
             }
             Action::SetTheme(name) => {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -40,6 +40,7 @@ use super::dialogs::{
 use super::diff::DiffView;
 use super::settings::SettingsView;
 use super::status_poller::{StatusPoller, StatusUpdate};
+use super::stop_poller::StopPoller;
 
 /// Extract a project group name from a session instance.
 /// Uses `worktree_info.main_repo_path` for worktree sessions (so all branches of the
@@ -472,6 +473,9 @@ pub struct HomeView {
     // Performance: background deletion
     pub(super) deletion_poller: DeletionPoller,
 
+    // Performance: background stop (docker stop can block up to ~10s)
+    pub(super) stop_poller: StopPoller,
+
     // Performance: background session creation (for sandbox)
     pub(super) creation_poller: CreationPoller,
     /// Set to true if user cancelled while creation was pending
@@ -816,6 +820,7 @@ impl HomeView {
             status_poller: StatusPoller::new(),
             pending_status_refresh: false,
             deletion_poller: DeletionPoller::new(),
+            stop_poller: StopPoller::new(),
             creation_poller: CreationPoller::new(),
             creation_cancelled: false,
             on_launch_hooks_ran: HashSet::new(),
@@ -1285,6 +1290,30 @@ impl HomeView {
                     inst.status = Status::Error;
                     inst.last_error = error;
                 });
+            }
+            return true;
+        }
+        false
+    }
+
+    /// Apply the result of a background stop. Returns true if an instance was
+    /// updated so the caller can trigger a redraw.
+    pub fn apply_stop_results(&mut self) -> bool {
+        use crate::session::Status;
+
+        if let Some(result) = self.stop_poller.try_recv_result() {
+            if result.success {
+                // Status was already set to Stopped optimistically when the
+                // stop was requested; reassert it in case the disk reload or
+                // a race changed it, and clear any stale error.
+                self.set_instance_error(&result.session_id, None);
+                self.set_instance_status(&result.session_id, Status::Stopped);
+            } else {
+                self.set_instance_error(&result.session_id, result.error);
+                self.set_instance_status(&result.session_id, Status::Error);
+            }
+            if let Err(e) = self.save() {
+                tracing::error!(target: "tui.home", "Failed to save after stop: {}", e);
             }
             return true;
         }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4064,6 +4064,45 @@ fn apply_status_update_skips_terminal_states() {
 
 #[test]
 #[serial]
+fn apply_stop_results_transitions_instance_to_stopped() {
+    use crate::session::Status;
+    use crate::tui::stop_poller::StopRequest;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+
+    // Pretend the session is live, then dispatch the stop to the background
+    // poller exactly as Action::StopSession does. The fixture instance has no
+    // tmux pane or sandbox, so perform_stop returns success quickly.
+    env.view
+        .mutate_instance(&id, |inst| inst.status = Status::Running);
+    let inst = env.view.get_instance(&id).unwrap().clone();
+    env.view.stop_poller.request_stop(StopRequest {
+        session_id: id.clone(),
+        instance: inst,
+    });
+
+    // Poll the result-application path the main loop runs each frame.
+    let mut applied = false;
+    for _ in 0..50 {
+        if env.view.apply_stop_results() {
+            applied = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(applied, "apply_stop_results never observed the stop result");
+
+    let inst = env.view.get_instance(&id).unwrap();
+    assert_eq!(inst.status, Status::Stopped);
+    assert_eq!(inst.last_error, None);
+}
+
+#[test]
+#[serial]
 fn apply_status_update_runs_status_hook_on_transition() {
     use crate::session::Status;
     use crate::status_hooks::{take_recorded_launches, StatusHookConfig};

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod remote_home;
 pub(crate) mod responsive;
 pub mod settings;
 mod status_poller;
+mod stop_poller;
 pub(crate) mod styles;
 
 pub use app::*;

--- a/src/tui/stop_poller.rs
+++ b/src/tui/stop_poller.rs
@@ -1,0 +1,102 @@
+//! Background stop handler for TUI responsiveness.
+//!
+//! Stopping a sandboxed session calls `docker stop`, which can block for up to
+//! the container's stop grace period (~10s). Running that on the UI event loop
+//! froze the TUI (issue #1496). This mirrors `DeletionPoller`: requests go to a
+//! worker thread, results come back over a channel the main loop polls each
+//! frame.
+
+use std::sync::mpsc;
+use std::thread;
+
+use crate::session::stop::perform_stop;
+pub use crate::session::stop::{StopRequest, StopResult};
+
+pub struct StopPoller {
+    request_tx: mpsc::Sender<StopRequest>,
+    result_rx: mpsc::Receiver<StopResult>,
+    _handle: thread::JoinHandle<()>,
+}
+
+impl StopPoller {
+    pub fn new() -> Self {
+        let (request_tx, request_rx) = mpsc::channel::<StopRequest>();
+        let (result_tx, result_rx) = mpsc::channel::<StopResult>();
+
+        let handle = thread::spawn(move || {
+            Self::stop_loop(request_rx, result_tx);
+        });
+
+        Self {
+            request_tx,
+            result_rx,
+            _handle: handle,
+        }
+    }
+
+    fn stop_loop(request_rx: mpsc::Receiver<StopRequest>, result_tx: mpsc::Sender<StopResult>) {
+        while let Ok(request) = request_rx.recv() {
+            let result = perform_stop(&request);
+            if result_tx.send(result).is_err() {
+                break;
+            }
+        }
+    }
+
+    pub fn request_stop(&self, request: StopRequest) {
+        let _ = self.request_tx.send(request);
+    }
+
+    pub fn try_recv_result(&self) -> Option<StopResult> {
+        self.result_rx.try_recv().ok()
+    }
+}
+
+impl Default for StopPoller {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::Instance;
+    use std::time::Duration;
+
+    fn create_test_instance() -> Instance {
+        Instance::new("Test Session", "/tmp/test-project")
+    }
+
+    #[test]
+    fn test_stop_poller_channel_communication() {
+        let poller = StopPoller::new();
+        let instance = create_test_instance();
+        let session_id = instance.id.clone();
+
+        poller.request_stop(StopRequest {
+            session_id: session_id.clone(),
+            instance,
+        });
+
+        let mut result = None;
+        for _ in 0..50 {
+            result = poller.try_recv_result();
+            if result.is_some() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(result.is_some(), "Timed out waiting for stop result");
+
+        let result = result.unwrap();
+        assert_eq!(result.session_id, session_id);
+        assert!(result.success);
+    }
+
+    #[test]
+    fn test_stop_poller_try_recv_returns_none_when_empty() {
+        let poller = StopPoller::new();
+        assert!(poller.try_recv_result().is_none());
+    }
+}

--- a/src/tui/stop_poller.rs
+++ b/src/tui/stop_poller.rs
@@ -44,7 +44,12 @@ impl StopPoller {
     }
 
     pub fn request_stop(&self, request: StopRequest) {
-        let _ = self.request_tx.send(request);
+        if let Err(e) = self.request_tx.send(request) {
+            // `perform_stop` is panic-safe, so a send failure means the worker
+            // thread is gone (channel closed at teardown). Log it rather than
+            // dropping silently so a stuck-looking "Stopping" row is traceable.
+            tracing::warn!(target: "tui.stop_poller", error = %e, "stop request dropped; worker thread unavailable");
+        }
     }
 
     pub fn try_recv_result(&self) -> Option<StopResult> {


### PR DESCRIPTION
## Description

Stopping a session from the TUI (`x` / `X`) ran `Instance::stop()` synchronously on the UI event loop. For sandboxed sessions that calls `docker stop`, which blocks for the container's stop grace period (~10s), freezing the entire TUI: no input, no redraws. The previous code pre-set `Stopped` to keep the status poller from clobbering the row, but the blocking call itself was the problem.

This mirrors the existing `DeletionPoller` async pattern with a new `StopPoller`:

- `src/session/stop.rs` (new): `StopRequest` / `StopResult` plus `perform_stop()`, the shared logic that runs `Instance::stop()` and refreshes the tmux cache.
- `src/tui/stop_poller.rs` (new): `StopPoller`, a worker thread that runs `perform_stop` off the UI thread and sends results back over a channel.
- `Action::StopSession` now sets `Stopped` optimistically (the status poller already skips `Stopped` rows) and dispatches the stop to the poller instead of blocking.
- The main loop polls `apply_stop_results()` each frame; on success it reasserts `Stopped` and clears any stale error, on failure it flips the row to `Error` with the message, same as before.

Net effect: the row updates instantly and the TUI stays responsive while the kill / `docker stop` happens in the background.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No screenshot: the change is behavioral (the TUI no longer blocks); the rendered row states (Stopped / Error) are unchanged from before.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a full e2e test, because: the hang only manifests with a real `docker stop` grace delay, which the e2e harness can't reproduce deterministically. Instead the lifecycle is covered by unit tests on `perform_stop` (`src/session/stop.rs`), channel round-trip tests on `StopPoller` (`src/tui/stop_poller.rs`), and a `HomeView`-level test that drives the dispatch and asserts the row transitions to `Stopped` (`apply_stop_results_transitions_instance_to_stopped` in `src/tui/home/tests.rs`).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude investigated the sync stop path, mirrored the existing `DeletionPoller` pattern, and wrote the tests; @njbrake reviewed the approach and changes.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #1496


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR moves session stopping off the TUI's UI thread into a background worker so stopping sandboxed sessions no longer freezes the interface.

## What changed (high level)

- Added a new session stop module and API:
  - src/session/stop.rs: StopRequest, StopResult, and perform_stop() to run Instance::stop() and refresh tmux cache.
  - Exported via src/session/mod.rs.
- Introduced an asynchronous stop worker:
  - src/tui/stop_poller.rs: StopPoller spawns a background thread, accepts StopRequest via channel, runs perform_stop(), and returns StopResult via channel.
  - Registered in src/tui/mod.rs.
- Integrated background stop into UI flow:
  - src/tui/app.rs: Action::StopSession now marks sessions Stopped optimistically and enqueues stop requests instead of blocking.
  - src/tui/home/mod.rs: HomeView now owns a StopPoller and exposes apply_stop_results() to drain and apply results (clear errors on success, set Error on failure).
- Tests:
  - Unit tests for perform_stop.
  - Channel/round-trip tests for StopPoller.
  - HomeView-level test asserting transition to Stopped.

## Benefits

- UI remains responsive during session stops (no freezes from long-running docker/container stop).
- Optimistic UX: session shows Stopped immediately; failures are applied asynchronously as Error with a message.
- Consistent architecture: mirrors existing DeletionPoller pattern for maintainability.
- Logging improved to surface dropped requests (helps debugging at shutdown).

## Technical details (brief)

- Action::StopSession sets status to Stopped, persists state, and sends StopRequest to StopPoller.
- StopPoller runs perform_stop() on a worker thread; results are non-blockingly polled each UI frame via apply_stop_results().
- perform_stop() invokes Instance::stop() off the UI thread and refreshes the tmux cache; it returns a StopResult indicating success or containing an error string.
- apply_stop_results() reasserts Stopped and clears last_error on success; on failure it sets status to Error with the failure message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->