### PR TITLE
feat(cockpit): surface queued-prompt count on sidebar session rows

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -56,6 +56,7 @@ import {
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { useClampedMenuPosition } from "../lib/menuPosition";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
+import { useQueuedCountForSessions } from "../hooks/useCockpitQueueCount";
 import { reportError } from "../lib/toastBus";
 import {
   repoGroupHasLiveWorkspace,
@@ -520,6 +521,11 @@ export const SessionRow = memo(function SessionRow({
     [workspace.sessions],
   );
   const hasDraft = useHasDraftForSessions(sessionIds);
+  // Queued cockpit follow-up prompts waiting to fire when the current
+  // turn ends. Summed across the workspace's sessions, mirroring how
+  // `hasDraft` ORs the same set. Lets a user juggling sessions see at a
+  // glance which rows have prompts pending without opening the cockpit.
+  const queuedCount = useQueuedCountForSessions(sessionIds);
 
   const setNotifyPreset = async (preset: NotifyPreset) => {
     setContextMenu(null);
@@ -856,6 +862,15 @@ export const SessionRow = memo(function SessionRow({
                   className="inline-flex shrink-0"
                 >
                   <Pencil className="h-3 w-3 text-amber-400/90" />
+                </span>
+              )}
+              {queuedCount > 0 && (
+                <span
+                  title={`${queuedCount} queued prompt${queuedCount === 1 ? "" : "s"}`}
+                  aria-label={`${queuedCount} queued`}
+                  className="inline-flex shrink-0 items-center rounded border border-sky-700/40 bg-sky-950/30 px-1 text-[10px] font-medium text-sky-300"
+                >
+                  {queuedCount}
                 </span>
               )}
               {effectiveArchived && (

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -868,7 +868,7 @@ export const SessionRow = memo(function SessionRow({
                 <span
                   title={`${queuedCount} queued prompt${queuedCount === 1 ? "" : "s"}`}
                   aria-label={`${queuedCount} queued`}
-                  className="inline-flex shrink-0 items-center rounded border border-sky-700/40 bg-sky-950/30 px-1 text-[10px] font-medium text-sky-300"
+                  className="inline-flex shrink-0 items-center rounded border border-sky-700/40 bg-sky-950/30 px-1 text-[10px] font-mono font-medium tabular-nums text-sky-300"
                 >
                   {queuedCount}
                 </span>

--- a/web/src/hooks/__tests__/useCockpitQueueCount.test.tsx
+++ b/web/src/hooks/__tests__/useCockpitQueueCount.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useQueuedCountForSessions } from "../useCockpitQueueCount";
+import {
+  STORAGE_KEY_PREFIX,
+  clearQueueCount,
+  setQueueCount,
+} from "../../lib/cockpitStateStorage";
+
+function entryKey(id: string): string {
+  return `${STORAGE_KEY_PREFIX}${id}`;
+}
+
+// Write a persisted cockpit-state entry shaped like useCockpit's
+// persistState output, with `queuedPrompts` of the given length.
+function writeEntry(id: string, queued: number, savedAt = Date.now()): void {
+  const queuedPrompts = Array.from({ length: queued }, (_, i) => ({
+    id: `${id}-${i}`,
+    text: `q${i}`,
+    queuedAt: new Date(savedAt).toISOString(),
+  }));
+  localStorage.setItem(
+    entryKey(id),
+    JSON.stringify({ savedAt, state: { lastSeq: 0, activity: [], queuedPrompts } }),
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  // Reset the module-level in-memory count cache between cases so a
+  // prior test's writes don't leak into the next.
+  clearQueueCount();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  clearQueueCount();
+});
+
+describe("useQueuedCountForSessions", () => {
+  it("returns 0 when no session has queued prompts", () => {
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+  });
+
+  it("lazily reads the count from a persisted localStorage entry", () => {
+    writeEntry("a", 3);
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(3);
+  });
+
+  it("sums queued counts across the workspace's sessions", () => {
+    writeEntry("a", 2);
+    writeEntry("b", 1);
+    const { result } = renderHook(() => useQueuedCountForSessions(["a", "b"]));
+    expect(result.current).toBe(3);
+  });
+
+  // Story: queued prompts drain (Stopped pops the head) or the queue is
+  // cleared; the badge updates to the remaining count and disappears at 0.
+  it("updates same-tab as the queue grows and drains via persistState", () => {
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+
+    act(() => setQueueCount("a", 2));
+    expect(result.current).toBe(2);
+
+    act(() => setQueueCount("a", 1));
+    expect(result.current).toBe(1);
+
+    act(() => setQueueCount("a", 0));
+    expect(result.current).toBe(0);
+  });
+
+  // Story: one tab enqueues a prompt; another tab's sidebar updates via
+  // the `storage` event without polling.
+  it("updates cross-tab via a storage event without a local write", () => {
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+
+    const newValue = JSON.stringify({
+      savedAt: Date.now(),
+      state: {
+        lastSeq: 0,
+        activity: [],
+        queuedPrompts: [
+          { id: "a-0", text: "q0", queuedAt: "t" },
+          { id: "a-1", text: "q1", queuedAt: "t" },
+        ],
+      },
+    });
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: entryKey("a"),
+          newValue,
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBe(2);
+  });
+
+  it("does not react to a storage event for an unsubscribed session", () => {
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: entryKey("b"),
+          newValue: JSON.stringify({
+            savedAt: Date.now(),
+            state: { lastSeq: 0, activity: [], queuedPrompts: [{ id: "b-0", text: "x", queuedAt: "t" }] },
+          }),
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBe(0);
+  });
+
+  it("treats a TTL-expired entry as 0", () => {
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    writeEntry("a", 5, eightDaysAgo);
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+  });
+
+  it("treats a corrupt entry as 0", () => {
+    localStorage.setItem(entryKey("a"), "{not json");
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+  });
+
+  it("removes its storage listener on unmount", () => {
+    const { unmount, result } = renderHook(() =>
+      useQueuedCountForSessions(["a"]),
+    );
+    unmount();
+    // After unmount the listener is gone, so a cross-tab event must not
+    // throw or leave a dangling subscriber. The hook value is frozen at
+    // its last render.
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: entryKey("a"),
+          newValue: JSON.stringify({
+            savedAt: Date.now(),
+            state: { lastSeq: 0, activity: [], queuedPrompts: [{ id: "a-0", text: "x", queuedAt: "t" }] },
+          }),
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBe(0);
+  });
+});

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -24,6 +24,13 @@ import { isClearAlias } from "../lib/agentProfiles";
 import { useAgentProfile } from "../lib/agentProfileContext";
 import { getOrCreateDeviceBindingSecret } from "../lib/deviceBinding";
 import { safeSetItem } from "../lib/safeStorage";
+import {
+  STORAGE_KEY_PREFIX,
+  STATE_TTL_MS,
+  clearQueueCount,
+  setQueueCount,
+  type PersistedEntry,
+} from "../lib/cockpitStateStorage";
 import { getToken } from "../lib/token";
 import { setSessionArchive, setSessionSnooze } from "../lib/api";
 
@@ -79,14 +86,7 @@ export type Action =
 // session-delete handler and logout flow can drop stale entries
 // instead of waiting for them to age out.
 const STATE_CACHE_CAP = 32;
-const STORAGE_KEY_PREFIX = "aoe:cockpit-state:v1:";
-const STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const stateCache = new Map<string, CockpitState>();
-
-interface PersistedEntry {
-  savedAt: number;
-  state: CockpitState;
-}
 
 function storageKey(sessionId: string): string {
   return STORAGE_KEY_PREFIX + sessionId;
@@ -141,13 +141,18 @@ function evictOldestPersistedCockpitState(currentKey: string): boolean {
 function persistState(sessionId: string, state: CockpitState): void {
   const key = storageKey(sessionId);
   const body = JSON.stringify({ savedAt: Date.now(), state } satisfies PersistedEntry);
-  if (safeSetItem(key, body)) return;
+  if (safeSetItem(key, body)) {
+    setQueueCount(sessionId, state.queuedPrompts.length);
+    return;
+  }
   // Storage write failed (likely QuotaExceeded). Evict a single oldest
   // cockpit cache entry and retry exactly once. On a second failure the
   // cache is best-effort: the next reload replays from the server, so
   // we stay silent here per the deliberate UX choice for cache writes.
   if (!evictOldestPersistedCockpitState(key)) return;
-  safeSetItem(key, body);
+  if (safeSetItem(key, body)) {
+    setQueueCount(sessionId, state.queuedPrompts.length);
+  }
 }
 
 // Test-only exports so the eviction policy can be exercised without
@@ -300,9 +305,11 @@ export function clearCockpitCache(sessionId?: string): void {
   if (sessionId === undefined) {
     stateCache.clear();
     dropAllPersistedState();
+    clearQueueCount();
   } else {
     stateCache.delete(sessionId);
     dropPersistedState(sessionId);
+    clearQueueCount(sessionId);
   }
 }
 

--- a/web/src/hooks/useCockpitQueueCount.ts
+++ b/web/src/hooks/useCockpitQueueCount.ts
@@ -1,0 +1,39 @@
+// Sidebar "N queued" badge data source. Mirrors useHasDraftForSessions
+// (cockpitDrafts.ts) but returns the SUM of queued-prompt counts across
+// the given session ids, so a workspace row reflects pending follow-ups
+// for any of its sessions. Backed by the cockpit-state storage pub/sub;
+// re-renders the caller only when the relevant counts change.
+
+import { useMemo, useSyncExternalStore } from "react";
+
+import {
+  getQueuedCount,
+  subscribeCockpitState,
+} from "../lib/cockpitStateStorage";
+
+// Returns the total number of queued cockpit follow-up prompts across the
+// given session ids. Re-renders the caller only when one of THESE ids'
+// counts changes, not on every cockpit-state write anywhere in the app.
+export function useQueuedCountForSessions(
+  sessionIds: readonly string[],
+): number {
+  // Stable join key so getSnapshot returns the same primitive across
+  // renders unless the relevant counts actually change; otherwise
+  // useSyncExternalStore would tear under React 18's strict checks.
+  const ids = sessionIds.join("|");
+  const subscribe = useMemo(() => {
+    const filter = new Set(ids ? ids.split("|").filter(Boolean) : []);
+    return (cb: () => void) => subscribeCockpitState(cb, filter);
+  }, [ids]);
+  return useSyncExternalStore(
+    subscribe,
+    () => {
+      let total = 0;
+      for (const id of ids ? ids.split("|") : []) {
+        if (id) total += getQueuedCount(id);
+      }
+      return total;
+    },
+    () => 0,
+  );
+}

--- a/web/src/lib/cockpitStateStorage.test.ts
+++ b/web/src/lib/cockpitStateStorage.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  STORAGE_KEY_PREFIX,
+  STATE_TTL_MS,
+  clearQueueCount,
+  getQueuedCount,
+  setQueueCount,
+  subscribeCockpitState,
+} from "./cockpitStateStorage";
+
+function entryKey(id: string): string {
+  return `${STORAGE_KEY_PREFIX}${id}`;
+}
+
+function writeEntry(id: string, queued: number, savedAt = Date.now()): void {
+  const queuedPrompts = Array.from({ length: queued }, (_, i) => ({
+    id: `${id}-${i}`,
+    text: `q${i}`,
+    queuedAt: "t",
+  }));
+  localStorage.setItem(
+    entryKey(id),
+    JSON.stringify({ savedAt, state: { lastSeq: 0, activity: [], queuedPrompts } }),
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  clearQueueCount();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  clearQueueCount();
+  vi.restoreAllMocks();
+});
+
+describe("getQueuedCount", () => {
+  it("returns 0 for a missing entry", () => {
+    expect(getQueuedCount("nope")).toBe(0);
+  });
+
+  it("parses the count from localStorage on a cache miss", () => {
+    writeEntry("a", 4);
+    expect(getQueuedCount("a")).toBe(4);
+  });
+
+  it("memoises the count so a later localStorage edit is not re-read", () => {
+    writeEntry("a", 2);
+    expect(getQueuedCount("a")).toBe(2);
+    // Direct localStorage mutation does not invalidate the in-memory
+    // cache; only setQueueCount / a storage event / clear do.
+    writeEntry("a", 9);
+    expect(getQueuedCount("a")).toBe(2);
+  });
+
+  it("treats a TTL-expired entry as 0", () => {
+    writeEntry("a", 5, Date.now() - STATE_TTL_MS - 1);
+    expect(getQueuedCount("a")).toBe(0);
+  });
+
+  it("treats a corrupt entry as 0", () => {
+    localStorage.setItem(entryKey("a"), "{not json");
+    expect(getQueuedCount("a")).toBe(0);
+  });
+
+  it("treats an entry without a queuedPrompts array as 0", () => {
+    localStorage.setItem(
+      entryKey("a"),
+      JSON.stringify({ savedAt: Date.now(), state: { lastSeq: 0 } }),
+    );
+    expect(getQueuedCount("a")).toBe(0);
+  });
+
+  it("returns 0 when localStorage access throws", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    expect(getQueuedCount("a")).toBe(0);
+    spy.mockRestore();
+  });
+});
+
+describe("setQueueCount", () => {
+  it("publishes the count and notifies subscribers", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    setQueueCount("a", 3);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getQueuedCount("a")).toBe(3);
+    unsub();
+  });
+
+  it("does not notify a subscriber filtered to other sessions", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["b"]));
+    setQueueCount("a", 1);
+    expect(cb).not.toHaveBeenCalled();
+    unsub();
+  });
+});
+
+describe("clearQueueCount", () => {
+  it("clears one session and notifies that session's subscribers", () => {
+    setQueueCount("a", 2);
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    clearQueueCount("a");
+    expect(cb).toHaveBeenCalledTimes(1);
+    // Cache dropped; with no localStorage entry the count reads 0.
+    expect(getQueuedCount("a")).toBe(0);
+    unsub();
+  });
+
+  it("clears all sessions and notifies every subscriber", () => {
+    const cbA = vi.fn();
+    const cbB = vi.fn();
+    const unsubA = subscribeCockpitState(cbA, new Set(["a"]));
+    const unsubB = subscribeCockpitState(cbB, new Set(["b"]));
+    clearQueueCount();
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+    unsubA();
+    unsubB();
+  });
+});
+
+describe("subscribeCockpitState storage events", () => {
+  it("refreshes the cache and notifies on a matching cross-tab write", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: entryKey("a"),
+        newValue: JSON.stringify({
+          savedAt: Date.now(),
+          state: { lastSeq: 0, activity: [], queuedPrompts: [{ id: "a-0", text: "x", queuedAt: "t" }] },
+        }),
+        storageArea: localStorage,
+      }),
+    );
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getQueuedCount("a")).toBe(1);
+    unsub();
+  });
+
+  it("ignores keys outside the cockpit-state prefix", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "some:other:key",
+        newValue: "x",
+        storageArea: localStorage,
+      }),
+    );
+    expect(cb).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it("treats a removed entry (null newValue) as 0", () => {
+    setQueueCount("a", 3);
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: entryKey("a"),
+        newValue: null,
+        storageArea: localStorage,
+      }),
+    );
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getQueuedCount("a")).toBe(0);
+    unsub();
+  });
+
+  it("fires unconditionally and drops the cache on a cross-tab clear (null key)", () => {
+    setQueueCount("a", 2);
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: null, storageArea: localStorage }),
+    );
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getQueuedCount("a")).toBe(0);
+    unsub();
+  });
+
+  it("a null-filter listener fires for any session change", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, null);
+    setQueueCount("whatever", 1);
+    expect(cb).toHaveBeenCalledTimes(1);
+    unsub();
+  });
+
+  it("stops firing after unsubscribe", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    unsub();
+    setQueueCount("a", 1);
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: entryKey("a"),
+        newValue: null,
+        storageArea: localStorage,
+      }),
+    );
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/cockpitStateStorage.ts
+++ b/web/src/lib/cockpitStateStorage.ts
@@ -87,8 +87,13 @@ export function setQueueCount(sessionId: string, count: number): void {
 // Drop a session's cached count (session delete / cache clear). With no
 // argument, clears the whole cache.
 export function clearQueueCount(sessionId?: string): void {
-  if (sessionId === undefined) queueCounts.clear();
-  else queueCounts.delete(sessionId);
+  if (sessionId === undefined) {
+    queueCounts.clear();
+    notify(null);
+    return;
+  }
+  queueCounts.delete(sessionId);
+  notify(sessionId);
 }
 
 // Side-effect-free read of a session's queued-prompt count. Safe to call

--- a/web/src/lib/cockpitStateStorage.ts
+++ b/web/src/lib/cockpitStateStorage.ts
@@ -1,0 +1,143 @@
+// Storage layer for per-session cockpit state. The cockpit reducer state
+// is mirrored into localStorage under `aoe:cockpit-state:v1:<id>` by
+// useCockpit's persistState so a reload rehydrates without replaying the
+// whole transcript (see useCockpit.ts and #1132). This module owns the
+// key shape and TTL so both the writer (useCockpit) and read-only
+// consumers (the sidebar queued-prompt badge) share one source of truth,
+// without the sidebar having to import the heavy cockpit hook and its WS
+// machinery just to read a count.
+//
+// It also exposes a small pub/sub (mirroring cockpitDrafts.ts) plus an
+// in-memory queued-prompt count cache so the sidebar can render a live
+// "N queued" badge via useSyncExternalStore. The cache keeps a snapshot
+// read O(1) and avoids JSON.parsing the (potentially large) state blob
+// during render: persistState already holds queuedPrompts.length and
+// publishes it on every write, and cross-tab `storage` events parse the
+// new value exactly once.
+
+import type { CockpitState } from "./cockpitTypes";
+
+export const STORAGE_KEY_PREFIX = "aoe:cockpit-state:v1:";
+export const STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface PersistedEntry {
+  savedAt: number;
+  state: CockpitState;
+}
+
+function storageKey(sessionId: string): string {
+  return STORAGE_KEY_PREFIX + sessionId;
+}
+
+function sessionIdFromKey(key: string): string | null {
+  if (!key.startsWith(STORAGE_KEY_PREFIX)) return null;
+  return key.slice(STORAGE_KEY_PREFIX.length);
+}
+
+// Queued-prompt count per session id, kept in sync by setQueueCount
+// (same-tab writes) and the cross-tab storage listener. A missing entry
+// means "not yet known this page load"; getQueuedCount lazily fills it
+// from localStorage on first read so inactive sessions (no mounted
+// cockpit hook writing) still resolve a count.
+const queueCounts = new Map<string, number>();
+
+type Listener = () => void;
+
+// Each listener may register an optional id filter; null means "fire for
+// any cockpit-state change" (used for a cross-tab localStorage.clear()).
+const listeners = new Map<Listener, ReadonlySet<string> | null>();
+
+function notify(sessionId: string | null): void {
+  for (const [cb, filter] of listeners) {
+    if (filter === null || sessionId === null || filter.has(sessionId)) cb();
+  }
+}
+
+// Parse a queued-prompt count out of a raw persisted entry, honoring the
+// TTL. Returns null when the entry is missing, expired, corrupt, or
+// structurally invalid so callers fall back to 0 without caching a bogus
+// value.
+function parseQueuedCount(raw: string | null): number | null {
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as PersistedEntry | null;
+    if (
+      !parsed ||
+      typeof parsed.savedAt !== "number" ||
+      Number.isNaN(parsed.savedAt) ||
+      Date.now() - parsed.savedAt > STATE_TTL_MS
+    ) {
+      return null;
+    }
+    const q = (parsed.state as Partial<CockpitState> | undefined)?.queuedPrompts;
+    return Array.isArray(q) ? q.length : null;
+  } catch {
+    return null;
+  }
+}
+
+// Publish a session's current queued-prompt count. Called by useCockpit's
+// persistState on every successful write; the length is already in hand
+// there, so no JSON parsing happens on the write hot path.
+export function setQueueCount(sessionId: string, count: number): void {
+  queueCounts.set(sessionId, count);
+  notify(sessionId);
+}
+
+// Drop a session's cached count (session delete / cache clear). With no
+// argument, clears the whole cache.
+export function clearQueueCount(sessionId?: string): void {
+  if (sessionId === undefined) queueCounts.clear();
+  else queueCounts.delete(sessionId);
+}
+
+// Side-effect-free read of a session's queued-prompt count. Safe to call
+// from a useSyncExternalStore snapshot during render: it never mutates
+// localStorage (unlike useCockpit's loadPersistedState, which prunes
+// expired entries) and returns a primitive. Reads the in-memory cache
+// first; on a miss it parses localStorage once and memoises the result.
+export function getQueuedCount(sessionId: string): number {
+  const cached = queueCounts.get(sessionId);
+  if (cached !== undefined) return cached;
+  if (typeof window === "undefined") return 0;
+  let count: number;
+  try {
+    count = parseQueuedCount(window.localStorage.getItem(storageKey(sessionId))) ?? 0;
+  } catch {
+    // localStorage blocked/threw: don't memoise a transient failure.
+    return 0;
+  }
+  queueCounts.set(sessionId, count);
+  return count;
+}
+
+// Subscribe to cockpit-state changes. `filter` scopes the listener to a
+// set of session ids; null receives every change. Fires for same-tab
+// writes (via the notify in setQueueCount) and cross-tab writes (storage
+// event). Returns an unsubscribe function. Mirrors subscribeDrafts.
+export function subscribeCockpitState(
+  cb: Listener,
+  filter: ReadonlySet<string> | null = null,
+): () => void {
+  listeners.set(cb, filter);
+  const onStorage = (e: StorageEvent) => {
+    // localStorage.clear() in another tab leaves e.key null; drop the
+    // whole count cache and fire unconditionally.
+    if (e.key === null) {
+      queueCounts.clear();
+      cb();
+      return;
+    }
+    const sid = sessionIdFromKey(e.key);
+    if (sid === null) return;
+    // Refresh the cache from the cross-tab value (parsed once) so the
+    // next snapshot read is consistent, then notify if in scope.
+    queueCounts.set(sid, parseQueuedCount(e.newValue) ?? 0);
+    if (filter === null || filter.has(sid)) cb();
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(cb);
+    window.removeEventListener("storage", onStorage);
+  };
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1382,6 +1382,28 @@
       ]
     },
     {
+      "id": "story.sidebar-queued-count",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/sidebar-queued-count.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.queued-count-hook",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/hooks/__tests__/useCockpitQueueCount.test.tsx"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "story.sidebar-select-focuses-input",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/live/cockpit-stories/sidebar-queued-count.spec.ts
+++ b/web/tests/live/cockpit-stories/sidebar-queued-count.spec.ts
@@ -1,0 +1,109 @@
+// User story: queue follow-up prompts on a cockpit session mid-turn,
+// navigate away to the sidebar (dashboard) view, and see a count badge
+// on that session's row.
+//
+// Single cockpit-enabled session: kick off a long turn, queue two
+// follow-ups via the composer's Queue button, then navigate to `/` so
+// the sidebar is the primary surface and CockpitView unmounts. The
+// queued prompts are client-only state mirrored into localStorage by
+// persistState, so the sidebar row reads the count (2) without the
+// cockpit view mounted. The queue does not drain while no cockpit hook
+// is running, so the badge is stable on the dashboard.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import {
+  enableCockpitAndWait,
+  waitForCockpitView,
+  attachServeDiagnostics,
+} from "../../helpers/cockpit";
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "First turn." },
+        },
+        // Keep turn 1 in flight long enough to queue two follow-ups and
+        // navigate; well under the cockpit supervisor idle watchdog.
+        { sessionUpdate: "wait_ms", ms: 6_000 },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("sidebar row shows the queued-prompt count badge", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-sidebar-queue-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "sidebar-queue-a" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const sessionA = sessions.find((s) => s.title === "sidebar-queue-a");
+    if (!sessionA) throw new Error("seeded session 'sidebar-queue-a' missing");
+
+    await enableCockpitAndWait(serve.baseUrl, sessionA.id, 30_000, serve.home);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionA.id)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", {
+      name: /Send a message|Queue a follow-up/i,
+    });
+    await composer.fill("kick off A");
+    await composer.press("Enter");
+    await expect(page.getByText("First turn.")).toBeVisible({ timeout: 10_000 });
+
+    // The Queue button only renders while the turn is active.
+    const queueBtn = page.getByRole("button", {
+      name: /Queue follow-up message/i,
+    });
+    await expect(queueBtn).toBeVisible({ timeout: 5_000 });
+    await composer.fill("follow-up one");
+    await queueBtn.click();
+    await composer.fill("follow-up two");
+    await queueBtn.click();
+
+    // Navigate to the dashboard so the sidebar is the primary surface.
+    await page.goto(serve.baseUrl);
+
+    // The row for session A should carry a "2 queued" badge, read from
+    // the persisted client-only queue state.
+    await expect(page.getByTitle("2 queued prompts")).toBeVisible({
+      timeout: 15_000,
+    });
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

