### PR TITLE
feat(github): add GitHub client and token-resolution auth foundation

### DIFF
--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -1,0 +1,61 @@
+# GitHub Integration
+
+Agent of Empires talks to GitHub through a single backend client (`src/github/`).
+Every call to `api.github.com` goes through it, and it never shells out to `gh`
+for individual requests. This page documents how AoE finds a GitHub token, what
+happens when it cannot, and what is intentionally deferred.
+
+## How AoE finds your token
+
+`gh` is an optional token source, never a hard dependency. AoE resolves a token
+once, in this fixed order, and the first hit wins:
+
+1. The `GITHUB_TOKEN` environment variable.
+2. The `GH_TOKEN` environment variable.
+3. `gh auth token`, but only when the GitHub CLI is installed and authenticated.
+   AoE captures the token `gh` prints and sends it as `Authorization: Bearer
+   <token>`; it does not run `gh` per request.
+
+If you already use the GitHub CLI on your machine (the common case on a dev
+laptop), steps 1 and 2 miss, step 3 returns your existing token, and everything
+works with no prompt and no extra login.
+
+Empty or whitespace-only environment variables are ignored, so an exported but
+blank `GITHUB_TOKEN` falls through to `gh` rather than failing.
+
+## When no token is available
+
+Each failure produces its own hint, never a generic "auth required". The hint
+always matches the actual cause:
+
+| Situation | What AoE tells you |
+| --- | --- |
+| No env token and `gh` is not installed | Set `GITHUB_TOKEN` (or `GH_TOKEN`), or install the GitHub CLI and run `gh auth login`. |
+| `gh` is installed but not authenticated | Run `gh auth login`. AoE does not tell you to install `gh`, because it is already installed. |
+| `gh` returns an empty token | Re-authenticate with `gh auth login`, or set a token directly. |
+| Running `gh` fails | The underlying error, plus a note that you can set `GITHUB_TOKEN` to bypass `gh`. |
+
+## When a request fails
+
+Once a token is resolved, request failures are also typed so the surface (a TUI
+toast or a web error banner) can show the right next step:
+
+- **401 Unauthorized**: the token is missing, invalid, or expired. Re-authenticate.
+- **403 with a missing scope**: AoE names the required scope from GitHub's
+  `X-Accepted-OAuth-Scopes` response header, for example `repo` or `workflow`,
+  so you know exactly what to re-authorize.
+- **403 or 429 rate limited**: wait for the limit to reset. Authenticating raises
+  the limit, so an unauthenticated user is pointed at setting a token.
+- **404 Not Found**: the resource does not exist or is not visible to your token.
+- **Network unreachable**: distinguished from auth, so a GitHub outage never
+  tells you to re-login.
+
+## Deferred to follow-ups
+
+This foundation deliberately stops at token resolution, the typed errors above,
+and the read endpoints the update checker needs. The rest is tracked separately:
+
+- Device-flow login as the no-`gh`, no-env-token fallback: #1678.
+- GraphQL, ETag conditional caching, and rate-limit backoff in the client: #1679.
+- A guided scope-elevation re-auth flow on write failures: #1680.
+- GitHub Enterprise host derivation from the git remote: #1668.

--- a/src/github/auth.rs
+++ b/src/github/auth.rs
@@ -44,6 +44,7 @@ pub struct ResolvedToken {
 pub struct GhTokenOutput {
     pub success: bool,
     pub stdout: String,
+    pub stderr: String,
 }
 
 /// Abstraction over the process environment, so token resolution is testable.
@@ -70,6 +71,7 @@ impl TokenEnvironment for SystemEnvironment {
         Ok(GhTokenOutput {
             success: output.status.success(),
             stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         })
     }
 }
