### PR TITLE
fix(web): hide multi-repo workspaces from wizard Recent projects list

### DIFF
--- a/docs/guides/scratch-sessions.md
+++ b/docs/guides/scratch-sessions.md
@@ -115,7 +115,10 @@ logged so you can find it later.
 
 The wizard's **Recent projects** tab filters scratch sessions out
 once they exist, so a deleted scratch directory does not appear as a
-reusable recent project.
+reusable recent project. Multi-repo workspace sessions are filtered out
+of the same list, since the project step cannot rebuild a workspace from
+a single path; picking one would start a plain single-repo session and
+silently drop the other repos.
 
 ## Compatibility
 

--- a/web/src/components/session-wizard/__tests__/ProjectStep.workspace.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.workspace.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+//
+// Vitest coverage for the ProjectStep recents filter excluding
+// multi-repo workspace sessions (#1645). A workspace session collapses
+// to its `main_repo_path` in the Recent list, so picking it would start
+// a plain single-repo session and silently drop the other repos. The
+// guard in `collectRecentProjects` keeps workspaces out of the list
+// entirely (single path cannot reconstruct a workspace).
+//
+// Sits next to ProjectStep.scratch.test.tsx (#1324), which covers the
+// adjacent scratch-session skip.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import { ProjectStep } from "../steps/ProjectStep";
+import { initialData } from "../wizardReducer";
+import type { SessionResponse, WorkspaceRepoSummary } from "../../../lib/types";
+
+vi.mock("../../../lib/api", () => ({
+  fetchSessions: vi.fn(),
+  cloneRepo: vi.fn(),
+}));
+
+import { fetchSessions } from "../../../lib/api";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function mockSession(overrides: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "session",
+    project_path: overrides.project_path ?? "/repo/alpha",
+    group_path: overrides.group_path ?? "/repo/alpha",
+    tool: overrides.tool ?? "claude",
+    status: overrides.status ?? "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: overrides.last_accessed_at ?? null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: overrides.main_repo_path ?? null,
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+    },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: overrides.workspace_repos ?? [],
+    scratch: overrides.scratch ?? false,
+    ...overrides,
+  } as SessionResponse;
+}
+
+function workspaceRepos(): WorkspaceRepoSummary[] {
+  return [
+    { name: "gamma", source_path: "/repo/gamma", branch: "main" },
+    { name: "delta", source_path: "/repo/delta", branch: "main" },
+  ];
+}
+
+function renderStep() {
+  const onChange = vi.fn();
+  const utils = render(
+    <ProjectStep
+      data={{
+        ...initialData,
+        path: "",
+        extraRepoPaths: [],
+        scratch: false,
+      }}
+      onChange={onChange}
+    />,
+  );
+  return { onChange, ...utils };
+}
+
+describe("ProjectStep recents workspace filter (#1645)", () => {
+  it("does not surface multi-repo workspace sessions in the Recent tab", async () => {
+    // One single-repo session plus one workspace session. The workspace
+    // keys by its main_repo_path ("/repo/gamma"); without the guard it
+    // would render as a phantom single-repo recent entry that, when
+    // picked, drops the other repos. Only the real single-repo path
+    // ("alpha") must appear.
+    vi.mocked(fetchSessions).mockResolvedValue({
+      sessions: [
+        mockSession({
+          id: "s-single",
+          project_path: "/repo/alpha",
+          last_accessed_at: "2025-09-01T00:00:00Z",
+        }),
+        mockSession({
+          id: "s-workspace",
+          project_path: "/repo/gamma",
+          main_repo_path: "/repo/gamma",
+          workspace_repos: workspaceRepos(),
+          last_accessed_at: "2025-09-02T00:00:00Z",
+        }),
+      ],
+      workspace_ordering: [],
+    });
+
+    const { findAllByText, queryByText } = renderStep();
+    // The single-repo project renders; the workspace basename never does.
+    expect((await findAllByText("alpha")).length).toBeGreaterThan(0);
+    expect(queryByText("gamma")).toBeNull();
+  });
+
+  it("still surfaces single-repo sessions unchanged when no workspaces are present", async () => {
+    vi.mocked(fetchSessions).mockResolvedValue({
+      sessions: [
+        mockSession({
+          id: "s-a",
+          project_path: "/repo/alpha",
+          last_accessed_at: "2025-09-01T00:00:00Z",
+        }),
+        mockSession({
+          id: "s-b",
+          project_path: "/repo/beta",
+          last_accessed_at: "2025-09-02T00:00:00Z",
+        }),
+      ],
+      workspace_ordering: [],
+    });
+
+    const { findAllByText } = renderStep();
+    expect((await findAllByText("alpha")).length).toBeGreaterThan(0);
+    expect((await findAllByText("beta")).length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/components/session-wizard/steps/ProjectStep.tsx
+++ b/web/src/components/session-wizard/steps/ProjectStep.tsx
@@ -68,6 +68,11 @@ function collectRecentProjects(sessions: SessionResponse[]): RecentProject[] {
     // in to keeping the dir). They must not appear in the Recent list,
     // where they would be re-selectable as a project.
     if (s.scratch) continue;
+    // Multi-repo workspaces collapse to a single `main_repo_path` here, so
+    // picking one from Recent would start a plain single-repo session and
+    // silently drop the other repos. The project step cannot reconstruct a
+    // workspace from one path, so keep them out of the list entirely.
+    if (s.workspace_repos.length > 0) continue;
     const path = s.main_repo_path || s.project_path;
     if (!path) continue;
     const existing = map.get(path);

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -438,6 +438,17 @@
       ]
     },
     {
+      "id": "wizard.recent-hides-workspaces",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/session-wizard/__tests__/ProjectStep.workspace.test.tsx"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ProjectStep.tsx"
+      ]
+    },
+    {
       "id": "wizard.scratch-shortcut",
       "kind": "live-playwright",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The new-session wizard's **Recent projects** list derived its entries from the session list in `collectRecentProjects()`, filtering out only scratch sessions. Multi-repo workspace sessions fell through and were keyed by `s.main_repo_path || s.project_path`, so a workspace surfaced as a single-path recent entry. Picking it did not recreate the workspace; it collapsed to the main repo's path and started a plain single-repo session, silently dropping the other repos. A quiet data-shape bug masquerading as a normal start.

This adds one guard in `collectRecentProjects()` next to the existing scratch skip: sessions whose `workspace_repos` array is non-empty are excluded from the list. The marker field is already present on every `SessionResponse` (empty for single-repo sessions), so the check needs no backend change and no optional guard.

The scratch-sessions guide is updated to note that workspaces are filtered out of the Recent list alongside scratch sessions.

Closes #1645

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a multi-repo workspace session, then open the new-session wizard and check the Recent projects tab: the workspace's repo no longer appears as a selectable entry.
- [ ] With only single-repo sessions present, open the Recent tab: every single-repo project still appears, ordered most-recent-first as before.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added a Vitest + RTL spec (`web/src/components/session-wizard/__tests__/ProjectStep.workspace.test.tsx`) covering both user stories (workspace excluded, single-repo unchanged) and a `wizard.recent-hides-workspaces` entry in `web/tests/coverage-matrix.json`. The pure-render filter logic is isolated, so Vitest is the right layer per the matrix mandate (request-payload / pure-render permutations belong in Vitest, not live Playwright).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls, and confirmed the reproduce-then-fix test goes red on the pre-fix tree and green after.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The PR prevents multi-repo workspace sessions from appearing in the new-session wizard's "Recent projects" list, which was causing data loss when users tried to resume them.

**What was added:**
- A new test file validating that workspaces are filtered from the Recent list while single-repo sessions remain
- Filtering logic in the Recent projects collector to exclude workspace sessions
- Test coverage registration for the new workspace filtering behavior
- Documentation clarifying that workspaces don't appear in Recent

**What was modified:**
- `ProjectStep.tsx`: Added a check to skip sessions with `workspace_repos.length > 0` when building the Recent list
- `scratch-sessions.md`: Updated guide to note that workspaces are filtered from Recent, explaining they cannot be reconstructed from a single path
- `coverage-matrix.json`: Registered new test coverage entry

**What was removed:**
- Nothing removed; all changes are additive or filtering-based

## Benefits

- **Prevents data loss**: Users can no longer accidentally collapse a multi-repo workspace into a single-repo session by selecting it from Recent
- **Improved user experience**: Removes confusing entries from the Recent list that don't work as expected
- **No backend changes required**: The fix works with existing API responses since `workspace_repos` is already present on all session responses
- **Well-tested**: Includes focused test coverage verifying workspace exclusion and confirming single-repo behavior remains unchanged

## Technical Details

The solution adds a filtering condition `workspace_repos.length > 0` to the `collectRecentProjects()` function, which now excludes multi-repo workspaces alongside existing scratch session filtering. This leverages the existing `workspace_repos` array field present in every `SessionResponse` object (empty for single-repo sessions, populated for workspaces).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->