### PR TITLE
feat(web): first-run interactive tutorial for the dashboard

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -230,8 +230,15 @@ aoe serve --daemon
 - **Multi-profile** support (shows sessions from all profiles)
 - **Connected Devices** view in Settings > Security
 - **Push notifications** on Waiting / Idle / Error transitions, with per-session overrides ([guide](push-notifications.md))
+- **First-run tutorial** highlighting the major UI regions and their shortcuts (see below)
 
-### Mobile layout
+### First-run tutorial
+
+The first time you open the dashboard in a browser, an interactive walkthrough launches automatically and highlights the major regions: the command bar, the workspace sidebar, how to start a session, settings, and (inside a session) the diff panel and composer. Each step lists the keyboard shortcuts that apply to it, and every step has a **Skip** button so you can dismiss the whole tour in one click.
+
+Completing or skipping the tour records that you have seen it (a per-browser `aoe-tour-seen` flag in `localStorage`), so it does not launch again on reload. Because the flag is per origin, a debug build on port 8081 and a release build on port 8080 each track it separately.
+
+To replay it at any time, open the overflow menu (the three-dot **More options** button in the top bar) and choose **Show tutorial**. Re-triggering it adapts to where you are: on the dashboard it covers the dashboard regions; inside a session it also covers the composer, agent mode picker, and send/queue controls. The tutorial does not auto-launch on touch devices, where it is available only from the menu.
 
 On phones (below the `md` breakpoint) the dashboard shows a single full-viewport pane rather than the desktop side-by-side split. The right-panel button in the top bar opens a picker that swaps the main pane between three views: the **Agent terminal**, the **Diff** (changed files and review), and the **Paired terminal** (host or container shell). A back chip in the top-left of the diff and paired views returns you to the agent terminal.
 

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
             pname = "agent-of-empires-web";
             version = "0";
             src = ./web;
-            npmDepsHash = "sha256-0kDf8uOE1H7+f6/hZIZgjsav7dtWvj4G2q3dDCCusWU=";
+            npmDepsHash = "sha256-HxB9QA7pmEuHRsJ/1TLZAALkP/RD1J8PG3ZpHpYzMNo=";
             # tsc -b && vite build; output goes to web/dist
             installPhase = ''
               mkdir $out

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,6 +25,7 @@
         "marked": "^18.0.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-joyride": "^3.1.0",
         "react-router-dom": "^7.14.2",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
@@ -880,6 +881,22 @@
         }
       }
     },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -917,6 +934,45 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.1.0"
+      }
+    },
+    "node_modules/@gilbarbara/types/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -8258,6 +8314,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
+      "license": "MIT"
+    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
@@ -10458,12 +10520,44 @@
         "react": "^19.2.6"
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-joyride": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.1.0.tgz",
+      "integrity": "sha512-+UEDpNsYSHhhSW/OQcNl6+oODYx20EP6TykSD45if0MqAAZMYD+3DU64w9wP3fBjQswvq5BgK99w3rw6ing69g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19",
+        "react-dom": "16.8 - 19"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10811,6 +10905,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "marked": "^18.0.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-joyride": "^3.1.0",
     "react-router-dom": "^7.14.2",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,6 +65,8 @@ import { DiffFileViewer } from "./components/diff/DiffFileViewer";
 import { SettingsView } from "./components/SettingsView";
 import { ProjectsView } from "./components/ProjectsView";
 import { HelpOverlay } from "./components/HelpOverlay";
+import { useTour } from "./hooks/useTour";
+import type { TourScope } from "./lib/tourSteps";
 import { SessionWizard } from "./components/session-wizard/SessionWizard";
 import type { WizardPrefill } from "./components/session-wizard/SessionWizard";
 import type { SessionResponse } from "./lib/types";
@@ -457,10 +459,17 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [wizardPrefill, setWizardPrefill] = useState<WizardPrefill | undefined>(undefined);
   const [deletingWorkspaceId, setDeletingWorkspaceId] = useState<string | null>(null);
   const [serverAbout, setServerAbout] = useState<ServerAbout | null>(null);
+  // `serverAbout === null` conflates "not fetched yet" with "fetch failed", so
+  // the tour gates auto-launch on an explicit loaded flag instead.
+  const [serverAboutLoaded, setServerAboutLoaded] = useState(false);
 
   const refreshServerAbout = useCallback(async () => {
-    const about = await fetchAbout();
-    if (about) setServerAbout(about);
+    try {
+      const about = await fetchAbout();
+      if (about) setServerAbout(about);
+    } finally {
+      setServerAboutLoaded(true);
+    }
   }, []);
 
   useEffect(() => {
@@ -1004,6 +1013,31 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     ],
   );
 
+  const tourScope: TourScope =
+    !activeWorkspace || !activeSession
+      ? "dashboard"
+      : activeSession.cockpit_mode
+        ? "cockpit"
+        : "session";
+  // Only auto-launch on a settled, unobstructed dashboard. Any open overlay or
+  // an in-flight session route defers it (the flag stays unset until then).
+  const tourAutoLaunchReady =
+    serverAboutLoaded &&
+    sessionsLoaded &&
+    !activeSessionId &&
+    !showSettings &&
+    !showProjects &&
+    !showSessionWizard &&
+    !showHelp &&
+    !showAbout &&
+    !showPalette;
+  const tour = useTour({
+    scope: tourScope,
+    readOnly: !!serverAbout?.read_only,
+    isDesktop: !isCoarse,
+    autoLaunchReady: tourAutoLaunchReady,
+  });
+
   return (
     <CockpitPrefsProvider value={cockpitPrefs}>
     <div
@@ -1019,6 +1053,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         diffCollapsed={diffCollapsed}
         onOpenHelp={handleOpenHelp}
         onOpenAbout={handleOpenAbout}
+        onStartTutorial={tour.startTour}
         onLogout={onLogout}
         loginRequired={loginRequired}
         isOffline={!!error}
@@ -1074,6 +1109,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           }
         />
       )}
