### PR TITLE
feat(web): add "New scratch session" to the command palette

### DIFF
--- a/docs/guides/scratch-sessions.md
+++ b/docs/guides/scratch-sessions.md
@@ -62,6 +62,11 @@ wizard with scratch already enabled and jumped to the Review step.
 A follow-up `Cmd+Enter` / `Ctrl+Enter` launches the session, so two
 keystrokes is enough to spin up a fresh scratch session.
 
+**Command palette.** The same flow is reachable from the command
+palette (`Cmd+K` / `Ctrl+K`): search for "New scratch session" and
+run it to open the wizard prefilled for a scratch session. In
+read-only mode the creation commands are hidden from the palette.
+
 **Sidebar grouping.** Every scratch session has its own
 `scratch/<id>/` directory on disk, so the dashboard sidebar would
 otherwise render each one as its own one-session group. Scratch

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -629,10 +629,20 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     onSwipe: openDiff,
   });
 
+  // Read-only mode hides mutation UI. Guard creation at the handler so every
+  // caller (keyboard shortcut, command palette) is a no-op rather than opening
+  // a wizard that 403s on submit. Caught by the live read-only-mode spec.
   const handleNewSession = useCallback(() => {
+    if (serverAbout?.read_only) return;
     setWizardPrefill(undefined);
     setShowSessionWizard(true);
-  }, []);
+  }, [serverAbout?.read_only]);
+
+  const handleNewScratch = useCallback(() => {
+    if (serverAbout?.read_only) return;
+    setWizardPrefill({ scratch: true, skipToReview: true });
+    setShowSessionWizard(true);
+  }, [serverAbout?.read_only]);
 
   const handleCloneFromUrl = useCallback(() => {
     setWizardPrefill({ initialTab: "clone" });
@@ -698,23 +708,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   useKeyboardShortcuts(
     useCallback(
       () => ({
-        onNew: () => {
-          // Read-only mode hides mutation UI. The "n" shortcut must
-          // not open the wizard or the user gets a dead-end form that
-          // 403s on submit. Caught by the live read-only-mode spec.
-          if (serverAbout?.read_only) return;
-          setWizardPrefill(undefined);
-          setShowSessionWizard(true);
-        },
-        onNewScratch: () => {
-          // Same read-only guard as `onNew`: the wizard cannot land a
-          // POST /api/sessions when the server returns 403 on every
-          // mutation, and a scratch fast-create that 403s on submit is
-          // a worse footgun than a no-op.
-          if (serverAbout?.read_only) return;
-          setWizardPrefill({ scratch: true, skipToReview: true });
-          setShowSessionWizard(true);
-        },
+        onNew: handleNewSession,
+        onNewScratch: handleNewScratch,
         onDiff: () => toggleDiff(),
         // Escape closes local UI surfaces only (dialogs, palette,
         // wizard, settings, help, file viewer). Never wire this to
@@ -752,7 +747,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         handleCloseSettings,
         navigate,
         handleToggleTerminalFocus,
-        serverAbout,
+        handleNewSession,
+        handleNewScratch,
       ],
     ),
   );
@@ -762,7 +758,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     activeSessionId,
     loginRequired,
     hasActiveSession: !!activeSession,
+    readOnly: !!serverAbout?.read_only,
     onNewSession: handleNewSession,
+    onNewScratch: handleNewScratch,
     onSelectSession: handleSelectSession,
     onToggleDiff: toggleDiff,
     onOpenSettings: handleOpenSettings,

--- a/web/src/components/HelpOverlay.tsx
+++ b/web/src/components/HelpOverlay.tsx
@@ -25,12 +25,15 @@ export function HelpOverlay({ onClose }: Props) {
 
   const optKey = IS_MAC ? "⌥" : "Alt";
 
+  const shiftKey = IS_MAC ? "⇧" : "Shift";
+
   const shortcuts = [
     { key: `${modKey}K`, desc: "Open command palette" },
     { key: `${modKey}B`, desc: "Toggle left sidebar" },
     { key: `${modKey}${optKey}B`, desc: "Toggle right panel" },
     { key: `${modKey}\``, desc: "Toggle agent / shell terminal focus" },
     { key: "n", desc: "New session" },
+    { key: `${modKey}${shiftKey}N`, desc: "New scratch session" },
     { key: "D", desc: "Toggle diff panel" },
     { key: "s", desc: "Toggle settings" },
     { key: "Esc", desc: "Close dialog" },

--- a/web/src/hooks/__tests__/useCommandActions.test.tsx
+++ b/web/src/hooks/__tests__/useCommandActions.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+//
+// Contract test for the command-palette action list (#1643). Asserts the
+// "New scratch session" command is present with the right shape and dispatches
+// onNewScratch, and that both creation commands are hidden in read-only mode
+// (matching the sidebar / dashboard, which hide their "new" buttons rather than
+// offering a command that opens a wizard the server 403s on submit).
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCommandActions } from "../useCommandActions";
+import type { SessionResponse } from "../../lib/types";
+
+type Args = Parameters<typeof useCommandActions>[0];
+
+function baseArgs(overrides: Partial<Args> = {}): Args {
+  return {
+    sessions: [] as SessionResponse[],
+    activeSessionId: null,
+    loginRequired: false,
+    hasActiveSession: false,
+    readOnly: false,
+    onNewSession: vi.fn(),
+    onNewScratch: vi.fn(),
+    onSelectSession: vi.fn(),
+    onToggleDiff: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onOpenHelp: vi.fn(),
+    onOpenAbout: vi.fn(),
+    onGoDashboard: vi.fn(),
+    onToggleSidebar: vi.fn(),
+    onLogout: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("useCommandActions: scratch command", () => {
+  it("exposes a 'New scratch session' command", () => {
+    const { result } = renderHook(() => useCommandActions(baseArgs()));
+    const scratch = result.current.find(
+      (a) => a.id === "action:new-scratch-session",
+    );
+    expect(scratch).toBeDefined();
+    expect(scratch?.title).toBe("New scratch session");
+    expect(scratch?.group).toBe("Actions");
+    expect(scratch?.keywords).toContain("scratch");
+    expect(scratch?.shortcut).toMatch(/N$/);
+  });
+
+  it("renders the scratch command right after 'New session'", () => {
+    const { result } = renderHook(() => useCommandActions(baseArgs()));
+    const ids = result.current.map((a) => a.id);
+    const newSession = ids.indexOf("action:new-session");
+    const scratch = ids.indexOf("action:new-scratch-session");
+    expect(newSession).toBeGreaterThanOrEqual(0);
+    expect(scratch).toBe(newSession + 1);
+  });
+
+  it("perform dispatches onNewScratch", () => {
+    const onNewScratch = vi.fn();
+    const { result } = renderHook(() =>
+      useCommandActions(baseArgs({ onNewScratch })),
+    );
+    const scratch = result.current.find(
+      (a) => a.id === "action:new-scratch-session",
+    );
+    scratch?.perform();
+    expect(onNewScratch).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides both creation commands in read-only mode", () => {
+    const { result } = renderHook(() =>
+      useCommandActions(baseArgs({ readOnly: true })),
+    );
+    const ids = result.current.map((a) => a.id);
+    expect(ids).not.toContain("action:new-session");
+    expect(ids).not.toContain("action:new-scratch-session");
+  });
+});

--- a/web/src/hooks/useCommandActions.ts
+++ b/web/src/hooks/useCommandActions.ts
@@ -11,7 +11,9 @@ interface Args {
   activeSessionId: string | null;
   loginRequired: boolean;
   hasActiveSession: boolean;
+  readOnly: boolean;
   onNewSession: () => void;
+  onNewScratch: () => void;
   onSelectSession: (sessionId: string) => void;
   onToggleDiff: () => void;
   onOpenSettings: () => void;
@@ -27,7 +29,9 @@ export function useCommandActions({
   activeSessionId,
   loginRequired,
   hasActiveSession,
+  readOnly,
   onNewSession,
+  onNewScratch,
   onSelectSession,
   onToggleDiff,
   onOpenSettings,
@@ -40,14 +44,30 @@ export function useCommandActions({
   return useMemo(() => {
     const actions: CommandAction[] = [];
 
-    actions.push({
-      id: "action:new-session",
-      title: "New session",
-      group: "Actions",
-      keywords: ["create", "start", "agent", "worktree"],
-      shortcut: "n",
-      perform: onNewSession,
-    });
+    // Creation commands are mutation UI. In read-only mode the sidebar and
+    // dashboard already hide their "new session" buttons, so the palette must
+    // omit these too rather than offer a command that opens a wizard the
+    // server 403s on submit. The keyboard-shortcut path stays a guarded no-op
+    // (a key can't be hidden); these visible entries are dropped instead.
+    if (!readOnly) {
+      actions.push({
+        id: "action:new-session",
+        title: "New session",
+        group: "Actions",
+        keywords: ["create", "start", "agent", "worktree"],
+        shortcut: "n",
+        perform: onNewSession,
+      });
+
+      actions.push({
+        id: "action:new-scratch-session",
+        title: "New scratch session",
+        group: "Actions",
+        keywords: ["scratch", "temp", "temporary", "ephemeral", "throwaway", "create"],
+        shortcut: IS_MAC ? "⌘⇧N" : "Ctrl+Shift+N",
+        perform: onNewScratch,
+      });
+    }
 
     actions.push({
       id: "action:go-dashboard",
@@ -135,7 +155,9 @@ export function useCommandActions({
     activeSessionId,
     loginRequired,
     hasActiveSession,
+    readOnly,
     onNewSession,
+    onNewScratch,
     onSelectSession,
     onToggleDiff,
     onOpenSettings,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -449,6 +449,20 @@
       ]
     },
     {
+      "id": "palette.new-scratch-session",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/palette-scratch-launch.spec.ts",
+        "src/hooks/__tests__/useCommandActions.test.tsx"
+      ],
+      "components": [
+        "web/src/App.tsx",
+        "web/src/components/command-palette/CommandPalette.tsx",
+        "web/src/components/HelpOverlay.tsx"
+      ]
+    },
+    {
       "id": "sidebar.scratch-group",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/live/palette-scratch-launch.spec.ts
+++ b/web/tests/live/palette-scratch-launch.spec.ts
@@ -1,0 +1,86 @@
+// User story (#1643): a user who lives in the command palette can start a
+// scratch session. Open Cmd+K / Ctrl+K, run "New scratch session", and the
+// wizard opens prefilled for a scratch session jumped to the Review step;
+// Cmd+Enter / Ctrl+Enter then launches it. Read-only mode hides the creation
+// commands from the palette entirely.
+
+import { basename, dirname } from "node:path";
+import { test, expect } from "../helpers/liveTest";
+import { listSessions } from "../helpers/aoeServe";
+
+const PALETTE_PLACEHOLDER = "Search actions, sessions, settings…";
+
+test("palette 'New scratch session' opens the wizard and launches a scratch session", async ({
+  serve,
+  page,
+}) => {
+  await page.goto(serve.baseUrl);
+  await expect(
+    page.getByRole("button", { name: "New session", exact: true }).first(),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // ControlOrMeta honors the host's actual modifier (Cmd on macOS, Ctrl on
+  // CI), matching how useKeyboardShortcuts derives the palette chord.
+  await page.keyboard.press("ControlOrMeta+KeyK");
+  await expect(page.getByPlaceholder(PALETTE_PLACEHOLDER)).toBeVisible();
+
+  await page.getByPlaceholder(PALETTE_PLACEHOLDER).fill("scratch");
+  await page
+    .getByRole("option", { name: /New scratch session/i })
+    .click();
+
+  const wizard = page.locator(
+    'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+  );
+  await expect(wizard).toBeVisible({ timeout: 10_000 });
+
+  // skipToReview lands the wizard on Review with scratch enabled; the Launch
+  // button + scratch project marker prove the prefill plumbing fired.
+  await expect(
+    wizard.getByRole("button", { name: /Launch session/ }),
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(
+    wizard.getByText(/Scratch directory \(provisioned on create\)/),
+  ).toBeVisible();
+
+  await page.keyboard.press("ControlOrMeta+Enter");
+
+  await expect
+    .poll(async () => (await listSessions(serve.baseUrl)).length, {
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(0);
+
+  const sessions = await listSessions(serve.baseUrl);
+  expect(sessions).toHaveLength(1);
+  const session = sessions[0]!;
+  expect(session.scratch).toBe(true);
+  const projectPath = session.project_path as string;
+  expect(basename(dirname(projectPath))).toBe("scratch");
+});
+
+test("palette hides creation commands in read-only mode", async ({
+  serveReadOnly,
+  page,
+}) => {
+  // Wait for /api/about so the React state carries read_only before the
+  // palette renders; otherwise serverAbout is null and the guard is bypassed.
+  const aboutPromise = page.waitForResponse(
+    (r) => r.url().endsWith("/api/about") && r.status() === 200,
+    { timeout: 10_000 },
+  );
+  await page.goto(serveReadOnly.baseUrl);
+  await aboutPromise;
+  await page.waitForTimeout(200);
+
+  await page.locator("body").click();
+  await page.keyboard.press("ControlOrMeta+KeyK");
+  await expect(page.getByPlaceholder(PALETTE_PLACEHOLDER)).toBeVisible();
+
+  await expect(
+    page.getByRole("option", { name: /New scratch session/i }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("option", { name: /New session/i }),
+  ).toHaveCount(0);
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Scratch sessions could only be fast-created from the `Cmd/Ctrl+Shift+N` keyboard chord, which is undiscoverable. This adds a **New scratch session** command to the `Cmd+K` / `Ctrl+K` command palette so the same flow (open the wizard prefilled for scratch, jumped to the Review step) is reachable without knowing the shortcut. A matching entry was added to the keyboard-shortcut help overlay.

While wiring it, the read-only guard was unified. Both the keyboard shortcut and the palette now route through shared `handleNewSession` / `handleNewScratch` callbacks. Previously the palette's "New session" command used an unguarded handler, so in read-only mode it could open a wizard that the server 403s on submit. Now both creation commands are hidden from the palette in read-only mode, matching how the sidebar and dashboard already hide their "new session" buttons.

Closes #1643

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] Open the dashboard, press `Cmd+K` / `Ctrl+K`, type "scratch", run **New scratch session**, confirm the wizard opens on Review with scratch enabled; press `Cmd+Enter` / `Ctrl+Enter` and confirm a scratch session launches.
- [ ] Press `?` to open the help overlay and confirm a **New scratch session** entry shows the `Cmd/Ctrl+Shift+N` shortcut.
- [ ] Run `aoe serve --read-only`, open the palette, and confirm neither **New session** nor **New scratch session** appears.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Summary

This PR adds a "New scratch session" command to the command palette (Cmd+K / Ctrl+K) and documents the corresponding keyboard shortcut (Cmd+Shift+N / Ctrl+Shift+N) in the help overlay, making the existing scratch session fast-create feature discoverable without requiring users to know the chord by heart.

**What was added:**
- New "New scratch session" command in the command palette with appropriate keywords and platform-aware shortcut display
- "New scratch session" entry (Cmd+Shift+N / Ctrl+Shift+N) to the help overlay's keyboard shortcuts reference
- Comprehensive test coverage including unit tests (Vitest/RTL) and end-to-end tests (Playwright)
- Documentation update to the scratch-sessions guide

**What was changed:**
- Session creation logic now properly guards against read-only mode in both keyboard shortcuts and palette commands, preventing users from attempting to create sessions that would fail with permission errors
- Command palette configuration refactored to use explicit callbacks for new session and new scratch session creation
- Both keyboard shortcut and palette routes now use the same underlying guarded handler functions

**What was removed:**
- Unguarded palette command for "New session" that could open a wizard destined to 403 in read-only mode

## Benefits

1. **Improved Discoverability** — Users can now find the quick scratch session creation feature through the command palette, eliminating the need to memorize or discover the Cmd/Ctrl+Shift+N shortcut
2. **Better Read-Only UX** — Creation commands are hidden from the palette in read-only mode, preventing users from starting flows that cannot complete
3. **Consistent Behavior** — Keyboard shortcuts and palette commands now share the same read-only guard, eliminating potential inconsistencies
4. **Better Documentation** — Keyboard shortcuts are now centrally documented in the help overlay

## Technical Details

- `useCommandActions` hook updated to accept a `readOnly` flag and `onNewScratch` callback, allowing conditional rendering of creation commands
- `App.tsx` refactored with dedicated `handleNewSession` and `handleNewScratch` functions that early-return in read-only mode before opening any UI
- `HelpOverlay` component now derives shift-key formatting from platform detection and includes the new scratch session shortcut in its dashboard shortcuts list
- Coverage matrix and test suite expanded with new test surface `palette.new-scratch-session` mapping to Playwright and unit tests covering command structure, callback dispatch, and read-only hiding behavior

**Closes:** `#1643`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->