### PR TITLE
fix: reconcile session id from disk before restart (serve + TUI)

### DIFF
--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2238,6 +2238,12 @@ pub async fn ensure_session(
     let restart_result = tokio::task::spawn_blocking(
         move || -> Result<(Instance, crate::session::StartOutcome), Box<(Instance, anyhow::Error)>> {
             let mut inst = instance;
+            // The clone above came from `state.instances`, which lags disk by
+            // up to one status-poll tick (~2s). A CLI `set-session-id` that
+            // landed inside that window already wrote `sessions.json`; restart
+            // here would resume the stale in-memory sid and re-persist it over
+            // the user's change. Re-read the disk-authoritative value first.
+            inst.reconcile_session_id_from_disk();
             // Use kill_clean (vs bare tmux kill) so a remain-on-exit dead
             // pane is respawned-then-killed; bare kill races against the
             // session cache on macOS and can leave the corpse pane behind,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -743,11 +743,15 @@ impl Instance {
     }
 
     /// Reconcile `agent_session_id` against the disk-authoritative value
-    /// before a restart that would re-persist it. The daemon's in-memory
-    /// instances only catch up to disk on the next `status_poll_loop` tick
-    /// (~2s); inside that window a CLI `aoe session set-session-id` (or
-    /// `--clear`) has already written `sessions.json` while this clone still
-    /// holds the old sid. Restarting from the stale clone resumes the wrong
+    /// before a restart that would re-persist it. A long-running daemon (the
+    /// `aoe serve` REST `ensure_session` path, or a standalone `aoe -p ...`
+    /// TUI) mirrors `agent_session_id` in memory but never reloads it from
+    /// disk on its own: it is not a `merge_from_tui` field, so the TUI save
+    /// loop leaves it alone, and the serve poller only catches up on its next
+    /// `status_poll_loop` tick (~2s). Inside that window a CLI
+    /// `aoe session set-session-id` (or `--clear`) from another terminal has
+    /// already written `sessions.json` while this in-memory instance still
+    /// holds the old sid. Restarting off the stale value resumes the wrong
     /// conversation and re-persists the old sid back over the user's change.
     /// Re-reading from disk here closes that window. No-op when the instance
     /// is absent from storage or the read fails, leaving the in-memory value.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -742,6 +742,32 @@ impl Instance {
         }
     }
 
