### PR TITLE
fix(serve): surface real create-session errors on the web dashboard

### DIFF
--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -9,6 +9,9 @@ pub enum GitError {
     #[error("Worktree already exists at {}", .0.display())]
     WorktreeAlreadyExists(PathBuf),
 
+    #[error("Branch '{0}' is already in use by another worktree")]
+    BranchAlreadyCheckedOut(String),
+
     #[error("Worktree not found at {}", .0.display())]
     WorktreeNotFound(PathBuf),
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -31,6 +31,23 @@ fn sanitize_remote_credentials(s: &str) -> String {
     re.replace_all(s, "${1}<redacted>@").into_owned()
 }
 
+/// Classify a failed `git worktree add` into a typed error.
+///
+/// The branch-already-checked-out case (git prints `'<branch>' is already
+/// used by worktree at '<path>'`, or `already checked out at '<path>'` on
+/// older git) becomes a clean `BranchAlreadyCheckedOut` that names the
+/// branch and drops the raw stderr (including the other worktree's path).
+/// Everything else stays `WorktreeCommandFailed`, with any credentialed
+/// remote URL redacted before it can be surfaced.
+fn classify_worktree_add_failure(combined: &str, branch: &str) -> GitError {
+    let lower = combined.to_ascii_lowercase();
+    if lower.contains("already used by worktree") || lower.contains("already checked out at") {
+        GitError::BranchAlreadyCheckedOut(branch.to_string())
+    } else {
+        GitError::WorktreeCommandFailed(sanitize_remote_credentials(combined))
+    }
+}
+
 /// Remote name used as a fallback when no candidate remote can be picked
 /// from the local refs. Real selection happens in
 /// `detect_default_branch_info`, which walks every configured remote and
@@ -639,6 +656,11 @@ impl GitWorktree {
                 (true, false) => stderr,
                 (false, false) => format!("{stdout}\n{stderr}"),
             };
+            // Redact any credentialed remote URL before this text can reach
+            // the debug log or the client (via the warnings channel below or
+            // the error message). Idempotent, so the second pass inside
+            // `classify_worktree_add_failure` is a no-op.
+            let combined = sanitize_remote_credentials(&combined);
 
             // post-checkout hooks (e.g. pre-commit's hook-type=post-checkout
             // running uv-sync, npm install, etc.) can fail after git has
@@ -655,7 +677,7 @@ impl GitWorktree {
                 tracing::warn!(target: "git.worktree", "worktree create: {}", warning);
                 warnings.push(warning);
             } else {
-                return Err(GitError::WorktreeCommandFailed(combined));
+                return Err(classify_worktree_add_failure(&combined, branch));
             }
         }
 