When a cockpit session is mid-turn and the user enqueues follow-up prompts via the composer, the queued count is only visible inside `CockpitView` (the strip and the "N queued" hint on Send). The moment the user navigates to another session, that signal disappears. Sidebar rows already advertise other live cockpit signals (draft pencil, resuming pill, wakeup countdown, plan progress) but had no badge for queued follow-ups, so a user juggling sessions could not tell at a glance which ones have prompts waiting.

This adds a small per-row badge showing the queued-prompt count, summed across the workspace's sessions (mirroring how the draft pencil ORs the same set). The badge reuses the composer queue strip's sky palette so it reads as "informational pending."

The queue stays intentionally client-only. Rather than grow another one-off hook against the cockpit-state localStorage entry, a small `web/src/lib/cockpitStateStorage.ts` now owns the `aoe:cockpit-state:v1:` key shape and TTL, a pub/sub, and an in-memory queued-prompt count cache. `useCockpit`'s `persistState` publishes the count on every write (the length is already in hand, so no JSON parse on the hot path); cross-tab `storage` events parse once. The new `useQueuedCountForSessions` hook reads it through `useSyncExternalStore`, exactly mirroring `useHasDraftForSessions`. Extracting the storage layer keeps a single source of truth for the key/TTL while sparing the sidebar from importing the heavy cockpit reducer and WS machinery.