@@ -79,13 +81,21 @@ impl TokenEnvironment for SystemEnvironment {
 pub fn resolve_token<E: TokenEnvironment>(
     env: &E,
 ) -> std::result::Result<ResolvedToken, GitHubAuthError> {
-    if let Some(token) = env.env_var("GITHUB_TOKEN").filter(|t| !t.trim().is_empty()) {
+    if let Some(token) = env
+        .env_var("GITHUB_TOKEN")
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+    {
         return Ok(ResolvedToken {
             token,
             source: TokenSource::EnvGithubToken,
         });
     }
-    if let Some(token) = env.env_var("GH_TOKEN").filter(|t| !t.trim().is_empty()) {
+    if let Some(token) = env
+        .env_var("GH_TOKEN")
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+    {
         return Ok(ResolvedToken {
             token,
             source: TokenSource::EnvGhToken,
@@ -108,7 +118,17 @@ pub fn resolve_token<E: TokenEnvironment>(
                 })
             }
         }
-        Ok(_) => Err(GitHubAuthError::GhNotAuthenticated),
+        // A non-zero exit with the canonical "no oauth token" message (or no
+        // stderr at all) means the user simply is not signed in. Any other
+        // stderr is a real gh failure and must not be mislabeled as that.
+        Ok(output) => {
+            let stderr = output.stderr.trim();
+            if stderr.is_empty() || stderr.to_lowercase().contains("no oauth token") {
+                Err(GitHubAuthError::GhNotAuthenticated)
+            } else {
+                Err(GitHubAuthError::GhCommandFailed(stderr.to_string()))
+            }
+        }
         Err(e) => Err(GitHubAuthError::GhCommandFailed(e.to_string())),
     }
 }
@@ -146,6 +166,7 @@ mod tests {
                 Some(Ok(o)) => Ok(GhTokenOutput {
                     success: o.success,
                     stdout: o.stdout.clone(),
+                    stderr: o.stderr.clone(),
                 }),
                 Some(Err(e)) => Err(std::io::Error::new(e.kind(), e.to_string())),
                 None => panic!("gh_auth_token called unexpectedly"),
@@ -157,6 +178,15 @@ mod tests {
         Some(Ok(GhTokenOutput {
             success: true,
             stdout: stdout.to_string(),
+            stderr: String::new(),
+        }))
+    }
+
+    fn failed_gh(stderr: &str) -> Option<std::io::Result<GhTokenOutput>> {
+        Some(Ok(GhTokenOutput {
+            success: false,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
         }))
     }
 
@@ -228,10 +258,7 @@ mod tests {
     fn gh_installed_but_not_authenticated_says_login_not_install() {
         let env = FakeEnv {
             gh_available: true,
-            gh_result: Some(Ok(GhTokenOutput {
-                success: false,
-                stdout: String::new(),
-            })),
+            gh_result: failed_gh("no oauth token found for github.com"),
             ..Default::default()
         };
         let err = resolve_token(&env).unwrap_err();
@@ -239,6 +266,41 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("gh auth login"));
         assert!(!msg.contains("brew install") && !msg.contains("install the GitHub CLI"));
+    }
+
+    #[test]
+    fn gh_nonzero_with_empty_stderr_is_not_authenticated() {
+        let env = FakeEnv {
+            gh_available: true,
+            gh_result: failed_gh(""),
+            ..Default::default()
+        };
+        assert!(matches!(
+            resolve_token(&env).unwrap_err(),
+            GitHubAuthError::GhNotAuthenticated
+        ));
+    }
+
+    #[test]
+    fn gh_nonzero_with_unexpected_stderr_is_command_failed() {
+        let env = FakeEnv {
+            gh_available: true,
+            gh_result: failed_gh("error connecting to api.github.com"),
+            ..Default::default()
+        };
+        match resolve_token(&env).unwrap_err() {
+            GitHubAuthError::GhCommandFailed(msg) => assert!(msg.contains("connecting")),
+            other => panic!("expected GhCommandFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn env_token_is_trimmed() {
+        let env = FakeEnv {
+            github_token: Some("  gho_padded  ".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_token(&env).unwrap().token, "gho_padded");
     }
 
     #[test]

--- a/src/github/auth.rs
+++ b/src/github/auth.rs
@@ -1,0 +1,268 @@
+//! GitHub token resolution.
+//!
+//! `gh` is an optional token source, never a hard dependency and never a
+//! per-call shell-out. The resolver finds a token once, in a fixed order, and
+//! the client then sends it as `Authorization: Bearer <token>`:
+//!
+//! 1. `GITHUB_TOKEN` / `GH_TOKEN` environment variable.
+//! 2. `gh auth token`, only when `gh` is installed and authenticated.
+//! 3. Device-flow login as the no-`gh` fallback (deferred, see the GitHub
+//!    integration docs for the tracking issue).
+//!
+//! The environment is abstracted behind [`TokenEnvironment`] so the resolution
+//! order and per-case hint selection are unit-testable without touching real
+//! process state or requiring `gh` in CI.
+
+use crate::github::error::GitHubAuthError;
+use std::process::Command;
+
+/// Whether a client must carry a token or may run unauthenticated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMode {
+    /// Public, unauthenticated requests (for example the update check).
+    None,
+    /// Resolve a token and attach it; fail with a typed hint if none is found.
+    Required,
+}
+
+/// Where a resolved token came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenSource {
+    EnvGithubToken,
+    EnvGhToken,
+    GhCli,
+}
+
+/// A resolved token plus its provenance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedToken {
+    pub token: String,
+    pub source: TokenSource,
+}
+
+/// Result of invoking `gh auth token`.
+pub struct GhTokenOutput {
+    pub success: bool,
+    pub stdout: String,
+}
+
+/// Abstraction over the process environment, so token resolution is testable.
+pub trait TokenEnvironment {
+    fn env_var(&self, key: &str) -> Option<String>;
+    fn gh_available(&self) -> bool;
+    fn gh_auth_token(&self) -> std::io::Result<GhTokenOutput>;
+}
+
+/// Production environment backed by real env vars and the `gh` binary.
+pub struct SystemEnvironment;
+
+impl TokenEnvironment for SystemEnvironment {
+    fn env_var(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+
+    fn gh_available(&self) -> bool {
+        which::which("gh").is_ok()
+    }
+
+    fn gh_auth_token(&self) -> std::io::Result<GhTokenOutput> {
+        let output = Command::new("gh").args(["auth", "token"]).output()?;
+        Ok(GhTokenOutput {
+            success: output.status.success(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        })
+    }
+}
+
+/// Resolve a GitHub token in the fixed order, returning a typed error whose
+/// hint matches the exact failure when no token is available.
+pub fn resolve_token<E: TokenEnvironment>(
+    env: &E,
+) -> std::result::Result<ResolvedToken, GitHubAuthError> {
+    if let Some(token) = env.env_var("GITHUB_TOKEN").filter(|t| !t.trim().is_empty()) {
+        return Ok(ResolvedToken {
+            token,
+            source: TokenSource::EnvGithubToken,
+        });
+    }
+    if let Some(token) = env.env_var("GH_TOKEN").filter(|t| !t.trim().is_empty()) {
+        return Ok(ResolvedToken {
+            token,
+            source: TokenSource::EnvGhToken,
+        });
+    }
+
+    if !env.gh_available() {
+        return Err(GitHubAuthError::NoTokenNoGh);
+    }
+
+    match env.gh_auth_token() {
+        Ok(output) if output.success => {
+            let token = output.stdout.trim();
+            if token.is_empty() {
+                Err(GitHubAuthError::GhReturnedEmptyToken)
+            } else {
+                Ok(ResolvedToken {
+                    token: token.to_string(),
+                    source: TokenSource::GhCli,
+                })
+            }
+        }
+        Ok(_) => Err(GitHubAuthError::GhNotAuthenticated),
+        Err(e) => Err(GitHubAuthError::GhCommandFailed(e.to_string())),
+    }
+}
+
+/// Resolve a token from the real process environment.
+pub fn resolve_token_from_system() -> std::result::Result<ResolvedToken, GitHubAuthError> {
+    resolve_token(&SystemEnvironment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeEnv {
+        github_token: Option<String>,
+        gh_token: Option<String>,
+        gh_available: bool,
+        gh_result: Option<std::io::Result<GhTokenOutput>>,
+    }
+
+    impl TokenEnvironment for FakeEnv {
+        fn env_var(&self, key: &str) -> Option<String> {
+            match key {
+                "GITHUB_TOKEN" => self.github_token.clone(),
+                "GH_TOKEN" => self.gh_token.clone(),
+                _ => None,
+            }
+        }
+        fn gh_available(&self) -> bool {
+            self.gh_available
+        }
+        fn gh_auth_token(&self) -> std::io::Result<GhTokenOutput> {
+            match &self.gh_result {
+                Some(Ok(o)) => Ok(GhTokenOutput {
+                    success: o.success,
+                    stdout: o.stdout.clone(),
+                }),
+                Some(Err(e)) => Err(std::io::Error::new(e.kind(), e.to_string())),
+                None => panic!("gh_auth_token called unexpectedly"),
+            }
+        }
+    }
+
+    fn ok_gh(stdout: &str) -> Option<std::io::Result<GhTokenOutput>> {
+        Some(Ok(GhTokenOutput {
+            success: true,
+            stdout: stdout.to_string(),
+        }))
+    }
+
+    #[test]
+    fn github_token_env_wins_without_touching_gh() {
+        let env = FakeEnv {
+            github_token: Some("env-tok".to_string()),
+            gh_available: true,
+            gh_result: None, // would panic if gh were consulted
+            ..Default::default()
+        };
+        let resolved = resolve_token(&env).unwrap();
+        assert_eq!(resolved.token, "env-tok");
+        assert_eq!(resolved.source, TokenSource::EnvGithubToken);
+    }
+
+    #[test]
+    fn gh_token_env_used_when_github_token_absent() {
+        let env = FakeEnv {
+            gh_token: Some("gh-env-tok".to_string()),
+            gh_available: true,
+            gh_result: None,
+            ..Default::default()
+        };
+        let resolved = resolve_token(&env).unwrap();
+        assert_eq!(resolved.token, "gh-env-tok");
+        assert_eq!(resolved.source, TokenSource::EnvGhToken);
+    }
+
+    #[test]
+    fn empty_env_token_is_skipped() {
+        let env = FakeEnv {
+            github_token: Some("   ".to_string()),
+            gh_available: true,
+            gh_result: ok_gh("cli-tok\n"),
+            ..Default::default()
+        };
+        let resolved = resolve_token(&env).unwrap();
+        assert_eq!(resolved.token, "cli-tok");
+        assert_eq!(resolved.source, TokenSource::GhCli);
+    }
+
+    #[test]
+    fn gh_authenticated_reuses_token_no_prompt() {
+        let env = FakeEnv {
+            gh_available: true,
+            gh_result: ok_gh("gho_abc123\n"),
+            ..Default::default()
+        };
+        let resolved = resolve_token(&env).unwrap();
+        assert_eq!(resolved.token, "gho_abc123");
+        assert_eq!(resolved.source, TokenSource::GhCli);
+    }
+
+    #[test]
+    fn no_token_and_no_gh_yields_install_or_set_token_hint() {
+        let env = FakeEnv {
+            gh_available: false,
+            ..Default::default()
+        };
+        let err = resolve_token(&env).unwrap_err();
+        assert!(matches!(err, GitHubAuthError::NoTokenNoGh));
+        let msg = err.to_string();
+        assert!(msg.contains("GITHUB_TOKEN"));
+        assert!(msg.contains("install the GitHub CLI") || msg.contains("brew install gh"));
+    }
+
+    #[test]
+    fn gh_installed_but_not_authenticated_says_login_not_install() {
+        let env = FakeEnv {
+            gh_available: true,
+            gh_result: Some(Ok(GhTokenOutput {
+                success: false,
+                stdout: String::new(),
+            })),
+            ..Default::default()
+        };
+        let err = resolve_token(&env).unwrap_err();
+        assert!(matches!(err, GitHubAuthError::GhNotAuthenticated));
+        let msg = err.to_string();
+        assert!(msg.contains("gh auth login"));
+        assert!(!msg.contains("brew install") && !msg.contains("install the GitHub CLI"));
+    }
+
+    #[test]
+    fn gh_success_with_empty_output_is_empty_token_error() {
+        let env = FakeEnv {
+            gh_available: true,
+            gh_result: ok_gh("\n"),
+            ..Default::default()
+        };
+        let err = resolve_token(&env).unwrap_err();
+        assert!(matches!(err, GitHubAuthError::GhReturnedEmptyToken));
+    }
+
+    #[test]
+    fn gh_command_failure_is_reported() {
+        let env = FakeEnv {
+            gh_available: true,
+            gh_result: Some(Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "boom",
+            ))),
+            ..Default::default()
+        };
+        let err = resolve_token(&env).unwrap_err();
+        assert!(matches!(err, GitHubAuthError::GhCommandFailed(_)));
+    }
+}

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -135,7 +135,7 @@ fn classify_status(status: StatusCode, headers: &HeaderMap, body: &str) -> GitHu
         StatusCode::FORBIDDEN => {
             if is_rate_limited(headers) {
                 GitHubError::RateLimited
-            } else if let Some(scopes) = accepted_scopes(headers) {
+            } else if let Some(scopes) = missing_scope(headers, body) {
                 GitHubError::InsufficientScope { scopes }
             } else {
                 GitHubError::Api {
@@ -161,6 +161,18 @@ fn is_rate_limited(headers: &HeaderMap) -> bool {
         .map(|v| v.trim() == "0")
         .unwrap_or(false);
     remaining_zero || headers.contains_key("retry-after")
+}
+
+/// A 403 is only treated as a missing-scope failure when the response body
+/// actually says so. GitHub sends `X-Accepted-OAuth-Scopes` on many responses,
+/// including ones that are forbidden for unrelated reasons, so the header alone
+/// is not evidence. The named scope still comes from that header. Precise
+/// per-operation scope mapping is tracked in the scope-elevation follow-up.
+fn missing_scope(headers: &HeaderMap, body: &str) -> Option<String> {
+    if !body.to_lowercase().contains("scope") {
+        return None;
+    }
+    accepted_scopes(headers)
 }
 
 /// The scopes GitHub says the endpoint accepts, taken from
@@ -235,9 +247,13 @@ mod tests {
     }
 
     #[test]
-    fn forbidden_with_accepted_scopes_names_the_scope() {
+    fn forbidden_with_scope_error_names_the_scope() {
         let headers = headers_with(&[("x-accepted-oauth-scopes", "repo")]);
-        let err = classify_status(StatusCode::FORBIDDEN, &headers, "");
+        let err = classify_status(
+            StatusCode::FORBIDDEN,
+            &headers,
+            r#"{"message":"requires the repo scope"}"#,
+        );
         match err {
             GitHubError::InsufficientScope { scopes } => assert_eq!(scopes, "repo"),
             other => panic!("expected InsufficientScope, got {other:?}"),
@@ -247,11 +263,27 @@ mod tests {
     #[test]
     fn forbidden_with_workflow_scope_names_workflow() {
         let headers = headers_with(&[("x-accepted-oauth-scopes", "repo, workflow")]);
-        let err = classify_status(StatusCode::FORBIDDEN, &headers, "");
+        let err = classify_status(
+            StatusCode::FORBIDDEN,
+            &headers,
+            r#"{"message":"missing the workflow scope"}"#,
+        );
         match err {
             GitHubError::InsufficientScope { scopes } => assert!(scopes.contains("workflow")),
             other => panic!("expected InsufficientScope, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn forbidden_with_scope_header_but_no_scope_message_is_api() {
+        // The header alone is not evidence; many 403s carry it.
+        let headers = headers_with(&[("x-accepted-oauth-scopes", "repo")]);
+        let err = classify_status(
+            StatusCode::FORBIDDEN,
+            &headers,
+            r#"{"message":"Resource not accessible by integration"}"#,
+        );
+        assert!(matches!(err, GitHubError::Api { .. }));
     }
 
     #[test]

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -1,0 +1,315 @@
+//! Thin typed GitHub HTTP client built on the already-present `reqwest`.
+//!
+//! This is the single surface for talking to `api.github.com`. It owns the
+//! base URL, the standard headers, the optional bearer token, and the mapping
+//! from HTTP responses to the typed [`GitHubError`] taxonomy. Authenticated
+//! callers resolve a token via [`crate::github::auth`] and pass it to
+//! [`GitHubClient::authenticated`]; unauthenticated public reads (such as the
+//! update check) use [`GitHubClient::unauthenticated`].
+
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION};
+use reqwest::StatusCode;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use std::time::Duration;
+
+use crate::github::error::{GitHubError, Result};
+
+/// Configuration for constructing a [`GitHubClient`].
+#[derive(Debug, Clone)]
+pub struct GitHubClientConfig {
+    /// API base, normally `https://api.github.com`. Overridable for tests.
+    pub api_base: String,
+    pub user_agent: String,
+    pub timeout: Duration,
+}
+
+/// A configured GitHub HTTP client.
+pub struct GitHubClient {
+    http: reqwest::Client,
+    api_base: String,
+}
+
+/// A GitHub release, the only DTO needed by the current callers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubRelease {
+    pub tag_name: String,
+    #[serde(default)]
+    pub body: Option<String>,
+    pub published_at: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ApiErrorBody {
+    message: Option<String>,
+}
+
+impl GitHubClient {
+    /// Client for public, unauthenticated requests.
+    pub fn unauthenticated(config: GitHubClientConfig) -> Result<Self> {
+        Self::build(config, None)
+    }
+
+    /// Client that sends `Authorization: Bearer <token>` on every request.
+    /// Resolve the token with [`crate::github::auth::resolve_token_from_system`].
+    pub fn authenticated(config: GitHubClientConfig, token: &str) -> Result<Self> {
+        Self::build(config, Some(token))
+    }
+
+    fn build(config: GitHubClientConfig, token: Option<&str>) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-github-api-version"),
+            HeaderValue::from_static("2022-11-28"),
+        );
+        if let Some(token) = token {
+            let mut value = HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|_| GitHubError::Unauthorized)?;
+            value.set_sensitive(true);
+            headers.insert(AUTHORIZATION, value);
+        }
+
+        let http = reqwest::Client::builder()
+            .user_agent(config.user_agent)
+            .timeout(config.timeout)
+            .default_headers(headers)
+            .build()
+            .map_err(GitHubError::Http)?;
+
+        Ok(Self {
+            http,
+            api_base: config.api_base.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// `GET /repos/{owner}/{repo}/releases?per_page={per_page}`
+    pub async fn list_releases(
+        &self,
+        owner: &str,
+        repo: &str,
+        per_page: u8,
+    ) -> Result<Vec<GitHubRelease>> {
+        let url = format!(
+            "{}/repos/{}/{}/releases?per_page={}",
+            self.api_base, owner, repo, per_page
+        );
+        self.send_json(self.http.get(url)).await
+    }
+
+    /// `GET /repos/{owner}/{repo}/releases/latest`
+    pub async fn latest_release(&self, owner: &str, repo: &str) -> Result<GitHubRelease> {
+        let url = format!("{}/repos/{}/{}/releases/latest", self.api_base, owner, repo);
+        self.send_json(self.http.get(url)).await
+    }
+
+    async fn send_json<T: DeserializeOwned>(&self, request: reqwest::RequestBuilder) -> Result<T> {
+        let response = request.send().await.map_err(classify_transport_error)?;
+        let status = response.status();
+        if status.is_success() {
+            return response.json::<T>().await.map_err(GitHubError::Decode);
+        }
+        let headers = response.headers().clone();
+        let body = response.text().await.unwrap_or_default();
+        Err(classify_status(status, &headers, &body))
+    }
+}
+
+fn classify_transport_error(error: reqwest::Error) -> GitHubError {
+    if error.is_timeout() || error.is_connect() {
+        GitHubError::Network { source: error }
+    } else {
+        GitHubError::Http(error)
+    }
+}
+
+/// Map a non-success HTTP response to the typed error with the right hint.
+/// Pure and header-driven so it is unit-testable without a live API.
+fn classify_status(status: StatusCode, headers: &HeaderMap, body: &str) -> GitHubError {
+    match status {
+        StatusCode::UNAUTHORIZED => GitHubError::Unauthorized,
+        StatusCode::TOO_MANY_REQUESTS => GitHubError::RateLimited,
+        StatusCode::FORBIDDEN => {
+            if is_rate_limited(headers) {
+                GitHubError::RateLimited
+            } else if let Some(scopes) = accepted_scopes(headers) {
+                GitHubError::InsufficientScope { scopes }
+            } else {
+                GitHubError::Api {
+                    status,
+                    message: api_message(body),
+                }
+            }
+        }
+        StatusCode::NOT_FOUND => GitHubError::NotFound {
+            resource: api_message(body),
+        },
+        _ => GitHubError::Api {
+            status,
+            message: api_message(body),
+        },
+    }
+}
+
+fn is_rate_limited(headers: &HeaderMap) -> bool {
+    let remaining_zero = headers
+        .get("x-ratelimit-remaining")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.trim() == "0")
+        .unwrap_or(false);
+    remaining_zero || headers.contains_key("retry-after")
+}
+
+/// The scopes GitHub says the endpoint accepts, taken from
+/// `X-Accepted-OAuth-Scopes` so the hint names the real missing scope.
+fn accepted_scopes(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("x-accepted-oauth-scopes")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn api_message(body: &str) -> String {
+    if let Ok(parsed) = serde_json::from_str::<ApiErrorBody>(body) {
+        if let Some(message) = parsed.message {
+            return message;
+        }
+    }
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        "no response body".to_string()
+    } else {
+        trimmed.chars().take(200).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> GitHubClientConfig {
+        GitHubClientConfig {
+            api_base: "https://api.github.com".to_string(),
+            user_agent: "agent-of-empires-test".to_string(),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    #[test]
+    fn unauthenticated_client_builds() {
+        assert!(GitHubClient::unauthenticated(config()).is_ok());
+    }
+
+    #[test]
+    fn authenticated_client_builds_with_token() {
+        assert!(GitHubClient::authenticated(config(), "gho_token123").is_ok());
+    }
+
+    #[test]
+    fn api_base_trailing_slash_is_trimmed() {
+        let mut cfg = config();
+        cfg.api_base = "https://example.test/".to_string();
+        let client = GitHubClient::unauthenticated(cfg).unwrap();
+        assert_eq!(client.api_base, "https://example.test");
+    }
+
+    fn headers_with(pairs: &[(&'static str, &str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        for (name, value) in pairs {
+            headers.insert(
+                HeaderName::from_static(name),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        headers
+    }
+
+    #[test]
+    fn unauthorized_maps_to_unauthorized() {
+        let err = classify_status(StatusCode::UNAUTHORIZED, &HeaderMap::new(), "");
+        assert!(matches!(err, GitHubError::Unauthorized));
+    }
+
+    #[test]
+    fn forbidden_with_accepted_scopes_names_the_scope() {
+        let headers = headers_with(&[("x-accepted-oauth-scopes", "repo")]);
+        let err = classify_status(StatusCode::FORBIDDEN, &headers, "");
+        match err {
+            GitHubError::InsufficientScope { scopes } => assert_eq!(scopes, "repo"),
+            other => panic!("expected InsufficientScope, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forbidden_with_workflow_scope_names_workflow() {
+        let headers = headers_with(&[("x-accepted-oauth-scopes", "repo, workflow")]);
+        let err = classify_status(StatusCode::FORBIDDEN, &headers, "");
+        match err {
+            GitHubError::InsufficientScope { scopes } => assert!(scopes.contains("workflow")),
+            other => panic!("expected InsufficientScope, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forbidden_rate_limited_maps_to_rate_limited() {
+        let headers = headers_with(&[("x-ratelimit-remaining", "0")]);
+        let err = classify_status(StatusCode::FORBIDDEN, &headers, "");
+        assert!(matches!(err, GitHubError::RateLimited));
+    }
+
+    #[test]
+    fn too_many_requests_maps_to_rate_limited() {
+        let err = classify_status(StatusCode::TOO_MANY_REQUESTS, &HeaderMap::new(), "");
+        assert!(matches!(err, GitHubError::RateLimited));
+    }
+
+    #[test]
+    fn plain_forbidden_maps_to_api_error() {
+        let err = classify_status(
+            StatusCode::FORBIDDEN,
+            &HeaderMap::new(),
+            r#"{"message":"Resource protected"}"#,
+        );
+        match err {
+            GitHubError::Api { status, message } => {
+                assert_eq!(status, StatusCode::FORBIDDEN);
+                assert_eq!(message, "Resource protected");
+            }
+            other => panic!("expected Api, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_found_carries_message() {
+        let err = classify_status(
+            StatusCode::NOT_FOUND,
+            &HeaderMap::new(),
+            r#"{"message":"Not Found"}"#,
+        );
+        match err {
+            GitHubError::NotFound { resource } => assert_eq!(resource, "Not Found"),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn server_error_maps_to_api() {
+        let err = classify_status(StatusCode::INTERNAL_SERVER_ERROR, &HeaderMap::new(), "");
+        match err {
+            GitHubError::Api { status, message } => {
+                assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(message, "no response body");
+            }
+            other => panic!("expected Api, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn api_message_falls_back_to_raw_body() {
+        assert_eq!(api_message("plain text error"), "plain text error");
+    }
+}

--- a/src/github/error.rs
+++ b/src/github/error.rs
@@ -1,0 +1,144 @@
+//! Typed errors for the GitHub client and auth layer.
+//!
+//! Each failure case carries its own actionable hint so the TUI toast and the
+//! web error banner can show the user exactly what to do, never a generic
+//! "auth required". The wording mirrors the house convention in
+//! `src/git/error.rs` and `src/containers/error.rs`.
+
+use reqwest::StatusCode;
+use thiserror::Error;
+
+/// Failures while resolving a GitHub token from the environment or the `gh`
+/// CLI. Every variant maps to a distinct, actionable hint.
+#[derive(Debug, Error)]
+pub enum GitHubAuthError {
+    #[error(
+        "No GitHub token found and the GitHub CLI is not installed.\n\
+         Set a token: export GITHUB_TOKEN=<token> (or GH_TOKEN).\n\
+         Or install the GitHub CLI and sign in:\n\
+           macOS:  brew install gh\n\
+           Linux:  see https://github.com/cli/cli#installation\n\
+         then run: gh auth login"
+    )]
+    NoTokenNoGh,
+
+    #[error(
+        "The GitHub CLI is installed but not authenticated.\n\
+         Sign in with:\n\
+           gh auth login\n\
+         Or set a token directly: export GITHUB_TOKEN=<token>."
+    )]
+    GhNotAuthenticated,
+
+    #[error(
+        "The GitHub CLI returned an empty token.\n\
+         Re-authenticate with:\n\
+           gh auth login\n\
+         Or set a token directly: export GITHUB_TOKEN=<token>."
+    )]
+    GhReturnedEmptyToken,
+
+    #[error(
+        "Failed to run the GitHub CLI: {0}\n\
+         Set a token directly to bypass it: export GITHUB_TOKEN=<token>."
+    )]
+    GhCommandFailed(String),
+}
+
+/// Top-level error for any GitHub client operation.
+#[derive(Debug, Error)]
+pub enum GitHubError {
+    #[error("{0}")]
+    Auth(#[from] GitHubAuthError),
+
+    #[error(
+        "GitHub API is unreachable.\n\
+         Check your network connection or GitHub status: https://www.githubstatus.com/\n\
+         Details: {source}"
+    )]
+    Network {
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[error(
+        "GitHub rejected the credentials (HTTP 401).\n\
+         The token is missing, invalid, or expired.\n\
+         Re-authenticate with: gh auth login, or set a fresh GITHUB_TOKEN."
+    )]
+    Unauthorized,
+
+    #[error(
+        "GitHub token is missing a required scope (HTTP 403).\n\
+         This operation needs one of: {scopes}.\n\
+         Re-authenticate with a token that carries it, for example:\n\
+           gh auth login --scopes {scopes}\n\
+         or set GITHUB_TOKEN to a personal access token with that scope."
+    )]
+    InsufficientScope { scopes: String },
+
+    #[error(
+        "GitHub API rate limit exceeded.\n\
+         Wait for the limit to reset (see the X-RateLimit-Reset header) and retry.\n\
+         Authenticating raises the limit: set GITHUB_TOKEN or run gh auth login."
+    )]
+    RateLimited,
+
+    #[error("GitHub resource not found: {resource}")]
+    NotFound { resource: String },
+
+    #[error("GitHub API returned HTTP {status}: {message}")]
+    Api { status: StatusCode, message: String },
+
+    #[error("Failed to decode GitHub API response: {0}")]
+    Decode(#[source] reqwest::Error),
+
+    #[error("GitHub HTTP request failed: {0}")]
+    Http(#[source] reqwest::Error),
+}
+
+pub type Result<T> = std::result::Result<T, GitHubError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_token_no_gh_hint_mentions_token_and_install_not_just_gh_login() {
+        let msg = GitHubAuthError::NoTokenNoGh.to_string();
+        assert!(
+            msg.contains("GITHUB_TOKEN"),
+            "should suggest setting a token"
+        );
+        assert!(
+            msg.contains("install the GitHub CLI") || msg.contains("brew install gh"),
+            "should suggest installing gh"
+        );
+    }
+
+    #[test]
+    fn gh_not_authenticated_hint_says_login_not_install() {
+        let msg = GitHubAuthError::GhNotAuthenticated.to_string();
+        assert!(msg.contains("gh auth login"), "should tell user to log in");
+        assert!(
+            !msg.contains("brew install") && !msg.contains("install the GitHub CLI"),
+            "must not tell an installed-gh user to install gh"
+        );
+    }
+
+    #[test]
+    fn insufficient_scope_names_the_scope() {
+        let msg = GitHubError::InsufficientScope {
+            scopes: "repo".to_string(),
+        }
+        .to_string();
+        assert!(msg.contains("repo"), "must name the missing scope");
+    }
+
+    #[test]
+    fn network_error_is_distinct_from_auth() {
+        // The network hint must not tell the user to re-authenticate.
+        let auth = GitHubError::Unauthorized.to_string();
+        assert!(auth.contains("Re-authenticate"));
+    }
+}

--- a/src/github/error.rs
+++ b/src/github/error.rs
@@ -136,9 +136,31 @@ mod tests {
     }
 
     #[test]
-    fn network_error_is_distinct_from_auth() {
-        // The network hint must not tell the user to re-authenticate.
+    fn unauthorized_hint_mentions_reauthenticate() {
         let auth = GitHubError::Unauthorized.to_string();
         assert!(auth.contains("Re-authenticate"));
+    }
+
+    #[test]
+    fn network_hint_does_not_suggest_reauthenticating() {
+        // A GitHub outage must not tell the user to re-login. The Network
+        // variant needs a real reqwest error, so exercise it via a transport
+        // failure to a port that refuses connections.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let err = rt.block_on(async {
+            crate::github::GitHubClient::unauthenticated(crate::github::GitHubClientConfig {
+                api_base: "http://127.0.0.1:1".to_string(),
+                user_agent: "agent-of-empires-test".to_string(),
+                timeout: std::time::Duration::from_millis(200),
+            })
+            .unwrap()
+            .latest_release("o", "r")
+            .await
+            .unwrap_err()
+        });
+        assert!(!err.to_string().contains("Re-authenticate"));
     }
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,0 +1,22 @@
+//! GitHub client and auth foundation.
+//!
+//! One typed surface for talking to GitHub, shared by the TUI and the web
+//! backend. Token resolution, the HTTP client, and the error taxonomy live
+//! here so no other module shells out to `gh` or hits `api.github.com`
+//! directly.
+//!
+//! See `docs/github-integration.md` for the token resolution order, the
+//! per-failure hints, and what is deferred to follow-up issues.
+
+pub mod auth;
+pub mod client;
+pub mod error;
+
+pub use auth::{resolve_token, resolve_token_from_system, ResolvedToken, TokenSource};
+pub use client::{GitHubClient, GitHubClientConfig, GitHubRelease};
+pub use error::{GitHubAuthError, GitHubError, Result};
+
+/// Default GitHub REST API base.
+pub const DEFAULT_GITHUB_API_BASE: &str = "https://api.github.com";
+/// User-Agent sent on every GitHub request (GitHub requires one).
+pub const DEFAULT_USER_AGENT: &str = "agent-of-empires";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cli;
 pub mod cockpit;
 pub mod containers;
 pub mod git;
+pub mod github;
 pub mod hooks;
 pub mod logging;
 pub mod migrations;

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -10,28 +10,16 @@ use tracing::warn;
 
 use crate::session::{get_app_dir, get_update_settings};
 
-const DEFAULT_GITHUB_API_BASE: &str = "https://api.github.com";
+const GITHUB_OWNER: &str = "agent-of-empires";
+const GITHUB_REPO: &str = "agent-of-empires";
 
 /// Resolve the GitHub API base URL, honoring `AOE_UPDATE_API_BASE` for
 /// hermetic tests. The override mirrors `AOE_UPDATE_BASE_URL` (which
 /// covers tarball downloads); tests that need to exercise the CLI
 /// without rate-limiting GitHub set both.
 fn github_api_base() -> String {
-    std::env::var("AOE_UPDATE_API_BASE").unwrap_or_else(|_| DEFAULT_GITHUB_API_BASE.to_string())
-}
-
-fn github_api_latest_url() -> String {
-    format!(
-        "{}/repos/agent-of-empires/agent-of-empires/releases/latest",
-        github_api_base()
-    )
-}
-
-fn github_api_releases_url() -> String {
-    format!(
-        "{}/repos/agent-of-empires/agent-of-empires/releases?per_page=20",
-        github_api_base()
-    )
+    std::env::var("AOE_UPDATE_API_BASE")
+        .unwrap_or_else(|_| crate::github::DEFAULT_GITHUB_API_BASE.to_string())
 }
 
 /// Public release-page URL for a given version tag. Stable enough to
@@ -61,14 +49,6 @@ pub struct ReleaseInfo {
     pub version: String,
     pub body: String,
     pub published_at: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitHubRelease {
-    tag_name: String,
-    #[serde(default)]
-    body: Option<String>,
-    published_at: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -142,10 +122,11 @@ pub async fn check_for_update(current_version: &str, force: bool) -> Result<Upda
         }
     }
 
-    let client = reqwest::Client::builder()
-        .user_agent("agent-of-empires")
-        .timeout(std::time::Duration::from_secs(5))
-        .build()?;
+    let client = crate::github::GitHubClient::unauthenticated(crate::github::GitHubClientConfig {
+        api_base: github_api_base(),
+        user_agent: crate::github::DEFAULT_USER_AGENT.to_string(),
+        timeout: std::time::Duration::from_secs(5),
+    })?;
 
     // Fetch all releases (includes body/release notes)
     let releases = match fetch_releases(&client).await {
@@ -162,19 +143,10 @@ pub async fn check_for_update(current_version: &str, force: bool) -> Result<Upda
         .unwrap_or_default();
 
     if latest_version.is_empty() {
-        // Fall back to latest endpoint if releases fetch failed
-        let response = client.get(github_api_latest_url()).send().await?;
-        if !response.status().is_success() {
-            anyhow::bail!("Failed to check for updates: HTTP {}", response.status());
-        }
-        let release: GitHubRelease = response.json().await?;
-        let version = release.tag_name.trim_start_matches('v').to_string();
-
-        let release_info = ReleaseInfo {
-            version: version.clone(),
-            body: release.body.unwrap_or_default(),
-            published_at: release.published_at,
-        };
+        // Fall back to the latest-release endpoint if the releases list failed.
+        let release = client.latest_release(GITHUB_OWNER, GITHUB_REPO).await?;
+        let release_info = release_info_from(release);
+        let version = release_info.version.clone();
 
         let cache = UpdateCache {
             checked_at: chrono::Utc::now(),
@@ -218,34 +190,17 @@ pub async fn check_for_update(current_version: &str, force: bool) -> Result<Upda
 }
 
 #[tracing::instrument(target = "update.fetch", skip_all)]
-async fn fetch_releases(client: &reqwest::Client) -> Result<Vec<ReleaseInfo>> {
-    let url = github_api_releases_url();
-    tracing::debug!(target: "update.fetch", %url, "GET releases");
-    let response = client.get(&url).send().await?;
-    let status = response.status();
-    tracing::debug!(
-        target: "update.fetch",
-        status = %status,
-        content_length = ?response.content_length(),
-        "releases response"
-    );
+async fn fetch_releases(client: &crate::github::GitHubClient) -> Result<Vec<ReleaseInfo>> {
+    let releases = client.list_releases(GITHUB_OWNER, GITHUB_REPO, 20).await?;
+    Ok(releases.into_iter().map(release_info_from).collect())
+}
 
-    if !status.is_success() {
-        anyhow::bail!("Failed to fetch releases: HTTP {}", status);
+fn release_info_from(release: crate::github::GitHubRelease) -> ReleaseInfo {
+    ReleaseInfo {
+        version: release.tag_name.trim_start_matches('v').to_string(),
+        body: release.body.unwrap_or_default(),
+        published_at: release.published_at,
     }
-
-    let github_releases: Vec<GitHubRelease> = response.json().await?;
-
-    let releases = github_releases
-        .into_iter()
-        .map(|r| ReleaseInfo {
-            version: r.tag_name.trim_start_matches('v').to_string(),
-            body: r.body.unwrap_or_default(),
-            published_at: r.published_at,
-        })
-        .collect();
-
-    Ok(releases)
 }
 
 /// Get cached release notes, filtered to show only releases newer than from_version.

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -175,6 +175,13 @@ const PAGES = [
       "Canonical inventory of every Agent of Empires feature, grouped by surface and capability, with links to each guide.",
   },
   {
+    source: "docs/github-integration.md",
+    dest: "docs/github-integration.md",
+    title: "GitHub Integration",
+    description:
+      "How Agent of Empires resolves a GitHub token, the per-failure hints it shows, and what is deferred to follow-ups.",
+  },
+  {
     source: "docs/guides/podman.md",
     dest: "guides/podman.md",
     title: "Podman",
@@ -241,6 +248,7 @@ const URL_MAP = {
   "docs/sounds.md": "/docs/sounds/",
   "docs/push-notifications.md": "/docs/push-notifications/",
   "docs/features.md": "/docs/features/",
+  "docs/github-integration.md": "/docs/github-integration/",
   "docs/development.md": "/docs/development/",
   "docs/development/adding-agents.md": "/docs/development/adding-agents/",
   "docs/development/logging.md": "/docs/development/logging/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -46,6 +46,7 @@ export const docsNav: NavSection[] = [
     items: [
       { title: "CLI Reference", href: "/docs/cli/reference/" },
       { title: "HTTP API Reference", href: "/docs/api/" },
+      { title: "GitHub Integration", href: "/docs/github-integration/" },
       { title: "Configuration", href: "/docs/guides/configuration/" },
     ],
   },


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Foundation for the GitHub integration epic (#658). Adds one typed GitHub client and auth layer at `src/github/`, the single surface for talking to `api.github.com`, so nothing else shells out to `gh` per call or hits the REST API directly.

What landed:

- **Token resolution** (`src/github/auth.rs`): resolves a token once, in the fixed order `GITHUB_TOKEN` / `GH_TOKEN` env, then `gh auth token` when the GitHub CLI is installed and authenticated. `gh` is an optional token source, never a per-call shell-out; the token is sent as `Authorization: Bearer`. The resolver is generic over a `TokenEnvironment` seam so the order and hint selection are unit-tested without touching real process state or needing `gh` in CI.
- **Typed errors** (`src/github/error.rs`): distinct `thiserror` variants, each with its own actionable hint (no `gh` and no env token; `gh` installed but not authenticated, which says `gh auth login` and not "install"; empty token; missing scope named from the response header; rate limited; not found; network unreachable, kept distinct from auth so an outage never tells you to re-login).
- **HTTP client** (`src/github/client.rs`): thin `reqwest` wrapper with release endpoints and pure, header-driven response-error classification.
- **Update check migration** (`src/update/mod.rs`): the one pre-existing direct `api.github.com` caller now flows through the client. Behavior is preserved (the `AOE_UPDATE_API_BASE` test override, 5s timeout, on-disk cache, releases-list to latest fallback, fail-soft fetching).

Dependency decision: stayed `reqwest`-only (already in the tree) rather than adding octocrab, to avoid dep-tree bloat and keep header-level control of the error taxonomy. This was settled in a two-model design debate.

Deferred to follow-ups (no caller yet, and AGENTS.md forbids dead code):

- Device-flow login as the no-`gh`, no-env-token fallback: agent-of-empires/plugin-github#79
- GraphQL, ETag conditional caching, rate-limit backoff: agent-of-empires/agent-of-empires#1679
- Guided scope-elevation re-auth on write failures: agent-of-empires/plugin-github#78
- GitHub Enterprise host derivation: agent-of-empires/agent-of-empires#1668

Closes agent-of-empires/agent-of-empires#1667

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe update --check` and confirm it still prints `current:`, `latest:`, and `available:`. The release check now goes through the new GitHub client, so this proves the client works end to end.
- [ ] With `gh` authenticated and no `GITHUB_TOKEN` set: the auth layer resolves your existing `gh` token with no prompt (foundation only, no GitHub feature is wired to a surface yet; covered by unit tests).
- [ ] With no `GITHUB_TOKEN` and `gh` not installed: the resolver returns the install-or-set-token hint, not a wrong "run gh auth login" message (covered by unit tests).
- [ ] With `gh` installed but signed out: the resolver returns the `gh auth login` hint, not an "install gh" message (covered by unit tests).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: internal refactor of the update HTTP path; covered by Rust unit tests in `src/github/` plus the existing `tests/integration/update_command.rs` fixture.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the design debate, implementation, and this prose were drafted by Claude under my direction. I made the design calls (reqwest-only, defer device flow, migrate the update check), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR establishes a unified GitHub integration foundation that consolidates all GitHub API interactions into a single, reusable backend client with proper authentication and error handling. Previously, GitHub API calls were scattered across the codebase with ad-hoc authentication. This change creates a centralized integration point that both TUI and web backend can use consistently.

## What Was Added

**New GitHub Module** (`src/github/`)
- A complete backend GitHub client library with three core components:
  - **Token Resolution Layer**: Automatically discovers GitHub tokens from environment variables (`GITHUB_TOKEN`, `GH_TOKEN`) or via the GitHub CLI (`gh auth token`), with built-in fallback logic
  - **HTTP Client**: A thin, typed wrapper over the reqwest HTTP library that handles GitHub REST API calls and provides structured release data
  - **Error Handling**: Distinct, actionable error types that differentiate between scenarios like "no token found," "insufficient permissions," "rate limited," etc., enabling appropriate UI messaging

**Documentation**
- New guide (`docs/github-integration.md`) explaining the token resolution order, error handling strategy, and what features are intentionally deferred
- Website navigation updated to include the new GitHub integration reference

## What Changed

**Existing Update Check** (`src/update/mod.rs`)
- Refactored to use the new centralized GitHub client instead of making raw HTTP requests
- Preserved all prior behavior: supports `AOE_UPDATE_API_BASE` override, 5-second timeout, on-disk caching, fallback from release list to latest endpoint, and fail-soft behavior

**Library Exports** (`src/lib.rs`)
- The new `github` module is now exposed as a public API surface for the rest of the application

## Key Benefits

- **Single integration point**: All GitHub API calls now route through one typed client, eliminating scattered ad-hoc integrations
- **Consistent authentication**: Token discovery is centralized and testable, removing duplicated auth logic
- **Better error messaging**: Distinct error types make it possible to surface meaningful guidance to users (e.g., "Please authenticate with `gh auth login`" vs. "Rate limited, try again later")
- **Reduced dependencies**: Retained reqwest instead of adding octocrab, keeping the dependency footprint minimal
- **Unit-testable**: Token resolution is abstracted behind a trait, allowing thorough testing without relying on actual environment or CLI calls
- **Extensible foundation**: Architecture supports future features like device-flow login, GraphQL support, ETag caching, and rate-limit backoff

## Technical Highlights

- Token resolution abstracted via `TokenEnvironment` trait for testability; production uses `SystemEnvironment`
- HTTP error responses classified using status codes and response headers (e.g., `X-Accepted-OAuth-Scopes` for scope detection)
- Comprehensive unit test coverage for token discovery precedence, trimming, CLI error classification, and error type behavior
- Release data normalized into a simple `GitHubRelease` DTO with `tag_name`, `body`, and `published_at` fields

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->