@@ -2627,6 +2649,36 @@ mod tests {
         // is correct: there is no embedded password to redact.
         let s = "fatal: Could not read from remote: git@github.com:foo/bar.git";
         assert_eq!(sanitize_remote_credentials(s), s);
+    }
+
+    #[test]
+    fn test_classify_worktree_add_failure_branch_in_use() {
+        // Current git wording.
+        let combined =
+            "fatal: 'feature/foo' is already used by worktree at '/tmp/repo-worktrees/feature-foo'";
+        match classify_worktree_add_failure(combined, "feature/foo") {
+            GitError::BranchAlreadyCheckedOut(b) => assert_eq!(b, "feature/foo"),
+            other => panic!("expected BranchAlreadyCheckedOut, got {other:?}"),
+        }
+        // Older git wording.
+        let combined_old = "fatal: 'feature/foo' is already checked out at '/tmp/other'";
+        assert!(matches!(
+            classify_worktree_add_failure(combined_old, "feature/foo"),
+            GitError::BranchAlreadyCheckedOut(_)
+        ));
+    }
+
+    #[test]
+    fn test_classify_worktree_add_failure_redacts_credentials() {
+        let combined =
+            "fatal: unable to access 'https://alice:supersecret@github.com/foo/bar.git/': 403";
+        match classify_worktree_add_failure(combined, "feature/foo") {
+            GitError::WorktreeCommandFailed(msg) => {
+                assert!(!msg.contains("supersecret"), "token leaked: {msg}");
+                assert!(!msg.contains("alice:"), "username leaked: {msg}");
+            }
+            other => panic!("expected WorktreeCommandFailed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -1809,15 +1809,15 @@ mod tests {
             .unwrap();
 
         // Try creating again at a different path but same branch - git won't
-        // allow two worktrees to check out the same branch.
+        // allow two worktrees to check out the same branch. This is the
+        // branch-already-checked-out case, so it maps to the typed
+        // BranchAlreadyCheckedOut error naming the branch.
         let wt_path2 = dir.path().join("fail-worktree-2");
         let result = git_wt.create_worktree("fail-branch", &wt_path2, false, None);
-        assert!(result.is_err());
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(
-            err_msg.contains("worktree command failed"),
-            "Expected WorktreeCommandFailed error, got: {err_msg}"
-        );
+        match result {
+            Err(GitError::BranchAlreadyCheckedOut(branch)) => assert_eq!(branch, "fail-branch"),
+            other => panic!("Expected BranchAlreadyCheckedOut error, got: {other:?}"),
+        }
     }
 
     // ---- Full worktree creation flow tests for regular repos ----

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -10,6 +10,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::git::error::GitError;
 use crate::session::{EnsureReadyError, EnsureReadyOutcome, Instance, Status, Storage};
 
 use super::validate_no_shell_injection;
@@ -2057,7 +2058,7 @@ pub async fn create_session(
             tracing::warn!(target: "http.api.sessions", "Session creation failed: {}", e);
             (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "create_failed", "message": "Failed to create session"})),
+                Json(serde_json::json!({"error": "create_failed", "message": public_create_session_error(&e)})),
             )
                 .into_response()
         }
@@ -2070,6 +2071,33 @@ pub async fn create_session(
                 .into_response()
         }
     }
+}
+
+/// Pick the client-facing message for a failed session creation.
+///
+/// The full error is always logged server-side; this only governs what
+/// reaches the browser. We whitelist the well-typed `GitError` variants
+/// that carry a clear, actionable, credential-free message (a branch name
+/// or a worktree path the user chose) and let everything else fall back to
+/// the generic string. This keeps raw git stderr, libgit2 internals, IO
+/// paths, and arbitrary `bail!` strings off the wire even though the
+/// duplicate-worktree case now surfaces its real message.
+fn public_create_session_error(e: &anyhow::Error) -> String {
+    if let Some(git_err) = e.chain().find_map(|c| c.downcast_ref::<GitError>()) {
+        match git_err {
+            GitError::WorktreeAlreadyExists(_)
+            | GitError::BranchAlreadyCheckedOut(_)
+            | GitError::BranchNotFound(_)
+            | GitError::NotAGitRepo => return git_err.to_string(),
+            // Raw command output / libgit2 / IO: not safe to expose.
+            GitError::WorktreeCommandFailed(_)
+            | GitError::CloneFailed(_)
+            | GitError::WorktreeNotFound(_)
+            | GitError::Git2Error(_)
+            | GitError::IoError(_) => {}
+        }
+    }
+    "Failed to create session".to_string()
 }
 
 // --- Ensure agent session ---
