### PR TITLE
fix(cockpit): make failed tool cards foldable after auto-open

### DIFF
--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -407,4 +407,54 @@ describe("ToolCards failed-card folding (#1467)", () => {
     );
     expect(container.textContent).not.toContain("tool failed");
   });
+
+  // The MemoryRecall and Schedule cards previously gated their toggle on
+  // `hasBody` alone, so a failed card with no normal body had an
+  // unclickable header. They now include `status === "err"` in the
+  // predicate; exercise each failed-and-foldable so that branch (and the
+  // shared hook call site) stays covered.
+  const errToggleKinds: Array<[string, () => unknown]> = [
+    ["memoryRecall", () => fixtures.memoryRecallList],
+    ["scheduleWakeup", () => fixtures.scheduleWakeup],
+  ];
+
+  it.each(errToggleKinds)(
+    "auto-opens and folds a failed %s card",
+    (_label, getTool) => {
+      const { container, getAllByRole } = render(
+        <Wrap toolKey="claude">
+          <ToolCard
+            tool={getTool() as never}
+            result={makeError({ text: "kind-specific boom" })}
+          />
+        </Wrap>,
+      );
+      // Auto-open on failure: the rose error block is visible with no click.
+      expect(container.textContent).toContain("tool failed");
+      // The header is the card's first button; clicking it folds the body.
+      fireEvent.click(getAllByRole("button")[0]);
+      expect(container.textContent).not.toContain("tool failed");
+    },
+  );
+
+  it("auto-opens and folds a failed memory-file card", () => {
+    // A Read on a path under Claude's per-project memory dir dispatches
+    // to the dedicated MemoryCard, which shares the same hook.
+    const tool = makeToolCall({
+      id: "mem-1",
+      name: "Read",
+      kind: "read",
+      args_preview: JSON.stringify({
+        file_path: "/Users/test/.claude/projects/foo/memory/feedback_testing.md",
+      }),
+    });
+    const { container, getAllByRole } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={tool} result={makeError({ text: "memory read boom" })} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("tool failed");
+    fireEvent.click(getAllByRole("button")[0]);
+    expect(container.textContent).not.toContain("tool failed");
+  });
 });

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -313,3 +313,98 @@ describe("ToolCards MCP", () => {
     expect(container.textContent?.toLowerCase()).toContain("send message");
   });
 });
