### PR TITLE
feat(tui): guard against accidental exit (Ctrl+Q + confirm-before-quit)

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -652,6 +652,14 @@ pub struct SessionConfig {
     /// `default_attach_mode` regardless of this setting.
     #[serde(default)]
     pub click_action: ClickAction,
+
+    /// Show a "quit aoe?" confirmation when the user presses `q` to leave
+    /// the home screen, guarding against accidental exits (e.g. a Ctrl+Q
+    /// live-mode-exit habit landing on the home view). On by default;
+    /// the dialog offers a "don't warn me again" option that flips this
+    /// off. Ctrl+C still force-quits without a prompt.
+    #[serde(default = "default_true")]
+    pub confirm_before_quit: bool,
 }
 
 /// What a single mouse click on a session row does in the Agent view.
@@ -732,6 +740,7 @@ impl Default for SessionConfig {
             new_session_attach_mode: NewSessionAttachMode::default(),
             default_attach_mode: NewSessionAttachMode::default(),
             click_action: ClickAction::default(),
+            confirm_before_quit: true,
         }
     }
 }
@@ -2087,6 +2096,21 @@ mod tests {
             Some(&"--port 8080".to_string()),
             "agent_extra_args should survive roundtrip"
         );
+    }
+
+    #[test]
+    fn test_session_config_confirm_before_quit_defaults_on() {
+        // Default-on so existing users get the accidental-exit guard
+        // without opting in (#1569).
+        assert!(SessionConfig::default().confirm_before_quit);
+    }
+
+    #[test]
+    fn test_confirm_before_quit_absent_from_toml_defaults_on() {
+        // An older config.toml with no `confirm_before_quit` key must
+        // deserialize to the enabled default, not false.
+        let session: SessionConfig = toml::from_str("").unwrap();
+        assert!(session.confirm_before_quit);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1604,6 +1604,38 @@ fn poll_update_receiver(
     }
 }
 