@@ -2994,6 +3022,58 @@ mod tests {
         inst.status = Status::Running;
         inst.group_path = "work/projects".to_string();
         inst
+    }
+
+    #[test]
+    fn public_create_session_error_forwards_whitelisted_git_errors() {
+        let dup: anyhow::Error =
+            GitError::WorktreeAlreadyExists(std::path::PathBuf::from("/tmp/repo-worktrees/foo"))
+                .into();
+        assert_eq!(
+            public_create_session_error(&dup),
+            "Worktree already exists at /tmp/repo-worktrees/foo"
+        );
+
+        let in_use: anyhow::Error =
+            GitError::BranchAlreadyCheckedOut("feature/foo".to_string()).into();
+        assert_eq!(
+            public_create_session_error(&in_use),
+            "Branch 'feature/foo' is already in use by another worktree"
+        );
+
+        // Whitelisted variants survive an anyhow::Context wrapper too.
+        let wrapped = anyhow::Error::from(GitError::BranchNotFound("nope".to_string()))
+            .context("while creating worktree");
+        assert_eq!(
+            public_create_session_error(&wrapped),
+            "Branch 'nope' not found"
+        );
+    }
+
+    #[test]
+    fn public_create_session_error_hides_unsafe_messages() {
+        // Raw git stderr (even already-sanitized) must not reach the client.
+        let cmd: anyhow::Error = GitError::WorktreeCommandFailed(
+            "fatal: unable to access 'https://<redacted>@host/repo.git'".to_string(),
+        )
+        .into();
+        assert_eq!(
+            public_create_session_error(&cmd),
+            "Failed to create session"
+        );
+
+        let clone: anyhow::Error =
+            GitError::CloneFailed("https://alice:supersecret@host/repo.git".to_string()).into();
+        let msg = public_create_session_error(&clone);
+        assert_eq!(msg, "Failed to create session");
+        assert!(!msg.contains("supersecret"));
+
+        // A non-GitError anyhow also stays generic.
+        let other = anyhow::anyhow!("something internal at /home/user/.config/secret");
+        assert_eq!(
+            public_create_session_error(&other),
+            "Failed to create session"
+        );
     }
 
     #[test]

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -9,6 +9,7 @@ use anyhow::{bail, Result};
 use chrono::Utc;
 
 use crate::containers::{self, ContainerRuntimeInterface};
