### PR TITLE
fix: show full merged hook list before running hooks

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -668,7 +668,13 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
 
         if let Some(hooks) = resolved_hooks {
             if !hooks.on_create.is_empty() {
-                println!("Running on_create hooks...");
+                // Show the final merged hook list (repo hooks override global/profile
+                // per type) so the user can see exactly what runs, especially when
+                // `--trust-hooks` skipped the interactive approval prompt (#596).
+                println!("Running on_create hooks:");
+                for cmd in &hooks.on_create {
+                    println!("  {}", cmd);
+                }
                 let hook_env = repo_config::lifecycle_env_vars(&instance);
                 repo_config::execute_hooks(&hooks.on_create, &path, &hook_env)?;
                 println!("✓ on_create hooks completed");

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -623,16 +623,16 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                     let should_trust = if args.trust_hooks {
                         true
                     } else {
-                        println!("\nRepository hooks detected in .agent-of-empires/config.toml:");
-                        if !hooks.on_create.is_empty() {
-                            println!("  on_create:");
-                            for cmd in &hooks.on_create {
-                                println!("    {}", cmd);
-                            }
-                        }
-                        if !hooks.on_launch.is_empty() {
-                            println!("  on_launch:");
-                            for cmd in &hooks.on_launch {
+                        // Show the final merged set (repo overrides global/profile
+                        // per type) with source labels, mirroring the TUI trust
+                        // dialog, so the prompt reflects exactly what will run (#596).
+                        println!(
+                            "\nHooks for this session (repo overrides global config per type):"
+                        );
+                        let merged = repo_config::merge_hooks_for_display(profile, &hooks);
+                        for group in repo_config::hook_display_groups(&merged, &hooks, true) {
+                            println!("  {}:{}", group.name, group.source_label());
+                            for cmd in &group.commands {
                                 println!("    {}", cmd);
                             }
                         }

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -558,6 +558,55 @@ pub fn merge_hooks_for_display(profile: &str, repo_hooks: &HooksConfig) -> Hooks
     apply_repo_hook_overrides(base, repo_hooks)
 }
 
+/// One hook type's resolved commands plus where they came from, for display in the
+/// CLI trust prompt and the TUI trust dialog. `from_repo` is true when the repo
+/// defined this type (and thus overrode global); false means the commands fell
+/// through to global/profile config.
+pub struct HookDisplayGroup {
+    pub name: &'static str,
+    pub from_repo: bool,
+    pub commands: Vec<String>,
+}
+
+impl HookDisplayGroup {
+    /// Human-readable source suffix, e.g. ` (from repo)`. Shared so the CLI and TUI
+    /// render the exact same wording.
+    pub fn source_label(&self) -> &'static str {
+        if self.from_repo {
+            " (from repo)"
+        } else {
+            " (from global config)"
+        }
+    }
+}
+
+/// Build the per-type display groups for a merged hook set, labeling each type by
+/// source and dropping types with no commands. `include_destroy` controls whether
+/// `on_destroy` is listed: callers that only run the create lifecycle can omit it,
+/// while the trust surfaces show every type the user is trusting.
+pub fn hook_display_groups(
+    merged: &HooksConfig,
+    repo: &HooksConfig,
+    include_destroy: bool,
+) -> Vec<HookDisplayGroup> {
+    let mut types: Vec<(&'static str, &[String], &[String])> = vec![
+        ("on_create", &merged.on_create, &repo.on_create),
+        ("on_launch", &merged.on_launch, &repo.on_launch),
+    ];
+    if include_destroy {
+        types.push(("on_destroy", &merged.on_destroy, &repo.on_destroy));
+    }
+    types
+        .into_iter()
+        .filter(|(_, merged_cmds, _)| !merged_cmds.is_empty())
+        .map(|(name, merged_cmds, repo_cmds)| HookDisplayGroup {
+            name,
+            from_repo: !repo_cmds.is_empty(),
+            commands: merged_cmds.to_vec(),
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Hook execution
 // ---------------------------------------------------------------------------
@@ -1352,6 +1401,57 @@ mod tests {
         assert_eq!(merged.on_create, vec!["repo-create".to_string()]);
         assert_eq!(merged.on_launch, vec!["global-launch".to_string()]);
         assert_eq!(merged.on_destroy, vec!["global-destroy".to_string()]);
+    }
+
+    #[test]
+    fn test_hook_display_groups_labels_source_and_filters_empty() {
+        // Repo overrides on_create; on_launch falls through to global; on_destroy
+        // has no commands and must be dropped from the display groups.
+        let repo = HooksConfig {
+            on_create: vec!["repo-create".to_string()],
+            ..Default::default()
+        };
+        let merged = HooksConfig {
+            on_create: vec!["repo-create".to_string()],
+            on_launch: vec!["global-launch".to_string()],
+            on_destroy: vec![],
+        };
+        let groups = hook_display_groups(&merged, &repo, true);
+        assert_eq!(groups.len(), 2, "empty on_destroy should be filtered out");
+
+        assert_eq!(groups[0].name, "on_create");
+        assert!(groups[0].from_repo);
+        assert_eq!(groups[0].source_label(), " (from repo)");
+        assert_eq!(groups[0].commands, vec!["repo-create".to_string()]);
+
+        assert_eq!(groups[1].name, "on_launch");
+        assert!(!groups[1].from_repo);
+        assert_eq!(groups[1].source_label(), " (from global config)");
+        assert_eq!(groups[1].commands, vec!["global-launch".to_string()]);
+    }
+
+    #[test]
+    fn test_hook_display_groups_include_destroy_toggle() {
+        // on_destroy only appears when the caller opts in (e.g. the trust surfaces),
+        // not for create-lifecycle callers.
+        let repo = HooksConfig {
+            on_destroy: vec!["repo-destroy".to_string()],
+            ..Default::default()
+        };
+        let merged = HooksConfig {
+            on_destroy: vec!["repo-destroy".to_string()],
+            ..Default::default()
+        };
+        assert!(
+            hook_display_groups(&merged, &repo, false).is_empty(),
+            "on_destroy should be hidden when include_destroy is false"
+        );
+
+        let groups = hook_display_groups(&merged, &repo, true);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].name, "on_destroy");
+        assert!(groups[0].from_repo);
+        assert_eq!(groups[0].commands, vec!["repo-destroy".to_string()]);
     }
 
     #[test]

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -533,6 +533,31 @@ pub fn merge_hooks_with_config(profile: &str, repo_hooks: HooksConfig) -> Option
     }
 }
 
+/// Apply repo hooks onto a base (global/profile) hooks config, mirroring how hooks
+/// actually resolve: repo overrides global per type. Unlike `merge_hooks_with_config`
+/// this keeps `on_destroy` and never collapses to `None`, since it feeds the trust
+/// dialog rather than execution gating.
+fn apply_repo_hook_overrides(mut base: HooksConfig, repo_hooks: &HooksConfig) -> HooksConfig {
+    if !repo_hooks.on_create.is_empty() {
+        base.on_create = repo_hooks.on_create.clone();
+    }
+    if !repo_hooks.on_launch.is_empty() {
+        base.on_launch = repo_hooks.on_launch.clone();
+    }
+    if !repo_hooks.on_destroy.is_empty() {
+        base.on_destroy = repo_hooks.on_destroy.clone();
+    }
+    base
+}
+
+/// Resolve the full merged hook set for display in the trust dialog: global/profile
+/// hooks overlaid by the repo's per-type overrides. Lets the user see every command
+/// that will actually run, not just the repo-defined ones (#596).
+pub fn merge_hooks_for_display(profile: &str, repo_hooks: &HooksConfig) -> HooksConfig {
+    let base = super::profile_config::resolve_config_or_warn(profile).hooks;
+    apply_repo_hook_overrides(base, repo_hooks)
+}
+
 // ---------------------------------------------------------------------------
 // Hook execution
 // ---------------------------------------------------------------------------
@@ -1273,6 +1298,60 @@ mod tests {
     fn test_load_repo_config_nonexistent() {
         let result = load_repo_config(Path::new("/nonexistent/path")).unwrap();
         assert!(result.is_none());
+    }
+
+    fn global_hooks_fixture() -> HooksConfig {
+        HooksConfig {
+            on_create: vec!["global-create".to_string()],
+            on_launch: vec!["global-launch".to_string()],
+            on_destroy: vec!["global-destroy".to_string()],
+        }
+    }
+
+    #[test]
+    fn test_apply_repo_hook_overrides_replaces_not_appends() {
+        // A repo-defined type fully replaces the global list (per-field override,
+        // never append): the global command must NOT survive in the merged list.
+        let repo = HooksConfig {
+            on_create: vec!["repo-create-a".to_string(), "repo-create-b".to_string()],
+            on_launch: vec!["repo-launch".to_string()],
+            on_destroy: vec!["repo-destroy".to_string()],
+        };
+        let merged = apply_repo_hook_overrides(global_hooks_fixture(), &repo);
+        assert_eq!(
+            merged.on_create,
+            vec!["repo-create-a".to_string(), "repo-create-b".to_string()]
+        );
+        assert_eq!(merged.on_launch, vec!["repo-launch".to_string()]);
+        assert_eq!(merged.on_destroy, vec!["repo-destroy".to_string()]);
+        assert!(
+            !merged.on_create.iter().any(|c| c.starts_with("global")),
+            "global on_create should be replaced, not appended"
+        );
+    }
+
+    #[test]
+    fn test_apply_repo_hook_overrides_falls_through_to_global() {
+        // Types the repo leaves empty fall through to the global/profile values.
+        let repo = HooksConfig::default();
+        let merged = apply_repo_hook_overrides(global_hooks_fixture(), &repo);
+        assert_eq!(merged.on_create, vec!["global-create".to_string()]);
+        assert_eq!(merged.on_launch, vec!["global-launch".to_string()]);
+        assert_eq!(merged.on_destroy, vec!["global-destroy".to_string()]);
+    }
+
+    #[test]
+    fn test_apply_repo_hook_overrides_mixed_per_type() {
+        // Override and fall-through coexist: repo defines only on_create, so
+        // on_launch/on_destroy keep the global values.
+        let repo = HooksConfig {
+            on_create: vec!["repo-create".to_string()],
+            ..Default::default()
+        };
+        let merged = apply_repo_hook_overrides(global_hooks_fixture(), &repo);
+        assert_eq!(merged.on_create, vec!["repo-create".to_string()]);
+        assert_eq!(merged.on_launch, vec!["global-launch".to_string()]);
+        assert_eq!(merged.on_destroy, vec!["global-destroy".to_string()]);
     }
 
     #[test]

--- a/src/tui/dialogs/hook_trust.rs
+++ b/src/tui/dialogs/hook_trust.rs
@@ -5,7 +5,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::*;
 
 use super::DialogResult;
-use crate::session::HooksConfig;
+use crate::session::{repo_config, HooksConfig};
 use crate::tui::styles::Theme;
 
 pub struct HookTrustDialog {
@@ -129,45 +129,18 @@ impl HookTrustDialog {
     }
 
     fn build_hook_lines(&self) -> Vec<Line<'_>> {
-        // Render the merged set (what actually runs). Each type is sourced wholly
-        // from the repo or wholly from global config, since the merge overrides
-        // per type; label the source so it's clear which commands the repo added.
-        let groups: [(&str, &[String], &[String]); 3] = [
-            (
-                "on_create",
-                &self.merged_hooks.on_create,
-                &self.hooks.on_create,
-            ),
-            (
-                "on_launch",
-                &self.merged_hooks.on_launch,
-                &self.hooks.on_launch,
-            ),
-            (
-                "on_destroy",
-                &self.merged_hooks.on_destroy,
-                &self.hooks.on_destroy,
-            ),
-        ];
-
+        // Render the merged set (what actually runs) with per-type source labels,
+        // sharing the grouping logic with the CLI trust prompt.
         let mut lines = Vec::new();
-        for (name, merged, repo) in groups {
-            if merged.is_empty() {
-                continue;
-            }
+        for group in repo_config::hook_display_groups(&self.merged_hooks, &self.hooks, true) {
             if !lines.is_empty() {
                 lines.push(Line::from(""));
             }
-            let source = if repo.is_empty() {
-                " (from global config)"
-            } else {
-                " (from repo)"
-            };
             lines.push(Line::from(vec![
-                Span::styled(format!("{}:", name), Style::default().bold()),
-                Span::styled(source, Style::default().dim()),
+                Span::styled(format!("{}:", group.name), Style::default().bold()),
+                Span::styled(group.source_label(), Style::default().dim()),
             ]));
-            for cmd in merged {
+            for cmd in &group.commands {
                 lines.push(Line::from(format!("  {}", cmd)));
             }
         }
@@ -431,6 +404,50 @@ mod tests {
         assert!(
             text.contains("global-launch"),
             "missing global cmd: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn test_merged_display_renders_on_destroy_with_source() {
+        // on_create falls through to global; on_destroy is repo-defined. Both must
+        // render with the correct source label, exercising the on_destroy path.
+        let repo = HooksConfig {
+            on_destroy: vec!["repo-destroy".to_string()],
+            ..Default::default()
+        };
+        let merged = HooksConfig {
+            on_create: vec!["global-create".to_string()],
+            on_destroy: vec!["repo-destroy".to_string()],
+            ..Default::default()
+        };
+        let dialog = HookTrustDialog::new(
+            repo,
+            merged,
+            "hash".to_string(),
+            "/home/user/project".to_string(),
+        );
+        let text = lines_text(&dialog);
+        assert!(text.contains("on_create:"), "missing on_create: {}", text);
+        assert!(
+            text.contains("global-create"),
+            "missing global cmd: {}",
+            text
+        );
+        assert!(text.contains("on_destroy:"), "missing on_destroy: {}", text);
+        assert!(
+            text.contains("repo-destroy"),
+            "missing destroy cmd: {}",
+            text
+        );
+        assert!(
+            text.contains("(from global config)"),
+            "on_create should be labeled global: {}",
+            text
+        );
+        assert!(
+            text.contains("(from repo)"),
+            "on_destroy should be labeled repo: {}",
             text
         );
     }

--- a/src/tui/dialogs/hook_trust.rs
+++ b/src/tui/dialogs/hook_trust.rs
@@ -10,6 +10,10 @@ use crate::tui::styles::Theme;
 
 pub struct HookTrustDialog {
     hooks: HooksConfig,
+    /// Final merged hook set (repo hooks overlaid on global/profile) shown to the
+    /// user. `hooks` stays the repo-only set so the trust hash and post-approval
+    /// merge keep operating on what the repo actually defines.
+    merged_hooks: HooksConfig,
     hooks_hash: String,
     project_path: String,
     selected: bool, // true = Trust, false = Skip
@@ -32,9 +36,15 @@ pub enum HookTrustAction {
 }
 
 impl HookTrustDialog {
-    pub fn new(hooks: HooksConfig, hooks_hash: String, project_path: String) -> Self {
+    pub fn new(
+        hooks: HooksConfig,
+        merged_hooks: HooksConfig,
+        hooks_hash: String,
+        project_path: String,
+    ) -> Self {
         Self {
             hooks,
+            merged_hooks,
             hooks_hash,
             project_path,
             selected: false,
@@ -119,38 +129,45 @@ impl HookTrustDialog {
     }
 
     fn build_hook_lines(&self) -> Vec<Line<'_>> {
+        // Render the merged set (what actually runs). Each type is sourced wholly
+        // from the repo or wholly from global config, since the merge overrides
+        // per type; label the source so it's clear which commands the repo added.
+        let groups: [(&str, &[String], &[String]); 3] = [
+            (
+                "on_create",
+                &self.merged_hooks.on_create,
+                &self.hooks.on_create,
+            ),
+            (
+                "on_launch",
+                &self.merged_hooks.on_launch,
+                &self.hooks.on_launch,
+            ),
+            (
+                "on_destroy",
+                &self.merged_hooks.on_destroy,
+                &self.hooks.on_destroy,
+            ),
+        ];
+
         let mut lines = Vec::new();
-
-        if !self.hooks.on_create.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "on_create:",
-                Style::default().bold(),
-            )));
-            for cmd in &self.hooks.on_create {
-                lines.push(Line::from(format!("  {}", cmd)));
+        for (name, merged, repo) in groups {
+            if merged.is_empty() {
+                continue;
             }
-            lines.push(Line::from(""));
-        }
-
-        if !self.hooks.on_launch.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "on_launch:",
-                Style::default().bold(),
-            )));
-            for cmd in &self.hooks.on_launch {
-                lines.push(Line::from(format!("  {}", cmd)));
-            }
-            if !self.hooks.on_destroy.is_empty() {
+            if !lines.is_empty() {
                 lines.push(Line::from(""));
             }
-        }
-
-        if !self.hooks.on_destroy.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "on_destroy:",
-                Style::default().bold(),
-            )));
-            for cmd in &self.hooks.on_destroy {
+            let source = if repo.is_empty() {
+                " (from global config)"
+            } else {
+                " (from repo)"
+            };
+            lines.push(Line::from(vec![
+                Span::styled(format!("{}:", name), Style::default().bold()),
+                Span::styled(source, Style::default().dim()),
+            ]));
+            for cmd in merged {
                 lines.push(Line::from(format!("  {}", cmd)));
             }
         }
@@ -189,7 +206,7 @@ impl HookTrustDialog {
 
         // Header
         let header = Paragraph::new(
-            "This repo has hooks defined in .agent-of-empires/config.toml.\nAllow these commands to run?",
+            "This repo defines hooks in .agent-of-empires/config.toml.\nThese commands will run (repo overrides global per type). Allow them?",
         )
         .style(Style::default().fg(theme.text))
         .wrap(Wrap { trim: true });
@@ -271,12 +288,14 @@ mod tests {
     }
 
     fn test_dialog() -> HookTrustDialog {
+        let repo = HooksConfig {
+            on_create: vec!["npm install".to_string()],
+            on_launch: vec!["echo start".to_string()],
+            ..Default::default()
+        };
         HookTrustDialog::new(
-            HooksConfig {
-                on_create: vec!["npm install".to_string()],
-                on_launch: vec!["echo start".to_string()],
-                ..Default::default()
-            },
+            repo.clone(),
+            repo,
             "abc123".to_string(),
             "/home/user/project".to_string(),
         )
@@ -350,11 +369,69 @@ mod tests {
     fn test_empty_hooks_dialog() {
         let dialog = HookTrustDialog::new(
             HooksConfig::default(),
+            HooksConfig::default(),
             "empty_hash".to_string(),
             "/some/path".to_string(),
         );
         // Should build with no lines
         let lines = dialog.build_hook_lines();
         assert!(lines.is_empty());
+    }
+
+    fn lines_text(dialog: &HookTrustDialog) -> String {
+        dialog
+            .build_hook_lines()
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn test_merged_display_shows_global_and_repo_sources() {
+        // Repo overrides on_create; on_launch comes only from global config.
+        let repo = HooksConfig {
+            on_create: vec!["repo-create".to_string()],
+            ..Default::default()
+        };
+        let merged = HooksConfig {
+            on_create: vec!["repo-create".to_string()],
+            on_launch: vec!["global-launch".to_string()],
+            ..Default::default()
+        };
+        let dialog = HookTrustDialog::new(
+            repo,
+            merged,
+            "hash".to_string(),
+            "/home/user/project".to_string(),
+        );
+        let text = lines_text(&dialog);
+        assert!(text.contains("on_create:"), "missing on_create: {}", text);
+        assert!(
+            text.contains("(from repo)"),
+            "missing repo source: {}",
+            text
+        );
+        assert!(text.contains("repo-create"), "missing repo cmd: {}", text);
+        assert!(
+            text.contains("on_launch:"),
+            "merged global on_launch should show: {}",
+            text
+        );
+        assert!(
+            text.contains("(from global config)"),
+            "missing global source: {}",
+            text
+        );
+        assert!(
+            text.contains("global-launch"),
+            "missing global cmd: {}",
+            text
+        );
     }
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -4185,8 +4185,13 @@ impl HomeView {
         match repo_config::check_hook_trust(std::path::Path::new(&data.path)) {
             Ok(repo_config::HookTrustStatus::NeedsTrust { hooks, hooks_hash }) => {
                 use crate::tui::dialogs::HookTrustDialog;
-                self.hook_trust_dialog =
-                    Some(HookTrustDialog::new(hooks, hooks_hash, data.path.clone()));
+                let merged_hooks = repo_config::merge_hooks_for_display(&data.profile, &hooks);
+                self.hook_trust_dialog = Some(HookTrustDialog::new(
+                    hooks,
+                    merged_hooks,
+                    hooks_hash,
+                    data.path.clone(),
+                ));
                 self.pending_hook_trust_data = Some(data);
                 None
             }

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -933,6 +933,14 @@ fn test_cli_add_workspace_repo_hooks_execute() {
         "should print hook completion message.\nstdout: {}",
         stdout
     );
+    // #596: the merged hook commands should be printed before they run so the
+    // user (especially with --trust-hooks) sees exactly what executes.
+    assert!(
+        stdout.contains("Running on_create hooks:")
+            && stdout.contains(&format!("touch {}", hook_marker.display())),
+        "should print the merged on_create command list.\nstdout: {}",
+        stdout
+    );
     assert!(
         hook_marker.exists(),
         "hook marker file should exist, proving on_create hooks ran"
@@ -993,6 +1001,13 @@ on_create = ["touch {}"]
     assert!(
         stdout.contains("on_create hooks completed"),
         "should print hook completion message for global hooks.\nstdout: {}",
+        stdout
+    );
+    // #596: the merged list should surface the global fallback command too.
+    assert!(
+        stdout.contains("Running on_create hooks:")
+            && stdout.contains(&format!("touch {}", hook_marker.display())),
+        "should print the merged on_create command list for global hooks.\nstdout: {}",
         stdout
     );
     assert!(


### PR DESCRIPTION
## Description

Closes #596.

When `aoe add --trust-hooks` skipped the interactive approval prompt, the CLI only printed `Running on_create hooks...` with no command list, so users had no visibility into what actually ran. Repo hooks override global/profile hooks **per type** (not append), which can be surprising. The TUI trust dialog had the mirror gap: it previewed only the repo hooks, never the merged set.

This change surfaces the **final merged hook list** (what actually runs) in both paths:

- **CLI** (`src/cli/add.rs`): prints each merged `on_create` command before executing, e.g.
  ```
  Running on_create hooks:
    echo repo-hook
  ✓ on_create hooks completed
  ```
- **TUI** (`src/tui/dialogs/hook_trust.rs`): the Repository Hooks dialog now renders the merged set with per-type source labels (`(from repo)` / `(from global config)`) so it's clear which commands the repo contributed. The trust hash and post-approval merge still operate on the repo-only hooks, so trust semantics are unchanged.
- New `repo_config::merge_hooks_for_display()` resolves the merged set for display (keeps `on_destroy`, never collapses to `None`).

Global hooks are user-controlled, so this is a transparency/UX improvement, not a security change.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A)
- [x] For UI changes: included screenshot or recording (see Recordings)

## Recordings

**CLI** (`aoe add --trust-hooks` printing the merged `on_create` list):

<img width="1180" height="640" alt="aoe-596-cli" src="https://github.com/user-attachments/assets/b5405737-3cd8-4ce2-a657-7f88c166fca0" />

**TUI** (Repository Hooks dialog showing the merged list with source labels):

<img width="1200" height="720" alt="aoe-596-tui" src="https://github.com/user-attachments/assets/e8476150-3c37-4350-8a20-c0eb249a362d" />

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Coverage added:
- `repo_config`: unit tests for per-type **override** (`test_apply_repo_hook_overrides_replaces_not_appends`), **fall-through** (`test_apply_repo_hook_overrides_falls_through_to_global`), and mixed.
- `hook_trust`: `test_merged_display_shows_global_and_repo_sources` asserts both repo- and global-sourced types render with labels.
- `tests/e2e/cli.rs`: extended the two existing hook tests to assert the merged command list prints.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR improves transparency when running hooks by showing users exactly which hooks will execute before they actually run. Previously, when using `--trust-hooks` or approving hooks in the TUI, the merged hook list (combination of repository hooks and global/profile hooks) was hidden from the user.

### Key Improvements

**CLI Display**
- Added a "Running on_create hooks:" section that prints each merged hook command before execution, so users see what will actually run

**TUI Trust Dialog**
- The Repository Hooks dialog now displays the final merged hook set instead of just repo hooks
- Each hook command is labeled with its source: "(from repo)" or "(from global config)"
- Dialog text updated to clarify that repo hooks override global hooks "per type"

**New Helper Functions**
- Created `merge_hooks_for_display()` to combine repo and global/profile hooks for visibility
- Added `HookDisplayGroup` struct to organize hooks by type with source information
- Created `hook_display_groups()` to format merged hooks for consistent display across CLI and TUI

**Test Coverage**
- Extended e2e CLI tests to verify merged hook commands are printed before execution
- Added unit tests covering per-type override scenarios and mixed source display

### What Was Added
- New functions and structs in `repo_config.rs` for hook merging and display formatting
- Display logic in CLI and TUI to show merged hooks with source labels
- New test cases verifying merged hook visibility

### What Was Modified
- CLI hook trust prompt now renders merged hooks in grouped format
- TUI `HookTrustDialog` constructor updated to accept merged hook set
- TUI home input logic updated to compute and pass merged hooks to the dialog

### Benefits
- **User Clarity**: Users can now see the exact hooks that will run before they execute
- **Transparency**: Per-type override behavior (where repo hooks replace global hooks per field) is now visible
- **Consistency**: CLI and TUI now display merged hooks identically
- **Trust Preservation**: Trust and approval mechanisms remain unchanged; only the display is enhanced

---

## Technical Details

**Code Organization**:
- `src/session/repo_config.rs`: Added `merge_hooks_for_display()` public function, `HookDisplayGroup` struct with `source_label()` method, and `hook_display_groups()` function. Implemented private `apply_repo_hook_overrides()` helper that replaces global/profile hook lists per hook type when repo provides non-empty commands, preserving `on_destroy`.
- `src/cli/add.rs`: Modified hook trust prompt to iterate display groups and print merged commands; updated pre-execution hook output to display each `on_create` command individually.
- `src/tui/dialogs/hook_trust.rs`: Updated `HookTrustDialog` struct to include both `hooks` (repo-only) and `merged_hooks` fields; rewrote `build_hook_lines()` to use `repo_config::hook_display_groups()` for rendering with source labels.
- `src/tui/home/input.rs`: Modified `continue_session_creation()` to compute `merged_hooks` via `merge_hooks_for_display()` and pass to `HookTrustDialog::new()`.
- `tests/e2e/cli.rs`: Added assertions verifying "Running on_create hooks:" output and merged command presence for repo and global fallback test cases.

**Lines Changed**: +352/-50 across all files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->