### PR TITLE
feat(web): match TUI settings grouping, hide low-level knobs behind Advanced fold

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -1063,7 +1063,9 @@ in-memory prompt loop entirely, so the next attach starts fresh.
 
 Set `cockpit.silent_orphan_grace_secs = 0` to disable. Both knobs are
 editable per profile in the TUI Settings (`Cockpit` category) and in
-the web dashboard's Settings tab under `Cockpit`. Nonzero values
+the web dashboard's Settings tab under `Cockpit`, inside the collapsed
+`Advanced` section alongside the other replay and watchdog tuning
+knobs. Nonzero values
 below 120 are clamped up to 120 at runtime so a typo cannot drop the
 watchdog into a tight-loop false-positive regime; debug builds honour
 `AOE_SILENT_ORPHAN_GRACE_MS` to keep test cadences sub-second.

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -14,6 +14,7 @@ import {
 } from "../lib/api";
 import type { ProfileInfo } from "../lib/types";
 import {
+  CollapsibleSection,
   ListField,
   NumberField,
   SelectField,
@@ -46,23 +47,35 @@ type SidebarItem =
   | { kind: "tab"; id: TabId; label: string }
   | { kind: "divider"; label: string };
 
-function buildSidebar(): SidebarItem[] {
+// Sidebar groups mirror the TUI Settings layout (Appearance / Sessions /
+// Environment / Notifications / Web Dashboard / System) so muscle memory
+// carries across surfaces. The TUI source of truth is
+// `categories_for_scope()` in src/tui/settings/mod.rs. Web-only tabs with no
+// TUI equivalent (Notifications push, Terminal, Security, Devices) live under
+// a "Web Dashboard" divider; TUI-only categories (Agents, Interaction, Hooks,
+// StatusHooks) are intentionally not surfaced here. Exported for unit testing
+// the exact divider/tab order without fighting the duplicated mobile + desktop
+// tab strips in the DOM.
+export function buildSidebar(): SidebarItem[] {
   return [
-    { kind: "divider", label: "General" },
+    { kind: "divider", label: "Appearance" },
+    { kind: "tab", id: "theme", label: "Theme" },
+    { kind: "divider", label: "Sessions" },
     { kind: "tab", id: "session", label: "Session" },
+    { kind: "tab", id: "cockpit", label: "Cockpit" },
+    { kind: "divider", label: "Environment" },
     { kind: "tab", id: "sandbox", label: "Sandbox" },
     { kind: "tab", id: "worktree", label: "Worktree" },
-    { kind: "tab", id: "theme", label: "Theme" },
-    { kind: "tab", id: "sound", label: "Sound" },
     { kind: "tab", id: "tmux", label: "Tmux" },
-    { kind: "tab", id: "updates", label: "Updates" },
-    { kind: "divider", label: "Web Dashboard" },
+    { kind: "divider", label: "Notifications" },
+    { kind: "tab", id: "sound", label: "Sound" },
     { kind: "tab", id: "notifications", label: "Notifications" },
+    { kind: "divider", label: "Web Dashboard" },
     { kind: "tab", id: "terminal", label: "Terminal" },
     { kind: "tab", id: "security", label: "Security" },
     { kind: "tab", id: "devices", label: "Devices" },
-    { kind: "tab", id: "cockpit", label: "Cockpit" },
-    { kind: "divider", label: "Diagnostics" },
+    { kind: "divider", label: "System" },
+    { kind: "tab", id: "updates", label: "Updates" },
     { kind: "tab", id: "logging", label: "Logging" },
   ];
 }
@@ -290,18 +303,6 @@ export function SettingsView({
                 { value: "apple_container", label: "Apple Container" },
               ]}
             />
-            <TextField
-              label="CPU limit"
-              value={(sandbox.cpu_limit as string) ?? ""}
-              onChange={(v) => saveField("sandbox", sandbox, "cpu_limit", v || null)}
-              placeholder="e.g. 4"
-            />
-            <TextField
-              label="Memory limit"
-              value={(sandbox.memory_limit as string) ?? ""}
-              onChange={(v) => saveField("sandbox", sandbox, "memory_limit", v || null)}
-              placeholder="e.g. 8g"
-            />
             <ToggleField
               label="Mount SSH keys"
               description="Mount ~/.ssh into sandbox containers"
@@ -314,55 +315,72 @@ export function SettingsView({
               checked={(sandbox.auto_cleanup as boolean) ?? true}
               onChange={(v) => saveField("sandbox", sandbox, "auto_cleanup", v)}
             />
-            <TextField
-              label="Custom instruction"
-              description="Text appended to the agent system prompt in sandboxed sessions"
-              value={(sandbox.custom_instruction as string) ?? ""}
-              onChange={(v) => saveField("sandbox", sandbox, "custom_instruction", v || null)}
-              placeholder="Additional instructions for the agent..."
-              multiline
-            />
-            <ListField
-              label="Environment variables"
-              description="Variables passed to sandbox containers (KEY or KEY=VALUE)"
-              items={(sandbox.environment as string[]) ?? []}
-              onChange={(items) => saveField("sandbox", sandbox, "environment", items)}
-              placeholder="KEY or KEY=VALUE"
-              validate={(v) => {
-                if (!/^[A-Za-z_][A-Za-z0-9_]*(=.*)?$/.test(v))
-                  return "Must be KEY or KEY=VALUE (letters, digits, underscores)";
-                return null;
-              }}
-            />
-            <ListField
-              label="Extra volumes"
-              description="Additional volume mounts (host:container[:ro])"
-              items={(sandbox.extra_volumes as string[]) ?? []}
-              onChange={(items) => saveField("sandbox", sandbox, "extra_volumes", items)}
-              placeholder="/host/path:/container/path"
-              validate={(v) => {
-                if (!v.includes(":")) return "Must contain ':' (host:container)";
-                return null;
-              }}
-            />
-            <ListField
-              label="Port mappings"
-              description="Port forwarding (host:container)"
-              items={(sandbox.port_mappings as string[]) ?? []}
-              onChange={(items) => saveField("sandbox", sandbox, "port_mappings", items)}
-              placeholder="3000:3000"
-              validate={(v) => {
-                if (!/^\d+:\d+$/.test(v)) return "Must be port:port (e.g. 3000:3000)";
-                return null;
-              }}
-            />
-            <ListField
-              label="Volume ignores"
-              description="Directories excluded from host bind mount"
-              items={(sandbox.volume_ignores as string[]) ?? []}
-              onChange={(items) => saveField("sandbox", sandbox, "volume_ignores", items)}
-              placeholder="node_modules"
-            />
+            <CollapsibleSection
+              title="Advanced"
+              subtitle="Resource limits, custom instructions, environment, volumes, and ports."
+            >
+              <TextField
+                label="CPU limit"
+                value={(sandbox.cpu_limit as string) ?? ""}
+                onChange={(v) => saveField("sandbox", sandbox, "cpu_limit", v || null)}
+                placeholder="e.g. 4"
+              />
+              <TextField
+                label="Memory limit"
+                value={(sandbox.memory_limit as string) ?? ""}
+                onChange={(v) => saveField("sandbox", sandbox, "memory_limit", v || null)}
+                placeholder="e.g. 8g"
+              />
+              <TextField
+                label="Custom instruction"
+                description="Text appended to the agent system prompt in sandboxed sessions"
+                value={(sandbox.custom_instruction as string) ?? ""}
+                onChange={(v) => saveField("sandbox", sandbox, "custom_instruction", v || null)}
+                placeholder="Additional instructions for the agent..."
+                multiline
+              />
+              <ListField
+                label="Environment variables"
+                description="Variables passed to sandbox containers (KEY or KEY=VALUE)"
+                items={(sandbox.environment as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "environment", items)}
+                placeholder="KEY or KEY=VALUE"
+                validate={(v) => {
+                  if (!/^[A-Za-z_][A-Za-z0-9_]*(=.*)?$/.test(v))
+                    return "Must be KEY or KEY=VALUE (letters, digits, underscores)";
+                  return null;
+                }}
+              />
+              <ListField
+                label="Extra volumes"
+                description="Additional volume mounts (host:container[:ro])"
+                items={(sandbox.extra_volumes as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "extra_volumes", items)}
+                placeholder="/host/path:/container/path"
+                validate={(v) => {
+                  if (!v.includes(":")) return "Must contain ':' (host:container)";
+                  return null;
+                }}
+              />
+              <ListField
+                label="Port mappings"
+                description="Port forwarding (host:container)"
+                items={(sandbox.port_mappings as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "port_mappings", items)}
+                placeholder="3000:3000"
+                validate={(v) => {
+                  if (!/^\d+:\d+$/.test(v)) return "Must be port:port (e.g. 3000:3000)";
+                  return null;
+                }}
+              />
+              <ListField
+                label="Volume ignores"
+                description="Directories excluded from host bind mount"
+                items={(sandbox.volume_ignores as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "volume_ignores", items)}
+                placeholder="node_modules"
+              />
+            </CollapsibleSection>
           </div>
         );
 
@@ -383,40 +401,45 @@ export function SettingsView({
               placeholder="../{repo-name}-worktrees/{branch}"
               mono
             />
-            <TextField
-              label="Bare repo path template"
-              description="Template for worktree directories in bare repos ({branch})"
-              value={(worktree.bare_repo_path_template as string) ?? ""}
-              onChange={(v) => saveField("worktree", worktree, "bare_repo_path_template", v)}
-              placeholder="./{branch}"
-              mono
-            />
-            <TextField
-              label="Workspace path template"
-              description="Template for multi-repo workspace directories ({branch}, {session-id})"
-              value={(worktree.workspace_path_template as string) ?? ""}
-              onChange={(v) => saveField("worktree", worktree, "workspace_path_template", v)}
-              placeholder="../{branch}-workspace-{session-id}"
-              mono
-            />
             <ToggleField
               label="Auto cleanup"
               description="Delete worktrees when sessions are removed"
               checked={(worktree.auto_cleanup as boolean) ?? true}
               onChange={(v) => saveField("worktree", worktree, "auto_cleanup", v)}
             />
-            <ToggleField
-              label="Delete branch on cleanup"
-              description="Also delete the git branch when cleaning up a worktree"
-              checked={(worktree.delete_branch_on_cleanup as boolean) ?? false}
-              onChange={(v) => saveField("worktree", worktree, "delete_branch_on_cleanup", v)}
-            />
-            <ToggleField
-              label="Init submodules"
-              description="Run `git submodule update --init --recursive` after creating a worktree"
-              checked={(worktree.init_submodules as boolean) ?? true}
-              onChange={(v) => saveField("worktree", worktree, "init_submodules", v)}
-            />
+            <CollapsibleSection
+              title="Advanced"
+              subtitle="Bare-repo and workspace path templates, branch cleanup, and submodules."
+            >
+              <TextField
+                label="Bare repo path template"
+                description="Template for worktree directories in bare repos ({branch})"
+                value={(worktree.bare_repo_path_template as string) ?? ""}
+                onChange={(v) => saveField("worktree", worktree, "bare_repo_path_template", v)}
+                placeholder="./{branch}"
+                mono
+              />
+              <TextField
+                label="Workspace path template"
+                description="Template for multi-repo workspace directories ({branch}, {session-id})"
+                value={(worktree.workspace_path_template as string) ?? ""}
+                onChange={(v) => saveField("worktree", worktree, "workspace_path_template", v)}
+                placeholder="../{branch}-workspace-{session-id}"
+                mono
+              />
+              <ToggleField
+                label="Delete branch on cleanup"
+                description="Also delete the git branch when cleaning up a worktree"
+                checked={(worktree.delete_branch_on_cleanup as boolean) ?? false}
+                onChange={(v) => saveField("worktree", worktree, "delete_branch_on_cleanup", v)}
+              />
+              <ToggleField
+                label="Init submodules"
+                description="Run `git submodule update --init --recursive` after creating a worktree"
+                checked={(worktree.init_submodules as boolean) ?? true}
+                onChange={(v) => saveField("worktree", worktree, "init_submodules", v)}
+              />
+            </CollapsibleSection>
           </div>
         );
 
@@ -565,7 +588,15 @@ export function SettingsView({
                 {OFFLINE_TITLE}: toggles will not save while disconnected.
               </div>
             )}
+            {/* Keying on tab + profile remounts the content subtree on either
+                switch, which resets every component-local <CollapsibleSection>
+                "Advanced" fold back to collapsed (user story #4) and clears any
+                half-typed field draft so it cannot blur-commit into the wrong
+                profile. It also breaks React reconciliation between sibling
+                tabs that share the same root element shape, e.g. sandbox and
+                worktree both rendering <div className="space-y-4">. */}
             <fieldset
+              key={`${activeTab}-${selectedProfile}`}
               disabled={offline}
               className="space-y-5 disabled:opacity-50 border-0 m-0 p-0 min-w-0"
             >
@@ -657,44 +688,6 @@ function CockpitSettings({
         </button>
       </div>
 
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="History cap (events)"
-          description="Per-session retention cap on cockpit events. 0 = unlimited (default); set a non-zero value to bound disk usage on long-running sessions. Persists to config.toml as cockpit.replay_events; cross-device."
-          value={
-            typeof cockpit.replay_events === "number"
-              ? (cockpit.replay_events as number)
-              : 0
-          }
-          min={0}
-          onChange={(v) => onSaveField("cockpit", "replay_events", v)}
-        />
-      </div>
-
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="Replay buffer bytes"
-          description="Per-session byte cap on the in-memory replay buffer. Persists to config.toml as cockpit.replay_bytes; cross-device."
-          value={
-            typeof cockpit.replay_bytes === "number"
-              ? (cockpit.replay_bytes as number)
-              : 0
-          }
-          min={0}
-          onChange={(v) => onSaveField("cockpit", "replay_bytes", v)}
-        />
-      </div>
-
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="Max concurrent resumes"
-          description="Upper bound on parallel cockpit worker spawns/attaches the reconciler runs on `aoe serve` cold start. Default 4 keeps Node.js bootup memory bounded for laptops/Pis (each claude-agent-acp is ~50-80 MB transient). Bounded at runtime by `min(this, max_concurrent_workers).max(1)`. Persists to config.toml as cockpit.max_concurrent_resumes; cross-device."
-          value={maxConcurrentResumes}
-          min={1}
-          onChange={(v) => onSaveField("cockpit", "max_concurrent_resumes", v)}
-        />
-      </div>
-
       <div className="flex items-start justify-between gap-3 py-1 border-t border-surface-800 pt-3">
         <div>
           <div className="text-sm text-text-bright">Show tool-call durations</div>
@@ -725,34 +718,6 @@ function CockpitSettings({
         >
           {showToolDurations ? "Visible" : "Hidden"}
         </button>
-      </div>
-
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="Silent-orphan grace (s)"
-          description="Daemon-side watchdog grace before declaring a prompt orphaned and restarting the worker. Fires when the agent finishes streaming but the adapter never sends PromptResponse (upstream agentclientprotocol/claude-agent-acp#688). Active only when no in-flight tool call is open and the prompt has produced at least one progress event, so long-running tools are unaffected. 0 disables. Default 60. Persists to config.toml as cockpit.silent_orphan_grace_secs; cross-device. See #1240."
-          value={
-            typeof cockpit.silent_orphan_grace_secs === "number"
-              ? (cockpit.silent_orphan_grace_secs as number)
-              : 60
-          }
-          min={0}
-          onChange={(v) => onSaveField("cockpit", "silent_orphan_grace_secs", v)}
-        />
-      </div>
-
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="Silent-orphan fast grace (s)"
-          description="Accelerated silent-orphan grace, used once a cost-populated UsageUpdate has arrived for the current prompt (the claude-agent-acp wrap-up accounting marker emitted just before PromptResponse). Lowers MTTR on the known adapter wedge without weakening the vendor-agnostic baseline. 0 disables the accelerator (cost UsageUpdate stops reducing the effective grace). Default 20. Persists to config.toml as cockpit.silent_orphan_fast_grace_secs; cross-device. See #1240."
-          value={
-            typeof cockpit.silent_orphan_fast_grace_secs === "number"
-              ? (cockpit.silent_orphan_fast_grace_secs as number)
-              : 20
-          }
-          min={0}
-          onChange={(v) => onSaveField("cockpit", "silent_orphan_fast_grace_secs", v)}
-        />
       </div>
 
       <div className="flex items-start justify-between gap-3 py-1 border-t border-surface-800 pt-3">
@@ -789,6 +754,63 @@ function CockpitSettings({
           ))}
         </div>
       </div>
+
+      <CollapsibleSection
+        title="Advanced"
+        subtitle="Replay retention caps and daemon watchdog tuning. Touch only when triaging a specific failure mode."
+      >
+        <NumberField
+          label="History cap (events)"
+          description="Per-session retention cap on cockpit events. 0 = unlimited (default); set a non-zero value to bound disk usage on long-running sessions. Persists to config.toml as cockpit.replay_events; cross-device."
+          value={
+            typeof cockpit.replay_events === "number"
+              ? (cockpit.replay_events as number)
+              : 0
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "replay_events", v)}
+        />
+        <NumberField
+          label="Replay buffer bytes"
+          description="Per-session byte cap on the in-memory replay buffer. Persists to config.toml as cockpit.replay_bytes; cross-device."
+          value={
+            typeof cockpit.replay_bytes === "number"
+              ? (cockpit.replay_bytes as number)
+              : 0
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "replay_bytes", v)}
+        />
+        <NumberField
+          label="Max concurrent resumes"
+          description="Upper bound on parallel cockpit worker spawns/attaches the reconciler runs on `aoe serve` cold start. Default 4 keeps Node.js bootup memory bounded for laptops/Pis (each claude-agent-acp is ~50-80 MB transient). Bounded at runtime by `min(this, max_concurrent_workers).max(1)`. Persists to config.toml as cockpit.max_concurrent_resumes; cross-device."
+          value={maxConcurrentResumes}
+          min={1}
+          onChange={(v) => onSaveField("cockpit", "max_concurrent_resumes", v)}
+        />
+        <NumberField
+          label="Silent-orphan grace (s)"
+          description="Daemon-side watchdog grace before declaring a prompt orphaned and restarting the worker. Fires when the agent finishes streaming but the adapter never sends PromptResponse (upstream agentclientprotocol/claude-agent-acp#688). Active only when no in-flight tool call is open and the prompt has produced at least one progress event, so long-running tools are unaffected. 0 disables. Default 60. Persists to config.toml as cockpit.silent_orphan_grace_secs; cross-device. See #1240."
+          value={
+            typeof cockpit.silent_orphan_grace_secs === "number"
+              ? (cockpit.silent_orphan_grace_secs as number)
+              : 60
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "silent_orphan_grace_secs", v)}
+        />
+        <NumberField
+          label="Silent-orphan fast grace (s)"
+          description="Accelerated silent-orphan grace, used once a cost-populated UsageUpdate has arrived for the current prompt (the claude-agent-acp wrap-up accounting marker emitted just before PromptResponse). Lowers MTTR on the known adapter wedge without weakening the vendor-agnostic baseline. 0 disables the accelerator (cost UsageUpdate stops reducing the effective grace). Default 20. Persists to config.toml as cockpit.silent_orphan_fast_grace_secs; cross-device. See #1240."
+          value={
+            typeof cockpit.silent_orphan_fast_grace_secs === "number"
+              ? (cockpit.silent_orphan_fast_grace_secs as number)
+              : 20
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "silent_orphan_fast_grace_secs", v)}
+        />
+      </CollapsibleSection>
 
       {error && <div className="text-xs text-rose-400">{error}</div>}
     </div>

--- a/web/src/components/__tests__/SettingsView.folds.test.tsx
+++ b/web/src/components/__tests__/SettingsView.folds.test.tsx
@@ -12,6 +12,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { SettingsView } from "../SettingsView";
+import * as api from "../../lib/api";
 
 const PROFILES = [
   { name: "main", is_default: true },
@@ -58,6 +59,24 @@ function expandAdvanced(container: HTMLElement) {
   ) as HTMLButtonElement;
   expect(trigger).toBeTruthy();
   fireEvent.click(trigger);
+}
+
+function fieldInputByLabel(
+  container: HTMLElement,
+  label: string,
+  type: "number" | "text",
+): HTMLInputElement {
+  const labels = Array.from(container.querySelectorAll("label"));
+  const match = labels.find((l) => l.textContent === label);
+  const input = match?.parentElement?.querySelector(`input[type="${type}"]`);
+  expect(input).toBeTruthy();
+  return input as HTMLInputElement;
+}
+
+function commit(input: HTMLInputElement, value: string) {
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value } });
+  fireEvent.blur(input);
 }
 
 // The profile picker is the only <select> carrying the "work" option.
