### PR TITLE
fix(cockpit): settle tool card to a terminal state when stopped mid-execution

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -807,6 +807,10 @@ If the agent ignores `session/cancel` mid-tool-call (most commonly a `block: tru
 
 Follow-up prompts the daemon refused while the original turn was still in flight no longer vanish silently. The composer shows them as amber "Rejected" pills with a Retry button; clicking Retry re-dispatches the prompt through the normal send path against the freshly-respawned worker.
 
+### Tool card stuck "running" after a stop
+
+Stopping the agent while a tool call is mid-execution settles that tool's card to a distinct terminal **stopped** state: the elapsed-time timer freezes and the badge leaves the orange "running" state for a muted "stopped". This is intentional. The adapter resolves a cancelled prompt without sending a per-tool completion, so the cockpit closes any still-open tool calls itself when the turn ends. "stopped" is neither "done" (no success was reported) nor "failed" (no error was reported); the tool's real outcome was never reported. The same applies on reload (the state is reconstructed from the persisted turn-end event) and when the backend switches agents mid-turn.
+
 ### Rate-limit recovery
 
 When the active ACP backend reports `errorKind: "rate_limit"` on `session/prompt` (Claude's adapter does this when the Anthropic account is over its limit), aoe treats this as a non-crash terminal state rather than as a worker crash:

--- a/web/src/components/cockpit/CockpitRuntime.test.ts
+++ b/web/src/components/cockpit/CockpitRuntime.test.ts
@@ -443,3 +443,81 @@ describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
     }
   });
 });
+
+function toolStopped(id: string, text = ""): ActivityRow {
+  return {
+    id: `stopped-${id}-9`,
+    kind: "tool_stopped",
+    text,
+    toolCallId: id,
+    at: "2026-05-12T00:00:02Z",
+  };
+}
+
+describe("activityToThreadMessages; stopped status threading (#1646)", () => {
+  it("carries stopped onto a top-level tool-call part's result", () => {
+    const messages = activityToThreadMessages(
+      [userRow("go"), toolStart("t1"), toolStopped("t1")],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = assistant.content as Array<{
+      type: string;
+      result?: { stopped?: boolean };
+      isError?: boolean;
+    }>;
+    const tool = parts.find((p) => p.type === "tool-call")!;
+    expect(tool.result?.stopped).toBe(true);
+    // Stopped is not an error; assistant-ui's isError stays falsy.
+    expect(tool.isError).toBeFalsy();
+  });
+
+  it("preserves stopped on a subagent child through the payload round-trip", () => {
+    const parent: ToolCall = {
+      id: "task-1",
+      name: "Task",
+      kind: "think",
+      args_preview: JSON.stringify({ _aoe_title: "Task" }),
+      started_at: "2026-05-12T00:00:00Z",
+    };
+    const parentRow: ActivityRow = {
+      id: "start-task-1",
+      kind: "tool_start",
+      text: "Task",
+      toolCallId: "task-1",
+      tool: parent,
+      at: "2026-05-12T00:00:00Z",
+    };
+    const child: ToolCall = {
+      id: "ch-1",
+      name: "Read",
+      kind: "read",
+      args_preview: JSON.stringify({ path: "/x" }),
+      started_at: "2026-05-12T00:00:01Z",
+      parent_tool_call_id: "task-1",
+    };
+    const childRow: ActivityRow = {
+      id: "start-ch-1",
+      kind: "tool_start",
+      text: "Read",
+      toolCallId: "ch-1",
+      tool: child,
+      at: "2026-05-12T00:00:01Z",
+    };
+    const messages = activityToThreadMessages(
+      [userRow("go"), parentRow, childRow, toolStopped("ch-1")],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = assistant.content as Array<{
+      type: string;
+      toolName?: string;
+      argsText?: string;
+    }>;
+    const subagent = parts.find(
+      (p) => p.type === "tool-call" && p.toolName === SUBAGENT_TASK_NAME,
+    )!;
+    const payload = JSON.parse(subagent.argsText!);
+    expect(payload.children[0].result.stopped).toBe(true);
+  });
+});

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -297,10 +297,15 @@ export function activityToThreadMessages(
       currentAssistant.appendText(row.text);
     } else if (row.kind === "tool_start" && row.tool) {
       currentAssistant.appendToolCall(row.tool);
-    } else if (row.kind === "tool_complete" || row.kind === "tool_error") {
+    } else if (
+      row.kind === "tool_complete" ||
+      row.kind === "tool_error" ||
+      row.kind === "tool_stopped"
+    ) {
       currentAssistant.completeToolCall(
-        row.toolCallId ?? row.id.replace(/^done-/, ""),
+        row.toolCallId ?? row.id.replace(/^(done|stopped)-/, ""),
         row.kind === "tool_error",
+        row.kind === "tool_stopped",
         row.text,
         row.at,
       );
@@ -357,7 +362,7 @@ type DraftPart =
       toolCallId: string;
       toolName: string;
       argsText: string;
-      result?: { content: string; endedAt?: string };
+      result?: { content: string; endedAt?: string; stopped?: boolean };
       isError?: boolean;
     };
 
@@ -419,12 +424,13 @@ class AssistantBuilder {
   completeToolCall(
     toolCallId: string,
     isError: boolean,
+    stopped: boolean,
     resultText: string,
     endedAt: string,
   ) {
     for (const part of this.parts) {
       if (part.type === "tool-call" && part.toolCallId === toolCallId) {
-        part.result = { content: resultText, endedAt };
+        part.result = { content: resultText, endedAt, stopped: stopped || undefined };
         part.isError = isError || undefined;
         return;
       }
@@ -591,8 +597,10 @@ type GroupChildPayload = {
   argsText: string;
   // `endedAt` rides along from DraftPart.result (set in completeToolCall)
   // and CockpitView's pickEndedAt reads it to compute durations; keep it
-  // on the type so a future rebuild of `result` doesn't drop it.
-  result?: { content: string; endedAt?: string };
+  // on the type so a future rebuild of `result` doesn't drop it. `stopped`
+  // rides the same way so grouped/subagent children reconstruct as the
+  // distinct "stopped" terminal state instead of "done" (#1646).
+  result?: { content: string; endedAt?: string; stopped?: boolean };
   isError?: boolean;
 };
 

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -620,9 +620,7 @@ function AssistantToolCall(props: ToolCallProps) {
     props.result !== undefined
       ? {
           id: `done-${props.toolCallId}`,
-          kind: props.isError
-            ? ("tool_error" as const)
-            : ("tool_complete" as const),
+          kind: resultRowKind(props.isError, pickStopped(props.result)),
           text: resultContent,
           toolCallId: props.toolCallId,
           at: endedAt,
@@ -673,11 +671,34 @@ function pickEndedAt(result: unknown): string | null {
   return null;
 }
 
+/** Read the smuggled `stopped` flag set by AssistantBuilder.completeToolCall
+ *  for a tool closed by the reducer's turn-end sweep (#1646), so the
+ *  reconstructed row carries the distinct `tool_stopped` kind. */
+function pickStopped(result: unknown): boolean {
+  return (
+    !!result &&
+    typeof result === "object" &&
+    (result as { stopped?: unknown }).stopped === true
+  );
+}
+
+/** Map a completed tool's flags to its activity-row kind. Error wins
+ *  over stopped (a tool that errored before the turn ended is a real
+ *  failure); stopped wins over complete. See #1646. */
+function resultRowKind(
+  isError: boolean | undefined,
+  stopped: boolean,
+): "tool_error" | "tool_stopped" | "tool_complete" {
+  if (isError) return "tool_error";
+  if (stopped) return "tool_stopped";
+  return "tool_complete";
+}
+
 interface GroupChild {
   toolCallId: string;
   toolName: string;
   argsText: string;
-  result?: { content: string; endedAt?: string };
+  result?: { content: string; endedAt?: string; stopped?: boolean };
   isError?: boolean;
 }
 
@@ -728,9 +749,7 @@ function groupChildToItem(c: GroupChild): {
     c.result !== undefined
       ? {
           id: `done-${c.toolCallId}`,
-          kind: c.isError
-            ? ("tool_error" as const)
-            : ("tool_complete" as const),
+          kind: resultRowKind(c.isError, c.result.stopped === true),
           text: c.result.content,
           toolCallId: c.toolCallId,
           at: endedAt,
@@ -800,9 +819,7 @@ function AssistantSubagentTask({ argsText }: { argsText?: string }) {
       c.result !== undefined
         ? {
             id: `done-${c.toolCallId}`,
-            kind: c.isError
-              ? ("tool_error" as const)
-              : ("tool_complete" as const),
+            kind: resultRowKind(c.isError, c.result.stopped === true),
             text: c.result.content,
             toolCallId: c.toolCallId,
             at: endedAt,

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -35,6 +35,7 @@ import {
   fixtures,
   makeCompletion,
   makeError,
+  makeStopped,
   makeToolCall,
 } from "./__fixtures__/toolCalls";
 
@@ -158,6 +159,38 @@ describe("ToolCards dispatch", () => {
       </Wrap>,
     );
     expect(container.textContent).toContain("done");
+  });
+
+  it("renders the 'stopped' badge on tool_stopped results, not running/failed/done", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.bash} result={makeStopped()} />
+      </Wrap>,
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("stopped");
+    expect(text).not.toContain("running");
+    expect(text).not.toContain("failed");
+    expect(text).not.toContain("done");
+  });
+
+  it("freezes the duration on a tool_stopped result (endedAt is set)", () => {
+    // A stopped card carries a terminal `at`, so the duration is a fixed
+    // span rather than a live-ticking elapsed timer. started_at
+    // 00:00:00 -> at 00:00:01 == 1.0s. See #1646.
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={makeToolCall({
+            id: "bash-1",
+            kind: "execute",
+            started_at: "2026-05-21T00:00:00Z",
+          })}
+          result={makeStopped({ at: "2026-05-21T00:00:01Z" })}
+        />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("1.0s");
   });
 });
 

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -298,6 +298,32 @@ describe("TodoGroupCard fold (#1468)", () => {
     // The header surfaces the failed latest attempt rather than looking clean.
     expect(container.textContent).toContain("failed");
   });
+
+  it("surfaces a stopped header when the latest snapshot was interrupted (#1646)", () => {
+    const stoppedTail = {
+      tool: makeToolCall({
+        id: "td4",
+        name: "TodoWrite",
+        kind: "other",
+        args_preview: JSON.stringify({
+          todos: [{ content: "Interrupted plan", status: "in_progress" }],
+        }),
+      }),
+      result: makeStopped({ id: "stopped-td4", toolCallId: "td4" }),
+    };
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <TodoGroupCard items={[...items, stoppedTail]} />
+      </Wrap>,
+    );
+    // Collapsed preview falls back to the last good snapshot, not the
+    // interrupted one.
+    expect(container.textContent).toContain("Step Charlie");
+    expect(container.textContent).not.toContain("Interrupted plan");
+    // The header reads "stopped", not the misleading "done".
+    expect(container.textContent).toContain("stopped");
+    expect(container.textContent).not.toContain("done");
+  });
 });
 
 describe("ToolCards memory_recall (claude-agent-acp v0.37.0)", () => {

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -1157,9 +1157,16 @@ export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
       ) ?? null;
   const previewSnapshot = latestSuccessful ?? latestAttempt;
   const latestFailed = latestAttempt.result?.kind === "tool_error";
+  const latestStopped = latestAttempt.result?.kind === "tool_stopped";
   const breakdown = todoBreakdown(todoCounts(previewSnapshot.todos));
   const running = snapshots.some((s) => !s.result);
-  const status: Status = running ? "running" : latestFailed ? "err" : "ok";
+  const status: Status = running
+    ? "running"
+    : latestFailed
+      ? "err"
+      : latestStopped
+        ? "stopped"
+        : "ok";
 
   const startedAt = snapshots
     .map((s) => s.tool.started_at)
@@ -1176,7 +1183,7 @@ export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
   return (
     <CardChrome
       status={status}
-      neutralOnDone={!latestFailed}
+      neutralOnDone={!latestFailed && !latestStopped}
       icon={<ListChecks className="h-3.5 w-3.5" />}
       label="todos"
       primary={

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -232,11 +232,13 @@ function SubagentChildWrap({ children }: { children: ReactNode }) {
 
 /* ── Shared header bits ──────────────────────────────────────────── */
 
-type Status = "running" | "ok" | "err";
+type Status = "running" | "ok" | "err" | "stopped";
 
 function statusFor(result?: ActivityRow): Status {
   if (!result) return "running";
-  return result.kind === "tool_error" ? "err" : "ok";
+  if (result.kind === "tool_error") return "err";
+  if (result.kind === "tool_stopped") return "stopped";
+  return "ok";
 }
 
 // Per-card expand state for tool cards. Failed cards auto-open so the
@@ -272,7 +274,7 @@ function StatusDot({ status, neutral }: { status: Status; neutral?: boolean }) {
   const cls =
     status === "running"
       ? "bg-brand-400 animate-pulse"
-      : neutral
+      : neutral || status === "stopped"
         ? "bg-text-dim/60"
         : status === "ok"
           ? "bg-status-running"
@@ -291,6 +293,12 @@ function StatusBadge({ status }: { status: Status }) {
   }
   if (status === "err") {
     return <span className="text-[11px] text-status-error">failed</span>;
+  }
+  if (status === "stopped") {
+    // `--color-status-stopped` fails WCAG AA for text (it is a dot-only
+    // decorative token); the muted dot already differentiates from the
+    // green "done" dot, so keep the label on the legible dim slot.
+    return <span className="text-[11px] text-text-dim">stopped</span>;
   }
   return <span className="text-[11px] text-text-dim">done</span>;
 }
@@ -1134,13 +1142,19 @@ export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
   if (snapshots.length === 0) return null;
 
   // The collapsed preview shows the latest *successful* snapshot, since
-  // a TodoWrite that ended in tool_error never became the live state.
-  // The header still reflects the latest attempt so a failed trailing
-  // update surfaces as an error rather than looking clean. See #1468.
+  // a TodoWrite that ended in tool_error (or was interrupted by a stop,
+  // tool_stopped; see #1646) never became the live state. The header
+  // still reflects the latest attempt so a failed trailing update
+  // surfaces as an error rather than looking clean. See #1468.
   const latestAttempt = snapshots[snapshots.length - 1]!;
   const latestSuccessful =
-    [...snapshots].reverse().find((s) => s.result?.kind !== "tool_error") ??
-    null;
+    [...snapshots]
+      .reverse()
+      .find(
+        (s) =>
+          s.result?.kind !== "tool_error" &&
+          s.result?.kind !== "tool_stopped",
+      ) ?? null;
   const previewSnapshot = latestSuccessful ?? latestAttempt;
   const latestFailed = latestAttempt.result?.kind === "tool_error";
   const breakdown = todoBreakdown(todoCounts(previewSnapshot.todos));

--- a/web/src/components/cockpit/ToolErrorBody.tsx
+++ b/web/src/components/cockpit/ToolErrorBody.tsx
@@ -18,7 +18,7 @@ import {
 } from "../../lib/toolErrorParse";
 
 interface Props {
-  status: "running" | "ok" | "err";
+  status: "running" | "ok" | "err" | "stopped";
   /** Raw `result.text` from the completion row. claude-agent-acp wraps
    *  Claude's tool errors in `<tool_use_error>...</tool_use_error>`;
    *  the parser peels the wrapper and surfaces it as a label outside

--- a/web/src/components/cockpit/__fixtures__/toolCalls.ts
+++ b/web/src/components/cockpit/__fixtures__/toolCalls.ts
@@ -32,6 +32,10 @@ export function makeError(over: Partial<ActivityRow> = {}): ActivityRow {
   return makeCompletion({ kind: "tool_error", text: "failed", ...over });
 }
 
+export function makeStopped(over: Partial<ActivityRow> = {}): ActivityRow {
+  return makeCompletion({ kind: "tool_stopped", text: "", ...over });
+}
+
 export const fixtures = {
   bash: makeToolCall({
     id: "bash-1",

--- a/web/src/lib/cockpitStopSweep.test.ts
+++ b/web/src/lib/cockpitStopSweep.test.ts
@@ -1,0 +1,179 @@
+// Reducer tests for the turn-end open-tool sweep (#1646).
+//
+// When the agent is stopped while a tool is mid-execution,
+// claude-agent-acp resolves the prompt with StopReason::Cancelled and
+// never emits a per-tool completion, so the cockpit only ever sees a
+// turn-level Stopped. A tool card's status is derived from the paired
+// terminal row in state.activity, so without a sweep the card sticks on
+// "running" forever (orange badge + a timer that counts up), live and
+// on reload (the trailing Stopped is persisted and replayed through
+// this same reducer).
+//
+// These assert that every turn-ending arm synthesizes a tool_stopped
+// row for each still-open tool_start, exactly once, without disturbing
+// tools that already completed.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyEvent,
+  emptyCockpitState,
+  type CockpitEvent,
+  type CockpitFrame,
+  type CockpitState,
+  type ToolCall,
+} from "./cockpitTypes";
+
+function frame(seq: number, event: CockpitEvent): CockpitFrame {
+  return { session_id: "s-1", seq, event };
+}
+
+function toolCall(id: string): ToolCall {
+  return {
+    id,
+    name: `tool ${id}`,
+    kind: "execute",
+    args_preview: "{}",
+    started_at: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function start(state: CockpitState, seq: number, id: string): CockpitState {
+  return applyEvent(state, frame(seq, { ToolCallStarted: { tool_call: toolCall(id) } }));
+}
+
+function openRows(state: CockpitState): string[] {
+  const terminal = new Set(
+    state.activity
+      .filter(
+        (r) =>
+          r.kind === "tool_complete" ||
+          r.kind === "tool_error" ||
+          r.kind === "tool_stopped",
+      )
+      .map((r) => r.toolCallId),
+  );
+  return state.activity
+    .filter((r) => r.kind === "tool_start" && !terminal.has(r.toolCallId))
+    .map((r) => r.toolCallId!);
+}
+
+function stoppedRows(state: CockpitState) {
+  return state.activity.filter((r) => r.kind === "tool_stopped");
+}
+
+describe("turn-end open-tool sweep", () => {
+  it("closes an open tool on Stopped and clears inFlightTool", () => {
+    const opened = start(emptyCockpitState(), 1, "t1");
+    expect(openRows(opened)).toEqual(["t1"]);
+
+    const next = applyEvent(opened, frame(2, { Stopped: { reason: "cancelled" } }));
+
+    expect(openRows(next)).toEqual([]);
+    expect(next.inFlightTool).toBeNull();
+    const stopped = stoppedRows(next);
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0]).toMatchObject({ kind: "tool_stopped", toolCallId: "t1" });
+    expect(typeof stopped[0]!.at).toBe("string");
+  });
+
+  it("leaves an already-completed tool untouched", () => {
+    let state = start(emptyCockpitState(), 1, "t1");
+    state = applyEvent(
+      state,
+      frame(2, {
+        ToolCallCompleted: {
+          tool_call_id: "t1",
+          is_error: false,
+          content: "ok",
+          completed_at: "2026-01-01T00:00:01.000Z",
+        },
+      }),
+    );
+    const next = applyEvent(state, frame(3, { Stopped: { reason: "cancelled" } }));
+
+    expect(stoppedRows(next)).toHaveLength(0);
+    expect(
+      next.activity.filter((r) => r.kind === "tool_complete"),
+    ).toHaveLength(1);
+  });
+
+  it("closes only the still-open tool when several are in flight", () => {
+    let state = start(emptyCockpitState(), 1, "a");
+    state = start(state, 2, "b");
+    state = applyEvent(
+      state,
+      frame(3, {
+        ToolCallCompleted: { tool_call_id: "a", is_error: false, content: "" },
+      }),
+    );
+    const next = applyEvent(state, frame(4, { Stopped: { reason: "user_stopped" } }));
+
+    const stopped = stoppedRows(next);
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0]!.toolCallId).toBe("b");
+  });
+
+  it("drains buffered ToolCallContent into the synthesized row", () => {
+    let state = start(emptyCockpitState(), 1, "t1");
+    state = applyEvent(
+      state,
+      frame(2, { ToolCallContent: { tool_call_id: "t1", content: "partial output" } }),
+    );
+    const next = applyEvent(state, frame(3, { Stopped: { reason: "cancelled" } }));
+
+    expect(stoppedRows(next)[0]).toMatchObject({ text: "partial output" });
+    expect(next.toolOutputs.t1).toBeUndefined();
+  });
+
+  it("does not double-close on a second terminal event", () => {
+    const opened = start(emptyCockpitState(), 1, "t1");
+    const once = applyEvent(opened, frame(2, { Stopped: { reason: "cancelled" } }));
+    const twice = applyEvent(once, frame(3, { Stopped: { reason: "prompt_complete" } }));
+
+    expect(stoppedRows(twice)).toHaveLength(1);
+  });
+
+  it("synthesizes one row even when the store carries duplicate tool_start rows", () => {
+    // Pre-fix stores can replay the same tool_call_id twice; the dedupe
+    // in ToolCallStarted patches in place, so seed the duplicate directly
+    // to exercise the sweep's own toolCallId dedupe.
+    const base = start(emptyCockpitState(), 1, "dup");
+    const withDupe: CockpitState = {
+      ...base,
+      activity: base.activity.concat({
+        id: "start-dup-2",
+        kind: "tool_start",
+        text: "tool dup",
+        toolCallId: "dup",
+        at: "2026-01-01T00:00:00.000Z",
+      }),
+    };
+    const next = applyEvent(withDupe, frame(2, { Stopped: { reason: "cancelled" } }));
+
+    expect(stoppedRows(next)).toHaveLength(1);
+  });
+
+  it("repairs a persisted [start, Stopped] replay so reload is terminal", () => {
+    // Cold reload: no live state, replay the persisted frames in order.
+    const replayed = [
+      frame(1, { ToolCallStarted: { tool_call: toolCall("t1") } }),
+      frame(2, { Stopped: { reason: "cancelled" } }),
+    ].reduce(applyEvent, emptyCockpitState());
+
+    expect(openRows(replayed)).toEqual([]);
+    expect(stoppedRows(replayed)).toHaveLength(1);
+  });
+
+  it.each([
+    ["AgentSwitched", { AgentSwitched: { from: "claude", to: "codex", reason: "rate_limit" } }],
+    ["IncompatibleAgent", { IncompatibleAgent: { detail: { reason: "x" } } }],
+    ["AgentStartupError", { AgentStartupError: { message: "boom" } }],
+  ] as const)("closes open tools on %s", (_label, event) => {
+    const opened = start(emptyCockpitState(), 1, "t1");
+    const next = applyEvent(opened, frame(2, event as CockpitEvent));
+
+    expect(openRows(next)).toEqual([]);
+    expect(stoppedRows(next)).toHaveLength(1);
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -524,6 +524,7 @@ export interface ActivityRow {
     | "tool_start"
     | "tool_complete"
     | "tool_error"
+    | "tool_stopped"
     | "message"
     | "thinking"
     | "user_prompt"
@@ -937,6 +938,7 @@ export function applyEvent(
     // optimistic message above any still-arriving prior-turn agent
     // chunks. See #1170.
     next.inFlightTool = null;
+    sweepOpenToolCalls(next, frame.seq);
     next.lastStoppedSeq = Math.min(
       next.lastStoppedSeq + 1,
       next.pendingUserPromptSeq,
@@ -1031,6 +1033,7 @@ export function applyEvent(
     // `startupError` so legacy status logic still flips into Error.
     next.incompatibleAgent = event.IncompatibleAgent.detail;
     next.inFlightTool = null;
+    sweepOpenToolCalls(next, frame.seq);
     next.agentUnresponsive = false;
     next.lastStoppedSeq = Math.min(
       next.lastStoppedSeq + 1,
@@ -1042,6 +1045,7 @@ export function applyEvent(
   if ("AgentStartupError" in event) {
     next.startupError = event.AgentStartupError.message;
     next.inFlightTool = null;
+    sweepOpenToolCalls(next, frame.seq);
     // A failed respawn supersedes any in-progress unresponsive
     // escalation; the user sees the startup error banner instead.
     next.agentUnresponsive = false;
@@ -1228,6 +1232,9 @@ export function applyEvent(
     next.agent = to;
     next.rateLimit = null;
     next.inFlightTool = null;
+    // Close any tool the prior backend left open before appending the
+    // divider, so the transcript order is start -> stopped -> divider.
+    sweepOpenToolCalls(next, frame.seq);
     next.thinking = false;
     next.pendingApprovals = [];
     next.sessionUsage = null;
@@ -1310,6 +1317,65 @@ function pushActivity(rows: ActivityRow[], row: ActivityRow): ActivityRow[] {
     return next.slice(next.length - activityLimit);
   }
   return next;
+}
+
+/** Close any `tool_start` rows that never received a matching terminal
+ *  row by synthesizing a `tool_stopped` row for each. Called from the
+ *  turn-ending reducer arms (`Stopped`, `AgentSwitched`,
+ *  `IncompatibleAgent`, `AgentStartupError`): once the turn ends, no
+ *  tool that was part of it can still be running, yet the card status
+ *  is derived from the paired terminal row (see ToolCards `statusFor`),
+ *  not from the `inFlightTool` pointer the arms already null. Without
+ *  this sweep an interrupted tool's card sticks on "running" with a
+ *  live-ticking timer forever, live and on reload (the trailing
+ *  `Stopped` is persisted and replayed through this same reducer). The
+ *  case is reason-independent: even a `prompt_complete` with a dangling
+ *  open tool (the agent forgot to emit a completion) is "stopped", not
+ *  "done" or "failed", because the tool's real outcome was never
+ *  reported. Any text streamed via `ToolCallContent` before the stop is
+ *  drained into the synthesized row so it is not lost. See #1646. */
+function sweepOpenToolCalls(next: CockpitState, frameSeq: number): void {
+  const terminal = new Set<string>();
+  for (const row of next.activity) {
+    if (
+      (row.kind === "tool_complete" ||
+        row.kind === "tool_error" ||
+        row.kind === "tool_stopped") &&
+      row.toolCallId
+    ) {
+      terminal.add(row.toolCallId);
+    }
+  }
+  const now = new Date().toISOString();
+  let activity = next.activity;
+  let outputs = next.toolOutputs;
+  let drained = false;
+  // Iterate the pre-sweep snapshot; `pushActivity` returns fresh arrays
+  // assigned to the local `activity`, so the loop never sees the rows it
+  // appends. Dedupe by `toolCallId` because pre-fix stores can carry
+  // duplicate `tool_start` rows for one call.
+  for (const row of next.activity) {
+    if (row.kind !== "tool_start" || !row.toolCallId) continue;
+    const id = row.toolCallId;
+    if (terminal.has(id)) continue;
+    terminal.add(id);
+    const buffered = outputs[id] ?? "";
+    if (buffered) {
+      const { [id]: _drop, ...rest } = outputs;
+      void _drop;
+      outputs = rest;
+      drained = true;
+    }
+    activity = pushActivity(activity, {
+      id: `stopped-${id}-${frameSeq}`,
+      kind: "tool_stopped",
+      text: buffered,
+      toolCallId: id,
+      at: now,
+    });
+  }
+  next.activity = activity;
+  if (drained) next.toolOutputs = outputs;
 }
 
 /** Derived `turnActive` from the prompt / stop seq counters. Exported

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1124,6 +1124,34 @@
       ]
     },
     {
+      "id": "cockpit.tool-stopped-sweep",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/lib/cockpitStopSweep.test.ts",
+        "src/components/cockpit/CockpitRuntime.test.ts",
+        "src/components/cockpit/ToolCards.render.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitRuntime.tsx",
+        "web/src/components/cockpit/CockpitView.tsx",
+        "web/src/components/cockpit/ToolCards.tsx",
+        "web/src/components/cockpit/ToolErrorBody.tsx"
+      ]
+    },
+    {
+      "id": "cockpit.story.stop-tool-card-terminal",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx",
+        "web/src/components/cockpit/ToolCards.tsx"
+      ]
+    },
+    {
       "id": "cockpit.todo-group-fold",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts
+++ b/web/tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts
@@ -1,0 +1,117 @@
+// User story: Stopping mid-tool settles the tool card, it does not get
+// stuck "running" with a forever-counting timer. See #1646.
+//
+// A `tool_call` session/update (status=pending) with no completion
+// renders a running ToolCard. Before the fix, the card's status was
+// derived solely from a paired completion row, so a cancel (which emits
+// only a turn-level Stopped, never a per-tool completion) left the card
+// orange "running" forever, live and on reload. The reducer now sweeps
+// open tool calls to a terminal "stopped" state on any turn-ending
+// event, so the badge settles and the timer freezes.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import {
+  waitForCockpitView,
+  enableCockpitAndWait,
+  attachServeDiagnostics,
+} from "../../helpers/cockpit";
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-stuck-1",
+          title: "Slow tool",
+          kind: "read",
+          status: "pending",
+        },
+        { sessionUpdate: "wait_ms", ms: 30_000 },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("stopping mid-tool settles the card and survives reload", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-stuck-tool-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-stuck-tool" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-stuck-tool");
+    if (!seeded) throw new Error("seeded session 'story-stuck-tool' missing");
+    const sessionId = seeded.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("run a slow tool");
+    await composer.press("Enter");
+
+    // The running tool card mounts; the badge is "running" until the
+    // turn ends.
+    await expect(page.getByText("Slow tool")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("running", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const stopButton = page.getByRole("button", { name: "Stop" });
+    await expect(stopButton).toBeVisible({ timeout: 10_000 });
+    await stopButton.click();
+
+    // The card settles to the distinct terminal "stopped" state instead
+    // of staying "running" forever. `exact` so the lowercase badge does
+    // not match an unrelated "Stopped" banner.
+    await expect(page.getByText("stopped", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("running", { exact: true })).toBeHidden();
+
+    // The stuck state was persisted before the fix, so a reload must
+    // still show the card terminal: the trailing Stopped replays through
+    // the same reducer sweep.
+    await page.reload();
+    await waitForCockpitView(page);
+    await expect(page.getByText("Slow tool")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("stopped", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("running", { exact: true })).toBeHidden();
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/web/tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts
+++ b/web/tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts
@@ -12,7 +12,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { test as base, expect } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import {
   spawnAoeServe,
   listSessions,
@@ -42,7 +42,7 @@ const SCRIPT = {
   ],
 };
 
-base("stopping mid-tool settles the card and survives reload", async ({ page }, testInfo) => {
+test("stopping mid-tool settles the card and survives reload", async ({ page }, testInfo) => {
   let serveHandle: { home: string } | undefined;
   let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
   const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-stuck-tool-"));

--- a/web/tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts
+++ b/web/tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts
@@ -42,6 +42,16 @@ const SCRIPT = {
   ],
 };
 
+// The tool card whose primary title is "Slow tool". Anchored on the
+// exact title span (the prompt echo "run a slow tool" and the spinner
+// "Operating Slow tool…" are not exact matches), then walked up to the
+// card root so badge text reads only inside this card.
+function cardFor(page: import("@playwright/test").Page) {
+  return page
+    .getByText("Slow tool", { exact: true })
+    .locator("xpath=ancestor::div[contains(@class,'rounded-md')][1]");
+}
+
 test("stopping mid-tool settles the card and survives reload", async ({ page }, testInfo) => {
   let serveHandle: { home: string } | undefined;
   let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
@@ -73,10 +83,14 @@ test("stopping mid-tool settles the card and survives reload", async ({ page }, 
     await composer.fill("run a slow tool");
     await composer.press("Enter");
 
-    // The running tool card mounts; the badge is "running" until the
-    // turn ends.
-    await expect(page.getByText("Slow tool")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("running", { exact: true })).toBeVisible({
+    // The running tool card mounts; its badge is "running" until the
+    // turn ends. Scope assertions to the card so the badge text does not
+    // match the prompt echo ("run a slow tool") or the working spinner
+    // ("Operating Slow tool…"); `exact` title resolves to the card's
+    // primary span alone.
+    const card = cardFor(page);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card.getByText("running", { exact: true })).toBeVisible({
       timeout: 10_000,
     });
 
@@ -85,23 +99,23 @@ test("stopping mid-tool settles the card and survives reload", async ({ page }, 
     await stopButton.click();
 
     // The card settles to the distinct terminal "stopped" state instead
-    // of staying "running" forever. `exact` so the lowercase badge does
-    // not match an unrelated "Stopped" banner.
-    await expect(page.getByText("stopped", { exact: true })).toBeVisible({
+    // of staying "running" forever.
+    await expect(card.getByText("stopped", { exact: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("running", { exact: true })).toBeHidden();
+    await expect(card.getByText("running", { exact: true })).toBeHidden();
 
     // The stuck state was persisted before the fix, so a reload must
     // still show the card terminal: the trailing Stopped replays through
     // the same reducer sweep.
     await page.reload();
     await waitForCockpitView(page);
-    await expect(page.getByText("Slow tool")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("stopped", { exact: true })).toBeVisible({
+    const cardAfter = cardFor(page);
+    await expect(cardAfter).toBeVisible({ timeout: 10_000 });
+    await expect(cardAfter.getByText("stopped", { exact: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("running", { exact: true })).toBeHidden();
+    await expect(cardAfter.getByText("running", { exact: true })).toBeHidden();
   } finally {
     try {
       if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the web cockpit, stopping the agent while a tool call was mid-execution left the tool card stuck "running": the elapsed-time timer counted up forever and the badge stayed orange, as if the tool were still executing. The state persisted across reload, so it never self-healed.

The card's status is derived from whether a paired completion row exists in `state.activity` (`ToolCards.tsx` `statusFor`), not from the single `inFlightTool` pointer. On a mid-tool cancel, claude-agent-acp resolves the prompt with `StopReason::Cancelled` and never sends a per-tool `ToolCallUpdate`, so the backend emits only a turn-level `Stopped` and no per-tool completion. The reducer's `Stopped` arm nulled `inFlightTool` but never closed the open `tool_start` rows, so the card had no terminal row and stayed "running" forever. Because `Stopped` is persisted and replayed through the same reducer, reload reproduced the stuck state.

This adds a reducer sweep that, on any turn-ending event (`Stopped`, `AgentSwitched`, `IncompatibleAgent`, `AgentStartupError`), synthesizes a terminal row for every still-open tool call. It is reason-independent: once a turn ends, no tool from it can still be running, and a dangling tool whose outcome was never reported is "stopped", not "done" or "failed". The card gets a distinct terminal **stopped** state (muted dot, "stopped" badge) rather than the misleading "done" (claims a success that never happened) or "failed" (claims an error that never happened). The fix works live and on reload, since the sweep re-applies on the replayed trailing `Stopped`.

A durable backend fix (emitting per-tool terminal events at the cancel source so the persisted store is authoritative for every client) is deliberately left as a follow-up; the frontend sweep is self-contained and also repairs already-persisted sessions, which a backend-only fix would not.

Closes #1646

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the cockpit, prompt the agent to run a long tool (e.g. a slow shell command); confirm the tool card shows the orange "running" badge with a counting timer.
- [ ] Click Stop while the tool is still running; confirm the card's timer freezes and the badge changes to a muted "stopped" (not orange "running", not "failed").
- [ ] Reload the page; confirm the same card still shows "stopped", not "running".
- [ ] Let a normal tool complete; confirm it still shows "done". Let a tool error; confirm it still shows "failed".
- [ ] Trigger a mid-turn agent switch (e.g. rate-limit failover) with an open tool; confirm the open tool card settles to "stopped" above the switch divider.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction (with a `/debate` consult on scope). I made the design calls (frontend sweep + distinct "stopped" state now, backend emission deferred), reviewed each commit, and ran the test sweeps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary: Fix Tool Card Terminal State When Stopped Mid-Execution

## What changed (high level)
- Fixed a UI bug where stopping an agent while a tool call was mid-execution left the tool card stuck in a running state (timer continued, orange badge) even after reload.
- Added a reducer "turn-end sweep" that synthesizes terminal tool rows for any open tool calls when a turn ends, so tool cards freeze and show a terminal state.
- Introduced a distinct "stopped" visual state for tool cards (muted status dot and "stopped" badge) and froze elapsed timers for stopped runs.
- Threaded a `stopped` flag through message/bridge and grouping logic so stopped completions survive grouping, subagents, and persisted/replayed sessions.
- Added tests (reducer/unit, runtime/bridge, render, Playwright E2E story), fixtures, and docs updates.

## Key files added/updated
- Core sweep & types: web/src/lib/cockpitTypes.ts (adds "tool_stopped" kind, sweepOpenToolCalls)
- Runtime/bridge: web/src/components/cockpit/CockpitRuntime.tsx, web/src/components/cockpit/CockpitView.tsx
- UI rendering/status: web/src/components/cockpit/ToolCards.tsx, web/src/components/cockpit/ToolErrorBody.tsx
- Tests: web/src/lib/cockpitStopSweep.test.ts, web/src/components/cockpit/CockpitRuntime.test.ts, web/src/components/cockpit/ToolCards.render.test.tsx, web/tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts
- Fixtures/docs/coverage: web/src/components/cockpit/__fixtures__/toolCalls.ts, docs/cockpit.md, web/tests/coverage-matrix.json

## Benefits
- Ensures tool cards always settle to a terminal state when a turn ends without per-tool completion events (covers live sessions and persisted reloads).
- Improves UX by providing a clear, non-error "stopped" state instead of mislabeling as running/done/failed.
- Makes the frontend resilient to backend/adapter behavior that emits only turn-level stop events.
- Good test coverage reduces risk of regressions.

## Technical details (concise)
- Root cause: when a tool was canceled mid-execution, the backend emitted only a turn-level `Stopped` event and no per-tool completion; the UI inferred running from the lack of a terminal row.
- Fix:
  - Add sweepOpenToolCalls invoked on turn-ending events (`Stopped`, `AgentSwitched`, `IncompatibleAgent`, `AgentStartupError`) to:
    - Find `tool_start` rows missing terminal siblings (`tool_complete`/`tool_error`/`tool_stopped`).
    - Synthesize exactly one `tool_stopped` row per unique toolCallId, draining any buffered streamed content into it.
    - Clear `inFlightTool`, deduplicate duplicate starts, and avoid double-closing across repeated terminal events or replay.
  - Add new ActivityRow kind `"tool_stopped"` and thread a boolean `stopped` flag through assistant/bridge assembly and grouping so render code can distinguish stopped vs done/error.
  - UI: map `tool_stopped` → `"stopped"` status; render muted/stopped badge and freeze elapsed-time display.
- Tests:
  - Reducer/unit tests cover sweep behavior (dedupe, buffered content, replay/repair, no double-close).
  - Runtime/bridge tests ensure `stopped` threads into tool-call payloads and survives subagent/grouping.
  - Render tests check badge text, styling, and frozen duration.
  - Playwright E2E story verifies stop-mid-tool then reload preserves stopped state.

## Notes / follow-up
- Backend improvement to emit per-tool terminal events at cancel time is acknowledged and intentionally deferred; this PR provides a robust frontend repair until the backend emits per-tool terminals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->