No backend change: the WS contract and `SessionResponse` schema are untouched. The TTL means a session left unopened for 7 days drops to 0, which is acceptable (week-stale queued prompts are unlikely to still be wanted).

Closes #1516

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a cockpit session, send a prompt to start a turn, and while it is running queue two follow-ups via the composer Queue button.
- [ ] Navigate to the dashboard (sidebar) view; confirm that session's row shows a "2" badge (hover shows "2 queued prompts").
- [ ] Back in the cockpit, let the turn end so a queued prompt drains; confirm the sidebar badge drops to the remaining count and disappears at 0.
- [ ] Open the same dashboard in a second browser tab; enqueue a prompt in the first tab's cockpit and confirm the second tab's sidebar badge updates without a reload.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added live story `web/tests/live/cockpit-stories/sidebar-queued-count.spec.ts` (queue two, navigate to dashboard, assert badge) and Vitest `web/src/hooks/__tests__/useCockpitQueueCount.test.tsx` (same-tab drain to 0, cross-tab `storage` event, TTL/corrupt handling, multi-session sum, listener cleanup). Both registered in the coverage matrix.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (storage-layer extraction over a one-off hook, sky palette to match the queue strip, summing across sessions) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Adds a small queued-prompt badge to WorkspaceSidebar session rows so users can see how many follow-up prompts are queued for a session (and summed across a workspace) without opening CockpitView. The feature is client-only (localStorage), uses a 7-day TTL for persisted state, and syncs across tabs via storage events. Includes unit and end-to-end tests and a coverage-matrix update.

