### PR TITLE
fix(cockpit): preserve single newlines in sent user messages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
             pname = "agent-of-empires-web";
             version = "0";
             src = ./web;
-            npmDepsHash = "sha256-ENXpt7VIxLJHc+V26Qub3WlE8tQQ8Sq/5R/Gycm1ghA=";
+            npmDepsHash = "sha256-0kDf8uOE1H7+f6/hZIZgjsav7dtWvj4G2q3dDCCusWU=";
             # tsc -b && vite build; output goes to web/dist
             installPhase = ''
               mkdir $out

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.2",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.0.2",
         "tailwindcss": "^4.2.2"
@@ -35,7 +36,7 @@
         "@playwright/test": "^1.59.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "^25.9.1",
+        "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -9093,6 +9094,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -10630,6 +10645,21 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/remark-gfm": {
       "version": "4.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -33,6 +33,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.2",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.0.2",
     "tailwindcss": "^4.2.2"

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -505,9 +505,12 @@ function UserText({ text }: { text: string }) {
   // fenced code blocks render with syntax highlighting instead of
   // literal backticks. Smooth-reveal is off because user prompts arrive
   // complete; the pacing only matters for streamed agent tokens. See #1108.
+  // `breaks` is on because the composer is a plain <textarea>: a single
+  // shift+enter shows as a visible line break while typing, so the sent
+  // bubble must preserve that layout instead of collapsing it. See #1472.
   return (
     <div className="max-w-[80%] min-w-0 rounded-2xl rounded-br-sm border border-surface-700 bg-surface-800/70 px-3 py-1.5 text-sm">
-      <Markdown text={text} smooth={false} />
+      <Markdown text={text} smooth={false} breaks />
     </div>
   );
 }

--- a/web/src/components/cockpit/Markdown.breaks.test.tsx
+++ b/web/src/components/cockpit/Markdown.breaks.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+//
+// Rendering semantics for #1472. The cockpit Markdown wrapper delegates
+// the markdown -> HTML transform to @assistant-ui/react-markdown's
+// MarkdownTextPrimitive, which needs a deep assistant-ui runtime context
+// to mount and so cannot render standalone in jsdom (see Markdown.test.tsx,
+// which mocks the primitive and asserts the wrapper config instead).
+//
+// To exercise the actual line-break behaviour deterministically we render
+// the SAME remark plugin chain the component mounts (`remarkPluginsFor`)
+// through react-markdown, the engine the primitive wraps. The
+// breaks=false vs breaks=true contrast is the regression: with the old
+// chain a single newline collapses to whitespace; with remark-breaks it
+// becomes a <br>.
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import ReactMarkdown from "react-markdown";
+
+import { remarkPluginsFor } from "./Markdown";
+
+function renderMd(text: string, breaks: boolean) {
+  return render(
+    <ReactMarkdown remarkPlugins={remarkPluginsFor(breaks)}>
+      {text}
+    </ReactMarkdown>,
+  );
+}
+
+describe("remarkPluginsFor rendering (#1472)", () => {
+  it("collapses single newlines to whitespace without breaks (assistant default)", () => {
+    const { container } = renderMd("line a\nline b\nline c", false);
+    expect(container.querySelectorAll("br")).toHaveLength(0);
+    expect(container.querySelectorAll("p")).toHaveLength(1);
+  });
+
+  it("renders single newlines as <br> when breaks is enabled (user prompt)", () => {
+    const { container } = renderMd("line a\nline b\nline c", true);
+    expect(container.querySelectorAll("br")).toHaveLength(2);
+    expect(container.textContent).toContain("line a");
+    expect(container.textContent).toContain("line b");
+    expect(container.textContent).toContain("line c");
+  });
+
+  it("renders a blank line as a paragraph break when breaks is enabled", () => {
+    const { container } = renderMd("para one\n\npara two", true);
+    const paragraphs = container.querySelectorAll("p");
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs[0]?.textContent).toContain("para one");
+    expect(paragraphs[1]?.textContent).toContain("para two");
+    expect(container.querySelectorAll("br")).toHaveLength(0);
+  });
+
+  it("leaves fenced code blocks intact when breaks is enabled", () => {
+    const { container } = renderMd(
+      "```ts\nconst a = 1;\nconst b = 2;\n```",
+      true,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain("const a = 1;");
+    expect(pre?.textContent).toContain("const b = 2;");
+    // The newlines inside the code block must not become <br> nodes.
+    expect(container.querySelectorAll("pre br")).toHaveLength(0);
+    // And the fences themselves are absorbed, not rendered as literal text.
+    expect(container.textContent).not.toContain("```");
+  });
+});

--- a/web/src/components/cockpit/Markdown.test.tsx
+++ b/web/src/components/cockpit/Markdown.test.tsx
@@ -16,6 +16,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render } from "@testing-library/react";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
 vi.mock("../../hooks/useShikiTheme", () => ({
@@ -90,6 +91,16 @@ describe("Markdown wrapper config", () => {
   it("registers remark-gfm in the plugin list", () => {
     render(<Markdown text="x" />);
     expect(primitiveCalls[0]!.remarkPlugins).toContain(remarkGfm);
+  });
+
+  // #1472: user prompts opt into hard line breaks so the sent bubble
+  // matches the plain-textarea composer; assistant text leaves it off.
+  it("adds remark-breaks only when breaks is enabled", () => {
+    render(<Markdown text="x" breaks />);
+    render(<Markdown text="y" />);
+    expect(primitiveCalls[0]!.remarkPlugins).toContain(remarkBreaks);
+    expect(primitiveCalls[0]!.remarkPlugins).toContain(remarkGfm);
+    expect(primitiveCalls[1]!.remarkPlugins).not.toContain(remarkBreaks);
   });
 
   it("registers cockpit-specific component overrides", () => {

--- a/web/src/components/cockpit/Markdown.tsx
+++ b/web/src/components/cockpit/Markdown.tsx
@@ -18,7 +18,8 @@ import type {
   SyntaxHighlighterProps,
 } from "@assistant-ui/react-markdown";
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
 import {
@@ -40,18 +41,36 @@ interface Props {
    *  whose runtime status is `running`) should pass `smooth={true}`.
    *  See #1132. */
   smooth?: boolean;
+  /** Treat a single newline as a hard line break (remark-breaks). The
+   *  cockpit composer is a plain <textarea>, so a lone shift+enter shows
+   *  as a visible break while typing; enabling this keeps the sent user
+   *  bubble matching that layout. Default off so assistant text keeps
+   *  CommonMark soft-break semantics: model-authored markdown is often
+   *  hard-wrapped and streamed, and turning every wrap into a <br> would
+   *  add jarring mid-sentence breaks and streaming reflow. See #1472. */
+  breaks?: boolean;
+}
+
+/** remark plugin chain for the cockpit markdown surface. `breaks` opts
+ *  single newlines into hard <br> breaks; see the `breaks` prop on
+ *  {@link Markdown}. Exported so the regression tests exercise the exact
+ *  chain the component mounts. */
+export function remarkPluginsFor(breaks: boolean) {
+  return breaks ? [remarkGfm, remarkBreaks] : [remarkGfm];
 }
 
 /**
  * Render markdown text. Used for both assistant chunks and user
- * prompts; the smoothing pace is the only knob exposed.
+ * prompts; the smoothing pace and single-newline handling are the knobs
+ * exposed.
  */
-export function Markdown({ text, smooth = false }: Props) {
+export function Markdown({ text, smooth = false, breaks = false }: Props) {
+  const remarkPlugins = useMemo(() => remarkPluginsFor(breaks), [breaks]);
   return (
     <MarkdownTextPrimitive
       preprocess={() => text}
       smooth={smooth}
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={remarkPlugins}
       className="cockpit-markdown text-sm leading-relaxed"
       components={{
         SyntaxHighlighter: ShikiSyntaxHighlighter,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1006,6 +1006,18 @@
       ]
     },
     {
+      "id": "cockpit.story.composer-single-newline",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/composer-single-newline-renders.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx",
+        "web/src/components/cockpit/Markdown.tsx"
+      ]
+    },
+    {
       "id": "cockpit.tool-cards",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -998,7 +998,8 @@
       "kind": "vitest",
       "risk": "high",
       "specs": [
-        "src/components/cockpit/Markdown.test.tsx"
+        "src/components/cockpit/Markdown.test.tsx",
+        "src/components/cockpit/Markdown.breaks.test.tsx"
       ],
       "components": [
         "web/src/components/cockpit/Markdown.tsx"

--- a/web/tests/live/cockpit-stories/composer-single-newline-renders.spec.ts
+++ b/web/tests/live/cockpit-stories/composer-single-newline-renders.spec.ts
@@ -1,0 +1,58 @@
+// User story (#1472): a single newline in the composer is preserved in
+// the sent user message.
+//
+// The composer is a plain <textarea>, so a lone shift+enter shows as a
+// visible line break while typing. Before the fix the sent bubble ran
+// through remark-gfm only and collapsed single newlines to whitespace.
+// This drives the real cockpit render path (Markdown.tsx -> UserText
+// with breaks enabled): type three lines separated by single newlines,
+// send, and assert the rendered user bubble keeps them on separate rows
+// (two <br> nodes), not one wrapped paragraph.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+
+base("single newlines in a user message render as line breaks", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-single-newline" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-single-newline");
+    if (!seeded) throw new Error("seeded session 'story-single-newline' missing");
+    const sessionId = seeded.id;
+
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    // fill() sets the textarea value verbatim, including the newlines a
+    // shift+enter would have inserted; Enter then sends the whole thing.
+    await composer.fill("line a\nline b\nline c");
+    await composer.press("Enter");
+
+    // The sent user bubble (rounded-br-sm, right-aligned) must preserve
+    // the three lines as separate rows: two hard breaks between them.
+    const userBubble = page
+      .locator("div.rounded-br-sm")
+      .filter({ hasText: "line a" });
+    await expect(userBubble).toBeVisible({ timeout: 10_000 });
+    await expect(userBubble.locator("br")).toHaveCount(2);
+    await expect(userBubble).toContainText("line b");
+    await expect(userBubble).toContainText("line c");
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The cockpit composer is a plain `<textarea>`, so a single newline (shift+enter) shows as a visible line break while typing. After sending, the rendered user bubble collapsed that single newline to whitespace: it ran through `remark-gfm` only, where CommonMark soft-break semantics treat a lone `\n` inside a paragraph as whitespace and only a blank line starts a new paragraph. The composer and the sent message disagreed on what a newline meant, so users had to relearn that they needed blank lines to break.

This adds `remark-breaks` behind a new per-caller `breaks` prop on the shared `Markdown` component and turns it on for `UserText` only. User prompts now round-trip the line layout the composer showed. Assistant text keeps the prop off (default), so model-authored markdown, which is often hard-wrapped at a column width and streamed token by token, is unaffected: no jarring mid-sentence `<br>`, no streaming reflow as partial lines arrive. This was the deciding point against enabling `remark-breaks` globally. The plugin chain is exported as `remarkPluginsFor` so the regression tests exercise the exact chain the component mounts.

This aligns the cockpit message surface with the diff-comments surface, which already renders single newlines as hard breaks (`marked({ breaks: true })`).

Closes #1472

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the cockpit composer, type three short lines separated by single shift+enters, send, and confirm the user bubble shows three visually separated lines.
- [ ] Type two paragraphs separated by a blank line, send, and confirm the bubble shows two paragraph blocks.
- [ ] Paste a fenced code block into the composer, send, and confirm it renders as a highlighted code block (fences absorbed, not literal backticks).
- [ ] Confirm assistant replies are unchanged: a model message with a single mid-paragraph newline still soft-wraps into one paragraph (no new line break).

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Coverage spans both layers, and `web/tests/coverage-matrix.json` was updated (`cockpit.markdown` plus a new `cockpit.story.composer-single-newline`):

- Live Playwright (`tests/live/cockpit-stories/composer-single-newline-renders.spec.ts`): types three lines separated by single newlines, sends, and asserts the rendered user bubble keeps them on separate rows (two `<br>`). Drives the real `CockpitView.UserText` to `Markdown` render path end to end.
- Vitest: `@assistant-ui/react-markdown`'s `MarkdownTextPrimitive` needs a deep assistant-ui runtime context and cannot render standalone in jsdom, so `Markdown.test.tsx` (mocked primitive) asserts the wrapper wires `remark-breaks` only when `breaks` is set, and `Markdown.breaks.test.tsx` renders the exact `remarkPluginsFor` chain through `react-markdown`, the engine the primitive wraps, to assert the three user stories: single `\n` to `<br>`, blank line to two paragraphs, fenced code block left intact. The `breaks=false` vs `breaks=true` contrast is the regression that would have caught this bug.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, the A-vs-B design debate, and implementation were drafted by Claude under my direction. I made the design call (per-caller prop, not global), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a user experience issue where single newlines typed in the cockpit composer (using Shift+Enter) were being collapsed to whitespace in the rendered chat messages, misaligning the display between what users typed and what appeared in the conversation. The fix preserves line breaks in user-sent messages while keeping the rendering behavior unchanged for assistant-generated content.

## What Changed

**Added:**
- New `remark-breaks` npm dependency to enable hard line break rendering
- `breaks` prop to the `Markdown` component to conditionally enable the line-break behavior
- `remarkPluginsFor` exported helper function that builds the plugin chain based on the `breaks` flag
- Comprehensive test coverage: 
  - Playwright end-to-end test verifying the full composer → sent message flow
  - Vitest unit tests validating the plugin chain behavior
  - Assertion tests for the `Markdown` component's `breaks` prop wiring

**Modified:**
- `UserText` rendering in `CockpitView.tsx` to enable `breaks=true` when rendering user messages
- `Markdown.tsx` component signature and implementation to support the `breaks` configuration
- CI coverage matrix to include the new test suite

**Updated:**
- `flake.nix` with new npm dependency hash

## Technical Details

The solution uses the `remark-breaks` plugin, which converts single newlines (`\n`) into hard line breaks (`<br>`) in HTML rendering. This differs from the CommonMark default (used by `remark-gfm`) which treats single newlines as soft breaks (rendered as whitespace).

The implementation:
- Exports `remarkPluginsFor(breaks: boolean)` to make the exact plugin chain testable
- Conditionally appends `remark-breaks` only when `breaks=true`
- Applies this only to `UserText` components, leaving assistant-rendered content unaffected
- Uses `useMemo` in the component to avoid unnecessary plugin chain rebuilds

## Benefits
- **Better UX**: User messages now render exactly as typed in the composer
- **Consistency**: Aligns with diff-comment rendering behavior (which already uses `breaks: true`)
- **Maintainability**: Isolated the change to user-text rendering, avoiding unintended effects on assistant/model content
- **Testability**: Exported plugin chain allows tests to exercise the exact rendering configuration used in production

## Testing
The PR includes three layers of test coverage:
1. **E2E test** (`composer-single-newline-renders.spec.ts`): Verifies the real user workflow from composer textarea to rendered message
2. **Unit tests** (`Markdown.breaks.test.tsx`): Validates plugin chain behavior and rendering output for single newlines, blank lines, and code blocks
3. **Component tests** (`Markdown.test.tsx`): Asserts the `Markdown` wrapper correctly wires the `remark-breaks` plugin

Resolves issue `#1472`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->