### PR TITLE
feat(cockpit): fold consecutive TodoWrite cards into a TodoGroupCard

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -399,6 +399,29 @@ choice stays explicit.
 Tools without ACP support continue to work exactly as they do today
 (tmux + PTY); cockpit is additive, not a replacement.
 
+## Timeline card grouping
+
+To keep the timeline readable, cockpit folds two kinds of runs into
+single collapsible cards:
+
+- **Silent tool work.** A run of three or more consecutive tool calls
+  with no agent text between them (for example Read, Read, Grep, Read
+  during investigation) collapses into one "actions" card. Expand it to
+  see each call as its normal per-tool card.
+- **Consecutive TodoWrite updates.** When the agent fires three or more
+  `TodoWrite` calls back-to-back, the per-call snapshots fold into one
+  todo card titled "updated N times". Collapsed, the card shows the
+  latest list (the only snapshot whose pending/in-progress/done mix is
+  current), so you see what the agent is working on without expanding.
+  Expand it to inspect each individual update in order and audit how the
+  plan evolved during the turn.
+
+Folding only fires when every call in the run is the same shape. A
+TodoWrite sandwiched between real tool work (Read, Edit) stays inline as
+its own card rather than being hidden inside a group, so a status update
+between actions is never buried. Two-in-a-row stays inline as well; the
+fold threshold is three.
+
 ## Worker persistence across `aoe serve` restart
 
 > **Behavior change (cockpit-only).** Prior releases tore down every

--- a/web/src/components/cockpit/CockpitRuntime.test.ts
+++ b/web/src/components/cockpit/CockpitRuntime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   SUBAGENT_TASK_NAME,
+  TODO_GROUP_NAME,
   TOOL_GROUP_NAME,
   activityToThreadMessages,
 } from "./CockpitRuntime";
