### PR TITLE
fix(cockpit): bound expanded queued and rejected prompt rows

### DIFF
--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -2174,8 +2174,13 @@ function QueuedPromptRow({
               onClick={() => setEditing(true)}
               title="Click to edit"
               className={[
-                "block w-full text-left text-xs leading-5 text-text-secondary whitespace-pre-wrap break-words hover:text-text-primary",
-                isLong && !rowExpanded ? "line-clamp-3" : "",
+                "w-full text-left text-xs leading-5 text-text-secondary whitespace-pre-wrap break-words hover:text-text-primary",
+                // `line-clamp-3` only clamps when it owns the element's
+                // display (`-webkit-box`). A static `block` here wins the
+                // cascade and silently kills the clamp, so a huge collapsed
+                // paste renders in full. Keep `block` and `line-clamp-3`
+                // mutually exclusive. See #1642.
+                isLong && !rowExpanded ? "line-clamp-3" : "block",
               ]
                 .filter(Boolean)
                 .join(" ")}

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -1992,7 +1992,10 @@ function RejectedPromptsStrip({
                 !
               </span>
               <div className="min-w-0 flex-1">
-                <p className="truncate whitespace-pre-wrap break-words text-xs text-amber-100">
+                {/* Bound a huge rejected paste to a scrollable box so it
+                    cannot grow the strip and shove the composer off-screen,
+                    same hazard as the queued rows. See #1642. */}
+                <p className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words text-xs text-amber-100">
                   {r.text}
                 </p>
                 <p className="mt-0.5 text-[10px] text-amber-400/80">
@@ -2156,19 +2159,30 @@ function QueuedPromptRow({
         />
       ) : (
         <div className="min-w-0 flex-1">
-          <button
-            type="button"
-            onClick={() => setEditing(true)}
-            title="Click to edit"
-            className={[
-              "block w-full text-left text-xs leading-5 text-text-secondary whitespace-pre-wrap break-words hover:text-text-primary",
-              isLong && !rowExpanded ? "line-clamp-3" : "",
-            ]
-              .filter(Boolean)
-              .join(" ")}
+          {/* When expanded, a huge paste is bounded to a scrollable box
+              (max-h matches the composer's max-h-[200px]) so it can never
+              grow the strip and push the composer off-screen. The toggle
+              below stays a sibling of this box, so capping the height also
+              keeps "Show less" reachable. See #1642. */}
+          <div
+            className={
+              isLong && rowExpanded ? "max-h-48 overflow-y-auto" : ""
+            }
           >
-            {prompt.text}
-          </button>
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              title="Click to edit"
+              className={[
+                "block w-full text-left text-xs leading-5 text-text-secondary whitespace-pre-wrap break-words hover:text-text-primary",
+                isLong && !rowExpanded ? "line-clamp-3" : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+            >
+              {prompt.text}
+            </button>
+          </div>
           {isLong && (
             <button
               type="button"

--- a/web/src/components/cockpit/QueuedPromptsStrip.test.tsx
+++ b/web/src/components/cockpit/QueuedPromptsStrip.test.tsx
@@ -4,7 +4,7 @@
 // (#1356). The strip lifts up a visual hint when the queued items will
 // fire as separate POSTs because one of them is a clear-command alias.
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { AgentProfileProvider } from "../../lib/agentProfileContext";
@@ -105,5 +105,60 @@ describe("QueuedPromptsStrip clear-boundary divider (#1356)", () => {
   it("omits the Clear all button when the queue has exactly one entry", () => {
     const { queryByRole } = renderWithProfile("claude", [mk("a", "only")]);
     expect(queryByRole("button", { name: /clear all/i })).toBeNull();
+  });
+});
+
+describe("QueuedPromptRow expanded-state bounds (#1642)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // A multi-thousand-char paste: trips isQueuedPromptLong (>160 chars) so
+  // the row gets the clamp + "…" affordance.
+  const hugePaste = "lorem ipsum ".repeat(500);
+
+  it("clamps a long collapsed prompt and offers the expand affordance", () => {
+    const { getByTitle, getByRole } = renderWithProfile("claude", [
+      mk("a", hugePaste),
+    ]);
+    expect(getByTitle("Click to edit").className).toContain("line-clamp-3");
+    // Collapsed affordance is the "…" toggle.
+    expect(
+      getByRole("button", { name: "Show full queued prompt" }),
+    ).toBeTruthy();
+  });
+
+  it("bounds the expanded prompt to a scrollable box so it cannot grow the strip", () => {
+    const { getByTitle, getByRole } = renderWithProfile("claude", [
+      mk("a", hugePaste),
+    ]);
+    fireEvent.click(getByRole("button", { name: "Show full queued prompt" }));
+
+    // Clamp is gone once expanded.
+    const textButton = getByTitle("Click to edit");
+    expect(textButton.className).not.toContain("line-clamp-3");
+
+    // The text now lives inside a height-capped, scrollable wrapper, so a
+    // huge paste scrolls in place instead of pushing the composer off-screen.
+    const box = textButton.parentElement as HTMLElement;
+    expect(box.className).toContain("max-h-48");
+    expect(box.className).toContain("overflow-y-auto");
+  });
+
+  it("keeps the Show less toggle outside the scrollable region so it stays reachable", () => {
+    const { getByTitle, getByRole } = renderWithProfile("claude", [
+      mk("a", hugePaste),
+    ]);
+    fireEvent.click(getByRole("button", { name: "Show full queued prompt" }));
+
+    const collapseToggle = getByRole("button", {
+      name: "Collapse queued prompt",
+    });
+    expect(collapseToggle.textContent).toBe("Show less");
+
+    // The toggle must be a sibling of the capped box, not a descendant of
+    // it; otherwise it would scroll away with the paste and get buried.
+    const box = getByTitle("Click to edit").parentElement as HTMLElement;
+    expect(box.contains(collapseToggle)).toBe(false);
   });
 });

--- a/web/src/components/cockpit/QueuedPromptsStrip.test.tsx
+++ b/web/src/components/cockpit/QueuedPromptsStrip.test.tsx
@@ -121,7 +121,12 @@ describe("QueuedPromptRow expanded-state bounds (#1642)", () => {
     const { getByTitle, getByRole } = renderWithProfile("claude", [
       mk("a", hugePaste),
     ]);
-    expect(getByTitle("Click to edit").className).toContain("line-clamp-3");
+    const textButton = getByTitle("Click to edit");
+    expect(textButton.className).toContain("line-clamp-3");
+    // `block` must NOT co-exist with `line-clamp-3`: its `display:block`
+    // wins the cascade over line-clamp's `-webkit-box` and silently kills
+    // the clamp, rendering the whole paste. See #1642.
+    expect(textButton.className.split(/\s+/)).not.toContain("block");
     // Collapsed affordance is the "…" toggle.
     expect(
       getByRole("button", { name: "Show full queued prompt" }),

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1065,6 +1065,17 @@
       ]
     },
     {
+      "id": "cockpit.queued-prompt-expand-bounds",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/QueuedPromptsStrip.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx"
+      ]
+    },
+    {
       "id": "cockpit.todo-group-fold",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the web cockpit, pasting a huge block of text as a follow-up while the agent is busy queues it in the `QueuedPromptsStrip`, folded to three lines with a `…` affordance. Clicking `…` to read it blew out the layout: the expanded row rendered the full paste with no height cap, grew the strip until it shoved the composer off the bottom of the viewport, and buried the "Show less" control below the fold where it could not be reached.

This caps the expanded queued text in a `max-h-48` (192px, matching the composer's `max-h-[200px]`) scrollable box, so a multi-thousand-line paste scrolls in place instead of growing the strip. Because the "Show less" toggle stays a sibling of that capped box rather than living inside it, bounding the height also keeps the toggle reachable, no JSX reordering needed.

The rejected-prompt rows shared the same unbounded-growth hazard (their text had no height cap and a contradictory `truncate whitespace-pre-wrap`), so the same `max-h-48 overflow-y-auto` cap is applied there too.

This completes the work #1232 started: the per-row clamp covered the collapsed state but left the expanded state unbounded.

Closes #1642

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the cockpit, start an agent turn so it is busy, paste a multi-thousand-line block into the composer, and send it so it lands in the Queued strip.
- [ ] Click the `…` affordance on that queued row; confirm the row expands into a bounded box that scrolls internally and the composer stays visible at the bottom of the viewport.
- [ ] Without scrolling through the paste, confirm the "Show less" control is reachable, and clicking it re-folds the row.
- [ ] Confirm collapsed long queued prompts still clamp to three lines with the `…` affordance (no regression).
- [ ] Trigger a rejected prompt with a long body (paste a big block, retry while the agent is busy); confirm the rejected pill scrolls inside its box and does not push the composer off-screen.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

(Covered with Vitest + RTL in `web/src/components/cockpit/QueuedPromptsStrip.test.tsx`, the canonical layer for this row's render assertions, and registered as the `cockpit.queued-prompt-expand-bounds` surface in `web/tests/coverage-matrix.json`. Three new cases assert the expanded text carries the `max-h-48 overflow-y-auto` cap, the "Show less" toggle is rendered outside that scrollable region, and the collapsed clamp is unchanged. The two bug cases were confirmed red against the pre-fix source.)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (height cap value, applying the cap to rejected rows too), and confirmed the reproduce-then-fix tests.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR prevents very long queued and rejected prompts from expanding the cockpit's queued/rejected strips and pushing the composer off-screen by capping expanded prompt heights and making their overflow scrollable.

## What Was Added

- Expanded queued prompts are wrapped in a bounded, scrollable container (max-h-48 + overflow-y-auto) so very long text scrolls in place.
- Rejected prompt rows were changed from a broken truncate approach to the same bounded, scrollable container.
- Tests (Vitest + React Testing Library) asserting the expanded prompt uses the height cap and overflow, the collapsed clamp remains, and the "Show less" toggle stays outside the scrollable area.
- A coverage surface entry (cockpit.queued-prompt-expand-bounds) added to web/tests/coverage-matrix.json.
- Closes issue `#1642`.

## What Stayed the Same

- Collapsed queued prompts still show a three-line preview with the expand affordance.
- Toggle controls remain accessible and in the same location.

## Technical Details

- Files changed: web/src/components/cockpit/CockpitView.tsx (wrap expanded prompt text in max-h-48 overflow-y-auto; ensure toggle is sibling, not inside scrollable container), web/src/components/cockpit/QueuedPromptsStrip.test.tsx (three new tests), web/tests/coverage-matrix.json (new surface).
- Tests verify: collapsed line-clamp-3 remains, expanded view removes clamp and places text in a max-h-48 overflow-y-auto wrapper, and the "Show less" toggle is not a descendant of the scrollable container.

## Benefits

- Prevents long pasted prompts from breaking layout or hiding the composer.
- Keeps expand/collapse controls reachable without page scrolling.
- Makes rejected prompts consistent and resilient to large content.
- Low-risk, focused change with targeted test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->