+
+      {tour.tourElement}
 
       {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
 

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { SessionResponse } from "../lib/types";
 import { isSessionActive } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
+import { TOUR_ANCHORS, type TourAnchorId } from "../lib/tourSteps";
 
 interface Props {
   sessions: SessionResponse[];
@@ -153,6 +154,7 @@ export function Dashboard({
             onClick={onNewSession}
             icon="folder"
             featured
+            dataTour={TOUR_ANCHORS.dashboardNewSession}
           />
           <ActionPane
             title="Clone URL"
@@ -190,6 +192,7 @@ function ActionPane({
   href,
   icon,
   featured,
+  dataTour,
 }: {
   title: string;
   subtitle: string;
@@ -197,6 +200,7 @@ function ActionPane({
   href?: string;
   icon: "folder" | "git" | "book";
   featured?: boolean;
+  dataTour?: TourAnchorId;
 }) {
   const iconSvg = {
     folder: (
@@ -264,6 +268,7 @@ function ActionPane({
         href={href}
         target="_blank"
         rel="noopener noreferrer"
+        data-tour={dataTour}
         className={classes}
       >
         {iconSvg[icon]}
@@ -278,7 +283,7 @@ function ActionPane({
   }
 
   return (
-    <button onClick={onClick} className={`text-left ${classes}`}>
+    <button onClick={onClick} data-tour={dataTour} className={`text-left ${classes}`}>
       {iconSvg[icon]}
       <div>
         <p className={`font-medium text-text-primary ${featured ? "text-base" : "text-sm"}`}>

--- a/web/src/components/OverflowMenu.tsx
+++ b/web/src/components/OverflowMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { type TourAnchorId } from "../lib/tourSteps";
 
 export interface OverflowItem {
   label: string;
@@ -7,9 +8,12 @@ export interface OverflowItem {
 
 interface Props {
   items: OverflowItem[];
+  /** Tour anchor attached to the trigger button (the stable, always-rendered
+   *  element), so the tour can point at the menu without it being open. */
+  triggerDataTour?: TourAnchorId;
 }
 
-export function OverflowMenu({ items }: Props) {
+export function OverflowMenu({ items, triggerDataTour }: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -33,6 +37,7 @@ export function OverflowMenu({ items }: Props) {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((o) => !o)}
+        data-tour={triggerDataTour}
         className="w-8 h-8 flex items-center justify-center rounded-md cursor-pointer text-text-muted hover:text-text-secondary hover:bg-surface-700/50 transition-colors"
         aria-label="More options"
         aria-haspopup="menu"

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -4,6 +4,7 @@ import { CommentsBanner } from "./diff/comments/CommentsBanner";
 import { PairedShellPane } from "./PairedTerminal";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import type { RepoBase, RichDiffFile, SessionResponse } from "../lib/types";
+import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 
 const VSPLIT_STORAGE_KEY = "aoe-right-vsplit";
 const DEFAULT_TOP_RATIO = 0.5;
@@ -133,7 +134,7 @@ export function RightPanel({
   }, []);
 
   return (
-    <div ref={containerRef} className="flex-1 flex flex-col min-h-0 overflow-hidden md:bg-surface-800 md:pb-1.5">
+    <div ref={containerRef} {...tourAnchor(TOUR_ANCHORS.rightPanel)} className="flex-1 flex flex-col min-h-0 overflow-hidden md:bg-surface-800 md:pb-1.5">
       {/* Upper: file list */}
       <div
         style={{ flexBasis: `${topRatio * 100}%` }}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { SessionResponse, Workspace } from "../lib/types";
 import { PaletteTriggerPill } from "./PaletteTriggerPill";
 import { OverflowMenu, type OverflowItem } from "./OverflowMenu";
+import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 
 interface Props {
   activeWorkspace: Workspace | undefined;
@@ -12,6 +13,7 @@ interface Props {
   diffCollapsed: boolean;
   onOpenHelp: () => void;
   onOpenAbout: () => void;
+  onStartTutorial: () => void;
   onLogout: () => void;
   loginRequired: boolean;
   isOffline: boolean;
@@ -34,6 +36,7 @@ export function TopBar({
   diffCollapsed,
   onOpenHelp,
   onOpenAbout,
+  onStartTutorial,
   onLogout,
   loginRequired,
   isOffline,
@@ -43,14 +46,18 @@ export function TopBar({
   const overflowItems = useMemo<OverflowItem[]>(() => {
     const items: OverflowItem[] = [
       { label: "Help", onClick: onOpenHelp },
+      { label: "Show tutorial", onClick: onStartTutorial },
       { label: "About", onClick: onOpenAbout },
     ];
     if (loginRequired) items.push({ label: "Sign out", onClick: onLogout });
     return items;
-  }, [onOpenHelp, onOpenAbout, onLogout, loginRequired]);
+  }, [onOpenHelp, onStartTutorial, onOpenAbout, onLogout, loginRequired]);
 
   return (
-    <header className="h-12 bg-surface-800 border-b border-surface-700/20 flex items-center px-3 shrink-0 gap-2">
+    <header
+      {...tourAnchor(TOUR_ANCHORS.topbar)}
+      className="h-12 bg-surface-800 border-b border-surface-700/20 flex items-center px-3 shrink-0 gap-2"
+    >
       {/* LEFT ZONE */}
       <div className="flex items-center gap-2 min-w-0 shrink-0">
         <button
@@ -137,7 +144,7 @@ export function TopBar({
           </button>
         )}
 
-        <OverflowMenu items={overflowItems} />
+        <OverflowMenu items={overflowItems} triggerDataTour={TOUR_ANCHORS.topbarMore} />
       </div>
     </header>
   );

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -46,6 +46,7 @@ import {
   isSessionActive,
 } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
+import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import {
   renameSession,
   setSessionArchive,
@@ -1746,6 +1747,7 @@ export function WorkspaceSidebar({
         onClick={onToggle}
       />
       <div
+        {...tourAnchor(TOUR_ANCHORS.sidebar)}
         style={{ width }}
         className={`fixed top-12 bottom-0 left-0 z-40 md:static md:z-auto bg-surface-800 flex flex-col md:h-full shrink-0 transition-transform duration-300 ease-in-out md:transition-none ${
           open ? "translate-x-0" : "-translate-x-full md:hidden"
@@ -2032,6 +2034,7 @@ export function WorkspaceSidebar({
           </button>
           <button
             onClick={onSettings}
+            {...tourAnchor(TOUR_ANCHORS.sidebarSettings)}
             className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
             title="Settings"
             aria-label="Settings"

--- a/web/src/components/__tests__/Dashboard.tour.test.tsx
+++ b/web/src/components/__tests__/Dashboard.tour.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+//
+// Render-time half of the tour drift guard: the static guard proves the anchor
+// constant is wired in source, but not that it actually paints under a given
+// state. The dashboard new-session anchor is conditionally rendered (hidden in
+// read-only mode), so assert it resolves exactly once when writable and is gone
+// when read-only, matching the step's `writableOnly` metadata.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import { Dashboard } from "../Dashboard";
+import { TOUR_ANCHORS, tourSelector } from "../../lib/tourSteps";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderDashboard(readOnly: boolean) {
+  return render(
+    <Dashboard
+      sessions={[]}
+      onSelectSession={vi.fn()}
+      onNewSession={vi.fn()}
+      onCloneFromUrl={vi.fn()}
+      onToggleSidebar={vi.fn()}
+      readOnly={readOnly}
+    />,
+  );
+}
+
+describe("Dashboard tour anchors", () => {
+  it("renders the new-session anchor exactly once when writable", () => {
+    const { container } = renderDashboard(false);
+    expect(
+      container.querySelectorAll(tourSelector(TOUR_ANCHORS.dashboardNewSession)),
+    ).toHaveLength(1);
+  });
+
+  it("hides the new-session anchor in read-only mode", () => {
+    const { container } = renderDashboard(true);
+    expect(
+      container.querySelectorAll(tourSelector(TOUR_ANCHORS.dashboardNewSession)),
+    ).toHaveLength(0);
+  });
+});

--- a/web/src/components/__tests__/TopBar.test.tsx
+++ b/web/src/components/__tests__/TopBar.test.tsx
@@ -39,6 +39,7 @@ function renderTopBar(
       diffCollapsed={true}
       onOpenHelp={vi.fn()}
       onOpenAbout={vi.fn()}
+      onStartTutorial={vi.fn()}
       onLogout={vi.fn()}
       loginRequired={false}
       isOffline={overrides.isOffline ?? false}

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -30,6 +30,7 @@ import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import { SessionConfigControls } from "./SessionConfigControls";
 import type { CockpitState } from "../../lib/cockpitTypes";
 import { getDraft, setDraft } from "../../lib/cockpitDrafts";
+import { TOUR_ANCHORS, tourAnchor } from "../../lib/tourSteps";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { useAgentProfile } from "../../lib/agentProfileContext";
 import { useFocusTerminalTarget } from "../../hooks/useFocusTerminalTarget";
@@ -452,7 +453,7 @@ export function Composer({
   const wrapperLayout = composerWrapperLayout({ keyboardOpen });
   return (
     <div className={wrapperLayout.className} style={wrapperLayout.style}>
-      <div className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl">
+      <div {...tourAnchor(TOUR_ANCHORS.composer)} className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl">
         <ComposerPrimitive.Unstable_TriggerPopoverRoot>
           <ComposerPrimitive.Root
             className={[
@@ -935,7 +936,7 @@ function ModePicker({
   };
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={ref} {...tourAnchor(TOUR_ANCHORS.modePicker)} className="relative">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
@@ -1138,6 +1139,7 @@ function QueueSendButton({
     <button
       type="button"
       aria-label="Queue follow-up message"
+      {...tourAnchor(TOUR_ANCHORS.queueSend)}
       title={title}
       onClick={onSend}
       className={[

--- a/web/src/components/tour/TourRunner.tsx
+++ b/web/src/components/tour/TourRunner.tsx
@@ -25,16 +25,19 @@ export interface TourRunnerProps {
   onFinish: (markSeen: boolean) => void;
 }
 
-// Concrete DESIGN.md tokens (the engine needs hex, not Tailwind classes):
-// surface-800 #1e293b card, surface-700 #334155 border, surface-950 #020617
-// backdrop, brand-600 #d97706 primary, text-primary #e2e8f0.
+// Theme via the app's resolved-theme CSS variables (web/src/index.css) so the
+// tooltip tracks light vs dark instead of being pinned to dark hex. These land
+// as inline CSS styles, where var() resolves. The exception is overlayColor: it
+// is painted as an SVG fill *attribute*, where var() does not reliably resolve,
+// so the scrim stays a literal translucent dark (it reads correctly over both
+// light and dark content).
 const OPTIONS: Partial<Options> = {
   buttons: ["skip", "back", "primary"] as ButtonType[],
   showProgress: true,
   skipBeacon: true,
-  primaryColor: "#d97706",
+  primaryColor: "var(--color-brand-600)",
   overlayColor: "rgba(2, 6, 23, 0.65)",
-  textColor: "#e2e8f0",
+  textColor: "var(--color-text-primary)",
   zIndex: 10_000,
   scrollOffset: 96,
 };
@@ -43,17 +46,22 @@ const LOCALE = { skip: "Skip", last: "Done", next: "Next", back: "Back" };
 
 const STYLES: Partial<Styles> = {
   tooltip: {
-    backgroundColor: "#1e293b",
-    border: "1px solid #334155",
+    backgroundColor: "var(--color-surface-800)",
+    border: "1px solid var(--color-surface-700)",
     borderRadius: 10,
-    color: "#e2e8f0",
+    color: "var(--color-text-primary)",
     fontSize: 13,
   },
-  tooltipTitle: { color: "#f59e0b", fontSize: 14, fontWeight: 600 },
+  tooltipTitle: { color: "var(--color-brand-500)", fontSize: 14, fontWeight: 600 },
   tooltipContent: { padding: "10px 4px" },
-  buttonPrimary: { backgroundColor: "#d97706", borderRadius: 6, color: "#0f172a" },
-  buttonBack: { color: "#94a3b8" },
-  buttonSkip: { color: "#64748b" },
+  buttonPrimary: {
+    backgroundColor: "var(--color-brand-600)",
+    borderRadius: 6,
+    // Dark text reads on the amber primary in both themes; keep it fixed.
+    color: "#0f172a",
+  },
+  buttonBack: { color: "var(--color-text-secondary)" },
+  buttonSkip: { color: "var(--color-text-dim)" },
 };
 
 function StepBody({

--- a/web/src/components/tour/TourRunner.tsx
+++ b/web/src/components/tour/TourRunner.tsx
@@ -1,0 +1,119 @@
+// The only module that imports react-joyride. Lazy-loaded by TourProvider the
+// first time a tour actually runs, so returning users (who have the
+// `aoe-tour-seen` flag set) never download the engine. Everything react-joyride
+// specific (the component, its event/action constants, theming) lives here;
+// TourProvider stays engine-agnostic and deals only in TourStep data. Swapping
+// the engine later means rewriting this file alone.
+import { useCallback, useMemo } from "react";
+import {
+  Joyride,
+  ACTIONS,
+  EVENTS,
+  type ButtonType,
+  type EventData,
+  type Options,
+  type Step,
+  type Styles,
+} from "react-joyride";
+import { type TourStep, tourSelector } from "../../lib/tourSteps";
+
+export interface TourRunnerProps {
+  run: boolean;
+  steps: TourStep[];
+  /** Called once when the tour ends. `markSeen` is false for our own programmatic
+   *  stop (scope change / unmount), true for a user finish, skip, or close. */
+  onFinish: (markSeen: boolean) => void;
+}
+
+// Concrete DESIGN.md tokens (the engine needs hex, not Tailwind classes):
+// surface-800 #1e293b card, surface-700 #334155 border, surface-950 #020617
+// backdrop, brand-600 #d97706 primary, text-primary #e2e8f0.
+const OPTIONS: Partial<Options> = {
+  buttons: ["skip", "back", "primary"] as ButtonType[],
+  showProgress: true,
+  skipBeacon: true,
+  primaryColor: "#d97706",
+  overlayColor: "rgba(2, 6, 23, 0.65)",
+  textColor: "#e2e8f0",
+  zIndex: 10_000,
+  scrollOffset: 96,
+};
+
+const LOCALE = { skip: "Skip", last: "Done", next: "Next", back: "Back" };
+
+const STYLES: Partial<Styles> = {
+  tooltip: {
+    backgroundColor: "#1e293b",
+    border: "1px solid #334155",
+    borderRadius: 10,
+    color: "#e2e8f0",
+    fontSize: 13,
+  },
+  tooltipTitle: { color: "#f59e0b", fontSize: 14, fontWeight: 600 },
+  tooltipContent: { padding: "10px 4px" },
+  buttonPrimary: { backgroundColor: "#d97706", borderRadius: 6, color: "#0f172a" },
+  buttonBack: { color: "#94a3b8" },
+  buttonSkip: { color: "#64748b" },
+};
+
+function StepBody({
+  body,
+  shortcuts,
+}: {
+  body: string;
+  shortcuts?: readonly string[];
+}) {
+  return (
+    <div>
+      <p>{body}</p>
+      {shortcuts && shortcuts.length > 0 && (
+        <ul className="mt-2 space-y-0.5 text-[11px] text-text-muted">
+          {shortcuts.map((s) => (
+            <li key={s} className="font-mono">
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function toJoyrideStep(step: TourStep): Step {
+  return {
+    id: step.id,
+    target: tourSelector(step.anchor),
+    title: step.title,
+    content: <StepBody body={step.body} shortcuts={step.shortcuts} />,
+    placement: "auto",
+  };
+}
+
+export default function TourRunner({ run, steps, onFinish }: TourRunnerProps) {
+  const joyrideSteps = useMemo(() => steps.map(toJoyrideStep), [steps]);
+
+  const handleEvent = useCallback(
+    (data: EventData) => {
+      if (data.type !== EVENTS.TOUR_END) return;
+      // A user finish/skip/close marks the tour seen. Our own stop() (scope
+      // change, unmount) and target-not-found recovery must not, so the user is
+      // not silently opted out by navigation.
+      const markSeen =
+        data.action !== ACTIONS.STOP && data.action !== ACTIONS.RESET;
+      onFinish(markSeen);
+    },
+    [onFinish],
+  );
+
+  return (
+    <Joyride
+      run={run}
+      steps={joyrideSteps}
+      continuous
+      options={OPTIONS}
+      locale={LOCALE}
+      styles={STYLES}
+      onEvent={handleEvent}
+    />
+  );
+}

--- a/web/src/components/tour/TourRunner.tsx
+++ b/web/src/components/tour/TourRunner.tsx
@@ -7,8 +7,8 @@
 import { useCallback, useMemo } from "react";
 import {
   Joyride,
-  ACTIONS,
   EVENTS,
+  STATUS,
   type ButtonType,
   type EventData,
   type Options,
@@ -95,11 +95,13 @@ export default function TourRunner({ run, steps, onFinish }: TourRunnerProps) {
   const handleEvent = useCallback(
     (data: EventData) => {
       if (data.type !== EVENTS.TOUR_END) return;
-      // A user finish/skip/close marks the tour seen. Our own stop() (scope
-      // change, unmount) and target-not-found recovery must not, so the user is
-      // not silently opted out by navigation.
+      // Gate on the terminal status, not the action: a programmatic stop
+      // (run -> false on scope change / unmount) ends with a non-terminal
+      // status and may carry `action: null`, which an action allowlist would
+      // misread as a user finish and silently opt the user out. Only an
+      // actual finish or skip marks the tour seen.
       const markSeen =
-        data.action !== ACTIONS.STOP && data.action !== ACTIONS.RESET;
+        data.status === STATUS.FINISHED || data.status === STATUS.SKIPPED;
       onFinish(markSeen);
     },
     [onFinish],

--- a/web/src/hooks/__tests__/useTour.test.ts
+++ b/web/src/hooks/__tests__/useTour.test.ts
@@ -1,0 +1,37 @@
+// Auto-launch decision table for the first-run tutorial. The run -> engine
+// integration (rAF, lazy load, Joyride rendering, skip persistence) is covered
+// by the live Playwright smoke; this locks the pure gating logic that live
+// (desktop, first-run) cannot easily exercise: coarse-pointer and seen-flag
+// suppression, and scope gating.
+import { describe, expect, it } from "vitest";
+import { shouldAutoLaunch } from "../useTour";
+
+const base = {
+  autoLaunchReady: true,
+  scope: "dashboard" as const,
+  isDesktop: true,
+  seen: false,
+};
+
+describe("shouldAutoLaunch", () => {
+  it("launches on a settled dashboard, fine pointer, unseen", () => {
+    expect(shouldAutoLaunch(base)).toBe(true);
+  });
+
+  it("does not launch before the dashboard is ready", () => {
+    expect(shouldAutoLaunch({ ...base, autoLaunchReady: false })).toBe(false);
+  });
+
+  it("does not launch outside the dashboard scope", () => {
+    expect(shouldAutoLaunch({ ...base, scope: "session" })).toBe(false);
+    expect(shouldAutoLaunch({ ...base, scope: "cockpit" })).toBe(false);
+  });
+
+  it("does not auto-launch on coarse pointers", () => {
+    expect(shouldAutoLaunch({ ...base, isDesktop: false })).toBe(false);
+  });
+
+  it("does not auto-launch once the tour has been seen", () => {
+    expect(shouldAutoLaunch({ ...base, seen: true })).toBe(false);
+  });
+});

--- a/web/src/hooks/__tests__/useTour.test.ts
+++ b/web/src/hooks/__tests__/useTour.test.ts
@@ -11,6 +11,7 @@ const base = {
   scope: "dashboard" as const,
   isDesktop: true,
   seen: false,
+  automated: false,
 };
 
 describe("shouldAutoLaunch", () => {
@@ -33,5 +34,9 @@ describe("shouldAutoLaunch", () => {
 
   it("does not auto-launch once the tour has been seen", () => {
     expect(shouldAutoLaunch({ ...base, seen: true })).toBe(false);
+  });
+
+  it("does not auto-launch inside an automated browser session", () => {
+    expect(shouldAutoLaunch({ ...base, automated: true })).toBe(false);
   });
 });

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -76,36 +76,47 @@ export function useTour({
   const prevScopeRef = useRef(scope);
   const mountedRef = useRef(true);
 
-  useEffect(
-    () => () => {
+  // Set in setup, not just cleanup, so a StrictMode unmount/remount (or any
+  // remount) does not leave begin() permanently latched to a no-op.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
 
   // Defer one frame so a closing menu / freshly committed route has painted
-  // before we probe the DOM for anchors. No arbitrary timeout.
-  const begin = useCallback((): number => {
-    return requestAnimationFrame(() => {
-      if (!mountedRef.current) return;
-      const resolved = resolveTourSteps({ scope, readOnly, isDesktop });
-      if (resolved.length === 0) return;
-      setSteps(resolved);
-      setRun(true);
-    });
-  }, [scope, readOnly, isDesktop]);
+  // before we probe the DOM for anchors. No arbitrary timeout. `onStarted`
+  // fires synchronously, only when the tour actually starts (steps resolved),
+  // so callers can latch on real success rather than on the scheduling attempt.
+  const begin = useCallback(
+    (onStarted?: () => void): number => {
+      return requestAnimationFrame(() => {
+        if (!mountedRef.current) return;
+        const resolved = resolveTourSteps({ scope, readOnly, isDesktop });
+        if (resolved.length === 0) return;
+        onStarted?.();
+        setSteps(resolved);
+        setRun(true);
+      });
+    },
+    [scope, readOnly, isDesktop],
+  );
 
   const startTour = useCallback(() => {
     begin();
   }, [begin]);
 
   // Auto-launch: once per mount, dashboard scope, fine pointer, flag unset.
+  // The latch is set inside begin()'s success path so a frame where no anchor
+  // is painted yet does not permanently suppress the auto-launch.
   useEffect(() => {
     if (autoStartedRef.current) return;
     const seen = safeGetItem(TOUR_SEEN_KEY) === "1";
     if (!shouldAutoLaunch({ autoLaunchReady, scope, isDesktop, seen })) return;
-    autoStartedRef.current = true;
-    const id = begin();
+    const id = begin(() => {
+      autoStartedRef.current = true;
+    });
     return () => cancelAnimationFrame(id);
   }, [autoLaunchReady, scope, isDesktop, begin]);
 

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -40,20 +40,29 @@ export interface UseTourOptions {
 /**
  * Pure auto-launch decision, extracted so the truth table is unit-testable
  * without driving rAF / Suspense / the lazy engine. The tour auto-launches only
- * on a settled dashboard, with a fine pointer, when the user has not yet seen it.
+ * on a settled dashboard, with a fine pointer, when the user has not yet seen
+ * it, and never inside an automated browser session (a synthetic monitor, a
+ * scraper, or our own Playwright suites): the spotlight overlay would otherwise
+ * intercept clicks in unrelated flows. The menu re-trigger stays available.
  */
 export function shouldAutoLaunch(args: {
   autoLaunchReady: boolean;
   scope: TourScope;
   isDesktop: boolean;
   seen: boolean;
+  automated: boolean;
 }): boolean {
   return (
     args.autoLaunchReady &&
     args.scope === "dashboard" &&
     args.isDesktop &&
-    !args.seen
+    !args.seen &&
+    !args.automated
   );
+}
+
+function isAutomatedSession(): boolean {
+  return typeof navigator !== "undefined" && navigator.webdriver === true;
 }
 
 export interface UseTourResult {
@@ -113,7 +122,9 @@ export function useTour({
   useEffect(() => {
     if (autoStartedRef.current) return;
     const seen = safeGetItem(TOUR_SEEN_KEY) === "1";
-    if (!shouldAutoLaunch({ autoLaunchReady, scope, isDesktop, seen })) return;
+    const automated = isAutomatedSession();
+    if (!shouldAutoLaunch({ autoLaunchReady, scope, isDesktop, seen, automated }))
+      return;
     const id = begin(() => {
       autoStartedRef.current = true;
     });

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -1,0 +1,133 @@
+// First-run tutorial controller. Owns the tour's run state, the resolved step
+// snapshot, auto-launch policy, and `aoe-tour-seen` persistence. It is
+// engine-agnostic: the react-joyride coupling lives entirely in the lazy
+// TourRunner, which is only mounted (and only downloaded) while a tour runs, so
+// returning users never pay for the engine. App is the single consumer, so this
+// is a plain hook returning the element to render rather than a context.
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  resolveTourSteps,
+  type TourScope,
+  type TourStep,
+} from "../lib/tourSteps";
+import { safeGetItem, safeSetItem } from "../lib/safeStorage";
+
+// Per-origin localStorage already isolates dev (port 8081) from release (8080),
+// so a flat key needs no app-dir namespace.
+const TOUR_SEEN_KEY = "aoe-tour-seen";
+
+const TourRunner = lazy(() => import("../components/tour/TourRunner"));
+
+export interface UseTourOptions {
+  /** Which mutually-exclusive surface is mounted right now. */
+  scope: TourScope;
+  readOnly: boolean;
+  /** Fine pointer. Gates desktop-only steps and suppresses auto-launch on touch. */
+  isDesktop: boolean;
+  /** True once it is safe to auto-launch: server/about and sessions loaded, the
+   *  dashboard is painted, and no blocking overlay is open. */
+  autoLaunchReady: boolean;
+}
+
+/**
+ * Pure auto-launch decision, extracted so the truth table is unit-testable
+ * without driving rAF / Suspense / the lazy engine. The tour auto-launches only
+ * on a settled dashboard, with a fine pointer, when the user has not yet seen it.
+ */
+export function shouldAutoLaunch(args: {
+  autoLaunchReady: boolean;
+  scope: TourScope;
+  isDesktop: boolean;
+  seen: boolean;
+}): boolean {
+  return (
+    args.autoLaunchReady &&
+    args.scope === "dashboard" &&
+    args.isDesktop &&
+    !args.seen
+  );
+}
+
+export interface UseTourResult {
+  /** Launch the tour for the current scope. Ignores the seen flag. */
+  startTour: () => void;
+  isTourActive: boolean;
+  /** Render this somewhere stable in the tree (e.g. at the App root). */
+  tourElement: ReactNode;
+}
+
+export function useTour({
+  scope,
+  readOnly,
+  isDesktop,
+  autoLaunchReady,
+}: UseTourOptions): UseTourResult {
+  const [run, setRun] = useState(false);
+  const [steps, setSteps] = useState<TourStep[]>([]);
+  const autoStartedRef = useRef(false);
+  const prevScopeRef = useRef(scope);
+  const mountedRef = useRef(true);
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
+
+  // Defer one frame so a closing menu / freshly committed route has painted
+  // before we probe the DOM for anchors. No arbitrary timeout.
+  const begin = useCallback((): number => {
+    return requestAnimationFrame(() => {
+      if (!mountedRef.current) return;
+      const resolved = resolveTourSteps({ scope, readOnly, isDesktop });
+      if (resolved.length === 0) return;
+      setSteps(resolved);
+      setRun(true);
+    });
+  }, [scope, readOnly, isDesktop]);
+
+  const startTour = useCallback(() => {
+    begin();
+  }, [begin]);
+
+  // Auto-launch: once per mount, dashboard scope, fine pointer, flag unset.
+  useEffect(() => {
+    if (autoStartedRef.current) return;
+    const seen = safeGetItem(TOUR_SEEN_KEY) === "1";
+    if (!shouldAutoLaunch({ autoLaunchReady, scope, isDesktop, seen })) return;
+    autoStartedRef.current = true;
+    const id = begin();
+    return () => cancelAnimationFrame(id);
+  }, [autoLaunchReady, scope, isDesktop, begin]);
+
+  // Navigating to a different surface mid-tour cancels it without marking seen,
+  // so a returning user can still get the cockpit steps on a later re-trigger.
+  useEffect(() => {
+    if (prevScopeRef.current !== scope) {
+      prevScopeRef.current = scope;
+      setRun(false);
+    }
+  }, [scope]);
+
+  const handleFinish = useCallback((markSeen: boolean) => {
+    setRun(false);
+    if (markSeen) safeSetItem(TOUR_SEEN_KEY, "1");
+  }, []);
+
+  const tourElement = run ? (
+    <Suspense fallback={null}>
+      <TourRunner run={run} steps={steps} onFinish={handleFinish} />
+    </Suspense>
+  ) : null;
+
+  return { startTour, isTourActive: run, tourElement };
+}

--- a/web/src/lib/__tests__/tourSteps.test.ts
+++ b/web/src/lib/__tests__/tourSteps.test.ts
@@ -1,0 +1,171 @@
+// CI drift guard for the first-run tutorial, plus resolver coverage.
+//
+// The guard is the cheap, deterministic half of the "tour cannot silently
+// break" contract (issue #1513, user story 3): it couples TOUR_STEPS, the
+// TOUR_ANCHORS constants, and the actual `data-tour` attributes in component
+// source, so renaming or deleting an anchor on either side turns this red in
+// milliseconds. The render-time half (an eligible anchor that fails to paint)
+// is covered by the Dashboard render test and the live Playwright smoke.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  TOUR_ANCHORS,
+  TOUR_STEPS,
+  isStepEligible,
+  resolveTourSteps,
+  type TourAnchorId,
+  type TourStep,
+} from "../tourSteps";
+
+const SRC_DIR = join(process.cwd(), "src");
+// tourSteps.ts itself legitimately contains the `data-tour="..."` template in
+// tourSelector(); tests and stories are not shipped UI. Everything else must go
+// through the TOUR_ANCHORS constants.
+const EXCLUDED = [
+  join("lib", "tourSteps.ts"),
+  "__tests__",
+  ".test.",
+  ".stories.",
+];
+
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectSourceFiles(full, acc);
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+const COMPONENT_SOURCES = collectSourceFiles(SRC_DIR).filter(
+  (f) => !EXCLUDED.some((ex) => f.includes(ex)),
+);
+
+const ANCHOR_KEY_BY_VALUE = new Map<TourAnchorId, string>(
+  Object.entries(TOUR_ANCHORS).map(([key, value]) => [value, key]),
+);
+
+describe("tour drift guard", () => {
+  it("every step anchor is a known TOUR_ANCHORS value", () => {
+    const known = new Set<string>(Object.values(TOUR_ANCHORS));
+    for (const step of TOUR_STEPS) {
+      expect(known.has(step.anchor)).toBe(true);
+    }
+  });
+
+  it("every TOUR_ANCHORS value is used by at least one step (no orphan anchors)", () => {
+    const usedByStep = new Set(TOUR_STEPS.map((s) => s.anchor));
+    for (const value of Object.values(TOUR_ANCHORS)) {
+      expect(usedByStep.has(value)).toBe(true);
+    }
+  });
+
+  it("step ids are unique", () => {
+    const ids = TOUR_STEPS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every anchor a step points at is attached in component source via TOUR_ANCHORS.<key>", () => {
+    const usedInSource = new Set<string>();
+    const re = /TOUR_ANCHORS\.(\w+)/g;
+    for (const file of COMPONENT_SOURCES) {
+      const text = readFileSync(file, "utf8");
+      for (const m of text.matchAll(re)) usedInSource.add(m[1]);
+    }
+    for (const step of TOUR_STEPS) {
+      const key = ANCHOR_KEY_BY_VALUE.get(step.anchor);
+      expect(key, `anchor ${step.anchor} missing from TOUR_ANCHORS`).toBeDefined();
+      expect(
+        usedInSource.has(key as string),
+        `anchor "${step.anchor}" (step "${step.id}") is never attached in component source`,
+      ).toBe(true);
+    }
+  });
+
+  it("no raw data-tour string literals in component source (must use the typed constant)", () => {
+    const offenders: string[] = [];
+    for (const file of COMPONENT_SOURCES) {
+      const text = readFileSync(file, "utf8");
+      if (/data-tour=["']/.test(text)) offenders.push(file);
+    }
+    expect(offenders, `raw data-tour literals found in: ${offenders.join(", ")}`).toEqual([]);
+  });
+});
+
+describe("resolveTourSteps", () => {
+  const all: TourAnchorId[] = Object.values(TOUR_ANCHORS);
+  const present = (anchor: TourAnchorId) => all.includes(anchor);
+
+  it("returns only dashboard-scope steps with present anchors on the dashboard", () => {
+    const steps = resolveTourSteps({
+      scope: "dashboard",
+      readOnly: false,
+      isDesktop: true,
+      hasAnchor: present,
+    });
+    const ids = steps.map((s) => s.id);
+    expect(ids).toContain("sidebar");
+    expect(ids).toContain("new-session");
+    expect(ids).toContain("topbar-more");
+    // cockpit-only steps must not leak onto the dashboard
+    expect(ids).not.toContain("composer");
+    expect(ids).not.toContain("right-panel");
+  });
+
+  it("drops the writable-only new-session step in read-only mode", () => {
+    const steps = resolveTourSteps({
+      scope: "dashboard",
+      readOnly: true,
+      isDesktop: true,
+      hasAnchor: present,
+    });
+    expect(steps.map((s) => s.id)).not.toContain("new-session");
+  });
+
+  it("drops desktop-only steps on coarse pointers", () => {
+    const steps = resolveTourSteps({
+      scope: "cockpit",
+      readOnly: false,
+      isDesktop: false,
+      hasAnchor: present,
+    });
+    expect(steps.map((s) => s.id)).not.toContain("right-panel");
+  });
+
+  it("drops steps whose anchor is absent from the DOM", () => {
+    const steps = resolveTourSteps({
+      scope: "dashboard",
+      readOnly: false,
+      isDesktop: true,
+      hasAnchor: () => false,
+    });
+    expect(steps).toEqual([]);
+  });
+
+  it("preserves TOUR_STEPS order", () => {
+    const steps = resolveTourSteps({
+      scope: "cockpit",
+      readOnly: false,
+      isDesktop: true,
+      hasAnchor: present,
+    });
+    const orderInSource = TOUR_STEPS.map((s) => s.id);
+    const resolvedOrder = steps.map((s) => s.id);
+    const expected = orderInSource.filter((id) => resolvedOrder.includes(id));
+    expect(resolvedOrder).toEqual(expected);
+  });
+
+  it("isStepEligible ignores DOM presence (metadata only)", () => {
+    const composer = TOUR_STEPS.find((s) => s.id === "composer") as TourStep;
+    expect(
+      isStepEligible(composer, { scope: "cockpit", readOnly: false, isDesktop: true }),
+    ).toBe(true);
+    expect(
+      isStepEligible(composer, { scope: "dashboard", readOnly: false, isDesktop: true }),
+    ).toBe(false);
+  });
+});

--- a/web/src/lib/tourSteps.ts
+++ b/web/src/lib/tourSteps.ts
@@ -1,0 +1,177 @@
+// Declarative source of truth for the first-run interactive tutorial.
+//
+// This module is intentionally framework/engine-independent: it knows nothing
+// about react-joyride. Steps are described as plain data keyed by typed anchor
+// ids, and a single `tourAnchor()` helper is the only sanctioned way to attach
+// an anchor to a DOM node. The CI drift guard (tourSteps.test.ts) relies on that
+// convention: every anchor must be referenced through `TOUR_ANCHORS.<key>`, never
+// as a raw `data-tour="..."` literal, so a renamed or deleted anchor fails fast.
+
+/**
+ * Every UI region the tour can point at. The string value is the literal that
+ * lands in the DOM as `data-tour="<value>"`. Keep these on stable region
+ * containers, not on volatile rows or buttons that come and go per render.
+ */
+export const TOUR_ANCHORS = {
+  topbar: "topbar",
+  topbarMore: "topbar-more",
+  sidebar: "sidebar",
+  sidebarSettings: "sidebar-settings",
+  dashboardNewSession: "dashboard-new-session",
+  rightPanel: "right-panel",
+  composer: "cockpit-composer",
+  modePicker: "cockpit-mode-picker",
+  queueSend: "cockpit-queue-send",
+} as const;
+
+export type TourAnchorId = (typeof TOUR_ANCHORS)[keyof typeof TOUR_ANCHORS];
+
+/**
+ * The dashboard, a terminal session, and a cockpit session mount mutually
+ * exclusive UI. A step declares which scopes it belongs to; the resolver never
+ * shows a step outside its scope, so a missing anchor is only ever "legitimately
+ * absent on this view", never a silently swallowed regression.
+ */
+export type TourScope = "dashboard" | "session" | "cockpit";
+
+export interface TourStep {
+  /** Stable id, also used as the react-joyride step id. */
+  id: string;
+  anchor: TourAnchorId;
+  scopes: readonly TourScope[];
+  title: string;
+  body: string;
+  /** Human-readable shortcut hints rendered under the body, e.g. "⌘K / Ctrl+K". */
+  shortcuts?: readonly string[];
+  /** Drop the step when the dashboard is in read-only mode (mutation UI absent). */
+  writableOnly?: boolean;
+  /** Drop the step on coarse-pointer / non-desktop layouts (region not shown). */
+  desktopOnly?: boolean;
+}
+
+/** The CSS selector that resolves a given anchor in the DOM. */
+export function tourSelector(anchor: TourAnchorId): string {
+  return `[data-tour="${anchor}"]`;
+}
+
+/**
+ * The only sanctioned way to attach a tour anchor to a JSX element. Spread it:
+ * `<div {...tourAnchor(TOUR_ANCHORS.sidebar)} />`. Using this instead of a raw
+ * `data-tour="..."` string keeps the CI drift guard honest.
+ */
+export function tourAnchor(anchor: TourAnchorId): { "data-tour": TourAnchorId } {
+  return { "data-tour": anchor };
+}
+
+export const TOUR_STEPS: readonly TourStep[] = [
+  {
+    id: "topbar",
+    anchor: TOUR_ANCHORS.topbar,
+    scopes: ["dashboard", "session", "cockpit"],
+    title: "Command bar",
+    body: "Jump anywhere from the command palette: switch sessions, open settings, toggle panels.",
+    shortcuts: ["⌘K / Ctrl+K opens the palette"],
+  },
+  {
+    id: "sidebar",
+    anchor: TOUR_ANCHORS.sidebar,
+    scopes: ["dashboard", "session", "cockpit"],
+    title: "Workspaces and sessions",
+    body: "Your sessions are grouped by workspace here. Pick one to open its terminal or cockpit.",
+    shortcuts: ["⌘B / Ctrl+B toggles the sidebar"],
+  },
+  {
+    id: "new-session",
+    anchor: TOUR_ANCHORS.dashboardNewSession,
+    scopes: ["dashboard"],
+    title: "Start a session",
+    body: "Launch a new agent session: pick a project, choose an agent, and go.",
+    shortcuts: ["n opens the wizard", "⌘⇧N / Ctrl+Shift+N starts a scratch session"],
+    writableOnly: true,
+  },
+  {
+    id: "settings",
+    anchor: TOUR_ANCHORS.sidebarSettings,
+    scopes: ["dashboard", "session", "cockpit"],
+    title: "Settings and profiles",
+    body: "Tune sandboxing, worktrees, sounds, devices, and per-profile overrides here.",
+    shortcuts: ["s opens settings"],
+  },
+  {
+    id: "right-panel",
+    anchor: TOUR_ANCHORS.rightPanel,
+    scopes: ["session", "cockpit"],
+    title: "Diff and review",
+    body: "Review the agent's file changes and send comments back without leaving the session.",
+    shortcuts: ["D toggles the diff", "⌘⌥B / Ctrl+Alt+B toggles the panel"],
+    desktopOnly: true,
+  },
+  {
+    id: "composer",
+    anchor: TOUR_ANCHORS.composer,
+    scopes: ["cockpit"],
+    title: "Composer",
+    body: "Write instructions to the agent here. Type / for commands and @ to reference files.",
+  },
+  {
+    id: "mode-picker",
+    anchor: TOUR_ANCHORS.modePicker,
+    scopes: ["cockpit"],
+    title: "Agent mode",
+    body: "Switch the agent's mode (plan, accept edits, and so on) before you send.",
+  },
+  {
+    id: "queue-send",
+    anchor: TOUR_ANCHORS.queueSend,
+    scopes: ["cockpit"],
+    title: "Send and queue",
+    body: "Send a message, or queue follow-ups while the agent is still working on the last one.",
+  },
+  {
+    id: "topbar-more",
+    anchor: TOUR_ANCHORS.topbarMore,
+    scopes: ["dashboard", "session", "cockpit"],
+    title: "Replay this tour any time",
+    body: "Reopen this walkthrough whenever you like from here: More, then Show tutorial.",
+  },
+] as const;
+
+export interface ResolveTourContext {
+  scope: TourScope;
+  readOnly: boolean;
+  isDesktop: boolean;
+  /**
+   * Whether the anchor currently resolves in the DOM. Defaults to a
+   * `document.querySelector` probe; injectable for tests. Steps eligible by
+   * metadata but absent from the DOM are dropped (defense in depth on top of the
+   * scope filter), so the engine never points at a node that is not painted.
+   */
+  hasAnchor?: (anchor: TourAnchorId) => boolean;
+}
+
+/** Whether a step is eligible by metadata alone (ignores DOM presence). */
+export function isStepEligible(
+  step: TourStep,
+  ctx: Pick<ResolveTourContext, "scope" | "readOnly" | "isDesktop">,
+): boolean {
+  if (!step.scopes.includes(ctx.scope)) return false;
+  if (step.writableOnly && ctx.readOnly) return false;
+  if (step.desktopOnly && !ctx.isDesktop) return false;
+  return true;
+}
+
+function defaultHasAnchor(anchor: TourAnchorId): boolean {
+  if (typeof document === "undefined") return false;
+  return document.querySelector(tourSelector(anchor)) !== null;
+}
+
+/**
+ * The steps to actually run for the current view: scope/read-only/desktop
+ * eligibility first, then DOM presence. Order follows TOUR_STEPS.
+ */
+export function resolveTourSteps(ctx: ResolveTourContext): TourStep[] {
+  const hasAnchor = ctx.hasAnchor ?? defaultHasAnchor;
+  return TOUR_STEPS.filter(
+    (step) => isStepEligible(step, ctx) && hasAnchor(step.anchor),
+  );
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2323,7 +2323,11 @@
       "components": [
         "web/src/components/tour/TourRunner.tsx",
         "web/src/components/TopBar.tsx",
-        "web/src/components/OverflowMenu.tsx"
+        "web/src/components/OverflowMenu.tsx",
+        "web/src/components/Dashboard.tsx",
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/RightPanel.tsx",
+        "web/src/components/cockpit/Composer.tsx"
       ]
     },
     {
@@ -2336,7 +2340,9 @@
         "src/components/__tests__/Dashboard.tour.test.tsx"
       ],
       "components": [
-        "web/src/components/Dashboard.tsx"
+        "web/src/components/Dashboard.tsx",
+        "web/src/lib/tourSteps.ts",
+        "web/src/hooks/useTour.tsx"
       ]
     }
   ]

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2312,6 +2312,32 @@
       "components": [
         "web/src/components/cockpit/CockpitView.tsx"
       ]
+    },
+    {
+      "id": "onboarding.first-run-tutorial",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/tutorial.spec.ts"
+      ],
+      "components": [
+        "web/src/components/tour/TourRunner.tsx",
+        "web/src/components/TopBar.tsx",
+        "web/src/components/OverflowMenu.tsx"
+      ]
+    },
+    {
+      "id": "onboarding.tour-drift-guard",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/lib/__tests__/tourSteps.test.ts",
+        "src/hooks/__tests__/useTour.test.ts",
+        "src/components/__tests__/Dashboard.tour.test.tsx"
+      ],
+      "components": [
+        "web/src/components/Dashboard.tsx"
+      ]
     }
   ]
 }

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -1,0 +1,51 @@
+// User stories (issue #1513): the first-run tutorial auto-launches on a fresh
+// browser, is skippable, persists "seen" so it does not nag on reload, and is
+// re-triggerable from the TopBar overflow menu.
+//
+// A fresh `aoe serve` $HOME has no sessions, so the app lands on the empty
+// dashboard and the dashboard-scope tour auto-launches (Playwright is a
+// fine-pointer client, so the coarse-pointer suppression does not apply).
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+// First dashboard step's title (TOUR_STEPS[0] = topbar -> "Command bar").
+const FIRST_STEP = "Command bar";
+
+base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+
+    // Story 1: auto-launches on first load, with a Skip button on the step.
+    await expect(page.getByText(FIRST_STEP)).toBeVisible({ timeout: 10_000 });
+    const skip = page.getByRole("button", { name: "Skip" });
+    await expect(skip).toBeVisible();
+
+    // Skipping closes the tour and records the seen flag.
+    await skip.click();
+    await expect(page.getByText(FIRST_STEP)).toBeHidden();
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("aoe-tour-seen")))
+      .toBe("1");
+
+    // Story 1 (persistence): a reload must not auto-launch again.
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible();
+    await expect(page.getByText(FIRST_STEP)).toBeHidden();
+
+    // Story 2: re-trigger from the fixed entry point (TopBar overflow menu).
+    await page.getByRole("button", { name: "More options" }).click();
+    await page.getByRole("menuitem", { name: "Show tutorial" }).click();
+    await expect(page.getByText(FIRST_STEP)).toBeVisible({ timeout: 10_000 });
+
+    // The flag stays set after a manual re-trigger, so the next reload is quiet.
+    expect(await page.evaluate(() => localStorage.getItem("aoe-tour-seen"))).toBe("1");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -19,6 +19,14 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
   });
 
   try {
+    // Auto-launch is suppressed in automated sessions (navigator.webdriver) so
+    // the spotlight overlay never intercepts clicks in the rest of the suite.
+    // This spec is the one place that exercises auto-launch, so present as a
+    // real (non-automated) browser. Persists across reloads/navigations.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "webdriver", { get: () => false });
+    });
+
     await page.goto(serve.baseUrl);
 
     // Story 1: auto-launches on first load, with a Skip button on the step.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web dashboard had no guided introduction: a new user landed on the sidebar, topbar, composer, and diff panel and had to discover every feature by clicking around, with only a static `?` shortcut overlay for help. This adds a first-run interactive tutorial that walks through the major UI regions and the shortcuts that matter on each.

On first load in a browser the tour auto-launches on the empty dashboard, highlighting the command bar, workspace sidebar, New session, and settings, with a one-click **Skip** on every step. Completing or skipping it records a per-origin `aoe-tour-seen` flag, so it never nags on reload. It is re-triggerable any time from a fixed entry point (the top-bar overflow menu, "Show tutorial") and adapts to where you are: inside a session it also covers the composer, agent mode picker, and send/queue controls. Auto-launch is suppressed on touch devices, where the tour stays available from the menu.

The engine is `react-joyride` (MIT, React-19 native, actively maintained), chosen over `driver.js` (slowing, imperative/out-of-tree) and the AGPL-licensed alternatives. It renders inside the React tree and is code-split into its own lazy chunk, so returning users never download it. The tour data, typed anchor constants, and eligibility resolver are kept engine-independent, so the CI drift guard and a future engine swap both stay cheap.

A three-layer guard keeps the tour honest as the UI evolves: a fast static test couples the step list, the `TOUR_ANCHORS` constants, and the `data-tour` attributes in source (rename or delete either side and it goes red); a Dashboard render test covers the read-only conditional-render path; and a live Playwright smoke exercises auto-launch, skip, persistence, and re-trigger.

The keyboard-shortcut single-source-of-truth refactor (proposal C in the issue) is intentionally deferred to a focused follow-up, #1648.

Closes #1513

## How to test

- [ ] Clear `localStorage` key `aoe-tour-seen` (or use a fresh browser profile), run `aoe serve`, open the dashboard: the tour auto-launches and highlights the command bar, sidebar, New session, and settings, each step listing its shortcuts.
- [ ] Click **Skip** on any step: the tour closes immediately.
- [ ] Reload the page: the tour does not auto-launch again.
- [ ] Open the top-bar overflow menu (three dots) and choose **Show tutorial**: the tour relaunches from the first step.
- [ ] Open a cockpit session, then re-trigger **Show tutorial**: the tour now also covers the composer, agent mode picker, and send/queue controls.
- [ ] Emulate a coarse pointer / touch device: the tour does not auto-launch, but is still reachable from the menu.
- [ ] Rename a `data-tour` anchor without updating `web/src/lib/tourSteps.ts`, then run `cd web && npm run test:unit`: the drift guard fails.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the library swap analysis, the plan, and the implementation were drafted by Claude under my direction, with a multi-model `/debate` consulted on the architecture and the engine choice. I made the design calls and will run the manual test steps above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-level Summary

This PR adds a first-run, in-app interactive tutorial to the web dashboard that auto-launches for first-time desktop users, is skippable, and can be re-triggered from the TopBar overflow menu. It highlights key UI regions (command bar, workspace sidebar, New session CTA, settings) with contextual copy and shown keyboard shortcuts, persists a per-origin seen flag in localStorage so it won't auto-run again, and suppresses auto-launch on touch/automated sessions. The tour is lazy-loaded and engine-agnostic so it doesn't impact initial bundle size and can adapt when inside a session to include composer and send/queue controls.

## What changed (concise)

- Added a typed, engine-independent tour model and resolver: web/src/lib/tourSteps.ts
- Added a tour controller hook managing lifecycle, gating, and persistence: web/src/hooks/useTour.tsx
- Added a lazy-loaded joyride-based runner with custom styling and step rendering: web/src/components/tour/TourRunner.tsx
- Wired tour anchors (data-tour) into UI: TopBar, OverflowMenu trigger, Dashboard (New session), WorkspaceSidebar, RightPanel, Composer, ActionPane
- Exposed "Show tutorial" in TopBar (onStartTutorial) to manually re-trigger
- Added tests:
  - Vitest drift-guard and unit tests for step definitions and auto-launch logic
  - Component render test for Dashboard anchor
  - Playwright end-to-end test covering auto-launch, Skip, persistence, and re-trigger
- Added react-joyride dependency and documentation entry; updated build hash in flake.nix

## Benefits

- Better onboarding and feature discoverability without leaving the app
- Non-intrusive: skip + persisted suppression of auto-launch
- Re-playable on demand via TopBar
- Minimal runtime cost: tour code is code-split and lazy-loaded
- Maintained consistency via typed anchors and CI "drift guard"
- Well-covered by unit and E2E tests

## Potential follow-ups / improvement areas

- Centralize keyboard-shortcut definitions (noted as deferred to follow-up `#1648`)
- Expose a testing hook or opt-in for automated test runs instead of forcing navigator.webdriver toggles
- Consider a UI for clearing the seen flag (for support/debugging) or an admin-level re-run control

## Technical notes (brief)

- Persistence: localStorage flag `aoe-tour-seen` per origin; written only on explicit FINISHED/SKIPPED statuses
- Auto-launch gating: requires dashboard readiness, scope === "dashboard", desktop (fine-pointer), not seen, and not automated (navigator.webdriver false)
- Step resolution: filters TOUR_STEPS by scope/readOnly/desktop eligibility and DOM anchor presence via tourSelector/resolveTourSteps
- Tour UI: react-joyride wrapped in TourRunner, loaded via React.lazy + Suspense; runtime styles use CSS variables to follow app theme
- CI guards: Vitest tests enforce TOUR_STEPS ↔ data-tour attribute drift; Playwright smoke test verifies user flow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->