### PR TITLE
feat(tui): user-configurable home-screen keybinds (Global v1, search)

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -155,12 +155,41 @@ fn default_modifiers() -> crossterm::event::KeyModifiers {
     crossterm::event::KeyModifiers::NONE
 }
 
+/// Strip the redundant `SHIFT` bit from a runtime key event when the
+/// code is already an uppercase character. See `KeyBinding::matches`
+/// for the rationale; this is the runtime-side mirror of
+/// `sanitize_modifiers` in `src/tui/dialogs/capture_key.rs`.
+fn normalize_event_modifiers(
+    mods: crossterm::event::KeyModifiers,
+    code: &crossterm::event::KeyCode,
+) -> crossterm::event::KeyModifiers {
+    let mut out = mods;
+    if let crossterm::event::KeyCode::Char(c) = code {
+        if c.is_uppercase() {
+            out.remove(crossterm::event::KeyModifiers::SHIFT);
+        }
+    }
+    out
+}
+
 impl KeyBinding {
     /// True when the given crossterm key event matches this binding,
     /// modifier-exact. Mirrors `bindings.rs::chord_matches` so a
     /// modified key never silently triggers a bare-letter binding.
+    ///
+    /// Cross-platform note: on Windows (and on Linux since crossterm
+    /// 0.29's "Add shift modifier to uppercase char events on unix"
+    /// change) `KeyCode::Char('D') + KeyModifiers::SHIFT` is emitted
+    /// for Shift+letter, while on older Linux/macOS terminals the same
+    /// physical key arrives as `Char('D') + NONE`. The capture dialog
+    /// strips the redundant Shift bit on uppercase chars at storage
+    /// time (`sanitize_modifiers` in `capture_key.rs`), so we apply
+    /// the same normalization to the incoming event before comparing.
+    /// Without this, a binding captured on one platform would silently
+    /// stop matching on the other.
     pub fn matches(&self, event: &crossterm::event::KeyEvent) -> bool {
-        self.key.matches(&event.code) && event.modifiers == self.modifiers
+        self.key.matches(&event.code)
+            && normalize_event_modifiers(event.modifiers, &event.code) == self.modifiers
     }
 
     /// Render the chord as a `Ctrl+/`, `Shift+F5`, `a` style label for
@@ -1811,6 +1840,60 @@ mod tests {
         assert_eq!(config.default_profile, "custom");
         // Other fields should have defaults
         assert!(!config.worktree.enabled);
+    }
+
+    // Tests for KeyBinding cross-platform matching
+    #[test]
+    fn test_keybinding_matches_uppercase_char_with_or_without_shift() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        // Binding captured/stored as "uppercase D with no extra modifiers"
+        // (the capture dialog strips the redundant SHIFT bit at write
+        // time). The runtime event must match whether the underlying
+        // terminal reported the SHIFT bit (Windows / newer Unix crossterm)
+        // or not (older Unix / legacy paths).
+        let binding = KeyBinding {
+            key: KeyCodeRepr::Char('D'),
+            modifiers: KeyModifiers::NONE,
+        };
+        let without_shift = KeyEvent::new(KeyCode::Char('D'), KeyModifiers::NONE);
+        let with_shift = KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT);
+        assert!(binding.matches(&without_shift));
+        assert!(binding.matches(&with_shift));
+    }
+
+    #[test]
+    fn test_keybinding_matches_ctrl_shift_uppercase_normalizes() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        // Ctrl+Shift+D: capture stores `code=Char('D'), mods=CTRL` after
+        // stripping the redundant SHIFT bit. The runtime event from a
+        // crossterm version that includes SHIFT (CTRL|SHIFT) must still
+        // match the stored CTRL-only form.
+        let binding = KeyBinding {
+            key: KeyCodeRepr::Char('D'),
+            modifiers: KeyModifiers::CONTROL,
+        };
+        let ctrl_only = KeyEvent::new(KeyCode::Char('D'), KeyModifiers::CONTROL);
+        let ctrl_with_shift = KeyEvent::new(
+            KeyCode::Char('D'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        );
+        assert!(binding.matches(&ctrl_only));
+        assert!(binding.matches(&ctrl_with_shift));
+    }
+
+    #[test]
+    fn test_keybinding_lowercase_char_modifier_exact() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        // A bare lowercase chord must not silently match the modified
+        // form: a binding on `n` should not fire on Ctrl+n. The
+        // uppercase-normalization only strips redundant SHIFT, never
+        // CTRL or ALT.
+        let binding = KeyBinding {
+            key: KeyCodeRepr::Char('n'),
+            modifiers: KeyModifiers::NONE,
+        };
+        assert!(binding.matches(&KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)));
+        assert!(!binding.matches(&KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL)));
     }
 
     // Tests for ThemeConfig

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -55,6 +55,14 @@ pub struct Config {
     #[serde(default)]
     pub logging: LoggingConfig,
 
+    /// Configurable home-screen keybindings. Defaults reproduce the
+    /// hardcoded bindings (search = `/`, ...) so users without a
+    /// `keybinds` block in their JSON see no change. v1 is Global-only;
+    /// profile overrides are intentionally out of scope (see
+    /// `profile_config.rs`).
+    #[serde(default)]
+    pub keybinds: KeybindsConfig,
+
     /// Environment variables injected into the host command line for every
     /// session spawned at global scope. Entries are `KEY=value`, `KEY=$VAR`
     /// (read VAR from the host env), `KEY=$$literal` (escape a `$`), or
@@ -89,6 +97,246 @@ pub struct ToolSessionConfig {
     /// Only Alt+ single-character bindings are supported.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hotkey: Option<String>,
+}
+
+/// User-rebindable home-screen keymap. v1 (PR-A) ships with `search`
+/// only; remaining home-screen commands (new_session, restart_session,
+/// archive, favorite, snooze, delete, rename, group, settings) land in
+/// PR-B without churning the on-disk format.
+///
+/// Why explicit struct fields per command rather than `HashMap<String,
+/// KeyBinding>`: every command is known at compile time, so the
+/// conflict scan over `HomeKeybindCmd::iter()` is exhaustive and adding
+/// a new command is a deliberate code change rather than a typo in a
+/// JSON key.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct KeybindsConfig {
+    #[serde(default)]
+    pub home: HomeKeybinds,
+}
+
+/// Home-screen keybindings. Each field is the chord that triggers the
+/// named action. v1 (PR-A) lists only `search`; PR-B extends the
+/// struct without breaking the on-disk format.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HomeKeybinds {
+    /// Chord that opens the home-screen incremental search bar. Default
+    /// `/` matches the prior hardcoded binding.
+    #[serde(default = "default_search_binding")]
+    pub search: KeyBinding,
+}
+
+impl Default for HomeKeybinds {
+    fn default() -> Self {
+        Self {
+            search: default_search_binding(),
+        }
+    }
+}
+
+fn default_search_binding() -> KeyBinding {
+    KeyBinding {
+        key: KeyCodeRepr::Char('/'),
+        modifiers: crossterm::event::KeyModifiers::NONE,
+    }
+}
+
+/// A single chord: one printable key (or function key) plus a set of
+/// modifier flags. Serializes through `KeyCodeRepr` for a stable
+/// on-disk form regardless of crossterm's internal layout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeyBinding {
+    pub key: KeyCodeRepr,
+    #[serde(default = "default_modifiers", with = "key_modifiers_serde")]
+    pub modifiers: crossterm::event::KeyModifiers,
+}
+
+fn default_modifiers() -> crossterm::event::KeyModifiers {
+    crossterm::event::KeyModifiers::NONE
+}
+
+impl KeyBinding {
+    /// True when the given crossterm key event matches this binding,
+    /// modifier-exact. Mirrors `bindings.rs::chord_matches` so a
+    /// modified key never silently triggers a bare-letter binding.
+    pub fn matches(&self, event: &crossterm::event::KeyEvent) -> bool {
+        self.key.matches(&event.code) && event.modifiers == self.modifiers
+    }
+
+    /// Render the chord as a `Ctrl+/`, `Shift+F5`, `a` style label for
+    /// the settings UI.
+    pub fn display(&self) -> String {
+        use crossterm::event::KeyModifiers;
+        let mut parts: Vec<&str> = Vec::new();
+        if self.modifiers.contains(KeyModifiers::CONTROL) {
+            parts.push("Ctrl");
+        }
+        if self.modifiers.contains(KeyModifiers::ALT) {
+            parts.push("Alt");
+        }
+        if self.modifiers.contains(KeyModifiers::SHIFT) {
+            parts.push("Shift");
+        }
+        let key = self.key.display();
+        if parts.is_empty() {
+            key
+        } else {
+            format!("{}+{}", parts.join("+"), key)
+        }
+    }
+}
+
+/// Serializable wrapper around `crossterm::event::KeyCode`. Only the
+/// variants the home-screen dispatcher emits are representable; less
+/// common codes (caps lock, media keys, etc.) are intentionally
+/// rejected at the binding layer rather than silently round-tripped.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum KeyCodeRepr {
+    /// A printable character. Stored verbatim, including punctuation
+    /// like `/` and `\\` that the home-screen dispatcher matches today.
+    Char(char),
+    /// A function key (`F1` through `F12`).
+    F(u8),
+    Enter,
+    Tab,
+    BackTab,
+    Backspace,
+    Esc,
+    Insert,
+    Delete,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl KeyCodeRepr {
+    /// True when this representation describes the same logical key as
+    /// the given crossterm `KeyCode`.
+    pub fn matches(&self, code: &crossterm::event::KeyCode) -> bool {
+        use crossterm::event::KeyCode;
+        match (self, code) {
+            (KeyCodeRepr::Char(a), KeyCode::Char(b)) => a == b,
+            (KeyCodeRepr::F(a), KeyCode::F(b)) => a == b,
+            (KeyCodeRepr::Enter, KeyCode::Enter) => true,
+            (KeyCodeRepr::Tab, KeyCode::Tab) => true,
+            (KeyCodeRepr::BackTab, KeyCode::BackTab) => true,
+            (KeyCodeRepr::Backspace, KeyCode::Backspace) => true,
+            (KeyCodeRepr::Esc, KeyCode::Esc) => true,
+            (KeyCodeRepr::Insert, KeyCode::Insert) => true,
+            (KeyCodeRepr::Delete, KeyCode::Delete) => true,
+            (KeyCodeRepr::Home, KeyCode::Home) => true,
+            (KeyCodeRepr::End, KeyCode::End) => true,
+            (KeyCodeRepr::PageUp, KeyCode::PageUp) => true,
+            (KeyCodeRepr::PageDown, KeyCode::PageDown) => true,
+            (KeyCodeRepr::Up, KeyCode::Up) => true,
+            (KeyCodeRepr::Down, KeyCode::Down) => true,
+            (KeyCodeRepr::Left, KeyCode::Left) => true,
+            (KeyCodeRepr::Right, KeyCode::Right) => true,
+            _ => false,
+        }
+    }
+
+    /// Build a `KeyCodeRepr` from a crossterm `KeyCode`. Returns
+    /// `None` for codes the home-screen does not support so the
+    /// capture dialog can reject them with a clear error.
+    pub fn from_code(code: crossterm::event::KeyCode) -> Option<Self> {
+        use crossterm::event::KeyCode;
+        Some(match code {
+            KeyCode::Char(c) => KeyCodeRepr::Char(c),
+            KeyCode::F(n) => KeyCodeRepr::F(n),
+            KeyCode::Enter => KeyCodeRepr::Enter,
+            KeyCode::Tab => KeyCodeRepr::Tab,
+            KeyCode::BackTab => KeyCodeRepr::BackTab,
+            KeyCode::Backspace => KeyCodeRepr::Backspace,
+            KeyCode::Esc => KeyCodeRepr::Esc,
+            KeyCode::Insert => KeyCodeRepr::Insert,
+            KeyCode::Delete => KeyCodeRepr::Delete,
+            KeyCode::Home => KeyCodeRepr::Home,
+            KeyCode::End => KeyCodeRepr::End,
+            KeyCode::PageUp => KeyCodeRepr::PageUp,
+            KeyCode::PageDown => KeyCodeRepr::PageDown,
+            KeyCode::Up => KeyCodeRepr::Up,
+            KeyCode::Down => KeyCodeRepr::Down,
+            KeyCode::Left => KeyCodeRepr::Left,
+            KeyCode::Right => KeyCodeRepr::Right,
+            _ => return None,
+        })
+    }
+
+    /// Human label suitable for the settings UI. Punctuation rounds to
+    /// the literal character; function keys render as `F1`, etc.
+    pub fn display(&self) -> String {
+        match self {
+            KeyCodeRepr::Char(c) => c.to_string(),
+            KeyCodeRepr::F(n) => format!("F{n}"),
+            KeyCodeRepr::Enter => "Enter".to_string(),
+            KeyCodeRepr::Tab => "Tab".to_string(),
+            KeyCodeRepr::BackTab => "BackTab".to_string(),
+            KeyCodeRepr::Backspace => "Backspace".to_string(),
+            KeyCodeRepr::Esc => "Esc".to_string(),
+            KeyCodeRepr::Insert => "Insert".to_string(),
+            KeyCodeRepr::Delete => "Delete".to_string(),
+            KeyCodeRepr::Home => "Home".to_string(),
+            KeyCodeRepr::End => "End".to_string(),
+            KeyCodeRepr::PageUp => "PageUp".to_string(),
+            KeyCodeRepr::PageDown => "PageDown".to_string(),
+            KeyCodeRepr::Up => "Up".to_string(),
+            KeyCodeRepr::Down => "Down".to_string(),
+            KeyCodeRepr::Left => "Left".to_string(),
+            KeyCodeRepr::Right => "Right".to_string(),
+        }
+    }
+}
+
+/// Serde shim for `crossterm::event::KeyModifiers`. Stored as a sorted
+/// list of lowercase names (`["ctrl", "shift"]`) so the on-disk form
+/// is stable and human-readable.
+mod key_modifiers_serde {
+    use crossterm::event::KeyModifiers;
+    use serde::de::Error as DeError;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &KeyModifiers, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut names: Vec<&'static str> = Vec::new();
+        if value.contains(KeyModifiers::CONTROL) {
+            names.push("ctrl");
+        }
+        if value.contains(KeyModifiers::ALT) {
+            names.push("alt");
+        }
+        if value.contains(KeyModifiers::SHIFT) {
+            names.push("shift");
+        }
+        names.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<KeyModifiers, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let names: Vec<String> = Vec::deserialize(deserializer)?;
+        let mut mods = KeyModifiers::NONE;
+        for name in &names {
+            match name.as_str() {
+                "ctrl" | "control" => mods |= KeyModifiers::CONTROL,
+                "alt" => mods |= KeyModifiers::ALT,
+                "shift" => mods |= KeyModifiers::SHIFT,
+                other => {
+                    return Err(D::Error::custom(format!("unknown key modifier: {other}")));
+                }
+            }
+        }
+        Ok(mods)
+    }
 }
 
 /// Persistent logging configuration. Drives the default tracing

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -53,6 +53,13 @@ pub struct ProfileConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cockpit: Option<CockpitConfigOverride>,
 
