### PR TITLE
refactor(web): remove redundant top-bar breadcrumb

### DIFF
--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -40,9 +40,6 @@ export function TopBar({
   isDevBuild,
   onGoDashboard,
 }: Props) {
-  const repoName =
-    activeWorkspace?.projectPath.split("/").filter(Boolean).pop() ?? null;
-
   const overflowItems = useMemo<OverflowItem[]>(() => {
     const items: OverflowItem[] = [
       { label: "Help", onClick: onOpenHelp },
@@ -85,25 +82,6 @@ export function TopBar({
           <img src="/icon-192.png" alt="" width="18" height="18" className="rounded-sm" />
           <span className="font-mono text-xs leading-none">aoe</span>
         </button>
-
-        {/* Breadcrumb (hidden on mobile). Suppress the workspace crumb when it
-            equals the repo name to avoid "/ foo / foo" duplication. */}
-        {(repoName || activeWorkspace) && (
-          <div className="hidden sm:flex items-center gap-1.5 min-w-0 text-xs font-mono">
-            <span className="text-text-dim">/</span>
-            {repoName && (
-              <span className="text-text-muted truncate max-w-[140px]">{repoName}</span>
-            )}
-            {activeWorkspace && activeWorkspace.displayName !== repoName && (
-              <>
-                <span className="text-text-dim">/</span>
-                <span className="text-accent-600 truncate max-w-[200px]">
-                  {activeWorkspace.displayName}
-                </span>
-              </>
-            )}
-          </div>
-        )}
       </div>
 
       {/* CENTER ZONE — palette trigger */}

--- a/web/src/components/__tests__/TopBar.test.tsx
+++ b/web/src/components/__tests__/TopBar.test.tsx
@@ -15,16 +15,24 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render } from "@testing-library/react";
 
 import { TopBar } from "../TopBar";
+import type { SessionResponse, Workspace } from "../../lib/types";
 
 afterEach(() => {
   cleanup();
 });
 
-function renderTopBar(overrides: { isDevBuild?: boolean; isOffline?: boolean } = {}) {
+function renderTopBar(
+  overrides: {
+    isDevBuild?: boolean;
+    isOffline?: boolean;
+    activeWorkspace?: Workspace;
+    activeSession?: SessionResponse | null;
+  } = {},
+) {
   return render(
     <TopBar
-      activeWorkspace={undefined}
-      activeSession={null}
+      activeWorkspace={overrides.activeWorkspace}
+      activeSession={overrides.activeSession ?? null}
       onToggleSidebar={vi.fn()}
       onOpenPalette={vi.fn()}
       onToggleDiff={vi.fn()}
@@ -52,6 +60,27 @@ describe("TopBar", () => {
     const { queryByLabelText, queryByText } = renderTopBar({ isDevBuild: false });
     expect(queryByLabelText("Debug build")).toBeNull();
     expect(queryByText("DEV")).toBeNull();
+  });
+
+  it("does not render the workspace/repo breadcrumb even with an active workspace and session", () => {
+    const workspace = {
+      id: "ws-1",
+      branch: null,
+      projectPath: "/home/user/breadcrumb-repo",
+      displayName: "breadcrumb-feature",
+      agents: [],
+      primaryAgent: "claude",
+      status: "idle",
+      sessions: [],
+    } as unknown as Workspace;
+    const { queryByText } = renderTopBar({
+      activeWorkspace: workspace,
+      activeSession: {} as SessionResponse,
+    });
+    // The old breadcrumb rendered the repo name (last path segment) and the
+    // workspace display name; both must be gone now that #1456 removed it.
+    expect(queryByText("breadcrumb-repo")).toBeNull();
+    expect(queryByText("breadcrumb-feature")).toBeNull();
   });
 
   it("renders the offline badge independent of the DEV badge", () => {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The top bar rendered an `aoe / repo / session` breadcrumb fragment that duplicated information the left sidebar already conveys: the active workspace and session row gets `bg-surface-850` plus a brand-coloured left border in `WorkspaceSidebar.tsx`. The crumb was redundant chrome.

This removes the breadcrumb block from `TopBar.tsx` along with the `repoName` derivation that only fed it. The `aoe` brand pill (dashboard home link) stays. The `activeWorkspace` prop is kept because the diff-toggle button still reads it, so `App.tsx` needs no change.

Edge case noted in the issue: when the sidebar is collapsed there is no top-bar "you are here" hint. That is accepted as sidebar-only per the issue; users open the sidebar to see the active session. No fallback crumb is added.

A Vitest regression in `TopBar.test.tsx` asserts the breadcrumb stays gone even when an active workspace and session are passed; it fails on the pre-removal tree and passes after.

Closes #1456

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: copy/chrome removal only; covered by a Vitest regression in `web/src/components/__tests__/TopBar.test.tsx`. The existing mocked Playwright `web/tests/top-bar.spec.ts` never asserted the breadcrumb, and `TopBar.tsx` is already tracked in `coverage-matrix.json`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] Open the web dashboard with an active workspace and session selected; confirm the top bar shows only the `aoe` brand pill on the left, no `/ repo / session` text.
- [ ] Resize the viewport from mobile to 1440px wide; confirm the palette pill stays centered and the breadcrumb never reappears at any width.
- [ ] Confirm the diff-toggle button still appears in the right zone when a session is active.
- [ ] Confirm the active workspace/session is still identifiable from the sidebar active-row highlight.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed the diff, and confirmed the regression test goes red before the fix and green after.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR removes a redundant breadcrumb from the top navigation bar that was showing the current workspace and repository path (displayed as "aoe / repo / session"). This functionality was already indicated visually by the left sidebar's active-row highlight, making the top-bar breadcrumb unnecessary.

## What Was Removed

- **Breadcrumb rendering section** from the TopBar component that displayed the workspace, repository, and session path
- **repoName calculation** that derived the repository name from the workspace's project path, which was only used by the removed breadcrumb

## What Was Kept

- The "aoe" brand pill (the dashboard home link) remains in the header
- The `activeWorkspace` prop, which is still needed by the diff-toggle button functionality elsewhere in the component
- All other layout elements and styling remain unchanged

## What Was Added

- A regression test in TopBar.test.tsx that verifies the breadcrumb is no longer rendered
- Updated test helper to accept more flexible workspace and session configuration for better test coverage

## Trade-offs

The PR accepts an edge case where users with a collapsed sidebar will have no visual "you are here" indicator in the top bar. This is a deliberate choice to simplify the UI and eliminate duplication.

## Benefits

- **Eliminates UI redundancy**: Removes duplicate navigation context already provided by the sidebar
- **Cleaner header**: Simplifies the top bar layout by removing the multi-level breadcrumb
- **Reduced complexity**: Removes unused repoName derivation logic
- **Improved maintainability**: Less code to maintain in the TopBar component
- **Test coverage**: Adds regression tests to prevent accidental re-introduction of the breadcrumb

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->