## What Was Added

- web/src/lib/cockpitStateStorage.ts — new storage/coordination module:
  - key prefix and TTL (aoe:cockpit-state:v1:, 7 days)
  - PersistedEntry shape parsing with TTL/corruption handling
  - in-memory per-session queued-count cache
  - setQueueCount / getQueuedCount / clearQueueCount helpers
  - subscribeCockpitState pub/sub with cross-tab storage event handling
- web/src/hooks/useCockpitQueueCount.ts — new hook useQueuedCountForSessions(sessionIds) that returns the summed queued count for given sessions using useSyncExternalStore and the cockpitStateStorage subscription API
- UI: WorkspaceSidebar.tsx — integrates the hook and renders a small queued-count badge on SessionRow when count > 0 (pluralized text + aria labels; uses composer queue palette)
- Tests:
  - web/src/hooks/__tests__/useCockpitQueueCount.test.tsx — unit tests for hook (same-tab, cross-tab, TTL, corrupt entries, unmount)
  - web/src/lib/cockpitStateStorage.test.ts — unit tests for storage module (TTL, corrupt entries, cache/memoization, clear-notify paths, storage-event branches)
  - web/tests/live/cockpit-stories/sidebar-queued-count.spec.ts — Playwright live spec verifying badge persists when navigating away from cockpit view
  - Updated web/tests/coverage-matrix.json with two new entries

