### PR TITLE
feat(tui): expose mouse-capture toggle in Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ website/src/pages/docs/development/*.md
 *.cast
 /test-results
 
+# PR review GIFs (uploaded to PR descriptions, not tracked)
+.gifs/
+
 # Coverage output (Vitest + Playwright + merged)
 web/coverage/
 web/playwright-report/

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -546,6 +546,16 @@ pub struct SessionConfig {
     #[serde(default = "default_true")]
     pub agent_status_hooks: bool,
 
+    /// Request xterm mouse tracking from the terminal so the TUI handles the
+    /// scroll wheel (preview-pane scroll, #795) and click-to-select rows.
+    /// Disable to hand wheel and text selection back to the terminal, e.g.
+    /// iOS Mosh + Termius/Blink, which don't reliably forward mouse-tracking
+    /// escapes. The `AOE_MOUSE_CAPTURE` env var stays as an opt-out backstop:
+    /// capture is requested only when this is true and the env var hasn't
+    /// disabled it. Default on.
+    #[serde(default = "default_true")]
+    pub mouse_capture: bool,
+
     /// User-defined custom agents: name -> launch command
     /// (e.g., "lenovo-claude" = "ssh -t lenovo claude").
     /// Custom agent names appear in the TUI agent picker alongside built-in agents.
@@ -710,6 +720,7 @@ impl Default for SessionConfig {
             agent_extra_args: HashMap::new(),
             agent_command_override: HashMap::new(),
             agent_status_hooks: true,
+            mouse_capture: true,
             custom_agents: HashMap::new(),
             agent_detect_as: HashMap::new(),
             strict_hotkeys: false,

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -238,6 +238,9 @@ pub struct SessionConfigOverride {
     pub agent_status_hooks: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mouse_capture: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_agents: Option<HashMap<String, String>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -477,6 +480,9 @@ pub fn apply_session_overrides(
     }
     if let Some(agent_status_hooks) = source.agent_status_hooks {
         target.agent_status_hooks = agent_status_hooks;
+    }
+    if let Some(mouse_capture) = source.mouse_capture {
+        target.mouse_capture = mouse_capture;
     }
     if let Some(ref custom_agents) = source.custom_agents {
         target.custom_agents = custom_agents.clone();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -103,6 +103,19 @@ pub struct App {
     /// it back on when the surface dismisses. Default true to match the
     /// startup `EnableMouseCapture` in `tui::run`.
     mouse_captured: bool,
+    /// Whether the resolved config permits xterm mouse tracking (the
+    /// `session.mouse_capture` field plus the `AOE_MOUSE_CAPTURE` backstop).
+    /// This is permission, not live state: `mouse_captured` tracks whether
+    /// tracking is actually engaged right now. Refreshed from disk on the
+    /// periodic reload so toggling Settings > Interaction > Mouse Capture takes
+    /// effect without a restart. When false, `sync_mouse_capture` keeps xterm
+    /// tracking off entirely.
+    mouse_capture_allowed: bool,
+    /// True when running under Mosh (`MOSH_CONNECTION` set). Mosh mangles
+    /// xterm mouse-tracking escapes, so `tui::run` skips the startup
+    /// `EnableMouseCapture` and `sync_mouse_capture` must not re-enable
+    /// tracking mid-session either.
+    mosh_active: bool,
     /// Set by `Action::OpenCockpit` so the async main loop can pick it
     /// up and enter the cockpit view (which needs `event_stream` access
     /// the sync `execute_action` can't lend out).
@@ -175,6 +188,7 @@ impl App {
         profile: &str,
         available_tools: AvailableTools,
         suppress_first_run_dialogs: bool,
+        mosh_active: bool,
     ) -> Result<Self> {
         let no_agents = !available_tools.any_available();
         let active_profile = if profile.is_empty() {
@@ -233,9 +247,13 @@ impl App {
             update_status_rx: None,
             dismissed_update_version,
             event_stream: Some(EventStream::new()),
-            // Initial state matches whatever `tui::run` did at startup;
-            // capture is on by default, off only if AOE_MOUSE_CAPTURE=0.
-            mouse_captured: crate::tui::mouse_capture_requested(),
+            // Initial state matches whatever `tui::run` did at startup: capture
+            // is requested by default, but Mosh suppresses the actual escape, so
+            // `mouse_captured` (live state) also factors in `mosh_active`.
+            // `mouse_capture_allowed` is permission only and ignores Mosh.
+            mouse_captured: crate::tui::mouse_capture_requested(&config.session) && !mosh_active,
+            mouse_capture_allowed: crate::tui::mouse_capture_requested(&config.session),
+            mosh_active,
             #[cfg(feature = "serve")]
             pending_cockpit_open: None,
             pending_install_version: None,
@@ -254,14 +272,17 @@ impl App {
         &mut self,
         terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     ) -> Result<()> {
-        // Mouse capture is on by default; AOE_MOUSE_CAPTURE=0 opts out so
-        // iOS Mosh + Termius/Blink use the terminal app's native scrollback
-        // for touch-scroll (Mosh doesn't reliably forward mouse-tracking
-        // escapes to mobile clients).
-        if !crate::tui::mouse_capture_requested() {
-            return Ok(());
-        }
-        let desired = !self.home.wants_text_selection();
+        // Mouse capture is on by default; the Mouse Capture setting (or the
+        // AOE_MOUSE_CAPTURE=0 backstop) opts out so iOS Mosh + Termius/Blink
+        // use the terminal app's native scrollback for touch-scroll (Mosh
+        // doesn't reliably forward mouse-tracking escapes to mobile clients).
+        // Folding `mouse_capture_allowed` into `desired` (rather than an early
+        // return) means flipping the setting off mid-session disables tracking
+        // on the next sync instead of leaving it stuck on. `mosh_active` is
+        // folded in too so a mid-session enable never emits the escape under
+        // Mosh, matching the startup gate in `tui::run`.
+        let desired =
+            self.mouse_capture_allowed && !self.mosh_active && !self.home.wants_text_selection();
         if desired == self.mouse_captured {
             return Ok(());
         }
@@ -318,7 +339,7 @@ impl App {
             crossterm::terminal::LeaveAlternateScreen,
             DisableBracketedPaste,
         )?;
-        if crate::tui::mouse_capture_requested() {
+        if self.mouse_captured {
             crossterm::execute!(terminal.backend_mut(), DisableMouseCapture)?;
         }
         crossterm::execute!(terminal.backend_mut(), crossterm::cursor::Show)?;
@@ -345,8 +366,8 @@ impl App {
         )?;
         // Defer mouse-capture restore to sync_mouse_capture so we don't
         // briefly enable it only to disable again when the user returned
-        // to the serve view. sync_mouse_capture itself respects the
-        // AOE_MOUSE_CAPTURE opt-out.
+        // to the serve view. sync_mouse_capture itself respects the Mouse
+        // Capture setting and the AOE_MOUSE_CAPTURE opt-out.
         self.sync_mouse_capture(terminal)?;
         std::io::Write::flush(terminal.backend_mut())?;
 
@@ -1084,6 +1105,17 @@ impl App {
             if last_disk_refresh.elapsed() >= DISK_REFRESH_INTERVAL && self.home.live_send.is_none()
             {
                 self.home.reload()?;
+                // Pick up a Settings > Interaction > Mouse Capture toggle from
+                // disk and apply it now, so capture turns on/off within the
+                // reload window instead of waiting for a restart.
+                let profile = self.home.active_profile.as_deref().unwrap_or("default");
+                let mouse_capture_allowed = crate::session::resolve_config(profile)
+                    .map(|c| crate::tui::mouse_capture_requested(&c.session))
+                    .unwrap_or(self.mouse_capture_allowed);
+                if mouse_capture_allowed != self.mouse_capture_allowed {
+                    self.mouse_capture_allowed = mouse_capture_allowed;
+                    self.sync_mouse_capture(terminal)?;
+                }
                 last_disk_refresh = std::time::Instant::now();
                 refresh_needed = true;
                 needs_full_refresh = true;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -32,12 +32,23 @@ use std::io::{self, IsTerminal, Write};
 use crate::migrations;
 
 /// Whether the TUI should request mouse capture (`\e[?1000h` etc.) from the
-/// terminal. Default ON to preserve the preview-pane mouse-wheel scroll
-/// feature added in #795. Set `AOE_MOUSE_CAPTURE=0` (or `false`) on iOS
-/// Mosh + Termius/Blink to opt out, so the terminal app's own scrollback
-/// buffer handles wheel events (Mosh doesn't reliably forward mouse
-/// tracking to mobile clients).
-pub fn mouse_capture_requested() -> bool {
+/// terminal. The Settings entry (Interaction > Mouse Capture, backed by
+/// `session.mouse_capture`) is the primary control; the `AOE_MOUSE_CAPTURE`
+/// env var stays as an opt-out backstop for environments where the toggle
+/// isn't reachable (e.g. iOS Mosh + Termius/Blink, which don't reliably
+/// forward mouse-tracking escapes to mobile clients). Capture is requested
+/// only when the config allows it AND the env var hasn't disabled it, so a
+/// `false` from either source wins and an existing `AOE_MOUSE_CAPTURE=0`
+/// keeps working. Default ON to preserve the preview-pane mouse-wheel scroll
+/// feature added in #795.
+pub fn mouse_capture_requested(session: &crate::session::config::SessionConfig) -> bool {
+    session.mouse_capture && env_mouse_capture_allows()
+}
+
+/// The legacy `AOE_MOUSE_CAPTURE` opt-out: `0`/`false` disables capture, any
+/// other value (or an unset var) leaves it enabled. Kept as a backstop to
+/// the Settings toggle.
+fn env_mouse_capture_allows() -> bool {
     std::env::var("AOE_MOUSE_CAPTURE")
         .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false")))
         .unwrap_or(true)
@@ -123,8 +134,9 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
     // Mouse capture is ON by default to preserve preview-pane wheel scroll
-    // (#795); set AOE_MOUSE_CAPTURE=0 to opt out on iOS Mosh + Termius/Blink,
-    // which can't reliably forward mouse-tracking escapes to mobile clients.
+    // (#795); toggle it off via Settings > Interaction > Mouse Capture, or set
+    // AOE_MOUSE_CAPTURE=0 as a backstop on iOS Mosh + Termius/Blink, which
+    // can't reliably forward mouse-tracking escapes to mobile clients.
     //
     // Additionally: even when explicitly requested, Mosh mangles xterm
     // mouse-tracking escapes (inverted/duplicated scroll on Termius, Blink,
@@ -133,7 +145,12 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     // when present, fall back to the terminal's native scroll regardless of
     // AOE_MOUSE_CAPTURE so the user can select text without aoe eating events.
     let mosh_active = std::env::var_os("MOSH_CONNECTION").is_some();
-    if mouse_capture_requested() && !mosh_active {
+    // Resolve once for the enable/disable bookends; `App` re-resolves on its
+    // own reload cadence so a mid-session settings toggle still applies.
+    let startup_session_config = crate::session::resolve_config(profile)
+        .map(|c| c.session)
+        .unwrap_or_default();
+    if mouse_capture_requested(&startup_session_config) && !mosh_active {
         execute!(stdout, EnableMouseCapture)?;
     }
     let backend = CrosstermBackend::new(stdout);
@@ -160,7 +177,12 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     };
 
     // Create app and run
-    let mut app = App::new(profile, available_tools, combined_warning.is_some())?;
+    let mut app = App::new(
+        profile,
+        available_tools,
+        combined_warning.is_some(),
+        mosh_active,
+    )?;
     if let Some(warning) = combined_warning {
         app.show_startup_warning(&warning);
     }
@@ -175,10 +197,79 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
         LeaveAlternateScreen,
         DisableBracketedPaste
     )?;
-    if mouse_capture_requested() && !mosh_active {
+    if mouse_capture_requested(&startup_session_config) && !mosh_active {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
     }
     terminal.show_cursor()?;
 
     result
+}
+
+#[cfg(test)]
+mod mouse_capture_tests {
+    use super::mouse_capture_requested;
+    use crate::session::config::SessionConfig;
+    use serial_test::serial;
+
+    /// Restores `AOE_MOUSE_CAPTURE` to its prior value on drop so the
+    /// process-global env var doesn't leak between serial tests.
+    struct EnvGuard(Option<String>);
+
+    impl EnvGuard {
+        fn set(val: Option<&str>) -> Self {
+            let prev = std::env::var("AOE_MOUSE_CAPTURE").ok();
+            apply(val);
+            EnvGuard(prev)
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            apply(self.0.as_deref());
+        }
+    }
+
+    fn apply(val: Option<&str>) {
+        match val {
+            Some(v) => std::env::set_var("AOE_MOUSE_CAPTURE", v),
+            None => std::env::remove_var("AOE_MOUSE_CAPTURE"),
+        }
+    }
+
+    fn session_with(mouse_capture: bool) -> SessionConfig {
+        SessionConfig {
+            mouse_capture,
+            ..SessionConfig::default()
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn enabled_config_without_env_requests_capture() {
+        let _g = EnvGuard::set(None);
+        assert!(mouse_capture_requested(&session_with(true)));
+    }
+
+    #[test]
+    #[serial]
+    fn disabled_config_opts_out_even_without_env() {
+        let _g = EnvGuard::set(None);
+        assert!(!mouse_capture_requested(&session_with(false)));
+    }
+
+    #[test]
+    #[serial]
+    fn env_zero_still_wins_over_enabled_config() {
+        // The pre-existing AOE_MOUSE_CAPTURE=0 escape hatch keeps working
+        // even though the config defaults to enabled (#1346).
+        let _g = EnvGuard::set(Some("0"));
+        assert!(!mouse_capture_requested(&session_with(true)));
+    }
+
+    #[test]
+    #[serial]
+    fn env_true_does_not_re_enable_disabled_config() {
+        let _g = EnvGuard::set(Some("1"));
+        assert!(!mouse_capture_requested(&session_with(false)));
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -145,8 +145,8 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     // when present, fall back to the terminal's native scroll regardless of
     // AOE_MOUSE_CAPTURE so the user can select text without aoe eating events.
     let mosh_active = std::env::var_os("MOSH_CONNECTION").is_some();
-    // Resolve once for the enable/disable bookends; `App` re-resolves on its
-    // own reload cadence so a mid-session settings toggle still applies.
+    // Resolve once for the startup enable; `App` re-resolves on its own reload
+    // cadence so a mid-session settings toggle still applies.
     let startup_session_config = crate::session::resolve_config(profile)
         .map(|c| c.session)
         .unwrap_or_default();
@@ -197,7 +197,10 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
         LeaveAlternateScreen,
         DisableBracketedPaste
     )?;
-    if mouse_capture_requested(&startup_session_config) && !mosh_active {
+    // Always disable on teardown (except Mosh, where we never enabled): a
+    // mid-session Settings toggle can turn capture on after startup, so gating
+    // disable on the startup snapshot would leave capture stuck on at exit.
+    if !mosh_active {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
     }
     terminal.show_cursor()?;

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -109,6 +109,7 @@ pub enum FieldKey {
     NewSessionAttachMode,
     DefaultAttachMode,
     ClickAction,
+    MouseCapture,
     // Sound
     SoundEnabled,
     SoundMode,
@@ -1947,6 +1948,12 @@ fn build_interaction_fields(
         session.and_then(|s| s.click_action),
     );
 
+    let (mouse_capture, mouse_capture_override) = resolve_value(
+        scope,
+        global.session.mouse_capture,
+        session.and_then(|s| s.mouse_capture),
+    );
+
     vec![
         SettingField {
             key: FieldKey::DefaultAttachMode,
@@ -2042,6 +2049,24 @@ fn build_interaction_fields(
             inherited_display: inherited_if(
                 live_send_exit_chord_override,
                 FieldValue::Text(global.session.live_send_exit_chord.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::MouseCapture,
+            label: "Mouse Capture",
+            description: "Request xterm mouse tracking so the TUI handles the \
+                 scroll wheel (preview-pane scroll) and click-to-select rows. \
+                 Disable to hand the wheel and text selection back to the \
+                 terminal, e.g. iOS Mosh + Termius/Blink where mouse-tracking \
+                 escapes aren't forwarded reliably. The AOE_MOUSE_CAPTURE env \
+                 var remains an opt-out backstop and can still force capture \
+                 off when set.",
+            value: FieldValue::Bool(mouse_capture),
+            category: SettingsCategory::Interaction,
+            has_override: mouse_capture_override,
+            inherited_display: inherited_if(
+                mouse_capture_override,
+                FieldValue::Bool(global.session.mouse_capture),
             ),
         },
     ]
@@ -2538,6 +2563,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         }
         (FieldKey::AgentStatusHooks, FieldValue::Bool(v)) => {
             config.session.agent_status_hooks = *v;
+        }
+        (FieldKey::MouseCapture, FieldValue::Bool(v)) => {
+            config.session.mouse_capture = *v;
         }
         (FieldKey::DefaultImage, FieldValue::Text(v)) => config.sandbox.default_image = v.clone(),
         (FieldKey::Environment, FieldValue::List(v)) => config.sandbox.environment = v.clone(),
@@ -3039,6 +3067,11 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
         (FieldKey::AgentStatusHooks, FieldValue::Bool(v)) => {
             set_profile_override(*v, &mut config.session, |s, val| {
                 s.agent_status_hooks = val;
+            });
+        }
+        (FieldKey::MouseCapture, FieldValue::Bool(v)) => {
+            set_profile_override(*v, &mut config.session, |s, val| {
+                s.mouse_capture = val;
             });
         }
         (FieldKey::AgentExtraArgs, FieldValue::List(v)) => {
@@ -3715,6 +3748,7 @@ mod tests {
             FieldKey::NewSessionAttachMode,
             FieldKey::ClickAction,
             FieldKey::LiveSendExitChord,
+            FieldKey::MouseCapture,
         ] {
             assert!(
                 interaction_keys.contains(&k),

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -822,6 +822,11 @@ impl SettingsView {
                     s.agent_status_hooks = None;
                 }
             }
+            FieldKey::MouseCapture => {
+                if let Some(ref mut s) = config.session {
+                    s.mouse_capture = None;
+                }
+            }
             FieldKey::DefaultTerminalMode => {
                 if let Some(ref mut s) = config.sandbox {
                     s.default_terminal_mode = None;

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -27,6 +27,7 @@ mod profile_picker;
 mod project_registry;
 mod sandbox;
 mod serve;
+mod settings;
 mod tool_sessions;
 mod tui_launch;
 mod unified_view;

--- a/tests/e2e/settings.rs
+++ b/tests/e2e/settings.rs
@@ -1,0 +1,34 @@
+//! E2E coverage for the Settings TUI.
+
+use serial_test::serial;
+
+use crate::harness::{require_tmux, TuiTestHarness};
+
+/// The mouse-capture toggle (issue #1346) must be reachable from the Settings
+/// search and editable, so the env-only `AOE_MOUSE_CAPTURE` escape hatch is no
+/// longer the only knob. Search jumps to the field in the Interaction tab;
+/// Space flips it from the default-on state to Disabled.
+#[test]
+#[serial]
+fn settings_exposes_editable_mouse_capture_toggle() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("settings_mouse_capture");
+    h.spawn_tui();
+
+    h.wait_for("No sessions yet");
+    h.send_keys("s");
+    h.wait_for("Settings");
+
+    // Settings-wide search jumps straight to the field regardless of which
+    // category it lives in.
+    h.send_keys("/");
+    h.type_text("mouse capture");
+    h.wait_for("Mouse Capture");
+    h.send_keys("Enter");
+    h.assert_screen_contains("Mouse Capture");
+
+    // Default is on; toggling lands on the Disabled state.
+    h.send_keys("Space");
+    h.wait_for("Disabled");
+}


### PR DESCRIPTION
## Description

PR #1084 added `AOE_MOUSE_CAPTURE` as the only opt-out for the xterm mouse-tracking enabled by default in #795. Per `AGENTS.md` ("Settings & Configuration": every configurable field must be editable in the settings TUI), the long-term shape is a Settings toggle with the env var as a backstop. This wires that up.

**What changed**
- Add `session.mouse_capture: bool` (default `true`) to `SessionConfig`, wired through the full settings chain: `FieldKey::MouseCapture`, a `SettingField` in the **Interaction** tab, `apply_field_to_global` / `apply_field_to_profile`, `clear_profile_override`, and the `SessionConfigOverride` field + `merge_configs` logic.
- `mouse_capture_requested()` now takes the resolved `SessionConfig`. Capture is requested only when the config allows it **and** `AOE_MOUSE_CAPTURE` hasn't disabled it, so a `false` from either source wins and existing `AOE_MOUSE_CAPTURE=0` opt-outs keep working (the env var stays as a backstop for environments where the toggle isn't reachable, e.g. iOS Mosh).
- `App` refreshes the resolved gate on its periodic disk reload, so toggling the setting applies within the reload window instead of needing a restart. `sync_mouse_capture` folds the gate into `desired` so flipping it off mid-session disables tracking on the next sync.
- Comments in `src/tui/mod.rs` and `src/tui/app.rs` now point at the Settings entry alongside the env var.

Closes #1346

## Demo

> Settings → search → **Interaction → Mouse Capture** (default on, toggleable). The env var still works as a backstop.

**Before** (env var is the only knob; no Settings entry):
<img width="1400" height="820" alt="mouse-capture-before" src="https://github.com/user-attachments/assets/a5baafde-fea8-4921-be54-549438ff1f87" />


**After** (Mouse Capture toggle in the Interaction tab):
<img width="1400" height="820" alt="mouse-capture-after" src="https://github.com/user-attachments/assets/3d4ac34b-6fad-4199-a5f9-d1f8324b39b6" />

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary <!-- inline comments updated to point at the Settings entry -->
- [x] For UI changes: included screenshot or recording <!-- before/after gifs above -->

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow <!-- TUI-only change -->

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/` <!-- tests/e2e/settings.rs: opens Settings, searches, jumps to Mouse Capture, toggles it. Plus in-module unit tests for the config+env precedence in src/tui/mod.rs and the Interaction-tab placement test in src/tui/settings/fields.rs. -->
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**
Implementation, tests, and the before/after recordings were produced with Claude Code; reviewed by me.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR exposes xterm mouse-capture as a first-class, editable setting in the TUI Settings UI (Interaction > Mouse Capture) instead of being controllable only via the AOE_MOUSE_CAPTURE environment variable. The setting is persisted on the session/profile layer, respects the existing env-var opt-out, and the running app picks up changes within the periodic disk-reload window.

## What changed (high level)

- Configuration
  - Added SessionConfig.mouse_capture: bool (default true).
  - Added SessionConfigOverride.mouse_capture: Option<bool> for per-profile overrides.
  - Merge/override logic updated to propagate the new override field.

- Settings UI
  - New FieldKey::MouseCapture variant.
  - "Mouse Capture" toggle added to Interaction tab with full apply/clear/profile-override semantics.

- Application behavior
  - mouse_capture_requested(session: &SessionConfig) now resolves via the session config and still respects AOE_MOUSE_CAPTURE as a backstop (false from either disables capture).
  - App tracks permission (mouse_capture_allowed) separately from live state (mouse_captured) and considers mosh_active and text-selection state when enabling capture.
  - Periodic disk reload refreshes permission and re-syncs capture, so toggles take effect mid-session within the reload window.
  - Teardown always disables mouse capture to avoid leaving the terminal captured.

- Tests & misc
  - Added end-to-end test validating the Settings toggle.
  - Unit tests updated for new API and env-var guarding.
  - .gitignore updated to ignore .gifs used for PR review recordings.
  - Comments updated to reference the Settings entry alongside AOE_MOUSE_CAPTURE.

## Benefits

- Users can toggle mouse capture from the TUI, with persistent session/profile configuration.
- Backward compatibility: existing AOE_MOUSE_CAPTURE=0 opt-outs still work.
- Runtime flexibility: permission changes are respected and applied without restart (within reload intervals).
- Consistent settings model: follows the project's profile-override patterns.

## Technical notes (concise)

- Public API change: mouse_capture_requested signature now accepts &SessionConfig.
- App::new gained a mosh_active parameter; App struct adds mouse_capture_allowed and uses mouse_captured for live state.
- Settings plumbing updated in src/tui/settings/* to surface, apply, and clear the new field.
- Tests added/updated: tests/e2e/settings.rs and mouse-capture unit tests in src/tui/mod.rs; env var handling preserved in tests to avoid interference.

## Potential enhancements / follow-ups

- Make immediate in-process application of the setting (without waiting for the periodic reload) deterministic for UX-critical toggles.
- Expose a shorter reload-apply path or notify the user when a change will take effect on next reload to reduce surprise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->