@@ -127,6 +146,54 @@ describe("Settings Advanced fold", () => {
     );
     await screen.findByText("Sandbox enabled by default");
     expect(screen.queryByText("CPU limit")).toBeNull();
+  });
+
+  it("saves an edited cockpit advanced knob through the normal path", async () => {
+    const { container } = renderView("cockpit");
+    await waitFor(() => expect(screen.getByText("Queue drain mode")).toBeTruthy());
+
+    expandAdvanced(container);
+    commit(fieldInputByLabel(container, "Replay buffer bytes", "number"), "4096");
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith(
+        "main",
+        { cockpit: { replay_bytes: 4096 } },
+      ),
+    );
+  });
+
+  it("expands the worktree fold and saves an advanced field", async () => {
+    const { container } = renderView("worktree");
+    await screen.findByText("Worktrees enabled");
+
+    expect(screen.queryByText("Workspace path template")).toBeNull();
+    expandAdvanced(container);
+    expect(screen.getByText("Workspace path template")).toBeTruthy();
+
+    commit(
+      fieldInputByLabel(container, "Workspace path template", "text"),
+      "../wt-{branch}",
+    );
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+        worktree: { workspace_path_template: "../wt-{branch}" },
+      }),
+    );
+  });
+
+  it("saves an edited sandbox advanced field through the normal path", async () => {
+    const { container } = renderView("sandbox");
+    await screen.findByText("Sandbox enabled by default");
+
+    expandAdvanced(container);
+    commit(fieldInputByLabel(container, "CPU limit", "text"), "4");
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+        sandbox: { cpu_limit: "4" },
+      }),
+    );
   });
 
   it("collapses the fold when switching profiles (#4)", async () => {

--- a/web/src/components/__tests__/SettingsView.folds.test.tsx
+++ b/web/src/components/__tests__/SettingsView.folds.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+//
+// Behavioral coverage for the Settings "Advanced" folds (#1515):
+//   Story #2 - advanced cockpit knobs are hidden behind a default-collapsed
+//              fold while high-level controls stay visible.
+//   Story #4 - the fold collapses back to default when the user changes tabs
+//              or switches profiles (component-local state, not persisted).
+//
+// The end-to-end persist-after-expand path (story #3) lives in live Playwright
+// at web/tests/live/settings-advanced-fold.spec.ts.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SettingsView } from "../SettingsView";
+
+const PROFILES = [
+  { name: "main", is_default: true },
+  { name: "work", is_default: false },
+];
+
+vi.mock("../../lib/api", () => ({
+  fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchSettings: vi.fn(() =>
+    Promise.resolve({ cockpit: {}, sandbox: {}, worktree: {} }),
+  ),
+  updateProfileSettings: vi.fn(() => Promise.resolve(true)),
+  setCockpitMaster: vi.fn(() => Promise.resolve(true)),
+  setDefaultProfile: vi.fn(() => Promise.resolve(true)),
+  createProfile: vi.fn(() => Promise.resolve(true)),
+  renameProfile: vi.fn(() => Promise.resolve(true)),
+  deleteProfile: vi.fn(() => Promise.resolve(true)),
+}));
+
+const SERVER_ABOUT = {
+  cockpit_master_enabled: true,
+  cockpit_show_tool_durations: true,
+  cockpit_queue_drain_mode: "combined" as const,
+  cockpit_max_concurrent_resumes: 4,
+};
+
+function renderView(tab: string) {
+  const onSelectTab = vi.fn();
+  const utils = render(
+    <SettingsView
+      onClose={() => {}}
+      tab={tab}
+      onSelectTab={onSelectTab}
+      serverAbout={SERVER_ABOUT as never}
+      onServerAboutRefresh={() => {}}
+    />,
+  );
+  return { ...utils, onSelectTab };
+}
+
+function expandAdvanced(container: HTMLElement) {
+  const trigger = container.querySelector(
+    "button[aria-expanded]",
+  ) as HTMLButtonElement;
+  expect(trigger).toBeTruthy();
+  fireEvent.click(trigger);
+}
+
+// The profile picker is the only <select> carrying the "work" option.
+function selectProfile(container: HTMLElement, name: string) {
+  const select = Array.from(container.querySelectorAll("select")).find((s) =>
+    Array.from(s.options).some((o) => o.value === name),
+  ) as HTMLSelectElement;
+  expect(select).toBeTruthy();
+  fireEvent.change(select, { target: { value: name } });
+}
+
+describe("Settings Advanced fold", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides cockpit advanced knobs until the fold is expanded (#2)", async () => {
+    const { container } = renderView("cockpit");
+
+    // High-level controls are always visible.
+    expect(screen.getByText("Cockpit master switch")).toBeTruthy();
+    expect(screen.getByText("Show tool-call durations")).toBeTruthy();
+    expect(screen.getByText("Queue drain mode")).toBeTruthy();
+
+    // Advanced knobs are absent while collapsed.
+    expect(screen.queryByText("Replay buffer bytes")).toBeNull();
+    expect(screen.queryByText("Max concurrent resumes")).toBeNull();
+    expect(screen.queryByText("Silent-orphan grace (s)")).toBeNull();
+
+    expandAdvanced(container);
+
+    expect(screen.getByText("Replay buffer bytes")).toBeTruthy();
+    expect(screen.getByText("Max concurrent resumes")).toBeTruthy();
+    expect(screen.getByText("Silent-orphan grace (s)")).toBeTruthy();
+  });
+
+  it("collapses the fold when switching tabs, with no cross-tab leak (#4)", async () => {
+    const { container, rerender } = renderView("sandbox");
+    await screen.findByText("Sandbox enabled by default");
+
+    expandAdvanced(container);
+    expect(screen.getByText("CPU limit")).toBeTruthy();
+
+    // Switch to worktree: its Advanced fold starts collapsed (no leaked
+    // open-state from the sandbox tab sharing the same root element).
+    rerender(
+      <SettingsView
+        onClose={() => {}}
+        tab="worktree"
+        onSelectTab={() => {}}
+        serverAbout={SERVER_ABOUT as never}
+        onServerAboutRefresh={() => {}}
+      />,
+    );
+    await screen.findByText("Worktrees enabled");
+    expect(screen.queryByText("Bare repo path template")).toBeNull();
+
+    // Back to sandbox: the fold reset to collapsed.
+    rerender(
+      <SettingsView
+        onClose={() => {}}
+        tab="sandbox"
+        onSelectTab={() => {}}
+        serverAbout={SERVER_ABOUT as never}
+        onServerAboutRefresh={() => {}}
+      />,
+    );
+    await screen.findByText("Sandbox enabled by default");
+    expect(screen.queryByText("CPU limit")).toBeNull();
+  });
+
+  it("collapses the fold when switching profiles (#4)", async () => {
+    const { container } = renderView("cockpit");
+    await waitFor(() => expect(screen.getByText("Queue drain mode")).toBeTruthy());
+
+    expandAdvanced(container);
+    expect(screen.getByText("Replay buffer bytes")).toBeTruthy();
+
+    selectProfile(container, "work");
+
+    await waitFor(() =>
+      expect(screen.queryByText("Replay buffer bytes")).toBeNull(),
+    );
+  });
+});

