### PR TITLE
feat(sandbox): optional SELinux relabel (:z) on bind mounts

### DIFF
--- a/docs/guides/podman.md
+++ b/docs/guides/podman.md
@@ -106,4 +106,15 @@ podman pull ghcr.io/agent-of-empires/aoe-sandbox:latest
 
 ### Permission Denied on Bind Mounts
 
-On SELinux-enabled systems (Fedora, RHEL), you may need to relabel project directories so the container can read them. Either disable SELinux for the volume, or relabel with `:Z` / `:z` (one-time, modifies host labels). AoE does not append SELinux flags automatically; if your distribution requires them, add them via `sandbox.extra_volumes` or relabel the project root.
+On SELinux-enforcing systems (Fedora, RHEL), the container runs as the confined `container_t` domain and is denied access to bind-mounted host paths (the credential dir, the project worktree) because they keep their `user_home_t` label. The symptom is a blank agent pane, or "Permission denied" / `?????????` even as root inside the container.
+
+The fix is to relabel those host paths to a container-accessible type. AoE can do this for you: set
+
+```toml
+[sandbox]
+selinux_relabel = true
+```
+
+which appends the `:z` (shared) SELinux relabel flag to every sandbox bind mount, so the runtime relabels the host paths to `container_file_t` at mount time. It is off by default (a no-op on non-SELinux hosts, and it modifies host labels, so it is opt-in). Only Docker and Podman honor the flag; Apple Container ignores it.
+
+Alternatively, relabel manually with `chcon -R -t container_file_t <path>` (one-time; reverted by a later `restorecon`), or make it durable with `semanage fcontext`.

