### PR TITLE
feat(web): fold new-session Session step behind Advanced, leave only title visible

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -9,7 +9,7 @@ For workflow guidance, see the [Workflow Guide](workflow.md).
 | Feature | CLI | TUI |
 |---------|-----|-----|
 | Create new branch | Use `-b` flag | Always creates new branch |
-| Use existing branch | Omit `-b` flag | "Attach to existing branch" toggle (TUI: `Ctrl+P`; web: in the session step under the branch field) |
+| Use existing branch | Omit `-b` flag | "Attach to existing branch" toggle (TUI: `Ctrl+P`; web: in the session step under the branch field, inside the "Advanced" disclosure) |
 | Branch validation | Checks if branch exists | None (always creates) |
 | Pick a base branch | `--base-branch <name>` | `Base` field in `Ctrl+P` overlay |
 
@@ -70,7 +70,7 @@ freshness signal.
 
 In the TUI, enable the Worktree checkbox to create a new branch and worktree. By default, the worktree name is derived from the session title. Press `Ctrl+P` on the Worktree field to set an explicit `Name`, attach to an existing branch, pick a `Base` branch the new branch is based on (defaults to the repo default), or configure extra repos. `Ctrl+P` on the `Base` field opens a branch picker over local and remote-tracking branches.
 
-The web dashboard's new-session wizard exposes the same control under an "Advanced" disclosure beneath the worktree name input; it shows a typeahead populated from local + remote branches via `GET /api/git/branches?include_remote=true`. The same step also exposes an "Attach to existing branch" toggle that flips the request from "create new branch" to "attach to whichever branch is named" — when on, the server re-uses any existing worktree for that branch and otherwise checks the branch out into a new worktree. Mirrors the TUI / CLI behavior (CLI: omit `-b`). See #969.
+The web dashboard's new-session wizard folds the worktree controls behind an "Advanced" disclosure on the session step, leaving only the session title visible by default. Inside Advanced, a "Base branch" disclosure beneath the worktree name input shows a typeahead populated from local + remote branches via `GET /api/git/branches?include_remote=true`. The same Advanced section also exposes an "Attach to existing branch" toggle that flips the request from "create new branch" to "attach to whichever branch is named": when on, the server re-uses any existing worktree for that branch and otherwise checks the branch out into a new worktree. Mirrors the TUI / CLI behavior (CLI: omit `-b`). See #969 and #1514.
 
 ## Configuration
 