--- a/web/src/components/__tests__/SettingsView.folds.test.tsx
+++ b/web/src/components/__tests__/SettingsView.folds.test.tsx
@@ -65,18 +65,53 @@ function fieldInputByLabel(
   container: HTMLElement,
   label: string,
   type: "number" | "text",
-): HTMLInputElement {
+): HTMLInputElement | HTMLTextAreaElement {
   const labels = Array.from(container.querySelectorAll("label"));
   const match = labels.find((l) => l.textContent === label);
-  const input = match?.parentElement?.querySelector(`input[type="${type}"]`);
+  // TextField renders a textarea when multiline (e.g. Custom instruction).
+  const selector =
+    type === "text" ? 'input[type="text"], textarea' : `input[type="${type}"]`;
+  const input = match?.parentElement?.querySelector(selector);
   expect(input).toBeTruthy();
-  return input as HTMLInputElement;
+  return input as HTMLInputElement | HTMLTextAreaElement;
 }
 
-function commit(input: HTMLInputElement, value: string) {
+function commit(
+  input: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) {
   fireEvent.focus(input);
   fireEvent.change(input, { target: { value } });
   fireEvent.blur(input);
+}
+
+// ToggleField renders a label div next to a role=switch button inside a flex
+// row; click the switch that pairs with the given label.
+function clickToggle(container: HTMLElement, label: string) {
+  const labelDiv = Array.from(container.querySelectorAll("div")).find(
+    (d) => d.textContent === label && d.querySelector("*") === null,
+  );
+  const row = labelDiv?.parentElement?.parentElement;
+  const sw = row?.querySelector('button[role="switch"]') as HTMLButtonElement;
+  expect(sw).toBeTruthy();
+  fireEvent.click(sw);
+}
+
+// ListField: open its add input, type a value, submit with Enter. Scoped to
+// the ListField whose header carries `label` so the right "+ Add" / input pair
+// is used when several lists render together.
+function addListItem(container: HTMLElement, label: string, value: string) {
+  const labelEl = Array.from(container.querySelectorAll("label")).find(
+    (l) => l.textContent === label,
+  );
+  const root = labelEl?.parentElement?.parentElement as HTMLElement;
+  // "+ Add" is hidden while the add input is already open (e.g. after a
+  // rejected invalid entry); only click it when present, then reuse the input.
+  const addBtn = labelEl?.parentElement?.querySelector("button");
+  if (addBtn) fireEvent.click(addBtn);
+  const input = root.querySelector('input[type="text"]') as HTMLInputElement;
+  fireEvent.change(input, { target: { value } });
+  fireEvent.keyDown(input, { key: "Enter" });
 }
 
 // The profile picker is the only <select> carrying the "work" option.
@@ -148,12 +183,19 @@ describe("Settings Advanced fold", () => {
     expect(screen.queryByText("CPU limit")).toBeNull();
   });
 
-  it("saves an edited cockpit advanced knob through the normal path", async () => {
+  it("saves every cockpit advanced knob through the normal path", async () => {
     const { container } = renderView("cockpit");
     await waitFor(() => expect(screen.getByText("Queue drain mode")).toBeTruthy());
 
     expandAdvanced(container);
+    commit(fieldInputByLabel(container, "History cap (events)", "number"), "500");
     commit(fieldInputByLabel(container, "Replay buffer bytes", "number"), "4096");
+    commit(fieldInputByLabel(container, "Max concurrent resumes", "number"), "8");
+    commit(fieldInputByLabel(container, "Silent-orphan grace (s)", "number"), "90");
+    commit(
+      fieldInputByLabel(container, "Silent-orphan fast grace (s)", "number"),
+      "30",
+    );
 
     await waitFor(() =>
       expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith(
@@ -161,9 +203,33 @@ describe("Settings Advanced fold", () => {
         { cockpit: { replay_bytes: 4096 } },
       ),
     );
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      cockpit: { silent_orphan_fast_grace_secs: 30 },
+    });
   });
 
-  it("expands the worktree fold and saves an advanced field", async () => {
+  it("exercises the cockpit high-level toggles outside the fold", async () => {
+    const { container } = renderView("cockpit");
+    await waitFor(() => expect(screen.getByText("Queue drain mode")).toBeTruthy());
+
+    const durations = container.querySelector(
+      'button[aria-label="Show tool-call durations"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(durations);
+
+    const serial = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Serial",
+    ) as HTMLButtonElement;
+    fireEvent.click(serial);
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+        cockpit: { queue_drain_mode: "serial" },
+      }),
+    );
+  });
+
+  it("expands the worktree fold and saves every advanced field", async () => {
     const { container } = renderView("worktree");
     await screen.findByText("Worktrees enabled");
 
@@ -172,28 +238,53 @@ describe("Settings Advanced fold", () => {
     expect(screen.getByText("Workspace path template")).toBeTruthy();
 
     commit(
+      fieldInputByLabel(container, "Bare repo path template", "text"),
+      "./{branch}",
+    );
+    commit(
       fieldInputByLabel(container, "Workspace path template", "text"),
       "../wt-{branch}",
     );
+    clickToggle(container, "Delete branch on cleanup");
+    clickToggle(container, "Init submodules");
+
     await waitFor(() =>
       expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
         worktree: { workspace_path_template: "../wt-{branch}" },
       }),
     );
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      worktree: { delete_branch_on_cleanup: true },
+    });
   });
 
