### PR TITLE
fix(cockpit): scroll long diff lines in Edit/Write tool card on mobile

### DIFF
--- a/web/src/components/diff/StringDiff.tsx
+++ b/web/src/components/diff/StringDiff.tsx
@@ -31,7 +31,12 @@ export function StringDiff({ oldText, newText, filePath }: Props) {
   const lineTokens = tokens?.[0];
 
   return (
-    <div className="leading-[1.6]">
+    // `overflow-x-auto` gives long diff lines a horizontal scroll context.
+    // The embedding `CardChrome` clips with `overflow-hidden` and `DiffLine`
+    // content is `whitespace-pre`, so without this the right side of any line
+    // wider than the card is unreachable on a narrow viewport. Mirrors the
+    // full-size `DiffFileViewer` scroll wrapper. See #1568.
+    <div data-testid="string-diff" className="leading-[1.6] overflow-x-auto">
       {hunk.lines.map((line, i) => (
         <DiffLine
           key={`${line.old_line_num ?? "_"}-${line.new_line_num ?? "_"}-${i}`}

--- a/web/src/components/diff/__tests__/StringDiff.test.tsx
+++ b/web/src/components/diff/__tests__/StringDiff.test.tsx
@@ -30,6 +30,19 @@ describe("StringDiff", () => {
     }
   });
 
+  it("gives the diff body a horizontal scroll context (#1568)", () => {
+    // Without `overflow-x-auto` the embedding card's `overflow-hidden` clips
+    // long `whitespace-pre` lines and the right side is unreachable on mobile.
+    const { getByTestId } = render(
+      <StringDiff
+        oldText="const x = 1;\n"
+        newText={`const x = ${"a".repeat(200)};\n`}
+        filePath="snippet.ts"
+      />,
+    );
+    expect(getByTestId("string-diff").className).toMatch(/\boverflow-x-auto\b/);
+  });
+
   it("returns null for an empty diff", () => {
     const { container } = render(
       <StringDiff oldText="" newText="" filePath="snippet.ts" />,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2007,6 +2007,19 @@
       ]
     },
     {
+      "id": "cockpit.story.edit-card-diff-scroll",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/edit-card-diff-scroll.spec.ts",
+        "src/components/diff/__tests__/StringDiff.test.tsx"
+      ],
+      "components": [
+        "web/src/components/diff/StringDiff.tsx",
+        "web/src/components/cockpit/ToolCards.tsx"
+      ]
+    },
+    {
       "id": "cockpit.story.queue-follow-up-with-nav",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/cockpit-stories/edit-card-diff-scroll.spec.ts
+++ b/web/tests/live/cockpit-stories/edit-card-diff-scroll.spec.ts
@@ -1,0 +1,139 @@
+// User story (#1568): the diff embedded inside the cockpit Edit/Write tool
+// card scrolls horizontally so a line wider than the card is reachable on a
+// narrow (mobile) viewport.
+//
+// The fake ACP agent emits an `edit` tool_call whose new_string carries a line
+// far wider than the card. On a 480px viewport the expanded card body used to
+// clip that line: `CardChrome` wraps the body in `overflow-hidden`, `DiffLine`
+// content is `whitespace-pre`, and nothing in between gave a scroll context.
+// The fix adds `overflow-x-auto` to `StringDiff`'s container (mirroring the
+// full-size `DiffFileViewer` wrapper), so the diff body scrolls while the card
+// chrome and the transcript viewport stay put.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import {
+  waitForCockpitView,
+  enableCockpitAndWait,
+  attachServeDiagnostics,
+} from "../../helpers/cockpit";
+
+// A single new-string line far wider than a 480px card, with no break
+// opportunities, so `whitespace-pre` forces it past the card edge.
+const LONG_LINE = `const x = "${"a".repeat(300)}";`;
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-edit-1",
+          title: "edit big.txt",
+          kind: "edit",
+          status: "completed",
+          rawInput: {
+            file_path: "big.txt",
+            old_string: "const x = 1;",
+            new_string: LONG_LINE,
+          },
+        },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("edit card diff scrolls horizontally on a narrow viewport", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-edit-scroll-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    // Narrow viewport so the long line is wider than the card.
+    await page.setViewportSize({ width: 480, height: 800 });
+
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-edit-scroll" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-edit-scroll");
+    if (!seeded) throw new Error("seeded session 'story-edit-scroll' missing");
+    const sessionId = seeded.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("edit the file");
+    await composer.press("Enter");
+
+    // The edit card renders collapsed; its header carries the file path.
+    const cardHeader = page
+      .getByRole("button")
+      .filter({ hasText: "big.txt" })
+      .first();
+    await expect(cardHeader).toBeVisible({ timeout: 10_000 });
+    await cardHeader.click();
+
+    // The diff body is now expanded.
+    const diff = page.getByTestId("string-diff");
+    await expect(diff).toBeVisible({ timeout: 10_000 });
+
+    // Core regression: the diff container is an `overflow-x` scroll context
+    // (pre-fix it was the default `visible`, so the long line was clipped by
+    // the card's `overflow-hidden` and unreachable).
+    const overflowX = await diff.evaluate((el) => getComputedStyle(el).overflowX);
+    expect(["auto", "scroll"]).toContain(overflowX);
+
+    // And the content actually overflows that container, so the scroll
+    // affordance is real rather than vacuous.
+    await expect
+      .poll(async () =>
+        diff.evaluate(
+          (el) => (el as HTMLElement).scrollWidth - (el as HTMLElement).clientWidth,
+        ),
+      )
+      .toBeGreaterThan(0);
+
+    // Chrome stays put: scrolling lives on the diff body, not the transcript
+    // viewport, so the whole panel never gains a horizontal scrollbar.
+    const viewport = page.getByTestId("cockpit-viewport");
+    await expect(viewport).toBeVisible();
+    await expect
+      .poll(async () =>
+        viewport.evaluate(
+          (el) => (el as HTMLElement).scrollWidth - (el as HTMLElement).clientWidth,
+        ),
+      )
+      .toBeLessThanOrEqual(0);
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On mobile (reported on Pixel 8 Pro), the diff embedded inside the cockpit Edit/Write tool card had no horizontal scroll. Lines wider than the viewport were clipped at the right edge of the card, so only the start of each line was visible and the rest was unreachable. The full-size right-panel diff viewer was unaffected.

Root cause: the embedded diff path (`ToolCards.tsx` → `StringDiff` → `DiffLine`) had no scroll context. `CardChrome` clips with `overflow-hidden`, `DiffLine` content is `whitespace-pre`, and `StringDiff`'s container added no `overflow-x`, so long lines extended past the card edge with no way to reach them.

Fix: add `overflow-x-auto` to `StringDiff`'s container, mirroring the full-size `DiffFileViewer` scroll wrapper. Landing it on `StringDiff` (not just the one card body) means any future embed consumer inherits correct scroll behavior. The diff body now scrolls horizontally while the card chrome and the transcript viewport stay put. A `data-testid` anchors the regression test.

Closes #1568

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the cockpit on a mobile browser (or a narrow desktop viewport, ~480px wide).
- [ ] Trigger an agent turn that performs an Edit or Write whose old/new string contains a line wider than the card.
- [ ] Expand the tool card.
- [ ] Drag/scroll the diff body sideways: the line endings are now reachable.
- [ ] Confirm the card outer chrome and the page do not scroll horizontally; only the diff body does.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added `web/tests/live/cockpit-stories/edit-card-diff-scroll.spec.ts` (live cockpit story: fake ACP edit tool_call with a 300-char line on a 480px viewport, asserts the diff body is an `overflow-x` scroll context whose content overflows while the transcript viewport never gains a horizontal scrollbar) plus a Vitest assertion in `web/src/components/diff/__tests__/StringDiff.test.tsx`, registered as `cockpit.story.edit-card-diff-scroll` in the coverage matrix.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design call (approach B: fix at the `StringDiff` layer), reviewed each commit, and verified the Vitest red/green and the live Playwright story locally.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a display issue where long lines in embedded diffs (within the Edit/Write tool card) were being cut off on mobile devices and narrow viewports, with no way for users to see the complete line. The fix enables horizontal scrolling specifically for the diff content while keeping the rest of the page fixed and non-scrollable.

## What Changed

**Core Fix:**
- Modified the `StringDiff` component to use a horizontally scrollable container for displaying diff content
- Added explanatory comments documenting the scroll behavior for future maintainers

**Testing:**
- Added a unit test verifying the diff container has the correct scrolling class applied
- Added a Playwright regression test simulating a mobile viewport (480px width) with very long lines to ensure:
  - The diff content scrolls horizontally when lines exceed the viewport width
  - The outer transcript viewport does NOT gain a horizontal scrollbar (only the diff scrolls)
- Updated the test coverage matrix to track the new test and the components it covers

## Benefits

✓ **Resolves mobile usability issue** – Users on phones and narrow browsers can now scroll to see long lines in diffs  
✓ **Isolated scrolling** – Only the diff area scrolls horizontally; the main page and card chrome remain fixed  
✓ **Regression protection** – Automated tests prevent this issue from reoccurring  
✓ **Consistent behavior** – Mirrors the existing scroll pattern used in other diff viewers across the codebase

## Technical Details

The root cause was a combination of:
- The card chrome using `overflow: hidden` (cutting off content)
- DiffLine using `whitespace-pre` (preventing line wrapping)
- StringDiff's container lacking horizontal overflow rules

**Solution:** Added `overflow-x: auto` to the StringDiff container, similar to the existing `DiffFileViewer` implementation. This prevents long lines from extending past the card boundaries while enabling smooth horizontal scrolling when needed.

**Test Coverage:**
- Unit test: Validates the `overflow-x-auto` class is applied to the container
- Playwright test: Validates the overflow behavior on a 480px mobile-like viewport with a 300-character unbreakable line, confirming the diff scrolls horizontally while the transcript viewport remains non-scrollable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->