--- a/web/src/components/session-wizard/__tests__/SessionStep.advanced.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionStep.advanced.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+//
+// Vitest coverage for the SessionStep "Advanced" disclosure (#1514).
+// The fold moved the worktree toggle, branch input, attach-existing
+// toggle, base-branch picker, and group input behind a top-level
+// "Advanced" disclosure that defaults closed. These tests render the
+// component directly, expand the disclosure, and exercise each folded
+// control so the moved render + handler lines stay covered.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, fireEvent } from "@testing-library/react";
+
+import { SessionStep } from "../steps/SessionStep";
+import { initialData, type WizardData } from "../wizardReducer";
+
+vi.mock("../../../lib/api", () => ({
+  fetchBranches: vi.fn().mockResolvedValue([]),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderStep(overrides: Partial<WizardData> = {}) {
+  const onChange = vi.fn();
+  const utils = render(
+    <SessionStep
+      data={{
+        ...initialData,
+        path: "/repo/alpha",
+        useWorktree: true,
+        scratch: false,
+        ...overrides,
+      }}
+      onChange={onChange}
+    />,
+  );
+  const expandAdvanced = () =>
+    fireEvent.click(utils.getByRole("button", { name: "Advanced" }));
+  return { onChange, expandAdvanced, ...utils };
+}
+
+describe("SessionStep Advanced disclosure (#1514)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides every non-title control until Advanced is expanded", () => {
+    const { queryByRole, queryByPlaceholderText, getByPlaceholderText } =
+      renderStep();
+    // Title input is always visible.
+    expect(getByPlaceholderText("Auto-generated if empty")).toBeTruthy();
+    // Folded controls are absent before expanding.
+    expect(queryByRole("switch")).toBeNull();
+    expect(queryByPlaceholderText("Uses session title if empty")).toBeNull();
+    expect(
+      queryByPlaceholderText("Optional, for organizing related sessions"),
+    ).toBeNull();
+  });
+
+  it("reveals the worktree toggle, branch input, attach toggle, and group when expanded", () => {
+    const { expandAdvanced, getByPlaceholderText, getByRole } = renderStep();
+    expandAdvanced();
+    expect(getByRole("switch", { name: /Create a worktree/ })).toBeTruthy();
+    expect(getByPlaceholderText("Uses session title if empty")).toBeTruthy();
+    expect(getByRole("switch", { name: /Attach to existing branch/ })).toBeTruthy();
+    // The base-branch picker's disclosure button (its input shares the
+    // same accessible name but is not a button).
+    expect(getByRole("button", { name: "Base branch" })).toBeTruthy();
+    expect(
+      getByPlaceholderText("Optional, for organizing related sessions"),
+    ).toBeTruthy();
+  });
+
+  it("editing the branch input emits a worktreeBranch change", () => {
+    const { expandAdvanced, onChange, getByPlaceholderText } = renderStep();
+    expandAdvanced();
+    fireEvent.change(getByPlaceholderText("Uses session title if empty"), {
+      target: { value: "feat/x" },
+    });
+    expect(onChange).toHaveBeenCalledWith("worktreeBranch", "feat/x");
+  });
+
+  it("toggling attach-existing emits an attachExisting change", () => {
+    const { expandAdvanced, onChange, getByText } = renderStep();
+    expandAdvanced();
+    fireEvent.click(getByText("Attach to existing branch"));
+    expect(onChange).toHaveBeenCalledWith("attachExisting", true);
+  });
+
+  it("hides the Base branch picker once attach-existing is on", () => {
+    const { expandAdvanced, queryByRole } = renderStep({ attachExisting: true });
+    expandAdvanced();
+    expect(queryByRole("button", { name: "Base branch" })).toBeNull();
+  });
+
+  it("expanding the Base branch picker renders the base-branch input", () => {
+    const { expandAdvanced, getByRole, getByLabelText } = renderStep();
+    expandAdvanced();
+    fireEvent.click(getByRole("button", { name: "Base branch" }));
+    expect(getByLabelText("Base branch")).toBeTruthy();
+  });
+
+  it("editing the group input emits a group change", () => {
+    const { expandAdvanced, onChange, getByPlaceholderText } = renderStep();
+    expandAdvanced();
+    fireEvent.change(
+      getByPlaceholderText("Optional, for organizing related sessions"),
+      { target: { value: "backend" } },
+    );
+    expect(onChange).toHaveBeenCalledWith("group", "backend");
+  });
+});

--- a/web/src/components/session-wizard/__tests__/SessionStep.scratch.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionStep.scratch.test.tsx
@@ -32,6 +32,10 @@ function renderStep(overrides: { scratch?: boolean; useWorktree?: boolean } = {}
       onChange={onChange}
     />,
   );
+  // #1514 folds the worktree controls + scratch note behind a top-level
+  // "Advanced" disclosure that defaults closed. Expand it so the branches
+  // these tests exercise actually render.
+  fireEvent.click(utils.getByRole("button", { name: "Advanced" }));
   return { onChange, ...utils };
 }
 