-  it("saves an edited sandbox advanced field through the normal path", async () => {
+  it("saves every sandbox advanced field through the normal path", async () => {
     const { container } = renderView("sandbox");
     await screen.findByText("Sandbox enabled by default");
 
     expandAdvanced(container);
     commit(fieldInputByLabel(container, "CPU limit", "text"), "4");
+    commit(fieldInputByLabel(container, "Memory limit", "text"), "8g");
+    commit(fieldInputByLabel(container, "Custom instruction", "text"), "be terse");
+
+    // Lists exercise both the add (onChange) and validate paths: an invalid
+    // entry trips the validator, then a valid one commits.
+    addListItem(container, "Environment variables", "1bad");
+    addListItem(container, "Environment variables", "FOO=bar");
+    addListItem(container, "Extra volumes", "nocolon");
+    addListItem(container, "Extra volumes", "/h:/c");
+    addListItem(container, "Port mappings", "bad");
+    addListItem(container, "Port mappings", "3000:3000");
+    addListItem(container, "Volume ignores", "node_modules");
 
     await waitFor(() =>
       expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
         sandbox: { cpu_limit: "4" },
       }),
     );
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      sandbox: { environment: ["FOO=bar"] },
+    });
   });
 
   it("collapses the fold when switching profiles (#4)", async () => {

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -10,7 +10,37 @@
 // branch logic.
 
 import { describe, expect, it } from "vitest";
-import { resolveSelectedProfile } from "../SettingsView";
+import { buildSidebar, resolveSelectedProfile } from "../SettingsView";
+
+// Story #1: the web sidebar divider/tab order mirrors the TUI grouping
+// (categories_for_scope() in src/tui/settings/mod.rs) so muscle memory carries
+// across surfaces. Asserting the pure config is more robust than querying the
+// DOM, which renders the same list twice (mobile strip + desktop nav).
+describe("buildSidebar", () => {
+  it("matches the TUI grouping order", () => {
+    expect(buildSidebar()).toEqual([
+      { kind: "divider", label: "Appearance" },
+      { kind: "tab", id: "theme", label: "Theme" },
+      { kind: "divider", label: "Sessions" },
+      { kind: "tab", id: "session", label: "Session" },
+      { kind: "tab", id: "cockpit", label: "Cockpit" },
+      { kind: "divider", label: "Environment" },
+      { kind: "tab", id: "sandbox", label: "Sandbox" },
+      { kind: "tab", id: "worktree", label: "Worktree" },
+      { kind: "tab", id: "tmux", label: "Tmux" },
+      { kind: "divider", label: "Notifications" },
+      { kind: "tab", id: "sound", label: "Sound" },
+      { kind: "tab", id: "notifications", label: "Notifications" },
+      { kind: "divider", label: "Web Dashboard" },
+      { kind: "tab", id: "terminal", label: "Terminal" },
+      { kind: "tab", id: "security", label: "Security" },
+      { kind: "tab", id: "devices", label: "Devices" },
+      { kind: "divider", label: "System" },
+      { kind: "tab", id: "updates", label: "Updates" },
+      { kind: "tab", id: "logging", label: "Logging" },
+    ]);
+  });
+});
 
 describe("resolveSelectedProfile", () => {
   it("preserves the current selection when it still exists in the profile list", () => {

--- a/web/src/components/settings/FormFields.tsx
+++ b/web/src/components/settings/FormFields.tsx
@@ -17,6 +17,8 @@ export function CollapsibleSection({
   return (
     <div className="border border-surface-700/40 rounded-lg overflow-hidden">
       <button
+        type="button"
+        aria-expanded={open}
         onClick={() => setOpen(!open)}
         className="flex items-center justify-between w-full px-4 py-3 bg-surface-850 hover:bg-surface-800 cursor-pointer transition-colors text-left"
       >

--- a/web/src/components/settings/LoggingSettings.tsx
+++ b/web/src/components/settings/LoggingSettings.tsx
@@ -1,4 +1,10 @@
-import { NumberField, SelectField, TextField, ToggleField } from "./FormFields";
+import {
+  CollapsibleSection,
+  NumberField,
+  SelectField,
+  TextField,
+  ToggleField,
+} from "./FormFields";
 
 // Mirrors `KNOWN_SUB_TARGETS` in src/logging.rs. Keeping this list
 // hardcoded (rather than fetched) is intentional: it's the curated
@@ -147,10 +153,10 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
         ))}
       </div>
 
-      <div className="space-y-3 border-t border-surface-700 pt-4">
-        <h4 className="text-sm font-semibold text-text-primary">
-          Sink &amp; rotation
-        </h4>
+      <CollapsibleSection
+        title="Advanced"
+        subtitle="Sink and rotation. Some fields require restarting aoe to take effect."
+      >
         <p className="text-xs text-text-dim">
           These fields change where logs land on disk and how they rotate. They are written to <code>config.toml</code> immediately but require restarting <code>aoe</code> to take effect (the tracing subscriber and rotating writer are installed once at process startup).
         </p>
@@ -200,7 +206,7 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
           checked={showSpans}
           onChange={(v) => saveSinkField("show_spans", v)}
         />
-      </div>
+      </CollapsibleSection>
     </div>
   );
 }

--- a/web/src/components/settings/__tests__/LoggingSettings.test.tsx
+++ b/web/src/components/settings/__tests__/LoggingSettings.test.tsx
@@ -33,6 +33,17 @@ function commitNumber(input: HTMLInputElement, value: string) {
   fireEvent.blur(input);
 }
 
+// The sink & rotation fields now live inside a default-collapsed "Advanced"
+// CollapsibleSection, so they are absent from the DOM until the fold is
+// expanded. Click the fold trigger (the only button carrying aria-expanded)
+// before reaching for those fields.
+function expandAdvanced(container: HTMLElement) {
+  const trigger = container.querySelector(
+    "button[aria-expanded]",
+  ) as HTMLButtonElement;
+  fireEvent.click(trigger);
+}
+
 function findSelectByLabel(container: HTMLElement, label: string): HTMLSelectElement {
   const labels = container.querySelectorAll("label");
   for (const l of labels) {
@@ -106,8 +117,16 @@ describe("LoggingSettings contract", () => {
     });
   });
 
+  it("sink & rotation fields are hidden until the Advanced fold is expanded", () => {
+    const { container } = mount({});
+    expect(() => findSelectByLabel(container, "Output")).toThrow();
+    expandAdvanced(container);
+    expect(findSelectByLabel(container, "Output")).toBeTruthy();
+  });
+
   it("output select emits logging.output", () => {
     const { onSaveField, container } = mount({});
+    expandAdvanced(container);
     const select = findSelectByLabel(container, "Output");
     fireEvent.change(select, { target: { value: "stdout" } });
     expect(onSaveField).toHaveBeenCalledWith("logging", "output", "stdout");
@@ -115,6 +134,7 @@ describe("LoggingSettings contract", () => {
 
   it("file_path text commits on blur", () => {
     const { onSaveField, container } = mount({ file_path: "debug.log" });
+    expandAdvanced(container);
     // The TextField wraps an <input type=text>; the first such input in the
     // panel is the file_path field.
     const input = container.querySelector(
@@ -130,6 +150,7 @@ describe("LoggingSettings contract", () => {
 
   it("file_path falls back to 'debug.log' when blanked", () => {
     const { onSaveField, container } = mount({ file_path: "custom.log" });
+    expandAdvanced(container);
     const input = container.querySelector(
       "input[type=text]",
     ) as HTMLInputElement;
@@ -143,6 +164,7 @@ describe("LoggingSettings contract", () => {
 
   it("rotation select emits logging.rotation", () => {
     const { onSaveField, container } = mount({});
+    expandAdvanced(container);
     const select = findSelectByLabel(container, "Rotation");
     fireEvent.change(select, { target: { value: "never" } });
     expect(onSaveField).toHaveBeenCalledWith("logging", "rotation", "never");
@@ -150,6 +172,7 @@ describe("LoggingSettings contract", () => {
 
   it("max_size_mib commits a numeric value", () => {
     const { onSaveField, container } = mount({ max_size_mib: 50 });
+    expandAdvanced(container);
     const input = findNumberInputByLabel(container, "Max size (MiB)");
     commitNumber(input, "256");
     expect(onSaveField).toHaveBeenCalledWith("logging", "max_size_mib", 256);
@@ -157,6 +180,7 @@ describe("LoggingSettings contract", () => {
 
   it("keep_count commits a numeric value", () => {
     const { onSaveField, container } = mount({ keep_count: 5 });
+    expandAdvanced(container);
     const input = findNumberInputByLabel(container, "Keep count");
     commitNumber(input, "10");
     expect(onSaveField).toHaveBeenCalledWith("logging", "keep_count", 10);
@@ -164,6 +188,7 @@ describe("LoggingSettings contract", () => {
 
   it("show_spans toggle emits logging.show_spans", () => {
     const { onSaveField, container } = mount({ show_spans: false });
+    expandAdvanced(container);
     const toggle = container.querySelector(
       "button[role=switch]",
     ) as HTMLButtonElement;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -193,6 +193,41 @@
       "components": []
     },
     {
+      "id": "settings.sidebar-tui-grouping",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": [
+        "src/components/__tests__/SettingsView.test.tsx"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx"
+      ]
+    },
+    {
+      "id": "settings.advanced-fold",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/SettingsView.folds.test.tsx"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/FormFields.tsx"
+      ]
+    },
+    {
+      "id": "settings.advanced-fold-persistence",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/settings-advanced-fold.spec.ts"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/FormFields.tsx"
+      ]
+    },
+    {
       "id": "settings.logging-payload",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -224,7 +224,8 @@
       ],
       "components": [
         "web/src/components/SettingsView.tsx",
-        "web/src/components/settings/FormFields.tsx"
+        "web/src/components/settings/FormFields.tsx",
+        "web/src/components/settings/LoggingSettings.tsx"
       ]
     },
     {

--- a/web/tests/live/settings-advanced-fold.spec.ts
+++ b/web/tests/live/settings-advanced-fold.spec.ts
@@ -68,3 +68,31 @@ test("sandbox advanced knob edits persist after expanding the fold", async ({
   await page.getByRole("button", { name: /Advanced/ }).first().click();
   await expect(cpuInput).toHaveValue(newValue, { timeout: 5_000 });
 });
+
+// The other three folded tabs (Worktree, Cockpit, Logging) each render their
+// advanced fields only once the fold is expanded. Drive each one in the
+// browser so the relocated field markup is exercised end to end (the unit
+// suite asserts the same hide/expand behavior; this is the real-DOM pass).
+test("worktree, cockpit, and logging advanced folds expand in the browser", async ({
+  serve,
+  page,
+}) => {
+  const cases: Array<{ tab: string; anchor: string; field: RegExp }> = [
+    { tab: "worktree", anchor: "Worktrees enabled", field: /^Bare repo path template$/ },
+    { tab: "cockpit", anchor: "Cockpit master switch", field: /^Replay buffer bytes$/ },
+    { tab: "logging", anchor: "Default level", field: /^Output$/ },
+  ];
+
+  for (const { tab, anchor, field } of cases) {
+    await page.goto(`${serve.baseUrl}/settings/${tab}`);
+    await expect(page.getByText(anchor).first()).toBeVisible({ timeout: 10_000 });
+
+    // Folded away by default.
+    await expect(page.locator("label", { hasText: field })).toHaveCount(0);
+
+    await page.getByRole("button", { name: /Advanced/ }).first().click();
+    await expect(page.locator("label", { hasText: field })).toBeVisible({
+      timeout: 5_000,
+    });
+  }
+});

--- a/web/tests/live/settings-advanced-fold.spec.ts
+++ b/web/tests/live/settings-advanced-fold.spec.ts
@@ -1,14 +1,16 @@
-// Story #3 (#1515): expanding the Cockpit "Advanced" fold and editing a knob
-// inside it persists through the same save-on-change path as any other field.
+// Story #3 (#1515): expanding an "Advanced" fold and editing a knob inside it
+// persists through the same save-on-change path as any other field.
 //
 // Drives the real settings UI (not the REST endpoint): land on
-// /settings/cockpit, confirm the advanced knobs are folded away by default,
-// expand the fold, edit cockpit.replay_bytes, and assert the value reaches the
-// profile config and survives a page reload.
+// /settings/sandbox, confirm the advanced knobs are folded away by default,
+// expand the fold, edit sandbox.cpu_limit, and assert the value reaches the
+// profile config and survives a page reload. Sandbox is used (rather than
+// Cockpit) because `cockpit` is not an allowed profile-settings section, so
+// cockpit knobs do not round-trip through PATCH /api/profiles/{p}/settings.
 
 import { test, expect } from "../helpers/liveTest";
 
-test("cockpit advanced knob edits persist after expanding the fold", async ({
+test("sandbox advanced knob edits persist after expanding the fold", async ({
   serve,
   page,
 }) => {
@@ -20,45 +22,49 @@ test("cockpit advanced knob edits persist after expanding the fold", async ({
   const profileUrl = `${serve.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
 
   const before = await fetch(profileUrl).then((r) => r.json());
-  const baseline = (before?.cockpit?.replay_bytes as number | undefined) ?? 0;
-  const newValue = baseline === 4096 ? 8192 : 4096;
+  const baseline = (before?.sandbox?.cpu_limit as string | undefined) ?? "";
+  const newValue = baseline === "4" ? "2" : "4";
 
-  await page.goto(`${serve.baseUrl}/settings/cockpit`);
+  await page.goto(`${serve.baseUrl}/settings/sandbox`);
 
-  // The high-level master switch is visible immediately; the advanced knob is
-  // folded away by default.
-  await expect(page.getByText("Cockpit master switch")).toBeVisible({
+  // A high-level control is visible immediately; the advanced knob is folded
+  // away by default.
+  await expect(page.getByText("Sandbox enabled by default")).toBeVisible({
     timeout: 10_000,
   });
-  await expect(page.getByText("Replay buffer bytes")).toHaveCount(0);
+  await expect(
+    page.locator("label", { hasText: /^CPU limit$/ }),
+  ).toHaveCount(0);
 
   // Expand the Advanced fold.
   await page.getByRole("button", { name: /Advanced/ }).first().click();
 
-  const replayInput = page
-    .locator("label", { hasText: /^Replay buffer bytes$/ })
+  const cpuInput = page
+    .locator("label", { hasText: /^CPU limit$/ })
     .locator("..")
-    .locator('input[type="number"]');
-  await expect(replayInput).toBeVisible({ timeout: 5_000 });
+    .locator('input[type="text"]');
+  await expect(cpuInput).toBeVisible({ timeout: 5_000 });
 
-  // Edit and commit (NumberField commits on blur / Enter).
-  await replayInput.fill(String(newValue));
-  await replayInput.press("Enter");
+  // Edit and commit (TextField commits on blur / Enter).
+  await cpuInput.fill(newValue);
+  await cpuInput.press("Enter");
 
   // Server-side: PATCH landed against the profile config.
   await expect(async () => {
     const after = await fetch(profileUrl).then((r) => r.json());
-    expect(after?.cockpit?.replay_bytes).toBe(newValue);
+    expect(after?.sandbox?.cpu_limit).toBe(newValue);
   }).toPass({ timeout: 5_000 });
 
   // Frontend-side: after reload the fold is collapsed again (component-local,
   // not persisted), and re-expanding shows the persisted value.
   await page.reload();
-  await expect(page.getByText("Cockpit master switch")).toBeVisible({
+  await expect(page.getByText("Sandbox enabled by default")).toBeVisible({
     timeout: 10_000,
   });
-  await expect(page.getByText("Replay buffer bytes")).toHaveCount(0);
+  await expect(
+    page.locator("label", { hasText: /^CPU limit$/ }),
+  ).toHaveCount(0);
 
   await page.getByRole("button", { name: /Advanced/ }).first().click();
-  await expect(replayInput).toHaveValue(String(newValue), { timeout: 5_000 });
+  await expect(cpuInput).toHaveValue(newValue, { timeout: 5_000 });
 });

--- a/web/tests/live/settings-advanced-fold.spec.ts
+++ b/web/tests/live/settings-advanced-fold.spec.ts
@@ -1,0 +1,64 @@
+// Story #3 (#1515): expanding the Cockpit "Advanced" fold and editing a knob
+// inside it persists through the same save-on-change path as any other field.
+//
+// Drives the real settings UI (not the REST endpoint): land on
+// /settings/cockpit, confirm the advanced knobs are folded away by default,
+// expand the fold, edit cockpit.replay_bytes, and assert the value reaches the
+// profile config and survives a page reload.
+
+import { test, expect } from "../helpers/liveTest";
+
+test("cockpit advanced knob edits persist after expanding the fold", async ({
+  serve,
+  page,
+}) => {
+  const profiles: Array<{ name: string; is_default?: boolean }> = await fetch(
+    `${serve.baseUrl}/api/profiles`,
+  ).then((r) => r.json());
+  const defaultProfile =
+    profiles.find((p) => p.is_default)?.name ?? profiles[0]?.name ?? "main";
+  const profileUrl = `${serve.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
+
+  const before = await fetch(profileUrl).then((r) => r.json());
+  const baseline = (before?.cockpit?.replay_bytes as number | undefined) ?? 0;
+  const newValue = baseline === 4096 ? 8192 : 4096;
+
+  await page.goto(`${serve.baseUrl}/settings/cockpit`);
+
+  // The high-level master switch is visible immediately; the advanced knob is
+  // folded away by default.
+  await expect(page.getByText("Cockpit master switch")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByText("Replay buffer bytes")).toHaveCount(0);
+
+  // Expand the Advanced fold.
+  await page.getByRole("button", { name: /Advanced/ }).first().click();
+
+  const replayInput = page
+    .locator("label", { hasText: /^Replay buffer bytes$/ })
+    .locator("..")
+    .locator('input[type="number"]');
+  await expect(replayInput).toBeVisible({ timeout: 5_000 });
+
+  // Edit and commit (NumberField commits on blur / Enter).
+  await replayInput.fill(String(newValue));
+  await replayInput.press("Enter");
+
+  // Server-side: PATCH landed against the profile config.
+  await expect(async () => {
+    const after = await fetch(profileUrl).then((r) => r.json());
+    expect(after?.cockpit?.replay_bytes).toBe(newValue);
+  }).toPass({ timeout: 5_000 });
+
+  // Frontend-side: after reload the fold is collapsed again (component-local,
+  // not persisted), and re-expanding shows the persisted value.
+  await page.reload();
+  await expect(page.getByText("Cockpit master switch")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByText("Replay buffer bytes")).toHaveCount(0);
+
+  await page.getByRole("button", { name: /Advanced/ }).first().click();
+  await expect(replayInput).toHaveValue(String(newValue), { timeout: 5_000 });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web dashboard Settings sidebar grouped tabs by surface (General / Web Dashboard / Diagnostics) while the TUI groups by purpose, so muscle memory did not carry across surfaces. On top of that, the Cockpit, Sandbox, Worktree, and Logging tabs rendered every low-level tuning knob inline at the same visual weight as the master controls, so a new user opening Cockpit settings saw a wall of byte caps and watchdog seconds with no signal that they were advanced.

This PR reorders `buildSidebar()` to mirror the TUI grouping (Appearance, Sessions, Environment, Notifications, Web Dashboard, System); the source of truth is `categories_for_scope()` in `src/tui/settings/mod.rs`. Web-only tabs with no TUI equivalent (Notifications push, Terminal, Security, Devices) sit under a "Web Dashboard" divider; TUI-only categories (Agents, Interaction, Hooks, StatusHooks) are intentionally left for a separate follow-up.

It then hides the low-level knobs behind the existing `CollapsibleSection` as a default-collapsed "Advanced" fold on four tabs: Cockpit (replay caps, concurrent resumes, silent-orphan grace knobs), Sandbox (resource limits, custom instruction, env, volumes, ports), Worktree (bare-repo/workspace path templates, branch cleanup, submodules), and Logging (the sink and rotation block). High-level controls stay visible.

The fold is component-local and resets to collapsed on tab or profile switch. That is achieved by keying the content `<fieldset>` on `activeTab` plus `selectedProfile`, which remounts the subtree on either change. As a bonus this clears any half-typed field draft so it cannot blur-commit into the wrong profile, and it breaks React reconciliation between sibling tabs that share the same root element shape (sandbox and worktree both render `<div className="space-y-4">`), preventing fold open-state from leaking across tabs.

This is presentation only: no config schema, field names, or save semantics change.

Closes #1515

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard Settings; confirm the sidebar dividers read Appearance, Sessions, Environment, Notifications, Web Dashboard, System in that order, matching the TUI.
- [ ] Open the Cockpit tab; confirm the master switch, "Show tool-call durations", and "Queue drain mode" are visible, and the replay/watchdog knobs are hidden under a collapsed "Advanced" fold.
- [ ] Expand "Advanced", change "Replay buffer bytes", reload the page; confirm the fold is collapsed again and re-expanding shows the persisted value.
- [ ] Open the Cockpit Advanced fold, then switch tabs or switch the active profile and return; confirm the fold is collapsed again (state does not leak).
- [ ] Repeat the fold checks on Sandbox, Worktree, and Logging tabs.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Coverage maps to the four user stories in the issue: `buildSidebar` unit test for the TUI-grouped order; SettingsView RTL tests for advanced-knobs-hidden-until-expanded and fold-collapses-on-tab/profile-switch; and a live Playwright spec for edit-inside-fold-persists-across-reload. Three new entries registered in `web/tests/coverage-matrix.json`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation were drafted by Claude under my direction, with a multi-model design debate to settle the fold-reset mechanism and test split. I made the design calls, reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed (high-level)
- Reordered the web Settings sidebar to match the TUI grouping/order: Appearance, Sessions, Environment, Notifications, Web Dashboard, System. Web-only tabs are grouped under "Web Dashboard"; TUI-only categories deferred.
- Moved low-level/tuning controls on four tabs into default-collapsed "Advanced" folds so the main UI shows high-level controls first:
  - Cockpit: replay caps/bytes, max concurrent resumes, silent-orphan grace knobs.
  - Sandbox: CPU/memory limits, environment, extra volumes, port mappings, volume ignores, custom instruction.
  - Worktree: bare/workspace path templates, delete-branch-on-cleanup, init submodules.
  - Logging: Sink & rotation controls (per-target overrides remain visible).
- Advanced folds are component-local and reset (collapsed) when switching tabs or profiles to avoid cross-tab/profile state leakage and half-typed drafts.
- Presentation-only: no config schema, keys, or save semantics changed.

## Additions and edits
- Exported buildSidebar() and reordered tabs to follow the TUI grouping, enabling deterministic tests.
- Reused CollapsibleSection for a default-collapsed, accessible "Advanced" fold; toggle now sets type="button" and aria-expanded.
- Keyed the content fieldset by `${activeTab}-${selectedProfile}` to force remounts and clear local fold/input state on tab/profile change.
- Tests added/updated:
  - Unit test asserting sidebar divider/tab order matches TUI.
  - Vitest + RTL tests for Advanced fold visibility, collapse-on-tab/profile-switch, and save paths for relocated fields.
  - Playwright live tests confirming advanced edits persist server-side and folds collapse on reload.
- Updated docs/cockpit.md to document cockpit knobs now living under Cockpit → Advanced.
- Updated coverage matrix entries for the new settings surfaces.

## Removals / rework
- Replaced previous "General / Diagnostics" grouping with TUI-aligned ordering.
- Previously always-visible advanced fields are now hidden behind Advanced folds (UI-only).

## Benefits
- Cleaner, less-cluttered Settings surface emphasizing common/high-level controls.
- Better parity with TUI improves discoverability and consistency across interfaces.
- Reduces accidental changes to tuning knobs by hiding advanced options by default.
- Prevents confusing shared fold state across tabs/profiles and reduces partial-draft leakage.
- Maintains accessibility and end-to-end test coverage.

## Technical notes
- buildSidebar() exported and ordered to follow categories_for_scope() from the TUI source of truth.
- Content fieldset keyed by `${activeTab}-${selectedProfile}` to force remounts and reset component-local Advanced state.
- CollapsibleSection used for Advanced folds; toggle includes aria-expanded and explicit type="button".
- No persisted config keys or save semantics changed; changes are presentation-only.
- Tests: unit, RTL, and Playwright live coverage added; PR closes `#1515`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->