### PR TITLE
fix(cockpit): make ConfigOptionCategory forward-compatible on the TS and Rust sides

### DIFF
--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2961,7 +2961,21 @@ fn map_acp_config_option(
         SessionConfigOptionCategory::Model => ConfigOptionCategory::Model,
         SessionConfigOptionCategory::ThoughtLevel => ConfigOptionCategory::ThoughtLevel,
         SessionConfigOptionCategory::Other(s) => ConfigOptionCategory::Other(s),
-        _ => ConfigOptionCategory::Other(String::new()),
+        // The schema enum is `#[non_exhaustive]`, so this arm is required
+        // to compile. Unknown category *names* arrive via the untagged
+        // `Other(String)` arm above; this fires only when upstream adds a
+        // genuinely new named variant we haven't mapped yet. Warn so the
+        // gap is visible instead of silently surfacing a categoryless
+        // option with an empty payload.
+        other => {
+            tracing::warn!(
+                target: "cockpit.acp",
+                variant = ?other,
+                "unknown SessionConfigOptionCategory; treating as Other(\"\"). \
+                 Bump claude-agent-acp or add a match arm.",
+            );
+            ConfigOptionCategory::Other(String::new())
+        }
     });
 
     // Only `Select` is rendered today; future kinds (boolean toggles
@@ -6658,6 +6672,58 @@ mod tests {
                 assert_eq!(options[1].category, ConfigOptionCategory::ThoughtLevel);
                 assert_eq!(options[1].current_value, "default");
                 assert_eq!(options[2].category, ConfigOptionCategory::Mode);
+            }
+            other => panic!("expected ConfigOptionsUpdated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_config_option_preserves_unknown_category_name() {
+        // Forward-compat path for #1563: a category name aoe doesn't
+        // recognize arrives via the upstream untagged `Other(String)`
+        // arm. It must pass through as `Other(<name>)` and the option
+        // must not be dropped from the descriptor list. (The wildcard
+        // `_` arm that warns fires only for a genuinely new *named*
+        // upstream variant, which cannot be constructed against the
+        // current `#[non_exhaustive]` schema, so it is verified by
+        // inspection rather than a unit test.)
+        use agent_client_protocol::schema::{
+            ConfigOptionUpdate, SessionConfigKind, SessionConfigOption,
+            SessionConfigOptionCategory, SessionConfigSelect, SessionConfigSelectOption,
+            SessionConfigSelectOptions,
+        };
+        let unknown = SessionConfigOption::new(
+            "future",
+            "Future Selector",
+            SessionConfigKind::Select(SessionConfigSelect::new(
+                "a",
+                SessionConfigSelectOptions::Ungrouped(vec![SessionConfigSelectOption::new(
+                    "a", "A",
+                )]),
+            )),
+        )
+        .category(SessionConfigOptionCategory::Other(
+            "future_category".to_string(),
+        ));
+        let update = ConfigOptionUpdate::new(vec![unknown]);
+
+        let events = map_update_to_events(
+            SessionUpdate::ConfigOptionUpdate(update),
+            &agent_profiles::CLAUDE,
+        );
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Event::ConfigOptionsUpdated { options } => {
+                assert_eq!(
+                    options.len(),
+                    1,
+                    "unknown-category option must not be dropped"
+                );
+                assert_eq!(options[0].id, "future");
+                assert_eq!(
+                    options[0].category,
+                    ConfigOptionCategory::Other("future_category".to_string()),
+                );
             }
             other => panic!("expected ConfigOptionsUpdated, got {other:?}"),
         }

--- a/web/src/components/cockpit/SessionConfigControls.test.tsx
+++ b/web/src/components/cockpit/SessionConfigControls.test.tsx
@@ -196,6 +196,48 @@ describe("SessionConfigControls", () => {
     expect(other.disabled).toBe(false);
   });
 