--- a/web/src/components/session-wizard/steps/SessionStep.tsx
+++ b/web/src/components/session-wizard/steps/SessionStep.tsx
@@ -44,10 +44,19 @@ function Toggle({ checked, onChange, disabled }: { checked: boolean; onChange: (
 }
 
 export function SessionStep({ data, onChange }: Props) {
+  // Everything except the title input is folded behind this disclosure
+  // so the common "name it, hit Next" path is a single visible control.
+  // Defaults to a new worktree branched off HEAD; the submit path in
+  // SessionWizard reads useWorktree/worktreeBranch/attachExisting/
+  // baseBranch/group from reducer state regardless of what is on screen,
+  // so a hidden toggle keeps its default value. See #1514.
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   return (
     <div>
       <h2 className="text-lg font-semibold text-text-primary mb-1">Name your session</h2>
-      <p className="text-sm text-text-muted mb-5">Give it a title and decide whether to work in a git worktree.</p>
+      <p className="text-sm text-text-muted mb-5">
+        Give it a title; defaults to a new git worktree branched off the current HEAD. Expand Advanced to change the branch, attach to an existing one, or set a group.
+      </p>
 
       <div className="mb-5">
         <label className="block text-sm text-text-dim mb-1.5">Session title</label>
@@ -61,101 +70,122 @@ export function SessionStep({ data, onChange }: Props) {
         <p className="text-xs text-text-dim mt-1">Shown in the dashboard. Renaming it later does not rename the git branch.</p>
       </div>
 
-      {/* Worktree controls are meaningless for scratch sessions: the
-          working directory is a fresh scratch dir, not a git repo. The
-          reducer also forces useWorktree to false when scratch flips
-          on; this hide is purely a UX confirmation that the worktree
-          path is not available in scratch mode. */}
-      {data.scratch ? (
-        <p
-          className="text-xs text-text-dim mb-3"
-          aria-label="Worktree disabled: scratch session"
+      <button
+        type="button"
+        onClick={() => setAdvancedOpen((v) => !v)}
+        aria-expanded={advancedOpen}
+        className="flex items-center gap-1.5 text-sm text-text-dim hover:text-text-secondary cursor-pointer"
+      >
+        <span
+          className={`inline-block transition-transform ${advancedOpen ? "rotate-90" : ""}`}
+          aria-hidden="true"
         >
-          Scratch sessions do not use git worktrees.
-        </p>
-      ) : (
-        <label
-          className="flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer mb-3"
-          onClick={(e) => {
-            // Clicks that land on the Toggle button already drive
-            // `onChange("useWorktree", v)`. Letting the label's own
-            // handler also fire would flip the value a second time
-            // and land back on the original. Skip the label handler
-            // for clicks originating inside the Toggle.
-            if (
-              (e.target as HTMLElement).closest('button[role="switch"]')
-            ) {
-              return;
-            }
-            onChange("useWorktree", !data.useWorktree);
-          }}
-        >
-          <div className="flex-1">
-            <div className="text-sm font-medium text-text-primary">Create a worktree</div>
-            <div className="text-xs text-text-dim mt-0.5 leading-snug">
-              Run the agent in a new git worktree branched off the current HEAD. Off = run directly in the repo folder.
-            </div>
-          </div>
-          <Toggle
-            checked={data.useWorktree}
-            onChange={(v) => onChange("useWorktree", v)}
-          />
-        </label>
-      )}
-
-      {!data.scratch && data.useWorktree && (
-        <div className="mb-5">
-          <label className="block text-sm text-text-dim mb-1.5">Branch / worktree name</label>
-          <input
-            type="text"
-            value={data.worktreeBranch}
-            onChange={(e) => onChange("worktreeBranch", e.target.value)}
-            placeholder="Uses session title if empty"
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-base font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
-          />
-          <p className="text-xs text-text-dim mt-1">The branch name is also the worktree directory name. Leave blank to use the session title.</p>
-
-          <label
-            className="mt-3 flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer"
-            onClick={() => onChange("attachExisting", !data.attachExisting)}
-          >
-            <div className="flex-1">
-              <div className="text-sm font-medium text-text-primary">Attach to existing branch</div>
-              <div className="text-xs text-text-dim mt-0.5 leading-snug">
-                Re-use a branch + worktree that already exists. Off = create a new branch.
+          ▸
+        </span>
+        Advanced
+      </button>
+      {advancedOpen && (
+        <div className="mt-3 pl-4 border-l border-surface-700/40">
+          {/* Worktree controls are meaningless for scratch sessions: the
+              working directory is a fresh scratch dir, not a git repo. The
+              reducer also forces useWorktree to false when scratch flips
+              on; this hide is purely a UX confirmation that the worktree
+              path is not available in scratch mode. */}
+          {data.scratch ? (
+            <p
+              className="text-xs text-text-dim mb-3"
+              aria-label="Worktree disabled: scratch session"
+            >
+              Scratch sessions do not use git worktrees.
+            </p>
+          ) : (
+            <label
+              className="flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer mb-3"
+              onClick={(e) => {
+                // Clicks that land on the Toggle button already drive
+                // `onChange("useWorktree", v)`. Letting the label's own
+                // handler also fire would flip the value a second time
+                // and land back on the original. Skip the label handler
+                // for clicks originating inside the Toggle.
+                if (
+                  (e.target as HTMLElement).closest('button[role="switch"]')
+                ) {
+                  return;
+                }
+                onChange("useWorktree", !data.useWorktree);
+              }}
+            >
+              <div className="flex-1">
+                <div className="text-sm font-medium text-text-primary">Create a worktree</div>
+                <div className="text-xs text-text-dim mt-0.5 leading-snug">
+                  Run the agent in a new git worktree branched off the current HEAD. Off = run directly in the repo folder.
+                </div>
               </div>
-            </div>
-            <Toggle
-              checked={data.attachExisting}
-              onChange={(v) => onChange("attachExisting", v)}
-            />
-          </label>
-
-          {!data.attachExisting && (
-            <AdvancedWorktreeOptions data={data} onChange={onChange} />
+              <Toggle
+                checked={data.useWorktree}
+                onChange={(v) => onChange("useWorktree", v)}
+              />
+            </label>
           )}
+
+          {!data.scratch && data.useWorktree && (
+            <div className="mb-5">
+              <label className="block text-sm text-text-dim mb-1.5">Branch / worktree name</label>
+              <input
+                type="text"
+                value={data.worktreeBranch}
+                onChange={(e) => onChange("worktreeBranch", e.target.value)}
+                placeholder="Uses session title if empty"
+                className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-base font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
+              />
+              <p className="text-xs text-text-dim mt-1">The branch name is also the worktree directory name. Leave blank to use the session title.</p>
+
+              <label
+                className="mt-3 flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer"
+                onClick={() => onChange("attachExisting", !data.attachExisting)}
+              >
+                <div className="flex-1">
+                  <div className="text-sm font-medium text-text-primary">Attach to existing branch</div>
+                  <div className="text-xs text-text-dim mt-0.5 leading-snug">
+                    Re-use a branch + worktree that already exists. Off = create a new branch.
+                  </div>
+                </div>
+                <Toggle
+                  checked={data.attachExisting}
+                  onChange={(v) => onChange("attachExisting", v)}
+                />
+              </label>
+
+              {!data.attachExisting && (
+                <AdvancedWorktreeOptions data={data} onChange={onChange} />
+              )}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm text-text-dim mb-1.5">Group</label>
+            <input
+              type="text"
+              value={data.group}
+              onChange={(e) => onChange("group", e.target.value)}
+              placeholder="Optional, for organizing related sessions"
+              className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
+            />
+          </div>
         </div>
       )}
-
-      <div>
-        <label className="block text-sm text-text-dim mb-1.5">Group</label>
-        <input
-          type="text"
-          value={data.group}
-          onChange={(e) => onChange("group", e.target.value)}
-          placeholder="Optional, for organizing related sessions"
-          className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
-        />
-      </div>
     </div>
   );
 }
 
 /**
- * Collapsed "Advanced" section under the worktree name input. Currently
- * houses the base-branch picker (#948). Hidden by default and only
- * matters when the user expands it; defaulting to the repo default
- * means the common case stays exactly as before.
+ * Collapsed "Base branch" section under the worktree name input. Houses
+ * the base-branch picker (#948). Hidden by default and only matters when
+ * the user expands it; defaulting to the repo default means the common
+ * case stays exactly as before. Labeled "Base branch" rather than
+ * "Advanced" since #1514 wraps the whole worktree block in an outer
+ * "Advanced" disclosure, and two nested buttons both reading "Advanced"
+ * would be ambiguous.
  */
 function AdvancedWorktreeOptions({
   data,
@@ -210,7 +240,7 @@ function AdvancedWorktreeOptions({
         >
           ▸
         </span>
-        Advanced
+        Base branch
       </button>
       {open && (
         <div className="mt-2 pl-4 border-l border-surface-700/40">

--- a/web/tests/live/cockpit-stories/wizard-group-field.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-group-field.spec.ts
@@ -37,6 +37,10 @@ base("wizard session step records Group", async ({ page }, testInfo) => {
       page.getByRole("heading", { name: "Name your session", exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
+    // #1514 folds the Group input behind a top-level "Advanced"
+    // disclosure that defaults closed; expand it first.
+    await page.getByRole("button", { name: "Advanced" }).click();
+
     const groupField = page.getByPlaceholder(
       "Optional, for organizing related sessions",
     );

--- a/web/tests/live/cockpit-stories/wizard-worktree-toggle.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-worktree-toggle.spec.ts
@@ -40,6 +40,10 @@ base("wizard worktree toggle hides and shows the branch input", async ({ page },
       page.getByRole("heading", { name: "Name your session", exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
+    // #1514 folds the worktree controls behind a top-level "Advanced"
+    // disclosure that defaults closed; expand it first.
+    await page.getByRole("button", { name: "Advanced" }).click();
+
     const branchLabel = page.getByText("Branch / worktree name");
     await expect(branchLabel).toBeVisible({ timeout: 10_000 });
 

--- a/web/tests/live/wizard-scratch-hides-worktree.spec.ts
+++ b/web/tests/live/wizard-scratch-hides-worktree.spec.ts
@@ -33,6 +33,11 @@ base("scratch hides the worktree section on the Session step", async ({ page }, 
       wizard.getByRole("heading", { name: "Name your session", exact: true }),
     ).toBeVisible({ timeout: 10_000 });
 
+    // #1514 folds the worktree section (and, for scratch, the
+    // explanatory note that replaces it) behind a top-level "Advanced"
+    // disclosure that defaults closed; expand it first.
+    await wizard.getByRole("button", { name: "Advanced" }).click();
+
     // Explanatory note appears in place of the worktree controls.
     await expect(
       wizard.getByText(/Scratch sessions do not use git worktrees/),

--- a/web/tests/wizard-attach-existing.spec.ts
+++ b/web/tests/wizard-attach-existing.spec.ts
@@ -83,34 +83,44 @@ async function openSessionStep(page: Page) {
   await expect(page.getByText("Name your session")).toBeVisible();
 }
 
+// #1514 folds the worktree controls (including the attach-existing
+// toggle and the Base branch picker) behind a top-level "Advanced"
+// disclosure that defaults closed. Expand it before asserting on them.
+async function expandAdvanced(page: Page) {
+  await page.getByRole("button", { name: "Advanced" }).click();
+}
+
 test.describe("Wizard attach-existing toggle (#969)", () => {
-  test("toggle is off by default; Advanced section visible", async ({ page }) => {
+  test("toggle is off by default; Base branch section visible", async ({ page }) => {
     await mockApis(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     const attachToggle = page
       .locator("label", { hasText: "Attach to existing branch" })
       .locator("role=switch");
     await expect(attachToggle).toBeVisible();
     await expect(attachToggle).toHaveAttribute("aria-checked", "false");
-    // Advanced disclosure is the base-branch picker (only meaningful for new-branch creates).
-    await expect(page.getByRole("button", { name: /Advanced/i })).toBeVisible();
+    // The base-branch picker (only meaningful for new-branch creates) is
+    // its own "Base branch" disclosure inside Advanced.
+    await expect(page.getByRole("button", { name: "Base branch" })).toBeVisible();
   });
 
-  test("turning attach on hides the Advanced base-branch section", async ({
+  test("turning attach on hides the Base branch section", async ({
     page,
   }) => {
     await mockApis(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     const attachToggle = page
       .locator("label", { hasText: "Attach to existing branch" })
       .locator("role=switch");
     await attachToggle.click();
     await expect(attachToggle).toHaveAttribute("aria-checked", "true");
-    await expect(page.getByRole("button", { name: /Advanced/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Base branch" })).toHaveCount(0);
   });
 
   test("submit with attach off sends create_new_branch=true", async ({ page }) => {
@@ -150,6 +160,7 @@ test.describe("Wizard attach-existing toggle (#969)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     await page.getByPlaceholder("Uses session title if empty").fill("feat/new");
     await page.getByRole("button", { name: /Next/ }).click();
     // Agent step → Next (defaults already set)
@@ -198,6 +209,7 @@ test.describe("Wizard attach-existing toggle (#969)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     await page
       .getByPlaceholder("Uses session title if empty")
       .fill("feat/existing");

--- a/web/tests/wizard-base-branch.spec.ts
+++ b/web/tests/wizard-base-branch.spec.ts
@@ -99,8 +99,15 @@ async function openWizardOnSessionStep(page: Page) {
   await nextBtn.click();
 }
 
+// #1514 folds the worktree controls (including the Base branch picker)
+// behind a top-level "Advanced" disclosure that defaults closed. Expand
+// it before reaching the base-branch picker.
+async function expandAdvanced(page: Page) {
+  await page.getByRole("button", { name: "Advanced" }).click();
+}
+
 test.describe("Wizard base branch (#948)", () => {
-  test("Advanced section is collapsed by default on the session step", async ({ page }) => {
+  test("Base branch section is collapsed by default on the session step", async ({ page }) => {
     await mockApis(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
@@ -108,8 +115,9 @@ test.describe("Wizard base branch (#948)", () => {
     await openWizardOnSessionStep(page);
     // Session step renders "Name your session" as the heading.
     await expect(page.getByText("Name your session")).toBeVisible();
+    await expandAdvanced(page);
     // Worktree toggle is on by default; if a previous test left it
-    // off, click to re-enable so the Advanced section renders.
+    // off, click to re-enable so the Base branch section renders.
     // `#969` added a second toggle ("Attach to existing branch") on this
     // step, so target the worktree toggle by its accessible name.
     const toggle = page.getByRole("switch", { name: /Create a worktree/ });
@@ -117,12 +125,12 @@ test.describe("Wizard base branch (#948)", () => {
       await toggle.click();
     }
     await expect(
-      page.getByRole("button", { name: /Advanced/i }),
+      page.getByRole("button", { name: "Base branch" }),
     ).toBeVisible();
     await expect(page.getByLabel("Base branch")).toHaveCount(0);
   });
 
-  test("expanding Advanced fetches branches with include_remote=true", async ({
+  test("expanding Base branch fetches branches with include_remote=true", async ({
     page,
   }) => {
     await mockApis(page);
@@ -142,7 +150,8 @@ test.describe("Wizard base branch (#948)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openWizardOnSessionStep(page);
-    await page.getByRole("button", { name: /Advanced/i }).click();
+    await expandAdvanced(page);
+    await page.getByRole("button", { name: "Base branch" }).click();
     await expect(page.getByLabel("Base branch")).toBeVisible();
     await expect.poll(() => capturedUrl?.searchParams.get("include_remote")).toBe(
       "true",
@@ -164,7 +173,8 @@ test.describe("Wizard base branch (#948)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openWizardOnSessionStep(page);
-    await page.getByRole("button", { name: /Advanced/i }).click();
+    await expandAdvanced(page);
+    await page.getByRole("button", { name: "Base branch" }).click();
     const baseInput = page.getByLabel("Base branch");
     await baseInput.click();
     const option = page.getByRole("option", { name: /release-1\.2/ });

--- a/web/tests/wizard-session-step.spec.ts
+++ b/web/tests/wizard-session-step.spec.ts
@@ -84,6 +84,14 @@ async function openSessionStep(page: Page) {
   await expect(page.getByText("Name your session")).toBeVisible();
 }
 
+// #1514: the worktree toggle, branch input, attach-existing toggle,
+// base-branch picker, and group input all live behind the top-level
+// "Advanced" disclosure now. Expand it before asserting on those
+// controls.
+async function expandAdvanced(page: Page) {
+  await page.getByRole("button", { name: "Advanced" }).click();
+}
+
 test.describe("Wizard session step (#1219)", () => {
   test("title input is empty by default and updates as the user types", async ({ page }) => {
     await mockApis(page);
@@ -96,23 +104,25 @@ test.describe("Wizard session step (#1219)", () => {
     await expect(titleInput).toHaveValue("my-feature");
   });
 
-  test("worktree toggle is on by default and gates the branch input + Advanced section", async ({
+  test("worktree toggle is on by default and gates the branch input + Base branch section", async ({
     page,
   }) => {
     await mockApis(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     const worktreeToggle = page.getByRole("switch", { name: /Create a worktree/ });
     await expect(worktreeToggle).toHaveAttribute("aria-checked", "true");
     // Branch input visible while worktree is on.
     await expect(page.getByPlaceholder("Uses session title if empty")).toBeVisible();
-    await expect(page.getByRole("button", { name: /Advanced/ })).toBeVisible();
-    // Flip off: branch input + Advanced disappear.
+    await expect(page.getByRole("button", { name: "Base branch" })).toBeVisible();
+    // Flip off: branch input + Base branch picker disappear. The outer
+    // Advanced disclosure stays open.
     await worktreeToggle.click();
     await expect(worktreeToggle).toHaveAttribute("aria-checked", "false");
     await expect(page.getByPlaceholder("Uses session title if empty")).toHaveCount(0);
-    await expect(page.getByRole("button", { name: /Advanced/ })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Base branch" })).toHaveCount(0);
   });
 
   test("branch input mirrors the slugified title while not manually edited", async ({
@@ -123,16 +133,17 @@ test.describe("Wizard session step (#1219)", () => {
     await page.goto("/");
     await openSessionStep(page);
     await page.getByPlaceholder("Auto-generated if empty").fill("My Cool Feature");
+    await expandAdvanced(page);
     const branchInput = page.getByPlaceholder("Uses session title if empty");
     // SET_FIELD on title cascades into worktreeBranch via slugifyBranch().
     await expect(branchInput).toHaveValue("my-cool-feature");
   });
 
-  test("submit sends worktree_branch derived from title when the user leaves branch blank", async ({
+  test("submit sends worktree_branch + create_new_branch with Advanced left closed (#1514)", async ({
     page,
   }) => {
     await mockApis(page);
-    let captured: { worktree_branch?: string } | null = null;
+    let captured: { worktree_branch?: string; create_new_branch?: boolean } | null = null;
     await page.route("**/api/sessions", (r) => {
       if (r.request().method() === "POST") {
         captured = JSON.parse(r.request().postData() || "{}");
@@ -167,11 +178,15 @@ test.describe("Wizard session step (#1219)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    // Story 3: fill only the title; never expand Advanced. The worktree
+    // toggle is hidden but defaults on, so the default new-worktree
+    // behavior must still reach the request body.
     await page.getByPlaceholder("Auto-generated if empty").fill("Cool Feature");
     await page.getByRole("button", { name: /Next/ }).click();
     await page.getByRole("button", { name: /Next/ }).click();
     await page.getByRole("button", { name: /Launch session/ }).click();
     await expect.poll(() => captured?.worktree_branch).toBe("cool-feature");
+    expect(captured?.create_new_branch).toBe(true);
   });
 
   test("group input propagates to the create-session POST body", async ({ page }) => {
@@ -211,6 +226,7 @@ test.describe("Wizard session step (#1219)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     await page
       .getByPlaceholder("Optional, for organizing related sessions")
       .fill("backend");
@@ -218,5 +234,49 @@ test.describe("Wizard session step (#1219)", () => {
     await page.getByRole("button", { name: /Next/ }).click();
     await page.getByRole("button", { name: /Launch session/ }).click();
     await expect.poll(() => captured?.group).toBe("backend");
+  });
+
+  test("only the title input and Advanced toggle are visible by default (#1514)", async ({
+    page,
+  }) => {
+    await mockApis(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openSessionStep(page);
+    // Title input + Advanced disclosure are the only controls on screen.
+    await expect(page.getByPlaceholder("Auto-generated if empty")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Advanced" })).toBeVisible();
+    // Everything else is folded away.
+    await expect(page.getByRole("switch")).toHaveCount(0);
+    await expect(page.getByPlaceholder("Uses session title if empty")).toHaveCount(0);
+    await expect(
+      page.getByPlaceholder("Optional, for organizing related sessions"),
+    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Base branch" })).toHaveCount(0);
+  });
+
+  test("expanding Advanced reveals the worktree toggle, branch, attach toggle, and group (#1514)", async ({
+    page,
+  }) => {
+    await mockApis(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openSessionStep(page);
+    await expandAdvanced(page);
+    // Worktree toggle defaults on even though it was hidden.
+    await expect(page.getByRole("switch", { name: /Create a worktree/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    await expect(page.getByPlaceholder("Uses session title if empty")).toBeVisible();
+    await expect(
+      page.getByRole("switch", { name: /Attach to existing branch/ }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Base branch" })).toBeVisible();
+    // Group input is visible and editable.
+    const groupInput = page.getByPlaceholder("Optional, for organizing related sessions");
+    await expect(groupInput).toBeVisible();
+    await groupInput.fill("backend");
+    await expect(groupInput).toHaveValue("backend");
   });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Clicking "+" on an existing repo and reaching the Session step used to present five interactive controls stacked above the fold: title, "Create a worktree" toggle, branch input, "Attach to existing branch" toggle, and a Group input. The common path is "name it, hit Next", so the wall of knobs was a daily papercut.

This folds everything except the Session title behind a single top-level "Advanced" disclosure that defaults closed. The title input stays visible; the worktree toggle, branch input, attach-existing toggle, base-branch picker, and Group input now live inside Advanced. The wizard submit path already reads every field from reducer state regardless of what is on screen, so the default new-worktree behavior is unchanged when the toggle is hidden, and the API contract does not change.

The base-branch picker's own nested disclosure is relabeled from "Advanced" to "Base branch" so two nested buttons are not both labeled "Advanced". Docs in `docs/guides/worktrees.md` are updated to match.

Closes #1514

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, press `n` to open the new-session wizard, pick a recent repo, and hit Next to reach the Session step. Confirm only the "Session title" input and an "Advanced" toggle are visible.
- [ ] Expand "Advanced". Confirm the "Create a worktree" toggle (on by default), the branch/worktree name input, the "Attach to existing branch" toggle, the "Base branch" picker, and the Group input all appear and stay editable.
- [ ] Without expanding Advanced, fill only the Session title and click Next, Next, Launch. Confirm the session is created in a new worktree branched off HEAD (the hidden worktree toggle keeps its default).
- [ ] Toggle "Create a worktree" off inside Advanced and confirm the branch input and "Base branch" picker disappear while Advanced stays open.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` (`wizard-session-step.spec.ts`). The `wizard` entry in `web/tests/coverage-matrix.json` already maps this spec and `SessionStep.tsx`, so no matrix change was needed; `validate-coverage-matrix.mjs` passes.
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)


**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (no auto-open on prefill, rename the inner picker to "Base branch"), reviewed each commit, and confirmed the Playwright specs pass.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR simplifies the new-session wizard by hiding most Session-step controls behind a top-level "Advanced" disclosure that defaults closed, leaving only the Session title input visible by default.

What changed (user-facing)
- Only the Session title input and its helper copy are visible when the Session step opens.
- Moved into a collapsed top-level "Advanced" disclosure: "Create a worktree" toggle, branch/worktree name input, "Attach to existing branch" toggle, the base-branch picker (nested disclosure relabeled "Base branch"), and the Group field.
- Helper copy under the title now explains the default behavior (creates a new git worktree branched off HEAD; expand Advanced to change).
- Advanced will auto-open on first render if any advanced-controlled field is prefilled.
- Documentation updated (docs/guides/worktrees.md).
- Playwright and Vitest tests updated/added to reflect and verify the new visibility/behavior.

What was preserved
- Submission and reducer behavior unchanged: hidden fields still contribute to the reducer and POST payload (e.g., create_new_branch defaults to true; worktree_branch still derived from the title).
- No backend/API changes.

Benefits
- Cleaner, less overwhelming Session step for most users while keeping advanced controls accessible.
- Maintains backwards compatibility with existing submit behavior and API expectations.

Technical details
- UI: SessionStep component now tracks advancedOpen and wraps non-title controls in an Advanced disclosure; inner disclosure relabeled to "Base branch"; minor event-handling fixes to the worktree toggle.
- Tests: Playwright specs under web/tests/ and Vitest/RTL tests updated/added to cover default collapsed state, expansion behavior, control wiring, and submit payloads when Advanced remains closed.
- Docs: docs/guides/worktrees.md updated to reflect the UI changes and clarify base-branch / attach-to-existing semantics.

Potential follow-ups
- Consider telemetry or user testing to validate discoverability of advanced controls.
- Optionally persist Advanced open state per user/session for frequent power users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->