+use crate::git::error::GitError;
 use crate::git::GitWorktree;
 
 use super::{
@@ -470,7 +471,7 @@ pub fn build_instance(
                 let worktree_path = git_wt.compute_path(branch, template, &session_id[..8])?;
 
                 if worktree_path.exists() {
-                    bail!("Worktree already exists at {}", worktree_path.display());
+                    return Err(GitError::WorktreeAlreadyExists(worktree_path.clone()).into());
                 }
 
                 let w = git_wt.create_worktree(

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -16,6 +16,17 @@
       ]
     },
     {
+      "id": "session.create-duplicate-worktree-error",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/session-create-duplicate-worktree.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ReviewStep.tsx"
+      ]
+    },
+    {
       "id": "terminal.live-output-resize",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/live/session-create-duplicate-worktree.spec.ts
+++ b/web/tests/live/session-create-duplicate-worktree.spec.ts
@@ -1,0 +1,67 @@
+// Live regression for #1649: a duplicate worktree/branch must surface the
+// real collision message, not the generic "Failed to create session".
+//
+// Drives the create-session HTTP boundary directly (the bug lived in the
+// handler, not the wizard UI): POST /api/sessions twice with the same new
+// branch against a real git repo. The first creates the worktree; the
+// second collides on the precomputed path and must return the informative
+// error the frontend already renders verbatim.
+
+import { test, expect } from "@playwright/test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+test("duplicate worktree branch returns the real collision error, not a generic one", async ({}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      const projectDir = join(home, "project");
+      mkdirSync(projectDir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: projectDir, env });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+        cwd: projectDir,
+        env: {
+          ...env,
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@t",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@t",
+        },
+      });
+    },
+  });
+
+  try {
+    const payload = {
+      path: join(serve.home, "project"),
+      tool: "claude",
+      title: "dup-session",
+      worktree_branch: "dup-branch",
+      create_new_branch: true,
+    };
+
+    const first = await fetch(`${serve.baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    expect(first.status).toBe(201);
+
+    const second = await fetch(`${serve.baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    expect(second.status).toBe(400);
+
+    const body = await second.json();
+    expect(body.message).toContain("Worktree already exists");
+    expect(body.message).not.toBe("Failed to create session");
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Creating a session whose worktree path or branch already exists failed on the web dashboard with a generic red "Failed to create session" box. The real, actionable error existed all along (the builder produces "Worktree already exists at /path/...", and the git layer knows when a branch is checked out elsewhere), but the create-session HTTP handler logged it and then substituted a hardcoded string, so the user never saw it.

The handler now forwards the real message through a whitelist of well-typed `GitError` variants (`WorktreeAlreadyExists`, `BranchAlreadyCheckedOut`, `BranchNotFound`, `NotAGitRepo`). Everything else still falls back to the generic string, so raw git stderr, libgit2 internals, IO paths, and arbitrary `bail!` strings never reach the browser. This whitelist-at-the-boundary shape was chosen over blindly forwarding `e.to_string()`: an `anyhow` Display only shows the top context (it can leak too much or mask the useful cause), and sanitizing a single construction site does not make the whole error graph safe to expose.

Supporting changes:
- The builder's duplicate-path `bail!` is now the typed `GitError::WorktreeAlreadyExists`, so the headline case is matched cleanly rather than by string.
- The "branch already used by / checked out at" git stderr maps to a new typed `GitError::BranchAlreadyCheckedOut(branch)` that names the branch and drops the raw stderr (including the other worktree's path).
- Credentialed remote URLs in a `git worktree add` failure are redacted at the source before that text can reach the log or the client (the warnings channel and the error message both consume it).

No frontend change is needed: the dashboard already renders whatever `message` the server returns (`web/src/lib/api.ts` -> `ReviewStep.tsx`).

Closes #1649

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start `aoe serve --no-auth`, open the dashboard, and create a worktree session on a git repo with a new branch (e.g. `dup-branch`). It succeeds.
- [ ] Create another session on the same repo with the same new branch name. The wizard now shows "Worktree already exists at ..." instead of "Failed to create session".
- [ ] Confirm the message names the actual conflict (the worktree path), so the cause is obvious.
- [ ] Sanity check that an unrelated git failure does not leak details: the generic "Failed to create session" still appears for non-whitelisted errors (verified by unit test).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a multi-model design debate that pushed the fix from forward-all to the whitelist-at-the-boundary shape. I made the design calls, reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR improves how the web dashboard displays error messages when users try to create duplicate sessions. Previously, all session creation failures showed a generic "Failed to create session" message. Now, the system forwards specific, user-friendly error messages for certain types of failures (like "Worktree already exists at [path]" or "Branch is already in use by another worktree") while still protecting sensitive information.

### Changes Made

**Error Handling & Messages:**
- Added a new error type `BranchAlreadyCheckedOut` to distinguish branch conflicts from other failures
- Created a helper function to classify git worktree failures into appropriate error types
- Added a whitelist at the HTTP handler boundary that forwards only safe, user-ready error messages to the dashboard

**Code Safety:**
- Implemented credential redaction to remove any embedded passwords or API keys from error messages before they reach logs or clients
- Converted a hardcoded error message to use the new typed error system

**Session Creation Path:**
- Updated the session builder to return typed errors instead of generic text messages
- Modified git worktree operations to detect and classify specific failure scenarios

**Testing & Coverage:**
- Added a Playwright test that verifies the dashboard shows "Worktree already exists..." when creating duplicate sessions
- Added unit tests for the new error classification logic and credential redaction

## Benefits

- **Better user experience**: Users see specific, actionable error messages instead of generic failures
- **Improved security**: Sensitive information (credentials, internal paths, git internals) is filtered before reaching the client
- **Easier debugging**: Clear distinction between different types of session creation failures
- **Type safety**: Error messages are now typed and validated, reducing the chance of missing cases

## Technical Details

The implementation follows a whitelist-at-boundary security pattern: git errors are classified into safe variants (`WorktreeAlreadyExists`, `BranchAlreadyCheckedOut`, `BranchNotFound`, `NotAGitRepo`) that can be safely shown to users, while unsafe variants (command failures, clone errors, libgit2 internals, I/O errors) default to the generic message. The error classification happens at two levels:

1. In `git/worktree.rs`: A new `classify_worktree_add_failure()` function maps git stderr patterns to typed `GitError` variants, with credential redaction applied before storage
2. In `server/api/sessions.rs`: A `public_create_session_error()` helper walks the error chain, extracts the `GitError` if present, and forwards only whitelisted variants to HTTP responses

This approach prevents information leakage while preserving the user-actionable error messages already produced upstream by git operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->