## What Was Modified

- web/src/hooks/useCockpit.ts — now imports storage primitives from cockpitStateStorage and publishes setQueueCount during persistState writes; clearCockpitCache now clears per-session queued counts as well
- WorkspaceSidebar.tsx — session row renders queued-count badge (small visual/typography tweaks applied in follow-up commits)
- Commit fixes: adjusted queued-badge typography to match sibling badges (monospace/tabular numbers) and fixed notification ordering so clearing the queue notifies subscribers correctly; added unit tests for these paths.

## Benefits

- Immediate visibility: users can see pending follow-ups from the sidebar without opening CockpitView.
- Lightweight and safe: client-only persistence with a TTL; no backend or WebSocket schema changes.
- Cross-tab sync: updates propagate across browser tabs via storage events.
- Low render cost: in-memory cache avoids parsing large persisted state blobs during renders.
- Well-tested: unit and e2e tests cover same-tab, cross-tab, TTL, corruption, summing across sessions, and UI behavior.

## Technical details (short)

- New API: STORAGE_KEY_PREFIX, STATE_TTL_MS, PersistedEntry, setQueueCount(sessionId, count), getQueuedCount(sessionId), clearQueueCount(sessionId?), subscribeCockpitState(cb, filter?)
- useQueuedCountForSessions builds a stable join key from sessionIds, subscribes with a Set filter, and derives the total via getQueuedCount() inside useSyncExternalStore.
- persistState in useCockpit writes the persisted entry (safeSetItem), calls setQueueCount(sessionId, queuedPrompts.length), and retries once after evicting the oldest persisted entry on quota errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->