+/// What a `q` key press at the home screen should do. Factored out of the
+/// key handler so the quit policy is unit-testable.
+#[derive(Debug, PartialEq, Eq)]
+enum QuitIntent {
+    /// Don't quit. Ctrl+Q lands here: it's reserved for exiting live-send
+    /// mode and must never close aoe from the home view (#1569).
+    Ignore,
+    /// A session is mid-creation; confirm before cancelling it.
+    ConfirmDuringCreation,
+    /// Confirm-before-quit is enabled; show the quit confirmation.
+    Confirm,
+    /// Quit immediately.
+    Quit,
+}
+
+fn quit_intent(
+    modifiers: KeyModifiers,
+    creation_pending: bool,
+    confirm_before_quit: bool,
+) -> QuitIntent {
+    if modifiers.contains(KeyModifiers::CONTROL) {
+        return QuitIntent::Ignore;
+    }
+    if creation_pending {
+        return QuitIntent::ConfirmDuringCreation;
+    }
+    if confirm_before_quit {
+        return QuitIntent::Confirm;
+    }
+    QuitIntent::Quit
+}
+
 impl App {
     async fn handle_key(
         &mut self,
@@ -1624,12 +1656,23 @@ impl App {
                 self.should_quit = true;
                 return Ok(());
             }
-            (KeyCode::Char('q'), _) if !self.home.has_dialog() => {
-                if self.home.is_creation_pending() {
-                    self.home.show_quit_during_creation_confirm();
-                    return Ok(());
+            (KeyCode::Char('q'), modifiers) if !self.home.has_dialog() => {
+                match quit_intent(
+                    modifiers,
+                    self.home.is_creation_pending(),
+                    self.home.confirm_before_quit(),
+                ) {
+                    QuitIntent::Ignore => {}
+                    QuitIntent::ConfirmDuringCreation => {
+                        self.home.show_quit_during_creation_confirm();
+                    }
+                    QuitIntent::Confirm => {
+                        self.home.show_quit_confirm();
+                    }
+                    QuitIntent::Quit => {
+                        self.should_quit = true;
+                    }
                 }
-                self.should_quit = true;
                 return Ok(());
             }
             // Ctrl+x dismisses the update bar / status toast. Gated on
@@ -2271,6 +2314,51 @@ pub enum Action {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ctrl_q_never_quits() {
+        // The whole point of #1569: Ctrl+Q is a live-mode-exit habit and
+        // must not close aoe from the home view, regardless of the other
+        // flags.
+        for creation_pending in [false, true] {
+            for confirm in [false, true] {
+                assert_eq!(
+                    quit_intent(KeyModifiers::CONTROL, creation_pending, confirm),
+                    QuitIntent::Ignore,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plain_q_quits_when_confirm_disabled() {
+        assert_eq!(
+            quit_intent(KeyModifiers::NONE, false, false),
+            QuitIntent::Quit,
+        );
+    }
+
+    #[test]
+    fn plain_q_confirms_when_enabled() {
+        assert_eq!(
+            quit_intent(KeyModifiers::NONE, false, true),
+            QuitIntent::Confirm,
+        );
+    }
+
+    #[test]
+    fn creation_pending_confirms_before_anything_else() {
+        // Creation-in-progress takes precedence over the quit confirm so
+        // the user is warned the hook will be cancelled.
+        assert_eq!(
+            quit_intent(KeyModifiers::NONE, true, true),
+            QuitIntent::ConfirmDuringCreation,
+        );
+        assert_eq!(
+            quit_intent(KeyModifiers::NONE, true, false),
+            QuitIntent::ConfirmDuringCreation,
+        );
+    }
 
     #[test]
     fn test_action_enum() {

--- a/src/tui/components/checkbox.rs
+++ b/src/tui/components/checkbox.rs
@@ -55,6 +55,18 @@ impl CheckboxStyle {
             focused_underline: Some(UnderlineScope::Row),
         }
     }
+
+    /// Style used by the quit confirmation's "don't warn me again"
+    /// checkbox: a single always-toggleable opt-in that reads as a normal
+    /// control (accent when ticked), not a destructive one.
+    pub fn confirm(theme: &Theme) -> Self {
+        Self {
+            focused_color: theme.accent,
+            checked_color: theme.accent,
+            focused_glyph_bold: false,
+            focused_underline: None,
+        }
+    }
 }
 
 /// Build a single checkbox row.

--- a/src/tui/dialogs/confirm.rs
+++ b/src/tui/dialogs/confirm.rs
@@ -6,13 +6,25 @@ use ratatui::widgets::*;
 
 use super::DialogResult;
 use crate::tui::components::buttons::render_yes_no;
+use crate::tui::components::checkbox::{checkbox_line, CheckboxStyle};
 use crate::tui::styles::Theme;
+
+/// The dialog's emphasis color. Destructive confirmations (delete, stop,
+/// cancel-a-running-hook) alarm in red; neutral ones (quitting, with
+/// sessions left running) use the calmer "heads-up" amber so a routine
+/// prompt doesn't read like a data-loss warning.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Tone {
+    Destructive,
+    Neutral,
+}
 
 pub struct ConfirmDialog {
     title: String,
     message: String,
     action: String,
     selected: bool, // true = Yes, false = No
+    tone: Tone,
     /// When set, the dialog shows a "don't warn me again" checkbox the
     /// user can toggle with Space. The caller reads `dont_ask_again()`
     /// on Submit to persist the opt-out. `None` hides the checkbox.
@@ -28,10 +40,18 @@ impl ConfirmDialog {
             message: message.to_string(),
             action: action.to_string(),
             selected: false,
+            tone: Tone::Destructive,
             dont_ask_again: None,
             yes_button_area: Rect::default(),
             no_button_area: Rect::default(),
         }
+    }
+
+    /// Render with the calmer "heads-up" emphasis instead of the default
+    /// destructive red. For confirmations that aren't about losing data.
+    pub fn neutral(mut self) -> Self {
+        self.tone = Tone::Neutral;
+        self
     }
 
     /// Offer a "don't warn me again" checkbox (unchecked to start). The
@@ -106,56 +126,78 @@ impl ConfirmDialog {
     }
 
     pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        // The checkbox row adds a line, so grow the dialog when offered.
-        let height = if self.dont_ask_again.is_some() { 9 } else { 8 };
-        let dialog_area = super::centered_rect(area, 50, height);
+        // Spacer rows separate message / checkbox / buttons so the dialog
+        // breathes; grow the height (and a touch of width) to fit them when
+        // the checkbox is shown.
+        let (width, height) = if self.dont_ask_again.is_some() {
+            (56, 11)
+        } else {
+            (50, 8)
+        };
+        let dialog_area = super::centered_rect(area, width, height);
 
         frame.render_widget(Clear, dialog_area);
 
+        let emphasis = match self.tone {
+            Tone::Destructive => theme.error,
+            Tone::Neutral => theme.waiting,
+        };
         let block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(theme.error))
+            .border_style(Style::default().fg(emphasis))
             .title(format!(" {} ", self.title))
-            .title_style(Style::default().fg(theme.error).bold());
+            .title_style(Style::default().fg(emphasis).bold());
 
         let inner = block.inner(dialog_area);
         frame.render_widget(block, dialog_area);
 
-        let constraints: &[Constraint] = if self.dont_ask_again.is_some() {
-            &[
-                Constraint::Min(1),
-                Constraint::Length(1),
-                Constraint::Length(2),
-            ]
-        } else {
-            &[Constraint::Min(1), Constraint::Length(2)]
-        };
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .margin(1)
-            .constraints(constraints)
-            .split(inner);
+        if let Some(checked) = self.dont_ask_again {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .margin(1)
+                .constraints([
+                    Constraint::Min(1),    // message
+                    Constraint::Length(1), // spacer
+                    Constraint::Length(1), // checkbox
+                    Constraint::Length(1), // spacer
+                    Constraint::Length(2), // buttons
+                ])
+                .split(inner);
 
-        // Message
+            self.render_message(frame, chunks[0], theme);
+            let line = checkbox_line(
+                theme,
+                "Don't warn me again",
+                Some("space"),
+                0,
+                checked,
+                false,
+                CheckboxStyle::confirm(theme),
+            );
+            frame.render_widget(Paragraph::new(line), chunks[2]);
+            let (yes, no) = render_yes_no(frame, chunks[4], theme, self.selected);
+            self.yes_button_area = yes;
+            self.no_button_area = no;
+        } else {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .margin(1)
+                .constraints([Constraint::Min(1), Constraint::Length(2)])
+                .split(inner);
+
+            self.render_message(frame, chunks[0], theme);
+            let (yes, no) = render_yes_no(frame, chunks[1], theme, self.selected);
+            self.yes_button_area = yes;
+            self.no_button_area = no;
+        }
+    }
+
+    fn render_message(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let message = Paragraph::new(&*self.message)
             .style(Style::default().fg(theme.text))
             .wrap(Wrap { trim: true });
-        frame.render_widget(message, chunks[0]);
-
-        let buttons_chunk = if let Some(checked) = self.dont_ask_again {
-            let mark = if checked { "x" } else { " " };
-            let checkbox = Paragraph::new(format!("[{mark}] Don't warn me again (space)"))
-                .style(Style::default().fg(theme.dimmed));
-            frame.render_widget(checkbox, chunks[1]);
-            chunks[2]
-        } else {
-            chunks[1]
-        };
-
-        let (yes, no) = render_yes_no(frame, buttons_chunk, theme, self.selected);
-        self.yes_button_area = yes;
-        self.no_button_area = no;
+        frame.render_widget(message, area);
     }
 }
 
@@ -300,6 +342,60 @@ mod tests {
 
         dialog.handle_key(key(KeyCode::Char(' ')));
         assert!(!dialog.dont_ask_again());
+    }
+
+    /// Render the quit dialog and return the foreground color of the cell
+    /// under a given character of the "Don't warn me again" label, plus the
+    /// top-border color. Guards the styling: the label must read as normal
+    /// text (not the disabled-looking `dimmed`), and the border must use the
+    /// neutral heads-up tone rather than destructive red.
+    #[test]
+    fn quit_dialog_label_is_readable_and_border_is_neutral() {
+        use crate::tui::styles::load_theme;
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut dialog = ConfirmDialog::new("Quit", "Quit aoe?", "quit")
+            .neutral()
+            .offering_dont_ask_again();
+        let theme = load_theme("empire");
+        let backend = TestBackend::new(70, 14);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| dialog.render(f, f.area(), &theme))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+
+        // Find the checkbox row and the column where the label "D" starts.
+        let mut label_fg = None;
+        let mut border_fg = None;
+        for y in 0..buf.area.height {
+            let row: String = (0..buf.area.width).map(|x| buf[(x, y)].symbol()).collect();
+            if border_fg.is_none() && row.contains('╭') {
+                let bx = row.find('╭').unwrap() as u16;
+                border_fg = Some(buf[(bx, y)].fg);
+            }
+            if let Some(idx) = row.find("Don't warn") {
+                label_fg = Some(buf[(idx as u16, y)].fg);
+            }
+        }
+
+        assert_eq!(
+            label_fg,
+            Some(theme.text),
+            "checkbox label should use normal text color, not dimmed/disabled"
+        );
+        assert_ne!(
+            label_fg,
+            Some(theme.dimmed),
+            "checkbox label must not be dimmed"
+        );
+        assert_eq!(
+            border_fg,
+            Some(theme.waiting),
+            "neutral quit dialog should use the heads-up tone, not destructive red"
+        );
+        assert_ne!(border_fg, Some(theme.error));
     }
 
     #[test]

--- a/src/tui/dialogs/confirm.rs
+++ b/src/tui/dialogs/confirm.rs
@@ -13,6 +13,10 @@ pub struct ConfirmDialog {
     message: String,
     action: String,
     selected: bool, // true = Yes, false = No
+    /// When set, the dialog shows a "don't warn me again" checkbox the
+    /// user can toggle with Space. The caller reads `dont_ask_again()`
+    /// on Submit to persist the opt-out. `None` hides the checkbox.
+    dont_ask_again: Option<bool>,
     yes_button_area: Rect,
     no_button_area: Rect,
 }
@@ -24,9 +28,23 @@ impl ConfirmDialog {
             message: message.to_string(),
             action: action.to_string(),
             selected: false,
+            dont_ask_again: None,
             yes_button_area: Rect::default(),
             no_button_area: Rect::default(),
         }
+    }
+
+    /// Offer a "don't warn me again" checkbox (unchecked to start). The
+    /// caller inspects `dont_ask_again()` after a Submit to act on it.
+    pub fn offering_dont_ask_again(mut self) -> Self {
+        self.dont_ask_again = Some(false);
+        self
+    }
+
+    /// Whether the user ticked "don't warn me again". Always false when
+    /// the checkbox wasn't offered.
+    pub fn dont_ask_again(&self) -> bool {
+        self.dont_ask_again.unwrap_or(false)
     }
 
     /// Route a left-click. `Some(Submit)` for `[Yes]`, `Some(Cancel)`
@@ -67,6 +85,10 @@ impl ConfirmDialog {
                 }
             }
             KeyCode::Char('y') | KeyCode::Char('Y') => DialogResult::Submit(()),
+            KeyCode::Char(' ') if self.dont_ask_again.is_some() => {
+                self.dont_ask_again = Some(!self.dont_ask_again.unwrap_or(false));
+                DialogResult::Continue
+            }
             KeyCode::Left | KeyCode::Char('h') => {
                 self.selected = true;
                 DialogResult::Continue
@@ -84,7 +106,9 @@ impl ConfirmDialog {
     }
 
     pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let dialog_area = super::centered_rect(area, 50, 8);
+        // The checkbox row adds a line, so grow the dialog when offered.
+        let height = if self.dont_ask_again.is_some() { 9 } else { 8 };
+        let dialog_area = super::centered_rect(area, 50, height);
 
         frame.render_widget(Clear, dialog_area);
 
@@ -98,10 +122,19 @@ impl ConfirmDialog {
         let inner = block.inner(dialog_area);
         frame.render_widget(block, dialog_area);
 
+        let constraints: &[Constraint] = if self.dont_ask_again.is_some() {
+            &[
+                Constraint::Min(1),
+                Constraint::Length(1),
+                Constraint::Length(2),
+            ]
+        } else {
+            &[Constraint::Min(1), Constraint::Length(2)]
+        };
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .margin(1)
-            .constraints([Constraint::Min(1), Constraint::Length(2)])
+            .constraints(constraints)
             .split(inner);
 
         // Message
@@ -110,7 +143,17 @@ impl ConfirmDialog {
             .wrap(Wrap { trim: true });
         frame.render_widget(message, chunks[0]);
 
-        let (yes, no) = render_yes_no(frame, chunks[1], theme, self.selected);
+        let buttons_chunk = if let Some(checked) = self.dont_ask_again {
+            let mark = if checked { "x" } else { " " };
+            let checkbox = Paragraph::new(format!("[{mark}] Don't warn me again (space)"))
+                .style(Style::default().fg(theme.dimmed));
+            frame.render_widget(checkbox, chunks[1]);
+            chunks[2]
+        } else {
+            chunks[1]
+        };
+
+        let (yes, no) = render_yes_no(frame, buttons_chunk, theme, self.selected);
         self.yes_button_area = yes;
         self.no_button_area = no;
     }
@@ -234,5 +277,37 @@ mod tests {
         let mut dialog = ConfirmDialog::new("Test", "Message", "action");
         let result = dialog.handle_key(key(KeyCode::Char('x')));
         assert!(matches!(result, DialogResult::Continue));
+    }
+
+    #[test]
+    fn dont_ask_again_defaults_false_when_not_offered() {
+        let mut dialog = ConfirmDialog::new("Test", "Message", "action");
+        assert!(!dialog.dont_ask_again());
+        // Space is inert when the checkbox isn't offered.
+        let result = dialog.handle_key(key(KeyCode::Char(' ')));
+        assert!(matches!(result, DialogResult::Continue));
+        assert!(!dialog.dont_ask_again());
+    }
+
+    #[test]
+    fn space_toggles_dont_ask_again_when_offered() {
+        let mut dialog = ConfirmDialog::new("Quit", "Quit?", "quit").offering_dont_ask_again();
+        assert!(!dialog.dont_ask_again());
+
+        let result = dialog.handle_key(key(KeyCode::Char(' ')));
+        assert!(matches!(result, DialogResult::Continue));
+        assert!(dialog.dont_ask_again());
+
+        dialog.handle_key(key(KeyCode::Char(' ')));
+        assert!(!dialog.dont_ask_again());
+    }
+
+    #[test]
+    fn dont_ask_again_survives_into_submit() {
+        let mut dialog = ConfirmDialog::new("Quit", "Quit?", "quit").offering_dont_ask_again();
+        dialog.handle_key(key(KeyCode::Char(' ')));
+        let result = dialog.handle_key(key(KeyCode::Char('y')));
+        assert!(matches!(result, DialogResult::Submit(())));
+        assert!(dialog.dont_ask_again());
     }
 }

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -141,7 +141,11 @@ pub struct Ctx {
 }
 
 fn chord_matches(c: &Chord, key: &KeyEvent) -> bool {
-    key.code == c.code && (!c.ctrl || key.modifiers.contains(KeyModifiers::CONTROL))
+    // Match the Ctrl modifier exactly: a non-ctrl chord must NOT fire when
+    // Ctrl is held. Otherwise `k('q')` would also match Ctrl+Q (reserved for
+    // exiting live-send mode, #1569) and `k('d')` would match Ctrl+D, letting
+    // a modified chord trigger a bare-letter action.
+    key.code == c.code && key.modifiers.contains(KeyModifiers::CONTROL) == c.ctrl
 }
 
 fn context_holds(context: Context, ctx: &Ctx) -> bool {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -728,6 +728,7 @@ impl HomeView {
                         self.settings_close_confirm = false;
                     }
                     DialogResult::Submit(()) => {
+                        let dont_ask_again = dialog.dont_ask_again();
                         self.confirm_dialog = None;
                         if self.settings_close_confirm {
                             // Discard branch: force-close settings (the
@@ -737,6 +738,9 @@ impl HomeView {
                             }
                             self.settings_view = None;
                             self.settings_close_confirm = false;
+                        }
+                        if action == "quit" && dont_ask_again {
+                            self.disable_confirm_before_quit();
                         }
                         self.pending_dialog_click_action = self.dispatch_confirm_submit(&action);
                     }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -630,6 +630,7 @@ impl HomeView {
                 None
             }
             "quit_during_creation" => Some(Action::Quit),
+            "quit" => Some(Action::Quit),
             _ => None,
         }
     }
@@ -1438,7 +1439,11 @@ impl HomeView {
                 }
                 DialogResult::Submit(_) => {
                     let action = dialog.action().to_string();
+                    let dont_ask_again = dialog.dont_ask_again();
                     self.confirm_dialog = None;
+                    if action == "quit" && dont_ask_again {
+                        self.disable_confirm_before_quit();
+                    }
                     if let Some(emit) = self.dispatch_confirm_submit(&action) {
                         return Some(emit);
                     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -567,6 +567,10 @@ pub struct HomeView {
     // dictation / stray keystrokes triggering destructive actions).
     pub(super) strict_hotkeys: bool,
 
+    // When true, pressing `q` to leave the home screen shows a quit
+    // confirmation first (guards against accidental exits, #1569).
+    pub(super) confirm_before_quit: bool,
+
     // Number of live `aoe` TUI processes (including this one), refreshed on a
     // throttle from the app loop. The footer surfaces it when >1 so the user
     // knows another instance is attached (the two clash over agent pane sizes
@@ -725,6 +729,7 @@ impl HomeView {
             .cloned()
             .unwrap_or_else(|| resolved.status_hooks.clone());
         let strict_hotkeys = resolved.session.strict_hotkeys;
+        let confirm_before_quit = resolved.session.confirm_before_quit;
         let idle_decay_window =
             crate::tui::styles::idle_decay_window(resolved.theme.idle_decay_minutes);
         let user_config = load_config().ok().flatten();
@@ -847,6 +852,7 @@ impl HomeView {
             status_hook_config,
             status_hook_configs,
             strict_hotkeys,
+            confirm_before_quit,
             active_tui_count: 1,
             idle_decay_window,
             settings_view: None,
@@ -2008,6 +2014,49 @@ impl HomeView {
             "A session is still being created. Quit anyway? The hook will be cancelled.",
             "quit_during_creation",
         ));
+    }
+
+    /// Whether `q` on the home screen should confirm before quitting.
+    pub fn confirm_before_quit(&self) -> bool {
+        self.confirm_before_quit
+    }
+
+    /// Show the "quit aoe?" confirmation, with a "don't warn me again"
+    /// checkbox that flips `confirm_before_quit` off when ticked (#1569).
+    pub fn show_quit_confirm(&mut self) {
+        self.confirm_dialog = Some(
+            ConfirmDialog::new(
+                "Quit Agent of Empires",
+                "Quit aoe? Your sessions keep running in the background.",
+                "quit",
+            )
+            .offering_dont_ask_again(),
+        );
+    }
+
+    /// Persist `confirm_before_quit = false` and update the cached flag so
+    /// the quit confirmation stops appearing. Called when the user ticks
+    /// "don't warn me again" in the quit dialog.
+    pub(super) fn disable_confirm_before_quit(&mut self) {
+        self.confirm_before_quit = false;
+        match load_config() {
+            Ok(Some(mut config)) => {
+                config.session.confirm_before_quit = false;
+                if let Err(e) = save_config(&config) {
+                    tracing::warn!(target: "tui.home", "Failed to save config: {e}");
+                }
+            }
+            Ok(None) => {
+                let mut config = crate::session::config::Config::default();
+                config.session.confirm_before_quit = false;
+                if let Err(e) = save_config(&config) {
+                    tracing::warn!(target: "tui.home", "Failed to save config: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(target: "tui.home", "Failed to load config: {e}");
+            }
+        }
     }
 
     /// Clean up a pending creation on TUI shutdown. Waits briefly for the
@@ -3689,6 +3738,7 @@ impl HomeView {
         self.status_hook_config = config.status_hooks.clone();
         self.refresh_status_hook_config_cache();
         self.strict_hotkeys = config.session.strict_hotkeys;
+        self.confirm_before_quit = config.session.confirm_before_quit;
         self.row_tag_mode = config.session.row_tag;
         self.profile_default_attach_mode = config.session.default_attach_mode;
         self.idle_decay_window =

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2027,9 +2027,10 @@ impl HomeView {
         self.confirm_dialog = Some(
             ConfirmDialog::new(
                 "Quit Agent of Empires",
-                "Quit aoe? Your sessions keep running in the background.",
+                "Quit?\nYour sessions persist in the background.",
                 "quit",
             )
+            .neutral()
             .offering_dont_ask_again(),
         );
     }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -273,6 +273,56 @@ fn test_q_returns_quit_action() {
 
 #[test]
 #[serial]
+fn test_ctrl_q_does_not_quit_home() {
+    // #1569: Ctrl+Q is a live-mode-exit habit; on the home view it must
+    // not quit aoe. (The app-level handler swallows it; the home view
+    // itself must also never treat it as a quit.)
+    let mut env = create_test_env_empty();
+    let action = env.view.handle_key(
+        KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL),
+        None,
+    );
+    assert_eq!(action, None);
+}
+
+#[test]
+#[serial]
+fn test_quit_confirm_dont_ask_again_persists_opt_out() {
+    let mut env = create_test_env_empty();
+    env.view.confirm_before_quit = true;
+
+    env.view.show_quit_confirm();
+    assert!(env.view.confirm_dialog.is_some());
+
+    // Tick "don't warn me again", then confirm.
+    env.view.handle_key(key(KeyCode::Char(' ')), None);
+    let action = env.view.handle_key(key(KeyCode::Char('y')), None);
+
+    assert_eq!(action, Some(Action::Quit));
+    assert!(!env.view.confirm_before_quit);
+    // The opt-out is persisted so it survives a restart.
+    let saved = crate::session::config::load_config()
+        .unwrap()
+        .expect("config should have been written");
+    assert!(!saved.session.confirm_before_quit);
+}
+
+#[test]
+#[serial]
+fn test_quit_confirm_without_opt_out_keeps_flag() {
+    let mut env = create_test_env_empty();
+    env.view.confirm_before_quit = true;
+
+    env.view.show_quit_confirm();
+    // Confirm without ticking the checkbox.
+    let action = env.view.handle_key(key(KeyCode::Char('y')), None);
+
+    assert_eq!(action, Some(Action::Quit));
+    assert!(env.view.confirm_before_quit);
+}
+
+#[test]
+#[serial]
 fn test_question_mark_opens_help() {
     let mut env = create_test_env_empty();
     assert!(!env.view.show_help);

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -97,6 +97,7 @@ pub enum FieldKey {
     // Session
     DefaultTool,
     StrictHotkeys,
+    ConfirmBeforeQuit,
     SnoozeDurationMinutes,
     RestartWakeMessage,
     RowTag,
@@ -1721,6 +1722,16 @@ fn build_session_fields(
 
     if scope == SettingsScope::Global {
         fields.push(SettingField {
+            key: FieldKey::ConfirmBeforeQuit,
+            label: "Confirm Before Quit",
+            description: "Warn before quitting aoe when you press `q` on the home screen \
+                          (the dialog can also turn this off). Ctrl+C always force-quits.",
+            value: FieldValue::Bool(global.session.confirm_before_quit),
+            category: SettingsCategory::Session,
+            has_override: false,
+            inherited_display: None,
+        });
+        fields.push(SettingField {
             key: FieldKey::SessionIdPollerMaxThreads,
             label: "Max Session-ID Poller Threads",
             description:
@@ -2575,6 +2586,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         }
         (FieldKey::YoloModeDefault, FieldValue::Bool(v)) => config.session.yolo_mode_default = *v,
         (FieldKey::StrictHotkeys, FieldValue::Bool(v)) => config.session.strict_hotkeys = *v,
+        (FieldKey::ConfirmBeforeQuit, FieldValue::Bool(v)) => {
+            config.session.confirm_before_quit = *v
+        }
         (FieldKey::SnoozeDurationMinutes, FieldValue::Number(v)) => {
             config.session.snooze_duration_minutes = *v as u32;
         }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -1054,8 +1054,10 @@ impl SettingsView {
             }
             // Logging is global-only for v1 (no profile overrides); the
             // "clear override" gesture is a no-op for these keys.
-            // SessionIdPollerMaxThreads is also global-only.
-            FieldKey::LoggingDefaultLevel
+            // SessionIdPollerMaxThreads and ConfirmBeforeQuit are also
+            // global-only.
+            FieldKey::ConfirmBeforeQuit
+            | FieldKey::LoggingDefaultLevel
             | FieldKey::LoggingTarget(_)
             | FieldKey::LoggingOutput
             | FieldKey::LoggingFilePath

--- a/tests/e2e/tool_sessions.rs
+++ b/tests/e2e/tool_sessions.rs
@@ -239,8 +239,11 @@ hotkey = "Alt+t"
     );
 
     // Quit the TUI so the removal CLI can write sessions.json without
-    // racing the TUI's poller.
+    // racing the TUI's poller. `q` opens the quit confirmation (#1569),
+    // so confirm with `y` to actually exit.
     h.send_keys("q");
+    h.wait_for("Quit Agent of Empires");
+    h.send_keys("y");
     h.wait_for_exit(Duration::from_secs(5));
 
     // Remove the agent session. `perform_deletion` invokes

--- a/tests/e2e/tui_launch.rs
+++ b/tests/e2e/tui_launch.rs
@@ -28,7 +28,15 @@ fn test_tui_quit_with_q() {
     h.spawn_tui();
 
     h.wait_for(" aoe ");
+    // `q` opens the quit confirmation (on by default, #1569); it does not
+    // exit on its own anymore.
     h.send_keys("q");
+    h.wait_for("Quit Agent of Empires");
+    // Confirm to actually exit.
+    h.send_keys("y");
     h.wait_for_exit(Duration::from_secs(5));
-    assert!(!h.session_alive(), "session should have exited after 'q'");
+    assert!(
+        !h.session_alive(),
+        "session should have exited after confirming quit"
+    );
 }


### PR DESCRIPTION
## Description

Fixes #1569. Two changes to prevent accidental aoe exits.

**1. Ctrl+Q no longer quits aoe.** It is reserved for exiting live-send mode. The home-view quit handler matched `q` with any modifier, so a Ctrl+Q live-mode-exit habit landing on the home screen closed the whole app. Plain `q` still quits.

**2. Confirm-before-quit (on by default).** Pressing `q` on the home screen now shows a "Quit Agent of Empires" confirmation with a `[ ] Don't warn me again (space)` checkbox. Ticking it and confirming persists the new `confirm_before_quit` setting off. The setting is editable in the global Settings panel ("Confirm Before Quit"). Ctrl+C still force-quits without a prompt, and an in-progress session creation keeps its existing "quit anyway?" confirmation (takes precedence).

The quit-key policy is factored into a unit-tested `quit_intent` helper. The new setting lives on `SessionConfig` with a serde default so existing configs inherit the guard.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

<!-- No screenshot: the change is a confirmation dialog reachable only by pressing `q`; the e2e test exercises it end to end. -->

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

`tests/e2e/tui_launch.rs::test_tui_quit_with_q` now verifies the confirmation dialog appears on `q` and that confirming with `y` exits. Plus unit tests for the `quit_intent` policy (incl. Ctrl+Q never quitting), the dialog's "don't warn again" toggle and persistence, the config default-on (incl. deserialization from an older config.toml), and home-level Ctrl+Q-does-not-quit / opt-out flows.

Verified locally: `cargo fmt --check`, `cargo clippy --all-targets`, `cargo build --features serve`, `cargo test --lib` (2424 passed), `cargo test --test e2e` (83 passed, 2 docker ignored).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Opus)

**Any Additional AI Details you'd like to share:** Implemented via Claude Code through back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR reduces accidental quits by reserving Ctrl+Q for live-send (it no longer quits on the home screen) and adding an opt-out quit confirmation when pressing plain `q` on the home screen.

## What changed (high level)

- Quit behavior
  - Ctrl+Q is no longer treated as a home-screen quit (still used for live-send).
  - Plain `q` opens a “Quit Agent of Empires” confirmation dialog by default.
  - Ctrl+C remains an immediate force-quit; in-progress session-creation retains its higher-priority “quit anyway?” confirmation.

- Confirmation flow
  - The quit dialog includes a “[ ] Don’t warn me again (space)” checkbox. Ticking and confirming persists the preference so future plain-`q` presses skip the dialog.
  - The persisted preference can be edited from the global Settings panel.

- Configuration and Settings
  - Added SessionConfig.confirm_before_quit: bool (defaults to true via serde default).
  - Settings UI exposes a global “Confirm Before Quit” boolean bound to the session config.

- UI and internal behavior
  - ConfirmDialog can optionally render and return the checkbox state; Space toggles the checkbox when offered.
  - HomeView caches the confirm_before_quit flag, opens the quit dialog, and can persist disabling confirmations.
  - Keybinding matching tightened so modifier chords require exact modifier matches to avoid accidental triggers.

- Tests and e2e updates
  - Unit tests for quit decision logic (quit_intent), confirm dialog checkbox behavior and persistence, and SessionConfig deserialization/defaults.
  - E2E TUI tests updated to expect and confirm the new quit dialog.

## Benefits

- Reduces accidental application exits while preserving existing live-send and force-quit behaviors.
- Safe default for existing users (confirmation enabled) with a clear, persistent opt-out and a Settings control to re-enable.
- Centralized quit logic and tests improve maintainability and regressions protection.

## Technical notes

- Introduced QuitIntent enum and a unit-tested quit_intent(...) helper that centralizes plain-`q` behavior.
- ConfirmDialog extended with optional dont_ask_again state, offering builder (offering_dont_ask_again) and accessor (dont_ask_again()).
- SessionConfig gained confirm_before_quit with serde default_true; HomeView reads/caches and can persist changes to config.
- Checkbox style added for the confirm dialog; dialog layout adjusted to accommodate the extra row.
- HomeView.show_quit_confirm() and disable_confirm_before_quit() added; Settings field FieldKey::ConfirmBeforeQuit added and treated as global-only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->