### PR TITLE
feat(sandbox): add volume_ignores_strategy = \"named\" to fix macOS VirtioFS shadowin

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -227,6 +227,7 @@ default_terminal_mode = "host"
 | `environment` | `["TERM", "COLORTERM", "FORCE_COLOR", "NO_COLOR"]` | Env vars for containers (see below) |
 | `extra_volumes` | `[]` | Additional Docker volume mounts |
 | `volume_ignores` | `[]` | Directories to exclude from the project mount via anonymous volumes |
+| `volume_ignores_strategy` | `"anonymous"` | Volume mounting strategy: `"anonymous"` (default) or `"named"` (required on macOS/VirtioFS to reliably shadow bind-mount subdirectories; named volumes are explicitly removed on session delete) |
 | `auto_cleanup` | `true` | Remove containers when sessions are deleted |
 | `default_terminal_mode` | `"host"` | Paired terminal location: `"host"` or `"container"` |
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -70,11 +70,26 @@ environment = ["ANTHROPIC_API_KEY"]
 | `memory_limit` | (none) | Memory limit (e.g., "8g") |
 | `environment` | `[]` | Env vars for containers (bare KEY or KEY=VALUE, see below) |
 | `volume_ignores` | `[]` | Directories to exclude from the project mount via anonymous volumes |
+| `volume_ignores_strategy` | `"anonymous"` | How `volume_ignores` are mounted: `"anonymous"` (default) or `"named"` (required on macOS/VirtioFS, see below) |
 | `extra_volumes` | `[]` | Additional volume mounts |
 | `mount_ssh` | `false` | Mount `~/.ssh/` read-only into containers |
 | `default_terminal_mode` | `"host"` | Paired terminal location: `"host"` (on host machine) or `"container"` (inside Docker) |
 
 ## Volume Mounts
+
+### Volume Ignores Strategy (macOS/VirtioFS)
+
+By default, `volume_ignores` paths are mounted as **anonymous volumes** (`volume_ignores_strategy = "anonymous"`). This works on Linux, but on macOS with Docker Desktop's VirtioFS, anonymous volumes may not reliably shadow bind-mount subdirectories, causing host-side directories like `.venv` or `node_modules` to remain visible inside the container.
+
+To fix this on macOS, set `volume_ignores_strategy = "named"`. This mounts each `volume_ignores` path as a **deterministic named Docker/Podman volume** stored entirely inside the Docker VM, bypassing VirtioFS. Named volumes are explicitly removed when the session is deleted.
+
+```toml
+[sandbox]
+volume_ignores = ["node_modules", ".venv", "target"]
+volume_ignores_strategy = "named"
+```
+
+> Named volumes are not supported on Apple Container. Setting `"named"` on Apple Container falls back to anonymous volume behavior with a warning.
 
 ### Automatic Mounts
 

--- a/src/containers/container_interface.rs
+++ b/src/containers/container_interface.rs
@@ -8,6 +8,13 @@ pub struct VolumeMount {
     pub read_only: bool,
 }
 
+/// A named Docker/Podman volume mounted at a specific container path.
+/// Used by `volume_ignores_strategy = "named"` to bypass VirtioFS shadowing on macOS.
+pub struct NamedVolumeMount {
+    pub volume_name: String,
+    pub container_path: String,
+}
+
 /// An environment variable entry for a container.
 ///
 /// `Inherit` entries use Docker's `-e KEY` form (no value in argv), which reads