+    /// Reconcile `agent_session_id` against the disk-authoritative value
+    /// before a restart that would re-persist it. The daemon's in-memory
+    /// instances only catch up to disk on the next `status_poll_loop` tick
+    /// (~2s); inside that window a CLI `aoe session set-session-id` (or
+    /// `--clear`) has already written `sessions.json` while this clone still
+    /// holds the old sid. Restarting from the stale clone resumes the wrong
+    /// conversation and re-persists the old sid back over the user's change.
+    /// Re-reading from disk here closes that window. No-op when the instance
+    /// is absent from storage or the read fails, leaving the in-memory value.
+    pub fn reconcile_session_id_from_disk(&mut self) {
+        match super::storage::Storage::new(&self.source_profile).and_then(|s| s.load()) {
+            Ok(instances) => {
+                if let Some(disk) = instances.into_iter().find(|i| i.id == self.id) {
+                    self.agent_session_id = disk.agent_session_id;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(target: "session.store",
+                    session = %self.id,
+                    error = %e,
+                    "failed to reload disk agent_session_id before restart; using in-memory value",
+                );
+            }
+        }
+    }
+
     /// Splice TUI-mirrored, persisted fields from `src` onto `self`. Used by
     /// `HomeView::save` for fields the TUI is the canonical disk writer of
     /// (the daemon's `status_poll_loop` keeps these in memory only). The
@@ -4966,6 +4992,67 @@ mod tests {
             let loaded = storage.load().unwrap();
             assert_eq!(loaded.len(), 1);
             assert_eq!(loaded[0].agent_session_id, None);
+        }
+
+        #[test]
+        #[serial]
+        fn reconcile_session_id_from_disk_picks_up_cli_set() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let storage = crate::session::storage::Storage::new("reconcile-test").unwrap();
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = "reconcile-test".to_string();
+            inst.agent_session_id = Some("old-sid".to_string());
+            let id = inst.id.clone();
+            let on_disk = inst.clone();
+            storage
+                .update(|i, g| {
+                    *i = vec![on_disk.clone()];
+                    *g = crate::session::GroupTree::new_with_groups(&[on_disk.clone()], &[])
+                        .get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
+            // Simulate a CLI `set-session-id` landing on disk while `inst` is a
+            // stale in-memory daemon clone.
+            super::persist_session_to_storage("reconcile-test", &id, "new-sid");
+
+            assert_eq!(inst.agent_session_id.as_deref(), Some("old-sid"));
+            inst.reconcile_session_id_from_disk();
+            assert_eq!(inst.agent_session_id.as_deref(), Some("new-sid"));
+        }
+
+        #[test]
+        #[serial]
+        fn reconcile_session_id_from_disk_picks_up_cli_clear() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let storage = crate::session::storage::Storage::new("reconcile-clear").unwrap();
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = "reconcile-clear".to_string();
+            inst.agent_session_id = Some("old-sid".to_string());
+            let id = inst.id.clone();
+            let on_disk = inst.clone();
+            storage
+                .update(|i, g| {
+                    *i = vec![on_disk.clone()];
+                    *g = crate::session::GroupTree::new_with_groups(&[on_disk.clone()], &[])
+                        .get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
+            clear_session_id_on_disk("reconcile-clear", &id);
+
+            inst.reconcile_session_id_from_disk();
+            assert_eq!(inst.agent_session_id, None);
         }
 
         #[cfg(feature = "serve")]

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -250,6 +250,16 @@ impl HomeView {
         // non-status fields restart_with_size touches are kept.
         let size = crate::terminal::get_size();
         self.try_mutate_instance_writeback_on_err(&id, |inst| {
+            // The live instance can hold a stale `agent_session_id` relative
+            // to disk: a CLI `aoe session set-session-id`/`--clear` from
+            // another terminal writes `sessions.json` while this long-running
+            // TUI still mirrors the old sid (it is not a `merge_from_tui`
+            // field, so the periodic save loop never reloads it). Restarting
+            // off the stale value resumes the wrong conversation and
+            // re-persists the old sid over the user's change. Re-read the
+            // disk-authoritative value first, mirroring the REST
+            // `ensure_session` restart path.
+            inst.reconcile_session_id_from_disk();
             inst.restart_with_size(size).map(|_| ())
         })?;
 


### PR DESCRIPTION
Fixes #1024

## Description

A CLI `aoe session set-session-id <title> ""` (or `--clear`) correctly updates `sessions.json` on disk, but a long-running daemon keeps the **old** `agent_session_id` in memory and re-persists it on the next restart, silently undoing the CLI change. This is critical when paired with health-scan archiving: the session enters a `--resume <archived-sid>` death loop because the daemon won't honor the CLI clear.

Root cause: `agent_session_id` is **not** a `merge_from_tui` field, so the in-memory value is never reloaded from disk on its own — the TUI save loop leaves it alone and the serve poller only catches up on its next `status_poll_loop` tick (~2s). A restart that fires off the stale in-memory instance resumes the wrong conversation and writes the old sid back over the user's change.

### Fix

Add `Instance::reconcile_session_id_from_disk()` — re-reads the disk-authoritative `agent_session_id` — and call it immediately before the restart on **both** long-running-daemon restart paths the issue names:

- `aoe serve` REST `ensure_session` (`src/server/api/sessions.rs`)
- standalone TUI (`aoe -p default`) `restart_selected_session` (`src/tui/home/operations.rs`)

It is a no-op when the instance is absent from storage or the read fails, leaving the in-memory value intact.

The CLI `aoe session restart` and serve startup-recovery paths already read disk fresh, so they need no change.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added unit tests for the reconcile against both a CLI set and a CLI clear landing on disk while a stale in-memory instance is reconciled (`reconcile_session_id_from_disk_picks_up_cli_set`, `..._cli_clear`). The two restart call sites are thin wrappers over the tested function.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code

- [x] I am an AI Agent filling out this form (check box if true)