+
+// #1467: failed tool cards auto-open on failure but must stay foldable.
+// Before the fix the card was hard-wired `expanded={open || status ===
+// "err"}`, so the chevron rotated but never collapsed the body.
+describe("ToolCards failed-card folding (#1467)", () => {
+  it("renders the error body on first paint for a failed card", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeError({ text: "boom: command failed" })}
+        />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("tool failed");
+    expect(container.textContent).toContain("boom: command failed");
+  });
+
+  it("folds the error body when the chevron is clicked", () => {
+    const { container, getByRole } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeError({ text: "boom: command failed" })}
+        />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("tool failed");
+    fireEvent.click(getByRole("button"));
+    expect(container.textContent).not.toContain("tool failed");
+    expect(container.textContent).not.toContain("boom: command failed");
+    // Clicking again re-expands.
+    fireEvent.click(getByRole("button"));
+    expect(container.textContent).toContain("tool failed");
+  });
+
+  it("keeps a successful card collapsed by default", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeCompletion({ text: "hello world\n" })}
+        />
+      </Wrap>,
+    );
+    // Header is present, body output is hidden until the user expands.
+    expect(container.textContent).toContain("bash");
+    expect(container.textContent).not.toContain("hello world");
+  });
+
+  it("auto-opens a card that fails mid-stream (running -> err)", () => {
+    const { container, rerender } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.bash} result={undefined} />
+      </Wrap>,
+    );
+    // Running: no error body yet.
+    expect(container.textContent).not.toContain("tool failed");
+    rerender(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeError({ text: "boom: command failed" })}
+        />
+      </Wrap>,
+    );
+    // The error row arrives and the card opens with no user click.
+    expect(container.textContent).toContain("tool failed");
+    expect(container.textContent).toContain("boom: command failed");
+  });
+
+  it("respects the user's fold once set, even if the card re-enters err", () => {
+    const { container, getByRole, rerender } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeError({ text: "boom: command failed" })}
+        />
+      </Wrap>,
+    );
+    // User folds the failed card.
+    fireEvent.click(getByRole("button"));
+    expect(container.textContent).not.toContain("tool failed");
+    // A later render still reports err: the card stays folded.
+    rerender(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeError({ text: "boom again" })}
+        />
+      </Wrap>,
+    );
+    expect(container.textContent).not.toContain("tool failed");
+  });
+});

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -8,11 +8,13 @@
 // header and put output in a syntax-highlighted body.
 
 import {
+  useCallback,
   useEffect,
   useMemo,
   useState,
   type CSSProperties,
   type ReactNode,
+  type SetStateAction,
 } from "react";
 import {
   Brain,
@@ -235,6 +237,30 @@ type Status = "running" | "ok" | "err";
 function statusFor(result?: ActivityRow): Status {
   if (!result) return "running";
   return result.kind === "tool_error" ? "err" : "ok";
+}
+
+// Per-card expand state for tool cards. Failed cards auto-open so the
+// user sees the error immediately, but the chevron must still fold them
+// once read. We model the user's choice as a nullable override: while
+// it is null we derive openness from the current props
+// (`status === "err" || defaultOpen`), so both a replayed already-failed
+// card (mounts as err) and a live card that fails mid-stream
+// (running -> err) open during render with no effect and no one-frame
+// collapse flash. The first user toggle pins `userOpen` and is respected
+// from then on, even if the card later re-enters err. See #1467.
+function useToolCardExpansion(status: Status, defaultOpen = false) {
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+  const open = userOpen ?? (status === "err" || defaultOpen);
+  const setOpen = useCallback(
+    (action: SetStateAction<boolean>) => {
+      setUserOpen((prev) => {
+        const current = prev ?? (status === "err" || defaultOpen);
+        return typeof action === "function" ? action(current) : action;
+      });
+    },
+    [status, defaultOpen],
+  );
+  return [open, setOpen] as const;
 }
 
 function StatusDot({ status, neutral }: { status: Status; neutral?: boolean }) {
@@ -601,7 +627,7 @@ function ExecuteToolCard({ tool, result }: Props) {
   const command = pickFirst(argCommand, title, tool.name) ?? "(no command)";
   const description = pickStr(args, "description");
   const output = result?.text ?? "";
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
 
   const meta =
     output && status !== "running" ? (
@@ -662,7 +688,7 @@ function ReadToolCard({ tool, result }: Props) {
   const range = formatRange(args);
   const ext = argPath?.match(/\.([a-z0-9]+)$/i)?.[1]?.toLowerCase();
   const content = result?.text ?? "";
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
 
   const meta = content && (
     <span className="hidden md:inline text-[11px] text-text-dim">
@@ -684,7 +710,7 @@ function ReadToolCard({ tool, result }: Props) {
           {meta}
         </>
       }
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={
         status === "err" || content ? () => setOpen((v) => !v) : undefined
       }
@@ -720,7 +746,7 @@ function EditToolCard({ tool, result }: Props) {
   const oldText = pickStr(args, "old_string", "oldString", "old_str") ?? "";
   const newText =
     pickStr(args, "new_string", "newString", "new_str", "content") ?? "";
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
   const hasDiff = oldText !== "" || newText !== "";
   const verb = oldText ? "edit" : "write";
 
@@ -748,7 +774,7 @@ function EditToolCard({ tool, result }: Props) {
       label={verb}
       primary={path}
       meta={errorChip ? undefined : meta}
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={
         status === "err" || hasDiff ? () => setOpen((v) => !v) : undefined
       }
@@ -777,7 +803,7 @@ function DeleteToolCard({ tool, result }: Props) {
   const argPath = pickStr(args, "path", "file_path", "filePath", "filename");
   const title = pickStr(args, "_aoe_title");
   const path = pickFirst(argPath, title, tool.name) ?? "(unknown file)";
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
   return (
     <CardChrome
       status={status}
@@ -786,7 +812,7 @@ function DeleteToolCard({ tool, result }: Props) {
       icon={<Trash2 className="h-3.5 w-3.5 text-rose-400" />}
       label="delete"
       primary={path}
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={status === "err" ? () => setOpen((v) => !v) : undefined}
       body={
         status === "err" ? (
@@ -819,7 +845,7 @@ function SearchToolCard({ tool, result, provenance }: SearchProps) {
   const path = pickStr(args, "path", "directory", "scope");
   const output = result?.text ?? "";
   const lines = output ? output.split("\n").filter(Boolean) : [];
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
 
   return (
     <CardChrome
@@ -843,7 +869,7 @@ function SearchToolCard({ tool, result, provenance }: SearchProps) {
           )}
         </>
       }
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={
         status === "err" || lines.length > 0 ? () => setOpen((v) => !v) : undefined
       }
@@ -887,7 +913,7 @@ function FetchToolCard({ tool, result }: Props) {
   const title = pickStr(args, "_aoe_title");
   const url = pickFirst(argUrl, title, tool.name) ?? "(no url)";
   const output = result?.text ?? "";
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
 
   return (
     <CardChrome
@@ -897,7 +923,7 @@ function FetchToolCard({ tool, result }: Props) {
       icon={<Globe className="h-3.5 w-3.5" />}
       label="fetch"
       primary={url}
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={
         status === "err" || output ? () => setOpen((v) => !v) : undefined
       }
@@ -1043,7 +1069,7 @@ function TodoList({ todos }: { todos: TodoItem[] }) {
 function TodoUpdateCard({ tool, result, todos }: TodoCardProps) {
   const status = statusFor(result);
   const counts = useMemo(() => todoCounts(todos), [todos]);
-  const [open, setOpen] = useState(todos.length <= 5);
+  const [open, setOpen] = useToolCardExpansion(status, todos.length <= 5);
   const breakdown = todoBreakdown(counts);
 
   return (
@@ -1059,7 +1085,7 @@ function TodoUpdateCard({ tool, result, todos }: TodoCardProps) {
           )}
         </>
       }
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={() => setOpen((v) => !v)}
       startedAt={tool.started_at}
       endedAt={result?.at}
@@ -1199,7 +1225,7 @@ interface SkillProps extends Props {
 
 function SkillToolCard({ tool, result, skillName }: SkillProps) {
   const status = statusFor(result);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
   // Memo on the raw string so downstream memos see a stable args reference
   // and don't recompute every render.
   const args = useMemo(
@@ -1228,7 +1254,7 @@ function SkillToolCard({ tool, result, skillName }: SkillProps) {
       icon={<Sparkles className="h-3.5 w-3.5" />}
       label="skill"
       primary={skillName}
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={
         status === "err" || hasBody ? () => setOpen((v) => !v) : undefined
       }
@@ -1488,7 +1514,7 @@ interface McpProps extends Props {
 
 function McpToolCard({ tool, result, server, verb }: McpProps) {
   const status = statusFor(result);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
   // Memo on the raw string so downstream memos see a stable args reference
   // and don't recompute every render.
   const args = useMemo(
@@ -1542,7 +1568,7 @@ function McpToolCard({ tool, result, server, verb }: McpProps) {
           )}
         </>
       }
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={
         status === "err" || hasBody ? () => setOpen((v) => !v) : undefined
       }
@@ -1581,7 +1607,7 @@ interface MemoryCardProps extends Props {
  *  classifyMemory and render here. See issue #1071. */
 function MemoryCard({ tool, result, hit }: MemoryCardProps) {
   const status = statusFor(result);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
 
   const args = useMemo(
     () => parseJsonObject(tool.args_preview),
@@ -1627,7 +1653,7 @@ function MemoryCard({ tool, result, hit }: MemoryCardProps) {
         </>
       }
       meta={meta}
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={
         status === "err" || hasBody ? () => setOpen((v) => !v) : undefined
       }
@@ -1694,7 +1720,7 @@ function MemoryCard({ tool, result, hit }: MemoryCardProps) {
 function MemoryRecallCard({ tool, result }: Props) {
   const status = statusFor(result);
   const recall = tool.memory_recall;
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
 
   if (!recall) {
     // Defensive: dispatcher only enters this branch when memory_recall
@@ -1726,8 +1752,10 @@ function MemoryRecallCard({ tool, result }: Props) {
       icon={<Brain className="h-3.5 w-3.5" />}
       label="Memory recall"
       primary={primary}
-      expanded={open || status === "err"}
-      onToggle={hasBody ? () => setOpen((v) => !v) : undefined}
+      expanded={open}
+      onToggle={
+        status === "err" || hasBody ? () => setOpen((v) => !v) : undefined
+      }
       body={
         <ToolErrorBody status={status} errorText={result?.text}>
           {status !== "err" && hasBody ? (
@@ -1832,7 +1860,7 @@ interface ScheduleProps extends Props {
 
 function ScheduleToolCard({ tool, result, kind }: ScheduleProps) {
   const status = statusFor(result);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
   const args = useMemo(
     () => parseJsonObject(tool.args_preview),
     [tool.args_preview],
@@ -1937,8 +1965,10 @@ function ScheduleToolCard({ tool, result, kind }: ScheduleProps) {
       label={label}
       primary={primary}
       meta={meta}
-      expanded={open || status === "err"}
-      onToggle={hasBody ? () => setOpen((v) => !v) : undefined}
+      expanded={open}
+      onToggle={
+        status === "err" || hasBody ? () => setOpen((v) => !v) : undefined
+      }
       startedAt={tool.started_at}
       endedAt={result?.at}
       body={
@@ -1975,7 +2005,7 @@ function ScheduleToolCard({ tool, result, kind }: ScheduleProps) {
 
 function GenericToolCard({ tool, result }: Props) {
   const status = statusFor(result);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useToolCardExpansion(status);
   const output = result?.text ?? "";
   return (
     <CardChrome
@@ -1985,7 +2015,7 @@ function GenericToolCard({ tool, result }: Props) {
       icon={<Sparkles className="h-3.5 w-3.5" />}
       label={tool.kind || "tool"}
       primary={tool.name}
-      expanded={open || status === "err"}
+      expanded={open}
       onToggle={
         status === "err" || tool.args_preview || output
           ? () => setOpen((v) => !v)

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1982,6 +1982,18 @@
       ]
     },
     {
+      "id": "cockpit.story.fold-failed-tool-card",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/fold-failed-tool-card.spec.ts",
+        "src/components/cockpit/ToolCards.render.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/ToolCards.tsx"
+      ]
+    },
+    {
       "id": "cockpit.story.queue-follow-up-with-nav",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/cockpit-stories/fold-failed-tool-card.spec.ts
+++ b/web/tests/live/cockpit-stories/fold-failed-tool-card.spec.ts
@@ -1,0 +1,119 @@
+// User story (#1467): a failed tool card auto-opens so the error is
+// visible, but the header chevron must still fold it once the user has
+// read it.
+//
+// The fake ACP agent emits a tool_call (pending) to render the card,
+// then a tool_call_update with status "failed" carrying the error text.
+// `src/cockpit/acp_client.rs` maps the failed update to a tool_error row,
+// so the web `statusFor` resolves to "err" and the card opens on its own.
+// Clicking the header collapses the rose error block; clicking again
+// re-expands it.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import {
+  waitForCockpitView,
+  enableCockpitAndWait,
+  attachServeDiagnostics,
+} from "../../helpers/cockpit";
+
+const ERROR_TEXT = "boom: the command exploded";
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-fail-1",
+          title: "rm -rf /nope",
+          kind: "execute",
+          status: "pending",
+          rawInput: { command: "rm -rf /nope" },
+        },
+        {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tc-fail-1",
+          status: "failed",
+          content: [
+            {
+              type: "content",
+              content: { type: "text", text: ERROR_TEXT },
+            },
+          ],
+        },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("failed tool card auto-opens and folds via the chevron", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-fold-fail-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-fold-fail" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-fold-fail");
+    if (!seeded) throw new Error("seeded session 'story-fold-fail' missing");
+    const sessionId = seeded.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("run the failing command");
+    await composer.press("Enter");
+
+    // The failed card auto-opens: both the rose "tool failed" label and
+    // the error text are visible without any user interaction.
+    const errorText = page.getByText(ERROR_TEXT);
+    await expect(errorText).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("tool failed")).toBeVisible();
+
+    // The card header is the only button carrying the "failed" status
+    // badge; clicking it folds the body.
+    const cardHeader = page
+      .getByRole("button")
+      .filter({ hasText: /failed/i })
+      .first();
+    await cardHeader.click();
+    await expect(errorText).toBeHidden({ timeout: 10_000 });
+
+    // Clicking again re-expands it.
+    await cardHeader.click();
+    await expect(errorText).toBeVisible({ timeout: 10_000 });
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the web cockpit transcript, failed tool cards were hard-wired `expanded={open || status === "err"}`. The header chevron rotated on click but the body never collapsed, so once a tool call failed the card stayed fully unfurled (rose error block plus the "Show attempted action" details) for the lifetime of the transcript. On a long run with many failed Edits / Reads / Bash / MCP calls, the user had no way to compact the noise after reading each failure.

This restores the chevron. A new shared `useToolCardExpansion(status, defaultOpen)` hook models the user's choice as a nullable override: while it is unset, openness is derived from the current props (`status === "err" || defaultOpen`), so a failed card still auto-opens immediately, whether it was replayed already-failed or fails live mid-stream (running to err). The first user toggle pins the state and is respected from then on, even if the card later re-enters err. The pattern derives during render, so there is no effect and no one-frame collapse flash on a live failure.

The hook replaces the per-card `useState(false)` on all 13 leaf cards. That includes bash / Execute, which previously never auto-opened on error (it alone used `expanded={open}` without the err fallback); it now behaves consistently with every other leaf card. Two cards whose toggle predicate gated only on `hasBody` (MemoryRecall, Schedule) now also include `status === "err"`, so a failed card with no normal body still has a clickable header. Group and subagent cards keep `expanded={open}` and are unchanged.

This is a render-only change: no backend, protocol, settings, or migration. No `docs/` page advertised the auto-expand behavior, so no docs change is needed.

Closes #1467

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the cockpit, run a tool call that fails (e.g. a Bash command with a non-zero exit, or an Edit on an unread file). Confirm the card opens by default with the rose error block visible.
- [ ] Click the card's header chevron. Confirm the rose error block and the "Show attempted action" details collapse, while the header status dot and "failed" badge stay.
- [ ] Click the chevron again. Confirm the body re-expands.
- [ ] Trigger a tool that is in flight and then fails (watch a running tool turn into an error). Confirm the card auto-opens the moment the error arrives, with no manual click.
- [ ] Fold a failed card, then let the same tool report an error again. Confirm it stays folded (your last toggle is respected).
- [ ] Confirm a successful tool card still renders collapsed by default, and a todos card with a short list still opens by default.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. The approach was pressure-tested with a multi-model debate; I made the design calls (land the fix alone with no new setting, include the bash card for consistency, use the derived-override hook) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR fixes a UX bug so failed tool-call cards in the Cockpit UI auto-open on first render but remain foldable afterward. Previously cards used expanded={open || status === "err"}, which forced error cards open and prevented the header chevron from collapsing them. The change centralizes expansion logic in a shared hook so user toggles persist and headers stay interactive for error states.

What changed, at a glance:
- Added a shared hook useToolCardExpansion(status, defaultOpen?) that derives openness from status and default only until the user toggles—after the first toggle the user's choice is pinned.
- Replaced per-card useState open handling on ~13 leaf tool-card variants with the hook (bash/execute, read/edit/write, delete, search, fetch, todo update, skill, MCP, memory, memory-recall, schedule, generic fallback).
- Adjusted toggle logic for memory-recall and schedule so headers remain clickable when status === "err".
- Added/updated tests: a Playwright live story to exercise auto-open + fold behavior and Vitest render tests covering initial auto-open, chevron collapse/expand, mid-stream errors, and user-pinned collapse persistence.
- Updated coverage-matrix.json to include the new live-playwright surface.

Benefits
- Restores expected user control: users can collapse error cards and keep them collapsed even if the card later reports err.
- Consistent behavior across card types (bash/execute now matches other leaf cards).
- No backend, protocol, settings, or migrations required—backward compatible and non-breaking.
- Tests added to protect regression and cover live interaction.

Potential future enhancements
- Expose a persistent preference (e.g., cockpit.auto_expand_failed_tool_calls) so initial auto-open behavior can be configured per user; currently out of scope.

---

Technical details

Implementation approach
- useToolCardExpansion(status, defaultOpen?) implements a two-phase model: derived openness (status === "err" || defaultOpen) while no user interaction has occurred, then a pinned override after the first user toggle. The derived value is computed during render (avoids flashes), and setOpen accepts boolean or functional updates.

Files touched (high-level)
- web/src/components/cockpit/ToolCards.tsx — adds the hook and replaces ~13 per-card useState usages; simplifies expanded prop usage to expanded={open}.
- web/src/components/cockpit/ToolCards.render.test.tsx — new/extended Vitest suite validating failed-card folding behavior.
- web/tests/live/cockpit-stories/fold-failed-tool-card.spec.ts — Playwright live test for auto-open, fold, and re-expand.
- web/tests/coverage-matrix.json — adds coverage entry for the new live story.

No public API, backend, or migration changes were made.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->