@@ -83,6 +90,8 @@ pub struct ContainerConfig {
     pub working_dir: String,
     pub volumes: Vec<VolumeMount>,
     pub anonymous_volumes: Vec<String>,
+    /// Named volumes for volume_ignores when strategy = "named". Cleaned up explicitly on session delete.
+    pub named_ignore_volumes: Vec<NamedVolumeMount>,
     pub environment: Vec<EnvEntry>,
     pub cpu_limit: Option<String>,
     pub memory_limit: Option<String>,

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -135,13 +135,13 @@ impl DockerContainer {
         result
     }
 
-    /// Remove all named ignore volumes for this session (prefix = `aoe-vi-{session_id}`).
+    /// Remove all named ignore volumes for this session (prefix = `aoe-vi-{session_id}-`).
     ///
     /// Must be called after container removal during session deletion. Named volumes are not
     /// removed by `docker rm -v`; they require explicit cleanup. Safe to call even when the
     /// container is already gone — volumes can outlive their container.
     pub fn remove_named_ignore_volumes(&self, session_id: &str) {
-        let prefix = format!("aoe-vi-{}", session_id);
+        let prefix = format!("aoe-vi-{}-", session_id);
         if let Err(e) = self.runtime.base.remove_named_ignore_volumes(&prefix) {
             tracing::warn!(
                 target: "containers.runtime",

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 
 use crate::cli::truncate_id;
 use crate::session::{Config, ContainerRuntimeName};
-pub use container_interface::{ContainerConfig, ContainerRuntimeInterface, EnvEntry, VolumeMount};
+pub use container_interface::{
+    ContainerConfig, ContainerRuntimeInterface, EnvEntry, NamedVolumeMount, VolumeMount,
+};
 use error::Result;
 pub use runtime::ContainerRuntime;
 
@@ -133,6 +135,24 @@ impl DockerContainer {
         result
     }
 
+    /// Remove all named ignore volumes for this session (prefix = `aoe-vi-{session_id}`).
+    ///
+    /// Must be called after container removal during session deletion. Named volumes are not
+    /// removed by `docker rm -v`; they require explicit cleanup. Safe to call even when the
+    /// container is already gone — volumes can outlive their container.
+    pub fn remove_named_ignore_volumes(&self, session_id: &str) {
+        let prefix = format!("aoe-vi-{}", session_id);
+        if let Err(e) = self.runtime.base.remove_named_ignore_volumes(&prefix) {
+            tracing::warn!(
+                target: "containers.runtime",
+                name = %self.name,
+                %session_id,
+                error = %e,
+                "failed to remove named ignore volumes"
+            );
+        }
+    }
+
     pub fn exec_command(&self, options: Option<&str>, cmd: &str) -> String {
         self.runtime.exec_command(&self.name, options, cmd)
     }
@@ -188,6 +208,7 @@ mod tests {
                 "/workspace/myproject/target".to_string(),
                 "/workspace/myproject/node_modules".to_string(),
             ],
+            named_ignore_volumes: vec![],
             environment: vec![],
             cpu_limit: None,
             memory_limit: None,
@@ -217,6 +238,7 @@ mod tests {
             working_dir: "/workspace".to_string(),
             volumes: vec![],
             anonymous_volumes: vec![],
+            named_ignore_volumes: vec![],
             environment: vec![],
             cpu_limit: None,
             memory_limit: None,

--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -358,6 +358,7 @@ mod tests {
         let rt = ContainerRuntime::podman();
         assert!(rt.base.supports_read_only_volumes);
         assert!(rt.base.supports_remove_volumes);
+        assert!(rt.base.supports_named_volumes);
         assert_eq!(rt.base.remove_subcommand, "rm");
         assert_eq!(rt.base.pull_prefix, &["pull"]);
     }

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -23,6 +23,8 @@ pub(crate) struct RuntimeBase {
     pub supports_read_only_volumes: bool,
     /// Whether this runtime supports `-v` on remove to clean up anonymous volumes
     pub supports_remove_volumes: bool,
+    /// Whether this runtime supports `volume ls` / `volume rm` for named volumes
+    pub supports_named_volumes: bool,
 }
 
 impl RuntimeBase {
@@ -34,6 +36,7 @@ impl RuntimeBase {
         remove_subcommand: "rm",
         supports_read_only_volumes: true,
         supports_remove_volumes: true,
+        supports_named_volumes: true,
     };
 
     pub const APPLE_CONTAINER: Self = Self {
@@ -44,6 +47,7 @@ impl RuntimeBase {
         remove_subcommand: "delete",
         supports_read_only_volumes: false,
         supports_remove_volumes: false,
+        supports_named_volumes: false,
     };
 
     pub const PODMAN: Self = Self {
@@ -57,6 +61,7 @@ impl RuntimeBase {
         remove_subcommand: "rm",
         supports_read_only_volumes: true,
         supports_remove_volumes: true,
+        supports_named_volumes: true,
     };
 
     pub fn command(&self) -> Command {
@@ -191,6 +196,24 @@ impl RuntimeBase {
             args.push(path.clone());
         }
 
+        if self.supports_named_volumes {
+            for nv in &config.named_ignore_volumes {
+                args.push("-v".to_string());
+                args.push(format!("{}:{}", nv.volume_name, nv.container_path));
+            }
+        } else if !config.named_ignore_volumes.is_empty() {
+            // Apple Container doesn't support named volumes; fall back to anonymous behavior.
+            tracing::warn!(
+                target: "containers.runtime",
+                runtime = %self.name,
+                "named volume_ignores_strategy is not supported; falling back to anonymous volumes"
+            );
+            for nv in &config.named_ignore_volumes {
+                args.push("-v".to_string());
+                args.push(nv.container_path.clone());
+            }
+        }
+
         let (env_argv, _inherit) = docker_env_args(&config.environment);
         args.extend(env_argv);
 
@@ -303,6 +326,61 @@ impl RuntimeBase {
         Ok(())
     }
 
+    /// Remove all named ignore volumes whose names start with the given prefix.
+    ///
+    /// Used to clean up volumes created with `volume_ignores_strategy = "named"` after
+    /// a session container is deleted. Volumes can outlive the container, so this must
+    /// be called even when the container is already gone.
+    ///
+    /// This is a no-op on runtimes that don't support named volumes (e.g. Apple Container).
+    pub fn remove_named_ignore_volumes(&self, prefix: &str) -> Result<()> {
+        if !self.supports_named_volumes {
+            return Ok(());
+        }
+
+        // List volumes whose names start with the prefix.
+        let list_output = self
+            .command()
+            .args([
+                "volume",
+                "ls",
+                "--filter",
+                &format!("name={}", prefix),
+                "-q",
+            ])
+            .output()?;
+
+        if !list_output.status.success() {
+            let stderr = String::from_utf8_lossy(&list_output.stderr);
+            tracing::warn!(target: "containers.runtime", runtime = %self.name, %prefix, "failed to list named ignore volumes: {}", stderr);
+            return Ok(());
+        }
+
+        let stdout = String::from_utf8_lossy(&list_output.stdout);
+        // Filter in Rust to exact prefix match (docker's --filter is substring-based).
+        let names: Vec<&str> = stdout
+            .lines()
+            .map(str::trim)
+            .filter(|n| !n.is_empty() && n.starts_with(prefix))
+            .collect();
+
+        if names.is_empty() {
+            return Ok(());
+        }
+
+        tracing::debug!(target: "containers.runtime", runtime = %self.name, ?names, "removing named ignore volumes");
+        let mut rm_args = vec!["volume", "rm"];
+        rm_args.extend(names.iter().copied());
+        let rm_output = self.command().args(&rm_args).output()?;
+
+        if !rm_output.status.success() {
+            let stderr = String::from_utf8_lossy(&rm_output.stderr);
+            tracing::warn!(target: "containers.runtime", runtime = %self.name, "failed to remove named ignore volumes: {}", stderr);
+        }
+
+        Ok(())
+    }
+
     pub fn exec_command(&self, name: &str, options: Option<&str>, cmd: &str) -> String {
         if let Some(opt_str) = options {
             [self.binary, "exec", "-it", opt_str, name, cmd].join(" ")
@@ -337,6 +415,7 @@ mod tests {
                 read_only: true,
             }],
             anonymous_volumes: vec![],
+            named_ignore_volumes: vec![],
             environment: vec![],
             cpu_limit: None,
             memory_limit: None,
@@ -360,6 +439,7 @@ mod tests {
                 read_only: true,
             }],
             anonymous_volumes: vec![],
+            named_ignore_volumes: vec![],
             environment: vec![],
             cpu_limit: None,
             memory_limit: None,
@@ -405,6 +485,7 @@ mod tests {
                 read_only: false,
             }],
             anonymous_volumes: vec!["/tmp/cache".to_string()],
+            named_ignore_volumes: vec![],
             environment: vec![EnvEntry::Literal {
                 key: "KEY".to_string(),
                 value: "VALUE".to_string(),
@@ -443,6 +524,7 @@ mod tests {
             working_dir: "/workspace".to_string(),
             volumes: vec![],
             anonymous_volumes: vec![],
+            named_ignore_volumes: vec![],
             environment: vec![EnvEntry::Inherit {
                 key: "GH_TOKEN".to_string(),
                 value: "ghp_secret123".to_string(),
@@ -466,6 +548,7 @@ mod tests {
             working_dir: "/workspace".to_string(),
             volumes: vec![],
             anonymous_volumes: vec![],
+            named_ignore_volumes: vec![],
             environment: vec![
                 EnvEntry::Inherit {
                     key: "SECRET".to_string(),
@@ -497,6 +580,7 @@ mod tests {
             working_dir: "/workspace".to_string(),
             volumes: vec![],
             anonymous_volumes: vec![],
+            named_ignore_volumes: vec![],
             environment: vec![],
             cpu_limit: None,
             memory_limit: None,
@@ -515,5 +599,89 @@ mod tests {
         assert_eq!(p_indices.len(), 2);
         assert_eq!(args[p_indices[0] + 1], "3000:3000");
         assert_eq!(args[p_indices[1] + 1], "5432:5432");
+    }
+
+    #[test]
+    fn test_named_ignore_volumes_rendered_as_name_colon_path_on_docker() {
+        use crate::containers::container_interface::NamedVolumeMount;
+        let base = RuntimeBase::DOCKER;
+        let config = ContainerConfig {
+            working_dir: "/workspace".to_string(),
+            volumes: vec![],
+            anonymous_volumes: vec![],
+            named_ignore_volumes: vec![NamedVolumeMount {
+                volume_name: "aoe-vi-sess1-workspace-node_modules-abc123def456".to_string(),
+                container_path: "/workspace/node_modules".to_string(),
+            }],
+            environment: vec![],
+            cpu_limit: None,
+            memory_limit: None,
+            port_mappings: vec![],
+        };
+
+        let args = base.build_create_args("test", "alpine:latest", &config);
+
+        let v_positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "-v")
+            .map(|(i, _)| i)
+            .collect();
+        let volume_args: Vec<&str> = v_positions.iter().map(|&i| args[i + 1].as_str()).collect();
+
+        assert!(
+            volume_args.contains(
+                &"aoe-vi-sess1-workspace-node_modules-abc123def456:/workspace/node_modules"
+            ),
+            "Named volume must render as name:/path, got: {:?}",
+            volume_args
+        );
+    }
+
+    #[test]
+    fn test_named_ignore_volumes_fall_back_to_anonymous_on_apple_container() {
+        use crate::containers::container_interface::NamedVolumeMount;
+        let base = RuntimeBase::APPLE_CONTAINER;
+        let config = ContainerConfig {
+            working_dir: "/workspace".to_string(),
+            volumes: vec![],
+            anonymous_volumes: vec![],
+            named_ignore_volumes: vec![NamedVolumeMount {
+                volume_name: "aoe-vi-sess1-workspace-node_modules-abc123".to_string(),
+                container_path: "/workspace/node_modules".to_string(),
+            }],
+            environment: vec![],
+            cpu_limit: None,
+            memory_limit: None,
+            port_mappings: vec![],
+        };
+
+        let args = base.build_create_args("test", "alpine:latest", &config);
+
+        let v_positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "-v")
+            .map(|(i, _)| i)
+            .collect();
+        let volume_args: Vec<&str> = v_positions.iter().map(|&i| args[i + 1].as_str()).collect();
+
+        // Apple Container must use bare path, not name:path
+        assert!(
+            volume_args.contains(&"/workspace/node_modules"),
+            "Apple Container fallback must use bare container path, got: {:?}",
+            volume_args
+        );
+        assert!(
+            !volume_args.iter().any(|a| a.contains("aoe-vi-")),
+            "Apple Container must not use the volume name in -v args"
+        );
+    }
+
+    #[test]
+    fn test_supports_named_volumes_flags() {
+        assert!(RuntimeBase::DOCKER.supports_named_volumes);
+        assert!(RuntimeBase::PODMAN.supports_named_volumes);
+        assert!(!RuntimeBase::APPLE_CONTAINER.supports_named_volumes);
     }
 }

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -624,6 +624,7 @@ fn try_sandbox_dir_cleanup(
     let container = DockerContainer::from_session_id(&instance.id);
     let rm_result = container.remove(true);
     tracing::debug!(target: "git.worktree", ?rm_result, "container force-removed");
+    container.remove_named_ignore_volumes(&instance.id);
 
     match remove_worktree_dir(worktree_path, main_repo, true) {
         Ok(()) => true,

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -651,6 +651,8 @@ pub fn cleanup_instance(
                     tracing::warn!(target: "session.create", "Failed to clean up container: {}", e);
                 }
             }
+            // Remove named ignore volumes even if the container is already gone.
+            container.remove_named_ignore_volumes(&instance.id);
         }
     }
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1138,6 +1138,10 @@ pub struct SandboxConfig {
     #[serde(default, deserialize_with = "super::serde_helpers::string_or_vec")]
     pub volume_ignores: Vec<String>,
 
+    /// Strategy for mounting volume_ignores paths (anonymous or named)
+    #[serde(default)]
+    pub volume_ignores_strategy: VolumeIgnoresStrategy,
+
     /// Mount ~/.ssh into sandbox containers (default: false)
     #[serde(default)]
     pub mount_ssh: bool,
@@ -1161,6 +1165,21 @@ pub enum ContainerRuntimeName {
     Podman,
 }
 
+/// Volume mounting strategy for volume_ignores paths.
+///
+/// On macOS with Docker Desktop's VirtioFS, anonymous volumes don't always shadow
+/// bind-mount subdirectories. Use `Named` to mount deterministic named Docker/Podman
+/// volumes instead, which live in the Docker VM and bypass VirtioFS reliably.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VolumeIgnoresStrategy {
+    /// Use anonymous volumes (default; works on Linux; may not shadow on macOS/VirtioFS)
+    #[default]
+    Anonymous,
+    /// Use deterministic named volumes (required on macOS/VirtioFS; explicitly cleaned up on session delete)
+    Named,
+}
+
 impl Default for SandboxConfig {
     fn default() -> Self {
         Self {
@@ -1174,6 +1193,7 @@ impl Default for SandboxConfig {
             port_mappings: Vec::new(),
             default_terminal_mode: DefaultTerminalMode::default(),
             volume_ignores: Vec::new(),
+            volume_ignores_strategy: VolumeIgnoresStrategy::default(),
             mount_ssh: false,
             custom_instruction: None,
             container_runtime: ContainerRuntimeName::default(),
@@ -2261,5 +2281,42 @@ keep_count = 10
         let reparsed: LoggingConfig = toml::from_str(&serialized).unwrap();
         assert_eq!(reparsed.output, SinkKind::Stdout);
         assert_eq!(reparsed.rotation, RotationKind::Never);
+    }
+
+    #[test]
+    fn test_volume_ignores_strategy_defaults_to_anonymous() {
+        let config: SandboxConfig = toml::from_str("").unwrap();
+        assert_eq!(
+            config.volume_ignores_strategy,
+            VolumeIgnoresStrategy::Anonymous
+        );
+    }
+
+    #[test]
+    fn test_volume_ignores_strategy_named_roundtrip() {
+        let toml_str = r#"
+volume_ignores = ["node_modules"]
+volume_ignores_strategy = "named"
+"#;
+        let config: SandboxConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.volume_ignores_strategy, VolumeIgnoresStrategy::Named);
+        assert_eq!(config.volume_ignores, vec!["node_modules"]);
+
+        let serialized = toml::to_string(&config).unwrap();
+        let reparsed: SandboxConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            reparsed.volume_ignores_strategy,
+            VolumeIgnoresStrategy::Named
+        );
+    }
+
+    #[test]
+    fn test_volume_ignores_strategy_anonymous_roundtrip() {
+        let toml_str = r#"volume_ignores_strategy = "anonymous""#;
+        let config: SandboxConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.volume_ignores_strategy,
+            VolumeIgnoresStrategy::Anonymous
+        );
     }
 }

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -8,8 +8,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use crate::containers::{ContainerConfig, EnvEntry, VolumeMount};
+use crate::containers::{ContainerConfig, EnvEntry, NamedVolumeMount, VolumeMount};
 use crate::git::GitWorktree;
+use crate::session::config::VolumeIgnoresStrategy;
 
 use super::environment::collect_environment;
 use super::instance::SandboxInfo;
@@ -962,6 +963,34 @@ impl<'a> ContainerAgentSelection<'a> {
     }
 }
 
+/// Produce a deterministic Docker volume name for a named volume_ignores mount.
+///
+/// Uses the full session ID as a prefix so volumes can be enumerated on deletion.
+/// A short hash of the container path is appended to handle slug collisions.
+fn named_volume_for(session_id: &str, container_path: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let sanitize = |s: &str| -> String {
+        s.chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-' {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect()
+    };
+    let slug: String = sanitize(container_path.trim_start_matches('/'))
+        .chars()
+        .take(40)
+        .collect();
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    container_path.hash(&mut h);
+    let hash = format!("{:x}", h.finish());
+    let hash12 = &hash[..12.min(hash.len())];
+    format!("aoe-vi-{}-{}-{}", session_id, slug, hash12)
+}
+
 /// Build a full `ContainerConfig` for creating a sandboxed container.
 ///
 /// `profile` selects which profile's overrides (volumes, mount_ssh, volume_ignores)
@@ -1247,13 +1276,10 @@ pub(crate) fn build_container_config(
         }
     }
 
-    // Filter anonymous_volumes to exclude paths that conflict with extra_volumes
-    // (extra_volumes should take precedence over volume_ignores)
-    // Conflicts include:
-    //   - Exact match: both point to same path
-    //   - Anonymous volume is parent of extra_volume (would shadow the mount)
-    //   - Anonymous volume is inside extra_volume (redundant/conflicting)
-    let anonymous_volumes: Vec<String> = volume_ignore_bases
+    // Expand all volume_ignores paths and filter conflicts with extra_volumes.
+    // (extra_volumes take precedence over volume_ignores)
+    // Conflicts: exact match, anonymous is a parent of extra, or inside extra.
+    let expanded_ignore_paths: Vec<String> = volume_ignore_bases
         .iter()
         .flat_map(|base_path| {
             sandbox_config
@@ -1261,14 +1287,30 @@ pub(crate) fn build_container_config(
                 .iter()
                 .map(move |ignore| format!("{}/{}", base_path, ignore))
         })
-        .filter(|anon_path| {
+        .filter(|path| {
             !extra_volume_container_paths.iter().any(|extra_path| {
-                anon_path == extra_path
-                    || extra_path.starts_with(&format!("{}/", anon_path))
-                    || anon_path.starts_with(&format!("{}/", extra_path))
+                path == extra_path
+                    || extra_path.starts_with(&format!("{}/", path))
+                    || path.starts_with(&format!("{}/", extra_path))
             })
         })
         .collect();
+
+    // Route by strategy: anonymous volumes are the default; named volumes fix VirtioFS on macOS.
+    let (anonymous_volumes, named_ignore_volumes): (Vec<String>, Vec<NamedVolumeMount>) =
+        match sandbox_config.volume_ignores_strategy {
+            VolumeIgnoresStrategy::Anonymous => (expanded_ignore_paths, vec![]),
+            VolumeIgnoresStrategy::Named => {
+                let named = expanded_ignore_paths
+                    .into_iter()
+                    .map(|container_path| NamedVolumeMount {
+                        volume_name: named_volume_for(instance_id, &container_path),
+                        container_path,
+                    })
+                    .collect();
+                (vec![], named)
+            }
+        };
 
     // Deduplicate volumes by container_path (last writer wins, so extra_volumes
     // from user config override automatic mounts).
@@ -1287,6 +1329,7 @@ pub(crate) fn build_container_config(
         working_dir: workspace_path,
         volumes: deduped,
         anonymous_volumes,
+        named_ignore_volumes,
         environment,
         cpu_limit: sandbox_config.cpu_limit,
         memory_limit: sandbox_config.memory_limit,
@@ -3594,5 +3637,54 @@ volume_ignores = ["target"]
         );
 
         std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+    }
+
+    // --- named_volume_for tests ---
+
+    #[test]
+    fn test_named_volume_for_is_deterministic() {
+        let a = named_volume_for("sess-abc123", "/workspace/node_modules");
+        let b = named_volume_for("sess-abc123", "/workspace/node_modules");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_named_volume_for_differs_by_path() {
+        let a = named_volume_for("sess-abc123", "/workspace/node_modules");
+        let b = named_volume_for("sess-abc123", "/workspace/.venv");
+        assert_ne!(a, b, "Different paths must produce different volume names");
+    }
+
+    #[test]
+    fn test_named_volume_for_differs_by_session_id() {
+        let a = named_volume_for("sess-aaa", "/workspace/node_modules");
+        let b = named_volume_for("sess-bbb", "/workspace/node_modules");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_named_volume_for_sanitizes_unsafe_chars() {
+        let name = named_volume_for("sess-1", "/workspace/path with spaces/foo:bar");
+        assert!(
+            !name.contains(' ') && !name.contains(':'),
+            "Volume name must not contain spaces or colons"
+        );
+    }
+
+    #[test]
+    fn test_named_volume_for_starts_with_prefix() {
+        let name = named_volume_for("sess-xyz", "/workspace/target");
+        assert!(name.starts_with("aoe-vi-sess-xyz-"));
+    }
+
+    #[test]
+    fn test_named_volume_for_slug_collision_prevented_by_hash() {
+        // Two paths that have the same 40-char slug prefix (unlikely but possible for long paths)
+        // are disambiguated by the hash suffix.
+        let path1 = "/workspace/a-very-long-directory-name-that-exceeds-40-chars-v1";
+        let path2 = "/workspace/a-very-long-directory-name-that-exceeds-40-chars-v2";
+        let a = named_volume_for("sess-1", path1);
+        let b = named_volume_for("sess-1", path2);
+        assert_ne!(a, b);
     }
 }

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -3687,4 +3687,18 @@ volume_ignores = ["target"]
         let b = named_volume_for("sess-1", path2);
         assert_ne!(a, b);
     }
+
+    #[test]
+    fn test_named_volume_for_prefix_does_not_match_longer_session_id() {
+        // "sess1" must not match volumes belonging to "sess10".
+        // The cleanup prefix is "aoe-vi-{session_id}-" (trailing dash), so a volume
+        // named "aoe-vi-sess10-..." must NOT start with "aoe-vi-sess1-".
+        let vol_sess10 = named_volume_for("sess10", "/workspace/node_modules");
+        let prefix_sess1 = format!("aoe-vi-{}-", "sess1");
+        assert!(
+            !vol_sess10.starts_with(&prefix_sess1),
+            "Volume for sess10 must not match the cleanup prefix for sess1: {}",
+            vol_sess10
+        );
+    }
 }

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -154,6 +154,9 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                 messages.push("Container removed".to_string());
             }
         }
+        // Remove named ignore volumes even if the container is already gone — volumes created
+        // with volume_ignores_strategy = "named" outlive the container and need explicit cleanup.
+        container.remove_named_ignore_volumes(&request.instance.id);
     }
 
     // Stage 4: worktree cleanup. Container is gone, agent is gone, no

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -25,7 +25,7 @@ pub use config::{
     get_update_settings, load_config, save_config, validate_snooze_duration, ClickAction, Config,
     ContainerRuntimeName, DefaultTerminalMode, GroupByMode, NewSessionAttachMode, RowTagMode,
     SandboxConfig, SessionConfig, ThemeConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode,
-    UpdatesConfig, WorktreeConfig,
+    UpdatesConfig, VolumeIgnoresStrategy, WorktreeConfig,
 };
 pub(crate) use environment::user_shell;
 pub use environment::{validate_env_entries, validate_env_entry};

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -10,7 +10,7 @@ use std::fs;
 
 use super::config::{
     ColorMode, Config, ContainerRuntimeName, DefaultTerminalMode, TmuxClipboardMode, TmuxMouseMode,
-    TmuxStatusBarMode,
+    TmuxStatusBarMode, VolumeIgnoresStrategy,
 };
 use super::get_profile_dir;
 
@@ -206,6 +206,9 @@ pub struct SandboxConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container_runtime: Option<ContainerRuntimeName>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub volume_ignores_strategy: Option<VolumeIgnoresStrategy>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -408,6 +411,9 @@ pub fn apply_sandbox_overrides(
     }
     if let Some(container_runtime) = source.container_runtime {
         target.container_runtime = container_runtime;
+    }
+    if let Some(volume_ignores_strategy) = source.volume_ignores_strategy {
+        target.volume_ignores_strategy = volume_ignores_strategy;
     }
 }
 

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -3,6 +3,7 @@
 use crate::session::{
     validate_check_interval, validate_snooze_duration, Config, ContainerRuntimeName,
     DefaultTerminalMode, ProfileConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode,
+    VolumeIgnoresStrategy,
 };
 use crate::sound::{
     validate_sound_exists, volume_from_option, volume_options, volume_to_index, SoundMode,
@@ -85,6 +86,7 @@ pub enum FieldKey {
     ExtraVolumes,
     PortMappings,
     VolumeIgnores,
+    VolumeIgnoresStrategy,
     MountSsh,
     CustomInstruction,
     ContainerRuntime,
@@ -1250,6 +1252,11 @@ fn build_sandbox_fields(
         global.sandbox.container_runtime,
         sb.and_then(|s| s.container_runtime),
     );
+    let (volume_ignores_strategy, o_vis) = resolve_value(
+        scope,
+        global.sandbox.volume_ignores_strategy,
+        sb.and_then(|s| s.volume_ignores_strategy),
+    );
 
     let terminal_mode_selected = match default_terminal_mode {
         DefaultTerminalMode::Host => 0,
@@ -1275,6 +1282,16 @@ fn build_sandbox_fields(
     };
     let container_runtime_options =
         vec!["Docker".into(), "Podman".into(), "Apple Container".into()];
+
+    let volume_ignores_strategy_selected = match volume_ignores_strategy {
+        VolumeIgnoresStrategy::Anonymous => 0,
+        VolumeIgnoresStrategy::Named => 1,
+    };
+    let global_volume_ignores_strategy_selected = match global.sandbox.volume_ignores_strategy {
+        VolumeIgnoresStrategy::Anonymous => 0,
+        VolumeIgnoresStrategy::Named => 1,
+    };
+    let volume_ignores_strategy_options = vec!["anonymous".into(), "named".into()];
 
     vec![
         SettingField {
@@ -1398,6 +1415,24 @@ fn build_sandbox_fields(
             inherited_display: inherited_if(
                 o7,
                 FieldValue::List(global.sandbox.volume_ignores.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::VolumeIgnoresStrategy,
+            label: "Volume Ignores Strategy",
+            description: "anonymous: default, works on Linux. named: use deterministic Docker/Podman named volumes, required on macOS/VirtioFS to reliably shadow bind-mount subdirectories.",
+            value: FieldValue::Select {
+                selected: volume_ignores_strategy_selected,
+                options: volume_ignores_strategy_options.clone(),
+            },
+            category: SettingsCategory::Sandbox,
+            has_override: o_vis,
+            inherited_display: inherited_if(
+                o_vis,
+                FieldValue::Select {
+                    selected: global_volume_ignores_strategy_selected,
+                    options: volume_ignores_strategy_options,
+                },
             ),
         },
         SettingField {
@@ -2568,6 +2603,12 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
                 _ => ContainerRuntimeName::AppleContainer,
             };
         }
+        (FieldKey::VolumeIgnoresStrategy, FieldValue::Select { selected, .. }) => {
+            config.sandbox.volume_ignores_strategy = match selected {
+                1 => VolumeIgnoresStrategy::Named,
+                _ => VolumeIgnoresStrategy::Anonymous,
+            };
+        }
         // Tmux
         (FieldKey::StatusBar, FieldValue::Select { selected, .. }) => {
             config.tmux.status_bar = match selected {
@@ -2951,6 +2992,15 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
             };
             set_profile_override(runtime, &mut config.sandbox, |s, val| {
                 s.container_runtime = val
+            });
+        }
+        (FieldKey::VolumeIgnoresStrategy, FieldValue::Select { selected, .. }) => {
+            let strategy = match selected {
+                1 => VolumeIgnoresStrategy::Named,
+                _ => VolumeIgnoresStrategy::Anonymous,
+            };
+            set_profile_override(strategy, &mut config.sandbox, |s, val| {
+                s.volume_ignores_strategy = val
             });
         }
         // Tmux

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -867,6 +867,11 @@ impl SettingsView {
                     s.container_runtime = None;
                 }
             }
+            FieldKey::VolumeIgnoresStrategy => {
+                if let Some(ref mut s) = config.sandbox {
+                    s.volume_ignores_strategy = None;
+                }
+            }
             // Sound
             FieldKey::SoundEnabled => {
                 if let Some(ref mut s) = config.sound {

--- a/tests/integration/sandbox_integration.rs
+++ b/tests/integration/sandbox_integration.rs
@@ -140,8 +140,8 @@ fn test_container_lifecycle() {
     let config = containers::ContainerConfig {
         working_dir: "/workspace".to_string(),
         volumes: vec![],
-
         anonymous_volumes: vec![],
+        named_ignore_volumes: vec![],
         environment: vec![],
         cpu_limit: None,
         memory_limit: None,
@@ -182,8 +182,8 @@ fn test_container_force_remove() {
     let config = containers::ContainerConfig {
         working_dir: "/workspace".to_string(),
         volumes: vec![],
-
         anonymous_volumes: vec![],
+        named_ignore_volumes: vec![],
         environment: vec![],
         cpu_limit: None,
         memory_limit: None,


### PR DESCRIPTION
Adds an opt-in named volume strategy for volume_ignores that bypasses Docker Desktop's VirtioFS layer on macOS. Anonymous volumes don't reliably shadow bind-mount subdirectories on VirtioFS; deterministic named volumes stored in the Docker VM do.

Closes #1092

## Description
<!-- Describe your changes and the problem they solve -->
On macOS, Docker Desktop's VirtioFS layer doesn't consistently shadow bind-mount subdirectories with anonymous volumes. This means \`volume_ignores\` entries like \`node_modules\` or \`target\` remain visible inside the container instead of appearing empty, corrupting both host and container environments.

This PR adds an opt-in \`volume_ignores_strategy = \"named\"\` config field. When set, each \`volume_ignores\` path is mounted as a deterministic named Docker/Podman volume stored entirely in the Docker VM, bypassing VirtioFS. The default remains \`\"anonymous\"\`, preserving existing Linux behavior.

Closes #1092

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
Claude Sonnet 4.6 (Claude Code) for implementation

**Any Additional AI Details you'd like to share:**

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds an opt-in sandbox configuration, volume_ignores_strategy, to address macOS Docker Desktop (VirtioFS) shadowing problems by letting ignored project subdirectories be mounted as deterministic named volumes instead of anonymous volumes. Default behavior stays the same ("anonymous") to preserve Linux behavior.

## What changed (high-level)

Added
- New config: sandbox.volume_ignores_strategy (anonymous | named) with serde support and defaults.
- NamedVolumeMount struct and ContainerConfig.named_ignore_volumes to represent named-volume mounts.
- Deterministic naming helper (aoe-vi-{session_id}-{sanitized+hashed-path}) for named ignore volumes.
- Runtime capability flag supports_named_volumes and runtime logic to mount named volumes when supported; fall back with a warning for runtimes that do not support named volumes (Apple Container).
- Cleanup paths to remove named ignore volumes on session deletion and container teardown (including recovery paths).
- Settings UI and profile overrides to expose and persist the new strategy.
- Tests covering config parsing, named-volume name determinism, runtime rendering, and integration test updates.
- Documentation entries explaining the option and macOS-specific behavior.

Modified
- Container build path to select anonymous vs named ignore mounts and to filter ignores that conflict with explicit extra volumes.
- Session deletion and sandbox recovery to call named-volume cleanup even if containers are already gone.
- Re-exports to include VolumeIgnoresStrategy.

Removed
- Nothing removed.

## Benefits

- Resolves macOS VirtioFS shadowing so ignored directories (e.g., node_modules, .venv, target) are reliably hidden inside containers, reducing cross-environment corruption risk.
- Backward-compatible: default anonymous behavior unchanged for existing users (Linux).
- Deterministic names enable reliable lifecycle management and cleanup.
- Configurable per-profile and available in the UI for easy adoption.

## Technical notes (concise)

- New enum VolumeIgnoresStrategy (Anonymous | Named) serialized as snake_case.
- named_volume_for(session_id, container_path) produces a sanitized slug plus a hash suffix (max length) and prefix aoe-vi-{session_id}- to avoid collisions.
- RuntimeBase gained supports_named_volumes flag; build_create_args mounts named volumes as name:container_path when supported.
- remove_named_ignore_volumes(prefix) lists volumes by prefix and removes matches; no-op with warning on unsupported runtimes.
- Apple Container backend falls back to anonymous-style mounts and logs a warning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->