@@ -27,6 +28,27 @@ function toolStart(id: string, kind = "read"): ActivityRow {
     id: `start-${id}`,
     kind: "tool_start",
     text: "Read",
+    toolCallId: id,
+    tool,
+    at: "2026-05-12T00:00:00Z",
+  };
+}
+
+function todoStart(
+  id: string,
+  todos: Array<{ content: string; status: string }>,
+): ActivityRow {
+  const tool: ToolCall = {
+    id,
+    name: `Update TODOs: ${todos.map((t) => t.content).join(", ")}`,
+    kind: "think",
+    args_preview: JSON.stringify({ todos }),
+    started_at: "2026-05-12T00:00:00Z",
+  };
+  return {
+    id: `start-${id}`,
+    kind: "tool_start",
+    text: "Update TODOs",
     toolCallId: id,
     tool,
     at: "2026-05-12T00:00:00Z",
@@ -129,6 +151,95 @@ describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
     expect(groups).toHaveLength(0);
     const toolParts = parts.filter((p) => p.type === "tool-call");
     expect(toolParts).toHaveLength(4);
+  });
+
+  it("folds ≥3 consecutive TodoWrite snapshots into one todo group (#1468)", () => {
+    const messages = activityToThreadMessages(
+      [
+        userRow("go"),
+        todoStart("td1", [{ content: "a", status: "pending" }]),
+        todoStart("td2", [{ content: "a", status: "in_progress" }]),
+        todoStart("td3", [{ content: "a", status: "completed" }]),
+      ],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = assistant.content as Array<{
+      type: string;
+      toolName?: string;
+    }>;
+    const toolParts = parts.filter((p) => p.type === "tool-call");
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]!.toolName).toBe(TODO_GROUP_NAME);
+  });
+
+  it("leaves 2 consecutive TodoWrite snapshots inline (#1468)", () => {
+    const messages = activityToThreadMessages(
+      [
+        userRow("go"),
+        todoStart("td1", [{ content: "a", status: "pending" }]),
+        todoStart("td2", [{ content: "a", status: "completed" }]),
+      ],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = assistant.content as Array<{
+      type: string;
+      toolName?: string;
+    }>;
+    const toolParts = parts.filter((p) => p.type === "tool-call");
+    expect(toolParts).toHaveLength(2);
+    for (const p of toolParts) {
+      expect(p.toolName).not.toBe(TODO_GROUP_NAME);
+      expect(p.toolName).not.toBe(TOOL_GROUP_NAME);
+    }
+  });
+
+  it("keeps a ≥3 run mixing TodoWrite with real tool work inline (#1468)", () => {
+    const messages = activityToThreadMessages(
+      [
+        userRow("go"),
+        todoStart("td1", [{ content: "a", status: "pending" }]),
+        todoStart("td2", [{ content: "a", status: "in_progress" }]),
+        toolStart("r1"),
+      ],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = assistant.content as Array<{
+      type: string;
+      toolName?: string;
+    }>;
+    const toolParts = parts.filter((p) => p.type === "tool-call");
+    expect(toolParts).toHaveLength(3);
+    for (const p of toolParts) {
+      expect(p.toolName).not.toBe(TODO_GROUP_NAME);
+      expect(p.toolName).not.toBe(TOOL_GROUP_NAME);
+    }
+  });
+
+  it("text between TodoWrite snapshots splits the fold (#1468)", () => {
+    const messages = activityToThreadMessages(
+      [
+        userRow("go"),
+        todoStart("a1", [{ content: "a", status: "pending" }]),
+        todoStart("a2", [{ content: "a", status: "in_progress" }]),
+        messageRow("Working on it."),
+        todoStart("b1", [{ content: "a", status: "in_progress" }]),
+        todoStart("b2", [{ content: "a", status: "completed" }]),
+      ],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = assistant.content as Array<{
+      type: string;
+      toolName?: string;
+    }>;
+    const groups = parts.filter(
+      (p) => p.type === "tool-call" && p.toolName === TODO_GROUP_NAME,
+    );
+    // Each side of the text is a run of 2, below the fold threshold.
+    expect(groups).toHaveLength(0);
   });
 
   it("smuggles parent_tool_call_id through args_preview as _aoe_parent_tool_call_id (#1041)", () => {

--- a/web/src/components/cockpit/CockpitRuntime.test.ts
+++ b/web/src/components/cockpit/CockpitRuntime.test.ts
@@ -171,6 +171,14 @@ describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
     const toolParts = parts.filter((p) => p.type === "tool-call");
     expect(toolParts).toHaveLength(1);
     expect(toolParts[0]!.toolName).toBe(TODO_GROUP_NAME);
+    // The folded payload preserves each snapshot in original order so
+    // the expand-history view can replay the plan's evolution.
+    const payload = JSON.parse(
+      (toolParts[0] as { argsText?: string }).argsText!,
+    );
+    expect(
+      payload.children.map((c: { toolCallId: string }) => c.toolCallId),
+    ).toEqual(["td1", "td2", "td3"]);
   });
 
   it("leaves 2 consecutive TodoWrite snapshots inline (#1468)", () => {

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -589,7 +589,10 @@ type GroupChildPayload = {
   toolCallId: string;
   toolName: string;
   argsText: string;
-  result?: { content: string };
+  // `endedAt` rides along from DraftPart.result (set in completeToolCall)
+  // and CockpitView's pickEndedAt reads it to compute durations; keep it
+  // on the type so a future rebuild of `result` doesn't drop it.
+  result?: { content: string; endedAt?: string };
   isError?: boolean;
 };
 

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -579,6 +579,43 @@ const TOOL_GROUP_MIN_RUN = 3;
  *  the `_aoe_` prefix so it can't collide with a real ACP tool kind. */
 export const TOOL_GROUP_NAME = "_aoe_tool_group";
 
+/** Synthetic toolName for a run of consecutive TodoWrite snapshots
+ *  folded into one card. Distinct from TOOL_GROUP_NAME so the renderer
+ *  dispatches it to TodoGroupCard (latest list always visible, history
+ *  on expand) rather than the generic actions group. See #1468. */
+export const TODO_GROUP_NAME = "_aoe_todo_group";
+
+type GroupChildPayload = {
+  toolCallId: string;
+  toolName: string;
+  argsText: string;
+  result?: { content: string };
+  isError?: boolean;
+};
+
+/** Flatten a run of tool-call parts into the verbatim child payload the
+ *  group renderers reconstruct from. Shared by the generic actions
+ *  group and the TodoWrite group (#1468). */
+function buildGroupChildren(run: DraftPart[]): {
+  childIds: string[];
+  children: GroupChildPayload[];
+} {
+  const childIds: string[] = [];
+  const children: GroupChildPayload[] = [];
+  for (const p of run) {
+    if (p.type !== "tool-call") continue;
+    childIds.push(p.toolCallId);
+    children.push({
+      toolCallId: p.toolCallId,
+      toolName: p.toolName,
+      argsText: p.argsText,
+      result: p.result,
+      isError: p.isError,
+    });
+  }
+  return { childIds, children };
+}
+
 /** Walk an assistant message's parts and collapse runs of consecutive
  *  tool-call parts (regardless of kind) into one synthetic group part
  *  when the run is ≥ TOOL_GROUP_MIN_RUN long. The grouping boundary is
@@ -595,16 +632,29 @@ function collapseToolRuns(parts: DraftPart[]): DraftPart[] {
     if (run.length < TOOL_GROUP_MIN_RUN) {
       for (const p of run) out.push(p);
     } else {
-      // TodoWrite calls aren't silent tool work; they're status
-      // updates the user wants to see one-by-one (#1064). Detect them
-      // via the `_aoe_title` echo we stash in argsText (the adapter
-      // names them "Update TODOs: …") and exempt the group entirely
-      // when any child looks like a TodoWrite. Cheap: argsText is
-      // already parsed JSON, just sniff the prefix.
-      const hasTodoWrite = run.some(
-        (p) => p.type === "tool-call" && isTodoWriteArgsText(p.argsText),
-      );
-      if (hasTodoWrite) {
+      // A run made up entirely of consecutive TodoWrite snapshots is
+      // the spam case (#1468): fold it into one TodoGroupCard that
+      // shows the latest list collapsed and the per-call history on
+      // expand. TodoWrites are detected via the `_aoe_title` echo /
+      // `todos` payload stashed in argsText.
+      const isTodo = (p: DraftPart) =>
+        p.type === "tool-call" && isTodoWriteArgsText(p.argsText);
+      if (run.every(isTodo)) {
+        const { childIds, children } = buildGroupChildren(run);
+        out.push({
+          type: "tool-call",
+          toolCallId: `todogroup-${childIds.join("-")}`,
+          toolName: TODO_GROUP_NAME,
+          argsText: JSON.stringify({ children }),
+        });
+        run = [];
+        return;
+      }
+      // A run that MIXES TodoWrite with real tool work stays inline: a
+      // status update sandwiched between Reads/Edits shouldn't be
+      // hidden inside a generic actions group, and pulling it out
+      // would reorder the timeline. See #1064, #1468.
+      if (run.some(isTodo)) {
         for (const p of run) out.push(p);
         run = [];
         return;
@@ -620,25 +670,7 @@ function collapseToolRuns(parts: DraftPart[]): DraftPart[] {
         run = [];
         return;
       }
-      const childIds: string[] = [];
-      const children: Array<{
-        toolCallId: string;
-        toolName: string;
-        argsText: string;
-        result?: { content: string };
-        isError?: boolean;
-      }> = [];
-      for (const p of run) {
-        if (p.type !== "tool-call") continue;
-        childIds.push(p.toolCallId);
-        children.push({
-          toolCallId: p.toolCallId,
-          toolName: p.toolName,
-          argsText: p.argsText,
-          result: p.result,
-          isError: p.isError,
-        });
-      }
+      const { childIds, children } = buildGroupChildren(run);
       out.push({
         type: "tool-call",
         toolCallId: `group-${childIds.join("-")}`,

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -34,6 +34,7 @@ import { ApprovalCard } from "./ApprovalCard";
 import {
   CockpitRuntime,
   SUBAGENT_TASK_NAME,
+  TODO_GROUP_NAME,
   TOOL_GROUP_NAME,
   type CockpitContext,
 } from "./CockpitRuntime";
@@ -48,7 +49,12 @@ import {
 } from "./queuedPromptsLayout";
 import { StartupErrorScreen } from "./StartupErrorScreen";
 import { pickWorkerStoppedVariant } from "./workerStoppedBanner";
-import { SubagentCard, ToolCard, ToolGroupCard } from "./ToolCards";
+import {
+  SubagentCard,
+  ToolCard,
+  ToolGroupCard,
+  TodoGroupCard,
+} from "./ToolCards";
 import { DiffCommentsUserCard } from "../diff/comments/DiffCommentsUserCard";
 import { parseDiffCommentsSentinel } from "../diff/comments/buildPrompt";
 import {
@@ -67,6 +73,7 @@ import { useApprovalSound } from "../../hooks/useApprovalSound";
 import { useIsCoarsePointer } from "../../hooks/useIsCoarsePointer";
 import type {
   Approval,
+  ActivityRow,
   ApprovalDecision,
   CockpitState,
   Plan,
@@ -573,6 +580,11 @@ function AssistantToolCall(props: ToolCallProps) {
     return <AssistantToolGroup argsText={props.argsText} />;
   }
 
+  // Run of consecutive TodoWrite snapshots folded into one card (#1468).
+  if (props.toolName === TODO_GROUP_NAME) {
+    return <AssistantTodoGroup argsText={props.argsText} />;
+  }
+
   if (props.toolName === SUBAGENT_TASK_NAME) {
     return <AssistantSubagentTask argsText={props.argsText} />;
   }
@@ -665,54 +677,72 @@ interface GroupChild {
   isError?: boolean;
 }
 
-function AssistantToolGroup({ argsText }: { argsText?: string }) {
-  let children: GroupChild[] = [];
-  if (argsText) {
-    try {
-      const parsed = JSON.parse(argsText);
-      if (parsed && Array.isArray(parsed.children)) {
-        children = parsed.children as GroupChild[];
-      }
-    } catch {
-      // Malformed payload; fall through to an empty group rather than
-      // crashing the assistant-ui render.
+/** Parse the `{ children: [...] }` payload CockpitRuntime stashes in a
+ *  group part's argsText. Returns an empty list on malformed JSON
+ *  rather than crashing the assistant-ui render. */
+function parseGroupChildren(argsText?: string): GroupChild[] {
+  if (!argsText) return [];
+  try {
+    const parsed = JSON.parse(argsText);
+    if (parsed && Array.isArray(parsed.children)) {
+      return parsed.children as GroupChild[];
     }
+  } catch {
+    // ignore
   }
-  const items = children.map((c) => {
-    const fallbackAt = toolCallTimestamp(c.toolCallId);
-    let parsedArgs: Record<string, unknown> = {};
-    try {
-      const p = JSON.parse(c.argsText);
-      if (p && typeof p === "object" && !Array.isArray(p)) {
-        parsedArgs = p as Record<string, unknown>;
-      }
-    } catch {
-      // ignore
+  return [];
+}
+
+/** Reconstruct the ToolCall + completion-row pair a group child stands
+ *  for, mirroring the top-level AssistantToolCall path so durations and
+ *  per-kind dispatch behave identically inside a group. */
+function groupChildToItem(c: GroupChild): {
+  tool: ToolCall;
+  result?: ActivityRow;
+  kind: string;
+} {
+  const fallbackAt = toolCallTimestamp(c.toolCallId);
+  let parsedArgs: Record<string, unknown> = {};
+  try {
+    const p = JSON.parse(c.argsText);
+    if (p && typeof p === "object" && !Array.isArray(p)) {
+      parsedArgs = p as Record<string, unknown>;
     }
-    const startedAt = pickStartedAt(parsedArgs, c.argsText) ?? fallbackAt;
-    const endedAt = pickEndedAt(c.result) ?? fallbackAt;
-    const tool: ToolCall = {
-      id: c.toolCallId,
-      name: prettifyToolName(c.toolName, parsedArgs),
-      kind: c.toolName,
-      args_preview: c.argsText,
-      started_at: startedAt,
-    };
-    const result =
-      c.result !== undefined
-        ? {
-            id: `done-${c.toolCallId}`,
-            kind: c.isError
-              ? ("tool_error" as const)
-              : ("tool_complete" as const),
-            text: c.result.content,
-            toolCallId: c.toolCallId,
-            at: endedAt,
-          }
-        : undefined;
-    return { tool, result, kind: c.toolName };
-  });
+  } catch {
+    // ignore
+  }
+  const startedAt = pickStartedAt(parsedArgs, c.argsText) ?? fallbackAt;
+  const endedAt = pickEndedAt(c.result) ?? fallbackAt;
+  const tool: ToolCall = {
+    id: c.toolCallId,
+    name: prettifyToolName(c.toolName, parsedArgs),
+    kind: c.toolName,
+    args_preview: c.argsText,
+    started_at: startedAt,
+  };
+  const result =
+    c.result !== undefined
+      ? {
+          id: `done-${c.toolCallId}`,
+          kind: c.isError
+            ? ("tool_error" as const)
+            : ("tool_complete" as const),
+          text: c.result.content,
+          toolCallId: c.toolCallId,
+          at: endedAt,
+        }
+      : undefined;
+  return { tool, result, kind: c.toolName };
+}
+
+function AssistantToolGroup({ argsText }: { argsText?: string }) {
+  const items = parseGroupChildren(argsText).map(groupChildToItem);
   return <ToolGroupCard items={items} />;
+}
+
+function AssistantTodoGroup({ argsText }: { argsText?: string }) {
+  const items = parseGroupChildren(argsText).map(groupChildToItem);
+  return <TodoGroupCard items={items} />;
 }
 
 interface SubagentPayload {

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -241,6 +241,30 @@ describe("TodoGroupCard fold (#1468)", () => {
     // History renders each call in original order.
     expect(text.indexOf("Step Alpha")).toBeLessThan(text.indexOf("Step Bravo"));
   });
+
+  it("falls back to the last successful snapshot when the latest failed", () => {
+    const failedTail = {
+      tool: makeToolCall({
+        id: "td4",
+        name: "TodoWrite",
+        kind: "other",
+        args_preview: JSON.stringify({
+          todos: [{ content: "Broken plan", status: "in_progress" }],
+        }),
+      }),
+      result: makeError({ id: "done-td4", toolCallId: "td4" }),
+    };
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <TodoGroupCard items={[...items, failedTail]} />
+      </Wrap>,
+    );
+    // Collapsed preview shows the last good snapshot, not the failed one.
+    expect(container.textContent).toContain("Step Charlie");
+    expect(container.textContent).not.toContain("Broken plan");
+    // The header surfaces the failed latest attempt rather than looking clean.
+    expect(container.textContent).toContain("failed");
+  });
 });
 
 describe("ToolCards memory_recall (claude-agent-acp v0.37.0)", () => {

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -29,9 +29,14 @@ vi.mock("../../hooks/useShikiTheme", () => ({
   useShikiTheme: () => ({ theme: "dark-plus", appearance: "dark" }),
 }));
 
-import { ToolCard } from "./ToolCards";
+import { ToolCard, TodoGroupCard } from "./ToolCards";
 import { AgentProfileProvider } from "../../lib/agentProfileContext";
-import { fixtures, makeCompletion, makeError } from "./__fixtures__/toolCalls";
+import {
+  fixtures,
+  makeCompletion,
+  makeError,
+  makeToolCall,
+} from "./__fixtures__/toolCalls";
 
 function Wrap({
   toolKey,
@@ -185,6 +190,56 @@ describe("ToolCards profile-gated dispatch (claude)", () => {
       </Wrap>,
     );
     expect(container.textContent).toContain("checking deploy");
+  });
+});
+
+describe("TodoGroupCard fold (#1468)", () => {
+  function snapshot(id: string, content: string, status: string) {
+    return {
+      tool: makeToolCall({
+        id,
+        name: "TodoWrite",
+        kind: "other",
+        args_preview: JSON.stringify({ todos: [{ content, status }] }),
+      }),
+      result: makeCompletion({ id: `done-${id}`, toolCallId: id }),
+    };
+  }
+
+  const items = [
+    snapshot("td1", "Step Alpha", "in_progress"),
+    snapshot("td2", "Step Bravo", "in_progress"),
+    snapshot("td3", "Step Charlie", "in_progress"),
+  ];
+
+  it("shows the latest snapshot collapsed without expanding", () => {
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <TodoGroupCard items={items} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("todos");
+    expect(container.textContent).toContain("updated 3 times");
+    // Collapsed view shows the latest list only.
+    expect(container.textContent).toContain("Step Charlie");
+    expect(container.textContent).not.toContain("Step Alpha");
+    expect(container.textContent).not.toContain("Step Bravo");
+  });
+
+  it("reveals every snapshot in order on expand", () => {
+    const { container, getByRole } = render(
+      <Wrap toolKey="claude">
+        <TodoGroupCard items={items} />
+      </Wrap>,
+    );
+    // Collapsed: only the group header carries a toggle.
+    fireEvent.click(getByRole("button"));
+    const text = container.textContent ?? "";
+    expect(text).toContain("Step Alpha");
+    expect(text).toContain("Step Bravo");
+    expect(text).toContain("Step Charlie");
+    // History renders each call in original order.
+    expect(text.indexOf("Step Alpha")).toBeLessThan(text.indexOf("Step Bravo"));
   });
 });
 

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -1097,8 +1097,11 @@ export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
         .filter(
           (
             s,
-          ): s is { tool: ToolCall; result?: ActivityRow; todos: TodoItem[] } =>
-            s !== null,
+          ): s is {
+            tool: ToolCall;
+            result: ActivityRow | undefined;
+            todos: TodoItem[];
+          } => s !== null,
         ),
     [items, profile],
   );

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -278,6 +278,11 @@ interface CardChromeProps {
   expanded: boolean;
   onToggle?: () => void;
   body?: React.ReactNode;
+  /** Region rendered unconditionally below the header, regardless of
+   *  `expanded`. Used by `TodoGroupCard` to keep the latest todo list
+   *  visible while the per-snapshot history stays behind the expand
+   *  toggle (#1468). */
+  subBody?: React.ReactNode;
   /** When true and the card has settled (`status !== "running"`),
    *  render a neutral dot and omit the status badge. Used by
    *  `ToolGroupCard` so a single child error doesn't roll up to a
@@ -326,6 +331,7 @@ function CardChrome({
   expanded,
   onToggle,
   body,
+  subBody,
   startedAt,
   endedAt,
   neutralOnDone,
@@ -366,6 +372,7 @@ function CardChrome({
           />
         )}
       </Header>
+      {subBody}
       {expanded && body}
     </div>
   );
@@ -989,21 +996,55 @@ const TODO_CLASS: Record<TodoStatus, string> = {
   cancelled: "text-text-dim line-through",
 };
 
-function TodoUpdateCard({ tool, result, todos }: TodoCardProps) {
-  const status = statusFor(result);
-  const counts = useMemo(() => {
-    const c = { pending: 0, in_progress: 0, completed: 0, cancelled: 0 };
-    for (const t of todos) c[t.status] += 1;
-    return c;
-  }, [todos]);
-  const [open, setOpen] = useState(todos.length <= 5);
+function todoCounts(todos: TodoItem[]): Record<TodoStatus, number> {
+  const c: Record<TodoStatus, number> = {
+    pending: 0,
+    in_progress: 0,
+    completed: 0,
+    cancelled: 0,
+  };
+  for (const t of todos) c[t.status] += 1;
+  return c;
+}
 
+function todoBreakdown(counts: Record<TodoStatus, number>): string[] {
   const breakdown: string[] = [];
   if (counts.in_progress > 0) breakdown.push(`${counts.in_progress} active`);
   if (counts.pending > 0) breakdown.push(`${counts.pending} pending`);
   if (counts.completed > 0) breakdown.push(`${counts.completed} done`);
-  if (counts.cancelled > 0)
-    breakdown.push(`${counts.cancelled} cancelled`);
+  if (counts.cancelled > 0) breakdown.push(`${counts.cancelled} cancelled`);
+  return breakdown;
+}
+
+/** The todo checklist itself, shared by the per-call `TodoUpdateCard`
+ *  body and the folded `TodoGroupCard`'s always-visible latest list. */
+function TodoList({ todos }: { todos: TodoItem[] }) {
+  return (
+    <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
+      <ul className="flex flex-col gap-1 font-mono text-xs">
+        {todos.map((t, i) => (
+          <li
+            key={`${i}-${t.content}`}
+            className={`flex items-start gap-2 ${TODO_CLASS[t.status]}`}
+          >
+            <span className="select-none w-4 shrink-0 text-center">
+              {TODO_GLYPH[t.status]}
+            </span>
+            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">
+              {t.content}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function TodoUpdateCard({ tool, result, todos }: TodoCardProps) {
+  const status = statusFor(result);
+  const counts = useMemo(() => todoCounts(todos), [todos]);
+  const [open, setOpen] = useState(todos.length <= 5);
+  const breakdown = todoBreakdown(counts);
 
   return (
     <CardChrome
@@ -1024,24 +1065,92 @@ function TodoUpdateCard({ tool, result, todos }: TodoCardProps) {
       endedAt={result?.at}
       body={
         <ToolErrorBody status={status} errorText={result?.text}>
-          <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
-            <ul className="flex flex-col gap-1 font-mono text-xs">
-              {todos.map((t, i) => (
-                <li
-                  key={`${i}-${t.content}`}
-                  className={`flex items-start gap-2 ${TODO_CLASS[t.status]}`}
-                >
-                  <span className="select-none w-4 shrink-0 text-center">
-                    {TODO_GLYPH[t.status]}
-                  </span>
-                  <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">
-                    {t.content}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
+          <TodoList todos={todos} />
         </ToolErrorBody>
+      }
+    />
+  );
+}
+
+interface TodoGroupChild {
+  tool: ToolCall;
+  result?: ActivityRow;
+}
+
+/** Folds a run of consecutive TodoWrite snapshots into one card. The
+ *  collapsed view shows the latest list (the only snapshot whose
+ *  pending/in_progress/completed mix is current); expanding reveals
+ *  each individual update in order so the plan's evolution during the
+ *  turn stays auditable. See #1468. */
+export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
+  const profile = useAgentProfile();
+  const [open, setOpen] = useState(false);
+  const snapshots = useMemo(
+    () =>
+      items
+        .map((it) => {
+          const c = classifyTodoWrite(it.tool, profile);
+          return c.isTodoWrite
+            ? { tool: it.tool, result: it.result, todos: c.todos }
+            : null;
+        })
+        .filter(
+          (
+            s,
+          ): s is { tool: ToolCall; result?: ActivityRow; todos: TodoItem[] } =>
+            s !== null,
+        ),
+    [items, profile],
+  );
+  if (snapshots.length === 0) return null;
+
+  const latest = snapshots[snapshots.length - 1]!;
+  const breakdown = todoBreakdown(todoCounts(latest.todos));
+  const running = snapshots.some((s) => !s.result);
+  const status: Status = running ? "running" : "ok";
+
+  const startedAt = snapshots
+    .map((s) => s.tool.started_at)
+    .sort()
+    .at(0);
+  const allDone = snapshots.every((s) => s.result);
+  const endedAt = allDone
+    ? snapshots
+        .map((s) => s.result!.at)
+        .sort()
+        .at(-1)
+    : undefined;
+
+  return (
+    <CardChrome
+      status={status}
+      neutralOnDone
+      icon={<ListChecks className="h-3.5 w-3.5" />}
+      label="todos"
+      primary={
+        <>
+          <span>updated {snapshots.length} times</span>
+          {breakdown.length > 0 && (
+            <span className="ml-2 text-text-dim">· {breakdown.join(" · ")}</span>
+          )}
+        </>
+      }
+      expanded={open}
+      onToggle={() => setOpen((v) => !v)}
+      startedAt={startedAt}
+      endedAt={endedAt}
+      subBody={<TodoList todos={latest.todos} />}
+      body={
+        <div className="border-t border-surface-800 bg-surface-900/30 px-2 py-1">
+          {snapshots.map((s) => (
+            <TodoUpdateCard
+              key={s.tool.id}
+              tool={s.tool}
+              result={s.result}
+              todos={s.todos}
+            />
+          ))}
+        </div>
       }
     />
   );

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -1107,10 +1107,19 @@ export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
   );
   if (snapshots.length === 0) return null;
 
-  const latest = snapshots[snapshots.length - 1]!;
-  const breakdown = todoBreakdown(todoCounts(latest.todos));
+  // The collapsed preview shows the latest *successful* snapshot, since
+  // a TodoWrite that ended in tool_error never became the live state.
+  // The header still reflects the latest attempt so a failed trailing
+  // update surfaces as an error rather than looking clean. See #1468.
+  const latestAttempt = snapshots[snapshots.length - 1]!;
+  const latestSuccessful =
+    [...snapshots].reverse().find((s) => s.result?.kind !== "tool_error") ??
+    null;
+  const previewSnapshot = latestSuccessful ?? latestAttempt;
+  const latestFailed = latestAttempt.result?.kind === "tool_error";
+  const breakdown = todoBreakdown(todoCounts(previewSnapshot.todos));
   const running = snapshots.some((s) => !s.result);
-  const status: Status = running ? "running" : "ok";
+  const status: Status = running ? "running" : latestFailed ? "err" : "ok";
 
   const startedAt = snapshots
     .map((s) => s.tool.started_at)
@@ -1127,7 +1136,7 @@ export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
   return (
     <CardChrome
       status={status}
-      neutralOnDone
+      neutralOnDone={!latestFailed}
       icon={<ListChecks className="h-3.5 w-3.5" />}
       label="todos"
       primary={
@@ -1142,7 +1151,11 @@ export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
       onToggle={() => setOpen((v) => !v)}
       startedAt={startedAt}
       endedAt={endedAt}
-      subBody={<TodoList todos={latest.todos} />}
+      subBody={
+        previewSnapshot.result?.kind === "tool_error" ? undefined : (
+          <TodoList todos={previewSnapshot.todos} />
+        )
+      }
       body={
         <div className="border-t border-surface-800 bg-surface-900/30 px-2 py-1">
           {snapshots.map((s) => (

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -984,6 +984,20 @@
       ]
     },
     {
+      "id": "cockpit.todo-group-fold",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/CockpitRuntime.test.ts",
+        "src/components/cockpit/ToolCards.render.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitRuntime.tsx",
+        "web/src/components/cockpit/CockpitView.tsx",
+        "web/src/components/cockpit/ToolCards.tsx"
+      ]
+    },
+    {
       "id": "cockpit.context-primer-banner",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Claude fires `TodoWrite` many times per substantive turn (add items, mark one in progress, mark it done, add more), and each call rendered as its own `TodoUpdateCard`. A turn with six todo updates produced six stacked, near-duplicate cards that buried the actual tool work and pushed the only current snapshot (the latest) under several superseded ones.

This iterates on #1064 (which deliberately shipped per-call todo cards for v1) by folding runs of consecutive `TodoWrite` updates into one `TodoGroupCard`:

- A run of three or more back-to-back `TodoWrite` calls with no other tool work between them now collapses into a single card titled "updated N times".
- Collapsed (default), the card shows the latest todo list, the only snapshot whose pending / in-progress / done mix is current, so you see what the agent is working on without expanding.
- Expanded, it shows each individual `TodoWrite` snapshot as its own card in order, so the plan's evolution during the turn stays auditable.

The fold reuses the existing `collapseToolRuns` infrastructure (#1057). It only fires when every call in the run is a `TodoWrite`; a `TodoWrite` sandwiched between real tool work (Read, Edit) keeps the inline exemption from #1064 so a status update between actions is never hidden inside a group. The fold lives entirely in the timeline rendering; the `acp_client` synthesis path is unchanged (out of scope per the issue).

Closes #1468

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a cockpit session with Claude and send a prompt that makes the agent plan, then work through several todo items in one turn.
- [ ] Confirm the consecutive todo updates render as one card titled "updated N times" instead of N stacked cards.
- [ ] Without expanding, confirm the card shows the current todo list (latest snapshot) and the counts chip (e.g. `1 active · 2 done`).
- [ ] Expand the card and confirm each individual update appears as its own card, in the order they were emitted.
- [ ] Trigger a turn where a single todo update lands between real tool calls (Read / Edit), and confirm that update stays inline as its own card rather than being folded.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Detail: covered with Vitest + RTL (the appropriate layer per `AGENTS.md` for this component-logic change) rather than Playwright. `CockpitRuntime.test.ts` pins the fold/no-fold/mixed-run cases; `ToolCards.render.test.tsx` pins the `TodoGroupCard` collapsed-latest and expand-history rendering. `web/tests/coverage-matrix.json` gains a `cockpit.todo-group-fold` entry. The new specs were verified red against the pre-fix tree.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (fold only all-TodoWrite runs, keep mixed runs inline, latest-list-always-visible card), reviewed each commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

- Folded consecutive TodoWrite timeline entries into a single collapsible TodoGroup card when 3+ TodoWrite tool-calls occur back-to-back with no intervening agent content.
- Added a TodoGroupCard that shows the latest successful snapshot in the collapsed view (as a persistent sub-body) and exposes each individual TodoWrite snapshot in order when expanded.
- Extended CardChrome with a subBody region used to always surface the latest todo snapshot in the collapsed state.
- Refactored todo UI into shared helpers (status counts/breakdown) and a reusable TodoList component; updated TodoUpdateCard to use these.
- Timeline renderer (CockpitRuntime) now emits a synthetic group part (TODO_GROUP_NAME "_aoe_todo_group") for Todo-only runs and reuses collapseToolRuns infrastructure; runs mixing TodoWrite with other tool calls remain inline.
- Tests (Vitest + RTL) added/updated to cover fold/no-fold/mixed-run cases, collapsed-preview behavior (shows last successful snapshot; falls back when needed), and preservation of child order in folded groups.
- Documentation updated to describe timeline grouping behavior and fold conditions; coverage-matrix updated.

## Benefits

- Cleaner timeline with reduced spam from repeated TodoWrite updates.
- Preserves auditability by exposing full ordered history when expanded.
- Collapsed view focuses attention on the current live todo state while hiding intermediate noise.
- Folding only applies to pure TodoWrite runs, avoiding surprising reordering when real tool work is present.
- Implementation reuses existing grouping infrastructure, minimizing scope and backend changes.

## Notable Implementation Notes / Tech Details

- New exported constant: TODO_GROUP_NAME = "_aoe_todo_group".
- collapseToolRuns enhanced to detect TodoWrite-only runs (isTodoWrite predicate) and to build a synthetic group payload listing child tool-call ids, payloads, and result/error metadata.
- Folded preview chooses the last successful snapshot; if trailing attempts fail, preview falls back to the most recent successful snapshot; if all fail, collapsed preview body may be omitted.
- Group child payload type widened to preserve endedAt (duration) metadata.
- Tests include an assertion that folded group children preserve original tool-call id order to keep snapshot sequence deterministic.
- Backend synthesis/emission of one ToolCall per update is unchanged; folding is strictly a renderer-side transformation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->