+  // #1562: an unknown category arrives on the wire as a bare string
+  // (the Rust `Other(String)` arm is `#[serde(untagged)]`). The picker
+  // filters by string equality, so an unknown-category option must not
+  // break the model / effort lookup and gets no widget of its own.
+  it("ignores an unknown-category option and still finds the known ones", () => {
+    const unknown: ConfigOptionDescriptor = {
+      id: "future",
+      name: "Future Selector",
+      category: "future_category",
+      current_value: "a",
+      options: [{ value: "a", name: "A" }],
+    };
+    render(
+      <SessionConfigControls
+        configOptions={[unknown, modelOption(), effortOption()]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("config-option-model")).toBeTruthy();
+    expect(screen.getByTestId("config-option-effort")).toBeTruthy();
+    expect(screen.queryByTestId("config-option-future")).toBeNull();
+  });
+
+  it("renders nothing when only an unknown-category option is present", () => {
+    const unknown: ConfigOptionDescriptor = {
+      id: "future",
+      name: "Future Selector",
+      category: "future_category",
+      current_value: "a",
+      options: [{ value: "a", name: "A" }],
+    };
+    const { container } = render(
+      <SessionConfigControls
+        configOptions={[unknown]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
   it("truncates long model labels in the chip", () => {
     const longModel: ConfigOptionDescriptor = {
       ...modelOption(),

--- a/web/src/lib/__tests__/cockpitTypes.types.test.ts
+++ b/web/src/lib/__tests__/cockpitTypes.types.test.ts
@@ -1,0 +1,26 @@
+// Type-level regression tests for the cockpit wire types. These run
+// under Vitest's typecheck mode (see `test.typecheck` in
+// `vite.config.ts`); a failing assertion is a tsc error, not a runtime
+// failure. Guards #1562: the Rust `ConfigOptionCategory::Other(String)`
+// arm is `#[serde(untagged)]`, so an unknown category arrives on the
+// wire as a bare string. The TS type must accept any string for those,
+// not the `{ Other: string }` object shape that never matches.
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { ConfigOptionCategory } from "../cockpitTypes";
+
+describe("ConfigOptionCategory", () => {
+  it("accepts an arbitrary wire string for unknown categories", () => {
+    // Fails to type-check under the old `{ Other: string }` variant: a
+    // bare string is not assignable to it.
+    expectTypeOf<string>().toExtend<ConfigOptionCategory>();
+    expectTypeOf("future_category").toExtend<ConfigOptionCategory>();
+  });
+
+  it("still admits the known spec literals", () => {
+    expectTypeOf<"mode">().toExtend<ConfigOptionCategory>();
+    expectTypeOf<"model">().toExtend<ConfigOptionCategory>();
+    expectTypeOf<"thought_level">().toExtend<ConfigOptionCategory>();
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -105,14 +105,16 @@ export interface AvailableCommand {
 /** Semantic category for a session configuration option, mirroring
  *  ACP's `SessionConfigOptionCategory`. The cockpit UI uses this to
  *  pick the right widget per category (model dropdown, effort
- *  segmented control). Unknown categories preserve their string
- *  payload so the broadcast frame stays forward-compatible. See
- *  #1403. */
+ *  segmented control). The Rust `Other(String)` arm is
+ *  `#[serde(untagged)]`, so an unknown category arrives on the wire as
+ *  a bare string, not a `{ Other: string }` object. Modeling it as a
+ *  catch-all string keeps the broadcast frame forward-compatible while
+ *  preserving autocomplete on the known literals. See #1403, #1562. */
 export type ConfigOptionCategory =
   | "mode"
   | "model"
   | "thought_level"
-  | { Other: string };
+  | (string & {});
 
 /** One choice in a `Select`-kind ConfigOptionDescriptor. */
 export interface ConfigOptionChoice {

--- a/web/tsconfig.vitest.json
+++ b/web/tsconfig.vitest.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo"
   },
-  "include": ["src"],
+  // Scoped to the dedicated type-test files only. tsc still pulls in the
+  // production source they import, but the rest of the runtime test
+  // suite (excluded from tsc by `tsconfig.app.json`) stays unchecked, so
+  // its pre-existing loose typings don't fail the typecheck run.
+  "include": ["src/**/*.types.test.ts"],
   "exclude": []
 }

--- a/web/tsconfig.vitest.json
+++ b/web/tsconfig.vitest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": []
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -36,7 +36,22 @@ export default defineConfig({
   // expects but aren't valid vitest tests, so we explicitly exclude them.
   test: {
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
-    exclude: ["tests/**", "node_modules/**", "dist/**"],
+    // Type-level tests (`*.types.test.ts`) run under the typecheck runner
+    // below, not the runtime runner, so keep them out of `include`.
+    exclude: [
+      "tests/**",
+      "node_modules/**",
+      "dist/**",
+      "src/**/*.types.test.ts",
+    ],
+    // `expectTypeOf` assertions in `*.types.test.ts` are checked by tsc.
+    // A failing assertion surfaces as a type error. Scoped to the
+    // dedicated type-test files so the rest of the suite stays fast.
+    typecheck: {
+      enabled: true,
+      include: ["src/**/*.types.test.ts"],
+      tsconfig: "./tsconfig.vitest.json",
+    },
     setupFiles: ["./src/test-setup.ts"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two `#1548` post-merge follow-ups on `ConfigOptionCategory`, the cockpit's per-session config selector category. They are the TS and Rust halves of the same forward-compat gap, so they ship together.

**#1562 (web):** The Rust `ConfigOptionCategory::Other(String)` arm is `#[serde(untagged)]`, so an unknown category serializes on the wire as a bare string, never the `{ Other: string }` object the TS type declared. That variant could never match a real payload; the bug was latent only because every consumer string-compares against the known literals. The TS type is widened to a catch-all string (`string & {}`, which keeps autocomplete on the known literals). A type-level regression test fails to compile under the old shape, and RTL coverage confirms an unknown-category option does not break the model / effort lookup.

To make the type-only fix testable with a true red/green, this wires Vitest's typecheck runner against a dedicated `tsconfig.vitest.json`, scoped to `*.types.test.ts` files so the rest of the suite stays runtime-only.

**#1563 (Rust):** The wildcard arm in `map_acp_config_option` collapsed any future named `SessionConfigOptionCategory` variant to `Other("")` with no diagnostic, so an upstream schema bump that adds a category would silently surface a categoryless option with an empty payload. A `tracing::warn!` is added on that arm. The arm is required because the upstream enum is `#[non_exhaustive]`; it is unreachable with the current schema (unknown category *names* arrive via the untagged `Other(String)` arm), so it fires only on the next upstream variant addition and is verified by inspection. A unit test locks the reachable path: an unknown category name passes through as `Other(name)` and the option is not dropped.

Closes #1562
Closes #1563

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] `cd web && npx vitest --run --typecheck.enabled` passes, including `src/lib/__tests__/cockpitTypes.types.test.ts`.
- [ ] Temporarily revert `ConfigOptionCategory` back to `| { Other: string }` and re-run the above; the type test fails to compile (proves the regression test bites).
- [ ] `cd web && npx vitest run src/components/cockpit/SessionConfigControls.test.tsx` passes; an unknown-category option renders no widget and does not break the model / effort selectors.
- [ ] `cargo test --features serve --lib map_config_option_preserves_unknown_category_name` passes; an unknown category name maps to `Other(name)` and is not dropped.
- [ ] Inspect `src/cockpit/acp_client.rs`: the wildcard category arm emits `tracing::warn!(target: "cockpit.acp", ...)` before producing the placeholder.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

(No user-visible UI change: both fixes are internal forward-compat. No docs surface affected.)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The TS change is type-only with no runtime/visible behavior change, so a Playwright spec would not bite. Coverage is added at the right layer instead: a Vitest type test (`cockpitTypes.types.test.ts`) and RTL cases on `SessionConfigControls`. The existing `cockpit.config-pickers` matrix entry already lists the touched components.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

#1563 is a cockpit ACP adapter diagnostic; covered by a Rust unit test on `map_acp_config_option`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (catch-all `string & {}` over plain `string`; shipping the warn even though its firing path is unreachable today), reviewed each commit, and ran the validation steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR makes ConfigOptionCategory forward-compatible across the web (TypeScript) and cockpit (Rust) codepaths so unknown or future category variants are handled safely and visibly.

## What changed (high-level)

- Web/TypeScript:
  - Broadened the ConfigOptionCategory wire type to accept unknown categories as plain strings instead of an object wrapper.
  - Added a type-level test and RTL tests to ensure unknown categories don't break lookups or UI rendering.
  - Added a Vitest-specific tsconfig and updated vite config so type-only tests run under the typecheck runner without affecting runtime tests.

- Rust/Cockpit:
  - Improved the wildcard mapping for unknown categories to preserve unknown names and emit a tracing::warn! when an unmapped variant is seen.
  - Added a unit test verifying unknown category names are preserved instead of being dropped or replaced.

## Benefits

- Forward compatibility for future ConfigOptionCategory variants without immediate code changes.
- Preserves unknown category data instead of discarding it.
- Rust-side warnings make schema evolution visible to developers.
- Type-level tests catch serialization/type shape regressions early.

## Technical details (brief)

- The Rust enum serializes unknown variants as an untagged bare string; the TS type previously expected { Other: string }. The TS type is changed to a catch-all string (string & {}) to match Rust’s serde behavior while keeping autocomplete for known literals.
- Vitest now runs *.types.test.ts under a dedicated tsconfig (web/tsconfig.vitest.json) to perform tsc typechecks without enabling typecheck across runtime tests.
- The Rust map_acp_config_option wildcard arm retains mapping to Other(name) for #[non_exhaustive] variants and adds tracing::warn! to surface new upstream enum additions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->