### PR TITLE
fix(server): demote loopback bypass logs to debug

### DIFF
--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -350,6 +350,32 @@ fn passphrase_wall_entry_action(path: &str, client_ip: IpAddr) -> PassphraseWall
     PassphraseWallEntryAction::Continue
 }
 
+/// Emit the passphrase-only loopback-bypass event. This fires on every
+/// request a local caller makes (the TUI / dashboard poll `/api/*`
+/// continuously), so it is a frequent, expected control-flow event and
+/// belongs at `debug`, not `info`. See #1647. Extracted so the level is
+/// assertable with a tracing capture layer without standing up the full
+/// middleware.
+fn log_loopback_bypass_passphrase(client_ip: IpAddr, path: &str) {
+    tracing::debug!(
+        target: "auth.passphrase",
+        ip = %client_ip,
+        path = %path,
+        "loopback bypass: skipping passphrase factor in passphrase-only mode"
+    );
+}
+
+/// Emit the token-mode loopback-bypass event. Same per-request frequency
+/// and rationale as [`log_loopback_bypass_passphrase`]; see #1647.
+fn log_loopback_bypass_token(client_ip: IpAddr, path: &str) {
+    tracing::debug!(
+        target: "auth",
+        ip = %client_ip,
+        path = %path,
+        "loopback bypass: valid token + loopback peer; skipping passphrase factor"
+    );
+}
+
 /// Whether a request path + method needs an elevated login session
 /// (step-up auth, 15-minute passphrase confirmation window).
 ///
