### PR TITLE
chore: merge cockpit-main batch into main

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -1063,7 +1063,9 @@ in-memory prompt loop entirely, so the next attach starts fresh.
 
 Set `cockpit.silent_orphan_grace_secs = 0` to disable. Both knobs are
 editable per profile in the TUI Settings (`Cockpit` category) and in
-the web dashboard's Settings tab under `Cockpit`. Nonzero values
+the web dashboard's Settings tab under `Cockpit`, inside the collapsed
+`Advanced` section alongside the other replay and watchdog tuning
+knobs. Nonzero values
 below 120 are clamped up to 120 at runtime so a typo cannot drop the
 watchdog into a tight-loop false-positive regime; debug builds honour
 `AOE_SILENT_ORPHAN_GRACE_MS` to keep test cadences sub-second.

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -807,6 +807,10 @@ If the agent ignores `session/cancel` mid-tool-call (most commonly a `block: tru
 
 Follow-up prompts the daemon refused while the original turn was still in flight no longer vanish silently. The composer shows them as amber "Rejected" pills with a Retry button; clicking Retry re-dispatches the prompt through the normal send path against the freshly-respawned worker.
 
+### Tool card stuck "running" after a stop
+
+Stopping the agent while a tool call is mid-execution settles that tool's card to a distinct terminal **stopped** state: the elapsed-time timer freezes and the badge leaves the orange "running" state for a muted "stopped". This is intentional. The adapter resolves a cancelled prompt without sending a per-tool completion, so the cockpit closes any still-open tool calls itself when the turn ends. "stopped" is neither "done" (no success was reported) nor "failed" (no error was reported); the tool's real outcome was never reported. The same applies on reload (the state is reconstructed from the persisted turn-end event) and when the backend switches agents mid-turn.
+
 ### Rate-limit recovery
 
 When the active ACP backend reports `errorKind: "rate_limit"` on `session/prompt` (Claude's adapter does this when the Anthropic account is over its limit), aoe treats this as a non-crash terminal state rather than as a worker crash:

--- a/docs/guides/scratch-sessions.md
+++ b/docs/guides/scratch-sessions.md
@@ -120,7 +120,10 @@ logged so you can find it later.
 
 The wizard's **Recent projects** tab filters scratch sessions out
 once they exist, so a deleted scratch directory does not appear as a
-reusable recent project.
+reusable recent project. Multi-repo workspace sessions are filtered out
+of the same list, since the project step cannot rebuild a workspace from
+a single path; picking one would start a plain single-repo session and
+silently drop the other repos.
 
 ## Compatibility
 

--- a/docs/guides/scratch-sessions.md
+++ b/docs/guides/scratch-sessions.md
@@ -62,6 +62,11 @@ wizard with scratch already enabled and jumped to the Review step.
 A follow-up `Cmd+Enter` / `Ctrl+Enter` launches the session, so two
 keystrokes is enough to spin up a fresh scratch session.
 
+**Command palette.** The same flow is reachable from the command
+palette (`Cmd+K` / `Ctrl+K`): search for "New scratch session" and
+run it to open the wizard prefilled for a scratch session. In
+read-only mode the creation commands are hidden from the palette.
+
 **Sidebar grouping.** Every scratch session has its own
 `scratch/<id>/` directory on disk, so the dashboard sidebar would
 otherwise render each one as its own one-session group. Scratch

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -230,8 +230,15 @@ aoe serve --daemon
 - **Multi-profile** support (shows sessions from all profiles)
 - **Connected Devices** view in Settings > Security
 - **Push notifications** on Waiting / Idle / Error transitions, with per-session overrides ([guide](push-notifications.md))
+- **First-run tutorial** highlighting the major UI regions and their shortcuts (see below)
 
-### Mobile layout
+### First-run tutorial
+
+The first time you open the dashboard in a browser, an interactive walkthrough launches automatically and highlights the major regions: the command bar, the workspace sidebar, how to start a session, settings, and (inside a session) the diff panel and composer. Each step lists the keyboard shortcuts that apply to it, and every step has a **Skip** button so you can dismiss the whole tour in one click.
+
+Completing or skipping the tour records that you have seen it (a per-browser `aoe-tour-seen` flag in `localStorage`), so it does not launch again on reload. Because the flag is per origin, a debug build on port 8081 and a release build on port 8080 each track it separately.
+
+To replay it at any time, open the overflow menu (the three-dot **More options** button in the top bar) and choose **Show tutorial**. Re-triggering it adapts to where you are: on the dashboard it covers the dashboard regions; inside a session it also covers the composer, agent mode picker, and send/queue controls. The tutorial does not auto-launch on touch devices, where it is available only from the menu.
 
 On phones (below the `md` breakpoint) the dashboard shows a single full-viewport pane rather than the desktop side-by-side split. The right-panel button in the top bar opens a picker that swaps the main pane between three views: the **Agent terminal**, the **Diff** (changed files and review), and the **Paired terminal** (host or container shell). A back chip in the top-left of the diff and paired views returns you to the agent terminal.
 

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -248,6 +248,8 @@ This replaces the earlier slide-in overlay, which left the paired terminal almos
 
 By default the sidebar shows your manually-ordered list. Drag a row with a press-and-hold gesture to move it; the new order persists across browsers and devices via `workspace-ordering.json`.
 
+To reorder whole projects, grab the drag handle on the left of a project/group header and drag it up or down. This sets an explicit group order instead of leaving project placement to be derived from whichever session sits highest. Unlike row ordering, the group order is per-browser (localStorage), not synced across devices. A project that appears after you have set an order slots in at the top. The Multi-repo and Scratch groups default to the bottom but are draggable too, so you can lift them anywhere; once dragged they hold their chosen spot. Group drag is disabled while a filter is active or while Recent activity sort is selected, since the order is computed in those cases.
+
 A sort toggle next to the filter button in the sidebar header switches to **Recent activity** mode, which orders workspaces by the most recent of `last_accessed_at`, `idle_entered_at`, and `created_at` across each workspace's sessions, descending. Drag-to-reorder is disabled while Recent activity is selected, because the order is computed; the press-and-hold gesture does nothing in that mode.
 
 The toggle's state is per-browser (localStorage), not synced across devices and not tied to your profile. Toggling back to manual restores the stored manual order and re-enables drag. The multi-repo group stays pinned at the bottom in both modes.

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -9,7 +9,7 @@ For workflow guidance, see the [Workflow Guide](workflow.md).
 | Feature | CLI | TUI |
 |---------|-----|-----|
 | Create new branch | Use `-b` flag | Always creates new branch |
-| Use existing branch | Omit `-b` flag | "Attach to existing branch" toggle (TUI: `Ctrl+P`; web: in the session step under the branch field) |
+| Use existing branch | Omit `-b` flag | "Attach to existing branch" toggle (TUI: `Ctrl+P`; web: in the session step under the branch field, inside the "Advanced" disclosure) |
 | Branch validation | Checks if branch exists | None (always creates) |
 | Pick a base branch | `--base-branch <name>` | `Base` field in `Ctrl+P` overlay |
 
@@ -70,7 +70,7 @@ freshness signal.
 
 In the TUI, enable the Worktree checkbox to create a new branch and worktree. By default, the worktree name is derived from the session title. Press `Ctrl+P` on the Worktree field to set an explicit `Name`, attach to an existing branch, pick a `Base` branch the new branch is based on (defaults to the repo default), or configure extra repos. `Ctrl+P` on the `Base` field opens a branch picker over local and remote-tracking branches.
 
-The web dashboard's new-session wizard exposes the same control under an "Advanced" disclosure beneath the worktree name input; it shows a typeahead populated from local + remote branches via `GET /api/git/branches?include_remote=true`. The same step also exposes an "Attach to existing branch" toggle that flips the request from "create new branch" to "attach to whichever branch is named" — when on, the server re-uses any existing worktree for that branch and otherwise checks the branch out into a new worktree. Mirrors the TUI / CLI behavior (CLI: omit `-b`). See #969.
+The web dashboard's new-session wizard folds the worktree controls behind an "Advanced" disclosure on the session step, leaving only the session title visible by default. Inside Advanced, a "Base branch" disclosure beneath the worktree name input shows a typeahead populated from local + remote branches via `GET /api/git/branches?include_remote=true`. The same Advanced section also exposes an "Attach to existing branch" toggle that flips the request from "create new branch" to "attach to whichever branch is named": when on, the server re-uses any existing worktree for that branch and otherwise checks the branch out into a new worktree. Mirrors the TUI / CLI behavior (CLI: omit `-b`). See #969 and #1514.
 
 ## Configuration
 

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
             pname = "agent-of-empires-web";
             version = "0";
             src = ./web;
-            npmDepsHash = "sha256-0kDf8uOE1H7+f6/hZIZgjsav7dtWvj4G2q3dDCCusWU=";
+            npmDepsHash = "sha256-HxB9QA7pmEuHRsJ/1TLZAALkP/RD1J8PG3ZpHpYzMNo=";
             # tsc -b && vite build; output goes to web/dist
             installPhase = ''
               mkdir $out

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2961,7 +2961,21 @@ fn map_acp_config_option(
         SessionConfigOptionCategory::Model => ConfigOptionCategory::Model,
         SessionConfigOptionCategory::ThoughtLevel => ConfigOptionCategory::ThoughtLevel,
         SessionConfigOptionCategory::Other(s) => ConfigOptionCategory::Other(s),
-        _ => ConfigOptionCategory::Other(String::new()),
+        // The schema enum is `#[non_exhaustive]`, so this arm is required
+        // to compile. Unknown category *names* arrive via the untagged
+        // `Other(String)` arm above; this fires only when upstream adds a
+        // genuinely new named variant we haven't mapped yet. Warn so the
+        // gap is visible instead of silently surfacing a categoryless
+        // option with an empty payload.
+        other => {
+            tracing::warn!(
+                target: "cockpit.acp",
+                variant = ?other,
+                "unknown SessionConfigOptionCategory; treating as Other(\"\"). \
+                 Bump claude-agent-acp or add a match arm.",
+            );
+            ConfigOptionCategory::Other(String::new())
+        }
     });
 
     // Only `Select` is rendered today; future kinds (boolean toggles
@@ -6658,6 +6672,58 @@ mod tests {
                 assert_eq!(options[1].category, ConfigOptionCategory::ThoughtLevel);
                 assert_eq!(options[1].current_value, "default");
                 assert_eq!(options[2].category, ConfigOptionCategory::Mode);
+            }
+            other => panic!("expected ConfigOptionsUpdated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_config_option_preserves_unknown_category_name() {
+        // Forward-compat path for #1563: a category name aoe doesn't
+        // recognize arrives via the upstream untagged `Other(String)`
+        // arm. It must pass through as `Other(<name>)` and the option
+        // must not be dropped from the descriptor list. (The wildcard
+        // `_` arm that warns fires only for a genuinely new *named*
+        // upstream variant, which cannot be constructed against the
+        // current `#[non_exhaustive]` schema, so it is verified by
+        // inspection rather than a unit test.)
+        use agent_client_protocol::schema::{
+            ConfigOptionUpdate, SessionConfigKind, SessionConfigOption,
+            SessionConfigOptionCategory, SessionConfigSelect, SessionConfigSelectOption,
+            SessionConfigSelectOptions,
+        };
+        let unknown = SessionConfigOption::new(
+            "future",
+            "Future Selector",
+            SessionConfigKind::Select(SessionConfigSelect::new(
+                "a",
+                SessionConfigSelectOptions::Ungrouped(vec![SessionConfigSelectOption::new(
+                    "a", "A",
+                )]),
+            )),
+        )
+        .category(SessionConfigOptionCategory::Other(
+            "future_category".to_string(),
+        ));
+        let update = ConfigOptionUpdate::new(vec![unknown]);
+
+        let events = map_update_to_events(
+            SessionUpdate::ConfigOptionUpdate(update),
+            &agent_profiles::CLAUDE,
+        );
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Event::ConfigOptionsUpdated { options } => {
+                assert_eq!(
+                    options.len(),
+                    1,
+                    "unknown-category option must not be dropped"
+                );
+                assert_eq!(options[0].id, "future");
+                assert_eq!(
+                    options[0].category,
+                    ConfigOptionCategory::Other("future_category".to_string()),
+                );
             }
             other => panic!("expected ConfigOptionsUpdated, got {other:?}"),
         }

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -9,6 +9,9 @@ pub enum GitError {
     #[error("Worktree already exists at {}", .0.display())]
     WorktreeAlreadyExists(PathBuf),
 
+    #[error("Branch '{0}' is already in use by another worktree")]
+    BranchAlreadyCheckedOut(String),
+
     #[error("Worktree not found at {}", .0.display())]
     WorktreeNotFound(PathBuf),
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -31,6 +31,23 @@ fn sanitize_remote_credentials(s: &str) -> String {
     re.replace_all(s, "${1}<redacted>@").into_owned()
 }
 
+/// Classify a failed `git worktree add` into a typed error.
+///
+/// The branch-already-checked-out case (git prints `'<branch>' is already
+/// used by worktree at '<path>'`, or `already checked out at '<path>'` on
+/// older git) becomes a clean `BranchAlreadyCheckedOut` that names the
+/// branch and drops the raw stderr (including the other worktree's path).
+/// Everything else stays `WorktreeCommandFailed`, with any credentialed
+/// remote URL redacted before it can be surfaced.
+fn classify_worktree_add_failure(combined: &str, branch: &str) -> GitError {
+    let lower = combined.to_ascii_lowercase();
+    if lower.contains("already used by worktree") || lower.contains("already checked out at") {
+        GitError::BranchAlreadyCheckedOut(branch.to_string())
+    } else {
+        GitError::WorktreeCommandFailed(sanitize_remote_credentials(combined))
+    }
+}
+
 /// Remote name used as a fallback when no candidate remote can be picked
 /// from the local refs. Real selection happens in
 /// `detect_default_branch_info`, which walks every configured remote and
@@ -639,6 +656,11 @@ impl GitWorktree {
                 (true, false) => stderr,
                 (false, false) => format!("{stdout}\n{stderr}"),
             };
+            // Redact any credentialed remote URL before this text can reach
+            // the debug log or the client (via the warnings channel below or
+            // the error message). Idempotent, so the second pass inside
+            // `classify_worktree_add_failure` is a no-op.
+            let combined = sanitize_remote_credentials(&combined);
 
             // post-checkout hooks (e.g. pre-commit's hook-type=post-checkout
             // running uv-sync, npm install, etc.) can fail after git has
@@ -655,7 +677,7 @@ impl GitWorktree {
                 tracing::warn!(target: "git.worktree", "worktree create: {}", warning);
                 warnings.push(warning);
             } else {
-                return Err(GitError::WorktreeCommandFailed(combined));
+                return Err(classify_worktree_add_failure(&combined, branch));
             }
         }
 
@@ -1787,15 +1809,15 @@ mod tests {
             .unwrap();
 
         // Try creating again at a different path but same branch - git won't
-        // allow two worktrees to check out the same branch.
+        // allow two worktrees to check out the same branch. This is the
+        // branch-already-checked-out case, so it maps to the typed
+        // BranchAlreadyCheckedOut error naming the branch.
         let wt_path2 = dir.path().join("fail-worktree-2");
         let result = git_wt.create_worktree("fail-branch", &wt_path2, false, None);
-        assert!(result.is_err());
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(
-            err_msg.contains("worktree command failed"),
-            "Expected WorktreeCommandFailed error, got: {err_msg}"
-        );
+        match result {
+            Err(GitError::BranchAlreadyCheckedOut(branch)) => assert_eq!(branch, "fail-branch"),
+            other => panic!("Expected BranchAlreadyCheckedOut error, got: {other:?}"),
+        }
     }
 
     // ---- Full worktree creation flow tests for regular repos ----
@@ -2627,6 +2649,36 @@ mod tests {
         // is correct: there is no embedded password to redact.
         let s = "fatal: Could not read from remote: git@github.com:foo/bar.git";
         assert_eq!(sanitize_remote_credentials(s), s);
+    }
+
+    #[test]
+    fn test_classify_worktree_add_failure_branch_in_use() {
+        // Current git wording.
+        let combined =
+            "fatal: 'feature/foo' is already used by worktree at '/tmp/repo-worktrees/feature-foo'";
+        match classify_worktree_add_failure(combined, "feature/foo") {
+            GitError::BranchAlreadyCheckedOut(b) => assert_eq!(b, "feature/foo"),
+            other => panic!("expected BranchAlreadyCheckedOut, got {other:?}"),
+        }
+        // Older git wording.
+        let combined_old = "fatal: 'feature/foo' is already checked out at '/tmp/other'";
+        assert!(matches!(
+            classify_worktree_add_failure(combined_old, "feature/foo"),
+            GitError::BranchAlreadyCheckedOut(_)
+        ));
+    }
+
+    #[test]
+    fn test_classify_worktree_add_failure_redacts_credentials() {
+        let combined =
+            "fatal: unable to access 'https://alice:supersecret@github.com/foo/bar.git/': 403";
+        match classify_worktree_add_failure(combined, "feature/foo") {
+            GitError::WorktreeCommandFailed(msg) => {
+                assert!(!msg.contains("supersecret"), "token leaked: {msg}");
+                assert!(!msg.contains("alice:"), "username leaked: {msg}");
+            }
+            other => panic!("expected WorktreeCommandFailed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -10,6 +10,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::git::error::GitError;
 use crate::session::{EnsureReadyError, EnsureReadyOutcome, Instance, Status, Storage};
 
 use super::validate_no_shell_injection;
@@ -2057,7 +2058,7 @@ pub async fn create_session(
             tracing::warn!(target: "http.api.sessions", "Session creation failed: {}", e);
             (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "create_failed", "message": "Failed to create session"})),
+                Json(serde_json::json!({"error": "create_failed", "message": public_create_session_error(&e)})),
             )
                 .into_response()
         }
@@ -2070,6 +2071,33 @@ pub async fn create_session(
                 .into_response()
         }
     }
+}
+
+/// Pick the client-facing message for a failed session creation.
+///
+/// The full error is always logged server-side; this only governs what
+/// reaches the browser. We whitelist the well-typed `GitError` variants
+/// that carry a clear, actionable, credential-free message (a branch name
+/// or a worktree path the user chose) and let everything else fall back to
+/// the generic string. This keeps raw git stderr, libgit2 internals, IO
+/// paths, and arbitrary `bail!` strings off the wire even though the
+/// duplicate-worktree case now surfaces its real message.
+fn public_create_session_error(e: &anyhow::Error) -> String {
+    if let Some(git_err) = e.chain().find_map(|c| c.downcast_ref::<GitError>()) {
+        match git_err {
+            GitError::WorktreeAlreadyExists(_)
+            | GitError::BranchAlreadyCheckedOut(_)
+            | GitError::BranchNotFound(_)
+            | GitError::NotAGitRepo => return git_err.to_string(),
+            // Raw command output / libgit2 / IO: not safe to expose.
+            GitError::WorktreeCommandFailed(_)
+            | GitError::CloneFailed(_)
+            | GitError::WorktreeNotFound(_)
+            | GitError::Git2Error(_)
+            | GitError::IoError(_) => {}
+        }
+    }
+    "Failed to create session".to_string()
 }
 
 // --- Ensure agent session ---
@@ -2994,6 +3022,58 @@ mod tests {
         inst.status = Status::Running;
         inst.group_path = "work/projects".to_string();
         inst
+    }
+
+    #[test]
+    fn public_create_session_error_forwards_whitelisted_git_errors() {
+        let dup: anyhow::Error =
+            GitError::WorktreeAlreadyExists(std::path::PathBuf::from("/tmp/repo-worktrees/foo"))
+                .into();
+        assert_eq!(
+            public_create_session_error(&dup),
+            "Worktree already exists at /tmp/repo-worktrees/foo"
+        );
+
+        let in_use: anyhow::Error =
+            GitError::BranchAlreadyCheckedOut("feature/foo".to_string()).into();
+        assert_eq!(
+            public_create_session_error(&in_use),
+            "Branch 'feature/foo' is already in use by another worktree"
+        );
+
+        // Whitelisted variants survive an anyhow::Context wrapper too.
+        let wrapped = anyhow::Error::from(GitError::BranchNotFound("nope".to_string()))
+            .context("while creating worktree");
+        assert_eq!(
+            public_create_session_error(&wrapped),
+            "Branch 'nope' not found"
+        );
+    }
+
+    #[test]
+    fn public_create_session_error_hides_unsafe_messages() {
+        // Raw git stderr (even already-sanitized) must not reach the client.
+        let cmd: anyhow::Error = GitError::WorktreeCommandFailed(
+            "fatal: unable to access 'https://<redacted>@host/repo.git'".to_string(),
+        )
+        .into();
+        assert_eq!(
+            public_create_session_error(&cmd),
+            "Failed to create session"
+        );
+
+        let clone: anyhow::Error =
+            GitError::CloneFailed("https://alice:supersecret@host/repo.git".to_string()).into();
+        let msg = public_create_session_error(&clone);
+        assert_eq!(msg, "Failed to create session");
+        assert!(!msg.contains("supersecret"));
+
+        // A non-GitError anyhow also stays generic.
+        let other = anyhow::anyhow!("something internal at /home/user/.config/secret");
+        assert_eq!(
+            public_create_session_error(&other),
+            "Failed to create session"
+        );
     }
 
     #[test]

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -350,6 +350,32 @@ fn passphrase_wall_entry_action(path: &str, client_ip: IpAddr) -> PassphraseWall
     PassphraseWallEntryAction::Continue
 }
 
+/// Emit the passphrase-only loopback-bypass event. This fires on every
+/// request a local caller makes (the TUI / dashboard poll `/api/*`
+/// continuously), so it is a frequent, expected control-flow event and
+/// belongs at `debug`, not `info`. See #1647. Extracted so the level is
+/// assertable with a tracing capture layer without standing up the full
+/// middleware.
+fn log_loopback_bypass_passphrase(client_ip: IpAddr, path: &str) {
+    tracing::debug!(
+        target: "auth.passphrase",
+        ip = %client_ip,
+        path = %path,
+        "loopback bypass: skipping passphrase factor in passphrase-only mode"
+    );
+}
+
+/// Emit the token-mode loopback-bypass event. Same per-request frequency
+/// and rationale as [`log_loopback_bypass_passphrase`]; see #1647.
+fn log_loopback_bypass_token(client_ip: IpAddr, path: &str) {
+    tracing::debug!(
+        target: "auth",
+        ip = %client_ip,
+        path = %path,
+        "loopback bypass: valid token + loopback peer; skipping passphrase factor"
+    );
+}
+
 /// Whether a request path + method needs an elevated login session
 /// (step-up auth, 15-minute passphrase confirmation window).
 ///
@@ -516,12 +542,7 @@ async fn run_passphrase_wall(
     match passphrase_wall_entry_action(&path, client_ip) {
         PassphraseWallEntryAction::BypassExempt => return next.run(request).await,
         PassphraseWallEntryAction::BypassLoopback => {
-            tracing::info!(
-                target: "auth.passphrase",
-                ip = %client_ip,
-                path = %path,
-                "loopback bypass: skipping passphrase factor in passphrase-only mode"
-            );
+            log_loopback_bypass_passphrase(client_ip, &path);
             return next.run(request).await;
         }
         PassphraseWallEntryAction::Continue => {}
@@ -823,12 +844,7 @@ pub async fn auth_middleware(
     match post_token_auth_action(login_enabled, login_exempt, client_ip) {
         PostTokenAuthAction::Bypass => {
             if login_enabled && !login_exempt && is_local_trusted(client_ip) {
-                tracing::info!(
-                    target: "auth",
-                    ip = %client_ip,
-                    path = %path,
-                    "loopback bypass: valid token + loopback peer; skipping passphrase factor"
-                );
+                log_loopback_bypass_token(client_ip, &path);
             }
         }
         PostTokenAuthAction::RequireLogin => {
@@ -948,6 +964,57 @@ async fn handle_session_authenticated(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Records (level, target) for every event so the loopback-bypass
+    // helpers' log level is assertable without standing up the full
+    // axum middleware (AppState is too heavy to build in a unit test).
+    #[derive(Clone, Default)]
+    struct LevelCapture(std::sync::Arc<std::sync::Mutex<Vec<(tracing::Level, String)>>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for LevelCapture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let meta = event.metadata();
+            self.0
+                .lock()
+                .unwrap()
+                .push((*meta.level(), meta.target().to_string()));
+        }
+    }
+
+    fn capture_events(f: impl FnOnce()) -> Vec<(tracing::Level, String)> {
+        use tracing_subscriber::layer::SubscriberExt;
+        let capture = LevelCapture::default();
+        let events = capture.0.clone();
+        let subscriber = tracing_subscriber::registry::Registry::default().with(capture);
+        tracing::subscriber::with_default(subscriber, f);
+        let recorded = events.lock().unwrap();
+        recorded.clone()
+    }
+
+    // #1647: the loopback bypass fires on essentially every local
+    // request, so it must log at debug, not info, to keep the
+    // default-level log readable.
+    #[test]
+    fn loopback_bypass_passphrase_logs_at_debug() {
+        let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+        let events = capture_events(|| log_loopback_bypass_passphrase(loopback, "/api/sessions"));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, tracing::Level::DEBUG);
+        assert_eq!(events[0].1, "auth.passphrase");
+    }
+
+    #[test]
+    fn loopback_bypass_token_logs_at_debug() {
+        let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+        let events = capture_events(|| log_loopback_bypass_token(loopback, "/api/sessions"));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, tracing::Level::DEBUG);
+        assert_eq!(events[0].1, "auth");
+    }
 
     #[test]
     fn constant_time_eq_matching() {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -9,6 +9,7 @@ use anyhow::{bail, Result};
 use chrono::Utc;
 
 use crate::containers::{self, ContainerRuntimeInterface};
+use crate::git::error::GitError;
 use crate::git::GitWorktree;
 
 use super::{
@@ -470,7 +471,7 @@ pub fn build_instance(
                 let worktree_path = git_wt.compute_path(branch, template, &session_id[..8])?;
 
                 if worktree_path.exists() {
-                    bail!("Worktree already exists at {}", worktree_path.display());
+                    return Err(GitError::WorktreeAlreadyExists(worktree_path.clone()).into());
                 }
 
                 let w = git_wt.create_worktree(

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,6 +25,7 @@
         "marked": "^18.0.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-joyride": "^3.1.0",
         "react-router-dom": "^7.14.2",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
@@ -880,6 +881,22 @@
         }
       }
     },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -917,6 +934,45 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.1.0"
+      }
+    },
+    "node_modules/@gilbarbara/types/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -8258,6 +8314,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
+      "license": "MIT"
+    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
@@ -10458,12 +10520,44 @@
         "react": "^19.2.6"
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-joyride": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.1.0.tgz",
+      "integrity": "sha512-+UEDpNsYSHhhSW/OQcNl6+oODYx20EP6TykSD45if0MqAAZMYD+3DU64w9wP3fBjQswvq5BgK99w3rw6ing69g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19",
+        "react-dom": "16.8 - 19"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10811,6 +10905,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "marked": "^18.0.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-joyride": "^3.1.0",
     "react-router-dom": "^7.14.2",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,6 +65,8 @@ import { DiffFileViewer } from "./components/diff/DiffFileViewer";
 import { SettingsView } from "./components/SettingsView";
 import { ProjectsView } from "./components/ProjectsView";
 import { HelpOverlay } from "./components/HelpOverlay";
+import { useTour } from "./hooks/useTour";
+import type { TourScope } from "./lib/tourSteps";
 import { SessionWizard } from "./components/session-wizard/SessionWizard";
 import type { WizardPrefill } from "./components/session-wizard/SessionWizard";
 import type { SessionResponse } from "./lib/types";
@@ -457,10 +459,17 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [wizardPrefill, setWizardPrefill] = useState<WizardPrefill | undefined>(undefined);
   const [deletingWorkspaceId, setDeletingWorkspaceId] = useState<string | null>(null);
   const [serverAbout, setServerAbout] = useState<ServerAbout | null>(null);
+  // `serverAbout === null` conflates "not fetched yet" with "fetch failed", so
+  // the tour gates auto-launch on an explicit loaded flag instead.
+  const [serverAboutLoaded, setServerAboutLoaded] = useState(false);
 
   const refreshServerAbout = useCallback(async () => {
-    const about = await fetchAbout();
-    if (about) setServerAbout(about);
+    try {
+      const about = await fetchAbout();
+      if (about) setServerAbout(about);
+    } finally {
+      setServerAboutLoaded(true);
+    }
   }, []);
 
   useEffect(() => {
@@ -1004,6 +1013,31 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     ],
   );
 
+  const tourScope: TourScope =
+    !activeWorkspace || !activeSession
+      ? "dashboard"
+      : activeSession.cockpit_mode
+        ? "cockpit"
+        : "session";
+  // Only auto-launch on a settled, unobstructed dashboard. Any open overlay or
+  // an in-flight session route defers it (the flag stays unset until then).
+  const tourAutoLaunchReady =
+    serverAboutLoaded &&
+    sessionsLoaded &&
+    !activeSessionId &&
+    !showSettings &&
+    !showProjects &&
+    !showSessionWizard &&
+    !showHelp &&
+    !showAbout &&
+    !showPalette;
+  const tour = useTour({
+    scope: tourScope,
+    readOnly: !!serverAbout?.read_only,
+    isDesktop: !isCoarse,
+    autoLaunchReady: tourAutoLaunchReady,
+  });
+
   return (
     <CockpitPrefsProvider value={cockpitPrefs}>
     <div
@@ -1019,6 +1053,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         diffCollapsed={diffCollapsed}
         onOpenHelp={handleOpenHelp}
         onOpenAbout={handleOpenAbout}
+        onStartTutorial={tour.startTour}
         onLogout={onLogout}
         loginRequired={loginRequired}
         isOffline={!!error}
@@ -1074,6 +1109,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           }
         />
       )}
+
+      {tour.tourElement}
 
       {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -629,10 +629,20 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     onSwipe: openDiff,
   });
 