+    // NOTE: there is intentionally no `keybinds` override field here.
+    // Configurable home-screen keybinds are Global-only for v1; the
+    // settings UI accepts edits only in the Global scope and the
+    // merger never inherits a per-profile keymap. Per-profile
+    // overrides can land later without breaking the on-disk format
+    // by adding `keybinds: Option<KeybindsConfigOverride>` and an
+    // arm to `merge_configs`.
     /// Per-profile override for the host-side `environment` list. When
     /// `Some`, replaces the global list entirely (matching the existing
     /// `sandbox.environment` override semantics). `None` inherits the

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -10,7 +10,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::*;
 use unicode_width::UnicodeWidthStr;
 
-use crate::session::config::SortOrder;
+use crate::session::config::{HomeKeybinds, SortOrder};
 use crate::tui::styles::Theme;
 
 /// Width of the key column, in cells. 11 fits the longest key strings
@@ -30,7 +30,11 @@ const SMALL_VIEWPORT_WIDTH: u16 = 40;
 /// Same idea for height: drop top/bottom margin below this.
 const SMALL_VIEWPORT_HEIGHT: u16 = 16;
 
-fn shortcuts(strict: bool, live_on_enter: bool) -> Vec<(&'static str, Vec<(String, String)>)> {
+fn shortcuts(
+    strict: bool,
+    live_on_enter: bool,
+    keybinds: &HomeKeybinds,
+) -> Vec<(&'static str, Vec<(String, String)>)> {
     use crate::tui::home::bindings::{self, HelpSection as Sec};
 
     let (enter_desc, tab_desc) = if live_on_enter {
@@ -50,9 +54,9 @@ fn shortcuts(strict: bool, live_on_enter: bool) -> Vec<(&'static str, Vec<(Strin
     let mut other: Vec<(String, String)> = Vec::new();
     for b in bindings::BINDINGS {
         let Some(help) = &b.help else { continue };
-        let mut label = bindings::label(b.id, strict);
+        let mut label = bindings::label(b.id, strict, keybinds);
         if label.is_empty() {
-            label = bindings::label(b.id, false);
+            label = bindings::label(b.id, false, keybinds);
         }
         if label.is_empty() {
             continue;
@@ -126,8 +130,13 @@ struct HelpSection {
     rows: Vec<(String, String)>,
 }
 
-fn build_sections(strict: bool, sort_order: SortOrder, live_on_enter: bool) -> Vec<HelpSection> {
-    let raw = shortcuts(strict, live_on_enter);
+fn build_sections(
+    strict: bool,
+    sort_order: SortOrder,
+    live_on_enter: bool,
+    keybinds: &HomeKeybinds,
+) -> Vec<HelpSection> {
+    let raw = shortcuts(strict, live_on_enter, keybinds);
     let sort_label = format!("(current sort: {})", sort_order.label());
     raw.into_iter()
         .map(|(title, keys)| {
@@ -280,6 +289,7 @@ impl HelpOverlay {
     /// clamped to the valid range so that overshoot from input handlers
     /// (for example, treating `End` as `u16::MAX`) is naturally
     /// corrected on the next paint.
+    #[allow(clippy::too_many_arguments)]
     pub fn render(
         frame: &mut Frame,
         area: Rect,
@@ -287,6 +297,7 @@ impl HelpOverlay {
         sort_order: SortOrder,
         strict_hotkeys: bool,
         live_on_enter: bool,
+        keybinds: &HomeKeybinds,
         scroll: &mut u16,
     ) {
         if area.width == 0 || area.height == 0 {
@@ -295,7 +306,7 @@ impl HelpOverlay {
         let dialog_area = compute_dialog_area(area);
         frame.render_widget(Clear, dialog_area);
 
-        let sections = build_sections(strict_hotkeys, sort_order, live_on_enter);
+        let sections = build_sections(strict_hotkeys, sort_order, live_on_enter, keybinds);
 
         let version = format!(" Agent of Empires v{} ", env!("CARGO_PKG_VERSION"));
         let block = Block::default()
@@ -381,7 +392,7 @@ mod tests {
     #[test]
     fn help_contains_resize_shortcut() {
         for strict in [false, true] {
-            let all = shortcuts(strict, false);
+            let all = shortcuts(strict, false, &HomeKeybinds::default());
             let views_section = all.iter().find(|(name, _)| *name == "Views");
             assert!(views_section.is_some(), "Views section should exist");
             let (_, keys) = views_section.unwrap();
@@ -409,7 +420,7 @@ mod tests {
         ];
         for (desc_sub, non_strict_key, strict_key) in cases {
             for (strict, expected_key) in [(false, non_strict_key), (true, strict_key)] {
-                let all = shortcuts(strict, false);
+                let all = shortcuts(strict, false, &HomeKeybinds::default());
                 let found = all.iter().any(|(_, keys)| {
                     keys.iter()
                         .any(|(k, desc)| k == expected_key && desc.contains(desc_sub))
@@ -428,7 +439,7 @@ mod tests {
         // non-strict) but did not advertise it in the help overlay. Lock the
         // listing in so a future binding rename keeps the docs honest.
         for (strict, expected_key) in [(false, "h"), (true, "H")] {
-            let all = shortcuts(strict, false);
+            let all = shortcuts(strict, false, &HomeKeybinds::default());
             let attention = all
                 .iter()
                 .find(|(name, _)| name.starts_with("Attention"))
@@ -448,7 +459,7 @@ mod tests {
         // so users see them together instead of scattered across Navigation
         // and Actions.
         for strict in [false, true] {
-            let all = shortcuts(strict, false);
+            let all = shortcuts(strict, false, &HomeKeybinds::default());
             let attention = all
                 .iter()
                 .find(|(name, _)| name.starts_with("Attention"))
@@ -480,7 +491,7 @@ mod tests {
         // Asserts both keymaps surface the Ctrl+K command palette entry in
         // their "Other" section so users can discover the palette from `?`.
         for strict in [false, true] {
-            let all = shortcuts(strict, false);
+            let all = shortcuts(strict, false, &HomeKeybinds::default());
             let other = all
                 .iter()
                 .find(|(name, _)| *name == "Other")
@@ -501,7 +512,7 @@ mod tests {
         // `default_attach_mode` so the two rows aren't lying.
         for strict in [false, true] {
             for live_on_enter in [false, true] {
-                let all = shortcuts(strict, live_on_enter);
+                let all = shortcuts(strict, live_on_enter, &HomeKeybinds::default());
                 let actions_name = if strict {
                     "Actions (strict mode)"
                 } else {
@@ -599,7 +610,7 @@ mod tests {
         // Sanity check: the chosen 4 → 3 split keeps max column height
         // below the naive [1, 3, 0] alternative that would happen if we
         // pushed all extras to one column.
-        let sections = build_sections(false, SortOrder::Newest, false);
+        let sections = build_sections(false, SortOrder::Newest, false, &HomeKeybinds::default());
         let heights: Vec<usize> = sections.iter().map(section_height).collect();
         let cols = distribute_sections(sections.len(), 3);
         let max_h = cols
@@ -627,7 +638,16 @@ mod tests {
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                HelpOverlay::render(frame, area, &theme, SortOrder::Newest, false, false, scroll);
+                HelpOverlay::render(
+                    frame,
+                    area,
+                    &theme,
+                    SortOrder::Newest,
+                    false,
+                    false,
+                    &HomeKeybinds::default(),
+                    scroll,
+                );
             })
             .unwrap();
         terminal.backend().buffer().clone()

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -14,8 +14,11 @@ use crate::session::config::{HomeKeybinds, SortOrder};
 use crate::tui::styles::Theme;
 
 /// Width of the key column, in cells. 11 fits the longest key strings
-/// in either keymap (`Home/End/G`, `Shift+drag` = 10 cells) with one
-/// cell of padding before the description.
+/// in the stock keymap (`Home/End/G`, `Shift+drag` = 10 cells) with one
+/// cell of padding before the description. Rebinds (via the Keybinds
+/// settings tab) can produce wider chords; `key_field_width` lifts the
+/// floor at runtime so a longer user chord doesn't crash into the
+/// description.
 const KEY_FIELD_WIDTH: usize = 11;
 /// Cells of left indent before each shortcut row.
 const ROW_INDENT: usize = 2;
@@ -154,16 +157,32 @@ fn section_height(section: &HelpSection) -> usize {
     1 + section.rows.len()
 }
 
+/// Effective key-column width for the current section set. Floors at the
+/// `KEY_FIELD_WIDTH` constant so the stock layout is unchanged, but lifts
+/// when a user-configured chord (e.g. `Ctrl+Shift+F1`) is wider than the
+/// static budget. Layout (`min_column_width`) and rendering
+/// (`render_column_lines`) MUST share the same value or the description
+/// column will be misaligned.
+fn key_field_width(sections: &[HelpSection]) -> usize {
+    sections
+        .iter()
+        .flat_map(|s| s.rows.iter().map(|(key, _)| key.width()))
+        .max()
+        .unwrap_or(0)
+        .max(KEY_FIELD_WIDTH)
+}
+
 /// Minimum width a column needs to render every row of every section
 /// without truncating the description.
 fn min_column_width(sections: &[HelpSection]) -> u16 {
+    let key_width = key_field_width(sections);
     let row_width = sections
         .iter()
         .flat_map(|s| s.rows.iter().map(|(_, d)| d.width()))
         .max()
         .unwrap_or(0)
         + ROW_INDENT
-        + KEY_FIELD_WIDTH;
+        + key_width;
     let title_width = sections.iter().map(|s| s.title.width()).max().unwrap_or(0);
     row_width.max(title_width) as u16
 }
@@ -219,6 +238,9 @@ fn render_column_lines(
     indices: &[usize],
     theme: &Theme,
 ) -> Vec<Line<'static>> {
+    // Must agree with `min_column_width` so the description column lines
+    // up with the layout budget; both feed off the same function.
+    let key_width = key_field_width(sections);
     let mut lines: Vec<Line> = Vec::new();
     for (i, &si) in indices.iter().enumerate() {
         let section = &sections[si];
@@ -227,7 +249,7 @@ fn render_column_lines(
             Style::default().fg(theme.accent).bold(),
         )));
         for (key, desc) in &section.rows {
-            let pad = KEY_FIELD_WIDTH.saturating_sub(key.width());
+            let pad = key_width.saturating_sub(key.width());
             let key_cell = format!("{}{}{}", " ".repeat(ROW_INDENT), key, " ".repeat(pad));
             lines.push(Line::from(vec![
                 Span::styled(key_cell, Style::default().fg(theme.waiting)),

--- a/src/tui/dialogs/capture_key.rs
+++ b/src/tui/dialogs/capture_key.rs
@@ -1,0 +1,221 @@
+//! Capture-key dialog: the modal that prompts the user to type a
+//! single chord and returns it via `DialogResult::Submit(KeyBinding)`.
+//!
+//! Used by the Keybinds settings tab. Esc cancels. Bare modifier keys
+//! (`Shift`, `Ctrl`, `Alt` released alone) are ignored so the dialog
+//! stays open until the user types the actual key. Unrepresentable
+//! codes (caps lock, media keys, etc.) surface a status-line error
+//! and the dialog stays open for retry.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+
+use super::DialogResult;
+use crate::session::config::{KeyBinding, KeyCodeRepr};
+use crate::tui::settings::HomeKeybindCmd;
+use crate::tui::styles::Theme;
+
+/// Dialog that captures one keystroke and returns it as a `KeyBinding`.
+/// The owning view runs the conflict scan on `Submit`; if a conflict
+/// is found, the view sets an error via `set_error` and the dialog
+/// stays open for retry.
+pub struct CaptureKeyDialog {
+    command: HomeKeybindCmd,
+    error: Option<String>,
+}
+
+impl CaptureKeyDialog {
+    /// Open a dialog scoped to one command. The command is carried so
+    /// the conflict scan in the parent view can skip the row currently
+    /// being edited.
+    pub fn new(command: HomeKeybindCmd) -> Self {
+        Self {
+            command,
+            error: None,
+        }
+    }
+
+    /// The command this dialog is rebinding. Used by the conflict scan
+    /// to skip the row currently being edited.
+    pub fn command(&self) -> HomeKeybindCmd {
+        self.command
+    }
+
+    /// Surface a one-line error in the dialog. Called by the parent
+    /// view after a conflict-scan rejection.
+    pub fn set_error(&mut self, message: String) {
+        self.error = Some(message);
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<KeyBinding> {
+        // Esc cancels. Treat Esc-with-modifiers the same so a stuck
+        // Shift doesn't trap the user in the dialog.
+        if key.code == KeyCode::Esc {
+            return DialogResult::Cancel;
+        }
+
+        // Bare modifier keys (the user pressed Shift on its own while
+        // reaching for the real key). Ignore so the dialog stays open
+        // waiting for the actual chord.
+        if matches!(
+            key.code,
+            KeyCode::Null
+                | KeyCode::CapsLock
+                | KeyCode::ScrollLock
+                | KeyCode::NumLock
+                | KeyCode::Menu
+                | KeyCode::KeypadBegin
+                | KeyCode::Modifier(_)
+        ) {
+            return DialogResult::Continue;
+        }
+
+        // Reject codes we cannot serialize through `KeyCodeRepr`.
+        // Surface the error and stay open for retry.
+        let Some(repr) = KeyCodeRepr::from_code(key.code) else {
+            self.error = Some(format!(
+                "key not supported: {:?} (try a printable key or Fn)",
+                key.code
+            ));
+            return DialogResult::Continue;
+        };
+
+        DialogResult::Submit(KeyBinding {
+            key: repr,
+            modifiers: sanitize_modifiers(key.modifiers, &key.code),
+        })
+    }
+
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let (width, height) = (60, 9);
+        let dialog_area = super::centered_rect(area, width, height);
+        frame.render_widget(Clear, dialog_area);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .title(format!(" Rebind: {} ", self.command.label()))
+            .title_style(Style::default().fg(theme.accent).bold());
+
+        let inner = block.inner(dialog_area);
+        frame.render_widget(block, dialog_area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints([
+                Constraint::Length(1), // prompt
+                Constraint::Length(1), // spacer
+                Constraint::Length(1), // error or hint
+                Constraint::Min(0),    // spacer
+                Constraint::Length(1), // footer
+            ])
+            .split(inner);
+
+        let prompt = Paragraph::new("Press the key combination to bind, or Esc to cancel.")
+            .style(Style::default().fg(theme.text));
+        frame.render_widget(prompt, chunks[0]);
+
+        let message = match &self.error {
+            Some(err) => Line::from(Span::styled(err.clone(), Style::default().fg(theme.error))),
+            None => Line::from(Span::styled(
+                format!("Default: {}", self.command.default_binding().display()),
+                Style::default().fg(theme.dimmed),
+            )),
+        };
+        frame.render_widget(Paragraph::new(message), chunks[2]);
+
+        let footer = Line::from(vec![
+            Span::styled("Esc", Style::default().fg(theme.accent)),
+            Span::styled(" cancel", Style::default().fg(theme.dimmed)),
+        ]);
+        frame.render_widget(Paragraph::new(footer), chunks[4]);
+    }
+}
+
+/// Drop modifier flags that don't disambiguate a chord. Specifically:
+/// for a `KeyCode::Char(uppercase)` event, terminals deliver the Shift
+/// flag alongside the uppercase code (or, on some legacy paths, only
+/// the uppercase code without the flag). Stripping the redundant
+/// Shift keeps the on-disk form stable across both paths so two users
+/// with different terminals don't see different display strings for
+/// the same logical binding.
+fn sanitize_modifiers(mods: KeyModifiers, code: &KeyCode) -> KeyModifiers {
+    let mut out = mods;
+    if let KeyCode::Char(c) = code {
+        if c.is_uppercase() {
+            out.remove(KeyModifiers::SHIFT);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::settings::HomeKeybindCmd;
+
+    fn key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn esc_cancels() {
+        let mut dialog = CaptureKeyDialog::new(HomeKeybindCmd::Search);
+        let result = dialog.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(matches!(result, DialogResult::Cancel));
+    }
+
+    #[test]
+    fn printable_submits() {
+        let mut dialog = CaptureKeyDialog::new(HomeKeybindCmd::Search);
+        let result = dialog.handle_key(key('\\'));
+        match result {
+            DialogResult::Submit(binding) => {
+                assert_eq!(binding.key, KeyCodeRepr::Char('\\'));
+                assert_eq!(binding.modifiers, KeyModifiers::NONE);
+            }
+            _ => panic!("expected Submit"),
+        }
+    }
+
+    #[test]
+    fn function_key_submits() {
+        let mut dialog = CaptureKeyDialog::new(HomeKeybindCmd::Search);
+        let result = dialog.handle_key(KeyEvent::new(KeyCode::F(5), KeyModifiers::NONE));
+        match result {
+            DialogResult::Submit(binding) => {
+                assert_eq!(binding.key, KeyCodeRepr::F(5));
+            }
+            _ => panic!("expected Submit"),
+        }
+    }
+
+    #[test]
+    fn ctrl_combination_submits_with_modifier() {
+        let mut dialog = CaptureKeyDialog::new(HomeKeybindCmd::Search);
+        let result = dialog.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
+        match result {
+            DialogResult::Submit(binding) => {
+                assert_eq!(binding.key, KeyCodeRepr::Char('s'));
+                assert!(binding.modifiers.contains(KeyModifiers::CONTROL));
+            }
+            _ => panic!("expected Submit"),
+        }
+    }
+
+    #[test]
+    fn uppercase_strips_shift_for_stable_round_trip() {
+        let mut dialog = CaptureKeyDialog::new(HomeKeybindCmd::Search);
+        let result = dialog.handle_key(KeyEvent::new(KeyCode::Char('A'), KeyModifiers::SHIFT));
+        match result {
+            DialogResult::Submit(binding) => {
+                assert_eq!(binding.key, KeyCodeRepr::Char('A'));
+                assert!(!binding.modifiers.contains(KeyModifiers::SHIFT));
+            }
+            _ => panic!("expected Submit"),
+        }
+    }
+}

--- a/src/tui/dialogs/capture_key.rs
+++ b/src/tui/dialogs/capture_key.rs
@@ -95,6 +95,7 @@ impl CaptureKeyDialog {
         let block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
+            .padding(Padding::horizontal(1))
             .border_style(Style::default().fg(theme.accent))
             .title(format!(" Rebind: {} ", self.command.label()))
             .title_style(Style::default().fg(theme.accent).bold());
@@ -104,7 +105,7 @@ impl CaptureKeyDialog {
 
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .margin(1)
+            .margin(0)
             .constraints([
                 Constraint::Length(1), // prompt
                 Constraint::Length(1), // spacer

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -15,6 +15,7 @@ use tui_input::Input;
 use unicode_width::UnicodeWidthStr;
 
 use super::DialogResult;
+use crate::session::config::HomeKeybinds;
 use crate::tui::components::set_prefixed_input_cursor_position;
 use crate::tui::home::bindings::{self, ActionId};
 use crate::tui::styles::Theme;
@@ -86,7 +87,11 @@ pub struct PaletteCommand {
 /// keyboard dispatcher. Pure-navigation keys (j/k, arrows, h/l) are excluded.
 /// `Enter` (attach) and `Tab` (live-send) aren't relocatable keybindings, so
 /// they're appended explicitly rather than pulled from the registry.
-pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<PaletteCommand> {
+pub fn builtin_commands(
+    serve_enabled: bool,
+    strict_hotkeys: bool,
+    keybinds: &HomeKeybinds,
+) -> Vec<PaletteCommand> {
     let mut cmds: Vec<PaletteCommand> = bindings::BINDINGS
         .iter()
         .filter_map(|b| {
@@ -99,7 +104,7 @@ pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<Palett
                 title: meta.title.to_string(),
                 group: meta.group,
                 keywords: meta.keywords.to_vec(),
-                hotkey: bindings::label(b.id, strict_hotkeys),
+                hotkey: bindings::label(b.id, strict_hotkeys, keybinds),
                 payload: PaletteAction::Invoke(b.id),
             })
         })
@@ -489,7 +494,7 @@ mod tests {
     }
 
     fn make_dialog() -> CommandPaletteDialog {
-        CommandPaletteDialog::new(builtin_commands(false, false))
+        CommandPaletteDialog::new(builtin_commands(false, false, &HomeKeybinds::default()))
     }
 
     #[test]
@@ -523,7 +528,7 @@ mod tests {
         // (e.g., moving Tab elsewhere) or accidentally regressing the
         // payload to `Key(Tab)` would break strict-mode users who reach
         // live-send only through the palette.
-        let cmds = builtin_commands(false, false);
+        let cmds = builtin_commands(false, false, &HomeKeybinds::default());
         let entry = cmds
             .iter()
             .find(|c| c.id == "live-send")
@@ -541,7 +546,7 @@ mod tests {
         // `Invoke(ActionId::…)` so `run_action` opens the picker directly.
         // Previously these synthesized `Key('o')` / `Key('g')`, which the
         // strict-mode typing-guard would have swallowed.
-        let cmds = builtin_commands(false, true);
+        let cmds = builtin_commands(false, true, &HomeKeybinds::default());
         let sort = cmds
             .iter()
             .find(|c| c.id == "pick-sort")
@@ -638,8 +643,8 @@ mod tests {
 
     #[test]
     fn serve_command_only_with_feature() {
-        let with = builtin_commands(true, false);
-        let without = builtin_commands(false, false);
+        let with = builtin_commands(true, false, &HomeKeybinds::default());
+        let without = builtin_commands(false, false, &HomeKeybinds::default());
         assert!(with.iter().any(|c| c.id == "serve"));
         assert!(!without.iter().any(|c| c.id == "serve"));
     }
@@ -649,8 +654,8 @@ mod tests {
         // Picks one entry whose label moves under strict mode and one whose
         // binding gets relocated to Ctrl. Catches regressions where strict
         // mode was forgotten when adding a new entry.
-        let normal = builtin_commands(false, false);
-        let strict = builtin_commands(false, true);
+        let normal = builtin_commands(false, false, &HomeKeybinds::default());
+        let strict = builtin_commands(false, true, &HomeKeybinds::default());
 
         let new_normal = normal.iter().find(|c| c.id == "new-session").unwrap();
         let new_strict = strict.iter().find(|c| c.id == "new-session").unwrap();

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -1,5 +1,6 @@
 //! TUI dialog components
 
+mod capture_key;
 mod changelog;
 mod command_palette;
 mod confirm;
@@ -27,6 +28,7 @@ mod sort_picker;
 mod tool_picker;
 mod update_confirm;
 
+pub use capture_key::CaptureKeyDialog;
 pub use changelog::ChangelogDialog;
 pub use command_palette::{
     builtin_commands, CommandPaletteDialog, PaletteAction, PaletteCommand, PaletteGroup,

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -171,11 +171,11 @@ pub fn resolve(
     ctx: &Ctx,
     overrides: &HomeKeybinds,
 ) -> Option<ActionId> {
-    if overrides.search.matches(key) {
-        return Some(ActionId::SearchStart);
-    }
     for b in BINDINGS {
         if b.id == ActionId::SearchStart {
+            if overrides.search.matches(key) {
+                return Some(ActionId::SearchStart);
+            }
             continue;
         }
         let chords = if strict { b.strict } else { b.non_strict };
@@ -913,5 +913,41 @@ mod tests {
         assert_eq!(resolve(&key('/'), false, &c, &b), None);
         // Label reflects the rebound chord.
         assert_eq!(label(ActionId::SearchStart, false, &b), "\\");
+    }
+
+    #[test]
+    fn search_override_yields_to_context_gated_bindings() {
+        // Regression for the bindings.rs:174 precedence bug flagged on
+        // PR #1682: if the user rebinds search to a chord that a
+        // context-gated binding ahead of SearchStart in the BINDINGS
+        // table also owns (e.g. `n` for SearchNext while a search is
+        // active), the context-gated binding must still win. Without
+        // the in-loop override check, rebinding search to `n` made
+        // SearchStart shadow SearchNext during active searches.
+        let mut c = ctx();
+        c.has_search = true;
+        let b = HomeKeybinds {
+            search: KeyBinding {
+                key: KeyCodeRepr::Char('n'),
+                modifiers: KeyModifiers::NONE,
+            },
+        };
+        for strict in [false, true] {
+            assert_eq!(
+                resolve(&key('n'), strict, &c, &b),
+                Some(ActionId::SearchNext),
+                "strict={strict}: SearchNext must beat overridden SearchStart while search is active",
+            );
+        }
+        // Without an active search, the SearchNext context fails, so the
+        // override at SearchStart's table position is reached. SearchStart
+        // is listed ahead of NewSession in BINDINGS so the override wins
+        // over NewSession (an acceptable rebind conflict the user opts
+        // into by picking `n`).
+        c.has_search = false;
+        assert_eq!(
+            resolve(&key('n'), false, &c, &b),
+            Some(ActionId::SearchStart)
+        );
     }
 }

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -24,7 +24,7 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::ViewMode;
-use crate::session::config::SortOrder;
+use crate::session::config::{HomeKeybinds, SortOrder};
 use crate::tui::dialogs::PaletteGroup;
 
 /// Logical action. Each variant is dispatched by `HomeView::run_action`.
@@ -160,8 +160,24 @@ fn context_holds(context: Context, ctx: &Ctx) -> bool {
 /// Resolve a key event to an action, honoring strict mode and context guards.
 /// Returns the first matching binding in table order; context-guarded entries
 /// are listed before the unguarded entries that share their chord.
-pub fn resolve(key: &KeyEvent, strict: bool, ctx: &Ctx) -> Option<ActionId> {
+///
+/// `overrides` carries the user-configurable home-screen keymap. Commands that
+/// appear in `HomeKeybinds` (currently just `search`) are resolved from it and
+/// the matching static `BINDINGS` row is skipped, so a rebind cleanly replaces
+/// the default chord rather than coexisting with it.
+pub fn resolve(
+    key: &KeyEvent,
+    strict: bool,
+    ctx: &Ctx,
+    overrides: &HomeKeybinds,
+) -> Option<ActionId> {
+    if overrides.search.matches(key) {
+        return Some(ActionId::SearchStart);
+    }
     for b in BINDINGS {
+        if b.id == ActionId::SearchStart {
+            continue;
+        }
         let chords = if strict { b.strict } else { b.non_strict };
         if context_holds(b.context, ctx) && chords.iter().any(|c| chord_matches(c, key)) {
             return Some(b.id);
@@ -172,8 +188,13 @@ pub fn resolve(key: &KeyEvent, strict: bool, ctx: &Ctx) -> Option<ActionId> {
 
 /// Human-readable label for a binding's primary chord in the given mode, e.g.
 /// `"D"`, `"Ctrl+D"`, `"F5"`. Returns `""` if the action has no binding in the
-/// requested mode (e.g. `NextWaiting` in strict).
-pub fn label(id: ActionId, strict: bool) -> String {
+/// requested mode (e.g. `NextWaiting` in strict). For commands driven by
+/// `overrides`, the label is rendered from the user's chord so help text and
+/// palette hotkeys reflect the active binding.
+pub fn label(id: ActionId, strict: bool, overrides: &HomeKeybinds) -> String {
+    if id == ActionId::SearchStart {
+        return overrides.search.display();
+    }
     let Some(b) = BINDINGS.iter().find(|b| b.id == id) else {
         return String::new();
     };
@@ -684,12 +705,18 @@ pub fn palette_id(id: ActionId) -> &'static str {
 mod tests {
     use super::*;
 
+    use crate::session::config::{KeyBinding, KeyCodeRepr};
+
     fn ctx() -> Ctx {
         Ctx {
             view_mode: ViewMode::Agent,
             sort_order: SortOrder::Newest,
             has_search: false,
         }
+    }
+
+    fn binds() -> HomeKeybinds {
+        HomeKeybinds::default()
     }
 
     fn key(c: char) -> KeyEvent {
@@ -703,6 +730,7 @@ mod tests {
     #[test]
     fn non_strict_resolution() {
         let c = ctx();
+        let b = binds();
         let cases = [
             ('d', ActionId::Delete),
             ('D', ActionId::Diff),
@@ -720,7 +748,7 @@ mod tests {
         ];
         for (ch, want) in cases {
             assert_eq!(
-                resolve(&key(ch), false, &c),
+                resolve(&key(ch), false, &c, &b),
                 Some(want),
                 "non-strict '{ch}'"
             );
@@ -730,6 +758,7 @@ mod tests {
     #[test]
     fn strict_relocation_is_consistent() {
         let c = ctx();
+        let b = binds();
         // Shift+letter (the uppercase code) drives the primary action; the
         // secondary action moves to Ctrl+letter. No bare lowercase action keys.
         let shifted = [
@@ -741,7 +770,7 @@ mod tests {
             ('O', ActionId::SortPicker),
         ];
         for (ch, want) in shifted {
-            assert_eq!(resolve(&key(ch), true, &c), Some(want), "strict '{ch}'");
+            assert_eq!(resolve(&key(ch), true, &c, &b), Some(want), "strict '{ch}'");
         }
         let ctrled = [
             ('d', ActionId::Diff),
@@ -753,7 +782,7 @@ mod tests {
         ];
         for (ch, want) in ctrled {
             assert_eq!(
-                resolve(&ctrl_key(ch), true, &c),
+                resolve(&ctrl_key(ch), true, &c, &b),
                 Some(want),
                 "strict Ctrl+{ch}"
             );
@@ -764,45 +793,60 @@ mod tests {
     fn strict_bare_lowercase_action_letters_are_unbound() {
         // They fall through to the dispatcher's typing-guard, not an action.
         let c = ctx();
+        let b = binds();
         for ch in [
             'd', 'r', 't', 'n', 'p', 's', 'x', 'm', 'e', 'i', 'z', 'g', 'o',
         ] {
-            assert_eq!(resolve(&key(ch), true, &c), None, "strict bare '{ch}'");
+            assert_eq!(resolve(&key(ch), true, &c, &b), None, "strict bare '{ch}'");
         }
     }
 
     #[test]
     fn search_cycle_overrides_new_session_when_active() {
         let mut c = ctx();
+        let b = binds();
         c.has_search = true;
         for strict in [false, true] {
-            assert_eq!(resolve(&key('n'), strict, &c), Some(ActionId::SearchNext));
-            assert_eq!(resolve(&key('N'), strict, &c), Some(ActionId::SearchPrev));
+            assert_eq!(
+                resolve(&key('n'), strict, &c, &b),
+                Some(ActionId::SearchNext)
+            );
+            assert_eq!(
+                resolve(&key('N'), strict, &c, &b),
+                Some(ActionId::SearchPrev)
+            );
         }
         // Without an active search, the same keys are new-session actions.
         c.has_search = false;
-        assert_eq!(resolve(&key('n'), false, &c), Some(ActionId::NewSession));
-        assert_eq!(resolve(&key('N'), true, &c), Some(ActionId::NewSession));
+        assert_eq!(
+            resolve(&key('n'), false, &c, &b),
+            Some(ActionId::NewSession)
+        );
+        assert_eq!(resolve(&key('N'), true, &c, &b), Some(ActionId::NewSession));
     }
 
     #[test]
     fn context_guards_gate_attention_and_terminal_actions() {
+        let b = binds();
         // Favorite/snooze only resolve in Attention sort.
         let mut c = ctx();
-        assert_eq!(resolve(&key('f'), false, &c), None);
+        assert_eq!(resolve(&key('f'), false, &c, &b), None);
         c.sort_order = SortOrder::Attention;
         assert_eq!(
-            resolve(&key('f'), false, &c),
+            resolve(&key('f'), false, &c, &b),
             Some(ActionId::ToggleFavorite)
         );
-        assert_eq!(resolve(&key('h'), false, &c), Some(ActionId::ToggleSnooze));
+        assert_eq!(
+            resolve(&key('h'), false, &c, &b),
+            Some(ActionId::ToggleSnooze)
+        );
 
         // Container toggle only resolves in Terminal view.
         let mut c = ctx();
-        assert_eq!(resolve(&key('c'), false, &c), None);
+        assert_eq!(resolve(&key('c'), false, &c, &b), None);
         c.view_mode = ViewMode::Terminal;
         assert_eq!(
-            resolve(&key('c'), false, &c),
+            resolve(&key('c'), false, &c, &b),
             Some(ActionId::ToggleContainer)
         );
     }
@@ -810,26 +854,64 @@ mod tests {
     #[test]
     fn ctrl_o_sorts_in_both_modes() {
         let c = ctx();
+        let b = binds();
         assert_eq!(
-            resolve(&ctrl_key('o'), false, &c),
+            resolve(&ctrl_key('o'), false, &c, &b),
             Some(ActionId::SortPicker)
         );
         assert_eq!(
-            resolve(&ctrl_key('o'), true, &c),
+            resolve(&ctrl_key('o'), true, &c, &b),
             Some(ActionId::SortPicker)
         );
     }
 
     #[test]
     fn labels_match_mode() {
-        assert_eq!(label(ActionId::Diff, false), "D");
-        assert_eq!(label(ActionId::Diff, true), "Ctrl+D");
-        assert_eq!(label(ActionId::Delete, true), "D");
-        assert_eq!(label(ActionId::Projects, false), "p");
-        assert_eq!(label(ActionId::Projects, true), "P");
-        assert_eq!(label(ActionId::Profiles, true), "Ctrl+P");
-        assert_eq!(label(ActionId::Restart, false), "e");
+        let b = binds();
+        assert_eq!(label(ActionId::Diff, false, &b), "D");
+        assert_eq!(label(ActionId::Diff, true, &b), "Ctrl+D");
+        assert_eq!(label(ActionId::Delete, true, &b), "D");
+        assert_eq!(label(ActionId::Projects, false, &b), "p");
+        assert_eq!(label(ActionId::Projects, true, &b), "P");
+        assert_eq!(label(ActionId::Profiles, true, &b), "Ctrl+P");
+        assert_eq!(label(ActionId::Restart, false, &b), "e");
         // NextWaiting has no strict binding.
-        assert_eq!(label(ActionId::NextWaiting, true), "");
+        assert_eq!(label(ActionId::NextWaiting, true, &b), "");
+    }
+
+    #[test]
+    fn search_default_resolves_slash_and_skips_static_row() {
+        let c = ctx();
+        let b = binds();
+        // Default `/` still triggers search (override carries the default).
+        assert_eq!(
+            resolve(&key('/'), false, &c, &b),
+            Some(ActionId::SearchStart)
+        );
+        assert_eq!(
+            resolve(&key('/'), true, &c, &b),
+            Some(ActionId::SearchStart)
+        );
+        assert_eq!(label(ActionId::SearchStart, false, &b), "/");
+    }
+
+    #[test]
+    fn search_override_replaces_default_chord() {
+        let c = ctx();
+        let b = HomeKeybinds {
+            search: KeyBinding {
+                key: KeyCodeRepr::Char('\\'),
+                modifiers: KeyModifiers::NONE,
+            },
+        };
+        // Rebound chord triggers search.
+        assert_eq!(
+            resolve(&key('\\'), false, &c, &b),
+            Some(ActionId::SearchStart)
+        );
+        // The old `/` no longer triggers SearchStart (static row is skipped).
+        assert_eq!(resolve(&key('/'), false, &c, &b), None);
+        // Label reflects the rebound chord.
+        assert_eq!(label(ActionId::SearchStart, false, &b), "\\");
     }
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1800,7 +1800,7 @@ impl HomeView {
             sort_order: self.sort_order,
             has_search: !self.search_matches.is_empty(),
         };
-        if let Some(id) = bindings::resolve(&key, self.strict_hotkeys, &ctx) {
+        if let Some(id) = bindings::resolve(&key, self.strict_hotkeys, &ctx, &self.home_keybinds) {
             return self.run_action(id, update_info);
         }
 
@@ -2213,7 +2213,8 @@ impl HomeView {
 
     fn open_command_palette(&mut self) {
         let serve_enabled = cfg!(feature = "serve");
-        let mut entries: Vec<PaletteCommand> = builtin_commands(serve_enabled, self.strict_hotkeys);
+        let mut entries: Vec<PaletteCommand> =
+            builtin_commands(serve_enabled, self.strict_hotkeys, &self.home_keybinds);
 
         // Quit lives in the registry but is excluded from `builtin_commands`
         // (no palette metadata) so it can sit in the Settings group at the end;
@@ -2223,7 +2224,7 @@ impl HomeView {
             title: "Quit Agent of Empires".to_string(),
             group: PaletteGroup::Settings,
             keywords: vec!["exit", "close"],
-            hotkey: bindings::label(ActionId::Quit, self.strict_hotkeys),
+            hotkey: bindings::label(ActionId::Quit, self.strict_hotkeys, &self.home_keybinds),
             payload: PaletteAction::Invoke(ActionId::Quit),
         });
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -567,6 +567,11 @@ pub struct HomeView {
     // dictation / stray keystrokes triggering destructive actions).
     pub(super) strict_hotkeys: bool,
 
+    /// User-configurable home-screen keymap. Drives `bindings::resolve` for
+    /// rebindable commands (currently `search`). Re-read from config on
+    /// settings save via `refresh_from_config`.
+    pub(super) home_keybinds: crate::session::config::HomeKeybinds,
+
     // When true, pressing `q` to leave the home screen shows a quit
     // confirmation first (guards against accidental exits, #1569).
     pub(super) confirm_before_quit: bool,
@@ -729,6 +734,7 @@ impl HomeView {
             .cloned()
             .unwrap_or_else(|| resolved.status_hooks.clone());
         let strict_hotkeys = resolved.session.strict_hotkeys;
+        let home_keybinds = resolved.keybinds.home.clone();
         let confirm_before_quit = resolved.session.confirm_before_quit;
         let idle_decay_window =
             crate::tui::styles::idle_decay_window(resolved.theme.idle_decay_minutes);
@@ -852,6 +858,7 @@ impl HomeView {
             status_hook_config,
             status_hook_configs,
             strict_hotkeys,
+            home_keybinds,
             confirm_before_quit,
             active_tui_count: 1,
             idle_decay_window,
@@ -3739,6 +3746,7 @@ impl HomeView {
         self.status_hook_config = config.status_hooks.clone();
         self.refresh_status_hook_config_cache();
         self.strict_hotkeys = config.session.strict_hotkeys;
+        self.home_keybinds = config.keybinds.home.clone();
         self.confirm_before_quit = config.session.confirm_before_quit;
         self.row_tag_mode = config.session.row_tag;
         self.profile_default_attach_mode = config.session.default_attach_mode;

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -551,6 +551,7 @@ impl HomeView {
                 self.sort_order,
                 self.strict_hotkeys,
                 live_on_enter,
+                &self.home_keybinds,
                 &mut self.help_scroll,
             );
         }

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -1,5 +1,6 @@
 //! Setting field definitions and config mapping
 
+use crate::session::config::{HomeKeybinds, KeyBinding};
 use crate::session::{
     validate_check_interval, validate_snooze_duration, Config, ContainerRuntimeName,
     DefaultTerminalMode, ProfileConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode,
@@ -16,6 +17,7 @@ use super::SettingsScope;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingsCategory {
     Theme,
+    Keybinds,
     Updates,
     Worktree,
     Sandbox,
@@ -35,6 +37,7 @@ impl SettingsCategory {
     pub fn label(&self) -> &'static str {
         match self {
             Self::Theme => "Theme",
+            Self::Keybinds => "Keybinds",
             Self::Updates => "Updates",
             Self::Worktree => "Worktree",
             Self::Sandbox => "Sandbox",
@@ -50,6 +53,83 @@ impl SettingsCategory {
             Self::Logging => "Logging",
         }
     }
+}
+
+/// Home-screen commands eligible for user rebinding. v1 (PR-A) ships
+/// with `search` only; PR-B adds the remaining home-screen commands.
+/// `iter()` drives the conflict scan and the settings UI's field
+/// builder; adding a new command requires extending both `iter()` and
+/// `as_field_name()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HomeKeybindCmd {
+    Search,
+}
+
+impl HomeKeybindCmd {
+    /// Ordered list of every command for the settings UI and the
+    /// conflict scan. PR-B will append the remaining variants.
+    pub fn iter() -> &'static [HomeKeybindCmd] {
+        &[HomeKeybindCmd::Search]
+    }
+
+    /// Display label for the command's settings row. Title-case so the
+    /// row reads like `Search` rather than `search`.
+    pub fn label(self) -> &'static str {
+        match self {
+            HomeKeybindCmd::Search => "Search",
+        }
+    }
+
+    /// One-line help text shown beneath the row in the settings UI.
+    pub fn description(self) -> &'static str {
+        match self {
+            HomeKeybindCmd::Search => "Chord that opens the home-screen incremental search bar.",
+        }
+    }
+
+    /// Default chord. Matches the prior hardcoded binding so users
+    /// who never visit the settings tab see no behavior change.
+    pub fn default_binding(self) -> KeyBinding {
+        match self {
+            HomeKeybindCmd::Search => KeyBinding {
+                key: crate::session::config::KeyCodeRepr::Char('/'),
+                modifiers: crossterm::event::KeyModifiers::NONE,
+            },
+        }
+    }
+
+    /// Fetch the current binding from the home keymap.
+    pub fn get(self, home: &HomeKeybinds) -> &KeyBinding {
+        match self {
+            HomeKeybindCmd::Search => &home.search,
+        }
+    }
+
+    /// Store the new binding into the home keymap.
+    pub fn set(self, home: &mut HomeKeybinds, value: KeyBinding) {
+        match self {
+            HomeKeybindCmd::Search => home.search = value,
+        }
+    }
+}
+
+/// Conflict-scan: returns the command (if any) already bound to
+/// `candidate`, excluding `skip` (the command currently being
+/// rebound). Used by the capture dialog to refuse a collision.
+pub(crate) fn find_conflict(
+    keymap: &HomeKeybinds,
+    candidate: &KeyBinding,
+    skip: HomeKeybindCmd,
+) -> Option<HomeKeybindCmd> {
+    for cmd in HomeKeybindCmd::iter() {
+        if *cmd == skip {
+            continue;
+        }
+        if cmd.get(keymap) == candidate {
+            return Some(*cmd);
+        }
+    }
+    None
 }
 
 /// Type-safe field identifiers (prevents typos in string matching)
@@ -175,6 +255,11 @@ pub enum FieldKey {
     /// multiple section markers in one category are disambiguated by
     /// the label string on the parent `SettingField`.
     SectionMarker,
+    /// Configurable home-screen keybinding. Carries the command so the
+    /// apply path can write to the correct field on `HomeKeybinds`
+    /// without depending on the row's display label. v1 is Global-only;
+    /// the profile-apply pathway no-ops these keys.
+    Keybind(HomeKeybindCmd),
 }
 
 /// Map `UpdateCheckMode` to the Select index used by the settings TUI.
@@ -243,6 +328,7 @@ fn value_display_string(value: &FieldValue) -> String {
         FieldValue::List(items) => format!("[{} items]", items.len()),
         FieldValue::OptionalText(v) => v.clone().unwrap_or_else(|| "(empty)".to_string()),
         FieldValue::SectionHeader => String::new(),
+        FieldValue::KeyBinding { current, .. } => current.display(),
     }
 }
 
@@ -295,6 +381,13 @@ pub enum FieldValue {
     /// handlers skip cursor navigation past entries carrying this
     /// variant; apply / clear pathways no-op for them.
     SectionHeader,
+    /// Configurable home-screen keybinding. The row displays the
+    /// `current` chord plus the `default` chord for reference; Enter
+    /// opens the capture dialog so the user can type a replacement.
+    KeyBinding {
+        current: KeyBinding,
+        default: KeyBinding,
+    },
 }
 
 /// A setting field with metadata
@@ -367,6 +460,7 @@ pub fn build_fields_for_category(
 ) -> Vec<SettingField> {
     match category {
         SettingsCategory::Theme => build_theme_fields(scope, global, profile),
+        SettingsCategory::Keybinds => build_keybinds_fields(global),
         SettingsCategory::Updates => build_updates_fields(scope, global, profile),
         SettingsCategory::Worktree => build_worktree_fields(scope, global, profile),
         SettingsCategory::Sandbox => build_sandbox_fields(scope, global, profile),
@@ -381,6 +475,30 @@ pub fn build_fields_for_category(
         SettingsCategory::Cockpit => build_cockpit_fields(scope, global, profile),
         SettingsCategory::Logging => build_logging_fields(global),
     }
+}
+
+/// Build the rows of the `Keybinds` settings tab. v1 (PR-A) emits one
+/// row per `HomeKeybindCmd` variant; the row's value carries both the
+/// active chord and the default so the renderer can show
+/// `Search    /    (default: /)` without a second config lookup.
+fn build_keybinds_fields(global: &Config) -> Vec<SettingField> {
+    let home = &global.keybinds.home;
+    HomeKeybindCmd::iter()
+        .iter()
+        .copied()
+        .map(|cmd| SettingField {
+            key: FieldKey::Keybind(cmd),
+            label: cmd.label(),
+            description: cmd.description(),
+            value: FieldValue::KeyBinding {
+                current: cmd.get(home).clone(),
+                default: cmd.default_binding(),
+            },
+            category: SettingsCategory::Keybinds,
+            has_override: false,
+            inherited_display: None,
+        })
+        .collect()
 }
 
 const LOG_LEVEL_OPTIONS: &[&str] = &["trace", "debug", "info", "warn", "error"];
@@ -2870,6 +2988,12 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::SessionIdPollerMaxThreads, FieldValue::Number(v)) => {
             config.session.session_id_poller_max_threads = (*v).clamp(1, u32::MAX as u64) as u32;
         }
+        // Keybinds: write the new chord into the global keymap. The
+        // capture dialog has already verified the candidate is
+        // conflict-free, so this is a straight store.
+        (FieldKey::Keybind(cmd), FieldValue::KeyBinding { current, .. }) => {
+            cmd.set(&mut config.keybinds.home, current.clone());
+        }
         _ => {}
     }
 }
@@ -3354,6 +3478,11 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
             // the list as the profile-scope replacement of the global list.
             config.environment = if v.is_empty() { None } else { Some(v.clone()) };
         }
+        // Keybinds are Global-only for v1; the profile-apply path
+        // intentionally no-ops so a stray Enter from the user does
+        // not silently create a per-profile keymap that the merger
+        // would not consult.
+        (FieldKey::Keybind(_), _) => {}
         _ => {}
     }
 }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -6,6 +6,7 @@ use tui_input::Input;
 
 use crate::tui::dialogs::{CustomInstructionDialog, DialogResult};
 
+use super::fields::find_conflict;
 use super::{FieldKey, FieldValue, ListEditState, SettingsFocus, SettingsScope, SettingsView};
 
 /// Result of handling a key event in the settings view
@@ -44,6 +45,52 @@ impl SettingsView {
                 }
                 DialogResult::Cancel => {
                     self.custom_instruction_dialog = None;
+                    return SettingsAction::Continue;
+                }
+                DialogResult::Continue => {
+                    return SettingsAction::Continue;
+                }
+            }
+        }
+
+        // Handle the capture-key dialog. The dialog returns the new
+        // chord on Submit; the outer handler runs the conflict scan
+        // against the in-memory `global_config.keybinds.home` and
+        // either commits or re-arms the dialog with an error.
+        if let Some(ref mut dialog) = self.capture_key_dialog {
+            match dialog.handle_key(key) {
+                DialogResult::Submit(candidate) => {
+                    let cmd = dialog.command();
+                    if let Some(conflict) =
+                        find_conflict(&self.global_config.keybinds.home, &candidate, cmd)
+                    {
+                        // Re-arm the dialog with a status-line error so the
+                        // user can retype without losing the modal.
+                        if let Some(d) = self.capture_key_dialog.as_mut() {
+                            d.set_error(format!(
+                                "'{}' is already bound to \"{}\"",
+                                candidate.display(),
+                                conflict.label()
+                            ));
+                        }
+                        return SettingsAction::Continue;
+                    }
+                    // Commit: write the new chord into both the field
+                    // value (so the row redraws) and the global config
+                    // (so save persists it on Ctrl+s).
+                    let field = &mut self.fields[self.selected_field];
+                    if let FieldValue::KeyBinding {
+                        ref mut current, ..
+                    } = field.value
+                    {
+                        *current = candidate;
+                    }
+                    self.apply_field_to_config(self.selected_field);
+                    self.capture_key_dialog = None;
+                    return SettingsAction::Continue;
+                }
+                DialogResult::Cancel => {
+                    self.capture_key_dialog = None;
                     return SettingsAction::Continue;
                 }
                 DialogResult::Continue => {
@@ -320,6 +367,17 @@ impl SettingsView {
                             // never land the cursor here in the first
                             // place; this arm just makes the match
                             // exhaustive.
+                        }
+                        FieldValue::KeyBinding { .. } => {
+                            // Open the capture-key dialog. The dialog
+                            // is responsible for the conflict scan; on
+                            // submit it returns the new chord and the
+                            // outer handler writes it to the field
+                            // value plus the global config.
+                            if let FieldKey::Keybind(cmd) = field.key {
+                                self.capture_key_dialog =
+                                    Some(crate::tui::dialogs::CaptureKeyDialog::new(cmd));
+                            }
                         }
                     }
                 } else if self.focus == SettingsFocus::Categories {
@@ -1065,7 +1123,8 @@ impl SettingsView {
             | FieldKey::LoggingMaxSizeMib
             | FieldKey::LoggingKeepCount
             | FieldKey::LoggingShowSpans
-            | FieldKey::SessionIdPollerMaxThreads => {}
+            | FieldKey::SessionIdPollerMaxThreads
+            | FieldKey::Keybind(_) => {}
             FieldKey::HostEnvironment => {
                 config.environment = None;
             }
@@ -1155,6 +1214,7 @@ impl SettingsView {
         if self.editing_input.is_some()
             || self.list_edit_state.is_some()
             || self.custom_instruction_dialog.is_some()
+            || self.capture_key_dialog.is_some()
             || self.show_help
             || self.search_input.is_some()
         {
@@ -1219,6 +1279,7 @@ impl SettingsView {
         let suppress = self.editing_input.is_some()
             || self.list_edit_state.is_some()
             || self.custom_instruction_dialog.is_some()
+            || self.capture_key_dialog.is_some()
             || self.show_help
             || self.search_input.is_some();
         let new_pos = if suppress { None } else { Some((col, row)) };
@@ -1523,13 +1584,18 @@ mod tests {
         fn category_nav_skips_section_dividers() {
             use crate::tui::settings::CategoryRow;
             let (_t, mut view) = fresh_view();
-            // Constructor lands on the first Tab (Theme, the only tab
-            // in Appearance). One Down should jump over the next
-            // section header ("Sessions") and onto Session.
+            // Constructor lands on the first Tab (Theme). Walk Down
+            // through Appearance's tabs, then verify the next Down skips
+            // the "Sessions" section header onto Session.
             let start = view.selected_category;
             assert!(
                 matches!(view.categories[start], CategoryRow::Tab(_)),
                 "initial selected_category must be a Tab"
+            );
+            assert_eq!(
+                view.current_category(),
+                crate::tui::settings::SettingsCategory::Theme,
+                "initial category must be Theme"
             );
             press(&mut view, KeyCode::Down);
             assert!(
@@ -1538,16 +1604,32 @@ mod tests {
             );
             assert_eq!(
                 view.current_category(),
-                crate::tui::settings::SettingsCategory::Session,
-                "Down from Theme should land on Session, skipping the Sessions section header"
+                crate::tui::settings::SettingsCategory::Keybinds,
+                "Down from Theme should land on Keybinds, the next tab in Appearance"
             );
-            // Going back up should return to Theme, skipping the
-            // Appearance section header.
+            press(&mut view, KeyCode::Down);
+            assert!(
+                matches!(view.categories[view.selected_category], CategoryRow::Tab(_)),
+                "after second Down, selected_category must still point at a Tab"
+            );
+            assert_eq!(
+                view.current_category(),
+                crate::tui::settings::SettingsCategory::Session,
+                "Down from Keybinds should land on Session, skipping the Sessions section header"
+            );
+            // Going back up should return to Keybinds, then Theme, skipping
+            // the Appearance section header.
+            press(&mut view, KeyCode::Up);
+            assert_eq!(
+                view.current_category(),
+                crate::tui::settings::SettingsCategory::Keybinds,
+                "Up from Session should return to Keybinds, skipping the Sessions section header"
+            );
             press(&mut view, KeyCode::Up);
             assert_eq!(
                 view.current_category(),
                 crate::tui::settings::SettingsCategory::Theme,
-                "Up from Session should return to Theme, skipping the Sessions/Appearance headers"
+                "Up from Keybinds should return to Theme, skipping the Appearance header"
             );
         }
 

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -286,7 +286,13 @@ impl SettingsView {
 
         push_section(&mut rows, "Appearance");
         push_tab(&mut rows, SettingsCategory::Theme);
-        push_tab(&mut rows, SettingsCategory::Keybinds);
+        // Keybinds are global-only in v1: the non-Global apply path no-ops
+        // FieldKey::Keybind (see src/tui/settings/fields.rs), so showing the
+        // tab in Profile / Repo scope would let users edit and save with no
+        // persisted effect.
+        if scope == SettingsScope::Global {
+            push_tab(&mut rows, SettingsCategory::Keybinds);
+        }
 
         push_section(&mut rows, "Sessions");
         push_tab(&mut rows, SettingsCategory::Session);
@@ -566,6 +572,7 @@ impl SettingsView {
         self.editing_input.is_some()
             || self.list_edit_state.is_some()
             || self.custom_instruction_dialog.is_some()
+            || self.capture_key_dialog.is_some()
             || self.search_input.is_some()
     }
 

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -11,9 +11,9 @@ use crate::session::{
     repo_config_to_profile, save_config, save_profile_config, save_repo_config, Config,
     ProfileConfig, RepoConfig,
 };
-use crate::tui::dialogs::CustomInstructionDialog;
+use crate::tui::dialogs::{CaptureKeyDialog, CustomInstructionDialog};
 
-pub use fields::{FieldKey, FieldValue, SettingField, SettingsCategory};
+pub use fields::{FieldKey, FieldValue, HomeKeybindCmd, SettingField, SettingsCategory};
 pub use input::SettingsAction;
 
 /// Which scope of settings is being edited
@@ -125,6 +125,12 @@ pub struct SettingsView {
 
     /// Custom instruction editor dialog
     pub(super) custom_instruction_dialog: Option<CustomInstructionDialog>,
+
+    /// Capture-key dialog for the configurable home-screen keybinds.
+    /// Opened by pressing Enter on a `FieldValue::KeyBinding` row;
+    /// drains and dispatches to `handle_capture_key` on every keystroke
+    /// while present.
+    pub(super) capture_key_dialog: Option<CaptureKeyDialog>,
 
     /// Scroll offset for the fields panel (in lines)
     pub(super) fields_scroll_offset: u16,
@@ -239,6 +245,7 @@ impl SettingsView {
             editing_input: None,
             list_edit_state: None,
             custom_instruction_dialog: None,
+            capture_key_dialog: None,
             fields_scroll_offset: 0,
             fields_viewport_height: 0,
             fields_content_width: 0,
@@ -279,6 +286,7 @@ impl SettingsView {
 
         push_section(&mut rows, "Appearance");
         push_tab(&mut rows, SettingsCategory::Theme);
+        push_tab(&mut rows, SettingsCategory::Keybinds);
 
         push_section(&mut rows, "Sessions");
         push_tab(&mut rows, SettingsCategory::Session);

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -692,6 +692,14 @@ impl SettingsView {
             FieldValue::List(items) => {
                 self.render_list_field(frame, value_area, items, index, is_selected, theme);
             }
+            FieldValue::KeyBinding { current, default } => {
+                let display = if current == default {
+                    current.display()
+                } else {
+                    format!("{}  (default: {})", current.display(), default.display())
+                };
+                self.render_text_field(frame, value_area, &display, index, is_selected, theme);
+            }
             FieldValue::SectionHeader => {
                 // Already handled by the early return at the top of
                 // render_field; reaching this arm would mean the early


### PR DESCRIPTION
## Description

Adds user-configurable home-screen keybinds on top of the new declarative
`BINDINGS` registry from #1610, following the direction in #1606
(don't change defaults, make them configurable, validate against conflicts,
expose in the Settings TUI).

v1 ships exactly one user-facing rebindable command — the home-screen
search trigger — plus the storage format, dispatch wiring, and the
"Keybinds" Settings tab. Remaining home-screen commands land in a
follow-up so reviewers can audit the framework in isolation.

**Storage** — `config.keybinds.home` is a struct of named fields (one per
rebindable command), not a `HashMap<String, _>`, so every command is known
at compile time and the conflict scan over `HomeKeybindCmd::iter()` is
exhaustive. `KeyBinding` serializes through `KeyCodeRepr` (adjacent-tagged
enum) for a stable on-disk form across crossterm versions, and roundtrips
through both JSON and TOML.

**Dispatch** — `home::bindings::resolve()` and `label()` take a
`&HomeKeybinds` overrides arg. When a command is overridden, the user
chord wins and the matching static `BINDINGS` row is skipped, so a rebind
cleanly replaces the default rather than coexisting with it. Help overlay
and command palette pull through the same override-aware `label()`.

**UI** — new Settings tab "Keybinds" under Appearance. Each command renders
as `name : chord` with Enter opening a chord-capture dialog. The dialog
enforces conflict detection across the full `HomeKeybindCmd` set.

**Defaults preserved** — without a `keybinds` block in config, behavior is
identical to current upstream main. No user is forced into a new keymap.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: framework-only PR with full unit coverage at the `bindings::resolve`, `KeyBinding` serde, and Settings-tab-walk layers; PR-B will add an e2e flow that rebinds search and re-exercises the dispatch path end-to-end.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code, with human review of every diff and test before commit.

**Any Additional AI Details you'd like to share:**

The framework structure (named fields per command, adjacent-tagged enum
for `KeyCodeRepr`, override-aware `resolve`/`label`) was designed against
the constraints from #1606 (no default change, exhaustive conflict check,
visible in Settings) and the registry shape introduced by #1610. All
behavior is unit-tested, including TOML/JSON roundtrip and the
Theme → Keybinds → Session category-walk in the Settings tab list.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds user-configurable home-screen keybindings and a Settings TUI to view and rebind them. Defaults are preserved when no config is present; v1 exposes a single rebindable home-screen command (search) and implements storage, dispatch wiring, validation, and UI capture. Remaining home-screen commands will be added in follow-ups.

### What changed (high-level)
- New global keybinds configuration serialized in a stable format (JSON/TOML); omitting it keeps defaults.
- Settings UI: new "Keybinds" tab (Appearance → Global) listing rebindable commands; Enter opens a capture dialog.
- Capture dialog: modal to record a chord, validates supported keys, strips redundant Shift for uppercase chars, and prevents conflicts.
- Runtime dispatch and labels: home-screen resolving and label rendering now accept active HomeKeybinds overrides so user chords replace defaults and UI shows configured hotkeys.
- Help overlay and command palette display user-configured bindings and adjust layout to accommodate wider labels.
- Home view caches active keybinds and refreshes from config.
- Tests: unit coverage for matching/serde/resolve/Settings-tab walk; e2e rebind flows deferred to follow-ups.

### Benefits
- Enables non-technical users to rebind keys via the UI.
- Preserves backward compatibility and avoids surprising changes by keeping defaults unless overridden.
- Prevents conflicting bindings with immediate validation.
- Stable on-disk representation and cross-platform normalization for consistent behavior.

### Potential areas for follow-up
- Expand v1 Global-only scope to per-profile or repo-scoped keybind overrides.
- Add remaining home-screen commands to the rebindable set.
- End-to-end integration tests exercising UI capture → persist → runtime behavior.
- Consider ergonomics refinements for multi-key chords and more descriptive conflict resolution UX.

---

## Technical details

Storage
- Adds KeybindsConfig → HomeKeybinds → KeyBinding; KeyBinding stores KeyCodeRepr + KeyModifiers.
- KeyCodeRepr enumerates supported key codes and converts from crossterm::event::KeyCode; KeyModifiers serialized as a sorted lowercase list.

Dispatch & labels
- home::bindings::resolve(key, strict, ctx, overrides) and label(id, strict, overrides) accept HomeKeybinds to apply overrides.
- When a command is overridden, its static binding row is skipped so the user chord fully replaces the default.

UI
- New CaptureKeyDialog modal (src/tui/dialogs/capture_key.rs) with validation, error display, and Shift-stripping logic for uppercase characters.
- Settings plumbing: HomeKeybindCmd enum, FieldKey::Keybind, FieldValue::KeyBinding and build_keybinds_fields to render/edit entries.
- SettingsView holds optional capture_key_dialog state and applies changes only to Global config; profile/repo apply is a no-op for keybinds.
- Help overlay computes key_field_width from active labels; command palette and other dialogs take &HomeKeybinds to render labels.

Validation & tests
- Conflict detection via find_conflict scanning HomeKeybindCmd::iter().
- Unit tests added for resolve/label behavior, KeyBinding serde/matching, capture dialog behaviors, and Settings fields traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->