@@ -516,12 +542,7 @@ async fn run_passphrase_wall(
     match passphrase_wall_entry_action(&path, client_ip) {
         PassphraseWallEntryAction::BypassExempt => return next.run(request).await,
         PassphraseWallEntryAction::BypassLoopback => {
-            tracing::info!(
-                target: "auth.passphrase",
-                ip = %client_ip,
-                path = %path,
-                "loopback bypass: skipping passphrase factor in passphrase-only mode"
-            );
+            log_loopback_bypass_passphrase(client_ip, &path);
             return next.run(request).await;
         }
         PassphraseWallEntryAction::Continue => {}
@@ -823,12 +844,7 @@ pub async fn auth_middleware(
     match post_token_auth_action(login_enabled, login_exempt, client_ip) {
         PostTokenAuthAction::Bypass => {
             if login_enabled && !login_exempt && is_local_trusted(client_ip) {
-                tracing::info!(
-                    target: "auth",
-                    ip = %client_ip,
-                    path = %path,
-                    "loopback bypass: valid token + loopback peer; skipping passphrase factor"
-                );
+                log_loopback_bypass_token(client_ip, &path);
             }
         }
         PostTokenAuthAction::RequireLogin => {
@@ -948,6 +964,57 @@ async fn handle_session_authenticated(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Records (level, target) for every event so the loopback-bypass
+    // helpers' log level is assertable without standing up the full
+    // axum middleware (AppState is too heavy to build in a unit test).
+    #[derive(Clone, Default)]
+    struct LevelCapture(std::sync::Arc<std::sync::Mutex<Vec<(tracing::Level, String)>>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for LevelCapture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let meta = event.metadata();
+            self.0
+                .lock()
+                .unwrap()
+                .push((*meta.level(), meta.target().to_string()));
+        }
+    }
+
+    fn capture_events(f: impl FnOnce()) -> Vec<(tracing::Level, String)> {
+        use tracing_subscriber::layer::SubscriberExt;
+        let capture = LevelCapture::default();
+        let events = capture.0.clone();
+        let subscriber = tracing_subscriber::registry::Registry::default().with(capture);
+        tracing::subscriber::with_default(subscriber, f);
+        let recorded = events.lock().unwrap();
+        recorded.clone()
+    }
+
+    // #1647: the loopback bypass fires on essentially every local
+    // request, so it must log at debug, not info, to keep the
+    // default-level log readable.
+    #[test]
+    fn loopback_bypass_passphrase_logs_at_debug() {
+        let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+        let events = capture_events(|| log_loopback_bypass_passphrase(loopback, "/api/sessions"));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, tracing::Level::DEBUG);
+        assert_eq!(events[0].1, "auth.passphrase");
+    }
+
+    #[test]
+    fn loopback_bypass_token_logs_at_debug() {
+        let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+        let events = capture_events(|| log_loopback_bypass_token(loopback, "/api/sessions"));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, tracing::Level::DEBUG);
+        assert_eq!(events[0].1, "auth");
+    }
 
     #[test]
     fn constant_time_eq_matching() {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Running `aoe serve` in passphrase-only mode (and the token-mode loopback path) logged one `INFO` line per request from loopback callers:

```
INFO auth.passphrase: loopback bypass: skipping passphrase factor in passphrase-only mode ip=127.0.0.1 path=/api/sessions
```

The passphrase wall and the token path are per-request auth middleware, and the local TUI / dashboard poll `/api/*` continuously, so this fired on essentially every request and flooded `~/.agent-of-empires/debug.log` at the default level. The event is routine and expected (loopback bypass is the designed behavior from #1168 / #1525), so it belongs at `debug`, not `info`.

Both bypass branches (`src/server/auth.rs`, passphrase-only and token mode) are demoted to `debug!`. This matches the level taxonomy already documented in `docs/development/logging.md` (`debug` is for frequent / per-operation detail). The bypass detail stays available when debugging auth (`aoe log-level auth=debug`) and disappears from the default-level log. The `warn!` login_required / no-session paths keep their level.

The two emissions are extracted into `log_loopback_bypass_passphrase` and `log_loopback_bypass_token` so the level is assertable with a `tracing` capture layer; building the full `AppState` in a unit test is impractical, so this follows the same testable-seam pattern the file already uses for `passphrase_wall_entry_action` / `post_token_auth_action`.

Closes #1647

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe serve --auth=passphrase` at the default log level, then poll `/api/sessions` from a loopback client (TUI or `curl`); confirm no `loopback bypass` line appears in `~/.agent-of-empires/debug.log`.
- [ ] Run `aoe log-level auth=debug` (or set the auth target to debug), repeat the loopback poll, and confirm the `loopback bypass` line now appears.
- [ ] Confirm the `warn!` login_required diagnostics still surface at the default level for a remote (non-loopback) caller without a session.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Backend log-level fix: covered by a Rust unit test in `src/server/auth.rs` that installs a `tracing` capture layer and asserts both bypass events emit at `Level::DEBUG`. Verified red before the fix (events were `Level::INFO`).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes an issue where the server logs were being flooded with repetitive messages in passphrase-only mode. The problem occurred because internal loopback requests (from local tools like the TUI/dashboard) were triggering authentication bypass logs at a high visibility level, and these requests happen frequently.

## What Changed

**Problem Solved:**
- Reduced excessive logging that was cluttering the debug.log file when running the server in passphrase-only mode
- The server now only emits these repetitive authentication bypass messages at a lower visibility level (debug instead of info)
- This allows developers to still see these messages when debugging authentication issues, while preventing them from overwhelming the logs during normal operation

**Code Changes:**
- Two logging statements in the authentication module were demoted from INFO level to DEBUG level
- Two new helper functions were created to encapsulate these logging calls, making the code more maintainable
- Unit tests were added to verify that the logging happens at the correct level

**What Remains Unchanged:**
- The actual authentication bypass behavior and logic
- Warning-level logs for missing sessions and failed logins (these stay at their current visibility level)

## Benefits

- Cleaner, less cluttered debug logs that are easier to review
- Maintains debugging capability by keeping these messages visible when authentication debugging is enabled
- Better organization of logging code through extracted helper functions
- Improved test coverage to prevent regression

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->