+  // Read-only mode hides mutation UI. Guard creation at the handler so every
+  // caller (keyboard shortcut, command palette) is a no-op rather than opening
+  // a wizard that 403s on submit. Caught by the live read-only-mode spec.
   const handleNewSession = useCallback(() => {
+    if (serverAbout?.read_only) return;
     setWizardPrefill(undefined);
     setShowSessionWizard(true);
-  }, []);
+  }, [serverAbout?.read_only]);
+
+  const handleNewScratch = useCallback(() => {
+    if (serverAbout?.read_only) return;
+    setWizardPrefill({ scratch: true, skipToReview: true });
+    setShowSessionWizard(true);
+  }, [serverAbout?.read_only]);
 
   const handleCloneFromUrl = useCallback(() => {
     setWizardPrefill({ initialTab: "clone" });
@@ -698,23 +708,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   useKeyboardShortcuts(
     useCallback(
       () => ({
-        onNew: () => {
-          // Read-only mode hides mutation UI. The "n" shortcut must
-          // not open the wizard or the user gets a dead-end form that
-          // 403s on submit. Caught by the live read-only-mode spec.
-          if (serverAbout?.read_only) return;
-          setWizardPrefill(undefined);
-          setShowSessionWizard(true);
-        },
-        onNewScratch: () => {
-          // Same read-only guard as `onNew`: the wizard cannot land a
-          // POST /api/sessions when the server returns 403 on every
-          // mutation, and a scratch fast-create that 403s on submit is
-          // a worse footgun than a no-op.
-          if (serverAbout?.read_only) return;
-          setWizardPrefill({ scratch: true, skipToReview: true });
-          setShowSessionWizard(true);
-        },
+        onNew: handleNewSession,
+        onNewScratch: handleNewScratch,
         onDiff: () => toggleDiff(),
         // Escape closes local UI surfaces only (dialogs, palette,
         // wizard, settings, help, file viewer). Never wire this to
@@ -752,7 +747,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         handleCloseSettings,
         navigate,
         handleToggleTerminalFocus,
-        serverAbout,
+        handleNewSession,
+        handleNewScratch,
       ],
     ),
   );
@@ -762,7 +758,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     activeSessionId,
     loginRequired,
     hasActiveSession: !!activeSession,
+    readOnly: !!serverAbout?.read_only,
     onNewSession: handleNewSession,
+    onNewScratch: handleNewScratch,
     onSelectSession: handleSelectSession,
     onToggleDiff: toggleDiff,
     onOpenSettings: handleOpenSettings,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -233,11 +233,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   const [sidebarSortMode, setSidebarSortMode] = useSidebarSortMode();
 
-  const { groups, toggleRepoCollapsed, updateRepoAppearance } = useRepoGroups(
-    workspaces,
-    workspaceOrdering,
-    sidebarSortMode,
-  );
+  const { groups, toggleRepoCollapsed, updateRepoAppearance, reorderRepoGroups } =
+    useRepoGroups(workspaces, workspaceOrdering, sidebarSortMode);
 
   // Drag-end handler for the sidebar. Optimistically applies the new
   // order locally so the row snaps into place, then persists to the
@@ -1067,6 +1064,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           <WorkspaceSidebar
             groups={groups}
             onReorderWorkspaces={handleReorderWorkspaces}
+            onReorderGroups={reorderRepoGroups}
             activeId={activeWorkspace?.id ?? null}
             open={sidebarOpen}
             onToggle={() => setSidebarOpen(false)}

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { SessionResponse } from "../lib/types";
 import { isSessionActive } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
+import { TOUR_ANCHORS, type TourAnchorId } from "../lib/tourSteps";
 
 interface Props {
   sessions: SessionResponse[];
@@ -153,6 +154,7 @@ export function Dashboard({
             onClick={onNewSession}
             icon="folder"
             featured
+            dataTour={TOUR_ANCHORS.dashboardNewSession}
           />
           <ActionPane
             title="Clone URL"
@@ -190,6 +192,7 @@ function ActionPane({
   href,
   icon,
   featured,
+  dataTour,
 }: {
   title: string;
   subtitle: string;
@@ -197,6 +200,7 @@ function ActionPane({
   href?: string;
   icon: "folder" | "git" | "book";
   featured?: boolean;
+  dataTour?: TourAnchorId;
 }) {
   const iconSvg = {
     folder: (
@@ -264,6 +268,7 @@ function ActionPane({
         href={href}
         target="_blank"
         rel="noopener noreferrer"
+        data-tour={dataTour}
         className={classes}
       >
         {iconSvg[icon]}
@@ -278,7 +283,7 @@ function ActionPane({
   }
 
   return (
-    <button onClick={onClick} className={`text-left ${classes}`}>
+    <button onClick={onClick} data-tour={dataTour} className={`text-left ${classes}`}>
       {iconSvg[icon]}
       <div>
         <p className={`font-medium text-text-primary ${featured ? "text-base" : "text-sm"}`}>

--- a/web/src/components/HelpOverlay.tsx
+++ b/web/src/components/HelpOverlay.tsx
@@ -25,12 +25,15 @@ export function HelpOverlay({ onClose }: Props) {
 
   const optKey = IS_MAC ? "⌥" : "Alt";
 
+  const shiftKey = IS_MAC ? "⇧" : "Shift";
+
   const shortcuts = [
     { key: `${modKey}K`, desc: "Open command palette" },
     { key: `${modKey}B`, desc: "Toggle left sidebar" },
     { key: `${modKey}${optKey}B`, desc: "Toggle right panel" },
     { key: `${modKey}\``, desc: "Toggle agent / shell terminal focus" },
     { key: "n", desc: "New session" },
+    { key: `${modKey}${shiftKey}N`, desc: "New scratch session" },
     { key: "D", desc: "Toggle diff panel" },
     { key: "s", desc: "Toggle settings" },
     { key: "Esc", desc: "Close dialog" },

--- a/web/src/components/OverflowMenu.tsx
+++ b/web/src/components/OverflowMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { type TourAnchorId } from "../lib/tourSteps";
 
 export interface OverflowItem {
   label: string;
@@ -7,9 +8,12 @@ export interface OverflowItem {
 
 interface Props {
   items: OverflowItem[];
+  /** Tour anchor attached to the trigger button (the stable, always-rendered
+   *  element), so the tour can point at the menu without it being open. */
+  triggerDataTour?: TourAnchorId;
 }
 
-export function OverflowMenu({ items }: Props) {
+export function OverflowMenu({ items, triggerDataTour }: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -33,6 +37,7 @@ export function OverflowMenu({ items }: Props) {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((o) => !o)}
+        data-tour={triggerDataTour}
         className="w-8 h-8 flex items-center justify-center rounded-md cursor-pointer text-text-muted hover:text-text-secondary hover:bg-surface-700/50 transition-colors"
         aria-label="More options"
         aria-haspopup="menu"

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -4,6 +4,7 @@ import { CommentsBanner } from "./diff/comments/CommentsBanner";
 import { PairedShellPane } from "./PairedTerminal";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import type { RepoBase, RichDiffFile, SessionResponse } from "../lib/types";
+import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 
 const VSPLIT_STORAGE_KEY = "aoe-right-vsplit";
 const DEFAULT_TOP_RATIO = 0.5;
@@ -133,7 +134,7 @@ export function RightPanel({
   }, []);
 
   return (
-    <div ref={containerRef} className="flex-1 flex flex-col min-h-0 overflow-hidden md:bg-surface-800 md:pb-1.5">
+    <div ref={containerRef} {...tourAnchor(TOUR_ANCHORS.rightPanel)} className="flex-1 flex flex-col min-h-0 overflow-hidden md:bg-surface-800 md:pb-1.5">
       {/* Upper: file list */}
       <div
         style={{ flexBasis: `${topRatio * 100}%` }}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -14,6 +14,7 @@ import {
 } from "../lib/api";
 import type { ProfileInfo } from "../lib/types";
 import {
+  CollapsibleSection,
   ListField,
   NumberField,
   SelectField,
@@ -46,23 +47,35 @@ type SidebarItem =
   | { kind: "tab"; id: TabId; label: string }
   | { kind: "divider"; label: string };
 
-function buildSidebar(): SidebarItem[] {
+// Sidebar groups mirror the TUI Settings layout (Appearance / Sessions /
+// Environment / Notifications / Web Dashboard / System) so muscle memory
+// carries across surfaces. The TUI source of truth is
+// `categories_for_scope()` in src/tui/settings/mod.rs. Web-only tabs with no
+// TUI equivalent (Notifications push, Terminal, Security, Devices) live under
+// a "Web Dashboard" divider; TUI-only categories (Agents, Interaction, Hooks,
+// StatusHooks) are intentionally not surfaced here. Exported for unit testing
+// the exact divider/tab order without fighting the duplicated mobile + desktop
+// tab strips in the DOM.
+export function buildSidebar(): SidebarItem[] {
   return [
-    { kind: "divider", label: "General" },
+    { kind: "divider", label: "Appearance" },
+    { kind: "tab", id: "theme", label: "Theme" },
+    { kind: "divider", label: "Sessions" },
     { kind: "tab", id: "session", label: "Session" },
+    { kind: "tab", id: "cockpit", label: "Cockpit" },
+    { kind: "divider", label: "Environment" },
     { kind: "tab", id: "sandbox", label: "Sandbox" },
     { kind: "tab", id: "worktree", label: "Worktree" },
-    { kind: "tab", id: "theme", label: "Theme" },
-    { kind: "tab", id: "sound", label: "Sound" },
     { kind: "tab", id: "tmux", label: "Tmux" },
-    { kind: "tab", id: "updates", label: "Updates" },
-    { kind: "divider", label: "Web Dashboard" },
+    { kind: "divider", label: "Notifications" },
+    { kind: "tab", id: "sound", label: "Sound" },
     { kind: "tab", id: "notifications", label: "Notifications" },
+    { kind: "divider", label: "Web Dashboard" },
     { kind: "tab", id: "terminal", label: "Terminal" },
     { kind: "tab", id: "security", label: "Security" },
     { kind: "tab", id: "devices", label: "Devices" },
-    { kind: "tab", id: "cockpit", label: "Cockpit" },
-    { kind: "divider", label: "Diagnostics" },
+    { kind: "divider", label: "System" },
+    { kind: "tab", id: "updates", label: "Updates" },
     { kind: "tab", id: "logging", label: "Logging" },
   ];
 }
@@ -290,18 +303,6 @@ export function SettingsView({
                 { value: "apple_container", label: "Apple Container" },
               ]}
             />
-            <TextField
-              label="CPU limit"
-              value={(sandbox.cpu_limit as string) ?? ""}
-              onChange={(v) => saveField("sandbox", sandbox, "cpu_limit", v || null)}
-              placeholder="e.g. 4"
-            />
-            <TextField
-              label="Memory limit"
-              value={(sandbox.memory_limit as string) ?? ""}
-              onChange={(v) => saveField("sandbox", sandbox, "memory_limit", v || null)}
-              placeholder="e.g. 8g"
-            />
             <ToggleField
               label="Mount SSH keys"
               description="Mount ~/.ssh into sandbox containers"
@@ -314,55 +315,72 @@ export function SettingsView({
               checked={(sandbox.auto_cleanup as boolean) ?? true}
               onChange={(v) => saveField("sandbox", sandbox, "auto_cleanup", v)}
             />
-            <TextField
-              label="Custom instruction"
-              description="Text appended to the agent system prompt in sandboxed sessions"
-              value={(sandbox.custom_instruction as string) ?? ""}
-              onChange={(v) => saveField("sandbox", sandbox, "custom_instruction", v || null)}
-              placeholder="Additional instructions for the agent..."
-              multiline
-            />
-            <ListField
-              label="Environment variables"
-              description="Variables passed to sandbox containers (KEY or KEY=VALUE)"
-              items={(sandbox.environment as string[]) ?? []}
-              onChange={(items) => saveField("sandbox", sandbox, "environment", items)}
-              placeholder="KEY or KEY=VALUE"
-              validate={(v) => {
-                if (!/^[A-Za-z_][A-Za-z0-9_]*(=.*)?$/.test(v))
-                  return "Must be KEY or KEY=VALUE (letters, digits, underscores)";
-                return null;
-              }}
-            />
-            <ListField
-              label="Extra volumes"
-              description="Additional volume mounts (host:container[:ro])"
-              items={(sandbox.extra_volumes as string[]) ?? []}
-              onChange={(items) => saveField("sandbox", sandbox, "extra_volumes", items)}
-              placeholder="/host/path:/container/path"
-              validate={(v) => {
-                if (!v.includes(":")) return "Must contain ':' (host:container)";
-                return null;
-              }}
-            />
-            <ListField
-              label="Port mappings"
-              description="Port forwarding (host:container)"
-              items={(sandbox.port_mappings as string[]) ?? []}
-              onChange={(items) => saveField("sandbox", sandbox, "port_mappings", items)}
-              placeholder="3000:3000"
-              validate={(v) => {
-                if (!/^\d+:\d+$/.test(v)) return "Must be port:port (e.g. 3000:3000)";
-                return null;
-              }}
-            />
-            <ListField
-              label="Volume ignores"
-              description="Directories excluded from host bind mount"
-              items={(sandbox.volume_ignores as string[]) ?? []}
-              onChange={(items) => saveField("sandbox", sandbox, "volume_ignores", items)}
-              placeholder="node_modules"
-            />
+            <CollapsibleSection
+              title="Advanced"
+              subtitle="Resource limits, custom instructions, environment, volumes, and ports."
+            >
+              <TextField
+                label="CPU limit"
+                value={(sandbox.cpu_limit as string) ?? ""}
+                onChange={(v) => saveField("sandbox", sandbox, "cpu_limit", v || null)}
+                placeholder="e.g. 4"
+              />
+              <TextField
+                label="Memory limit"
+                value={(sandbox.memory_limit as string) ?? ""}
+                onChange={(v) => saveField("sandbox", sandbox, "memory_limit", v || null)}
+                placeholder="e.g. 8g"
+              />
+              <TextField
+                label="Custom instruction"
+                description="Text appended to the agent system prompt in sandboxed sessions"
+                value={(sandbox.custom_instruction as string) ?? ""}
+                onChange={(v) => saveField("sandbox", sandbox, "custom_instruction", v || null)}
+                placeholder="Additional instructions for the agent..."
+                multiline
+              />
+              <ListField
+                label="Environment variables"
+                description="Variables passed to sandbox containers (KEY or KEY=VALUE)"
+                items={(sandbox.environment as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "environment", items)}
+                placeholder="KEY or KEY=VALUE"
+                validate={(v) => {
+                  if (!/^[A-Za-z_][A-Za-z0-9_]*(=.*)?$/.test(v))
+                    return "Must be KEY or KEY=VALUE (letters, digits, underscores)";
+                  return null;
+                }}
+              />
+              <ListField
+                label="Extra volumes"
+                description="Additional volume mounts (host:container[:ro])"
+                items={(sandbox.extra_volumes as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "extra_volumes", items)}
+                placeholder="/host/path:/container/path"
+                validate={(v) => {
+                  if (!v.includes(":")) return "Must contain ':' (host:container)";
+                  return null;
+                }}
+              />
+              <ListField
+                label="Port mappings"
+                description="Port forwarding (host:container)"
+                items={(sandbox.port_mappings as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "port_mappings", items)}
+                placeholder="3000:3000"
+                validate={(v) => {
+                  if (!/^\d+:\d+$/.test(v)) return "Must be port:port (e.g. 3000:3000)";
+                  return null;
+                }}
+              />
+              <ListField
+                label="Volume ignores"
+                description="Directories excluded from host bind mount"
+                items={(sandbox.volume_ignores as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "volume_ignores", items)}
+                placeholder="node_modules"
+              />
+            </CollapsibleSection>
           </div>
         );
 
@@ -383,40 +401,45 @@ export function SettingsView({
               placeholder="../{repo-name}-worktrees/{branch}"
               mono
             />
-            <TextField
-              label="Bare repo path template"
-              description="Template for worktree directories in bare repos ({branch})"
-              value={(worktree.bare_repo_path_template as string) ?? ""}
-              onChange={(v) => saveField("worktree", worktree, "bare_repo_path_template", v)}
-              placeholder="./{branch}"
-              mono
-            />
-            <TextField
-              label="Workspace path template"
-              description="Template for multi-repo workspace directories ({branch}, {session-id})"
-              value={(worktree.workspace_path_template as string) ?? ""}
-              onChange={(v) => saveField("worktree", worktree, "workspace_path_template", v)}
-              placeholder="../{branch}-workspace-{session-id}"
-              mono
-            />
             <ToggleField
               label="Auto cleanup"
               description="Delete worktrees when sessions are removed"
               checked={(worktree.auto_cleanup as boolean) ?? true}
               onChange={(v) => saveField("worktree", worktree, "auto_cleanup", v)}
             />
-            <ToggleField
-              label="Delete branch on cleanup"
-              description="Also delete the git branch when cleaning up a worktree"
-              checked={(worktree.delete_branch_on_cleanup as boolean) ?? false}
-              onChange={(v) => saveField("worktree", worktree, "delete_branch_on_cleanup", v)}
-            />
-            <ToggleField
-              label="Init submodules"
-              description="Run `git submodule update --init --recursive` after creating a worktree"
-              checked={(worktree.init_submodules as boolean) ?? true}
-              onChange={(v) => saveField("worktree", worktree, "init_submodules", v)}
-            />
+            <CollapsibleSection
+              title="Advanced"
+              subtitle="Bare-repo and workspace path templates, branch cleanup, and submodules."
+            >
+              <TextField
+                label="Bare repo path template"
+                description="Template for worktree directories in bare repos ({branch})"
+                value={(worktree.bare_repo_path_template as string) ?? ""}
+                onChange={(v) => saveField("worktree", worktree, "bare_repo_path_template", v)}
+                placeholder="./{branch}"
+                mono
+              />
+              <TextField
+                label="Workspace path template"
+                description="Template for multi-repo workspace directories ({branch}, {session-id})"
+                value={(worktree.workspace_path_template as string) ?? ""}
+                onChange={(v) => saveField("worktree", worktree, "workspace_path_template", v)}
+                placeholder="../{branch}-workspace-{session-id}"
+                mono
+              />
+              <ToggleField
+                label="Delete branch on cleanup"
+                description="Also delete the git branch when cleaning up a worktree"
+                checked={(worktree.delete_branch_on_cleanup as boolean) ?? false}
+                onChange={(v) => saveField("worktree", worktree, "delete_branch_on_cleanup", v)}
+              />
+              <ToggleField
+                label="Init submodules"
+                description="Run `git submodule update --init --recursive` after creating a worktree"
+                checked={(worktree.init_submodules as boolean) ?? true}
+                onChange={(v) => saveField("worktree", worktree, "init_submodules", v)}
+              />
+            </CollapsibleSection>
           </div>
         );
 
@@ -565,7 +588,15 @@ export function SettingsView({
                 {OFFLINE_TITLE}: toggles will not save while disconnected.
               </div>
             )}
+            {/* Keying on tab + profile remounts the content subtree on either
+                switch, which resets every component-local <CollapsibleSection>
+                "Advanced" fold back to collapsed (user story #4) and clears any
+                half-typed field draft so it cannot blur-commit into the wrong
+                profile. It also breaks React reconciliation between sibling
+                tabs that share the same root element shape, e.g. sandbox and
+                worktree both rendering <div className="space-y-4">. */}
             <fieldset
+              key={`${activeTab}-${selectedProfile}`}
               disabled={offline}
               className="space-y-5 disabled:opacity-50 border-0 m-0 p-0 min-w-0"
             >
@@ -657,44 +688,6 @@ function CockpitSettings({
         </button>
       </div>
 
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="History cap (events)"
-          description="Per-session retention cap on cockpit events. 0 = unlimited (default); set a non-zero value to bound disk usage on long-running sessions. Persists to config.toml as cockpit.replay_events; cross-device."
-          value={
-            typeof cockpit.replay_events === "number"
-              ? (cockpit.replay_events as number)
-              : 0
-          }
-          min={0}
-          onChange={(v) => onSaveField("cockpit", "replay_events", v)}
-        />
-      </div>
-
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="Replay buffer bytes"
-          description="Per-session byte cap on the in-memory replay buffer. Persists to config.toml as cockpit.replay_bytes; cross-device."
-          value={
-            typeof cockpit.replay_bytes === "number"
-              ? (cockpit.replay_bytes as number)
-              : 0
-          }
-          min={0}
-          onChange={(v) => onSaveField("cockpit", "replay_bytes", v)}
-        />
-      </div>
-
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="Max concurrent resumes"
-          description="Upper bound on parallel cockpit worker spawns/attaches the reconciler runs on `aoe serve` cold start. Default 4 keeps Node.js bootup memory bounded for laptops/Pis (each claude-agent-acp is ~50-80 MB transient). Bounded at runtime by `min(this, max_concurrent_workers).max(1)`. Persists to config.toml as cockpit.max_concurrent_resumes; cross-device."
-          value={maxConcurrentResumes}
-          min={1}
-          onChange={(v) => onSaveField("cockpit", "max_concurrent_resumes", v)}
-        />
-      </div>
-
       <div className="flex items-start justify-between gap-3 py-1 border-t border-surface-800 pt-3">
         <div>
           <div className="text-sm text-text-bright">Show tool-call durations</div>
@@ -725,34 +718,6 @@ function CockpitSettings({
         >
           {showToolDurations ? "Visible" : "Hidden"}
         </button>
-      </div>
-
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="Silent-orphan grace (s)"
-          description="Daemon-side watchdog grace before declaring a prompt orphaned and restarting the worker. Fires when the agent finishes streaming but the adapter never sends PromptResponse (upstream agentclientprotocol/claude-agent-acp#688). Active only when no in-flight tool call is open and the prompt has produced at least one progress event, so long-running tools are unaffected. 0 disables. Default 60. Persists to config.toml as cockpit.silent_orphan_grace_secs; cross-device. See #1240."
-          value={
-            typeof cockpit.silent_orphan_grace_secs === "number"
-              ? (cockpit.silent_orphan_grace_secs as number)
-              : 60
-          }
-          min={0}
-          onChange={(v) => onSaveField("cockpit", "silent_orphan_grace_secs", v)}
-        />
-      </div>
-
-      <div className="border-t border-surface-800 pt-3">
-        <NumberField
-          label="Silent-orphan fast grace (s)"
-          description="Accelerated silent-orphan grace, used once a cost-populated UsageUpdate has arrived for the current prompt (the claude-agent-acp wrap-up accounting marker emitted just before PromptResponse). Lowers MTTR on the known adapter wedge without weakening the vendor-agnostic baseline. 0 disables the accelerator (cost UsageUpdate stops reducing the effective grace). Default 20. Persists to config.toml as cockpit.silent_orphan_fast_grace_secs; cross-device. See #1240."
-          value={
-            typeof cockpit.silent_orphan_fast_grace_secs === "number"
-              ? (cockpit.silent_orphan_fast_grace_secs as number)
-              : 20
-          }
-          min={0}
-          onChange={(v) => onSaveField("cockpit", "silent_orphan_fast_grace_secs", v)}
-        />
       </div>
 
       <div className="flex items-start justify-between gap-3 py-1 border-t border-surface-800 pt-3">
@@ -789,6 +754,63 @@ function CockpitSettings({
           ))}
         </div>
       </div>
+
+      <CollapsibleSection
+        title="Advanced"
+        subtitle="Replay retention caps and daemon watchdog tuning. Touch only when triaging a specific failure mode."
+      >
+        <NumberField
+          label="History cap (events)"
+          description="Per-session retention cap on cockpit events. 0 = unlimited (default); set a non-zero value to bound disk usage on long-running sessions. Persists to config.toml as cockpit.replay_events; cross-device."
+          value={
+            typeof cockpit.replay_events === "number"
+              ? (cockpit.replay_events as number)
+              : 0
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "replay_events", v)}
+        />
+        <NumberField
+          label="Replay buffer bytes"
+          description="Per-session byte cap on the in-memory replay buffer. Persists to config.toml as cockpit.replay_bytes; cross-device."
+          value={
+            typeof cockpit.replay_bytes === "number"
+              ? (cockpit.replay_bytes as number)
+              : 0
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "replay_bytes", v)}
+        />
+        <NumberField
+          label="Max concurrent resumes"
+          description="Upper bound on parallel cockpit worker spawns/attaches the reconciler runs on `aoe serve` cold start. Default 4 keeps Node.js bootup memory bounded for laptops/Pis (each claude-agent-acp is ~50-80 MB transient). Bounded at runtime by `min(this, max_concurrent_workers).max(1)`. Persists to config.toml as cockpit.max_concurrent_resumes; cross-device."
+          value={maxConcurrentResumes}
+          min={1}
+          onChange={(v) => onSaveField("cockpit", "max_concurrent_resumes", v)}
+        />
+        <NumberField
+          label="Silent-orphan grace (s)"
+          description="Daemon-side watchdog grace before declaring a prompt orphaned and restarting the worker. Fires when the agent finishes streaming but the adapter never sends PromptResponse (upstream agentclientprotocol/claude-agent-acp#688). Active only when no in-flight tool call is open and the prompt has produced at least one progress event, so long-running tools are unaffected. 0 disables. Default 60. Persists to config.toml as cockpit.silent_orphan_grace_secs; cross-device. See #1240."
+          value={
+            typeof cockpit.silent_orphan_grace_secs === "number"
+              ? (cockpit.silent_orphan_grace_secs as number)
+              : 60
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "silent_orphan_grace_secs", v)}
+        />
+        <NumberField
+          label="Silent-orphan fast grace (s)"
+          description="Accelerated silent-orphan grace, used once a cost-populated UsageUpdate has arrived for the current prompt (the claude-agent-acp wrap-up accounting marker emitted just before PromptResponse). Lowers MTTR on the known adapter wedge without weakening the vendor-agnostic baseline. 0 disables the accelerator (cost UsageUpdate stops reducing the effective grace). Default 20. Persists to config.toml as cockpit.silent_orphan_fast_grace_secs; cross-device. See #1240."
+          value={
+            typeof cockpit.silent_orphan_fast_grace_secs === "number"
+              ? (cockpit.silent_orphan_fast_grace_secs as number)
+              : 20
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "silent_orphan_fast_grace_secs", v)}
+        />
+      </CollapsibleSection>
 
       {error && <div className="text-xs text-rose-400">{error}</div>}
     </div>

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { SessionResponse, Workspace } from "../lib/types";
 import { PaletteTriggerPill } from "./PaletteTriggerPill";
 import { OverflowMenu, type OverflowItem } from "./OverflowMenu";
+import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 
 interface Props {
   activeWorkspace: Workspace | undefined;
@@ -12,6 +13,7 @@ interface Props {
   diffCollapsed: boolean;
   onOpenHelp: () => void;
   onOpenAbout: () => void;
+  onStartTutorial: () => void;
   onLogout: () => void;
   loginRequired: boolean;
   isOffline: boolean;
@@ -34,6 +36,7 @@ export function TopBar({
   diffCollapsed,
   onOpenHelp,
   onOpenAbout,
+  onStartTutorial,
   onLogout,
   loginRequired,
   isOffline,
@@ -43,14 +46,18 @@ export function TopBar({
   const overflowItems = useMemo<OverflowItem[]>(() => {
     const items: OverflowItem[] = [
       { label: "Help", onClick: onOpenHelp },
+      { label: "Show tutorial", onClick: onStartTutorial },
       { label: "About", onClick: onOpenAbout },
     ];
     if (loginRequired) items.push({ label: "Sign out", onClick: onLogout });
     return items;
-  }, [onOpenHelp, onOpenAbout, onLogout, loginRequired]);
+  }, [onOpenHelp, onStartTutorial, onOpenAbout, onLogout, loginRequired]);
 
   return (
-    <header className="h-12 bg-surface-800 border-b border-surface-700/20 flex items-center px-3 shrink-0 gap-2">
+    <header
+      {...tourAnchor(TOUR_ANCHORS.topbar)}
+      className="h-12 bg-surface-800 border-b border-surface-700/20 flex items-center px-3 shrink-0 gap-2"
+    >
       {/* LEFT ZONE */}
       <div className="flex items-center gap-2 min-w-0 shrink-0">
         <button
@@ -137,7 +144,7 @@ export function TopBar({
           </button>
         )}
 
-        <OverflowMenu items={overflowItems} />
+        <OverflowMenu items={overflowItems} triggerDataTour={TOUR_ANCHORS.topbarMore} />
       </div>
     </header>
   );

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -46,6 +46,7 @@ import {
   isSessionActive,
 } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
+import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import {
   renameSession,
   setSessionArchive,
@@ -1761,6 +1762,7 @@ export function WorkspaceSidebar({
         onClick={onToggle}
       />
       <div
+        {...tourAnchor(TOUR_ANCHORS.sidebar)}
         style={{ width }}
         className={`fixed top-12 bottom-0 left-0 z-40 md:static md:z-auto bg-surface-800 flex flex-col md:h-full shrink-0 transition-transform duration-300 ease-in-out md:transition-none ${
           open ? "translate-x-0" : "-translate-x-full md:hidden"
@@ -2047,6 +2049,7 @@ export function WorkspaceSidebar({
           </button>
           <button
             onClick={onSettings}
+            {...tourAnchor(TOUR_ANCHORS.sidebarSettings)}
             className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
             title="Settings"
             aria-label="Settings"

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -56,6 +56,7 @@ import {
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { useClampedMenuPosition } from "../lib/menuPosition";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
+import { useQueuedCountForSessions } from "../hooks/useCockpitQueueCount";
 import { reportError } from "../lib/toastBus";
 import {
   repoGroupHasLiveWorkspace,
@@ -520,6 +521,11 @@ export const SessionRow = memo(function SessionRow({
     [workspace.sessions],
   );
   const hasDraft = useHasDraftForSessions(sessionIds);
+  // Queued cockpit follow-up prompts waiting to fire when the current
+  // turn ends. Summed across the workspace's sessions, mirroring how
+  // `hasDraft` ORs the same set. Lets a user juggling sessions see at a
+  // glance which rows have prompts pending without opening the cockpit.
+  const queuedCount = useQueuedCountForSessions(sessionIds);
 
   const setNotifyPreset = async (preset: NotifyPreset) => {
     setContextMenu(null);
@@ -856,6 +862,15 @@ export const SessionRow = memo(function SessionRow({
                   className="inline-flex shrink-0"
                 >
                   <Pencil className="h-3 w-3 text-amber-400/90" />
+                </span>
+              )}
+              {queuedCount > 0 && (
+                <span
+                  title={`${queuedCount} queued prompt${queuedCount === 1 ? "" : "s"}`}
+                  aria-label={`${queuedCount} queued`}
+                  className="inline-flex shrink-0 items-center rounded border border-sky-700/40 bg-sky-950/30 px-1 text-[10px] font-mono font-medium tabular-nums text-sky-300"
+                >
+                  {queuedCount}
                 </span>
               )}
               {effectiveArchived && (

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -10,7 +10,15 @@ import {
   type MutableRefObject,
 } from "react";
 import { createPortal } from "react-dom";
-import { Archive, Clock, ListOrdered, Moon, Pencil, Pin } from "lucide-react";
+import {
+  Archive,
+  Clock,
+  GripVertical,
+  ListOrdered,
+  Moon,
+  Pencil,
+  Pin,
+} from "lucide-react";
 import {
   DndContext,
   MouseSensor,
@@ -18,6 +26,7 @@ import {
   useSensor,
   useSensors,
   closestCenter,
+  type CollisionDetection,
   type DragEndEvent,
 } from "@dnd-kit/core";
 import {
@@ -106,9 +115,27 @@ function closeOtherContextMenus() {
   menuBus.dispatchEvent(new Event("close"));
 }
 
+// Group headers and session rows are both sortable inside the one
+// sidebar DndContext, so a header drag must not collide with a session
+// droppable (or vice versa). dnd-kit registers every sortable in a
+// single droppable registry per context; without filtering, closestCenter
+// would happily report a workspace row as the drop target while dragging a
+// group. Restrict candidates to droppables whose `data.type` matches the
+// dragged item, then defer to closestCenter within that subset. See #1644.
+const typedClosestCenter: CollisionDetection = (args) => {
+  const activeType = args.active.data.current?.type;
+  return closestCenter({
+    ...args,
+    droppableContainers: args.droppableContainers.filter(
+      (container) => container.data.current?.type === activeType,
+    ),
+  });
+};
+
 interface Props {
   groups: RepoGroup[];
   onReorderWorkspaces: (newOrder: string[]) => void;
+  onReorderGroups: (orderedGroupIds: string[]) => void;
   activeId: string | null;
   open: boolean;
   onToggle: () => void;
@@ -392,7 +419,11 @@ function SortableSessionRow(props: {
   // triggers a drag.
   const dragOff = !!props.readOnly || !!props.dragDisabled;
   const { listeners, setNodeRef, transform, transition, isDragging } =
-    useSortable({ id: props.workspace.id, disabled: dragOff });
+    useSortable({
+      id: props.workspace.id,
+      disabled: dragOff,
+      data: { type: "workspace" },
+    });
   useEffect(() => {
     if (isDragging) {
       // Keep extending the window while dragging so a slow drag still
@@ -440,6 +471,58 @@ function SortableSessionRow(props: {
       }
     >
       <SessionRow {...props} indented />
+    </div>
+  );
+}
+
+// Props handed to the grip element so RepoGroupHeader can wire a dedicated
+// drag handle. The whole header is NOT draggable: it already owns an
+// expand/collapse click, a context menu, a rename input, and a new-session
+// button, so a header-wide drag would smother them. The grip is the sole
+// activator. See #1644.
+type DragHandleProps = {
+  setActivatorNodeRef: (el: HTMLElement | null) => void;
+  attributes: ReturnType<typeof useSortable>["attributes"];
+  listeners: ReturnType<typeof useSortable>["listeners"];
+};
+
+// Sortable wrapper around an entire repo-group block (header + its rows),
+// so the group moves as a unit. Only real repo groups are wrapped;
+// synthetic Multi-repo/Scratch groups render plainly and stay pinned.
+function SortableRepoGroup({
+  groupId,
+  disabled,
+  children,
+}: {
+  groupId: string;
+  disabled: boolean;
+  children: (handle: DragHandleProps) => React.ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: groupId, disabled, data: { type: "group" } });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    position: "relative",
+    zIndex: isDragging ? 20 : "auto",
+  } as const;
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={
+        "transition-shadow duration-150 " +
+        (isDragging ? "ring-2 ring-inset ring-brand-500 shadow-lg" : "")
+      }
+    >
+      {children({ setActivatorNodeRef, attributes, listeners })}
     </div>
   );
 }
@@ -1354,6 +1437,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
   onNewSession,
   onUpdateAppearance,
   offline,
+  dragHandle,
 }: {
   group: RepoGroup;
   hasActiveChild: boolean;
@@ -1361,6 +1445,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
   onNewSession: () => void;
   onUpdateAppearance: (repoId: string, update: RepoAppearanceUpdate) => void;
   offline: boolean;
+  dragHandle?: DragHandleProps;
 }) {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [renaming, setRenaming] = useState(false);
@@ -1472,6 +1557,19 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
         }`}
         style={headerStyle}
       >
+        {dragHandle && (
+          <button
+            ref={dragHandle.setActivatorNodeRef}
+            type="button"
+            aria-label={`Reorder project ${group.displayName}`}
+            data-testid="sidebar-group-drag-handle"
+            className="shrink-0 -ml-1 flex h-5 w-4 items-center justify-center text-text-dim hover:text-text-secondary cursor-grab active:cursor-grabbing touch-none"
+            {...dragHandle.attributes}
+            {...dragHandle.listeners}
+          >
+            <GripVertical className="h-3.5 w-3.5" />
+          </button>
+        )}
         <span className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`} />
         <button
           onClick={onClick}
@@ -1606,6 +1704,7 @@ function workspaceMatchesFilter(ws: Workspace, q: string): boolean {
 export function WorkspaceSidebar({
   groups,
   onReorderWorkspaces,
+  onReorderGroups,
   activeId,
   open,
   onToggle,
@@ -1666,9 +1765,28 @@ export function WorkspaceSidebar({
       const { active, over } = e;
       if (!over || active.id === over.id) return;
 
-      // Drag is constrained to within a single repo group (each group
-      // has its own SortableContext), so finding the active group and
-      // reordering inside it is sufficient.
+      // Two sortable layers share this context: group headers and session
+      // rows. Branch on the typed `data` payload, not on the id shape
+      // (repo paths vs uuid-like ids), so the dispatch stays robust if
+      // either id domain changes. Typed collision detection already keeps
+      // a header drag from landing on a row; the guard here is belt and
+      // braces. See #1644.
+      if (active.data.current?.type === "group") {
+        if (over.data.current?.type !== "group") return;
+        // Persist the full visible group order, synthetic groups
+        // included: they default to the bottom but can be dragged to any
+        // position, after which their stored rank holds. See #1644.
+        const orderedIds = groups.map((g) => g.id);
+        const oldIndex = orderedIds.indexOf(String(active.id));
+        const newIndex = orderedIds.indexOf(String(over.id));
+        if (oldIndex < 0 || newIndex < 0) return;
+        onReorderGroups(arrayMove(orderedIds, oldIndex, newIndex));
+        return;
+      }
+
+      // Workspace-row drag is constrained to within a single repo group
+      // (each group has its own SortableContext), so finding the active
+      // group and reordering inside it is sufficient.
       const groupIndex = groups.findIndex((g) =>
         g.workspaces.some((w) => w.id === active.id),
       );
@@ -1690,7 +1808,7 @@ export function WorkspaceSidebar({
       });
       onReorderWorkspaces(flat);
     },
-    [groups, onReorderWorkspaces],
+    [groups, onReorderWorkspaces, onReorderGroups],
   );
 
   const q = filterQuery.trim().toLowerCase();
@@ -1882,75 +2000,120 @@ export function WorkspaceSidebar({
           <DragSuppressContext.Provider value={dragSuppressRef}>
           <DndContext
             sensors={sensors}
-            collisionDetection={closestCenter}
+            collisionDetection={typedClosestCenter}
             onDragEnd={dragDisabled ? undefined : handleDragEnd}
           >
-            {filteredGroups.filter(repoGroupHasLiveWorkspace).map((group) => {
-              const showExpanded = q ? true : !group.collapsed;
-              const hasActiveChild = group.workspaces.some(
-                (ws) => ws.id === displayedActiveId,
+            {(() => {
+              const liveGroups = filteredGroups.filter(
+                repoGroupHasLiveWorkspace,
               );
+              // Every visible group is sortable, synthetic Multi-repo /
+              // Scratch included: they default to the bottom but can be
+              // dragged to any position. Group drag is off while a filter
+              // is active (the visible list is a partial projection) or
+              // whenever row drag is off (read-only or last-activity
+              // sort, where the order is computed). See #1644.
+              const sortableGroupIds = liveGroups.map((g) => g.id);
+              const groupDragDisabled = dragDisabled || q.length > 0;
+
+              const renderGroupBody = (
+                group: RepoGroup,
+                dragHandle?: DragHandleProps,
+              ) => {
+                const showExpanded = q ? true : !group.collapsed;
+                const hasActiveChild = group.workspaces.some(
+                  (ws) => ws.id === displayedActiveId,
+                );
+                return (
+                  <>
+                    <RepoGroupHeader
+                      group={{ ...group, collapsed: !showExpanded }}
+                      hasActiveChild={!showExpanded && hasActiveChild}
+                      onClick={() => !q && onToggleRepo(group.id)}
+                      onUpdateAppearance={onUpdateRepoAppearance}
+                      onNewSession={() =>
+                        group.id === MULTI_REPO_GROUP_ID ||
+                        group.id === SCRATCH_GROUP_ID
+                          ? onNew()
+                          : onCreateSession(group.repoPath)
+                      }
+                      offline={offline}
+                      dragHandle={dragHandle}
+                    />
+                    {showExpanded &&
+                      (() => {
+                        // Each group renders only its live tier. Sunk
+                        // workspaces (archived or actively snoozed across
+                        // every session) are pulled out into a single
+                        // global "Snoozed & archived" section at the very
+                        // bottom of the sidebar, rather than one footer
+                        // per repo group. See #1581.
+                        const liveWorkspaces = group.workspaces.filter(
+                          (ws) => !workspaceIsSunk(ws),
+                        );
+                        return (
+                          <SortableContext
+                            items={liveWorkspaces.map((ws) => ws.id)}
+                            strategy={verticalListSortingStrategy}
+                          >
+                            {liveWorkspaces.map((ws) => (
+                              <SortableSessionRow
+                                key={ws.id}
+                                workspace={ws}
+                                isActive={ws.id === displayedActiveId}
+                                onClick={() => {
+                                  setOptimisticActive({
+                                    id: ws.id,
+                                    fromActiveId: activeId,
+                                  });
+                                  onSelect(ws.id);
+                                }}
+                                onDelete={onDeleteSession}
+                                readOnly={readOnly}
+                                // Drag is disabled when the tier
+                                // comparator already controls placement:
+                                // lastActivity mode has no manual
+                                // concept, pinned rows always float to
+                                // the top of their group. See #1581.
+                                dragDisabled={
+                                  sortMode === "lastActivity" ||
+                                  workspaceIsPinned(ws)
+                                }
+                              />
+                            ))}
+                          </SortableContext>
+                        );
+                      })()}
+                  </>
+                );
+              };
+
               return (
-                <div key={group.id}>
-                  <RepoGroupHeader
-                    group={{ ...group, collapsed: !showExpanded }}
-                    hasActiveChild={!showExpanded && hasActiveChild}
-                    onClick={() => !q && onToggleRepo(group.id)}
-                    onUpdateAppearance={onUpdateRepoAppearance}
-                    onNewSession={() =>
-                      group.id === MULTI_REPO_GROUP_ID ||
-                      group.id === SCRATCH_GROUP_ID
-                        ? onNew()
-                        : onCreateSession(group.repoPath)
-                    }
-                    offline={offline}
-                  />
-                  {showExpanded && (() => {
-                    // Each group renders only its live tier. Sunk
-                    // workspaces (archived or actively snoozed across
-                    // every session) are pulled out into a single
-                    // global "Snoozed & archived" section at the very
-                    // bottom of the sidebar, rather than one footer
-                    // per repo group. See #1581.
-                    const liveWorkspaces = group.workspaces.filter(
-                      (ws) => !workspaceIsSunk(ws),
-                    );
-                    return (
-                      <SortableContext
-                        items={liveWorkspaces.map((ws) => ws.id)}
-                        strategy={verticalListSortingStrategy}
-                      >
-                        {liveWorkspaces.map((ws) => (
-                          <SortableSessionRow
-                            key={ws.id}
-                            workspace={ws}
-                            isActive={ws.id === displayedActiveId}
-                            onClick={() => {
-                              setOptimisticActive({
-                                id: ws.id,
-                                fromActiveId: activeId,
-                              });
-                              onSelect(ws.id);
-                            }}
-                            onDelete={onDeleteSession}
-                            readOnly={readOnly}
-                            // Drag is disabled when the tier comparator
-                            // already controls placement: lastActivity
-                            // mode has no manual concept, pinned rows
-                            // always float to the top of their group.
-                            // See #1581.
-                            dragDisabled={
-                              sortMode === "lastActivity" ||
-                              workspaceIsPinned(ws)
-                            }
-                          />
-                        ))}
-                      </SortableContext>
-                    );
-                  })()}
-                </div>
+                <SortableContext
+                  items={sortableGroupIds}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {liveGroups.map((group) => (
+                    <SortableRepoGroup
+                      key={group.id}
+                      groupId={group.id}
+                      disabled={groupDragDisabled}
+                    >
+                      {(handle) =>
+                        // Hide the grip when group drag is off (the
+                        // visible order is computed or filtered) so
+                        // there is no dead affordance, mirroring how
+                        // session rows drop their drag wiring.
+                        renderGroupBody(
+                          group,
+                          groupDragDisabled ? undefined : handle,
+                        )
+                      }
+                    </SortableRepoGroup>
+                  ))}
+                </SortableContext>
               );
-            })}
+            })()}
           </DndContext>
           </DragSuppressContext.Provider>
           {(() => {

--- a/web/src/components/__tests__/Dashboard.tour.test.tsx
+++ b/web/src/components/__tests__/Dashboard.tour.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+//
+// Render-time half of the tour drift guard: the static guard proves the anchor
+// constant is wired in source, but not that it actually paints under a given
+// state. The dashboard new-session anchor is conditionally rendered (hidden in
+// read-only mode), so assert it resolves exactly once when writable and is gone
+// when read-only, matching the step's `writableOnly` metadata.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import { Dashboard } from "../Dashboard";
+import { TOUR_ANCHORS, tourSelector } from "../../lib/tourSteps";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderDashboard(readOnly: boolean) {
+  return render(
+    <Dashboard
+      sessions={[]}
+      onSelectSession={vi.fn()}
+      onNewSession={vi.fn()}
+      onCloneFromUrl={vi.fn()}
+      onToggleSidebar={vi.fn()}
+      readOnly={readOnly}
+    />,
+  );
+}
+
+describe("Dashboard tour anchors", () => {
+  it("renders the new-session anchor exactly once when writable", () => {
+    const { container } = renderDashboard(false);
+    expect(
+      container.querySelectorAll(tourSelector(TOUR_ANCHORS.dashboardNewSession)),
+    ).toHaveLength(1);
+  });
+
+  it("hides the new-session anchor in read-only mode", () => {
+    const { container } = renderDashboard(true);
+    expect(
+      container.querySelectorAll(tourSelector(TOUR_ANCHORS.dashboardNewSession)),
+    ).toHaveLength(0);
+  });
+});

--- a/web/src/components/__tests__/SettingsView.folds.test.tsx
+++ b/web/src/components/__tests__/SettingsView.folds.test.tsx
@@ -1,0 +1,303 @@
+// @vitest-environment jsdom
+//
+// Behavioral coverage for the Settings "Advanced" folds (#1515):
+//   Story #2 - advanced cockpit knobs are hidden behind a default-collapsed
+//              fold while high-level controls stay visible.
+//   Story #4 - the fold collapses back to default when the user changes tabs
+//              or switches profiles (component-local state, not persisted).
+//
+// The end-to-end persist-after-expand path (story #3) lives in live Playwright
+// at web/tests/live/settings-advanced-fold.spec.ts.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SettingsView } from "../SettingsView";
+import * as api from "../../lib/api";
+
+const PROFILES = [
+  { name: "main", is_default: true },
+  { name: "work", is_default: false },
+];
+
+vi.mock("../../lib/api", () => ({
+  fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchSettings: vi.fn(() =>
+    Promise.resolve({ cockpit: {}, sandbox: {}, worktree: {} }),
+  ),
+  updateProfileSettings: vi.fn(() => Promise.resolve(true)),
+  setCockpitMaster: vi.fn(() => Promise.resolve(true)),
+  setDefaultProfile: vi.fn(() => Promise.resolve(true)),
+  createProfile: vi.fn(() => Promise.resolve(true)),
+  renameProfile: vi.fn(() => Promise.resolve(true)),
+  deleteProfile: vi.fn(() => Promise.resolve(true)),
+}));
+
+const SERVER_ABOUT = {
+  cockpit_master_enabled: true,
+  cockpit_show_tool_durations: true,
+  cockpit_queue_drain_mode: "combined" as const,
+  cockpit_max_concurrent_resumes: 4,
+};
+
+function renderView(tab: string) {
+  const onSelectTab = vi.fn();
+  const utils = render(
+    <SettingsView
+      onClose={() => {}}
+      tab={tab}
+      onSelectTab={onSelectTab}
+      serverAbout={SERVER_ABOUT as never}
+      onServerAboutRefresh={() => {}}
+    />,
+  );
+  return { ...utils, onSelectTab };
+}
+
+function expandAdvanced(container: HTMLElement) {
+  const trigger = container.querySelector(
+    "button[aria-expanded]",
+  ) as HTMLButtonElement;
+  expect(trigger).toBeTruthy();
+  fireEvent.click(trigger);
+}
+
+function fieldInputByLabel(
+  container: HTMLElement,
+  label: string,
+  type: "number" | "text",
+): HTMLInputElement | HTMLTextAreaElement {
+  const labels = Array.from(container.querySelectorAll("label"));
+  const match = labels.find((l) => l.textContent === label);
+  // TextField renders a textarea when multiline (e.g. Custom instruction).
+  const selector =
+    type === "text" ? 'input[type="text"], textarea' : `input[type="${type}"]`;
+  const input = match?.parentElement?.querySelector(selector);
+  expect(input).toBeTruthy();
+  return input as HTMLInputElement | HTMLTextAreaElement;
+}
+
+function commit(
+  input: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) {
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value } });
+  fireEvent.blur(input);
+}
+
+// ToggleField renders a label div next to a role=switch button inside a flex
+// row; click the switch that pairs with the given label.
+function clickToggle(container: HTMLElement, label: string) {
+  const labelDiv = Array.from(container.querySelectorAll("div")).find(
+    (d) => d.textContent === label && d.querySelector("*") === null,
+  );
+  const row = labelDiv?.parentElement?.parentElement;
+  const sw = row?.querySelector('button[role="switch"]') as HTMLButtonElement;
+  expect(sw).toBeTruthy();
+  fireEvent.click(sw);
+}
+
+// ListField: open its add input, type a value, submit with Enter. Scoped to
+// the ListField whose header carries `label` so the right "+ Add" / input pair
+// is used when several lists render together.
+function addListItem(container: HTMLElement, label: string, value: string) {
+  const labelEl = Array.from(container.querySelectorAll("label")).find(
+    (l) => l.textContent === label,
+  );
+  const root = labelEl?.parentElement?.parentElement as HTMLElement;
+  // "+ Add" is hidden while the add input is already open (e.g. after a
+  // rejected invalid entry); only click it when present, then reuse the input.
+  const addBtn = labelEl?.parentElement?.querySelector("button");
+  if (addBtn) fireEvent.click(addBtn);
+  const input = root.querySelector('input[type="text"]') as HTMLInputElement;
+  fireEvent.change(input, { target: { value } });
+  fireEvent.keyDown(input, { key: "Enter" });
+}
+
+// The profile picker is the only <select> carrying the "work" option.
+function selectProfile(container: HTMLElement, name: string) {
+  const select = Array.from(container.querySelectorAll("select")).find((s) =>
+    Array.from(s.options).some((o) => o.value === name),
+  ) as HTMLSelectElement;
+  expect(select).toBeTruthy();
+  fireEvent.change(select, { target: { value: name } });
+}
+
+describe("Settings Advanced fold", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides cockpit advanced knobs until the fold is expanded (#2)", async () => {
+    const { container } = renderView("cockpit");
+
+    // High-level controls are always visible.
+    expect(screen.getByText("Cockpit master switch")).toBeTruthy();
+    expect(screen.getByText("Show tool-call durations")).toBeTruthy();
+    expect(screen.getByText("Queue drain mode")).toBeTruthy();
+
+    // Advanced knobs are absent while collapsed.
+    expect(screen.queryByText("Replay buffer bytes")).toBeNull();
+    expect(screen.queryByText("Max concurrent resumes")).toBeNull();
+    expect(screen.queryByText("Silent-orphan grace (s)")).toBeNull();
+
+    expandAdvanced(container);
+
+    expect(screen.getByText("Replay buffer bytes")).toBeTruthy();
+    expect(screen.getByText("Max concurrent resumes")).toBeTruthy();
+    expect(screen.getByText("Silent-orphan grace (s)")).toBeTruthy();
+  });
+
+  it("collapses the fold when switching tabs, with no cross-tab leak (#4)", async () => {
+    const { container, rerender } = renderView("sandbox");
+    await screen.findByText("Sandbox enabled by default");
+
+    expandAdvanced(container);
+    expect(screen.getByText("CPU limit")).toBeTruthy();
+
+    // Switch to worktree: its Advanced fold starts collapsed (no leaked
+    // open-state from the sandbox tab sharing the same root element).
+    rerender(
+      <SettingsView
+        onClose={() => {}}
+        tab="worktree"
+        onSelectTab={() => {}}
+        serverAbout={SERVER_ABOUT as never}
+        onServerAboutRefresh={() => {}}
+      />,
+    );
+    await screen.findByText("Worktrees enabled");
+    expect(screen.queryByText("Bare repo path template")).toBeNull();
+
+    // Back to sandbox: the fold reset to collapsed.
+    rerender(
+      <SettingsView
+        onClose={() => {}}
+        tab="sandbox"
+        onSelectTab={() => {}}
+        serverAbout={SERVER_ABOUT as never}
+        onServerAboutRefresh={() => {}}
+      />,
+    );
+    await screen.findByText("Sandbox enabled by default");
+    expect(screen.queryByText("CPU limit")).toBeNull();
+  });
+
+  it("saves every cockpit advanced knob through the normal path", async () => {
+    const { container } = renderView("cockpit");
+    await waitFor(() => expect(screen.getByText("Queue drain mode")).toBeTruthy());
+
+    expandAdvanced(container);
+    commit(fieldInputByLabel(container, "History cap (events)", "number"), "500");
+    commit(fieldInputByLabel(container, "Replay buffer bytes", "number"), "4096");
+    commit(fieldInputByLabel(container, "Max concurrent resumes", "number"), "8");
+    commit(fieldInputByLabel(container, "Silent-orphan grace (s)", "number"), "90");
+    commit(
+      fieldInputByLabel(container, "Silent-orphan fast grace (s)", "number"),
+      "30",
+    );
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith(
+        "main",
+        { cockpit: { replay_bytes: 4096 } },
+      ),
+    );
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      cockpit: { silent_orphan_fast_grace_secs: 30 },
+    });
+  });
+
+  it("exercises the cockpit high-level toggles outside the fold", async () => {
+    const { container } = renderView("cockpit");
+    await waitFor(() => expect(screen.getByText("Queue drain mode")).toBeTruthy());
+
+    const durations = container.querySelector(
+      'button[aria-label="Show tool-call durations"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(durations);
+
+    const serial = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Serial",
+    ) as HTMLButtonElement;
+    fireEvent.click(serial);
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+        cockpit: { queue_drain_mode: "serial" },
+      }),
+    );
+  });
+
+  it("expands the worktree fold and saves every advanced field", async () => {
+    const { container } = renderView("worktree");
+    await screen.findByText("Worktrees enabled");
+
+    expect(screen.queryByText("Workspace path template")).toBeNull();
+    expandAdvanced(container);
+    expect(screen.getByText("Workspace path template")).toBeTruthy();
+
+    commit(
+      fieldInputByLabel(container, "Bare repo path template", "text"),
+      "./{branch}",
+    );
+    commit(
+      fieldInputByLabel(container, "Workspace path template", "text"),
+      "../wt-{branch}",
+    );
+    clickToggle(container, "Delete branch on cleanup");
+    clickToggle(container, "Init submodules");
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+        worktree: { workspace_path_template: "../wt-{branch}" },
+      }),
+    );
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      worktree: { delete_branch_on_cleanup: true },
+    });
+  });
+
+  it("saves every sandbox advanced field through the normal path", async () => {
+    const { container } = renderView("sandbox");
+    await screen.findByText("Sandbox enabled by default");
+
+    expandAdvanced(container);
+    commit(fieldInputByLabel(container, "CPU limit", "text"), "4");
+    commit(fieldInputByLabel(container, "Memory limit", "text"), "8g");
+    commit(fieldInputByLabel(container, "Custom instruction", "text"), "be terse");
+
+    // Lists exercise both the add (onChange) and validate paths: an invalid
+    // entry trips the validator, then a valid one commits.
+    addListItem(container, "Environment variables", "1bad");
+    addListItem(container, "Environment variables", "FOO=bar");
+    addListItem(container, "Extra volumes", "nocolon");
+    addListItem(container, "Extra volumes", "/h:/c");
+    addListItem(container, "Port mappings", "bad");
+    addListItem(container, "Port mappings", "3000:3000");
+    addListItem(container, "Volume ignores", "node_modules");
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+        sandbox: { cpu_limit: "4" },
+      }),
+    );
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      sandbox: { environment: ["FOO=bar"] },
+    });
+  });
+
+  it("collapses the fold when switching profiles (#4)", async () => {
+    const { container } = renderView("cockpit");
+    await waitFor(() => expect(screen.getByText("Queue drain mode")).toBeTruthy());
+
+    expandAdvanced(container);
+    expect(screen.getByText("Replay buffer bytes")).toBeTruthy();
+
+    selectProfile(container, "work");
+
+    await waitFor(() =>
+      expect(screen.queryByText("Replay buffer bytes")).toBeNull(),
+    );
+  });
+});

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -10,7 +10,37 @@
 // branch logic.
 
 import { describe, expect, it } from "vitest";
-import { resolveSelectedProfile } from "../SettingsView";
+import { buildSidebar, resolveSelectedProfile } from "../SettingsView";
+
+// Story #1: the web sidebar divider/tab order mirrors the TUI grouping
+// (categories_for_scope() in src/tui/settings/mod.rs) so muscle memory carries
+// across surfaces. Asserting the pure config is more robust than querying the
+// DOM, which renders the same list twice (mobile strip + desktop nav).
+describe("buildSidebar", () => {
+  it("matches the TUI grouping order", () => {
+    expect(buildSidebar()).toEqual([
+      { kind: "divider", label: "Appearance" },
+      { kind: "tab", id: "theme", label: "Theme" },
+      { kind: "divider", label: "Sessions" },
+      { kind: "tab", id: "session", label: "Session" },
+      { kind: "tab", id: "cockpit", label: "Cockpit" },
+      { kind: "divider", label: "Environment" },
+      { kind: "tab", id: "sandbox", label: "Sandbox" },
+      { kind: "tab", id: "worktree", label: "Worktree" },
+      { kind: "tab", id: "tmux", label: "Tmux" },
+      { kind: "divider", label: "Notifications" },
+      { kind: "tab", id: "sound", label: "Sound" },
+      { kind: "tab", id: "notifications", label: "Notifications" },
+      { kind: "divider", label: "Web Dashboard" },
+      { kind: "tab", id: "terminal", label: "Terminal" },
+      { kind: "tab", id: "security", label: "Security" },
+      { kind: "tab", id: "devices", label: "Devices" },
+      { kind: "divider", label: "System" },
+      { kind: "tab", id: "updates", label: "Updates" },
+      { kind: "tab", id: "logging", label: "Logging" },
+    ]);
+  });
+});
 
 describe("resolveSelectedProfile", () => {
   it("preserves the current selection when it still exists in the profile list", () => {

--- a/web/src/components/__tests__/TopBar.test.tsx
+++ b/web/src/components/__tests__/TopBar.test.tsx
@@ -39,6 +39,7 @@ function renderTopBar(
       diffCollapsed={true}
       onOpenHelp={vi.fn()}
       onOpenAbout={vi.fn()}
+      onStartTutorial={vi.fn()}
       onLogout={vi.fn()}
       loginRequired={false}
       isOffline={overrides.isOffline ?? false}

--- a/web/src/components/cockpit/CockpitRuntime.test.ts
+++ b/web/src/components/cockpit/CockpitRuntime.test.ts
@@ -443,3 +443,81 @@ describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
     }
   });
 });
+
+function toolStopped(id: string, text = ""): ActivityRow {
+  return {
+    id: `stopped-${id}-9`,
+    kind: "tool_stopped",
+    text,
+    toolCallId: id,
+    at: "2026-05-12T00:00:02Z",
+  };
+}
+
+describe("activityToThreadMessages; stopped status threading (#1646)", () => {
+  it("carries stopped onto a top-level tool-call part's result", () => {
+    const messages = activityToThreadMessages(
+      [userRow("go"), toolStart("t1"), toolStopped("t1")],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = assistant.content as Array<{
+      type: string;
+      result?: { stopped?: boolean };
+      isError?: boolean;
+    }>;
+    const tool = parts.find((p) => p.type === "tool-call")!;
+    expect(tool.result?.stopped).toBe(true);
+    // Stopped is not an error; assistant-ui's isError stays falsy.
+    expect(tool.isError).toBeFalsy();
+  });
+
+  it("preserves stopped on a subagent child through the payload round-trip", () => {
+    const parent: ToolCall = {
+      id: "task-1",
+      name: "Task",
+      kind: "think",
+      args_preview: JSON.stringify({ _aoe_title: "Task" }),
+      started_at: "2026-05-12T00:00:00Z",
+    };
+    const parentRow: ActivityRow = {
+      id: "start-task-1",
+      kind: "tool_start",
+      text: "Task",
+      toolCallId: "task-1",
+      tool: parent,
+      at: "2026-05-12T00:00:00Z",
+    };
+    const child: ToolCall = {
+      id: "ch-1",
+      name: "Read",
+      kind: "read",
+      args_preview: JSON.stringify({ path: "/x" }),
+      started_at: "2026-05-12T00:00:01Z",
+      parent_tool_call_id: "task-1",
+    };
+    const childRow: ActivityRow = {
+      id: "start-ch-1",
+      kind: "tool_start",
+      text: "Read",
+      toolCallId: "ch-1",
+      tool: child,
+      at: "2026-05-12T00:00:01Z",
+    };
+    const messages = activityToThreadMessages(
+      [userRow("go"), parentRow, childRow, toolStopped("ch-1")],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = assistant.content as Array<{
+      type: string;
+      toolName?: string;
+      argsText?: string;
+    }>;
+    const subagent = parts.find(
+      (p) => p.type === "tool-call" && p.toolName === SUBAGENT_TASK_NAME,
+    )!;
+    const payload = JSON.parse(subagent.argsText!);
+    expect(payload.children[0].result.stopped).toBe(true);
+  });
+});

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -297,10 +297,15 @@ export function activityToThreadMessages(
       currentAssistant.appendText(row.text);
     } else if (row.kind === "tool_start" && row.tool) {
       currentAssistant.appendToolCall(row.tool);
-    } else if (row.kind === "tool_complete" || row.kind === "tool_error") {
+    } else if (
+      row.kind === "tool_complete" ||
+      row.kind === "tool_error" ||
+      row.kind === "tool_stopped"
+    ) {
       currentAssistant.completeToolCall(
-        row.toolCallId ?? row.id.replace(/^done-/, ""),
+        row.toolCallId ?? row.id.replace(/^(done|stopped)-/, ""),
         row.kind === "tool_error",
+        row.kind === "tool_stopped",
         row.text,
         row.at,
       );
@@ -357,7 +362,7 @@ type DraftPart =
       toolCallId: string;
       toolName: string;
       argsText: string;
-      result?: { content: string; endedAt?: string };
+      result?: { content: string; endedAt?: string; stopped?: boolean };
       isError?: boolean;
     };
 
@@ -419,12 +424,13 @@ class AssistantBuilder {
   completeToolCall(
     toolCallId: string,
     isError: boolean,
+    stopped: boolean,
     resultText: string,
     endedAt: string,
   ) {
     for (const part of this.parts) {
       if (part.type === "tool-call" && part.toolCallId === toolCallId) {
-        part.result = { content: resultText, endedAt };
+        part.result = { content: resultText, endedAt, stopped: stopped || undefined };
         part.isError = isError || undefined;
         return;
       }
@@ -591,8 +597,10 @@ type GroupChildPayload = {
   argsText: string;
   // `endedAt` rides along from DraftPart.result (set in completeToolCall)
   // and CockpitView's pickEndedAt reads it to compute durations; keep it
-  // on the type so a future rebuild of `result` doesn't drop it.
-  result?: { content: string; endedAt?: string };
+  // on the type so a future rebuild of `result` doesn't drop it. `stopped`
+  // rides the same way so grouped/subagent children reconstruct as the
+  // distinct "stopped" terminal state instead of "done" (#1646).
+  result?: { content: string; endedAt?: string; stopped?: boolean };
   isError?: boolean;
 };
 

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -1992,7 +1992,10 @@ function RejectedPromptsStrip({
                 !
               </span>
               <div className="min-w-0 flex-1">
-                <p className="truncate whitespace-pre-wrap break-words text-xs text-amber-100">
+                {/* Bound a huge rejected paste to a scrollable box so it
+                    cannot grow the strip and shove the composer off-screen,
+                    same hazard as the queued rows. See #1642. */}
+                <p className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words text-xs text-amber-100">
                   {r.text}
                 </p>
                 <p className="mt-0.5 text-[10px] text-amber-400/80">
@@ -2156,19 +2159,35 @@ function QueuedPromptRow({
         />
       ) : (
         <div className="min-w-0 flex-1">
-          <button
-            type="button"
-            onClick={() => setEditing(true)}
-            title="Click to edit"
-            className={[
-              "block w-full text-left text-xs leading-5 text-text-secondary whitespace-pre-wrap break-words hover:text-text-primary",
-              isLong && !rowExpanded ? "line-clamp-3" : "",
-            ]
-              .filter(Boolean)
-              .join(" ")}
+          {/* When expanded, a huge paste is bounded to a scrollable box
+              (max-h matches the composer's max-h-[200px]) so it can never
+              grow the strip and push the composer off-screen. The toggle
+              below stays a sibling of this box, so capping the height also
+              keeps "Show less" reachable. See #1642. */}
+          <div
+            className={
+              isLong && rowExpanded ? "max-h-48 overflow-y-auto" : ""
+            }
           >
-            {prompt.text}
-          </button>
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              title="Click to edit"
+              className={[
+                "w-full text-left text-xs leading-5 text-text-secondary whitespace-pre-wrap break-words hover:text-text-primary",
+                // `line-clamp-3` only clamps when it owns the element's
+                // display (`-webkit-box`). A static `block` here wins the
+                // cascade and silently kills the clamp, so a huge collapsed
+                // paste renders in full. Keep `block` and `line-clamp-3`
+                // mutually exclusive. See #1642.
+                isLong && !rowExpanded ? "line-clamp-3" : "block",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+            >
+              {prompt.text}
+            </button>
+          </div>
           {isLong && (
             <button
               type="button"

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -620,9 +620,7 @@ function AssistantToolCall(props: ToolCallProps) {
     props.result !== undefined
       ? {
           id: `done-${props.toolCallId}`,
-          kind: props.isError
-            ? ("tool_error" as const)
-            : ("tool_complete" as const),
+          kind: resultRowKind(props.isError, pickStopped(props.result)),
           text: resultContent,
           toolCallId: props.toolCallId,
           at: endedAt,
@@ -673,11 +671,34 @@ function pickEndedAt(result: unknown): string | null {
   return null;
 }
 
+/** Read the smuggled `stopped` flag set by AssistantBuilder.completeToolCall
+ *  for a tool closed by the reducer's turn-end sweep (#1646), so the
+ *  reconstructed row carries the distinct `tool_stopped` kind. */
+function pickStopped(result: unknown): boolean {
+  return (
+    !!result &&
+    typeof result === "object" &&
+    (result as { stopped?: unknown }).stopped === true
+  );
+}
+
+/** Map a completed tool's flags to its activity-row kind. Error wins
+ *  over stopped (a tool that errored before the turn ended is a real
+ *  failure); stopped wins over complete. See #1646. */
+function resultRowKind(
+  isError: boolean | undefined,
+  stopped: boolean,
+): "tool_error" | "tool_stopped" | "tool_complete" {
+  if (isError) return "tool_error";
+  if (stopped) return "tool_stopped";
+  return "tool_complete";
+}
+
 interface GroupChild {
   toolCallId: string;
   toolName: string;
   argsText: string;
-  result?: { content: string; endedAt?: string };
+  result?: { content: string; endedAt?: string; stopped?: boolean };
   isError?: boolean;
 }
 
@@ -728,9 +749,7 @@ function groupChildToItem(c: GroupChild): {
     c.result !== undefined
       ? {
           id: `done-${c.toolCallId}`,
-          kind: c.isError
-            ? ("tool_error" as const)
-            : ("tool_complete" as const),
+          kind: resultRowKind(c.isError, c.result.stopped === true),
           text: c.result.content,
           toolCallId: c.toolCallId,
           at: endedAt,
@@ -800,9 +819,7 @@ function AssistantSubagentTask({ argsText }: { argsText?: string }) {
       c.result !== undefined
         ? {
             id: `done-${c.toolCallId}`,
-            kind: c.isError
-              ? ("tool_error" as const)
-              : ("tool_complete" as const),
+            kind: resultRowKind(c.isError, c.result.stopped === true),
             text: c.result.content,
             toolCallId: c.toolCallId,
             at: endedAt,

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -30,6 +30,7 @@ import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import { SessionConfigControls } from "./SessionConfigControls";
 import type { CockpitState } from "../../lib/cockpitTypes";
 import { getDraft, setDraft } from "../../lib/cockpitDrafts";
+import { TOUR_ANCHORS, tourAnchor } from "../../lib/tourSteps";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { useAgentProfile } from "../../lib/agentProfileContext";
 import { useFocusTerminalTarget } from "../../hooks/useFocusTerminalTarget";
@@ -452,7 +453,7 @@ export function Composer({
   const wrapperLayout = composerWrapperLayout({ keyboardOpen });
   return (
     <div className={wrapperLayout.className} style={wrapperLayout.style}>
-      <div className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl">
+      <div {...tourAnchor(TOUR_ANCHORS.composer)} className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl">
         <ComposerPrimitive.Unstable_TriggerPopoverRoot>
           <ComposerPrimitive.Root
             className={[
@@ -935,7 +936,7 @@ function ModePicker({
   };
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={ref} {...tourAnchor(TOUR_ANCHORS.modePicker)} className="relative">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
@@ -1138,6 +1139,7 @@ function QueueSendButton({
     <button
       type="button"
       aria-label="Queue follow-up message"
+      {...tourAnchor(TOUR_ANCHORS.queueSend)}
       title={title}
       onClick={onSend}
       className={[

--- a/web/src/components/cockpit/QueuedPromptsStrip.test.tsx
+++ b/web/src/components/cockpit/QueuedPromptsStrip.test.tsx
@@ -4,7 +4,7 @@
 // (#1356). The strip lifts up a visual hint when the queued items will
 // fire as separate POSTs because one of them is a clear-command alias.
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { AgentProfileProvider } from "../../lib/agentProfileContext";
@@ -105,5 +105,65 @@ describe("QueuedPromptsStrip clear-boundary divider (#1356)", () => {
   it("omits the Clear all button when the queue has exactly one entry", () => {
     const { queryByRole } = renderWithProfile("claude", [mk("a", "only")]);
     expect(queryByRole("button", { name: /clear all/i })).toBeNull();
+  });
+});
+
+describe("QueuedPromptRow expanded-state bounds (#1642)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // A multi-thousand-char paste: trips isQueuedPromptLong (>160 chars) so
+  // the row gets the clamp + "…" affordance.
+  const hugePaste = "lorem ipsum ".repeat(500);
+
+  it("clamps a long collapsed prompt and offers the expand affordance", () => {
+    const { getByTitle, getByRole } = renderWithProfile("claude", [
+      mk("a", hugePaste),
+    ]);
+    const textButton = getByTitle("Click to edit");
+    expect(textButton.className).toContain("line-clamp-3");
+    // `block` must NOT co-exist with `line-clamp-3`: its `display:block`
+    // wins the cascade over line-clamp's `-webkit-box` and silently kills
+    // the clamp, rendering the whole paste. See #1642.
+    expect(textButton.className.split(/\s+/)).not.toContain("block");
+    // Collapsed affordance is the "…" toggle.
+    expect(
+      getByRole("button", { name: "Show full queued prompt" }),
+    ).toBeTruthy();
+  });
+
+  it("bounds the expanded prompt to a scrollable box so it cannot grow the strip", () => {
+    const { getByTitle, getByRole } = renderWithProfile("claude", [
+      mk("a", hugePaste),
+    ]);
+    fireEvent.click(getByRole("button", { name: "Show full queued prompt" }));
+
+    // Clamp is gone once expanded.
+    const textButton = getByTitle("Click to edit");
+    expect(textButton.className).not.toContain("line-clamp-3");
+
+    // The text now lives inside a height-capped, scrollable wrapper, so a
+    // huge paste scrolls in place instead of pushing the composer off-screen.
+    const box = textButton.parentElement as HTMLElement;
+    expect(box.className).toContain("max-h-48");
+    expect(box.className).toContain("overflow-y-auto");
+  });
+
+  it("keeps the Show less toggle outside the scrollable region so it stays reachable", () => {
+    const { getByTitle, getByRole } = renderWithProfile("claude", [
+      mk("a", hugePaste),
+    ]);
+    fireEvent.click(getByRole("button", { name: "Show full queued prompt" }));
+
+    const collapseToggle = getByRole("button", {
+      name: "Collapse queued prompt",
+    });
+    expect(collapseToggle.textContent).toBe("Show less");
+
+    // The toggle must be a sibling of the capped box, not a descendant of
+    // it; otherwise it would scroll away with the paste and get buried.
+    const box = getByTitle("Click to edit").parentElement as HTMLElement;
+    expect(box.contains(collapseToggle)).toBe(false);
   });
 });

--- a/web/src/components/cockpit/SessionConfigControls.test.tsx
+++ b/web/src/components/cockpit/SessionConfigControls.test.tsx
@@ -196,6 +196,48 @@ describe("SessionConfigControls", () => {
     expect(other.disabled).toBe(false);
   });
 
+  // #1562: an unknown category arrives on the wire as a bare string
+  // (the Rust `Other(String)` arm is `#[serde(untagged)]`). The picker
+  // filters by string equality, so an unknown-category option must not
+  // break the model / effort lookup and gets no widget of its own.
+  it("ignores an unknown-category option and still finds the known ones", () => {
+    const unknown: ConfigOptionDescriptor = {
+      id: "future",
+      name: "Future Selector",
+      category: "future_category",
+      current_value: "a",
+      options: [{ value: "a", name: "A" }],
+    };
+    render(
+      <SessionConfigControls
+        configOptions={[unknown, modelOption(), effortOption()]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("config-option-model")).toBeTruthy();
+    expect(screen.getByTestId("config-option-effort")).toBeTruthy();
+    expect(screen.queryByTestId("config-option-future")).toBeNull();
+  });
+
+  it("renders nothing when only an unknown-category option is present", () => {
+    const unknown: ConfigOptionDescriptor = {
+      id: "future",
+      name: "Future Selector",
+      category: "future_category",
+      current_value: "a",
+      options: [{ value: "a", name: "A" }],
+    };
+    const { container } = render(
+      <SessionConfigControls
+        configOptions={[unknown]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
   it("truncates long model labels in the chip", () => {
     const longModel: ConfigOptionDescriptor = {
       ...modelOption(),

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -35,6 +35,7 @@ import {
   fixtures,
   makeCompletion,
   makeError,
+  makeStopped,
   makeToolCall,
 } from "./__fixtures__/toolCalls";
 
@@ -159,6 +160,38 @@ describe("ToolCards dispatch", () => {
     );
     expect(container.textContent).toContain("done");
   });
+
+  it("renders the 'stopped' badge on tool_stopped results, not running/failed/done", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.bash} result={makeStopped()} />
+      </Wrap>,
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("stopped");
+    expect(text).not.toContain("running");
+    expect(text).not.toContain("failed");
+    expect(text).not.toContain("done");
+  });
+
+  it("freezes the duration on a tool_stopped result (endedAt is set)", () => {
+    // A stopped card carries a terminal `at`, so the duration is a fixed
+    // span rather than a live-ticking elapsed timer. started_at
+    // 00:00:00 -> at 00:00:01 == 1.0s. See #1646.
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={makeToolCall({
+            id: "bash-1",
+            kind: "execute",
+            started_at: "2026-05-21T00:00:00Z",
+          })}
+          result={makeStopped({ at: "2026-05-21T00:00:01Z" })}
+        />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("1.0s");
+  });
 });
 
 describe("ToolCards profile-gated dispatch (claude)", () => {
@@ -264,6 +297,32 @@ describe("TodoGroupCard fold (#1468)", () => {
     expect(container.textContent).not.toContain("Broken plan");
     // The header surfaces the failed latest attempt rather than looking clean.
     expect(container.textContent).toContain("failed");
+  });
+
+  it("surfaces a stopped header when the latest snapshot was interrupted (#1646)", () => {
+    const stoppedTail = {
+      tool: makeToolCall({
+        id: "td4",
+        name: "TodoWrite",
+        kind: "other",
+        args_preview: JSON.stringify({
+          todos: [{ content: "Interrupted plan", status: "in_progress" }],
+        }),
+      }),
+      result: makeStopped({ id: "stopped-td4", toolCallId: "td4" }),
+    };
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <TodoGroupCard items={[...items, stoppedTail]} />
+      </Wrap>,
+    );
+    // Collapsed preview falls back to the last good snapshot, not the
+    // interrupted one.
+    expect(container.textContent).toContain("Step Charlie");
+    expect(container.textContent).not.toContain("Interrupted plan");
+    // The header reads "stopped", not the misleading "done".
+    expect(container.textContent).toContain("stopped");
+    expect(container.textContent).not.toContain("done");
   });
 });
 

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -232,11 +232,13 @@ function SubagentChildWrap({ children }: { children: ReactNode }) {
 
 /* ── Shared header bits ──────────────────────────────────────────── */
 
-type Status = "running" | "ok" | "err";
+type Status = "running" | "ok" | "err" | "stopped";
 
 function statusFor(result?: ActivityRow): Status {
   if (!result) return "running";
-  return result.kind === "tool_error" ? "err" : "ok";
+  if (result.kind === "tool_error") return "err";
+  if (result.kind === "tool_stopped") return "stopped";
+  return "ok";
 }
 
 // Per-card expand state for tool cards. Failed cards auto-open so the
@@ -272,7 +274,7 @@ function StatusDot({ status, neutral }: { status: Status; neutral?: boolean }) {
   const cls =
     status === "running"
       ? "bg-brand-400 animate-pulse"
-      : neutral
+      : neutral || status === "stopped"
         ? "bg-text-dim/60"
         : status === "ok"
           ? "bg-status-running"
@@ -291,6 +293,12 @@ function StatusBadge({ status }: { status: Status }) {
   }
   if (status === "err") {
     return <span className="text-[11px] text-status-error">failed</span>;
+  }
+  if (status === "stopped") {
+    // `--color-status-stopped` fails WCAG AA for text (it is a dot-only
+    // decorative token); the muted dot already differentiates from the
+    // green "done" dot, so keep the label on the legible dim slot.
+    return <span className="text-[11px] text-text-dim">stopped</span>;
   }
   return <span className="text-[11px] text-text-dim">done</span>;
 }
@@ -1134,18 +1142,31 @@ export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
   if (snapshots.length === 0) return null;
 
   // The collapsed preview shows the latest *successful* snapshot, since
-  // a TodoWrite that ended in tool_error never became the live state.
-  // The header still reflects the latest attempt so a failed trailing
-  // update surfaces as an error rather than looking clean. See #1468.
+  // a TodoWrite that ended in tool_error (or was interrupted by a stop,
+  // tool_stopped; see #1646) never became the live state. The header
+  // still reflects the latest attempt so a failed trailing update
+  // surfaces as an error rather than looking clean. See #1468.
   const latestAttempt = snapshots[snapshots.length - 1]!;
   const latestSuccessful =
-    [...snapshots].reverse().find((s) => s.result?.kind !== "tool_error") ??
-    null;
+    [...snapshots]
+      .reverse()
+      .find(
+        (s) =>
+          s.result?.kind !== "tool_error" &&
+          s.result?.kind !== "tool_stopped",
+      ) ?? null;
   const previewSnapshot = latestSuccessful ?? latestAttempt;
   const latestFailed = latestAttempt.result?.kind === "tool_error";
+  const latestStopped = latestAttempt.result?.kind === "tool_stopped";
   const breakdown = todoBreakdown(todoCounts(previewSnapshot.todos));
   const running = snapshots.some((s) => !s.result);
-  const status: Status = running ? "running" : latestFailed ? "err" : "ok";
+  const status: Status = running
+    ? "running"
+    : latestFailed
+      ? "err"
+      : latestStopped
+        ? "stopped"
+        : "ok";
 
   const startedAt = snapshots
     .map((s) => s.tool.started_at)
@@ -1162,7 +1183,7 @@ export function TodoGroupCard({ items }: { items: TodoGroupChild[] }) {
   return (
     <CardChrome
       status={status}
-      neutralOnDone={!latestFailed}
+      neutralOnDone={!latestFailed && !latestStopped}
       icon={<ListChecks className="h-3.5 w-3.5" />}
       label="todos"
       primary={

--- a/web/src/components/cockpit/ToolErrorBody.tsx
+++ b/web/src/components/cockpit/ToolErrorBody.tsx
@@ -18,7 +18,7 @@ import {
 } from "../../lib/toolErrorParse";
 
 interface Props {
-  status: "running" | "ok" | "err";
+  status: "running" | "ok" | "err" | "stopped";
   /** Raw `result.text` from the completion row. claude-agent-acp wraps
    *  Claude's tool errors in `<tool_use_error>...</tool_use_error>`;
    *  the parser peels the wrapper and surfaces it as a label outside

--- a/web/src/components/cockpit/__fixtures__/toolCalls.ts
+++ b/web/src/components/cockpit/__fixtures__/toolCalls.ts
@@ -32,6 +32,10 @@ export function makeError(over: Partial<ActivityRow> = {}): ActivityRow {
   return makeCompletion({ kind: "tool_error", text: "failed", ...over });
 }
 
+export function makeStopped(over: Partial<ActivityRow> = {}): ActivityRow {
+  return makeCompletion({ kind: "tool_stopped", text: "", ...over });
+}
+
 export const fixtures = {
   bash: makeToolCall({
     id: "bash-1",

--- a/web/src/components/diff/StringDiff.tsx
+++ b/web/src/components/diff/StringDiff.tsx
@@ -31,7 +31,12 @@ export function StringDiff({ oldText, newText, filePath }: Props) {
   const lineTokens = tokens?.[0];
 
   return (
-    <div className="leading-[1.6]">
+    // `overflow-x-auto` gives long diff lines a horizontal scroll context.
+    // The embedding `CardChrome` clips with `overflow-hidden` and `DiffLine`
+    // content is `whitespace-pre`, so without this the right side of any line
+    // wider than the card is unreachable on a narrow viewport. Mirrors the
+    // full-size `DiffFileViewer` scroll wrapper. See #1568.
+    <div data-testid="string-diff" className="leading-[1.6] overflow-x-auto">
       {hunk.lines.map((line, i) => (
         <DiffLine
           key={`${line.old_line_num ?? "_"}-${line.new_line_num ?? "_"}-${i}`}

--- a/web/src/components/diff/__tests__/StringDiff.test.tsx
+++ b/web/src/components/diff/__tests__/StringDiff.test.tsx
@@ -30,6 +30,19 @@ describe("StringDiff", () => {
     }
   });
 
+  it("gives the diff body a horizontal scroll context (#1568)", () => {
+    // Without `overflow-x-auto` the embedding card's `overflow-hidden` clips
+    // long `whitespace-pre` lines and the right side is unreachable on mobile.
+    const { getByTestId } = render(
+      <StringDiff
+        oldText="const x = 1;\n"
+        newText={`const x = ${"a".repeat(200)};\n`}
+        filePath="snippet.ts"
+      />,
+    );
+    expect(getByTestId("string-diff").className).toMatch(/\boverflow-x-auto\b/);
+  });
+
   it("returns null for an empty diff", () => {
     const { container } = render(
       <StringDiff oldText="" newText="" filePath="snippet.ts" />,

--- a/web/src/components/session-wizard/__tests__/ProjectStep.workspace.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.workspace.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+//
+// Vitest coverage for the ProjectStep recents filter excluding
+// multi-repo workspace sessions (#1645). A workspace session collapses
+// to its `main_repo_path` in the Recent list, so picking it would start
+// a plain single-repo session and silently drop the other repos. The
+// guard in `collectRecentProjects` keeps workspaces out of the list
+// entirely (single path cannot reconstruct a workspace).
+//
+// Sits next to ProjectStep.scratch.test.tsx (#1324), which covers the
+// adjacent scratch-session skip.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import { ProjectStep } from "../steps/ProjectStep";
+import { initialData } from "../wizardReducer";
+import type { SessionResponse, WorkspaceRepoSummary } from "../../../lib/types";
+
+vi.mock("../../../lib/api", () => ({
+  fetchSessions: vi.fn(),
+  cloneRepo: vi.fn(),
+}));
+
+import { fetchSessions } from "../../../lib/api";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function mockSession(overrides: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "session",
+    project_path: overrides.project_path ?? "/repo/alpha",
+    group_path: overrides.group_path ?? "/repo/alpha",
+    tool: overrides.tool ?? "claude",
+    status: overrides.status ?? "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: overrides.last_accessed_at ?? null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: overrides.main_repo_path ?? null,
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+    },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: overrides.workspace_repos ?? [],
+    scratch: overrides.scratch ?? false,
+    ...overrides,
+  } as SessionResponse;
+}
+
+function workspaceRepos(): WorkspaceRepoSummary[] {
+  return [
+    { name: "gamma", source_path: "/repo/gamma", branch: "main" },
+    { name: "delta", source_path: "/repo/delta", branch: "main" },
+  ];
+}
+
+function renderStep() {
+  const onChange = vi.fn();
+  const utils = render(
+    <ProjectStep
+      data={{
+        ...initialData,
+        path: "",
+        extraRepoPaths: [],
+        scratch: false,
+      }}
+      onChange={onChange}
+    />,
+  );
+  return { onChange, ...utils };
+}
+
+describe("ProjectStep recents workspace filter (#1645)", () => {
+  it("does not surface multi-repo workspace sessions in the Recent tab", async () => {
+    // One single-repo session plus one workspace session. The workspace
+    // keys by its main_repo_path ("/repo/gamma"); without the guard it
+    // would render as a phantom single-repo recent entry that, when
+    // picked, drops the other repos. Only the real single-repo path
+    // ("alpha") must appear.
+    vi.mocked(fetchSessions).mockResolvedValue({
+      sessions: [
+        mockSession({
+          id: "s-single",
+          project_path: "/repo/alpha",
+          last_accessed_at: "2025-09-01T00:00:00Z",
+        }),
+        mockSession({
+          id: "s-workspace",
+          project_path: "/repo/gamma",
+          main_repo_path: "/repo/gamma",
+          workspace_repos: workspaceRepos(),
+          last_accessed_at: "2025-09-02T00:00:00Z",
+        }),
+      ],
+      workspace_ordering: [],
+    });
+
+    const { findAllByText, queryByText } = renderStep();
+    // The single-repo project renders; the workspace basename never does.
+    expect((await findAllByText("alpha")).length).toBeGreaterThan(0);
+    expect(queryByText("gamma")).toBeNull();
+  });
+
+  it("still surfaces single-repo sessions unchanged when no workspaces are present", async () => {
+    vi.mocked(fetchSessions).mockResolvedValue({
+      sessions: [
+        mockSession({
+          id: "s-a",
+          project_path: "/repo/alpha",
+          last_accessed_at: "2025-09-01T00:00:00Z",
+        }),
+        mockSession({
+          id: "s-b",
+          project_path: "/repo/beta",
+          last_accessed_at: "2025-09-02T00:00:00Z",
+        }),
+      ],
+      workspace_ordering: [],
+    });
+
+    const { findAllByText } = renderStep();
+    expect((await findAllByText("alpha")).length).toBeGreaterThan(0);
+    expect((await findAllByText("beta")).length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/components/session-wizard/__tests__/SessionStep.advanced.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionStep.advanced.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+//
+// Vitest coverage for the SessionStep "Advanced" disclosure (#1514).
+// The fold moved the worktree toggle, branch input, attach-existing
+// toggle, base-branch picker, and group input behind a top-level
+// "Advanced" disclosure that defaults closed. These tests render the
+// component directly, expand the disclosure, and exercise each folded
+// control so the moved render + handler lines stay covered.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, fireEvent } from "@testing-library/react";
+
+import { SessionStep } from "../steps/SessionStep";
+import { initialData, type WizardData } from "../wizardReducer";
+
+vi.mock("../../../lib/api", () => ({
+  fetchBranches: vi.fn().mockResolvedValue([]),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderStep(overrides: Partial<WizardData> = {}) {
+  const onChange = vi.fn();
+  const utils = render(
+    <SessionStep
+      data={{
+        ...initialData,
+        path: "/repo/alpha",
+        useWorktree: true,
+        scratch: false,
+        ...overrides,
+      }}
+      onChange={onChange}
+    />,
+  );
+  const expandAdvanced = () =>
+    fireEvent.click(utils.getByRole("button", { name: "Advanced" }));
+  return { onChange, expandAdvanced, ...utils };
+}
+
+describe("SessionStep Advanced disclosure (#1514)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides every non-title control until Advanced is expanded", () => {
+    const { queryByRole, queryByPlaceholderText, getByPlaceholderText } =
+      renderStep();
+    // Title input is always visible.
+    expect(getByPlaceholderText("Auto-generated if empty")).toBeTruthy();
+    // Folded controls are absent before expanding.
+    expect(queryByRole("switch")).toBeNull();
+    expect(queryByPlaceholderText("Uses session title if empty")).toBeNull();
+    expect(
+      queryByPlaceholderText("Optional, for organizing related sessions"),
+    ).toBeNull();
+  });
+
+  it("reveals the worktree toggle, branch input, attach toggle, and group when expanded", () => {
+    const { expandAdvanced, getByPlaceholderText, getByRole } = renderStep();
+    expandAdvanced();
+    expect(getByRole("switch", { name: /Create a worktree/ })).toBeTruthy();
+    expect(getByPlaceholderText("Uses session title if empty")).toBeTruthy();
+    expect(getByRole("switch", { name: /Attach to existing branch/ })).toBeTruthy();
+    // The base-branch picker's disclosure button (its input shares the
+    // same accessible name but is not a button).
+    expect(getByRole("button", { name: "Base branch" })).toBeTruthy();
+    expect(
+      getByPlaceholderText("Optional, for organizing related sessions"),
+    ).toBeTruthy();
+  });
+
+  it("editing the branch input emits a worktreeBranch change", () => {
+    const { expandAdvanced, onChange, getByPlaceholderText } = renderStep();
+    expandAdvanced();
+    fireEvent.change(getByPlaceholderText("Uses session title if empty"), {
+      target: { value: "feat/x" },
+    });
+    expect(onChange).toHaveBeenCalledWith("worktreeBranch", "feat/x");
+  });
+
+  it("toggling attach-existing emits an attachExisting change", () => {
+    const { expandAdvanced, onChange, getByText } = renderStep();
+    expandAdvanced();
+    fireEvent.click(getByText("Attach to existing branch"));
+    expect(onChange).toHaveBeenCalledWith("attachExisting", true);
+  });
+
+  it("hides the Base branch picker once attach-existing is on", () => {
+    const { expandAdvanced, queryByRole } = renderStep({ attachExisting: true });
+    expandAdvanced();
+    expect(queryByRole("button", { name: "Base branch" })).toBeNull();
+  });
+
+  it("expanding the Base branch picker renders the base-branch input", () => {
+    const { expandAdvanced, getByRole, getByLabelText } = renderStep();
+    expandAdvanced();
+    fireEvent.click(getByRole("button", { name: "Base branch" }));
+    expect(getByLabelText("Base branch")).toBeTruthy();
+  });
+
+  it("editing the group input emits a group change", () => {
+    const { expandAdvanced, onChange, getByPlaceholderText } = renderStep();
+    expandAdvanced();
+    fireEvent.change(
+      getByPlaceholderText("Optional, for organizing related sessions"),
+      { target: { value: "backend" } },
+    );
+    expect(onChange).toHaveBeenCalledWith("group", "backend");
+  });
+});

--- a/web/src/components/session-wizard/__tests__/SessionStep.scratch.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionStep.scratch.test.tsx
@@ -32,6 +32,10 @@ function renderStep(overrides: { scratch?: boolean; useWorktree?: boolean } = {}
       onChange={onChange}
     />,
   );
+  // #1514 folds the worktree controls + scratch note behind a top-level
+  // "Advanced" disclosure that defaults closed. Expand it so the branches
+  // these tests exercise actually render.
+  fireEvent.click(utils.getByRole("button", { name: "Advanced" }));
   return { onChange, ...utils };
 }
 

--- a/web/src/components/session-wizard/steps/ProjectStep.tsx
+++ b/web/src/components/session-wizard/steps/ProjectStep.tsx
@@ -68,6 +68,11 @@ function collectRecentProjects(sessions: SessionResponse[]): RecentProject[] {
     // in to keeping the dir). They must not appear in the Recent list,
     // where they would be re-selectable as a project.
     if (s.scratch) continue;
+    // Multi-repo workspaces collapse to a single `main_repo_path` here, so
+    // picking one from Recent would start a plain single-repo session and
+    // silently drop the other repos. The project step cannot reconstruct a
+    // workspace from one path, so keep them out of the list entirely.
+    if (s.workspace_repos.length > 0) continue;
     const path = s.main_repo_path || s.project_path;
     if (!path) continue;
     const existing = map.get(path);

--- a/web/src/components/session-wizard/steps/SessionStep.tsx
+++ b/web/src/components/session-wizard/steps/SessionStep.tsx
@@ -44,10 +44,19 @@ function Toggle({ checked, onChange, disabled }: { checked: boolean; onChange: (
 }
 
 export function SessionStep({ data, onChange }: Props) {
+  // Everything except the title input is folded behind this disclosure
+  // so the common "name it, hit Next" path is a single visible control.
+  // Defaults to a new worktree branched off HEAD; the submit path in
+  // SessionWizard reads useWorktree/worktreeBranch/attachExisting/
+  // baseBranch/group from reducer state regardless of what is on screen,
+  // so a hidden toggle keeps its default value. See #1514.
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   return (
     <div>
       <h2 className="text-lg font-semibold text-text-primary mb-1">Name your session</h2>
-      <p className="text-sm text-text-muted mb-5">Give it a title and decide whether to work in a git worktree.</p>
+      <p className="text-sm text-text-muted mb-5">
+        Give it a title; defaults to a new git worktree branched off the current HEAD. Expand Advanced to change the branch, attach to an existing one, or set a group.
+      </p>
 
       <div className="mb-5">
         <label className="block text-sm text-text-dim mb-1.5">Session title</label>
@@ -61,101 +70,122 @@ export function SessionStep({ data, onChange }: Props) {
         <p className="text-xs text-text-dim mt-1">Shown in the dashboard. Renaming it later does not rename the git branch.</p>
       </div>
 
-      {/* Worktree controls are meaningless for scratch sessions: the
-          working directory is a fresh scratch dir, not a git repo. The
-          reducer also forces useWorktree to false when scratch flips
-          on; this hide is purely a UX confirmation that the worktree
-          path is not available in scratch mode. */}
-      {data.scratch ? (
-        <p
-          className="text-xs text-text-dim mb-3"
-          aria-label="Worktree disabled: scratch session"
+      <button
+        type="button"
+        onClick={() => setAdvancedOpen((v) => !v)}
+        aria-expanded={advancedOpen}
+        className="flex items-center gap-1.5 text-sm text-text-dim hover:text-text-secondary cursor-pointer"
+      >
+        <span
+          className={`inline-block transition-transform ${advancedOpen ? "rotate-90" : ""}`}
+          aria-hidden="true"
         >
-          Scratch sessions do not use git worktrees.
-        </p>
-      ) : (
-        <label
-          className="flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer mb-3"
-          onClick={(e) => {
-            // Clicks that land on the Toggle button already drive
-            // `onChange("useWorktree", v)`. Letting the label's own
-            // handler also fire would flip the value a second time
-            // and land back on the original. Skip the label handler
-            // for clicks originating inside the Toggle.
-            if (
-              (e.target as HTMLElement).closest('button[role="switch"]')
-            ) {
-              return;
-            }
-            onChange("useWorktree", !data.useWorktree);
-          }}
-        >
-          <div className="flex-1">
-            <div className="text-sm font-medium text-text-primary">Create a worktree</div>
-            <div className="text-xs text-text-dim mt-0.5 leading-snug">
-              Run the agent in a new git worktree branched off the current HEAD. Off = run directly in the repo folder.
-            </div>
-          </div>
-          <Toggle
-            checked={data.useWorktree}
-            onChange={(v) => onChange("useWorktree", v)}
-          />
-        </label>
-      )}
-
-      {!data.scratch && data.useWorktree && (
-        <div className="mb-5">
-          <label className="block text-sm text-text-dim mb-1.5">Branch / worktree name</label>
-          <input
-            type="text"
-            value={data.worktreeBranch}
-            onChange={(e) => onChange("worktreeBranch", e.target.value)}
-            placeholder="Uses session title if empty"
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-base font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
-          />
-          <p className="text-xs text-text-dim mt-1">The branch name is also the worktree directory name. Leave blank to use the session title.</p>
-
-          <label
-            className="mt-3 flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer"
-            onClick={() => onChange("attachExisting", !data.attachExisting)}
-          >
-            <div className="flex-1">
-              <div className="text-sm font-medium text-text-primary">Attach to existing branch</div>
-              <div className="text-xs text-text-dim mt-0.5 leading-snug">
-                Re-use a branch + worktree that already exists. Off = create a new branch.
+          ▸
+        </span>
+        Advanced
+      </button>
+      {advancedOpen && (
+        <div className="mt-3 pl-4 border-l border-surface-700/40">
+          {/* Worktree controls are meaningless for scratch sessions: the
+              working directory is a fresh scratch dir, not a git repo. The
+              reducer also forces useWorktree to false when scratch flips
+              on; this hide is purely a UX confirmation that the worktree
+              path is not available in scratch mode. */}
+          {data.scratch ? (
+            <p
+              className="text-xs text-text-dim mb-3"
+              aria-label="Worktree disabled: scratch session"
+            >
+              Scratch sessions do not use git worktrees.
+            </p>
+          ) : (
+            <label
+              className="flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer mb-3"
+              onClick={(e) => {
+                // Clicks that land on the Toggle button already drive
+                // `onChange("useWorktree", v)`. Letting the label's own
+                // handler also fire would flip the value a second time
+                // and land back on the original. Skip the label handler
+                // for clicks originating inside the Toggle.
+                if (
+                  (e.target as HTMLElement).closest('button[role="switch"]')
+                ) {
+                  return;
+                }
+                onChange("useWorktree", !data.useWorktree);
+              }}
+            >
+              <div className="flex-1">
+                <div className="text-sm font-medium text-text-primary">Create a worktree</div>
+                <div className="text-xs text-text-dim mt-0.5 leading-snug">
+                  Run the agent in a new git worktree branched off the current HEAD. Off = run directly in the repo folder.
+                </div>
               </div>
-            </div>
-            <Toggle
-              checked={data.attachExisting}
-              onChange={(v) => onChange("attachExisting", v)}
-            />
-          </label>
-
-          {!data.attachExisting && (
-            <AdvancedWorktreeOptions data={data} onChange={onChange} />
+              <Toggle
+                checked={data.useWorktree}
+                onChange={(v) => onChange("useWorktree", v)}
+              />
+            </label>
           )}
+
+          {!data.scratch && data.useWorktree && (
+            <div className="mb-5">
+              <label className="block text-sm text-text-dim mb-1.5">Branch / worktree name</label>
+              <input
+                type="text"
+                value={data.worktreeBranch}
+                onChange={(e) => onChange("worktreeBranch", e.target.value)}
+                placeholder="Uses session title if empty"
+                className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-base font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
+              />
+              <p className="text-xs text-text-dim mt-1">The branch name is also the worktree directory name. Leave blank to use the session title.</p>
+
+              <label
+                className="mt-3 flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer"
+                onClick={() => onChange("attachExisting", !data.attachExisting)}
+              >
+                <div className="flex-1">
+                  <div className="text-sm font-medium text-text-primary">Attach to existing branch</div>
+                  <div className="text-xs text-text-dim mt-0.5 leading-snug">
+                    Re-use a branch + worktree that already exists. Off = create a new branch.
+                  </div>
+                </div>
+                <Toggle
+                  checked={data.attachExisting}
+                  onChange={(v) => onChange("attachExisting", v)}
+                />
+              </label>
+
+              {!data.attachExisting && (
+                <AdvancedWorktreeOptions data={data} onChange={onChange} />
+              )}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm text-text-dim mb-1.5">Group</label>
+            <input
+              type="text"
+              value={data.group}
+              onChange={(e) => onChange("group", e.target.value)}
+              placeholder="Optional, for organizing related sessions"
+              className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
+            />
+          </div>
         </div>
       )}
-
-      <div>
-        <label className="block text-sm text-text-dim mb-1.5">Group</label>
-        <input
-          type="text"
-          value={data.group}
-          onChange={(e) => onChange("group", e.target.value)}
-          placeholder="Optional, for organizing related sessions"
-          className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
-        />
-      </div>
     </div>
   );
 }
 
 /**
- * Collapsed "Advanced" section under the worktree name input. Currently
- * houses the base-branch picker (#948). Hidden by default and only
- * matters when the user expands it; defaulting to the repo default
- * means the common case stays exactly as before.
+ * Collapsed "Base branch" section under the worktree name input. Houses
+ * the base-branch picker (#948). Hidden by default and only matters when
+ * the user expands it; defaulting to the repo default means the common
+ * case stays exactly as before. Labeled "Base branch" rather than
+ * "Advanced" since #1514 wraps the whole worktree block in an outer
+ * "Advanced" disclosure, and two nested buttons both reading "Advanced"
+ * would be ambiguous.
  */
 function AdvancedWorktreeOptions({
   data,
@@ -210,7 +240,7 @@ function AdvancedWorktreeOptions({
         >
           ▸
         </span>
-        Advanced
+        Base branch
       </button>
       {open && (
         <div className="mt-2 pl-4 border-l border-surface-700/40">

--- a/web/src/components/settings/FormFields.tsx
+++ b/web/src/components/settings/FormFields.tsx
@@ -17,6 +17,8 @@ export function CollapsibleSection({
   return (
     <div className="border border-surface-700/40 rounded-lg overflow-hidden">
       <button
+        type="button"
+        aria-expanded={open}
         onClick={() => setOpen(!open)}
         className="flex items-center justify-between w-full px-4 py-3 bg-surface-850 hover:bg-surface-800 cursor-pointer transition-colors text-left"
       >

--- a/web/src/components/settings/LoggingSettings.tsx
+++ b/web/src/components/settings/LoggingSettings.tsx
@@ -1,4 +1,10 @@
-import { NumberField, SelectField, TextField, ToggleField } from "./FormFields";
+import {
+  CollapsibleSection,
+  NumberField,
+  SelectField,
+  TextField,
+  ToggleField,
+} from "./FormFields";
 
 // Mirrors `KNOWN_SUB_TARGETS` in src/logging.rs. Keeping this list
 // hardcoded (rather than fetched) is intentional: it's the curated
@@ -147,10 +153,10 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
         ))}
       </div>
 
-      <div className="space-y-3 border-t border-surface-700 pt-4">
-        <h4 className="text-sm font-semibold text-text-primary">
-          Sink &amp; rotation
-        </h4>
+      <CollapsibleSection
+        title="Advanced"
+        subtitle="Sink and rotation. Some fields require restarting aoe to take effect."
+      >
         <p className="text-xs text-text-dim">
           These fields change where logs land on disk and how they rotate. They are written to <code>config.toml</code> immediately but require restarting <code>aoe</code> to take effect (the tracing subscriber and rotating writer are installed once at process startup).
         </p>
@@ -200,7 +206,7 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
           checked={showSpans}
           onChange={(v) => saveSinkField("show_spans", v)}
         />
-      </div>
+      </CollapsibleSection>
     </div>
   );
 }

--- a/web/src/components/settings/__tests__/LoggingSettings.test.tsx
+++ b/web/src/components/settings/__tests__/LoggingSettings.test.tsx
@@ -33,6 +33,17 @@ function commitNumber(input: HTMLInputElement, value: string) {
   fireEvent.blur(input);
 }
 
+// The sink & rotation fields now live inside a default-collapsed "Advanced"
+// CollapsibleSection, so they are absent from the DOM until the fold is
+// expanded. Click the fold trigger (the only button carrying aria-expanded)
+// before reaching for those fields.
+function expandAdvanced(container: HTMLElement) {
+  const trigger = container.querySelector(
+    "button[aria-expanded]",
+  ) as HTMLButtonElement;
+  fireEvent.click(trigger);
+}
+
 function findSelectByLabel(container: HTMLElement, label: string): HTMLSelectElement {
   const labels = container.querySelectorAll("label");
   for (const l of labels) {
@@ -106,8 +117,16 @@ describe("LoggingSettings contract", () => {
     });
   });
 
+  it("sink & rotation fields are hidden until the Advanced fold is expanded", () => {
+    const { container } = mount({});
+    expect(() => findSelectByLabel(container, "Output")).toThrow();
+    expandAdvanced(container);
+    expect(findSelectByLabel(container, "Output")).toBeTruthy();
+  });
+
   it("output select emits logging.output", () => {
     const { onSaveField, container } = mount({});
+    expandAdvanced(container);
     const select = findSelectByLabel(container, "Output");
     fireEvent.change(select, { target: { value: "stdout" } });
     expect(onSaveField).toHaveBeenCalledWith("logging", "output", "stdout");
@@ -115,6 +134,7 @@ describe("LoggingSettings contract", () => {
 
   it("file_path text commits on blur", () => {
     const { onSaveField, container } = mount({ file_path: "debug.log" });
+    expandAdvanced(container);
     // The TextField wraps an <input type=text>; the first such input in the
     // panel is the file_path field.
     const input = container.querySelector(
@@ -130,6 +150,7 @@ describe("LoggingSettings contract", () => {
 
   it("file_path falls back to 'debug.log' when blanked", () => {
     const { onSaveField, container } = mount({ file_path: "custom.log" });
+    expandAdvanced(container);
     const input = container.querySelector(
       "input[type=text]",
     ) as HTMLInputElement;
@@ -143,6 +164,7 @@ describe("LoggingSettings contract", () => {
 
   it("rotation select emits logging.rotation", () => {
     const { onSaveField, container } = mount({});
+    expandAdvanced(container);
     const select = findSelectByLabel(container, "Rotation");
     fireEvent.change(select, { target: { value: "never" } });
     expect(onSaveField).toHaveBeenCalledWith("logging", "rotation", "never");
@@ -150,6 +172,7 @@ describe("LoggingSettings contract", () => {
 
   it("max_size_mib commits a numeric value", () => {
     const { onSaveField, container } = mount({ max_size_mib: 50 });
+    expandAdvanced(container);
     const input = findNumberInputByLabel(container, "Max size (MiB)");
     commitNumber(input, "256");
     expect(onSaveField).toHaveBeenCalledWith("logging", "max_size_mib", 256);
@@ -157,6 +180,7 @@ describe("LoggingSettings contract", () => {
 
   it("keep_count commits a numeric value", () => {
     const { onSaveField, container } = mount({ keep_count: 5 });
+    expandAdvanced(container);
     const input = findNumberInputByLabel(container, "Keep count");
     commitNumber(input, "10");
     expect(onSaveField).toHaveBeenCalledWith("logging", "keep_count", 10);
@@ -164,6 +188,7 @@ describe("LoggingSettings contract", () => {
 
   it("show_spans toggle emits logging.show_spans", () => {
     const { onSaveField, container } = mount({ show_spans: false });
+    expandAdvanced(container);
     const toggle = container.querySelector(
       "button[role=switch]",
     ) as HTMLButtonElement;

--- a/web/src/components/tour/TourRunner.tsx
+++ b/web/src/components/tour/TourRunner.tsx
@@ -1,0 +1,129 @@
+// The only module that imports react-joyride. Lazy-loaded by TourProvider the
+// first time a tour actually runs, so returning users (who have the
+// `aoe-tour-seen` flag set) never download the engine. Everything react-joyride
+// specific (the component, its event/action constants, theming) lives here;
+// TourProvider stays engine-agnostic and deals only in TourStep data. Swapping
+// the engine later means rewriting this file alone.
+import { useCallback, useMemo } from "react";
+import {
+  Joyride,
+  EVENTS,
+  STATUS,
+  type ButtonType,
+  type EventData,
+  type Options,
+  type Step,
+  type Styles,
+} from "react-joyride";
+import { type TourStep, tourSelector } from "../../lib/tourSteps";
+
+export interface TourRunnerProps {
+  run: boolean;
+  steps: TourStep[];
+  /** Called once when the tour ends. `markSeen` is false for our own programmatic
+   *  stop (scope change / unmount), true for a user finish, skip, or close. */
+  onFinish: (markSeen: boolean) => void;
+}
+
+// Theme via the app's resolved-theme CSS variables (web/src/index.css) so the
+// tooltip tracks light vs dark instead of being pinned to dark hex. These land
+// as inline CSS styles, where var() resolves. The exception is overlayColor: it
+// is painted as an SVG fill *attribute*, where var() does not reliably resolve,
+// so the scrim stays a literal translucent dark (it reads correctly over both
+// light and dark content).
+const OPTIONS: Partial<Options> = {
+  buttons: ["skip", "back", "primary"] as ButtonType[],
+  showProgress: true,
+  skipBeacon: true,
+  primaryColor: "var(--color-brand-600)",
+  overlayColor: "rgba(2, 6, 23, 0.65)",
+  textColor: "var(--color-text-primary)",
+  zIndex: 10_000,
+  scrollOffset: 96,
+};
+
+const LOCALE = { skip: "Skip", last: "Done", next: "Next", back: "Back" };
+
+const STYLES: Partial<Styles> = {
+  tooltip: {
+    backgroundColor: "var(--color-surface-800)",
+    border: "1px solid var(--color-surface-700)",
+    borderRadius: 10,
+    color: "var(--color-text-primary)",
+    fontSize: 13,
+  },
+  tooltipTitle: { color: "var(--color-brand-500)", fontSize: 14, fontWeight: 600 },
+  tooltipContent: { padding: "10px 4px" },
+  buttonPrimary: {
+    backgroundColor: "var(--color-brand-600)",
+    borderRadius: 6,
+    // Dark text reads on the amber primary in both themes; keep it fixed.
+    color: "#0f172a",
+  },
+  buttonBack: { color: "var(--color-text-secondary)" },
+  buttonSkip: { color: "var(--color-text-dim)" },
+};
+
+function StepBody({
+  body,
+  shortcuts,
+}: {
+  body: string;
+  shortcuts?: readonly string[];
+}) {
+  return (
+    <div>
+      <p>{body}</p>
+      {shortcuts && shortcuts.length > 0 && (
+        <ul className="mt-2 space-y-0.5 text-[11px] text-text-muted">
+          {shortcuts.map((s) => (
+            <li key={s} className="font-mono">
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function toJoyrideStep(step: TourStep): Step {
+  return {
+    id: step.id,
+    target: tourSelector(step.anchor),
+    title: step.title,
+    content: <StepBody body={step.body} shortcuts={step.shortcuts} />,
+    placement: "auto",
+  };
+}
+
+export default function TourRunner({ run, steps, onFinish }: TourRunnerProps) {
+  const joyrideSteps = useMemo(() => steps.map(toJoyrideStep), [steps]);
+
+  const handleEvent = useCallback(
+    (data: EventData) => {
+      if (data.type !== EVENTS.TOUR_END) return;
+      // Gate on the terminal status, not the action: a programmatic stop
+      // (run -> false on scope change / unmount) ends with a non-terminal
+      // status and may carry `action: null`, which an action allowlist would
+      // misread as a user finish and silently opt the user out. Only an
+      // actual finish or skip marks the tour seen.
+      const markSeen =
+        data.status === STATUS.FINISHED || data.status === STATUS.SKIPPED;
+      onFinish(markSeen);
+    },
+    [onFinish],
+  );
+
+  return (
+    <Joyride
+      run={run}
+      steps={joyrideSteps}
+      continuous
+      options={OPTIONS}
+      locale={LOCALE}
+      styles={STYLES}
+      onEvent={handleEvent}
+    />
+  );
+}

--- a/web/src/hooks/__tests__/useCockpitQueueCount.test.tsx
+++ b/web/src/hooks/__tests__/useCockpitQueueCount.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useQueuedCountForSessions } from "../useCockpitQueueCount";
+import {
+  STORAGE_KEY_PREFIX,
+  clearQueueCount,
+  setQueueCount,
+} from "../../lib/cockpitStateStorage";
+
+function entryKey(id: string): string {
+  return `${STORAGE_KEY_PREFIX}${id}`;
+}
+
+// Write a persisted cockpit-state entry shaped like useCockpit's
+// persistState output, with `queuedPrompts` of the given length.
+function writeEntry(id: string, queued: number, savedAt = Date.now()): void {
+  const queuedPrompts = Array.from({ length: queued }, (_, i) => ({
+    id: `${id}-${i}`,
+    text: `q${i}`,
+    queuedAt: new Date(savedAt).toISOString(),
+  }));
+  localStorage.setItem(
+    entryKey(id),
+    JSON.stringify({ savedAt, state: { lastSeq: 0, activity: [], queuedPrompts } }),
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  // Reset the module-level in-memory count cache between cases so a
+  // prior test's writes don't leak into the next.
+  clearQueueCount();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  clearQueueCount();
+});
+
+describe("useQueuedCountForSessions", () => {
+  it("returns 0 when no session has queued prompts", () => {
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+  });
+
+  it("lazily reads the count from a persisted localStorage entry", () => {
+    writeEntry("a", 3);
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(3);
+  });
+
+  it("sums queued counts across the workspace's sessions", () => {
+    writeEntry("a", 2);
+    writeEntry("b", 1);
+    const { result } = renderHook(() => useQueuedCountForSessions(["a", "b"]));
+    expect(result.current).toBe(3);
+  });
+
+  // Story: queued prompts drain (Stopped pops the head) or the queue is
+  // cleared; the badge updates to the remaining count and disappears at 0.
+  it("updates same-tab as the queue grows and drains via persistState", () => {
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+
+    act(() => setQueueCount("a", 2));
+    expect(result.current).toBe(2);
+
+    act(() => setQueueCount("a", 1));
+    expect(result.current).toBe(1);
+
+    act(() => setQueueCount("a", 0));
+    expect(result.current).toBe(0);
+  });
+
+  // Story: one tab enqueues a prompt; another tab's sidebar updates via
+  // the `storage` event without polling.
+  it("updates cross-tab via a storage event without a local write", () => {
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+
+    const newValue = JSON.stringify({
+      savedAt: Date.now(),
+      state: {
+        lastSeq: 0,
+        activity: [],
+        queuedPrompts: [
+          { id: "a-0", text: "q0", queuedAt: "t" },
+          { id: "a-1", text: "q1", queuedAt: "t" },
+        ],
+      },
+    });
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: entryKey("a"),
+          newValue,
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBe(2);
+  });
+
+  it("does not react to a storage event for an unsubscribed session", () => {
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: entryKey("b"),
+          newValue: JSON.stringify({
+            savedAt: Date.now(),
+            state: { lastSeq: 0, activity: [], queuedPrompts: [{ id: "b-0", text: "x", queuedAt: "t" }] },
+          }),
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBe(0);
+  });
+
+  it("treats a TTL-expired entry as 0", () => {
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    writeEntry("a", 5, eightDaysAgo);
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+  });
+
+  it("treats a corrupt entry as 0", () => {
+    localStorage.setItem(entryKey("a"), "{not json");
+    const { result } = renderHook(() => useQueuedCountForSessions(["a"]));
+    expect(result.current).toBe(0);
+  });
+
+  it("removes its storage listener on unmount", () => {
+    const { unmount, result } = renderHook(() =>
+      useQueuedCountForSessions(["a"]),
+    );
+    unmount();
+    // After unmount the listener is gone, so a cross-tab event must not
+    // throw or leave a dangling subscriber. The hook value is frozen at
+    // its last render.
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: entryKey("a"),
+          newValue: JSON.stringify({
+            savedAt: Date.now(),
+            state: { lastSeq: 0, activity: [], queuedPrompts: [{ id: "a-0", text: "x", queuedAt: "t" }] },
+          }),
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBe(0);
+  });
+});

--- a/web/src/hooks/__tests__/useCommandActions.test.tsx
+++ b/web/src/hooks/__tests__/useCommandActions.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+//
+// Contract test for the command-palette action list (#1643). Asserts the
+// "New scratch session" command is present with the right shape and dispatches
+// onNewScratch, and that both creation commands are hidden in read-only mode
+// (matching the sidebar / dashboard, which hide their "new" buttons rather than
+// offering a command that opens a wizard the server 403s on submit).
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCommandActions } from "../useCommandActions";
+import type { SessionResponse } from "../../lib/types";
+
+type Args = Parameters<typeof useCommandActions>[0];
+
+function baseArgs(overrides: Partial<Args> = {}): Args {
+  return {
+    sessions: [] as SessionResponse[],
+    activeSessionId: null,
+    loginRequired: false,
+    hasActiveSession: false,
+    readOnly: false,
+    onNewSession: vi.fn(),
+    onNewScratch: vi.fn(),
+    onSelectSession: vi.fn(),
+    onToggleDiff: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onOpenHelp: vi.fn(),
+    onOpenAbout: vi.fn(),
+    onGoDashboard: vi.fn(),
+    onToggleSidebar: vi.fn(),
+    onLogout: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("useCommandActions: scratch command", () => {
+  it("exposes a 'New scratch session' command", () => {
+    const { result } = renderHook(() => useCommandActions(baseArgs()));
+    const scratch = result.current.find(
+      (a) => a.id === "action:new-scratch-session",
+    );
+    expect(scratch).toBeDefined();
+    expect(scratch?.title).toBe("New scratch session");
+    expect(scratch?.group).toBe("Actions");
+    expect(scratch?.keywords).toContain("scratch");
+    expect(scratch?.shortcut).toMatch(/N$/);
+  });
+
+  it("renders the scratch command right after 'New session'", () => {
+    const { result } = renderHook(() => useCommandActions(baseArgs()));
+    const ids = result.current.map((a) => a.id);
+    const newSession = ids.indexOf("action:new-session");
+    const scratch = ids.indexOf("action:new-scratch-session");
+    expect(newSession).toBeGreaterThanOrEqual(0);
+    expect(scratch).toBe(newSession + 1);
+  });
+
+  it("perform dispatches onNewScratch", () => {
+    const onNewScratch = vi.fn();
+    const { result } = renderHook(() =>
+      useCommandActions(baseArgs({ onNewScratch })),
+    );
+    const scratch = result.current.find(
+      (a) => a.id === "action:new-scratch-session",
+    );
+    scratch?.perform();
+    expect(onNewScratch).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides both creation commands in read-only mode", () => {
+    const { result } = renderHook(() =>
+      useCommandActions(baseArgs({ readOnly: true })),
+    );
+    const ids = result.current.map((a) => a.id);
+    expect(ids).not.toContain("action:new-session");
+    expect(ids).not.toContain("action:new-scratch-session");
+  });
+});

--- a/web/src/hooks/__tests__/useTour.test.ts
+++ b/web/src/hooks/__tests__/useTour.test.ts
@@ -1,0 +1,42 @@
+// Auto-launch decision table for the first-run tutorial. The run -> engine
+// integration (rAF, lazy load, Joyride rendering, skip persistence) is covered
+// by the live Playwright smoke; this locks the pure gating logic that live
+// (desktop, first-run) cannot easily exercise: coarse-pointer and seen-flag
+// suppression, and scope gating.
+import { describe, expect, it } from "vitest";
+import { shouldAutoLaunch } from "../useTour";
+
+const base = {
+  autoLaunchReady: true,
+  scope: "dashboard" as const,
+  isDesktop: true,
+  seen: false,
+  automated: false,
+};
+
+describe("shouldAutoLaunch", () => {
+  it("launches on a settled dashboard, fine pointer, unseen", () => {
+    expect(shouldAutoLaunch(base)).toBe(true);
+  });
+
+  it("does not launch before the dashboard is ready", () => {
+    expect(shouldAutoLaunch({ ...base, autoLaunchReady: false })).toBe(false);
+  });
+
+  it("does not launch outside the dashboard scope", () => {
+    expect(shouldAutoLaunch({ ...base, scope: "session" })).toBe(false);
+    expect(shouldAutoLaunch({ ...base, scope: "cockpit" })).toBe(false);
+  });
+
+  it("does not auto-launch on coarse pointers", () => {
+    expect(shouldAutoLaunch({ ...base, isDesktop: false })).toBe(false);
+  });
+
+  it("does not auto-launch once the tour has been seen", () => {
+    expect(shouldAutoLaunch({ ...base, seen: true })).toBe(false);
+  });
+
+  it("does not auto-launch inside an automated browser session", () => {
+    expect(shouldAutoLaunch({ ...base, automated: true })).toBe(false);
+  });
+});

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -24,6 +24,13 @@ import { isClearAlias } from "../lib/agentProfiles";
 import { useAgentProfile } from "../lib/agentProfileContext";
 import { getOrCreateDeviceBindingSecret } from "../lib/deviceBinding";
 import { safeSetItem } from "../lib/safeStorage";
+import {
+  STORAGE_KEY_PREFIX,
+  STATE_TTL_MS,
+  clearQueueCount,
+  setQueueCount,
+  type PersistedEntry,
+} from "../lib/cockpitStateStorage";
 import { getToken } from "../lib/token";
 import { setSessionArchive, setSessionSnooze } from "../lib/api";
 
@@ -79,14 +86,7 @@ export type Action =
 // session-delete handler and logout flow can drop stale entries
 // instead of waiting for them to age out.
 const STATE_CACHE_CAP = 32;
-const STORAGE_KEY_PREFIX = "aoe:cockpit-state:v1:";
-const STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const stateCache = new Map<string, CockpitState>();
-
-interface PersistedEntry {
-  savedAt: number;
-  state: CockpitState;
-}
 
 function storageKey(sessionId: string): string {
   return STORAGE_KEY_PREFIX + sessionId;
@@ -141,13 +141,18 @@ function evictOldestPersistedCockpitState(currentKey: string): boolean {
 function persistState(sessionId: string, state: CockpitState): void {
   const key = storageKey(sessionId);
   const body = JSON.stringify({ savedAt: Date.now(), state } satisfies PersistedEntry);
-  if (safeSetItem(key, body)) return;
+  if (safeSetItem(key, body)) {
+    setQueueCount(sessionId, state.queuedPrompts.length);
+    return;
+  }
   // Storage write failed (likely QuotaExceeded). Evict a single oldest
   // cockpit cache entry and retry exactly once. On a second failure the
   // cache is best-effort: the next reload replays from the server, so
   // we stay silent here per the deliberate UX choice for cache writes.
   if (!evictOldestPersistedCockpitState(key)) return;
-  safeSetItem(key, body);
+  if (safeSetItem(key, body)) {
+    setQueueCount(sessionId, state.queuedPrompts.length);
+  }
 }
 
 // Test-only exports so the eviction policy can be exercised without
@@ -300,9 +305,11 @@ export function clearCockpitCache(sessionId?: string): void {
   if (sessionId === undefined) {
     stateCache.clear();
     dropAllPersistedState();
+    clearQueueCount();
   } else {
     stateCache.delete(sessionId);
     dropPersistedState(sessionId);
+    clearQueueCount(sessionId);
   }
 }
 

--- a/web/src/hooks/useCockpitQueueCount.ts
+++ b/web/src/hooks/useCockpitQueueCount.ts
@@ -1,0 +1,39 @@
+// Sidebar "N queued" badge data source. Mirrors useHasDraftForSessions
+// (cockpitDrafts.ts) but returns the SUM of queued-prompt counts across
+// the given session ids, so a workspace row reflects pending follow-ups
+// for any of its sessions. Backed by the cockpit-state storage pub/sub;
+// re-renders the caller only when the relevant counts change.
+
+import { useMemo, useSyncExternalStore } from "react";
+
+import {
+  getQueuedCount,
+  subscribeCockpitState,
+} from "../lib/cockpitStateStorage";
+
+// Returns the total number of queued cockpit follow-up prompts across the
+// given session ids. Re-renders the caller only when one of THESE ids'
+// counts changes, not on every cockpit-state write anywhere in the app.
+export function useQueuedCountForSessions(
+  sessionIds: readonly string[],
+): number {
+  // Stable join key so getSnapshot returns the same primitive across
+  // renders unless the relevant counts actually change; otherwise
+  // useSyncExternalStore would tear under React 18's strict checks.
+  const ids = sessionIds.join("|");
+  const subscribe = useMemo(() => {
+    const filter = new Set(ids ? ids.split("|").filter(Boolean) : []);
+    return (cb: () => void) => subscribeCockpitState(cb, filter);
+  }, [ids]);
+  return useSyncExternalStore(
+    subscribe,
+    () => {
+      let total = 0;
+      for (const id of ids ? ids.split("|") : []) {
+        if (id) total += getQueuedCount(id);
+      }
+      return total;
+    },
+    () => 0,
+  );
+}

--- a/web/src/hooks/useCommandActions.ts
+++ b/web/src/hooks/useCommandActions.ts
@@ -11,7 +11,9 @@ interface Args {
   activeSessionId: string | null;
   loginRequired: boolean;
   hasActiveSession: boolean;
+  readOnly: boolean;
   onNewSession: () => void;
+  onNewScratch: () => void;
   onSelectSession: (sessionId: string) => void;
   onToggleDiff: () => void;
   onOpenSettings: () => void;
@@ -27,7 +29,9 @@ export function useCommandActions({
   activeSessionId,
   loginRequired,
   hasActiveSession,
+  readOnly,
   onNewSession,
+  onNewScratch,
   onSelectSession,
   onToggleDiff,
   onOpenSettings,
@@ -40,14 +44,30 @@ export function useCommandActions({
   return useMemo(() => {
     const actions: CommandAction[] = [];
 
-    actions.push({
-      id: "action:new-session",
-      title: "New session",
-      group: "Actions",
-      keywords: ["create", "start", "agent", "worktree"],
-      shortcut: "n",
-      perform: onNewSession,
-    });
+    // Creation commands are mutation UI. In read-only mode the sidebar and
+    // dashboard already hide their "new session" buttons, so the palette must
+    // omit these too rather than offer a command that opens a wizard the
+    // server 403s on submit. The keyboard-shortcut path stays a guarded no-op
+    // (a key can't be hidden); these visible entries are dropped instead.
+    if (!readOnly) {
+      actions.push({
+        id: "action:new-session",
+        title: "New session",
+        group: "Actions",
+        keywords: ["create", "start", "agent", "worktree"],
+        shortcut: "n",
+        perform: onNewSession,
+      });
+
+      actions.push({
+        id: "action:new-scratch-session",
+        title: "New scratch session",
+        group: "Actions",
+        keywords: ["scratch", "temp", "temporary", "ephemeral", "throwaway", "create"],
+        shortcut: IS_MAC ? "⌘⇧N" : "Ctrl+Shift+N",
+        perform: onNewScratch,
+      });
+    }
 
     actions.push({
       id: "action:go-dashboard",
@@ -135,7 +155,9 @@ export function useCommandActions({
     activeSessionId,
     loginRequired,
     hasActiveSession,
+    readOnly,
     onNewSession,
+    onNewScratch,
     onSelectSession,
     onToggleDiff,
     onOpenSettings,

--- a/web/src/hooks/useRepoGroups.test.ts
+++ b/web/src/hooks/useRepoGroups.test.ts
@@ -382,3 +382,137 @@ describe("useRepoGroups stateful API", () => {
     expect(result.current.groups[0].alias).toBe("pretty-name");
   });
 });
+
+describe("useRepoGroups manual group order (#1644)", () => {
+  const ORDER_KEY = "aoe-repo-group-order-v1";
+
+  it("orders groups by the persisted group order ahead of the min-rank fallback", () => {
+    const wA = workspace("a1", "/repo-a", [session({ id: "s-a" })]);
+    const wB = workspace("b1", "/repo-b", [session({ id: "s-b" })]);
+    // Min-rank would put /repo-a first (a1 ranked before b1); the stored
+    // group order flips it.
+    window.localStorage.setItem(
+      ORDER_KEY,
+      JSON.stringify(["/repo-b", "/repo-a"]),
+    );
+    const { result } = renderHook(() =>
+      useRepoGroups([wA, wB], ["a1", "b1"], "manual"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-b",
+      "/repo-a",
+    ]);
+  });
+
+  it("floats a group absent from the stored order above ranked groups", () => {
+    const wA = workspace("a1", "/repo-a", [session({ id: "s-a" })]);
+    const wB = workspace("b1", "/repo-b", [session({ id: "s-b" })]);
+    const wC = workspace("c1", "/repo-c", [session({ id: "s-c" })]);
+    // /repo-a is unranked in the stored order and a1 has the worst rank,
+    // so only "unknown sorts first" can put it at the top.
+    window.localStorage.setItem(
+      ORDER_KEY,
+      JSON.stringify(["/repo-b", "/repo-c"]),
+    );
+    const { result } = renderHook(() =>
+      useRepoGroups([wA, wB, wC], ["b1", "c1", "a1"], "manual"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-a",
+      "/repo-b",
+      "/repo-c",
+    ]);
+  });
+
+  it("defaults untouched synthetic groups to the bottom (multi-repo above scratch)", () => {
+    const wReal = workspace("real", "/repo-a", [session({ id: "s-real" })]);
+    const wMulti = workspace("multi", "/repo-a", [
+      session({ id: "s-multi", workspace_repos: multiRepos }),
+    ]);
+    const wScratch = workspace("sc", "/home/u/.agent-of-empires/scratch/aaa", [
+      session({ id: "s-sc", scratch: true }),
+    ]);
+    // Stored order only ranks the real group; the synthetic groups have
+    // no stored position and sink to their default bottom.
+    window.localStorage.setItem(ORDER_KEY, JSON.stringify(["/repo-a"]));
+    const { result } = renderHook(() =>
+      useRepoGroups([wReal, wMulti, wScratch], ["real", "multi", "sc"], "manual"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-a",
+      MULTI_REPO_GROUP_ID,
+      SCRATCH_GROUP_ID,
+    ]);
+  });
+
+  it("lets a synthetic group hold an explicit dragged position above a real group", () => {
+    const wReal = workspace("real", "/repo-a", [session({ id: "s-real" })]);
+    const wScratch = workspace("sc", "/home/u/.agent-of-empires/scratch/aaa", [
+      session({ id: "s-sc", scratch: true }),
+    ]);
+    // User dragged scratch above the real group; the stored order ranks
+    // it first, so it must render first rather than snapping to bottom.
+    window.localStorage.setItem(
+      ORDER_KEY,
+      JSON.stringify([SCRATCH_GROUP_ID, "/repo-a"]),
+    );
+    const { result } = renderHook(() =>
+      useRepoGroups([wReal, wScratch], ["real", "sc"], "manual"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      SCRATCH_GROUP_ID,
+      "/repo-a",
+    ]);
+  });
+
+  it("ignores the stored group order in lastActivity mode", () => {
+    const wA = workspace("a1", "/repo-a", [
+      session({
+        id: "s-a",
+        created_at: "2025-01-01T00:00:00Z",
+        last_accessed_at: "2025-09-01T00:00:00Z",
+      }),
+    ]);
+    const wB = workspace("b1", "/repo-b", [
+      session({ id: "s-b", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    // Stored order asks for /repo-b first; lastActivity must override and
+    // float /repo-a (fresher) to the top.
+    window.localStorage.setItem(
+      ORDER_KEY,
+      JSON.stringify(["/repo-b", "/repo-a"]),
+    );
+    const { result } = renderHook(() =>
+      useRepoGroups([wA, wB], ["a1", "b1"], "lastActivity"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-a",
+      "/repo-b",
+    ]);
+  });
+
+  it("reorderRepoGroups applies the new order and round-trips to localStorage", () => {
+    const wA = workspace("a1", "/repo-a", [session({ id: "s-a" })]);
+    const wB = workspace("b1", "/repo-b", [session({ id: "s-b" })]);
+    const { result, rerender } = renderHook(() =>
+      useRepoGroups([wA, wB], ["a1", "b1"], "manual"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-a",
+      "/repo-b",
+    ]);
+
+    act(() => {
+      result.current.reorderRepoGroups(["/repo-b", "/repo-a"]);
+    });
+    rerender();
+
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-b",
+      "/repo-a",
+    ]);
+    expect(window.localStorage.getItem(ORDER_KEY)).toBe(
+      JSON.stringify(["/repo-b", "/repo-a"]),
+    );
+  });
+});

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -8,6 +8,10 @@ import {
   type RepoAppearanceUpdate,
 } from "../lib/repoAppearance";
 import {
+  loadRepoGroupOrder,
+  persistRepoGroupOrder,
+} from "../lib/repoGroupOrder";
+import {
   compareWorkspacesByLastActivityDesc,
   repoGroupLastActivityMs,
   workspaceTriageTier,
@@ -55,13 +59,22 @@ export function useRepoGroups(
   groups: RepoGroup[];
   toggleRepoCollapsed: (repoId: string) => void;
   updateRepoAppearance: (repoId: string, update: RepoAppearanceUpdate) => void;
+  reorderRepoGroups: (orderedGroupIds: string[]) => void;
 } {
   const [collapsedMap, setCollapsedMap] = useState<Record<string, boolean>>({});
   const [appearanceMap, setAppearanceMap] = useState(loadRepoAppearances);
+  const [groupOrder, setGroupOrder] = useState<string[]>(loadRepoGroupOrder);
 
   const groups = useMemo(() => {
     const rank = new Map(workspaceOrdering.map((id, i) => [id, i] as const));
     const rankOf = (id: string) => rank.get(id) ?? Infinity;
+    // Manual per-browser group order (#1644). A group's position in this
+    // list is the primary sort key in manual mode; groups absent from it
+    // (a project added since the last reorder) sort ahead of ranked ones
+    // so brand-new projects float to the top, matching how a new
+    // workspace prepends to workspaceOrdering. Synthetic groups never
+    // appear here and stay pinned to the bottom below.
+    const groupRank = new Map(groupOrder.map((id, i) => [id, i] as const));
     // Triage tier (pinned at top, sunk at bottom) wins over every sort
     // mode, so both rank-based and activity-based comparators apply it
     // first and fall back to their respective within-tier comparison.
@@ -177,21 +190,45 @@ export function useRepoGroups(
       });
     }
 
+    const isSyntheticGroup = (id: string) =>
+      id === MULTI_REPO_GROUP_ID || id === SCRATCH_GROUP_ID;
+
     repoGroups.sort((a, b) => {
-      // Synthetic groups pin to the bottom in a stable order:
-      // real repos → multi-repo → scratch. Scratch is "most ad hoc"
-      // so it sits below multi-repo workspaces (which still
-      // represent real work).
-      if (a.id === SCRATCH_GROUP_ID) return 1;
-      if (b.id === SCRATCH_GROUP_ID) return -1;
-      if (a.id === MULTI_REPO_GROUP_ID) return 1;
-      if (b.id === MULTI_REPO_GROUP_ID) return -1;
       if (sortMode === "lastActivity") {
+        // The order is computed here, so manual group order (and group
+        // drag) does not apply; synthetic groups stay pinned to the
+        // bottom in a stable order: real repos → multi-repo → scratch.
+        if (a.id === SCRATCH_GROUP_ID) return 1;
+        if (b.id === SCRATCH_GROUP_ID) return -1;
+        if (a.id === MULTI_REPO_GROUP_ID) return 1;
+        if (b.id === MULTI_REPO_GROUP_ID) return -1;
         const ak = repoGroupLastActivityMs(a.workspaces);
         const bk = repoGroupLastActivityMs(b.workspaces);
         if (ak !== bk) return bk - ak;
         return a.repoPath.localeCompare(b.repoPath);
       }
+      // Manual mode: an explicit group order wins for any group the user
+      // has dragged, real or synthetic. A group with no stored position
+      // falls back by type, a brand-new real project floats to the top
+      // (matching new-workspace behavior), while an untouched synthetic
+      // group sinks to its default bottom. Once dragged, a synthetic
+      // group holds its chosen spot like any other. See #1644.
+      const ag = groupRank.get(a.id);
+      const bg = groupRank.get(b.id);
+      const SYNTHETIC_BOTTOM = Number.MAX_SAFE_INTEGER;
+      const keyOf = (id: string, rank: number | undefined) =>
+        rank != null ? rank : isSyntheticGroup(id) ? SYNTHETIC_BOTTOM : -1;
+      const ka = keyOf(a.id, ag);
+      const kb = keyOf(b.id, bg);
+      if (ka !== kb) return ka - kb;
+      if (ka === SYNTHETIC_BOTTOM) {
+        // Two untouched synthetic groups: multi-repo above scratch.
+        if (a.id === MULTI_REPO_GROUP_ID) return -1;
+        if (b.id === MULTI_REPO_GROUP_ID) return 1;
+        return 0;
+      }
+      // Two untouched real groups: fall back to the derived min-rank,
+      // then a deterministic repoPath tie-break.
       const am = Math.min(...a.workspaces.map((w) => rankOf(w.id)));
       const bm = Math.min(...b.workspaces.map((w) => rankOf(w.id)));
       if (am !== bm) return am - bm;
@@ -199,7 +236,14 @@ export function useRepoGroups(
     });
 
     return repoGroups;
-  }, [workspaces, workspaceOrdering, sortMode, collapsedMap, appearanceMap]);
+  }, [
+    workspaces,
+    workspaceOrdering,
+    sortMode,
+    collapsedMap,
+    appearanceMap,
+    groupOrder,
+  ]);
 
   const toggleRepoCollapsed = useCallback((repoId: string) => {
     setCollapsedMap((prev) => {
@@ -225,5 +269,18 @@ export function useRepoGroups(
     [],
   );
 
-  return { groups, toggleRepoCollapsed, updateRepoAppearance };
+  // Persist the full ordered list of real repo-group ids handed up by the
+  // sidebar drag. Synthetic ids are pinned to the bottom and never
+  // ranked, so the caller filters them out before calling this.
+  const reorderRepoGroups = useCallback((orderedGroupIds: string[]) => {
+    setGroupOrder(orderedGroupIds);
+    persistRepoGroupOrder(orderedGroupIds);
+  }, []);
+
+  return {
+    groups,
+    toggleRepoCollapsed,
+    updateRepoAppearance,
+    reorderRepoGroups,
+  };
 }

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -1,0 +1,155 @@
+// First-run tutorial controller. Owns the tour's run state, the resolved step
+// snapshot, auto-launch policy, and `aoe-tour-seen` persistence. It is
+// engine-agnostic: the react-joyride coupling lives entirely in the lazy
+// TourRunner, which is only mounted (and only downloaded) while a tour runs, so
+// returning users never pay for the engine. App is the single consumer, so this
+// is a plain hook returning the element to render rather than a context.
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  resolveTourSteps,
+  type TourScope,
+  type TourStep,
+} from "../lib/tourSteps";
+import { safeGetItem, safeSetItem } from "../lib/safeStorage";
+
+// Per-origin localStorage already isolates dev (port 8081) from release (8080),
+// so a flat key needs no app-dir namespace.
+const TOUR_SEEN_KEY = "aoe-tour-seen";
+
+const TourRunner = lazy(() => import("../components/tour/TourRunner"));
+
+export interface UseTourOptions {
+  /** Which mutually-exclusive surface is mounted right now. */
+  scope: TourScope;
+  readOnly: boolean;
+  /** Fine pointer. Gates desktop-only steps and suppresses auto-launch on touch. */
+  isDesktop: boolean;
+  /** True once it is safe to auto-launch: server/about and sessions loaded, the
+   *  dashboard is painted, and no blocking overlay is open. */
+  autoLaunchReady: boolean;
+}
+
+/**
+ * Pure auto-launch decision, extracted so the truth table is unit-testable
+ * without driving rAF / Suspense / the lazy engine. The tour auto-launches only
+ * on a settled dashboard, with a fine pointer, when the user has not yet seen
+ * it, and never inside an automated browser session (a synthetic monitor, a
+ * scraper, or our own Playwright suites): the spotlight overlay would otherwise
+ * intercept clicks in unrelated flows. The menu re-trigger stays available.
+ */
+export function shouldAutoLaunch(args: {
+  autoLaunchReady: boolean;
+  scope: TourScope;
+  isDesktop: boolean;
+  seen: boolean;
+  automated: boolean;
+}): boolean {
+  return (
+    args.autoLaunchReady &&
+    args.scope === "dashboard" &&
+    args.isDesktop &&
+    !args.seen &&
+    !args.automated
+  );
+}
+
+function isAutomatedSession(): boolean {
+  return typeof navigator !== "undefined" && navigator.webdriver === true;
+}
+
+export interface UseTourResult {
+  /** Launch the tour for the current scope. Ignores the seen flag. */
+  startTour: () => void;
+  isTourActive: boolean;
+  /** Render this somewhere stable in the tree (e.g. at the App root). */
+  tourElement: ReactNode;
+}
+
+export function useTour({
+  scope,
+  readOnly,
+  isDesktop,
+  autoLaunchReady,
+}: UseTourOptions): UseTourResult {
+  const [run, setRun] = useState(false);
+  const [steps, setSteps] = useState<TourStep[]>([]);
+  const autoStartedRef = useRef(false);
+  const prevScopeRef = useRef(scope);
+  const mountedRef = useRef(true);
+
+  // Set in setup, not just cleanup, so a StrictMode unmount/remount (or any
+  // remount) does not leave begin() permanently latched to a no-op.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Defer one frame so a closing menu / freshly committed route has painted
+  // before we probe the DOM for anchors. No arbitrary timeout. `onStarted`
+  // fires synchronously, only when the tour actually starts (steps resolved),
+  // so callers can latch on real success rather than on the scheduling attempt.
+  const begin = useCallback(
+    (onStarted?: () => void): number => {
+      return requestAnimationFrame(() => {
+        if (!mountedRef.current) return;
+        const resolved = resolveTourSteps({ scope, readOnly, isDesktop });
+        if (resolved.length === 0) return;
+        onStarted?.();
+        setSteps(resolved);
+        setRun(true);
+      });
+    },
+    [scope, readOnly, isDesktop],
+  );
+
+  const startTour = useCallback(() => {
+    begin();
+  }, [begin]);
+
+  // Auto-launch: once per mount, dashboard scope, fine pointer, flag unset.
+  // The latch is set inside begin()'s success path so a frame where no anchor
+  // is painted yet does not permanently suppress the auto-launch.
+  useEffect(() => {
+    if (autoStartedRef.current) return;
+    const seen = safeGetItem(TOUR_SEEN_KEY) === "1";
+    const automated = isAutomatedSession();
+    if (!shouldAutoLaunch({ autoLaunchReady, scope, isDesktop, seen, automated }))
+      return;
+    const id = begin(() => {
+      autoStartedRef.current = true;
+    });
+    return () => cancelAnimationFrame(id);
+  }, [autoLaunchReady, scope, isDesktop, begin]);
+
+  // Navigating to a different surface mid-tour cancels it without marking seen,
+  // so a returning user can still get the cockpit steps on a later re-trigger.
+  useEffect(() => {
+    if (prevScopeRef.current !== scope) {
+      prevScopeRef.current = scope;
+      setRun(false);
+    }
+  }, [scope]);
+
+  const handleFinish = useCallback((markSeen: boolean) => {
+    setRun(false);
+    if (markSeen) safeSetItem(TOUR_SEEN_KEY, "1");
+  }, []);
+
+  const tourElement = run ? (
+    <Suspense fallback={null}>
+      <TourRunner run={run} steps={steps} onFinish={handleFinish} />
+    </Suspense>
+  ) : null;
+
+  return { startTour, isTourActive: run, tourElement };
+}

--- a/web/src/lib/__tests__/cockpitTypes.types.test.ts
+++ b/web/src/lib/__tests__/cockpitTypes.types.test.ts
@@ -1,0 +1,26 @@
+// Type-level regression tests for the cockpit wire types. These run
+// under Vitest's typecheck mode (see `test.typecheck` in
+// `vite.config.ts`); a failing assertion is a tsc error, not a runtime
+// failure. Guards #1562: the Rust `ConfigOptionCategory::Other(String)`
+// arm is `#[serde(untagged)]`, so an unknown category arrives on the
+// wire as a bare string. The TS type must accept any string for those,
+// not the `{ Other: string }` object shape that never matches.
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { ConfigOptionCategory } from "../cockpitTypes";
+
+describe("ConfigOptionCategory", () => {
+  it("accepts an arbitrary wire string for unknown categories", () => {
+    // Fails to type-check under the old `{ Other: string }` variant: a
+    // bare string is not assignable to it.
+    expectTypeOf<string>().toExtend<ConfigOptionCategory>();
+    expectTypeOf("future_category").toExtend<ConfigOptionCategory>();
+  });
+
+  it("still admits the known spec literals", () => {
+    expectTypeOf<"mode">().toExtend<ConfigOptionCategory>();
+    expectTypeOf<"model">().toExtend<ConfigOptionCategory>();
+    expectTypeOf<"thought_level">().toExtend<ConfigOptionCategory>();
+  });
+});

--- a/web/src/lib/__tests__/tourSteps.test.ts
+++ b/web/src/lib/__tests__/tourSteps.test.ts
@@ -1,0 +1,171 @@
+// CI drift guard for the first-run tutorial, plus resolver coverage.
+//
+// The guard is the cheap, deterministic half of the "tour cannot silently
+// break" contract (issue #1513, user story 3): it couples TOUR_STEPS, the
+// TOUR_ANCHORS constants, and the actual `data-tour` attributes in component
+// source, so renaming or deleting an anchor on either side turns this red in
+// milliseconds. The render-time half (an eligible anchor that fails to paint)
+// is covered by the Dashboard render test and the live Playwright smoke.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  TOUR_ANCHORS,
+  TOUR_STEPS,
+  isStepEligible,
+  resolveTourSteps,
+  type TourAnchorId,
+  type TourStep,
+} from "../tourSteps";
+
+const SRC_DIR = join(process.cwd(), "src");
+// tourSteps.ts itself legitimately contains the `data-tour="..."` template in
+// tourSelector(); tests and stories are not shipped UI. Everything else must go
+// through the TOUR_ANCHORS constants.
+const EXCLUDED = [
+  join("lib", "tourSteps.ts"),
+  "__tests__",
+  ".test.",
+  ".stories.",
+];
+
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectSourceFiles(full, acc);
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+const COMPONENT_SOURCES = collectSourceFiles(SRC_DIR).filter(
+  (f) => !EXCLUDED.some((ex) => f.includes(ex)),
+);
+
+const ANCHOR_KEY_BY_VALUE = new Map<TourAnchorId, string>(
+  Object.entries(TOUR_ANCHORS).map(([key, value]) => [value, key]),
+);
+
+describe("tour drift guard", () => {
+  it("every step anchor is a known TOUR_ANCHORS value", () => {
+    const known = new Set<string>(Object.values(TOUR_ANCHORS));
+    for (const step of TOUR_STEPS) {
+      expect(known.has(step.anchor)).toBe(true);
+    }
+  });
+
+  it("every TOUR_ANCHORS value is used by at least one step (no orphan anchors)", () => {
+    const usedByStep = new Set(TOUR_STEPS.map((s) => s.anchor));
+    for (const value of Object.values(TOUR_ANCHORS)) {
+      expect(usedByStep.has(value)).toBe(true);
+    }
+  });
+
+  it("step ids are unique", () => {
+    const ids = TOUR_STEPS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every anchor a step points at is attached in component source via TOUR_ANCHORS.<key>", () => {
+    const usedInSource = new Set<string>();
+    const re = /TOUR_ANCHORS\.(\w+)/g;
+    for (const file of COMPONENT_SOURCES) {
+      const text = readFileSync(file, "utf8");
+      for (const m of text.matchAll(re)) usedInSource.add(m[1]);
+    }
+    for (const step of TOUR_STEPS) {
+      const key = ANCHOR_KEY_BY_VALUE.get(step.anchor);
+      expect(key, `anchor ${step.anchor} missing from TOUR_ANCHORS`).toBeDefined();
+      expect(
+        usedInSource.has(key as string),
+        `anchor "${step.anchor}" (step "${step.id}") is never attached in component source`,
+      ).toBe(true);
+    }
+  });
+
+  it("no raw data-tour string literals in component source (must use the typed constant)", () => {
+    const offenders: string[] = [];
+    for (const file of COMPONENT_SOURCES) {
+      const text = readFileSync(file, "utf8");
+      if (/data-tour=["']/.test(text)) offenders.push(file);
+    }
+    expect(offenders, `raw data-tour literals found in: ${offenders.join(", ")}`).toEqual([]);
+  });
+});
+
+describe("resolveTourSteps", () => {
+  const all: TourAnchorId[] = Object.values(TOUR_ANCHORS);
+  const present = (anchor: TourAnchorId) => all.includes(anchor);
+
+  it("returns only dashboard-scope steps with present anchors on the dashboard", () => {
+    const steps = resolveTourSteps({
+      scope: "dashboard",
+      readOnly: false,
+      isDesktop: true,
+      hasAnchor: present,
+    });
+    const ids = steps.map((s) => s.id);
+    expect(ids).toContain("sidebar");
+    expect(ids).toContain("new-session");
+    expect(ids).toContain("topbar-more");
+    // cockpit-only steps must not leak onto the dashboard
+    expect(ids).not.toContain("composer");
+    expect(ids).not.toContain("right-panel");
+  });
+
+  it("drops the writable-only new-session step in read-only mode", () => {
+    const steps = resolveTourSteps({
+      scope: "dashboard",
+      readOnly: true,
+      isDesktop: true,
+      hasAnchor: present,
+    });
+    expect(steps.map((s) => s.id)).not.toContain("new-session");
+  });
+
+  it("drops desktop-only steps on coarse pointers", () => {
+    const steps = resolveTourSteps({
+      scope: "cockpit",
+      readOnly: false,
+      isDesktop: false,
+      hasAnchor: present,
+    });
+    expect(steps.map((s) => s.id)).not.toContain("right-panel");
+  });
+
+  it("drops steps whose anchor is absent from the DOM", () => {
+    const steps = resolveTourSteps({
+      scope: "dashboard",
+      readOnly: false,
+      isDesktop: true,
+      hasAnchor: () => false,
+    });
+    expect(steps).toEqual([]);
+  });
+
+  it("preserves TOUR_STEPS order", () => {
+    const steps = resolveTourSteps({
+      scope: "cockpit",
+      readOnly: false,
+      isDesktop: true,
+      hasAnchor: present,
+    });
+    const orderInSource = TOUR_STEPS.map((s) => s.id);
+    const resolvedOrder = steps.map((s) => s.id);
+    const expected = orderInSource.filter((id) => resolvedOrder.includes(id));
+    expect(resolvedOrder).toEqual(expected);
+  });
+
+  it("isStepEligible ignores DOM presence (metadata only)", () => {
+    const composer = TOUR_STEPS.find((s) => s.id === "composer") as TourStep;
+    expect(
+      isStepEligible(composer, { scope: "cockpit", readOnly: false, isDesktop: true }),
+    ).toBe(true);
+    expect(
+      isStepEligible(composer, { scope: "dashboard", readOnly: false, isDesktop: true }),
+    ).toBe(false);
+  });
+});

--- a/web/src/lib/cockpitStateStorage.test.ts
+++ b/web/src/lib/cockpitStateStorage.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  STORAGE_KEY_PREFIX,
+  STATE_TTL_MS,
+  clearQueueCount,
+  getQueuedCount,
+  setQueueCount,
+  subscribeCockpitState,
+} from "./cockpitStateStorage";
+
+function entryKey(id: string): string {
+  return `${STORAGE_KEY_PREFIX}${id}`;
+}
+
+function writeEntry(id: string, queued: number, savedAt = Date.now()): void {
+  const queuedPrompts = Array.from({ length: queued }, (_, i) => ({
+    id: `${id}-${i}`,
+    text: `q${i}`,
+    queuedAt: "t",
+  }));
+  localStorage.setItem(
+    entryKey(id),
+    JSON.stringify({ savedAt, state: { lastSeq: 0, activity: [], queuedPrompts } }),
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  clearQueueCount();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  clearQueueCount();
+  vi.restoreAllMocks();
+});
+
+describe("getQueuedCount", () => {
+  it("returns 0 for a missing entry", () => {
+    expect(getQueuedCount("nope")).toBe(0);
+  });
+
+  it("parses the count from localStorage on a cache miss", () => {
+    writeEntry("a", 4);
+    expect(getQueuedCount("a")).toBe(4);
+  });
+
+  it("memoises the count so a later localStorage edit is not re-read", () => {
+    writeEntry("a", 2);
+    expect(getQueuedCount("a")).toBe(2);
+    // Direct localStorage mutation does not invalidate the in-memory
+    // cache; only setQueueCount / a storage event / clear do.
+    writeEntry("a", 9);
+    expect(getQueuedCount("a")).toBe(2);
+  });
+
+  it("treats a TTL-expired entry as 0", () => {
+    writeEntry("a", 5, Date.now() - STATE_TTL_MS - 1);
+    expect(getQueuedCount("a")).toBe(0);
+  });
+
+  it("treats a corrupt entry as 0", () => {
+    localStorage.setItem(entryKey("a"), "{not json");
+    expect(getQueuedCount("a")).toBe(0);
+  });
+
+  it("treats an entry without a queuedPrompts array as 0", () => {
+    localStorage.setItem(
+      entryKey("a"),
+      JSON.stringify({ savedAt: Date.now(), state: { lastSeq: 0 } }),
+    );
+    expect(getQueuedCount("a")).toBe(0);
+  });
+
+  it("returns 0 when localStorage access throws", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    expect(getQueuedCount("a")).toBe(0);
+    spy.mockRestore();
+  });
+});
+
+describe("setQueueCount", () => {
+  it("publishes the count and notifies subscribers", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    setQueueCount("a", 3);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getQueuedCount("a")).toBe(3);
+    unsub();
+  });
+
+  it("does not notify a subscriber filtered to other sessions", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["b"]));
+    setQueueCount("a", 1);
+    expect(cb).not.toHaveBeenCalled();
+    unsub();
+  });
+});
+
+describe("clearQueueCount", () => {
+  it("clears one session and notifies that session's subscribers", () => {
+    setQueueCount("a", 2);
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    clearQueueCount("a");
+    expect(cb).toHaveBeenCalledTimes(1);
+    // Cache dropped; with no localStorage entry the count reads 0.
+    expect(getQueuedCount("a")).toBe(0);
+    unsub();
+  });
+
+  it("clears all sessions and notifies every subscriber", () => {
+    const cbA = vi.fn();
+    const cbB = vi.fn();
+    const unsubA = subscribeCockpitState(cbA, new Set(["a"]));
+    const unsubB = subscribeCockpitState(cbB, new Set(["b"]));
+    clearQueueCount();
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+    unsubA();
+    unsubB();
+  });
+});
+
+describe("subscribeCockpitState storage events", () => {
+  it("refreshes the cache and notifies on a matching cross-tab write", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: entryKey("a"),
+        newValue: JSON.stringify({
+          savedAt: Date.now(),
+          state: { lastSeq: 0, activity: [], queuedPrompts: [{ id: "a-0", text: "x", queuedAt: "t" }] },
+        }),
+        storageArea: localStorage,
+      }),
+    );
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getQueuedCount("a")).toBe(1);
+    unsub();
+  });
+
+  it("ignores keys outside the cockpit-state prefix", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "some:other:key",
+        newValue: "x",
+        storageArea: localStorage,
+      }),
+    );
+    expect(cb).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it("treats a removed entry (null newValue) as 0", () => {
+    setQueueCount("a", 3);
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: entryKey("a"),
+        newValue: null,
+        storageArea: localStorage,
+      }),
+    );
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getQueuedCount("a")).toBe(0);
+    unsub();
+  });
+
+  it("fires unconditionally and drops the cache on a cross-tab clear (null key)", () => {
+    setQueueCount("a", 2);
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: null, storageArea: localStorage }),
+    );
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getQueuedCount("a")).toBe(0);
+    unsub();
+  });
+
+  it("a null-filter listener fires for any session change", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, null);
+    setQueueCount("whatever", 1);
+    expect(cb).toHaveBeenCalledTimes(1);
+    unsub();
+  });
+
+  it("stops firing after unsubscribe", () => {
+    const cb = vi.fn();
+    const unsub = subscribeCockpitState(cb, new Set(["a"]));
+    unsub();
+    setQueueCount("a", 1);
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: entryKey("a"),
+        newValue: null,
+        storageArea: localStorage,
+      }),
+    );
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/cockpitStateStorage.ts
+++ b/web/src/lib/cockpitStateStorage.ts
@@ -1,0 +1,148 @@
+// Storage layer for per-session cockpit state. The cockpit reducer state
+// is mirrored into localStorage under `aoe:cockpit-state:v1:<id>` by
+// useCockpit's persistState so a reload rehydrates without replaying the
+// whole transcript (see useCockpit.ts and #1132). This module owns the
+// key shape and TTL so both the writer (useCockpit) and read-only
+// consumers (the sidebar queued-prompt badge) share one source of truth,
+// without the sidebar having to import the heavy cockpit hook and its WS
+// machinery just to read a count.
+//
+// It also exposes a small pub/sub (mirroring cockpitDrafts.ts) plus an
+// in-memory queued-prompt count cache so the sidebar can render a live
+// "N queued" badge via useSyncExternalStore. The cache keeps a snapshot
+// read O(1) and avoids JSON.parsing the (potentially large) state blob
+// during render: persistState already holds queuedPrompts.length and
+// publishes it on every write, and cross-tab `storage` events parse the
+// new value exactly once.
+
+import type { CockpitState } from "./cockpitTypes";
+
+export const STORAGE_KEY_PREFIX = "aoe:cockpit-state:v1:";
+export const STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface PersistedEntry {
+  savedAt: number;
+  state: CockpitState;
+}
+
+function storageKey(sessionId: string): string {
+  return STORAGE_KEY_PREFIX + sessionId;
+}
+
+function sessionIdFromKey(key: string): string | null {
+  if (!key.startsWith(STORAGE_KEY_PREFIX)) return null;
+  return key.slice(STORAGE_KEY_PREFIX.length);
+}
+
+// Queued-prompt count per session id, kept in sync by setQueueCount
+// (same-tab writes) and the cross-tab storage listener. A missing entry
+// means "not yet known this page load"; getQueuedCount lazily fills it
+// from localStorage on first read so inactive sessions (no mounted
+// cockpit hook writing) still resolve a count.
+const queueCounts = new Map<string, number>();
+
+type Listener = () => void;
+
+// Each listener may register an optional id filter; null means "fire for
+// any cockpit-state change" (used for a cross-tab localStorage.clear()).
+const listeners = new Map<Listener, ReadonlySet<string> | null>();
+
+function notify(sessionId: string | null): void {
+  for (const [cb, filter] of listeners) {
+    if (filter === null || sessionId === null || filter.has(sessionId)) cb();
+  }
+}
+
+// Parse a queued-prompt count out of a raw persisted entry, honoring the
+// TTL. Returns null when the entry is missing, expired, corrupt, or
+// structurally invalid so callers fall back to 0 without caching a bogus
+// value.
+function parseQueuedCount(raw: string | null): number | null {
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as PersistedEntry | null;
+    if (
+      !parsed ||
+      typeof parsed.savedAt !== "number" ||
+      Number.isNaN(parsed.savedAt) ||
+      Date.now() - parsed.savedAt > STATE_TTL_MS
+    ) {
+      return null;
+    }
+    const q = (parsed.state as Partial<CockpitState> | undefined)?.queuedPrompts;
+    return Array.isArray(q) ? q.length : null;
+  } catch {
+    return null;
+  }
+}
+
+// Publish a session's current queued-prompt count. Called by useCockpit's
+// persistState on every successful write; the length is already in hand
+// there, so no JSON parsing happens on the write hot path.
+export function setQueueCount(sessionId: string, count: number): void {
+  queueCounts.set(sessionId, count);
+  notify(sessionId);
+}
+
+// Drop a session's cached count (session delete / cache clear). With no
+// argument, clears the whole cache.
+export function clearQueueCount(sessionId?: string): void {
+  if (sessionId === undefined) {
+    queueCounts.clear();
+    notify(null);
+    return;
+  }
+  queueCounts.delete(sessionId);
+  notify(sessionId);
+}
+
+// Side-effect-free read of a session's queued-prompt count. Safe to call
+// from a useSyncExternalStore snapshot during render: it never mutates
+// localStorage (unlike useCockpit's loadPersistedState, which prunes
+// expired entries) and returns a primitive. Reads the in-memory cache
+// first; on a miss it parses localStorage once and memoises the result.
+export function getQueuedCount(sessionId: string): number {
+  const cached = queueCounts.get(sessionId);
+  if (cached !== undefined) return cached;
+  if (typeof window === "undefined") return 0;
+  let count: number;
+  try {
+    count = parseQueuedCount(window.localStorage.getItem(storageKey(sessionId))) ?? 0;
+  } catch {
+    // localStorage blocked/threw: don't memoise a transient failure.
+    return 0;
+  }
+  queueCounts.set(sessionId, count);
+  return count;
+}
+
+// Subscribe to cockpit-state changes. `filter` scopes the listener to a
+// set of session ids; null receives every change. Fires for same-tab
+// writes (via the notify in setQueueCount) and cross-tab writes (storage
+// event). Returns an unsubscribe function. Mirrors subscribeDrafts.
+export function subscribeCockpitState(
+  cb: Listener,
+  filter: ReadonlySet<string> | null = null,
+): () => void {
+  listeners.set(cb, filter);
+  const onStorage = (e: StorageEvent) => {
+    // localStorage.clear() in another tab leaves e.key null; drop the
+    // whole count cache and fire unconditionally.
+    if (e.key === null) {
+      queueCounts.clear();
+      cb();
+      return;
+    }
+    const sid = sessionIdFromKey(e.key);
+    if (sid === null) return;
+    // Refresh the cache from the cross-tab value (parsed once) so the
+    // next snapshot read is consistent, then notify if in scope.
+    queueCounts.set(sid, parseQueuedCount(e.newValue) ?? 0);
+    if (filter === null || filter.has(sid)) cb();
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(cb);
+    window.removeEventListener("storage", onStorage);
+  };
+}

--- a/web/src/lib/cockpitStopSweep.test.ts
+++ b/web/src/lib/cockpitStopSweep.test.ts
@@ -1,0 +1,179 @@
+// Reducer tests for the turn-end open-tool sweep (#1646).
+//
+// When the agent is stopped while a tool is mid-execution,
+// claude-agent-acp resolves the prompt with StopReason::Cancelled and
+// never emits a per-tool completion, so the cockpit only ever sees a
+// turn-level Stopped. A tool card's status is derived from the paired
+// terminal row in state.activity, so without a sweep the card sticks on
+// "running" forever (orange badge + a timer that counts up), live and
+// on reload (the trailing Stopped is persisted and replayed through
+// this same reducer).
+//
+// These assert that every turn-ending arm synthesizes a tool_stopped
+// row for each still-open tool_start, exactly once, without disturbing
+// tools that already completed.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyEvent,
+  emptyCockpitState,
+  type CockpitEvent,
+  type CockpitFrame,
+  type CockpitState,
+  type ToolCall,
+} from "./cockpitTypes";
+
+function frame(seq: number, event: CockpitEvent): CockpitFrame {
+  return { session_id: "s-1", seq, event };
+}
+
+function toolCall(id: string): ToolCall {
+  return {
+    id,
+    name: `tool ${id}`,
+    kind: "execute",
+    args_preview: "{}",
+    started_at: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function start(state: CockpitState, seq: number, id: string): CockpitState {
+  return applyEvent(state, frame(seq, { ToolCallStarted: { tool_call: toolCall(id) } }));
+}
+
+function openRows(state: CockpitState): string[] {
+  const terminal = new Set(
+    state.activity
+      .filter(
+        (r) =>
+          r.kind === "tool_complete" ||
+          r.kind === "tool_error" ||
+          r.kind === "tool_stopped",
+      )
+      .map((r) => r.toolCallId),
+  );
+  return state.activity
+    .filter((r) => r.kind === "tool_start" && !terminal.has(r.toolCallId))
+    .map((r) => r.toolCallId!);
+}
+
+function stoppedRows(state: CockpitState) {
+  return state.activity.filter((r) => r.kind === "tool_stopped");
+}
+
+describe("turn-end open-tool sweep", () => {
+  it("closes an open tool on Stopped and clears inFlightTool", () => {
+    const opened = start(emptyCockpitState(), 1, "t1");
+    expect(openRows(opened)).toEqual(["t1"]);
+
+    const next = applyEvent(opened, frame(2, { Stopped: { reason: "cancelled" } }));
+
+    expect(openRows(next)).toEqual([]);
+    expect(next.inFlightTool).toBeNull();
+    const stopped = stoppedRows(next);
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0]).toMatchObject({ kind: "tool_stopped", toolCallId: "t1" });
+    expect(typeof stopped[0]!.at).toBe("string");
+  });
+
+  it("leaves an already-completed tool untouched", () => {
+    let state = start(emptyCockpitState(), 1, "t1");
+    state = applyEvent(
+      state,
+      frame(2, {
+        ToolCallCompleted: {
+          tool_call_id: "t1",
+          is_error: false,
+          content: "ok",
+          completed_at: "2026-01-01T00:00:01.000Z",
+        },
+      }),
+    );
+    const next = applyEvent(state, frame(3, { Stopped: { reason: "cancelled" } }));
+
+    expect(stoppedRows(next)).toHaveLength(0);
+    expect(
+      next.activity.filter((r) => r.kind === "tool_complete"),
+    ).toHaveLength(1);
+  });
+
+  it("closes only the still-open tool when several are in flight", () => {
+    let state = start(emptyCockpitState(), 1, "a");
+    state = start(state, 2, "b");
+    state = applyEvent(
+      state,
+      frame(3, {
+        ToolCallCompleted: { tool_call_id: "a", is_error: false, content: "" },
+      }),
+    );
+    const next = applyEvent(state, frame(4, { Stopped: { reason: "user_stopped" } }));
+
+    const stopped = stoppedRows(next);
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0]!.toolCallId).toBe("b");
+  });
+
+  it("drains buffered ToolCallContent into the synthesized row", () => {
+    let state = start(emptyCockpitState(), 1, "t1");
+    state = applyEvent(
+      state,
+      frame(2, { ToolCallContent: { tool_call_id: "t1", content: "partial output" } }),
+    );
+    const next = applyEvent(state, frame(3, { Stopped: { reason: "cancelled" } }));
+
+    expect(stoppedRows(next)[0]).toMatchObject({ text: "partial output" });
+    expect(next.toolOutputs.t1).toBeUndefined();
+  });
+
+  it("does not double-close on a second terminal event", () => {
+    const opened = start(emptyCockpitState(), 1, "t1");
+    const once = applyEvent(opened, frame(2, { Stopped: { reason: "cancelled" } }));
+    const twice = applyEvent(once, frame(3, { Stopped: { reason: "prompt_complete" } }));
+
+    expect(stoppedRows(twice)).toHaveLength(1);
+  });
+
+  it("synthesizes one row even when the store carries duplicate tool_start rows", () => {
+    // Pre-fix stores can replay the same tool_call_id twice; the dedupe
+    // in ToolCallStarted patches in place, so seed the duplicate directly
+    // to exercise the sweep's own toolCallId dedupe.
+    const base = start(emptyCockpitState(), 1, "dup");
+    const withDupe: CockpitState = {
+      ...base,
+      activity: base.activity.concat({
+        id: "start-dup-2",
+        kind: "tool_start",
+        text: "tool dup",
+        toolCallId: "dup",
+        at: "2026-01-01T00:00:00.000Z",
+      }),
+    };
+    const next = applyEvent(withDupe, frame(2, { Stopped: { reason: "cancelled" } }));
+
+    expect(stoppedRows(next)).toHaveLength(1);
+  });
+
+  it("repairs a persisted [start, Stopped] replay so reload is terminal", () => {
+    // Cold reload: no live state, replay the persisted frames in order.
+    const replayed = [
+      frame(1, { ToolCallStarted: { tool_call: toolCall("t1") } }),
+      frame(2, { Stopped: { reason: "cancelled" } }),
+    ].reduce(applyEvent, emptyCockpitState());
+
+    expect(openRows(replayed)).toEqual([]);
+    expect(stoppedRows(replayed)).toHaveLength(1);
+  });
+
+  it.each([
+    ["AgentSwitched", { AgentSwitched: { from: "claude", to: "codex", reason: "rate_limit" } }],
+    ["IncompatibleAgent", { IncompatibleAgent: { detail: { reason: "x" } } }],
+    ["AgentStartupError", { AgentStartupError: { message: "boom" } }],
+  ] as const)("closes open tools on %s", (_label, event) => {
+    const opened = start(emptyCockpitState(), 1, "t1");
+    const next = applyEvent(opened, frame(2, event as CockpitEvent));
+
+    expect(openRows(next)).toEqual([]);
+    expect(stoppedRows(next)).toHaveLength(1);
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -105,14 +105,16 @@ export interface AvailableCommand {
 /** Semantic category for a session configuration option, mirroring
  *  ACP's `SessionConfigOptionCategory`. The cockpit UI uses this to
  *  pick the right widget per category (model dropdown, effort
- *  segmented control). Unknown categories preserve their string
- *  payload so the broadcast frame stays forward-compatible. See
- *  #1403. */
+ *  segmented control). The Rust `Other(String)` arm is
+ *  `#[serde(untagged)]`, so an unknown category arrives on the wire as
+ *  a bare string, not a `{ Other: string }` object. Modeling it as a
+ *  catch-all string keeps the broadcast frame forward-compatible while
+ *  preserving autocomplete on the known literals. See #1403, #1562. */
 export type ConfigOptionCategory =
   | "mode"
   | "model"
   | "thought_level"
-  | { Other: string };
+  | (string & {});
 
 /** One choice in a `Select`-kind ConfigOptionDescriptor. */
 export interface ConfigOptionChoice {

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -524,6 +524,7 @@ export interface ActivityRow {
     | "tool_start"
     | "tool_complete"
     | "tool_error"
+    | "tool_stopped"
     | "message"
     | "thinking"
     | "user_prompt"
@@ -937,6 +938,7 @@ export function applyEvent(
     // optimistic message above any still-arriving prior-turn agent
     // chunks. See #1170.
     next.inFlightTool = null;
+    sweepOpenToolCalls(next, frame.seq);
     next.lastStoppedSeq = Math.min(
       next.lastStoppedSeq + 1,
       next.pendingUserPromptSeq,
@@ -1031,6 +1033,7 @@ export function applyEvent(
     // `startupError` so legacy status logic still flips into Error.
     next.incompatibleAgent = event.IncompatibleAgent.detail;
     next.inFlightTool = null;
+    sweepOpenToolCalls(next, frame.seq);
     next.agentUnresponsive = false;
     next.lastStoppedSeq = Math.min(
       next.lastStoppedSeq + 1,
@@ -1042,6 +1045,7 @@ export function applyEvent(
   if ("AgentStartupError" in event) {
     next.startupError = event.AgentStartupError.message;
     next.inFlightTool = null;
+    sweepOpenToolCalls(next, frame.seq);
     // A failed respawn supersedes any in-progress unresponsive
     // escalation; the user sees the startup error banner instead.
     next.agentUnresponsive = false;
@@ -1228,6 +1232,9 @@ export function applyEvent(
     next.agent = to;
     next.rateLimit = null;
     next.inFlightTool = null;
+    // Close any tool the prior backend left open before appending the
+    // divider, so the transcript order is start -> stopped -> divider.
+    sweepOpenToolCalls(next, frame.seq);
     next.thinking = false;
     next.pendingApprovals = [];
     next.sessionUsage = null;
@@ -1310,6 +1317,65 @@ function pushActivity(rows: ActivityRow[], row: ActivityRow): ActivityRow[] {
     return next.slice(next.length - activityLimit);
   }
   return next;
+}
+
+/** Close any `tool_start` rows that never received a matching terminal
+ *  row by synthesizing a `tool_stopped` row for each. Called from the
+ *  turn-ending reducer arms (`Stopped`, `AgentSwitched`,
+ *  `IncompatibleAgent`, `AgentStartupError`): once the turn ends, no
+ *  tool that was part of it can still be running, yet the card status
+ *  is derived from the paired terminal row (see ToolCards `statusFor`),
+ *  not from the `inFlightTool` pointer the arms already null. Without
+ *  this sweep an interrupted tool's card sticks on "running" with a
+ *  live-ticking timer forever, live and on reload (the trailing
+ *  `Stopped` is persisted and replayed through this same reducer). The
+ *  case is reason-independent: even a `prompt_complete` with a dangling
+ *  open tool (the agent forgot to emit a completion) is "stopped", not
+ *  "done" or "failed", because the tool's real outcome was never
+ *  reported. Any text streamed via `ToolCallContent` before the stop is
+ *  drained into the synthesized row so it is not lost. See #1646. */
+function sweepOpenToolCalls(next: CockpitState, frameSeq: number): void {
+  const terminal = new Set<string>();
+  for (const row of next.activity) {
+    if (
+      (row.kind === "tool_complete" ||
+        row.kind === "tool_error" ||
+        row.kind === "tool_stopped") &&
+      row.toolCallId
+    ) {
+      terminal.add(row.toolCallId);
+    }
+  }
+  const now = new Date().toISOString();
+  let activity = next.activity;
+  let outputs = next.toolOutputs;
+  let drained = false;
+  // Iterate the pre-sweep snapshot; `pushActivity` returns fresh arrays
+  // assigned to the local `activity`, so the loop never sees the rows it
+  // appends. Dedupe by `toolCallId` because pre-fix stores can carry
+  // duplicate `tool_start` rows for one call.
+  for (const row of next.activity) {
+    if (row.kind !== "tool_start" || !row.toolCallId) continue;
+    const id = row.toolCallId;
+    if (terminal.has(id)) continue;
+    terminal.add(id);
+    const buffered = outputs[id] ?? "";
+    if (buffered) {
+      const { [id]: _drop, ...rest } = outputs;
+      void _drop;
+      outputs = rest;
+      drained = true;
+    }
+    activity = pushActivity(activity, {
+      id: `stopped-${id}-${frameSeq}`,
+      kind: "tool_stopped",
+      text: buffered,
+      toolCallId: id,
+      at: now,
+    });
+  }
+  next.activity = activity;
+  if (drained) next.toolOutputs = outputs;
 }
 
 /** Derived `turnActive` from the prompt / stop seq counters. Exported

--- a/web/src/lib/repoGroupOrder.test.ts
+++ b/web/src/lib/repoGroupOrder.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { loadRepoGroupOrder, persistRepoGroupOrder } from "./repoGroupOrder";
+
+const ORDER_KEY = "aoe-repo-group-order-v1";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("repoGroupOrder", () => {
+  it("returns an empty list when nothing is stored", () => {
+    expect(loadRepoGroupOrder()).toEqual([]);
+  });
+
+  it("round-trips a persisted order through localStorage", () => {
+    persistRepoGroupOrder(["/repo-b", "/repo-a"]);
+    expect(window.localStorage.getItem(ORDER_KEY)).toBe(
+      JSON.stringify(["/repo-b", "/repo-a"]),
+    );
+    expect(loadRepoGroupOrder()).toEqual(["/repo-b", "/repo-a"]);
+  });
+
+  it("removes the key when persisting an empty order", () => {
+    persistRepoGroupOrder(["/repo-a"]);
+    persistRepoGroupOrder([]);
+    expect(window.localStorage.getItem(ORDER_KEY)).toBeNull();
+    expect(loadRepoGroupOrder()).toEqual([]);
+  });
+
+  it("ignores malformed JSON", () => {
+    window.localStorage.setItem(ORDER_KEY, "{not json");
+    expect(loadRepoGroupOrder()).toEqual([]);
+  });
+
+  it("ignores a stored value that is not an array", () => {
+    window.localStorage.setItem(ORDER_KEY, JSON.stringify({ a: 1 }));
+    expect(loadRepoGroupOrder()).toEqual([]);
+  });
+
+  it("drops non-string entries from the stored array", () => {
+    window.localStorage.setItem(
+      ORDER_KEY,
+      JSON.stringify(["/repo-a", 42, null, "/repo-b"]),
+    );
+    expect(loadRepoGroupOrder()).toEqual(["/repo-a", "/repo-b"]);
+  });
+});

--- a/web/src/lib/repoGroupOrder.ts
+++ b/web/src/lib/repoGroupOrder.ts
@@ -1,0 +1,29 @@
+import { safeGetItem, safeRemoveItem, safeSetItem } from "./safeStorage";
+
+// Persisted manual order of repo groups in the sidebar, client-only and
+// per-browser, mirroring the collapsed/appearance state in useRepoGroups
+// (the server stores only the flat workspace ordering, not group order).
+// A list of real repo-group ids (filesystem repo paths); synthetic
+// groups (Multi-repo, Scratch) are never stored here because they are
+// hard-pinned to the bottom regardless of manual order. See #1644.
+const STORAGE_KEY = "aoe-repo-group-order-v1";
+
+export function loadRepoGroupOrder(): string[] {
+  const raw = safeGetItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string");
+  } catch {
+    return [];
+  }
+}
+
+export function persistRepoGroupOrder(order: readonly string[]): void {
+  if (order.length === 0) {
+    safeRemoveItem(STORAGE_KEY);
+    return;
+  }
+  safeSetItem(STORAGE_KEY, JSON.stringify(order));
+}

--- a/web/src/lib/tourSteps.ts
+++ b/web/src/lib/tourSteps.ts
@@ -1,0 +1,177 @@
+// Declarative source of truth for the first-run interactive tutorial.
+//
+// This module is intentionally framework/engine-independent: it knows nothing
+// about react-joyride. Steps are described as plain data keyed by typed anchor
+// ids, and a single `tourAnchor()` helper is the only sanctioned way to attach
+// an anchor to a DOM node. The CI drift guard (tourSteps.test.ts) relies on that
+// convention: every anchor must be referenced through `TOUR_ANCHORS.<key>`, never
+// as a raw `data-tour="..."` literal, so a renamed or deleted anchor fails fast.
+
+/**
+ * Every UI region the tour can point at. The string value is the literal that
+ * lands in the DOM as `data-tour="<value>"`. Keep these on stable region
+ * containers, not on volatile rows or buttons that come and go per render.
+ */
+export const TOUR_ANCHORS = {
+  topbar: "topbar",
+  topbarMore: "topbar-more",
+  sidebar: "sidebar",
+  sidebarSettings: "sidebar-settings",
+  dashboardNewSession: "dashboard-new-session",
+  rightPanel: "right-panel",
+  composer: "cockpit-composer",
+  modePicker: "cockpit-mode-picker",
+  queueSend: "cockpit-queue-send",
+} as const;
+
+export type TourAnchorId = (typeof TOUR_ANCHORS)[keyof typeof TOUR_ANCHORS];
+
+/**
+ * The dashboard, a terminal session, and a cockpit session mount mutually
+ * exclusive UI. A step declares which scopes it belongs to; the resolver never
+ * shows a step outside its scope, so a missing anchor is only ever "legitimately
+ * absent on this view", never a silently swallowed regression.
+ */
+export type TourScope = "dashboard" | "session" | "cockpit";
+
+export interface TourStep {
+  /** Stable id, also used as the react-joyride step id. */
+  id: string;
+  anchor: TourAnchorId;
+  scopes: readonly TourScope[];
+  title: string;
+  body: string;
+  /** Human-readable shortcut hints rendered under the body, e.g. "⌘K / Ctrl+K". */
+  shortcuts?: readonly string[];
+  /** Drop the step when the dashboard is in read-only mode (mutation UI absent). */
+  writableOnly?: boolean;
+  /** Drop the step on coarse-pointer / non-desktop layouts (region not shown). */
+  desktopOnly?: boolean;
+}
+
+/** The CSS selector that resolves a given anchor in the DOM. */
+export function tourSelector(anchor: TourAnchorId): string {
+  return `[data-tour="${anchor}"]`;
+}
+
+/**
+ * The only sanctioned way to attach a tour anchor to a JSX element. Spread it:
+ * `<div {...tourAnchor(TOUR_ANCHORS.sidebar)} />`. Using this instead of a raw
+ * `data-tour="..."` string keeps the CI drift guard honest.
+ */
+export function tourAnchor(anchor: TourAnchorId): { "data-tour": TourAnchorId } {
+  return { "data-tour": anchor };
+}
+
+export const TOUR_STEPS: readonly TourStep[] = [
+  {
+    id: "topbar",
+    anchor: TOUR_ANCHORS.topbar,
+    scopes: ["dashboard", "session", "cockpit"],
+    title: "Command bar",
+    body: "Jump anywhere from the command palette: switch sessions, open settings, toggle panels.",
+    shortcuts: ["⌘K / Ctrl+K opens the palette"],
+  },
+  {
+    id: "sidebar",
+    anchor: TOUR_ANCHORS.sidebar,
+    scopes: ["dashboard", "session", "cockpit"],
+    title: "Workspaces and sessions",
+    body: "Your sessions are grouped by workspace here. Pick one to open its terminal or cockpit.",
+    shortcuts: ["⌘B / Ctrl+B toggles the sidebar"],
+  },
+  {
+    id: "new-session",
+    anchor: TOUR_ANCHORS.dashboardNewSession,
+    scopes: ["dashboard"],
+    title: "Start a session",
+    body: "Launch a new agent session: pick a project, choose an agent, and go.",
+    shortcuts: ["n opens the wizard", "⌘⇧N / Ctrl+Shift+N starts a scratch session"],
+    writableOnly: true,
+  },
+  {
+    id: "settings",
+    anchor: TOUR_ANCHORS.sidebarSettings,
+    scopes: ["dashboard", "session", "cockpit"],
+    title: "Settings and profiles",
+    body: "Tune sandboxing, worktrees, sounds, devices, and per-profile overrides here.",
+    shortcuts: ["s opens settings"],
+  },
+  {
+    id: "right-panel",
+    anchor: TOUR_ANCHORS.rightPanel,
+    scopes: ["session", "cockpit"],
+    title: "Diff and review",
+    body: "Review the agent's file changes and send comments back without leaving the session.",
+    shortcuts: ["D toggles the diff", "⌘⌥B / Ctrl+Alt+B toggles the panel"],
+    desktopOnly: true,
+  },
+  {
+    id: "composer",
+    anchor: TOUR_ANCHORS.composer,
+    scopes: ["cockpit"],
+    title: "Composer",
+    body: "Write instructions to the agent here. Type / for commands and @ to reference files.",
+  },
+  {
+    id: "mode-picker",
+    anchor: TOUR_ANCHORS.modePicker,
+    scopes: ["cockpit"],
+    title: "Agent mode",
+    body: "Switch the agent's mode (plan, accept edits, and so on) before you send.",
+  },
+  {
+    id: "queue-send",
+    anchor: TOUR_ANCHORS.queueSend,
+    scopes: ["cockpit"],
+    title: "Send and queue",
+    body: "Send a message, or queue follow-ups while the agent is still working on the last one.",
+  },
+  {
+    id: "topbar-more",
+    anchor: TOUR_ANCHORS.topbarMore,
+    scopes: ["dashboard", "session", "cockpit"],
+    title: "Replay this tour any time",
+    body: "Reopen this walkthrough whenever you like from here: More, then Show tutorial.",
+  },
+] as const;
+
+export interface ResolveTourContext {
+  scope: TourScope;
+  readOnly: boolean;
+  isDesktop: boolean;
+  /**
+   * Whether the anchor currently resolves in the DOM. Defaults to a
+   * `document.querySelector` probe; injectable for tests. Steps eligible by
+   * metadata but absent from the DOM are dropped (defense in depth on top of the
+   * scope filter), so the engine never points at a node that is not painted.
+   */
+  hasAnchor?: (anchor: TourAnchorId) => boolean;
+}
+
+/** Whether a step is eligible by metadata alone (ignores DOM presence). */
+export function isStepEligible(
+  step: TourStep,
+  ctx: Pick<ResolveTourContext, "scope" | "readOnly" | "isDesktop">,
+): boolean {
+  if (!step.scopes.includes(ctx.scope)) return false;
+  if (step.writableOnly && ctx.readOnly) return false;
+  if (step.desktopOnly && !ctx.isDesktop) return false;
+  return true;
+}
+
+function defaultHasAnchor(anchor: TourAnchorId): boolean {
+  if (typeof document === "undefined") return false;
+  return document.querySelector(tourSelector(anchor)) !== null;
+}
+
+/**
+ * The steps to actually run for the current view: scope/read-only/desktop
+ * eligibility first, then DOM presence. Order follows TOUR_STEPS.
+ */
+export function resolveTourSteps(ctx: ResolveTourContext): TourStep[] {
+  const hasAnchor = ctx.hasAnchor ?? defaultHasAnchor;
+  return TOUR_STEPS.filter(
+    (step) => isStepEligible(step, ctx) && hasAnchor(step.anchor),
+  );
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -16,6 +16,17 @@
       ]
     },
     {
+      "id": "session.create-duplicate-worktree-error",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/session-create-duplicate-worktree.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ReviewStep.tsx"
+      ]
+    },
+    {
       "id": "terminal.live-output-resize",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2007,6 +2007,19 @@
       ]
     },
     {
+      "id": "cockpit.story.edit-card-diff-scroll",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/edit-card-diff-scroll.spec.ts",
+        "src/components/diff/__tests__/StringDiff.test.tsx"
+      ],
+      "components": [
+        "web/src/components/diff/StringDiff.tsx",
+        "web/src/components/cockpit/ToolCards.tsx"
+      ]
+    },
+    {
       "id": "cockpit.story.queue-follow-up-with-nav",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -438,6 +438,17 @@
       ]
     },
     {
+      "id": "wizard.recent-hides-workspaces",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/session-wizard/__tests__/ProjectStep.workspace.test.tsx"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ProjectStep.tsx"
+      ]
+    },
+    {
       "id": "wizard.scratch-shortcut",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2383,6 +2383,38 @@
       "components": [
         "web/src/components/cockpit/CockpitView.tsx"
       ]
+    },
+    {
+      "id": "onboarding.first-run-tutorial",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/tutorial.spec.ts"
+      ],
+      "components": [
+        "web/src/components/tour/TourRunner.tsx",
+        "web/src/components/TopBar.tsx",
+        "web/src/components/OverflowMenu.tsx",
+        "web/src/components/Dashboard.tsx",
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/RightPanel.tsx",
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
+      "id": "onboarding.tour-drift-guard",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/lib/__tests__/tourSteps.test.ts",
+        "src/hooks/__tests__/useTour.test.ts",
+        "src/components/__tests__/Dashboard.tour.test.tsx"
+      ],
+      "components": [
+        "web/src/components/Dashboard.tsx",
+        "web/src/lib/tourSteps.ts",
+        "web/src/hooks/useTour.tsx"
+      ]
     }
   ]
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -449,6 +449,20 @@
       ]
     },
     {
+      "id": "palette.new-scratch-session",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/palette-scratch-launch.spec.ts",
+        "src/hooks/__tests__/useCommandActions.test.tsx"
+      ],
+      "components": [
+        "web/src/App.tsx",
+        "web/src/components/command-palette/CommandPalette.tsx",
+        "web/src/components/HelpOverlay.tsx"
+      ]
+    },
+    {
       "id": "sidebar.scratch-group",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1090,6 +1090,17 @@
       ]
     },
     {
+      "id": "cockpit.queued-prompt-expand-bounds",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/QueuedPromptsStrip.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx"
+      ]
+    },
+    {
       "id": "cockpit.todo-group-fold",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1382,6 +1382,28 @@
       ]
     },
     {
+      "id": "story.sidebar-queued-count",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/sidebar-queued-count.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.queued-count-hook",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/hooks/__tests__/useCockpitQueueCount.test.tsx"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "story.sidebar-select-focuses-input",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -193,6 +193,42 @@
       "components": []
     },
     {
+      "id": "settings.sidebar-tui-grouping",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": [
+        "src/components/__tests__/SettingsView.test.tsx"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx"
+      ]
+    },
+    {
+      "id": "settings.advanced-fold",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/SettingsView.folds.test.tsx"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/FormFields.tsx"
+      ]
+    },
+    {
+      "id": "settings.advanced-fold-persistence",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/settings-advanced-fold.spec.ts"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/FormFields.tsx",
+        "web/src/components/settings/LoggingSettings.tsx"
+      ]
+    },
+    {
       "id": "settings.logging-payload",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -539,6 +539,18 @@
       ]
     },
     {
+      "id": "sidebar.group-reorder",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/sidebar-group-reorder.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/hooks/useRepoGroups.ts"
+      ]
+    },
+    {
       "id": "sidebar.reorder-stationary-click",
       "kind": "mocked-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1124,6 +1124,34 @@
       ]
     },
     {
+      "id": "cockpit.tool-stopped-sweep",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/lib/cockpitStopSweep.test.ts",
+        "src/components/cockpit/CockpitRuntime.test.ts",
+        "src/components/cockpit/ToolCards.render.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitRuntime.tsx",
+        "web/src/components/cockpit/CockpitView.tsx",
+        "web/src/components/cockpit/ToolCards.tsx",
+        "web/src/components/cockpit/ToolErrorBody.tsx"
+      ]
+    },
+    {
+      "id": "cockpit.story.stop-tool-card-terminal",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx",
+        "web/src/components/cockpit/ToolCards.tsx"
+      ]
+    },
+    {
       "id": "cockpit.todo-group-fold",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/live/cockpit-stories/edit-card-diff-scroll.spec.ts
+++ b/web/tests/live/cockpit-stories/edit-card-diff-scroll.spec.ts
@@ -1,0 +1,139 @@
+// User story (#1568): the diff embedded inside the cockpit Edit/Write tool
+// card scrolls horizontally so a line wider than the card is reachable on a
+// narrow (mobile) viewport.
+//
+// The fake ACP agent emits an `edit` tool_call whose new_string carries a line
+// far wider than the card. On a 480px viewport the expanded card body used to
+// clip that line: `CardChrome` wraps the body in `overflow-hidden`, `DiffLine`
+// content is `whitespace-pre`, and nothing in between gave a scroll context.
+// The fix adds `overflow-x-auto` to `StringDiff`'s container (mirroring the
+// full-size `DiffFileViewer` wrapper), so the diff body scrolls while the card
+// chrome and the transcript viewport stay put.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import {
+  waitForCockpitView,
+  enableCockpitAndWait,
+  attachServeDiagnostics,
+} from "../../helpers/cockpit";
+
+// A single new-string line far wider than a 480px card, with no break
+// opportunities, so `whitespace-pre` forces it past the card edge.
+const LONG_LINE = `const x = "${"a".repeat(300)}";`;
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-edit-1",
+          title: "edit big.txt",
+          kind: "edit",
+          status: "completed",
+          rawInput: {
+            file_path: "big.txt",
+            old_string: "const x = 1;",
+            new_string: LONG_LINE,
+          },
+        },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("edit card diff scrolls horizontally on a narrow viewport", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-edit-scroll-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    // Narrow viewport so the long line is wider than the card.
+    await page.setViewportSize({ width: 480, height: 800 });
+
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-edit-scroll" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-edit-scroll");
+    if (!seeded) throw new Error("seeded session 'story-edit-scroll' missing");
+    const sessionId = seeded.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("edit the file");
+    await composer.press("Enter");
+
+    // The edit card renders collapsed; its header carries the file path.
+    const cardHeader = page
+      .getByRole("button")
+      .filter({ hasText: "big.txt" })
+      .first();
+    await expect(cardHeader).toBeVisible({ timeout: 10_000 });
+    await cardHeader.click();
+
+    // The diff body is now expanded.
+    const diff = page.getByTestId("string-diff");
+    await expect(diff).toBeVisible({ timeout: 10_000 });
+
+    // Core regression: the diff container is an `overflow-x` scroll context
+    // (pre-fix it was the default `visible`, so the long line was clipped by
+    // the card's `overflow-hidden` and unreachable).
+    const overflowX = await diff.evaluate((el) => getComputedStyle(el).overflowX);
+    expect(["auto", "scroll"]).toContain(overflowX);
+
+    // And the content actually overflows that container, so the scroll
+    // affordance is real rather than vacuous.
+    await expect
+      .poll(async () =>
+        diff.evaluate(
+          (el) => (el as HTMLElement).scrollWidth - (el as HTMLElement).clientWidth,
+        ),
+      )
+      .toBeGreaterThan(0);
+
+    // Chrome stays put: scrolling lives on the diff body, not the transcript
+    // viewport, so the whole panel never gains a horizontal scrollbar.
+    const viewport = page.getByTestId("cockpit-viewport");
+    await expect(viewport).toBeVisible();
+    await expect
+      .poll(async () =>
+        viewport.evaluate(
+          (el) => (el as HTMLElement).scrollWidth - (el as HTMLElement).clientWidth,
+        ),
+      )
+      .toBeLessThanOrEqual(0);
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/web/tests/live/cockpit-stories/sidebar-queued-count.spec.ts
+++ b/web/tests/live/cockpit-stories/sidebar-queued-count.spec.ts
@@ -1,0 +1,109 @@
+// User story: queue follow-up prompts on a cockpit session mid-turn,
+// navigate away to the sidebar (dashboard) view, and see a count badge
+// on that session's row.
+//
+// Single cockpit-enabled session: kick off a long turn, queue two
+// follow-ups via the composer's Queue button, then navigate to `/` so
+// the sidebar is the primary surface and CockpitView unmounts. The
+// queued prompts are client-only state mirrored into localStorage by
+// persistState, so the sidebar row reads the count (2) without the
+// cockpit view mounted. The queue does not drain while no cockpit hook
+// is running, so the badge is stable on the dashboard.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import {
+  enableCockpitAndWait,
+  waitForCockpitView,
+  attachServeDiagnostics,
+} from "../../helpers/cockpit";
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "First turn." },
+        },
+        // Keep turn 1 in flight long enough to queue two follow-ups and
+        // navigate; well under the cockpit supervisor idle watchdog.
+        { sessionUpdate: "wait_ms", ms: 6_000 },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("sidebar row shows the queued-prompt count badge", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-sidebar-queue-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "sidebar-queue-a" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const sessionA = sessions.find((s) => s.title === "sidebar-queue-a");
+    if (!sessionA) throw new Error("seeded session 'sidebar-queue-a' missing");
+
+    await enableCockpitAndWait(serve.baseUrl, sessionA.id, 30_000, serve.home);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionA.id)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", {
+      name: /Send a message|Queue a follow-up/i,
+    });
+    await composer.fill("kick off A");
+    await composer.press("Enter");
+    await expect(page.getByText("First turn.")).toBeVisible({ timeout: 10_000 });
+
+    // The Queue button only renders while the turn is active.
+    const queueBtn = page.getByRole("button", {
+      name: /Queue follow-up message/i,
+    });
+    await expect(queueBtn).toBeVisible({ timeout: 5_000 });
+    await composer.fill("follow-up one");
+    await queueBtn.click();
+    await composer.fill("follow-up two");
+    await queueBtn.click();
+
+    // Navigate to the dashboard so the sidebar is the primary surface.
+    await page.goto(serve.baseUrl);
+
+    // The row for session A should carry a "2 queued" badge, read from
+    // the persisted client-only queue state.
+    await expect(page.getByTitle("2 queued prompts")).toBeVisible({
+      timeout: 15_000,
+    });
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/web/tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts
+++ b/web/tests/live/cockpit-stories/stop-tool-card-terminal.spec.ts
@@ -1,0 +1,131 @@
+// User story: Stopping mid-tool settles the tool card, it does not get
+// stuck "running" with a forever-counting timer. See #1646.
+//
+// A `tool_call` session/update (status=pending) with no completion
+// renders a running ToolCard. Before the fix, the card's status was
+// derived solely from a paired completion row, so a cancel (which emits
+// only a turn-level Stopped, never a per-tool completion) left the card
+// orange "running" forever, live and on reload. The reducer now sweeps
+// open tool calls to a terminal "stopped" state on any turn-ending
+// event, so the badge settles and the timer freezes.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import {
+  waitForCockpitView,
+  enableCockpitAndWait,
+  attachServeDiagnostics,
+} from "../../helpers/cockpit";
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-stuck-1",
+          title: "Slow tool",
+          kind: "read",
+          status: "pending",
+        },
+        { sessionUpdate: "wait_ms", ms: 30_000 },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+// The tool card whose primary title is "Slow tool". Anchored on the
+// exact title span (the prompt echo "run a slow tool" and the spinner
+// "Operating Slow tool…" are not exact matches), then walked up to the
+// card root so badge text reads only inside this card.
+function cardFor(page: import("@playwright/test").Page) {
+  return page
+    .getByText("Slow tool", { exact: true })
+    .locator("xpath=ancestor::div[contains(@class,'rounded-md')][1]");
+}
+
+test("stopping mid-tool settles the card and survives reload", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-stuck-tool-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-stuck-tool" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-stuck-tool");
+    if (!seeded) throw new Error("seeded session 'story-stuck-tool' missing");
+    const sessionId = seeded.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("run a slow tool");
+    await composer.press("Enter");
+
+    // The running tool card mounts; its badge is "running" until the
+    // turn ends. Scope assertions to the card so the badge text does not
+    // match the prompt echo ("run a slow tool") or the working spinner
+    // ("Operating Slow tool…"); `exact` title resolves to the card's
+    // primary span alone.
+    const card = cardFor(page);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card.getByText("running", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const stopButton = page.getByRole("button", { name: "Stop" });
+    await expect(stopButton).toBeVisible({ timeout: 10_000 });
+    await stopButton.click();
+
+    // The card settles to the distinct terminal "stopped" state instead
+    // of staying "running" forever.
+    await expect(card.getByText("stopped", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(card.getByText("running", { exact: true })).toBeHidden();
+
+    // The stuck state was persisted before the fix, so a reload must
+    // still show the card terminal: the trailing Stopped replays through
+    // the same reducer sweep.
+    await page.reload();
+    await waitForCockpitView(page);
+    const cardAfter = cardFor(page);
+    await expect(cardAfter).toBeVisible({ timeout: 10_000 });
+    await expect(cardAfter.getByText("stopped", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(cardAfter.getByText("running", { exact: true })).toBeHidden();
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-group-field.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-group-field.spec.ts
@@ -37,6 +37,10 @@ base("wizard session step records Group", async ({ page }, testInfo) => {
       page.getByRole("heading", { name: "Name your session", exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
+    // #1514 folds the Group input behind a top-level "Advanced"
+    // disclosure that defaults closed; expand it first.
+    await page.getByRole("button", { name: "Advanced" }).click();
+
     const groupField = page.getByPlaceholder(
       "Optional, for organizing related sessions",
     );

--- a/web/tests/live/cockpit-stories/wizard-worktree-toggle.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-worktree-toggle.spec.ts
@@ -40,6 +40,10 @@ base("wizard worktree toggle hides and shows the branch input", async ({ page },
       page.getByRole("heading", { name: "Name your session", exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
+    // #1514 folds the worktree controls behind a top-level "Advanced"
+    // disclosure that defaults closed; expand it first.
+    await page.getByRole("button", { name: "Advanced" }).click();
+
     const branchLabel = page.getByText("Branch / worktree name");
     await expect(branchLabel).toBeVisible({ timeout: 10_000 });
 

--- a/web/tests/live/palette-scratch-launch.spec.ts
+++ b/web/tests/live/palette-scratch-launch.spec.ts
@@ -1,0 +1,86 @@
+// User story (#1643): a user who lives in the command palette can start a
+// scratch session. Open Cmd+K / Ctrl+K, run "New scratch session", and the
+// wizard opens prefilled for a scratch session jumped to the Review step;
+// Cmd+Enter / Ctrl+Enter then launches it. Read-only mode hides the creation
+// commands from the palette entirely.
+
+import { basename, dirname } from "node:path";
+import { test, expect } from "../helpers/liveTest";
+import { listSessions } from "../helpers/aoeServe";
+
+const PALETTE_PLACEHOLDER = "Search actions, sessions, settings…";
+
+test("palette 'New scratch session' opens the wizard and launches a scratch session", async ({
+  serve,
+  page,
+}) => {
+  await page.goto(serve.baseUrl);
+  await expect(
+    page.getByRole("button", { name: "New session", exact: true }).first(),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // ControlOrMeta honors the host's actual modifier (Cmd on macOS, Ctrl on
+  // CI), matching how useKeyboardShortcuts derives the palette chord.
+  await page.keyboard.press("ControlOrMeta+KeyK");
+  await expect(page.getByPlaceholder(PALETTE_PLACEHOLDER)).toBeVisible();
+
+  await page.getByPlaceholder(PALETTE_PLACEHOLDER).fill("scratch");
+  await page
+    .getByRole("option", { name: /New scratch session/i })
+    .click();
+
+  const wizard = page.locator(
+    'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+  );
+  await expect(wizard).toBeVisible({ timeout: 10_000 });
+
+  // skipToReview lands the wizard on Review with scratch enabled; the Launch
+  // button + scratch project marker prove the prefill plumbing fired.
+  await expect(
+    wizard.getByRole("button", { name: /Launch session/ }),
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(
+    wizard.getByText(/Scratch directory \(provisioned on create\)/),
+  ).toBeVisible();
+
+  await page.keyboard.press("ControlOrMeta+Enter");
+
+  await expect
+    .poll(async () => (await listSessions(serve.baseUrl)).length, {
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(0);
+
+  const sessions = await listSessions(serve.baseUrl);
+  expect(sessions).toHaveLength(1);
+  const session = sessions[0]!;
+  expect(session.scratch).toBe(true);
+  const projectPath = session.project_path as string;
+  expect(basename(dirname(projectPath))).toBe("scratch");
+});
+
+test("palette hides creation commands in read-only mode", async ({
+  serveReadOnly,
+  page,
+}) => {
+  // Wait for /api/about so the React state carries read_only before the
+  // palette renders; otherwise serverAbout is null and the guard is bypassed.
+  const aboutPromise = page.waitForResponse(
+    (r) => r.url().endsWith("/api/about") && r.status() === 200,
+    { timeout: 10_000 },
+  );
+  await page.goto(serveReadOnly.baseUrl);
+  await aboutPromise;
+  await page.waitForTimeout(200);
+
+  await page.locator("body").click();
+  await page.keyboard.press("ControlOrMeta+KeyK");
+  await expect(page.getByPlaceholder(PALETTE_PLACEHOLDER)).toBeVisible();
+
+  await expect(
+    page.getByRole("option", { name: /New scratch session/i }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("option", { name: /New session/i }),
+  ).toHaveCount(0);
+});

--- a/web/tests/live/session-create-duplicate-worktree.spec.ts
+++ b/web/tests/live/session-create-duplicate-worktree.spec.ts
@@ -1,0 +1,67 @@
+// Live regression for #1649: a duplicate worktree/branch must surface the
+// real collision message, not the generic "Failed to create session".
+//
+// Drives the create-session HTTP boundary directly (the bug lived in the
+// handler, not the wizard UI): POST /api/sessions twice with the same new
+// branch against a real git repo. The first creates the worktree; the
+// second collides on the precomputed path and must return the informative
+// error the frontend already renders verbatim.
+
+import { test, expect } from "@playwright/test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+test("duplicate worktree branch returns the real collision error, not a generic one", async ({}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      const projectDir = join(home, "project");
+      mkdirSync(projectDir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: projectDir, env });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+        cwd: projectDir,
+        env: {
+          ...env,
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@t",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@t",
+        },
+      });
+    },
+  });
+
+  try {
+    const payload = {
+      path: join(serve.home, "project"),
+      tool: "claude",
+      title: "dup-session",
+      worktree_branch: "dup-branch",
+      create_new_branch: true,
+    };
+
+    const first = await fetch(`${serve.baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    expect(first.status).toBe(201);
+
+    const second = await fetch(`${serve.baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    expect(second.status).toBe(400);
+
+    const body = await second.json();
+    expect(body.message).toContain("Worktree already exists");
+    expect(body.message).not.toBe("Failed to create session");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/settings-advanced-fold.spec.ts
+++ b/web/tests/live/settings-advanced-fold.spec.ts
@@ -1,0 +1,98 @@
+// Story #3 (#1515): expanding an "Advanced" fold and editing a knob inside it
+// persists through the same save-on-change path as any other field.
+//
+// Drives the real settings UI (not the REST endpoint): land on
+// /settings/sandbox, confirm the advanced knobs are folded away by default,
+// expand the fold, edit sandbox.cpu_limit, and assert the value reaches the
+// profile config and survives a page reload. Sandbox is used (rather than
+// Cockpit) because `cockpit` is not an allowed profile-settings section, so
+// cockpit knobs do not round-trip through PATCH /api/profiles/{p}/settings.
+
+import { test, expect } from "../helpers/liveTest";
+
+test("sandbox advanced knob edits persist after expanding the fold", async ({
+  serve,
+  page,
+}) => {
+  const profiles: Array<{ name: string; is_default?: boolean }> = await fetch(
+    `${serve.baseUrl}/api/profiles`,
+  ).then((r) => r.json());
+  const defaultProfile =
+    profiles.find((p) => p.is_default)?.name ?? profiles[0]?.name ?? "main";
+  const profileUrl = `${serve.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
+
+  const before = await fetch(profileUrl).then((r) => r.json());
+  const baseline = (before?.sandbox?.cpu_limit as string | undefined) ?? "";
+  const newValue = baseline === "4" ? "2" : "4";
+
+  await page.goto(`${serve.baseUrl}/settings/sandbox`);
+
+  // A high-level control is visible immediately; the advanced knob is folded
+  // away by default.
+  await expect(page.getByText("Sandbox enabled by default")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(
+    page.locator("label", { hasText: /^CPU limit$/ }),
+  ).toHaveCount(0);
+
+  // Expand the Advanced fold.
+  await page.getByRole("button", { name: /Advanced/ }).first().click();
+
+  const cpuInput = page
+    .locator("label", { hasText: /^CPU limit$/ })
+    .locator("..")
+    .locator('input[type="text"]');
+  await expect(cpuInput).toBeVisible({ timeout: 5_000 });
+
+  // Edit and commit (TextField commits on blur / Enter).
+  await cpuInput.fill(newValue);
+  await cpuInput.press("Enter");
+
+  // Server-side: PATCH landed against the profile config.
+  await expect(async () => {
+    const after = await fetch(profileUrl).then((r) => r.json());
+    expect(after?.sandbox?.cpu_limit).toBe(newValue);
+  }).toPass({ timeout: 5_000 });
+
+  // Frontend-side: after reload the fold is collapsed again (component-local,
+  // not persisted), and re-expanding shows the persisted value.
+  await page.reload();
+  await expect(page.getByText("Sandbox enabled by default")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(
+    page.locator("label", { hasText: /^CPU limit$/ }),
+  ).toHaveCount(0);
+
+  await page.getByRole("button", { name: /Advanced/ }).first().click();
+  await expect(cpuInput).toHaveValue(newValue, { timeout: 5_000 });
+});
+
+// The other three folded tabs (Worktree, Cockpit, Logging) each render their
+// advanced fields only once the fold is expanded. Drive each one in the
+// browser so the relocated field markup is exercised end to end (the unit
+// suite asserts the same hide/expand behavior; this is the real-DOM pass).
+test("worktree, cockpit, and logging advanced folds expand in the browser", async ({
+  serve,
+  page,
+}) => {
+  const cases: Array<{ tab: string; anchor: string; field: RegExp }> = [
+    { tab: "worktree", anchor: "Worktrees enabled", field: /^Bare repo path template$/ },
+    { tab: "cockpit", anchor: "Cockpit master switch", field: /^Replay buffer bytes$/ },
+    { tab: "logging", anchor: "Default level", field: /^Output$/ },
+  ];
+
+  for (const { tab, anchor, field } of cases) {
+    await page.goto(`${serve.baseUrl}/settings/${tab}`);
+    await expect(page.getByText(anchor).first()).toBeVisible({ timeout: 10_000 });
+
+    // Folded away by default.
+    await expect(page.locator("label", { hasText: field })).toHaveCount(0);
+
+    await page.getByRole("button", { name: /Advanced/ }).first().click();
+    await expect(page.locator("label", { hasText: field })).toBeVisible({
+      timeout: 5_000,
+    });
+  }
+});

--- a/web/tests/live/sidebar-group-reorder.spec.ts
+++ b/web/tests/live/sidebar-group-reorder.spec.ts
@@ -1,0 +1,133 @@
+// Live coverage for dragging project/group headers to reorder repo
+// groups in the sidebar (#1644). Group order is persisted client-only in
+// localStorage (see `repoGroupOrder.ts` + `useRepoGroups.ts`), so unlike
+// `workspace-ordering.spec.ts` there is no server PUT to assert; the
+// round-trip we care about is "drag, then reload, order survives".
+//
+// The grip is a dedicated drag handle on each real group header
+// (`data-testid='sidebar-group-drag-handle'`); the rest of the header
+// keeps its expand/collapse + context-menu behavior. dnd-kit's
+// MouseSensor activates on an 8px distance, so the drag is
+// mouse.down on the grip → mouse.move past 8px in steps over the target
+// header → mouse.up. Synthetic groups have no grip and stay pinned, and
+// group drag is disabled in last-activity sort mode (the order is
+// computed there).
+
+import { test as base, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { spawnAoeServe } from "../helpers/aoeServe";
+import { seedRepos } from "../helpers/sidebar";
+
+async function readGroupNames(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const headers = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        "[data-testid='sidebar-group-header']",
+      ),
+    );
+    return headers
+      .map(
+        (h) =>
+          h.querySelector("span[title]")?.textContent?.trim() ?? "",
+      )
+      .filter(Boolean);
+  });
+}
+
+base.describe("sidebar group-header reorder (#1644)", () => {
+  base("drag a group header to reorder, order persists across reload", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedRepos([
+        { titles: ["alpha-session"], subdir: "repo-alpha" },
+        { titles: ["beta-session"], subdir: "repo-beta" },
+      ]),
+    });
+
+    try {
+      await page.setViewportSize({ width: 1280, height: 720 });
+      await page.goto(`${serve.baseUrl}/`);
+
+      const grips = page.locator("[data-testid='sidebar-group-drag-handle']");
+      // Cold-start under load can lag past Playwright's default; the
+      // other live sidebar specs bump first-paint waits for the same
+      // reason. 15s covers a heavily-loaded CI worker.
+      await expect(grips).toHaveCount(2, { timeout: 15_000 });
+
+      const before = await readGroupNames(page);
+      expect(before).toHaveLength(2);
+
+      // Drag the bottom group's grip up onto the top group's header.
+      const sourceGrip = await grips.nth(1).boundingBox();
+      const targetHeader = await page
+        .locator("[data-testid='sidebar-group-header']")
+        .nth(0)
+        .boundingBox();
+      if (!sourceGrip || !targetHeader) throw new Error("drag boxes missing");
+
+      await page.mouse.move(
+        sourceGrip.x + sourceGrip.width / 2,
+        sourceGrip.y + sourceGrip.height / 2,
+      );
+      await page.mouse.down();
+      await page.mouse.move(
+        targetHeader.x + targetHeader.width / 2,
+        targetHeader.y + targetHeader.height / 3,
+        { steps: 12 },
+      );
+      await page.mouse.up();
+
+      const expected = [before[1], before[0]];
+      await expect
+        .poll(() => readGroupNames(page), { timeout: 4_000 })
+        .toEqual(expected);
+
+      // The order is client-only; a reload re-reads it from localStorage.
+      await page.reload();
+      // Cold-start under load can lag past Playwright's default; the
+      // other live sidebar specs bump first-paint waits for the same
+      // reason. 15s covers a heavily-loaded CI worker.
+      await expect(grips).toHaveCount(2, { timeout: 15_000 });
+      await expect
+        .poll(() => readGroupNames(page), { timeout: 4_000 })
+        .toEqual(expected);
+    } finally {
+      await serve.stop();
+    }
+  });
+
+  base("group drag handles are absent in last-activity sort mode", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedRepos([
+        { titles: ["alpha-session"], subdir: "repo-alpha" },
+        { titles: ["beta-session"], subdir: "repo-beta" },
+      ]),
+    });
+
+    try {
+      await page.setViewportSize({ width: 1280, height: 720 });
+      await page.goto(`${serve.baseUrl}/`);
+
+      const grips = page.locator("[data-testid='sidebar-group-drag-handle']");
+      // Cold-start under load can lag past Playwright's default; the
+      // other live sidebar specs bump first-paint waits for the same
+      // reason. 15s covers a heavily-loaded CI worker.
+      await expect(grips).toHaveCount(2, { timeout: 15_000 });
+
+      // Flip to last-activity sort; the order is computed there, so the
+      // grips disappear, matching how within-group row drag is gated.
+      await page.locator("[data-testid='sidebar-sort-toggle']").click();
+      await expect(
+        page.locator("[data-testid='sidebar-sort-toggle']"),
+      ).toHaveAttribute("data-sort-mode", "lastActivity");
+      await expect(grips).toHaveCount(0);
+    } finally {
+      await serve.stop();
+    }
+  });
+});

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -1,0 +1,59 @@
+// User stories (issue #1513): the first-run tutorial auto-launches on a fresh
+// browser, is skippable, persists "seen" so it does not nag on reload, and is
+// re-triggerable from the TopBar overflow menu.
+//
+// A fresh `aoe serve` $HOME has no sessions, so the app lands on the empty
+// dashboard and the dashboard-scope tour auto-launches (Playwright is a
+// fine-pointer client, so the coarse-pointer suppression does not apply).
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+// First dashboard step's title (TOUR_STEPS[0] = topbar -> "Command bar").
+const FIRST_STEP = "Command bar";
+
+base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    // Auto-launch is suppressed in automated sessions (navigator.webdriver) so
+    // the spotlight overlay never intercepts clicks in the rest of the suite.
+    // This spec is the one place that exercises auto-launch, so present as a
+    // real (non-automated) browser. Persists across reloads/navigations.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "webdriver", { get: () => false });
+    });
+
+    await page.goto(serve.baseUrl);
+
+    // Story 1: auto-launches on first load, with a Skip button on the step.
+    await expect(page.getByText(FIRST_STEP)).toBeVisible({ timeout: 10_000 });
+    const skip = page.getByRole("button", { name: "Skip" });
+    await expect(skip).toBeVisible();
+
+    // Skipping closes the tour and records the seen flag.
+    await skip.click();
+    await expect(page.getByText(FIRST_STEP)).toBeHidden();
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("aoe-tour-seen")))
+      .toBe("1");
+
+    // Story 1 (persistence): a reload must not auto-launch again.
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible();
+    await expect(page.getByText(FIRST_STEP)).toBeHidden();
+
+    // Story 2: re-trigger from the fixed entry point (TopBar overflow menu).
+    await page.getByRole("button", { name: "More options" }).click();
+    await page.getByRole("menuitem", { name: "Show tutorial" }).click();
+    await expect(page.getByText(FIRST_STEP)).toBeVisible({ timeout: 10_000 });
+
+    // The flag stays set after a manual re-trigger, so the next reload is quiet.
+    expect(await page.evaluate(() => localStorage.getItem("aoe-tour-seen"))).toBe("1");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/wizard-scratch-hides-worktree.spec.ts
+++ b/web/tests/live/wizard-scratch-hides-worktree.spec.ts
@@ -33,6 +33,11 @@ base("scratch hides the worktree section on the Session step", async ({ page }, 
       wizard.getByRole("heading", { name: "Name your session", exact: true }),
     ).toBeVisible({ timeout: 10_000 });
 
+    // #1514 folds the worktree section (and, for scratch, the
+    // explanatory note that replaces it) behind a top-level "Advanced"
+    // disclosure that defaults closed; expand it first.
+    await wizard.getByRole("button", { name: "Advanced" }).click();
+
     // Explanatory note appears in place of the worktree controls.
     await expect(
       wizard.getByText(/Scratch sessions do not use git worktrees/),

--- a/web/tests/wizard-attach-existing.spec.ts
+++ b/web/tests/wizard-attach-existing.spec.ts
@@ -83,34 +83,44 @@ async function openSessionStep(page: Page) {
   await expect(page.getByText("Name your session")).toBeVisible();
 }
 
+// #1514 folds the worktree controls (including the attach-existing
+// toggle and the Base branch picker) behind a top-level "Advanced"
+// disclosure that defaults closed. Expand it before asserting on them.
+async function expandAdvanced(page: Page) {
+  await page.getByRole("button", { name: "Advanced" }).click();
+}
+
 test.describe("Wizard attach-existing toggle (#969)", () => {
-  test("toggle is off by default; Advanced section visible", async ({ page }) => {
+  test("toggle is off by default; Base branch section visible", async ({ page }) => {
     await mockApis(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     const attachToggle = page
       .locator("label", { hasText: "Attach to existing branch" })
       .locator("role=switch");
     await expect(attachToggle).toBeVisible();
     await expect(attachToggle).toHaveAttribute("aria-checked", "false");
-    // Advanced disclosure is the base-branch picker (only meaningful for new-branch creates).
-    await expect(page.getByRole("button", { name: /Advanced/i })).toBeVisible();
+    // The base-branch picker (only meaningful for new-branch creates) is
+    // its own "Base branch" disclosure inside Advanced.
+    await expect(page.getByRole("button", { name: "Base branch" })).toBeVisible();
   });
 
-  test("turning attach on hides the Advanced base-branch section", async ({
+  test("turning attach on hides the Base branch section", async ({
     page,
   }) => {
     await mockApis(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     const attachToggle = page
       .locator("label", { hasText: "Attach to existing branch" })
       .locator("role=switch");
     await attachToggle.click();
     await expect(attachToggle).toHaveAttribute("aria-checked", "true");
-    await expect(page.getByRole("button", { name: /Advanced/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Base branch" })).toHaveCount(0);
   });
 
   test("submit with attach off sends create_new_branch=true", async ({ page }) => {
@@ -150,6 +160,7 @@ test.describe("Wizard attach-existing toggle (#969)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     await page.getByPlaceholder("Uses session title if empty").fill("feat/new");
     await page.getByRole("button", { name: /Next/ }).click();
     // Agent step → Next (defaults already set)
@@ -198,6 +209,7 @@ test.describe("Wizard attach-existing toggle (#969)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     await page
       .getByPlaceholder("Uses session title if empty")
       .fill("feat/existing");

--- a/web/tests/wizard-base-branch.spec.ts
+++ b/web/tests/wizard-base-branch.spec.ts
@@ -99,8 +99,15 @@ async function openWizardOnSessionStep(page: Page) {
   await nextBtn.click();
 }
 
+// #1514 folds the worktree controls (including the Base branch picker)
+// behind a top-level "Advanced" disclosure that defaults closed. Expand
+// it before reaching the base-branch picker.
+async function expandAdvanced(page: Page) {
+  await page.getByRole("button", { name: "Advanced" }).click();
+}
+
 test.describe("Wizard base branch (#948)", () => {
-  test("Advanced section is collapsed by default on the session step", async ({ page }) => {
+  test("Base branch section is collapsed by default on the session step", async ({ page }) => {
     await mockApis(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
@@ -108,8 +115,9 @@ test.describe("Wizard base branch (#948)", () => {
     await openWizardOnSessionStep(page);
     // Session step renders "Name your session" as the heading.
     await expect(page.getByText("Name your session")).toBeVisible();
+    await expandAdvanced(page);
     // Worktree toggle is on by default; if a previous test left it
-    // off, click to re-enable so the Advanced section renders.
+    // off, click to re-enable so the Base branch section renders.
     // `#969` added a second toggle ("Attach to existing branch") on this
     // step, so target the worktree toggle by its accessible name.
     const toggle = page.getByRole("switch", { name: /Create a worktree/ });
@@ -117,12 +125,12 @@ test.describe("Wizard base branch (#948)", () => {
       await toggle.click();
     }
     await expect(
-      page.getByRole("button", { name: /Advanced/i }),
+      page.getByRole("button", { name: "Base branch" }),
     ).toBeVisible();
     await expect(page.getByLabel("Base branch")).toHaveCount(0);
   });
 
-  test("expanding Advanced fetches branches with include_remote=true", async ({
+  test("expanding Base branch fetches branches with include_remote=true", async ({
     page,
   }) => {
     await mockApis(page);
@@ -142,7 +150,8 @@ test.describe("Wizard base branch (#948)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openWizardOnSessionStep(page);
-    await page.getByRole("button", { name: /Advanced/i }).click();
+    await expandAdvanced(page);
+    await page.getByRole("button", { name: "Base branch" }).click();
     await expect(page.getByLabel("Base branch")).toBeVisible();
     await expect.poll(() => capturedUrl?.searchParams.get("include_remote")).toBe(
       "true",
@@ -164,7 +173,8 @@ test.describe("Wizard base branch (#948)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openWizardOnSessionStep(page);
-    await page.getByRole("button", { name: /Advanced/i }).click();
+    await expandAdvanced(page);
+    await page.getByRole("button", { name: "Base branch" }).click();
     const baseInput = page.getByLabel("Base branch");
     await baseInput.click();
     const option = page.getByRole("option", { name: /release-1\.2/ });

--- a/web/tests/wizard-session-step.spec.ts
+++ b/web/tests/wizard-session-step.spec.ts
@@ -84,6 +84,14 @@ async function openSessionStep(page: Page) {
   await expect(page.getByText("Name your session")).toBeVisible();
 }
 
+// #1514: the worktree toggle, branch input, attach-existing toggle,
+// base-branch picker, and group input all live behind the top-level
+// "Advanced" disclosure now. Expand it before asserting on those
+// controls.
+async function expandAdvanced(page: Page) {
+  await page.getByRole("button", { name: "Advanced" }).click();
+}
+
 test.describe("Wizard session step (#1219)", () => {
   test("title input is empty by default and updates as the user types", async ({ page }) => {
     await mockApis(page);
@@ -96,23 +104,25 @@ test.describe("Wizard session step (#1219)", () => {
     await expect(titleInput).toHaveValue("my-feature");
   });
 
-  test("worktree toggle is on by default and gates the branch input + Advanced section", async ({
+  test("worktree toggle is on by default and gates the branch input + Base branch section", async ({
     page,
   }) => {
     await mockApis(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     const worktreeToggle = page.getByRole("switch", { name: /Create a worktree/ });
     await expect(worktreeToggle).toHaveAttribute("aria-checked", "true");
     // Branch input visible while worktree is on.
     await expect(page.getByPlaceholder("Uses session title if empty")).toBeVisible();
-    await expect(page.getByRole("button", { name: /Advanced/ })).toBeVisible();
-    // Flip off: branch input + Advanced disappear.
+    await expect(page.getByRole("button", { name: "Base branch" })).toBeVisible();
+    // Flip off: branch input + Base branch picker disappear. The outer
+    // Advanced disclosure stays open.
     await worktreeToggle.click();
     await expect(worktreeToggle).toHaveAttribute("aria-checked", "false");
     await expect(page.getByPlaceholder("Uses session title if empty")).toHaveCount(0);
-    await expect(page.getByRole("button", { name: /Advanced/ })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Base branch" })).toHaveCount(0);
   });
 
   test("branch input mirrors the slugified title while not manually edited", async ({
@@ -123,16 +133,17 @@ test.describe("Wizard session step (#1219)", () => {
     await page.goto("/");
     await openSessionStep(page);
     await page.getByPlaceholder("Auto-generated if empty").fill("My Cool Feature");
+    await expandAdvanced(page);
     const branchInput = page.getByPlaceholder("Uses session title if empty");
     // SET_FIELD on title cascades into worktreeBranch via slugifyBranch().
     await expect(branchInput).toHaveValue("my-cool-feature");
   });
 
-  test("submit sends worktree_branch derived from title when the user leaves branch blank", async ({
+  test("submit sends worktree_branch + create_new_branch with Advanced left closed (#1514)", async ({
     page,
   }) => {
     await mockApis(page);
-    let captured: { worktree_branch?: string } | null = null;
+    let captured: { worktree_branch?: string; create_new_branch?: boolean } | null = null;
     await page.route("**/api/sessions", (r) => {
       if (r.request().method() === "POST") {
         captured = JSON.parse(r.request().postData() || "{}");
@@ -167,11 +178,15 @@ test.describe("Wizard session step (#1219)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    // Story 3: fill only the title; never expand Advanced. The worktree
+    // toggle is hidden but defaults on, so the default new-worktree
+    // behavior must still reach the request body.
     await page.getByPlaceholder("Auto-generated if empty").fill("Cool Feature");
     await page.getByRole("button", { name: /Next/ }).click();
     await page.getByRole("button", { name: /Next/ }).click();
     await page.getByRole("button", { name: /Launch session/ }).click();
     await expect.poll(() => captured?.worktree_branch).toBe("cool-feature");
+    expect(captured?.create_new_branch).toBe(true);
   });
 
   test("group input propagates to the create-session POST body", async ({ page }) => {
@@ -211,6 +226,7 @@ test.describe("Wizard session step (#1219)", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
     await openSessionStep(page);
+    await expandAdvanced(page);
     await page
       .getByPlaceholder("Optional, for organizing related sessions")
       .fill("backend");
@@ -218,5 +234,49 @@ test.describe("Wizard session step (#1219)", () => {
     await page.getByRole("button", { name: /Next/ }).click();
     await page.getByRole("button", { name: /Launch session/ }).click();
     await expect.poll(() => captured?.group).toBe("backend");
+  });
+
+  test("only the title input and Advanced toggle are visible by default (#1514)", async ({
+    page,
+  }) => {
+    await mockApis(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openSessionStep(page);
+    // Title input + Advanced disclosure are the only controls on screen.
+    await expect(page.getByPlaceholder("Auto-generated if empty")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Advanced" })).toBeVisible();
+    // Everything else is folded away.
+    await expect(page.getByRole("switch")).toHaveCount(0);
+    await expect(page.getByPlaceholder("Uses session title if empty")).toHaveCount(0);
+    await expect(
+      page.getByPlaceholder("Optional, for organizing related sessions"),
+    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Base branch" })).toHaveCount(0);
+  });
+
+  test("expanding Advanced reveals the worktree toggle, branch, attach toggle, and group (#1514)", async ({
+    page,
+  }) => {
+    await mockApis(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openSessionStep(page);
+    await expandAdvanced(page);
+    // Worktree toggle defaults on even though it was hidden.
+    await expect(page.getByRole("switch", { name: /Create a worktree/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    await expect(page.getByPlaceholder("Uses session title if empty")).toBeVisible();
+    await expect(
+      page.getByRole("switch", { name: /Attach to existing branch/ }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Base branch" })).toBeVisible();
+    // Group input is visible and editable.
+    const groupInput = page.getByPlaceholder("Optional, for organizing related sessions");
+    await expect(groupInput).toBeVisible();
+    await groupInput.fill("backend");
+    await expect(groupInput).toHaveValue("backend");
   });
 });

--- a/web/tsconfig.vitest.json
+++ b/web/tsconfig.vitest.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo"
+  },
+  // Scoped to the dedicated type-test files only. tsc still pulls in the
+  // production source they import, but the rest of the runtime test
+  // suite (excluded from tsc by `tsconfig.app.json`) stays unchecked, so
+  // its pre-existing loose typings don't fail the typecheck run.
+  "include": ["src/**/*.types.test.ts"],
+  "exclude": []
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -36,7 +36,22 @@ export default defineConfig({
   // expects but aren't valid vitest tests, so we explicitly exclude them.
   test: {
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
-    exclude: ["tests/**", "node_modules/**", "dist/**"],
+    // Type-level tests (`*.types.test.ts`) run under the typecheck runner
+    // below, not the runtime runner, so keep them out of `include`.
+    exclude: [
+      "tests/**",
+      "node_modules/**",
+      "dist/**",
+      "src/**/*.types.test.ts",
+    ],
+    // `expectTypeOf` assertions in `*.types.test.ts` are checked by tsc.
+    // A failing assertion surfaces as a type error. Scoped to the
+    // dedicated type-test files so the rest of the suite stays fast.
+    typecheck: {
+      enabled: true,
+      include: ["src/**/*.types.test.ts"],
+      tsconfig: "./tsconfig.vitest.json",
+    },
     setupFiles: ["./src/test-setup.ts"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Description

Batched merge of the `cockpit-main` integration branch into `main`. Branch protection on `main` requires a human approval; autonomous PRs land on `cockpit-main` first, then ship up in periodic batches like this one. `cockpit-main` was synced with `main` (merge of the 8 direct-to-main commits) before opening, so the diff is the 13 batch commits only.

Each commit already passed CI and review on its own PR into `cockpit-main`.

### Commits

- `4e16bfc8` fix(cockpit): settle tool card to a terminal state when stopped mid-execution (#1659)
- `1a687491` feat(web): drag project headers to reorder sidebar groups (#1661)
- `efc4bf5c` fix(serve): surface real create-session errors on the web dashboard (#1660)
- `21ae18e9` fix(cockpit): bound expanded queued and rejected prompt rows (#1653)
- `e5baf095` fix(web): hide multi-repo workspaces from wizard Recent projects list (#1656)
- `1bab143d` feat(web): add "New scratch session" to the command palette (#1657)
- `b534d618` fix(server): demote loopback bypass logs to debug (#1654)
- `094651ac` feat(web): first-run interactive tutorial for the dashboard (#1650)
- `61da636a` feat(web): match TUI settings grouping, hide low-level knobs behind Advanced (#1638)
- `e1123df6` feat(web): fold new-session Session step behind Advanced (#1635)
- `8928be14` fix(cockpit): make ConfigOptionCategory forward-compatible on TS and Rust (#1639)
- `bebef782` feat(cockpit): surface queued-prompt count on sidebar session rows (#1636)
- `c6e8e6d6` fix(cockpit): scroll long diff lines in Edit/Write tool card on mobile (#1637)

## How tested

Each constituent PR passed `cargo fmt`, `cargo clippy`, `cargo test`, and web tests on its own merge into `cockpit-main`. CI re-runs on this PR against `main`.

## Issues closed

Aggregated from the batched PRs so they auto-close on merge into `main`:

Closes #1646
Closes #1644
Closes #1649
Closes #1642
Closes #1645
Closes #1643
Closes #1647
Closes #1513
Closes #1562
Closes #1563
Closes #1515
Closes #1514
Closes #1516
Closes #1568


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->