### PR TITLE
fix: horizontal scroll for long path inputs in TUI

### DIFF
--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -15,6 +15,7 @@ pub use dir_picker::{DirPicker, DirPickerResult};
 pub use help::HelpOverlay;
 pub use list_picker::{ListPicker, ListPickerResult};
 pub use preview::{format_scroll_indicator, Preview};
+pub(crate) use text_input::{focused_input_spans, input_scroll, visible_slice};
 pub use text_input::{
     longest_common_prefix, render_text_field, render_text_field_with_ghost,
     set_input_cursor_position, set_prefixed_input_cursor_position, GroupGhostCompletion,

--- a/src/tui/components/text_input.rs
+++ b/src/tui/components/text_input.rs
@@ -140,6 +140,7 @@ pub fn render_text_field(
 
 /// Like `render_text_field` but with optional ghost (autocomplete) text.
 /// If `ghost_text` is provided, it is rendered after the cursor in dimmed style.
+/// Supports horizontal scrolling when text exceeds available width.
 #[allow(clippy::too_many_arguments)]
 pub fn render_text_field_with_ghost(
     frame: &mut Frame,
@@ -163,6 +164,8 @@ pub fn render_text_field_with_ghost(
     };
 
     let value = input.value();
+    let prefix_width = label.width() + 1; // label + space
+    let available_width = area.width.saturating_sub(prefix_width as u16) as usize;
 
     let mut spans = vec![Span::styled(label, label_style), Span::raw(" ")];
 
@@ -171,30 +174,98 @@ pub fn render_text_field_with_ghost(
             spans.push(Span::styled(placeholder_text, value_style));
         }
     } else if is_focused {
+        let scroll = input.visual_scroll(available_width);
         let cursor_pos = input.cursor();
         let cursor_style = Style::default().fg(theme.background).bg(theme.accent);
 
-        // Split value into: before cursor, char at cursor, after cursor
-        let before: String = value.chars().take(cursor_pos).collect();
-        let cursor_char: String = value
-            .chars()
-            .nth(cursor_pos)
-            .map(|c| c.to_string())
-            .unwrap_or_else(|| " ".to_string());
-        let after: String = value.chars().skip(cursor_pos + 1).collect();
+        // Collect visible characters starting from scroll offset
+        let mut col = 0;
+        let mut visible_chars_start = 0;
+        for (i, c) in value.chars().enumerate() {
+            let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+            if col >= scroll {
+                break;
+            }
+            col += w;
+            visible_chars_start = i + 1;
+        }
 
-        if !before.is_empty() {
-            spans.push(Span::styled(before, value_style));
+        let mut visible_col = 0;
+        let mut visible_before = String::new();
+        let mut visible_cursor_char = String::new();
+        let mut visible_after = String::new();
+        let mut cursor_visible = false;
+        let mut chars_fit = true;
+
+        for (i, c) in value.chars().enumerate().skip(visible_chars_start) {
+            let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+            if visible_col + w > available_width {
+                chars_fit = false;
+                break;
+            }
+            if i < cursor_pos {
+                visible_before.push(c);
+            } else if i == cursor_pos {
+                visible_cursor_char = c.to_string();
+                cursor_visible = true;
+            } else {
+                visible_after.push(c);
+            }
+            visible_col += w;
         }
-        spans.push(Span::styled(cursor_char, cursor_style));
-        if !after.is_empty() {
-            spans.push(Span::styled(after, value_style));
+
+        // If cursor is at end (past last char), show space
+        if cursor_pos >= value.chars().count() && !cursor_visible && chars_fit {
+            visible_cursor_char = " ".to_string();
+            cursor_visible = true;
         }
+
+        if !visible_before.is_empty() {
+            spans.push(Span::styled(visible_before, value_style));
+        }
+        if cursor_visible {
+            spans.push(Span::styled(visible_cursor_char, cursor_style));
+        }
+        if !visible_after.is_empty() {
+            spans.push(Span::styled(visible_after, value_style));
+        }
+        // Only show ghost when end of input is visible
         if let Some(ghost) = ghost_text {
-            spans.push(Span::styled(ghost, Style::default().fg(theme.dimmed)));
+            let end_visible = value.chars().count() <= visible_chars_start || {
+                let mut col_check = 0;
+                for c in value.chars().skip(visible_chars_start) {
+                    col_check += unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+                }
+                col_check < available_width
+            };
+            if end_visible {
+                spans.push(Span::styled(ghost, Style::default().fg(theme.dimmed)));
+            }
         }
     } else {
-        spans.push(Span::styled(value, value_style));
+        // Non-focused: show visible portion of value
+        let scroll = input.visual_scroll(available_width);
+        let mut col = 0;
+        let mut visible_start = 0;
+        for (i, c) in value.chars().enumerate() {
+            let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+            if col >= scroll {
+                break;
+            }
+            col += w;
+            visible_start = i + 1;
+        }
+        let mut visible_col = 0;
+        let mut visible_value = String::new();
+        for c in value.chars().skip(visible_start) {
+            let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+            if visible_col + w > available_width {
+                break;
+            }
+            visible_value.push(c);
+            visible_col += w;
+        }
+        spans.push(Span::styled(visible_value, value_style));
     }
 
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
@@ -224,7 +295,12 @@ pub fn set_input_cursor_position(
         return;
     }
 
-    let cursor_col = prefix_width.saturating_add(input.visual_cursor());
+    let available_width = area.width.saturating_sub(prefix_width as u16) as usize;
+    let scroll = input.visual_scroll(available_width);
+    let visual_cursor = input.visual_cursor();
+    let visible_cursor = visual_cursor.saturating_sub(scroll);
+
+    let cursor_col = prefix_width.saturating_add(visible_cursor);
     let max_col = area.width.saturating_sub(1) as usize;
     let x = area.x.saturating_add(cursor_col.min(max_col) as u16);
     frame.set_cursor_position(Position::new(x, area.y));

--- a/src/tui/components/text_input.rs
+++ b/src/tui/components/text_input.rs
@@ -113,6 +113,112 @@ impl GroupGhostCompletion {
     }
 }
 
+fn char_width(c: char) -> usize {
+    unicode_width::UnicodeWidthChar::width(c).unwrap_or(0)
+}
+
+/// Finds the first char index to render given a horizontal scroll offset
+/// measured in display columns.
+fn visible_char_start(value: &str, scroll: usize) -> usize {
+    let mut col = 0;
+    let mut start = 0;
+    for (i, c) in value.chars().enumerate() {
+        if col >= scroll {
+            break;
+        }
+        col += char_width(c);
+        start = i + 1;
+    }
+    start
+}
+
+/// Builds the spans for a focused, horizontally-scrolled text input: the text
+/// before the cursor, a block-styled cursor cell, and the text after it.
+///
+/// Returns the spans plus whether the end of the input is within the viewport,
+/// which callers use to decide whether to append ghost (autocomplete) text.
+/// Pass `scroll` from `Input::visual_scroll(available_width.saturating_sub(1))`
+/// so the cursor cell always has a reserved column even at end of input.
+pub(crate) fn focused_input_spans(
+    value: &str,
+    cursor_pos: usize,
+    scroll: usize,
+    available_width: usize,
+    value_style: Style,
+    cursor_style: Style,
+) -> (Vec<Span<'static>>, bool) {
+    let visible_start = visible_char_start(value, scroll);
+
+    let mut visible_col = 0;
+    let mut before = String::new();
+    let mut cursor_char = String::new();
+    let mut after = String::new();
+    let mut cursor_visible = false;
+    let mut end_visible = true;
+
+    for (i, c) in value.chars().enumerate().skip(visible_start) {
+        let w = char_width(c);
+        if visible_col + w > available_width {
+            end_visible = false;
+            break;
+        }
+        if i < cursor_pos {
+            before.push(c);
+        } else if i == cursor_pos {
+            cursor_char = c.to_string();
+            cursor_visible = true;
+        } else {
+            after.push(c);
+        }
+        visible_col += w;
+    }
+
+    // Cursor sitting past the last char renders as a blank cell. The reserved
+    // column (see `scroll` note above) guarantees room for it.
+    if cursor_pos >= value.chars().count() && !cursor_visible {
+        cursor_char = " ".to_string();
+        cursor_visible = true;
+    }
+
+    let mut spans = Vec::new();
+    if !before.is_empty() {
+        spans.push(Span::styled(before, value_style));
+    }
+    if cursor_visible {
+        spans.push(Span::styled(cursor_char, cursor_style));
+    }
+    if !after.is_empty() {
+        spans.push(Span::styled(after, value_style));
+    }
+    (spans, end_visible)
+}
+
+/// Returns the visible substring of `value` for a non-focused (or cursor-less)
+/// input, clipped to `available_width` starting at `scroll`, plus whether the
+/// end of the input fit within the viewport.
+pub(crate) fn visible_slice(value: &str, scroll: usize, available_width: usize) -> (String, bool) {
+    let visible_start = visible_char_start(value, scroll);
+    let mut visible_col = 0;
+    let mut out = String::new();
+    let mut end_visible = true;
+    for c in value.chars().skip(visible_start) {
+        let w = char_width(c);
+        if visible_col + w > available_width {
+            end_visible = false;
+            break;
+        }
+        out.push(c);
+        visible_col += w;
+    }
+    (out, end_visible)
+}
+
+/// Horizontal scroll offset (in display columns) that keeps the cursor visible,
+/// reserving one column for the cursor cell at end of input.
+pub(crate) fn input_scroll(input: &Input, available_width: usize) -> usize {
+    input.visual_scroll(available_width.saturating_sub(1))
+}
+
 /// Renders a text input field with a label and cursor.
 ///
 /// When focused, displays an inverse-video cursor over the current character position.
@@ -174,98 +280,26 @@ pub fn render_text_field_with_ghost(
             spans.push(Span::styled(placeholder_text, value_style));
         }
     } else if is_focused {
-        let scroll = input.visual_scroll(available_width);
-        let cursor_pos = input.cursor();
+        let scroll = input_scroll(input, available_width);
         let cursor_style = Style::default().fg(theme.background).bg(theme.accent);
-
-        // Collect visible characters starting from scroll offset
-        let mut col = 0;
-        let mut visible_chars_start = 0;
-        for (i, c) in value.chars().enumerate() {
-            let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-            if col >= scroll {
-                break;
-            }
-            col += w;
-            visible_chars_start = i + 1;
-        }
-
-        let mut visible_col = 0;
-        let mut visible_before = String::new();
-        let mut visible_cursor_char = String::new();
-        let mut visible_after = String::new();
-        let mut cursor_visible = false;
-        let mut chars_fit = true;
-
-        for (i, c) in value.chars().enumerate().skip(visible_chars_start) {
-            let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-            if visible_col + w > available_width {
-                chars_fit = false;
-                break;
-            }
-            if i < cursor_pos {
-                visible_before.push(c);
-            } else if i == cursor_pos {
-                visible_cursor_char = c.to_string();
-                cursor_visible = true;
-            } else {
-                visible_after.push(c);
-            }
-            visible_col += w;
-        }
-
-        // If cursor is at end (past last char), show space
-        if cursor_pos >= value.chars().count() && !cursor_visible && chars_fit {
-            visible_cursor_char = " ".to_string();
-            cursor_visible = true;
-        }
-
-        if !visible_before.is_empty() {
-            spans.push(Span::styled(visible_before, value_style));
-        }
-        if cursor_visible {
-            spans.push(Span::styled(visible_cursor_char, cursor_style));
-        }
-        if !visible_after.is_empty() {
-            spans.push(Span::styled(visible_after, value_style));
-        }
-        // Only show ghost when end of input is visible
-        if let Some(ghost) = ghost_text {
-            let end_visible = value.chars().count() <= visible_chars_start || {
-                let mut col_check = 0;
-                for c in value.chars().skip(visible_chars_start) {
-                    col_check += unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-                }
-                col_check < available_width
-            };
-            if end_visible {
+        let (field_spans, end_visible) = focused_input_spans(
+            value,
+            input.cursor(),
+            scroll,
+            available_width,
+            value_style,
+            cursor_style,
+        );
+        spans.extend(field_spans);
+        if end_visible {
+            if let Some(ghost) = ghost_text {
                 spans.push(Span::styled(ghost, Style::default().fg(theme.dimmed)));
             }
         }
     } else {
-        // Non-focused: show visible portion of value
-        let scroll = input.visual_scroll(available_width);
-        let mut col = 0;
-        let mut visible_start = 0;
-        for (i, c) in value.chars().enumerate() {
-            let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-            if col >= scroll {
-                break;
-            }
-            col += w;
-            visible_start = i + 1;
-        }
-        let mut visible_col = 0;
-        let mut visible_value = String::new();
-        for c in value.chars().skip(visible_start) {
-            let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-            if visible_col + w > available_width {
-                break;
-            }
-            visible_value.push(c);
-            visible_col += w;
-        }
-        spans.push(Span::styled(visible_value, value_style));
+        let scroll = input_scroll(input, available_width);
+        let (visible, _) = visible_slice(value, scroll, available_width);
+        spans.push(Span::styled(visible, value_style));
     }
 
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
@@ -296,7 +330,7 @@ pub fn set_input_cursor_position(
     }
 
     let available_width = area.width.saturating_sub(prefix_width as u16) as usize;
-    let scroll = input.visual_scroll(available_width);
+    let scroll = input_scroll(input, available_width);
     let visual_cursor = input.visual_cursor();
     let visible_cursor = visual_cursor.saturating_sub(scroll);
 
@@ -498,5 +532,128 @@ mod tests {
         terminal
             .backend_mut()
             .assert_cursor_position(Position::new(10, 1));
+    }
+
+    // --- horizontal scrolling ---
+
+    #[test]
+    fn visible_char_start_skips_scrolled_columns() {
+        assert_eq!(visible_char_start("abcdef", 0), 0);
+        assert_eq!(visible_char_start("abcdef", 2), 2);
+        // Wide chars are two columns each, so a 2-column scroll skips one char.
+        assert_eq!(visible_char_start("你好世界", 2), 1);
+        assert_eq!(visible_char_start("你好世界", 4), 2);
+    }
+
+    #[test]
+    fn visible_slice_clips_and_reports_end_visibility() {
+        let (s, end) = visible_slice("abcdefghij", 0, 5);
+        assert_eq!(s, "abcde");
+        assert!(!end, "end of a too-long value is not visible");
+
+        let (s, end) = visible_slice("abc", 0, 5);
+        assert_eq!(s, "abc");
+        assert!(end, "short value fits entirely");
+
+        // Scrolled to the tail: the end becomes visible again.
+        let (s, end) = visible_slice("abcdefghij", 5, 5);
+        assert_eq!(s, "fghij");
+        assert!(end);
+    }
+
+    #[test]
+    fn focused_spans_keep_cursor_visible_at_end_of_long_value() {
+        let value = "0123456789"; // 10 single-width chars
+        let available_width = 5;
+        let input = Input::new(value.to_string()); // cursor at end
+        let scroll = input_scroll(&input, available_width);
+
+        let (spans, end_visible) = focused_input_spans(
+            value,
+            input.cursor(),
+            scroll,
+            available_width,
+            Style::default(),
+            Style::default(),
+        );
+
+        let rendered: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        // A column is reserved for the cursor, so the last char plus a blank
+        // cursor cell are both visible and the whole window stays within width.
+        assert!(end_visible);
+        assert!(rendered.ends_with("9 "), "got {rendered:?}");
+        assert!(rendered.width() <= available_width);
+    }
+
+    #[test]
+    fn focused_spans_hide_end_when_cursor_in_middle() {
+        let value = "0123456789";
+        let available_width = 5;
+        // Cursor near the start: the end of the value is scrolled off-screen.
+        let input = Input::new(value.to_string()).with_cursor(1);
+        let scroll = input_scroll(&input, available_width);
+
+        let (_, end_visible) = focused_input_spans(
+            value,
+            input.cursor(),
+            scroll,
+            available_width,
+            Style::default(),
+            Style::default(),
+        );
+
+        assert!(
+            !end_visible,
+            "ghost text must stay hidden when end is clipped"
+        );
+    }
+
+    fn row_text(terminal: &ratatui::Terminal<ratatui::backend::TestBackend>, y: u16) -> String {
+        let buf = terminal.backend().buffer();
+        let area = *buf.area();
+        let mut out = String::new();
+        for x in area.x..area.x + area.width {
+            out.push_str(buf[(x, y)].symbol());
+        }
+        out
+    }
+
+    #[test]
+    fn long_value_scrolls_to_show_tail_and_keeps_cursor_in_field() {
+        use ratatui::backend::{Backend, TestBackend};
+        use ratatui::Terminal;
+
+        let backend = TestBackend::new(20, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        // Label "Path:" + space = 6 cols; field width 16 → 10 cols for the value.
+        let value = "/very/long/path/that/exceeds/the/field";
+        let input = Input::new(value.to_string()); // cursor at end
+        let theme = load_theme("empire");
+        let field = Rect::new(0, 1, 16, 1);
+
+        terminal
+            .draw(|f| {
+                render_text_field(f, field, "Path:", &input, true, None, &theme);
+            })
+            .unwrap();
+
+        let row = row_text(&terminal, 1);
+        assert!(
+            row.contains("field"),
+            "tail of the value should be visible, got {row:?}"
+        );
+        assert!(
+            !row.contains("/very/long"),
+            "head should be scrolled off, got {row:?}"
+        );
+
+        // The cursor must land inside the field, not stuck past the right edge.
+        let pos = terminal.backend_mut().get_cursor_position().unwrap();
+        assert!(
+            pos.x < field.x + field.width,
+            "cursor {} escaped the field right edge {}",
+            pos.x,
+            field.x + field.width
+        );
     }
 }

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -8,8 +8,9 @@ use rattles::presets::prelude as spinners;
 
 use super::{NewSessionDialog, FIELD_HELP, HELP_DIALOG_WIDTH};
 use crate::tui::components::{
-    profile_cycler_spans, render_text_field, render_text_field_with_ghost,
-    set_prefixed_input_cursor_position, tool_cycler_spans,
+    focused_input_spans, input_scroll, profile_cycler_spans, render_text_field,
+    render_text_field_with_ghost, set_prefixed_input_cursor_position, tool_cycler_spans,
+    visible_slice,
 };
 use crate::tui::styles::Theme;
 
@@ -601,71 +602,21 @@ impl NewSessionDialog {
                 spans.push(Span::styled(placeholder_text, value_style));
             }
         } else if is_focused {
-            let scroll = self.path.visual_scroll(available_width);
-            let cursor_pos = self.path.cursor();
+            let scroll = input_scroll(&self.path, available_width);
             let cursor_style = if flashing_invalid {
                 Style::default().fg(theme.background).bg(theme.error)
             } else {
                 Style::default().fg(theme.background).bg(theme.accent)
             };
-
-            // Find visible start after scroll offset
-            let mut col = 0;
-            let mut visible_chars_start = 0;
-            for (i, c) in value.chars().enumerate() {
-                let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-                if col >= scroll {
-                    break;
-                }
-                col += w;
-                visible_chars_start = i + 1;
-            }
-
-            // Collect visible characters
-            let mut visible_col = 0;
-            let mut visible_before = String::new();
-            let mut visible_cursor_char = String::new();
-            let mut visible_after = String::new();
-            let mut cursor_visible = false;
-            let mut end_visible = true;
-
-            for (i, c) in value.chars().enumerate().skip(visible_chars_start) {
-                let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-                if visible_col + w > available_width {
-                    end_visible = false;
-                    break;
-                }
-                if i < cursor_pos {
-                    visible_before.push(c);
-                } else if i == cursor_pos {
-                    visible_cursor_char = c.to_string();
-                    cursor_visible = true;
-                } else {
-                    visible_after.push(c);
-                }
-                visible_col += w;
-            }
-
-            // Cursor at end (past last char)
-            if cursor_pos >= value.chars().count() && !cursor_visible {
-                // Only show cursor space if there's room
-                if visible_col < available_width {
-                    visible_cursor_char = " ".to_string();
-                    cursor_visible = true;
-                } else {
-                    end_visible = false;
-                }
-            }
-
-            if !visible_before.is_empty() {
-                spans.push(Span::styled(visible_before, value_style));
-            }
-            if cursor_visible {
-                spans.push(Span::styled(visible_cursor_char, cursor_style));
-            }
-            if !visible_after.is_empty() {
-                spans.push(Span::styled(visible_after, value_style));
-            }
+            let (field_spans, end_visible) = focused_input_spans(
+                value,
+                self.path.cursor(),
+                scroll,
+                available_width,
+                value_style,
+                cursor_style,
+            );
+            spans.extend(field_spans);
             // Only show ghost when end of input is visible
             if end_visible {
                 if let Some(ghost) = self.ghost_text() {
@@ -673,29 +624,9 @@ impl NewSessionDialog {
                 }
             }
         } else {
-            // Non-focused: show visible portion
-            let scroll = self.path.visual_scroll(available_width);
-            let mut col = 0;
-            let mut visible_start = 0;
-            for (i, c) in value.chars().enumerate() {
-                let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-                if col >= scroll {
-                    break;
-                }
-                col += w;
-                visible_start = i + 1;
-            }
-            let mut visible_col = 0;
-            let mut visible_value = String::new();
-            for c in value.chars().skip(visible_start) {
-                let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-                if visible_col + w > available_width {
-                    break;
-                }
-                visible_value.push(c);
-                visible_col += w;
-            }
-            spans.push(Span::styled(visible_value, value_style));
+            let scroll = input_scroll(&self.path, available_width);
+            let (visible, _) = visible_slice(value, scroll, available_width);
+            spans.push(Span::styled(visible, value_style));
         }
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
@@ -1266,34 +1197,8 @@ impl NewSessionDialog {
                                        th: &Theme,
                                        inp: &Input|
                  -> Line<'static> {
-                    let scroll = inp.visual_scroll(available_width);
-
-                    // Find visible start after scroll offset
-                    let mut col = 0;
-                    let mut visible_chars_start = 0;
-                    for (i, c) in val.chars().enumerate() {
-                        let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-                        if col >= scroll {
-                            break;
-                        }
-                        col += w;
-                        visible_chars_start = i + 1;
-                    }
-
-                    // Collect visible characters
-                    let mut visible_col = 0;
-                    let mut visible_value = String::new();
-                    let mut end_visible = true;
-
-                    for c in val.chars().skip(visible_chars_start) {
-                        let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-                        if visible_col + w > available_width {
-                            end_visible = false;
-                            break;
-                        }
-                        visible_value.push(c);
-                        visible_col += w;
-                    }
+                    let scroll = input_scroll(inp, available_width);
+                    let (visible_value, end_visible) = visible_slice(val, scroll, available_width);
 
                     let mut spans = vec![
                         Span::styled(prefix, Style::default().fg(th.accent)),

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -579,6 +579,9 @@ impl NewSessionDialog {
         let value_style = Style::default().fg(value_color);
 
         let value = self.path.value();
+        let prefix_width = 6; // "Path: "
+        let available_width = area.width.saturating_sub(prefix_width as u16) as usize;
+
         let mut spans = vec![Span::styled("Path:", label_style), Span::raw(" ")];
 
         // Scratch mode disables this field. The undo hint lives in the
@@ -598,6 +601,7 @@ impl NewSessionDialog {
                 spans.push(Span::styled(placeholder_text, value_style));
             }
         } else if is_focused {
+            let scroll = self.path.visual_scroll(available_width);
             let cursor_pos = self.path.cursor();
             let cursor_style = if flashing_invalid {
                 Style::default().fg(theme.background).bg(theme.error)
@@ -605,26 +609,93 @@ impl NewSessionDialog {
                 Style::default().fg(theme.background).bg(theme.accent)
             };
 
-            let before: String = value.chars().take(cursor_pos).collect();
-            let cursor_char: String = value
-                .chars()
-                .nth(cursor_pos)
-                .map(|c| c.to_string())
-                .unwrap_or_else(|| " ".to_string());
-            let after: String = value.chars().skip(cursor_pos + 1).collect();
+            // Find visible start after scroll offset
+            let mut col = 0;
+            let mut visible_chars_start = 0;
+            for (i, c) in value.chars().enumerate() {
+                let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+                if col >= scroll {
+                    break;
+                }
+                col += w;
+                visible_chars_start = i + 1;
+            }
 
-            if !before.is_empty() {
-                spans.push(Span::styled(before, value_style));
+            // Collect visible characters
+            let mut visible_col = 0;
+            let mut visible_before = String::new();
+            let mut visible_cursor_char = String::new();
+            let mut visible_after = String::new();
+            let mut cursor_visible = false;
+            let mut end_visible = true;
+
+            for (i, c) in value.chars().enumerate().skip(visible_chars_start) {
+                let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+                if visible_col + w > available_width {
+                    end_visible = false;
+                    break;
+                }
+                if i < cursor_pos {
+                    visible_before.push(c);
+                } else if i == cursor_pos {
+                    visible_cursor_char = c.to_string();
+                    cursor_visible = true;
+                } else {
+                    visible_after.push(c);
+                }
+                visible_col += w;
             }
-            spans.push(Span::styled(cursor_char, cursor_style));
-            if !after.is_empty() {
-                spans.push(Span::styled(after, value_style));
+
+            // Cursor at end (past last char)
+            if cursor_pos >= value.chars().count() && !cursor_visible {
+                // Only show cursor space if there's room
+                if visible_col < available_width {
+                    visible_cursor_char = " ".to_string();
+                    cursor_visible = true;
+                } else {
+                    end_visible = false;
+                }
             }
-            if let Some(ghost) = self.ghost_text() {
-                spans.push(Span::styled(ghost, Style::default().fg(theme.dimmed)));
+
+            if !visible_before.is_empty() {
+                spans.push(Span::styled(visible_before, value_style));
+            }
+            if cursor_visible {
+                spans.push(Span::styled(visible_cursor_char, cursor_style));
+            }
+            if !visible_after.is_empty() {
+                spans.push(Span::styled(visible_after, value_style));
+            }
+            // Only show ghost when end of input is visible
+            if end_visible {
+                if let Some(ghost) = self.ghost_text() {
+                    spans.push(Span::styled(ghost, Style::default().fg(theme.dimmed)));
+                }
             }
         } else {
-            spans.push(Span::styled(value, value_style));
+            // Non-focused: show visible portion
+            let scroll = self.path.visual_scroll(available_width);
+            let mut col = 0;
+            let mut visible_start = 0;
+            for (i, c) in value.chars().enumerate() {
+                let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+                if col >= scroll {
+                    break;
+                }
+                col += w;
+                visible_start = i + 1;
+            }
+            let mut visible_col = 0;
+            let mut visible_value = String::new();
+            for c in value.chars().skip(visible_start) {
+                let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+                if visible_col + w > available_width {
+                    break;
+                }
+                visible_value.push(c);
+                visible_col += w;
+            }
+            spans.push(Span::styled(visible_value, value_style));
         }
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
@@ -1186,17 +1257,52 @@ impl NewSessionDialog {
                     .as_ref()
                     .map(|g| g.ghost_text.clone());
 
+                let prefix_width = 4; // "  + " or "  > "
+                let available_width = area.width.saturating_sub(prefix_width as u16) as usize;
+
                 let make_input_line = |prefix: &'static str,
                                        val: &str,
                                        ghost: &Option<String>,
-                                       th: &Theme|
+                                       th: &Theme,
+                                       inp: &Input|
                  -> Line<'static> {
+                    let scroll = inp.visual_scroll(available_width);
+
+                    // Find visible start after scroll offset
+                    let mut col = 0;
+                    let mut visible_chars_start = 0;
+                    for (i, c) in val.chars().enumerate() {
+                        let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+                        if col >= scroll {
+                            break;
+                        }
+                        col += w;
+                        visible_chars_start = i + 1;
+                    }
+
+                    // Collect visible characters
+                    let mut visible_col = 0;
+                    let mut visible_value = String::new();
+                    let mut end_visible = true;
+
+                    for c in val.chars().skip(visible_chars_start) {
+                        let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+                        if visible_col + w > available_width {
+                            end_visible = false;
+                            break;
+                        }
+                        visible_value.push(c);
+                        visible_col += w;
+                    }
+
                     let mut spans = vec![
                         Span::styled(prefix, Style::default().fg(th.accent)),
-                        Span::styled(val.to_string(), Style::default().fg(th.accent).bold()),
+                        Span::styled(visible_value, Style::default().fg(th.accent).bold()),
                     ];
-                    if let Some(ref g) = ghost {
-                        spans.push(Span::styled(g.clone(), Style::default().fg(th.dimmed)));
+                    if end_visible {
+                        if let Some(ref g) = ghost {
+                            spans.push(Span::styled(g.clone(), Style::default().fg(th.dimmed)));
+                        }
                     }
                     spans.push(Span::styled("_", Style::default().fg(th.accent)));
                     Line::from(spans)
@@ -1214,12 +1320,24 @@ impl NewSessionDialog {
                             Style::default().fg(theme.text),
                         )));
                     }
-                    lines.push(make_input_line("  + ", input.value(), &ghost_text, theme));
+                    lines.push(make_input_line(
+                        "  + ",
+                        input.value(),
+                        &ghost_text,
+                        theme,
+                        input,
+                    ));
                     cursor_row = Some((lines.len() - 1, "  + ", input));
                 } else {
                     for (i, entry) in self.workspace_repos.iter().enumerate() {
                         if i == self.workspace_repo_selected_index {
-                            lines.push(make_input_line("  > ", input.value(), &ghost_text, theme));
+                            lines.push(make_input_line(
+                                "  > ",
+                                input.value(),
+                                &ghost_text,
+                                theme,
+                                input,
+                            ));
                             cursor_row = Some((lines.len() - 1, "  > ", input));
                         } else {
                             let prefix = "    ";


### PR DESCRIPTION
## Description

When path values exceed the visible input width in the new session dialog, text was clipped at the right edge with the cursor stuck at the rightmost column. Pressing right arrow immediately accepted ghost autocomplete instead of allowing navigation through the hidden text.

This PR adds horizontal scrolling to all text input renderers using `tui_input::Input::visual_scroll()`. The text now scrolls to keep the cursor visible, and ghost autocomplete only appears when the end of input is in the viewport.

Closes #1633

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Note: This is a rendering fix for existing input behavior. The underlying input state logic (cursor movement, ghost acceptance) is unchanged and covered by existing unit tests in `src/tui/dialogs/new_session/tests.rs`. The fix only affects visual presentation.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
opencode-go/qwen3.7-max

**Any Additional AI Details you'd like to share:**
AI assisted with code implementation and testing. Human reviewed all changes.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes horizontal clipping and cursor/navigation issues for long text inputs in the TUI (notably the New Session path field and extra-repo editor). Long values no longer trap the terminal cursor at the right edge or cause the right-arrow to accept ghost autocomplete instead of navigating hidden text.

## What changed (high level)
- Added shared, display-column-aware horizontal-scrolling helpers and reused them across text inputs.
- Focused input rendering now builds three segments (visible before-cursor, a styled cursor cell, visible after-cursor) so the viewport follows the cursor.
- Non-focused inputs are clipped to the visible viewport; ghost/autocomplete text is appended only when the true end of the value is visible.
- Refactored New Session path and extra-repo field rendering to use the new helpers.
- Re-exported the new helpers from the components module.

## Files moved/added/modified
- src/tui/components/text_input.rs — added helpers and core scrolling-aware rendering:
  - visible_char_start, focused_input_spans, visible_slice, input_scroll (pub(crate))
  - GroupGhostCompletion and utility routines consolidated here
  - Updated render_text_field_with_ghost to use scrolling helpers
- src/tui/dialogs/new_session/render.rs — updated path and extra-repo input rendering to use the new, Unicode-width-aware scrolling and focused spans
- src/tui/components/mod.rs — added crate re-exports for the new helpers

## Benefits
- Cursor always stays visible and can navigate through long inputs.
- Ghost/autocomplete is only shown when appropriate (end-of-input visible), preventing accidental acceptance.
- Unicode/wide-character aware clipping and scrolling.
- Removes duplicated logic and standardizes input rendering across fields.

## Technical details (concise)
- Scrolling is measured in display columns (Unicode width); visible_char_start maps a scroll offset to a character index.
- input_scroll(input, available_width) uses Input::visual_scroll(available_width - 1) to reserve one column so the block cursor and the end cell have room.
- focused_input_spans constructs styled Spans: before-cursor, cursor cell (including a blank cell when cursor is past end), after-cursor, and returns end-visibility to gate ghost rendering.
- visible_slice returns the clipped substring and whether the input's end fits in the viewport.
- Existing input state/behavior unchanged; changes are rendering-only. Tests added to cover scroll math, end-visibility, and end-to-end rendering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->