--- a/src/containers/container_interface.rs
+++ b/src/containers/container_interface.rs
@@ -86,6 +86,7 @@ pub fn docker_env_args(entries: &[EnvEntry]) -> (Vec<String>, Vec<(String, Strin
     (argv, inherit)
 }
 
+#[derive(Default)]
 pub struct ContainerConfig {
     pub working_dir: String,
     pub volumes: Vec<VolumeMount>,
@@ -96,6 +97,10 @@ pub struct ContainerConfig {
     pub cpu_limit: Option<String>,
     pub memory_limit: Option<String>,
     pub port_mappings: Vec<String>,
+    /// Append the SELinux relabel flag (`:z`) to host bind mounts so the container
+    /// can access them on SELinux-enforcing hosts (Fedora, RHEL). Set from
+    /// `sandbox.selinux_relabel`; only emitted for runtimes that support it.
+    pub selinux_relabel: bool,
 }
 
 pub trait ContainerRuntimeInterface {

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -213,6 +213,7 @@ mod tests {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: vec![],
+            ..Default::default()
         };
 
         let args = container.build_create_args(&config);
@@ -243,6 +244,7 @@ mod tests {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: vec![],
+            ..Default::default()
         };
 
         let args = container.build_create_args(&config);

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -25,6 +25,9 @@ pub(crate) struct RuntimeBase {
     pub supports_remove_volumes: bool,
     /// Whether this runtime supports `volume ls` / `volume rm` for named volumes
     pub supports_named_volumes: bool,
+    /// Whether this runtime supports the `:z`/`:Z` SELinux relabel volume flag
+    /// (Docker and Podman do; Apple Container does not).
+    pub supports_selinux_relabel: bool,
 }
 
 impl RuntimeBase {
@@ -37,6 +40,7 @@ impl RuntimeBase {
         supports_read_only_volumes: true,
         supports_remove_volumes: true,
         supports_named_volumes: true,
+        supports_selinux_relabel: true,
     };
 
     pub const APPLE_CONTAINER: Self = Self {
@@ -48,6 +52,7 @@ impl RuntimeBase {
         supports_read_only_volumes: false,
         supports_remove_volumes: false,
         supports_named_volumes: false,
+        supports_selinux_relabel: false,
     };
 
     pub const PODMAN: Self = Self {
@@ -62,6 +67,7 @@ impl RuntimeBase {
         supports_read_only_volumes: true,
         supports_remove_volumes: true,
         supports_named_volumes: true,
+        supports_selinux_relabel: true,
     };
 
     pub fn command(&self) -> Command {
@@ -182,10 +188,25 @@ impl RuntimeBase {
                     vol.container_path
                 );
             }
-            let mount = if vol.read_only && self.supports_read_only_volumes {
-                format!("{}:{}:ro", vol.host_path, vol.container_path)
-            } else {
+            let mut opts: Vec<&str> = Vec::new();
+            if vol.read_only && self.supports_read_only_volumes {
+                opts.push("ro");
+            }
+            if config.selinux_relabel && self.supports_selinux_relabel {
+                // `:z` (shared) relabels the host path to a container-accessible
+                // SELinux type. Shared rather than `:Z` because aoe mounts the
+                // credential dir into multiple sandbox containers.
+                opts.push("z");
+            }
+            let mount = if opts.is_empty() {
                 format!("{}:{}", vol.host_path, vol.container_path)
+            } else {
+                format!(
+                    "{}:{}:{}",
+                    vol.host_path,
+                    vol.container_path,
+                    opts.join(",")
+                )
             };
             args.push("-v".to_string());
             args.push(mount);
@@ -420,6 +441,7 @@ mod tests {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: vec![],
+            ..Default::default()
         };
 
         let args = base.build_create_args("test-container", "alpine:latest", &config);
@@ -444,6 +466,7 @@ mod tests {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: vec![],
+            ..Default::default()
         };
 
         let args = base.build_create_args("test-container", "alpine:latest", &config);
@@ -451,6 +474,55 @@ mod tests {
         // Should NOT include :ro suffix (Apple Container doesn't support it)
         assert!(args.contains(&"/host/path:/container/path".to_string()));
         assert!(!args.iter().any(|a| a.ends_with(":ro")));
+    }
+
+    #[test]
+    fn test_build_create_args_selinux_relabel() {
+        let base = RuntimeBase::PODMAN;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            volumes: vec![
+                VolumeMount {
+                    host_path: "/host/rw".to_string(),
+                    container_path: "/container/rw".to_string(),
+                    read_only: false,
+                },
+                VolumeMount {
+                    host_path: "/host/ro".to_string(),
+                    container_path: "/container/ro".to_string(),
+                    read_only: true,
+                },
+            ],
+            selinux_relabel: true,
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("test-container", "alpine:latest", &config);
+
+        // Read-write mount gets :z; read-only gets :ro,z.
+        assert!(args.contains(&"/host/rw:/container/rw:z".to_string()));
+        assert!(args.contains(&"/host/ro:/container/ro:ro,z".to_string()));
+    }
+
+    #[test]
+    fn test_build_create_args_selinux_relabel_unsupported_runtime() {
+        let base = RuntimeBase::APPLE_CONTAINER;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            volumes: vec![VolumeMount {
+                host_path: "/host/path".to_string(),
+                container_path: "/container/path".to_string(),
+                read_only: false,
+            }],
+            selinux_relabel: true,
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("test-container", "alpine:latest", &config);
+
+        // Apple Container doesn't support :z; the mount stays plain.
+        assert!(args.contains(&"/host/path:/container/path".to_string()));
+        assert!(!args.iter().any(|a| a.contains(":z")));
     }
 
     #[test]
@@ -493,6 +565,7 @@ mod tests {
             cpu_limit: Some("2".to_string()),
             memory_limit: Some("4g".to_string()),
             port_mappings: vec!["3000:3000".to_string()],
+            ..Default::default()
         };
 
         let args = base.build_create_args("test", "ubuntu:latest", &config);
@@ -532,6 +605,7 @@ mod tests {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: vec![],
+            ..Default::default()
         };
 
         let args = base.build_create_args("test", "alpine:latest", &config);
@@ -562,6 +636,7 @@ mod tests {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: vec![],
+            ..Default::default()
         };
 
         let args = base.build_create_args("test", "alpine:latest", &config);
@@ -585,6 +660,7 @@ mod tests {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: vec!["3000:3000".to_string(), "5432:5432".to_string()],
+            ..Default::default()
         };
 
         let args = base.build_create_args("test", "alpine:latest", &config);
@@ -617,6 +693,7 @@ mod tests {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: vec![],
+            ..Default::default()
         };
 
         let args = base.build_create_args("test", "alpine:latest", &config);
@@ -654,6 +731,7 @@ mod tests {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: vec![],
+            ..Default::default()
         };
 
         let args = base.build_create_args("test", "alpine:latest", &config);

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1166,6 +1166,12 @@ pub struct SandboxConfig {
     #[serde(default)]
     pub mount_ssh: bool,
 
+    /// Append the SELinux relabel flag (`:z`) to sandbox bind mounts so the
+    /// container can read them on SELinux-enforcing hosts (Fedora, RHEL). Off by
+    /// default; only emitted for Docker/Podman. Note: this relabels the host paths.
+    #[serde(default)]
+    pub selinux_relabel: bool,
+
     /// Custom instruction text appended to the agent's system prompt in sandboxed sessions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_instruction: Option<String>,
@@ -1215,6 +1221,7 @@ impl Default for SandboxConfig {
             volume_ignores: Vec::new(),
             volume_ignores_strategy: VolumeIgnoresStrategy::default(),
             mount_ssh: false,
+            selinux_relabel: false,
             custom_instruction: None,
             container_runtime: ContainerRuntimeName::default(),
         }

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -1334,6 +1334,7 @@ pub(crate) fn build_container_config(
         cpu_limit: sandbox_config.cpu_limit,
         memory_limit: sandbox_config.memory_limit,
         port_mappings: sandbox_config.port_mappings.clone(),
+        selinux_relabel: sandbox_config.selinux_relabel,
     })
 }
 

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -202,6 +202,9 @@ pub struct SandboxConfigOverride {
     pub mount_ssh: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selinux_relabel: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_instruction: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -408,6 +411,9 @@ pub fn apply_sandbox_overrides(
     }
     if let Some(mount_ssh) = source.mount_ssh {
         target.mount_ssh = mount_ssh;
+    }
+    if let Some(selinux_relabel) = source.selinux_relabel {
+        target.selinux_relabel = selinux_relabel;
     }
     if let Some(ref custom_instruction) = source.custom_instruction {
         target.custom_instruction = Some(custom_instruction.clone());

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -88,6 +88,7 @@ pub enum FieldKey {
     VolumeIgnores,
     VolumeIgnoresStrategy,
     MountSsh,
+    SelinuxRelabel,
     CustomInstruction,
     ContainerRuntime,
     // Tmux
@@ -1243,6 +1244,11 @@ fn build_sandbox_fields(
         global.sandbox.mount_ssh,
         sb.and_then(|s| s.mount_ssh),
     );
+    let (selinux_relabel, o_sel) = resolve_value(
+        scope,
+        global.sandbox.selinux_relabel,
+        sb.and_then(|s| s.selinux_relabel),
+    );
     let (custom_instruction, o_ci) = resolve_optional(
         scope,
         global.sandbox.custom_instruction.clone(),
@@ -1445,6 +1451,15 @@ fn build_sandbox_fields(
             category: SettingsCategory::Sandbox,
             has_override: o8,
             inherited_display: inherited_if(o8, FieldValue::Bool(global.sandbox.mount_ssh)),
+        },
+        SettingField {
+            key: FieldKey::SelinuxRelabel,
+            label: "SELinux Relabel",
+            description: "Append the :z SELinux relabel flag to sandbox bind mounts (needed on Fedora/RHEL; relabels host paths)",
+            value: FieldValue::Bool(selinux_relabel),
+            category: SettingsCategory::Sandbox,
+            has_override: o_sel,
+            inherited_display: inherited_if(o_sel, FieldValue::Bool(global.sandbox.selinux_relabel)),
         },
         SettingField {
             key: FieldKey::CustomInstruction,
@@ -2622,6 +2637,7 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::PortMappings, FieldValue::List(v)) => config.sandbox.port_mappings = v.clone(),
         (FieldKey::VolumeIgnores, FieldValue::List(v)) => config.sandbox.volume_ignores = v.clone(),
         (FieldKey::MountSsh, FieldValue::Bool(v)) => config.sandbox.mount_ssh = *v,
+        (FieldKey::SelinuxRelabel, FieldValue::Bool(v)) => config.sandbox.selinux_relabel = *v,
         (FieldKey::SandboxAutoCleanup, FieldValue::Bool(v)) => config.sandbox.auto_cleanup = *v,
         (FieldKey::CpuLimit, FieldValue::OptionalText(v)) => {
             config.sandbox.cpu_limit = v.clone();
@@ -2992,6 +3008,9 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
         }
         (FieldKey::MountSsh, FieldValue::Bool(v)) => {
             set_profile_override(*v, &mut config.sandbox, |s, val| s.mount_ssh = val);
+        }
+        (FieldKey::SelinuxRelabel, FieldValue::Bool(v)) => {
+            set_profile_override(*v, &mut config.sandbox, |s, val| s.selinux_relabel = val);
         }
         (FieldKey::SandboxAutoCleanup, FieldValue::Bool(v)) => {
             set_profile_override(*v, &mut config.sandbox, |s, val| s.auto_cleanup = val);

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -852,6 +852,11 @@ impl SettingsView {
                     s.mount_ssh = None;
                 }
             }
+            FieldKey::SelinuxRelabel => {
+                if let Some(ref mut s) = config.sandbox {
+                    s.selinux_relabel = None;
+                }
+            }
             FieldKey::CpuLimit => {
                 if let Some(ref mut s) = config.sandbox {
                     s.cpu_limit = None;

--- a/tests/integration/sandbox_integration.rs
+++ b/tests/integration/sandbox_integration.rs
@@ -146,6 +146,7 @@ fn test_container_lifecycle() {
         cpu_limit: None,
         memory_limit: None,
         port_mappings: vec![],
+        ..Default::default()
     };
 
     let container_id = container.create(&config).unwrap();
@@ -188,6 +189,7 @@ fn test_container_force_remove() {
         cpu_limit: None,
         memory_limit: None,
         port_mappings: vec![],
+        ..Default::default()
     };
 
     container.create(&config).unwrap();


### PR DESCRIPTION
## Description
Under SELinux in enforcing mode, the sandbox container (`container_t`) is denied
access to aoe's bind mounts (credentials, project worktree): aoe mounts them
without a relabel option, so they keep their host labels (e.g. `user_home_t`).
The agent can't read its synced credentials and the session comes up with a
blank pane.

This adds an opt-in `sandbox.selinux_relabel` option. When enabled, aoe appends
the `:z` (shared) SELinux relabel flag to every sandbox bind mount, so the runtime
relabels the host paths to `container_file_t` at mount time and the container can
read them.

- **Off by default** — no behavior change for existing users; a no-op where
  SELinux isn't enforcing; opt-in because relabeling modifies host labels.
- **`:z` (shared), not `:Z`** — both the credential dir and project worktrees can
  be bind-mounted into multiple concurrent containers (shared auth dir; the same
  project across concurrent sessions). A per-container `:Z` category would lock a
  path to one container and deny the others.
- Only emitted for runtimes that support it (Docker/Podman; not Apple Container).
- Editable in Settings → Sandbox and overridable per profile.
- `docs/guides/podman.md` currently notes that AoE doesn't append SELinux flags
  automatically and directs users to relabel manually; this adds an opt-in to
  have AoE do it (and updates that doc).

## PR Type
- [x] New Feature

## Checklist
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (`docs/guides/podman.md`)
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis
**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the new field follows the existing sandbox bool-field pattern (`mount_ssh`) and is covered by unit tests. The mount-flag behavior has new unit tests in `runtime_base.rs` (`:z`, `:ro,z`, and unsupported-runtime cases). A full e2e would need an SELinux-enforcing host, which CI doesn't provide. Manually verified on an SELinux-enforcing host (rootless Podman): with `selinux_relabel = true`, a sandboxed session on a non-relabeled project dir comes up working, and the mounts gain the `z` option (`container_file_t` applied) with no manual `chcon`.

## AI Usage
- [x] AI was used

**AI Model/Tool used:** Claude (Claude Code)

- [ ] I am an AI Agent filling out this form

<img width="1349" height="792" alt="Screenshot 2026-05-30 at 22 24 43" src="https://github.com/user-attachments/assets/8e781a9b-1001-4cc4-9831-ffd987719ba6" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Summary

This PR introduces a new optional SELinux configuration option for AoE sandbox containers. The feature allows users to enable SELinux relabeling on bind-mounted directories (credentials and project worktree) when running on SELinux-enforcing systems. This solves a permission issue where containers cannot access host paths that maintain their original host security labels.

**What was added:**
- New `sandbox.selinux_relabel` configuration option (disabled by default)
- Per-profile override support for the SELinux setting
- TUI settings page entry to enable/disable the feature
- Updated Podman documentation with guidance on using the new option

**What was modified:**
- Container configuration to track the SELinux relabel flag
- Runtime implementations (Docker, Podman, Apple Container) to conditionally apply the `:z` relabel flag to mount arguments
- Test coverage updated to verify proper flag handling across different runtimes

**What was NOT changed:**
- Default behavior remains unchanged (opt-in feature, disabled by default)
- Existing configuration and settings are unaffected
- No changes to core container execution logic

## Benefits

- **Solves SELinux permission issues**: Users on SELinux-enforcing systems can now run containers without manual workarounds
- **Backward compatible**: Off by default, so existing users are unaffected
- **Safe approach**: Uses `:z` (shared) relabel rather than `:Z` (unshared), allowing multiple containers to access the same mount
- **Configurable**: Can be set globally or per-profile, giving users fine-grained control
- **Runtime-aware**: Only applies to runtimes that support SELinux flags (Docker/Podman), not Apple Container runtime

## Technical Details

The implementation adds a `selinux_relabel: bool` field throughout the configuration stack:
- `SandboxConfig` stores the global setting (serde default: false)
- `SandboxConfigOverride` allows per-profile overrides
- `ContainerConfig` carries the flag to runtime layers
- `RuntimeBase` includes a `supports_selinux_relabel` capability flag (true for Docker/Podman, false for Apple Container)
- Mount argument construction in `build_create_args` dynamically appends `:z` or `:ro,z` when the feature is enabled and the runtime supports it

<!-- end of auto-generated comment: release notes by coderabbit.ai -->