### PR TITLE
fix(web): restore terminal select-to-copy via OSC 52 after xterm.js swap

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -244,6 +244,25 @@ On phones (below the `md` breakpoint) the dashboard shows a single full-viewport
 
 This replaces the earlier slide-in overlay, which left the paired terminal almost no room once the soft keyboard opened. Because each view now owns the whole viewport, the paired terminal handles the keyboard the same way the agent terminal does. The agent terminal and the paired shell stay alive in the background when you switch away, so their scrollback and focus are preserved. The desktop side-by-side split is unchanged.
 
+### Terminal copy and scroll
+
+The live terminal uses tmux for scrollback and selection, so copy and scroll
+work together with no modifier keys:
+
+- **Scroll** with the mouse wheel (or a two-finger swipe on touch) to move back
+  through tmux scrollback. A "Back to live" control returns you to the bottom.
+- **Select** by click-dragging across the text. Dragging upward past the top
+  edge scrolls into the scrollback and extends the selection, so you can grab
+  output taller than the window. Releasing the drag copies the selection to
+  your system clipboard automatically; no Ctrl/Cmd+C needed.
+
+Copy-to-clipboard relies on the browser Clipboard API, which is only available
+in a secure context: pages served over HTTPS (the remote-access tunnel modes)
+or over `http://localhost`. On a plain-HTTP LAN/VPN origin the browser blocks
+clipboard writes, and the selection stays visible but is not copied. Firefox
+is best-effort here because it does not support the asynchronous clipboard
+write the terminal uses; Chromium and Safari copy reliably.
+
 ### Sidebar sort
 
 By default the sidebar shows your manually-ordered list. Drag a row with a press-and-hold gesture to move it; the new order persists across browsers and devices via `workspace-ordering.json`.

--- a/web/src/hooks/useTerminal.lifecycle.test.ts
+++ b/web/src/hooks/useTerminal.lifecycle.test.ts
@@ -1728,6 +1728,18 @@ describe("useTerminal OSC 52 clipboard", () => {
     }
   });
 
+  it("swallows a rejected clipboard write", async () => {
+    writeText.mockRejectedValueOnce(new Error("no gesture"));
+    const div = await mountHook();
+    try {
+      expect(() => captured.oscHandlers[52]!("c;aGVsbG8=")).not.toThrow();
+      await flushAsync();
+      expect(writeText).toHaveBeenCalledWith("hello");
+    } finally {
+      div.remove();
+    }
+  });
+
   it("ignores an OSC 52 paste query (no clipboard write)", async () => {
     const div = await mountHook();
     try {
@@ -1745,6 +1757,148 @@ describe("useTerminal OSC 52 clipboard", () => {
       expect(() => captured.oscHandlers[52]!("c;!!!not base64!!!")).not.toThrow();
       await flushAsync();
       expect(writeText).not.toHaveBeenCalled();
+    } finally {
+      div.remove();
+    }
+  });
+
+  // base64("hi") === "aGk=".
+  const HI_OSC = "c;aGk=";
+
+  function fireDrag(
+    viewport: HTMLElement,
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+  ): void {
+    viewport.dispatchEvent(
+      new MouseEvent("mousedown", {
+        button: 0,
+        clientX: from.x,
+        clientY: from.y,
+        bubbles: true,
+      }),
+    );
+    window.dispatchEvent(
+      new MouseEvent("mouseup", {
+        button: 0,
+        clientX: to.x,
+        clientY: to.y,
+        bubbles: true,
+      }),
+    );
+  }
+
+  it("arms a ClipboardItem on drag release and resolves it from the OSC 52 payload", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText, write },
+      configurable: true,
+    });
+    class FakeClipboardItem {
+      constructor(public data: Record<string, Promise<Blob>>) {}
+    }
+    vi.stubGlobal("ClipboardItem", FakeClipboardItem);
+    const div = await mountHook();
+    try {
+      const viewport = div.querySelector(".xterm") as HTMLElement;
+      fireDrag(viewport, { x: 10, y: 10 }, { x: 120, y: 90 });
+      // The gesture pre-arms a promise-valued clipboard write.
+      expect(write).toHaveBeenCalledTimes(1);
+      // The OSC 52 escape resolves that pending write; the direct writeText
+      // fallback is not used on the ClipboardItem path.
+      captured.oscHandlers[52]!(HI_OSC);
+      await flushAsync();
+      expect(writeText).not.toHaveBeenCalled();
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("does not arm on a plain click (below the drag threshold)", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText, write },
+      configurable: true,
+    });
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        constructor(public d: unknown) {}
+      },
+    );
+    const div = await mountHook();
+    try {
+      const viewport = div.querySelector(".xterm") as HTMLElement;
+      fireDrag(viewport, { x: 10, y: 10 }, { x: 11, y: 11 });
+      expect(write).not.toHaveBeenCalled();
+      // An unarmed OSC 52 (e.g. the agent ran a copy itself) still writes.
+      captured.oscHandlers[52]!(HI_OSC);
+      await flushAsync();
+      expect(writeText).toHaveBeenCalledWith("hi");
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("falls back to writeText when promise ClipboardItem is unavailable", async () => {
+    vi.stubGlobal("ClipboardItem", undefined);
+    const div = await mountHook();
+    try {
+      const viewport = div.querySelector(".xterm") as HTMLElement;
+      fireDrag(viewport, { x: 10, y: 10 }, { x: 120, y: 90 });
+      captured.oscHandlers[52]!(HI_OSC);
+      await flushAsync();
+      expect(writeText).toHaveBeenCalledWith("hi");
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("clears the armed ClipboardItem write when no OSC 52 arrives in time", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText, write },
+      configurable: true,
+    });
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        constructor(public d: unknown) {}
+      },
+    );
+    const div = await mountHook();
+    try {
+      const viewport = div.querySelector(".xterm") as HTMLElement;
+      fireDrag(viewport, { x: 10, y: 10 }, { x: 120, y: 90 });
+      expect(write).toHaveBeenCalledTimes(1);
+      // No OSC 52 lands: the timeout fires and disarms.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600);
+      });
+      // A late OSC 52 no longer resolves the (expired) item; it writes direct.
+      captured.oscHandlers[52]!(HI_OSC);
+      await flushAsync();
+      expect(writeText).toHaveBeenCalledWith("hi");
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("disarms the writeText fallback after its timeout", async () => {
+    vi.stubGlobal("ClipboardItem", undefined);
+    const div = await mountHook();
+    try {
+      const viewport = div.querySelector(".xterm") as HTMLElement;
+      fireDrag(viewport, { x: 10, y: 10 }, { x: 120, y: 90 });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600);
+      });
+      // After the timeout the fallback resolver is cleared; a later OSC 52
+      // takes the direct-write path exactly once.
+      captured.oscHandlers[52]!(HI_OSC);
+      await flushAsync();
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(writeText).toHaveBeenCalledWith("hi");
     } finally {
       div.remove();
     }

--- a/web/src/hooks/useTerminal.lifecycle.test.ts
+++ b/web/src/hooks/useTerminal.lifecycle.test.ts
@@ -1765,6 +1765,18 @@ describe("useTerminal OSC 52 clipboard", () => {
   // base64("hi") === "aGk=".
   const HI_OSC = "c;aGk=";
 
+  // Stand-in for the browser ClipboardItem. A real ClipboardItem consumes
+  // the promise value (it awaits it to perform the write), so it never leaks
+  // an unhandled rejection when the hook's timeout rejects the pending blob.
+  // The fake must do the same or the timeout tests trip Vitest's
+  // unhandled-rejection guard (process exits non-zero even with all tests
+  // green).
+  class FakeClipboardItem {
+    constructor(public data: Record<string, Promise<Blob>>) {
+      for (const v of Object.values(data)) void Promise.resolve(v).catch(() => {});
+    }
+  }
+
   function fireDrag(
     viewport: HTMLElement,
     from: { x: number; y: number },
@@ -1794,9 +1806,6 @@ describe("useTerminal OSC 52 clipboard", () => {
       value: { writeText, write },
       configurable: true,
     });
-    class FakeClipboardItem {
-      constructor(public data: Record<string, Promise<Blob>>) {}
-    }
     vi.stubGlobal("ClipboardItem", FakeClipboardItem);
     const div = await mountHook();
     try {
@@ -1820,12 +1829,7 @@ describe("useTerminal OSC 52 clipboard", () => {
       value: { writeText, write },
       configurable: true,
     });
-    vi.stubGlobal(
-      "ClipboardItem",
-      class {
-        constructor(public d: unknown) {}
-      },
-    );
+    vi.stubGlobal("ClipboardItem", FakeClipboardItem);
     const div = await mountHook();
     try {
       const viewport = div.querySelector(".xterm") as HTMLElement;
@@ -1860,12 +1864,7 @@ describe("useTerminal OSC 52 clipboard", () => {
       value: { writeText, write },
       configurable: true,
     });
-    vi.stubGlobal(
-      "ClipboardItem",
-      class {
-        constructor(public d: unknown) {}
-      },
-    );
+    vi.stubGlobal("ClipboardItem", FakeClipboardItem);
     const div = await mountHook();
     try {
       const viewport = div.querySelector(".xterm") as HTMLElement;

--- a/web/src/hooks/useTerminal.lifecycle.test.ts
+++ b/web/src/hooks/useTerminal.lifecycle.test.ts
@@ -35,6 +35,7 @@ const { captured } = vi.hoisted(() => ({
     proposedDimensions: { cols: 100, rows: 30 } as
       | { cols: number; rows: number }
       | undefined,
+    oscHandlers: {} as Record<number, (data: string) => boolean>,
   },
 }));
 
@@ -79,6 +80,15 @@ vi.mock("@xterm/xterm", () => {
       captured.customWheel = fn;
     }
     attachCustomKeyEventHandler(_fn: (e: KeyboardEvent) => boolean): void {}
+    parser = {
+      registerOscHandler(
+        id: number,
+        cb: (data: string) => boolean,
+      ): { dispose: () => void } {
+        captured.oscHandlers[id] = cb;
+        return { dispose: () => {} };
+      },
+    };
     resize(cols: number, rows: number): void {
       this.cols = cols;
       this.rows = rows;
@@ -191,6 +201,7 @@ beforeEach(() => {
   captured.customWheel = undefined;
   captured.resizeObserverCallback = undefined;
   captured.proposedDimensions = { cols: 100, rows: 30 };
+  captured.oscHandlers = {};
   originalWebSocket = global.WebSocket;
   global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
   originalResizeObserver = global.ResizeObserver;
@@ -1647,6 +1658,93 @@ describe("useTerminal mobile backspace autorepeat", () => {
       });
       fireDelete(ta, 3);
       expect(delBytes(ws)).toBe(0);
+    } finally {
+      div.remove();
+    }
+  });
+});
+
+// OSC 52 clipboard handling. tmux emits OSC 52 on copy (set-clipboard on);
+// before #1499 xterm.js had no handler so select-to-copy silently failed.
+// The hook now registers a handler that decodes the base64 payload and
+// writes it to the system clipboard. These tests drive the captured handler
+// directly; the full drag -> tmux -> OSC 52 round-trip is covered by the
+// live Playwright spec.
+describe("useTerminal OSC 52 clipboard", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+  let originalClipboard: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      delete (navigator as unknown as { clipboard?: unknown }).clipboard;
+    }
+  });
+
+  async function mountHook(): Promise<HTMLDivElement> {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    renderHook(() => {
+      const term = useTerminal("s-osc52", "ws", false, false);
+      if (term.containerRef && !term.containerRef.current) {
+        (
+          term.containerRef as unknown as { current: HTMLDivElement | null }
+        ).current = div;
+      }
+      return term;
+    });
+    await flushAsync();
+    return div;
+  }
+
+  it("registers an OSC 52 handler on open", async () => {
+    const div = await mountHook();
+    try {
+      expect(typeof captured.oscHandlers[52]).toBe("function");
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("decodes a base64 payload and writes it to the clipboard", async () => {
+    const div = await mountHook();
+    try {
+      // "c;<base64>" where base64("hello world") = "aGVsbG8gd29ybGQ=".
+      captured.oscHandlers[52]!("c;aGVsbG8gd29ybGQ=");
+      await flushAsync();
+      expect(writeText).toHaveBeenCalledWith("hello world");
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("ignores an OSC 52 paste query (no clipboard write)", async () => {
+    const div = await mountHook();
+    try {
+      captured.oscHandlers[52]!("c;?");
+      await flushAsync();
+      expect(writeText).not.toHaveBeenCalled();
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("ignores an undecodable payload without throwing", async () => {
+    const div = await mountHook();
+    try {
+      expect(() => captured.oscHandlers[52]!("c;!!!not base64!!!")).not.toThrow();
+      await flushAsync();
+      expect(writeText).not.toHaveBeenCalled();
     } finally {
       div.remove();
     }

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -1327,6 +1327,10 @@ export function useTerminal(
               reject(new Error("osc52 clipboard timeout"));
             }, OSC52_CLIPBOARD_TIMEOUT_MS);
           });
+          // Attach our own rejection handler so a timeout never surfaces as an
+          // unhandled rejection if the clipboard implementation drops the
+          // promise (the write() consumer below also sees it; both fire).
+          pending.catch(() => {});
           navigator.clipboard.write([new ClipboardItem({ "text/plain": pending })]).catch(() => {
             // Rejected when no OSC 52 arrived within the timeout (drag
             // selected nothing) or the engine declined the async write.

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -91,6 +91,14 @@ const DEFAULT_FONT_SIZE = 14;
 const MOBILE_BREAKPOINT_PX = 768;
 const WHEEL_ZOOM_SENSITIVITY = 0.05;
 const WHEEL_PERSIST_DEBOUNCE_MS = 400;
+// How long, after a drag-select releases, to wait for tmux's OSC 52
+// clipboard escape to arrive over the WS before giving up. The escape is
+// emitted by tmux's copy-selection on mouse release and round-trips through
+// the PTY relay, so it lands a frame or two after `mouseup`. See #1499.
+const OSC52_CLIPBOARD_TIMEOUT_MS = 500;
+// Pointer travel (px) below which a press/release is treated as a click, not
+// a drag, so a plain focus click doesn't arm a clipboard write.
+const DRAG_COPY_THRESHOLD_PX = 4;
 const RESIZE_DEBOUNCE_MS = 50;
 // First-resize debounce: longer than the steady-state value so the
 // initial layout transition (sidebar mount, splitter snap, font swap)
@@ -295,6 +303,54 @@ export function useTerminal(
     term.loadAddon(new WebLinksAddon());
 
     term.open(termEl);
+
+    // Select-to-copy bridge. tmux owns text selection here: mouse-mode is on
+    // (src/tmux/utils.rs) so a drag drives tmux copy-mode, which is the only
+    // way to select across the scrollback boundary given xterm's
+    // `scrollback: 0`. On copy, tmux (`set-clipboard on`) emits an OSC 52
+    // clipboard escape, but xterm.js has no built-in OSC 52 handler, so the
+    // payload was dropped on the floor and select-to-copy silently failed
+    // after the wterm -> xterm.js swap. We decode it and write it to the
+    // system clipboard. The escape arrives asynchronously over the WS, after
+    // the `mouseup` that triggered the copy, so a bare
+    // `navigator.clipboard.writeText()` is rejected for lacking a user
+    // gesture; `armClipboardCopy()` below pre-arms a gesture-bound
+    // `ClipboardItem` promise that this handler resolves. See #1499.
+    let osc52Resolve: ((text: string) => void) | null = null;
+    const writeClipboardText = (text: string) => {
+      navigator.clipboard?.writeText(text).catch((err) => {
+        // Expected on browsers that won't honor an async write without a
+        // live user gesture (notably Firefox, which lacks promise-valued
+        // ClipboardItem). Best-effort; logged, not surfaced.
+        tdbg("clipboard writeText failed", err);
+      });
+    };
+    term.parser.registerOscHandler(52, (data) => {
+      // Payload shape: "<targets>;<base64>" where targets is e.g. "c"
+      // (clipboard), "p" (primary), or "cp". A lone "?" in the data half is
+      // a paste query we don't answer.
+      const sep = data.indexOf(";");
+      if (sep === -1) return true;
+      const encoded = data.slice(sep + 1);
+      if (encoded === "" || encoded === "?") return true;
+      let text: string;
+      try {
+        const bin = atob(encoded);
+        const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+        text = new TextDecoder().decode(bytes);
+      } catch (err) {
+        tdbg("osc52 decode failed", err);
+        return true;
+      }
+      if (osc52Resolve) {
+        osc52Resolve(text);
+        osc52Resolve = null;
+      } else {
+        // Not a user drag (e.g. the agent itself ran a copy); write directly.
+        writeClipboardText(text);
+      }
+      return true;
+    });
 
     // Mobile soft-keyboard Backspace autorepeat arrives as a stream of
     // `beforeinput` events (inputType "deleteContentBackward", with keydown
@@ -1244,6 +1300,77 @@ export function useTerminal(
     };
     viewport.addEventListener("click", onClickCapture, true);
 
+    // Arm a clipboard write tied to the synchronous `mouseup` that ends a
+    // drag-select, so the OSC 52 escape tmux emits asynchronously over the WS
+    // keeps the browser's user-gesture authorization (see the OSC 52 handler
+    // registered after term.open). A promise-valued ClipboardItem is the
+    // gesture-preserving path (Safari/Chromium); browsers without it
+    // (Firefox) fall back to a best-effort writeText, which may be blocked.
+    // See #1499.
+    const armClipboardCopy = () => {
+      let settled = false;
+      const finish = () => {
+        settled = true;
+        osc52Resolve = null;
+      };
+      try {
+        if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+          const pending = new Promise<Blob>((resolve, reject) => {
+            osc52Resolve = (text) => {
+              if (settled) return;
+              finish();
+              resolve(new Blob([text], { type: "text/plain" }));
+            };
+            setTimeout(() => {
+              if (settled) return;
+              finish();
+              reject(new Error("osc52 clipboard timeout"));
+            }, OSC52_CLIPBOARD_TIMEOUT_MS);
+          });
+          navigator.clipboard.write([new ClipboardItem({ "text/plain": pending })]).catch(() => {
+            // Rejected when no OSC 52 arrived within the timeout (drag
+            // selected nothing) or the engine declined the async write.
+            // Harmless.
+          });
+          return;
+        }
+      } catch {
+        // Promise-valued ClipboardItem unsupported (Firefox); fall through to
+        // the best-effort writeText path below.
+      }
+      osc52Resolve = (text) => {
+        if (settled) return;
+        finish();
+        writeClipboardText(text);
+      };
+      setTimeout(() => {
+        if (!settled) finish();
+      }, OSC52_CLIPBOARD_TIMEOUT_MS);
+    };
+    let mouseDownPoint: { x: number; y: number } | null = null;
+    const onMouseDownCapture = (e: MouseEvent) => {
+      if (e.button === 0) mouseDownPoint = { x: e.clientX, y: e.clientY };
+    };
+    const onWindowMouseUp = (e: MouseEvent) => {
+      const start = mouseDownPoint;
+      mouseDownPoint = null;
+      if (e.button !== 0 || !start) return;
+      // Threshold filters plain focus clicks; only a real drag (which tmux
+      // turns into a copy-mode selection) should arm a clipboard write.
+      if (
+        Math.hypot(e.clientX - start.x, e.clientY - start.y) <
+        DRAG_COPY_THRESHOLD_PX
+      ) {
+        return;
+      }
+      armClipboardCopy();
+    };
+    // mousedown on the viewport so only drags that begin inside the terminal
+    // count; mouseup on the window so a release outside the terminal bounds
+    // (the user dragged past the top edge into scrollback) still arms.
+    viewport.addEventListener("mousedown", onMouseDownCapture, { capture: true });
+    window.addEventListener("mouseup", onWindowMouseUp, { capture: true });
+
     // Mouse wheel: Ctrl+wheel = zoom (trackpad pinch), plain wheel =
     // scroll. tmux manages its own scrollback via mouse-mode escape
     // sequences, so we always synthesize SGR wheel sequences and emit
@@ -1386,6 +1513,10 @@ export function useTerminal(
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
       viewport.removeEventListener("click", onClickCapture, true);
+      viewport.removeEventListener("mousedown", onMouseDownCapture, {
+        capture: true,
+      });
+      window.removeEventListener("mouseup", onWindowMouseUp, { capture: true });
       viewport.removeEventListener("wheel", onWheelCapture, true);
       xtermTextarea?.removeEventListener("beforeinput", onBeforeInput, {
         capture: true,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -38,6 +38,17 @@
       ]
     },
     {
+      "id": "terminal.copy-on-select",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/terminal-copy-select.spec.ts"
+      ],
+      "components": [
+        "web/src/hooks/useTerminal.ts"
+      ]
+    },
+    {
       "id": "terminal.ws-reconnect",
       "kind": "mocked-playwright",
       "risk": "high",

--- a/web/tests/live/terminal-copy-select.spec.ts
+++ b/web/tests/live/terminal-copy-select.spec.ts
@@ -1,0 +1,118 @@
+// Live spec for issue #1499: select-to-copy in the xterm.js web terminal.
+//
+// Before the wterm -> xterm.js swap a plain drag-select landed text on the
+// clipboard with no modifier. After the swap it silently failed: tmux owns
+// the selection (mouse-mode is on) and emits an OSC 52 clipboard escape on
+// copy, but xterm.js had no OSC 52 handler so the payload was dropped. The
+// hook now registers a handler that writes the payload to the system
+// clipboard, bridging the async gesture gap with a ClipboardItem promise.
+//
+// This drives the full round-trip against a real backend: a fake `claude`
+// shim floods the pane with recognizable marker lines, then a mouse drag in
+// the browser selects text and we assert it reached the clipboard. tmux's
+// native mouse-drag-selection is the only path that selects across the
+// scrollback boundary, so this also exercises the "select above the visible
+// area" flow when the drag spans multiple rows.
+
+import { test as base, expect } from "@playwright/test";
+import { writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+const MARKER = "AOECOPY";
+
+base("plain drag-select copies terminal text to the clipboard", async ({
+  page,
+  context,
+}, testInfo) => {
+  const addSession = seedSessionViaAoeAdd({ title: "copytest" });
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: async (env) => {
+      // Replace the tail-f-dev-null stub with a shim that prints enough
+      // marker lines to overflow the pane (so scrollback exists), then
+      // holds the pane open. Runs before `aoe add` so the session's pane
+      // starts with this content already on screen.
+      const shim = join(env.shimBin, "claude");
+      writeFileSync(
+        shim,
+        '#!/bin/bash\nfor i in $(seq 1 80); do echo "' +
+          MARKER +
+          '$i line of terminal output"; done\nexec tail -f /dev/null\n',
+      );
+      chmodSync(shim, 0o755);
+      await addSession(env);
+    },
+  });
+
+  try {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: serve.baseUrl,
+    });
+
+    const sessions = await listSessions(serve.baseUrl);
+    expect(sessions.length).toBeGreaterThan(0);
+    const sessionId: string = sessions[0]!.id;
+
+    await page.goto(`${serve.baseUrl}/`);
+    const sessionRow = page
+      .getByRole("link")
+      .filter({ hasText: "copytest" })
+      .first();
+    await expect(sessionRow).toBeVisible({ timeout: 10_000 });
+    await sessionRow.click();
+    await expect(page).toHaveURL(new RegExp(`/session/${sessionId}`), {
+      timeout: 10_000,
+    });
+
+    const term = page.locator(".xterm").first();
+    await expect(term).toBeVisible({ timeout: 10_000 });
+
+    // Drag-select a row, then read the clipboard. Retry the whole gesture:
+    // the pane content arrives asynchronously over the WS and the OSC 52
+    // round-trips after mouseup, so the first attempt can land before
+    // either is ready. The selection is monotonic for our purposes (we only
+    // need one attempt to put a marker on the clipboard).
+    type Box = { x: number; y: number; width: number; height: number };
+    const dragAndRead = async (toY: (box: Box) => number, steps: number) => {
+      const box = await term.boundingBox();
+      if (!box) return "";
+      await page.evaluate(() => navigator.clipboard.writeText(""));
+      const startX = box.x + Math.min(12, box.width * 0.1);
+      const startY = box.y + box.height * 0.7;
+      await page.mouse.move(startX, startY);
+      await page.mouse.down();
+      await page.mouse.move(box.x + box.width * 0.85, toY(box), {
+        steps,
+      });
+      await page.mouse.up();
+      // Give the SGR drag-end -> tmux copy-selection -> OSC 52 -> WS ->
+      // clipboard round-trip a beat to settle before reading.
+      await page.waitForTimeout(150);
+      return page.evaluate(() => navigator.clipboard.readText());
+    };
+
+    // Single-row horizontal drag: the simplest select-to-copy.
+    await expect
+      .poll(async () => dragAndRead((b) => b.y + b.height * 0.7, 8), {
+        timeout: 25_000,
+        intervals: [500],
+      })
+      .toContain(MARKER);
+
+    // Multi-row drag (start low, release above the top edge): tmux extends
+    // the copy-mode selection across rows and into scrollback. The copied
+    // text should span more than one line and still carry a marker.
+    const multiline = await dragAndRead((b) => b.y - 40, 12);
+    expect(multiline).toContain(MARKER);
+    expect(multiline.split("\n").length).toBeGreaterThan(1);
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

After the web terminal moved from wterm to xterm.js in v1.8.0 (#1275), a plain drag-select in the terminal stopped reaching the clipboard. The highlight flashed and cleared on release and nothing was copied, with no modifier keys able to fix it.

Root cause: tmux owns the selection. Mouse-mode is on (the only way to select across the scrollback boundary, since xterm runs with `scrollback: 0` and tmux owns scrollback), so a drag drives tmux copy-mode. On copy, tmux (`set-clipboard on`) emits an OSC 52 clipboard escape, but xterm.js has no built-in OSC 52 handler, so the payload was silently dropped.

This registers an OSC 52 handler on the terminal that decodes the payload and writes it to the system clipboard. The escape arrives asynchronously over the WebSocket, after the `mouseup` that triggered the copy, so a bare `navigator.clipboard.writeText` is rejected for lacking a user gesture; the fix pre-arms a gesture-bound, promise-valued `ClipboardItem` on drag release and resolves it when the OSC 52 lands (Safari/Chromium), falling back to best-effort `writeText` on engines without promise-valued `ClipboardItem` (Firefox).

Wheel scrollback, drag-to-select into scrollback (handled natively by tmux), touch/pinch, "Back to live", and reconnect behavior are unchanged. No tmux or server change was needed: tmux's default `terminal-features` already advertises `xterm*:clipboard`, so the OSC 52 escape was already on the wire and just had nowhere to land.

Closes #1499

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] Open a session in the web terminal over HTTPS or `http://localhost`, produce more output than fits on screen (e.g. `seq 1 200`).
- [x] Drag-select a block of visible text with no modifier key, release, and paste elsewhere: the selection is on your clipboard.
- [x] Drag from a visible line upward past the top edge: the view scrolls into scrollback, the selection extends, and on release the multi-line selection is on the clipboard.
- [x] Scroll the wheel up/down: scrollback and the "Back to live" control still work as before.
- [x] (Firefox) Confirm copy is best-effort; (Chromium/Safari) confirm it copies reliably.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added a live Playwright spec (`web/tests/live/terminal-copy-select.spec.ts`, matrix entry `terminal.copy-on-select`) that drives the full drag-select to clipboard round-trip against a real backend, plus vitest coverage of the OSC 52 handler in `web/src/hooks/useTerminal.lifecycle.test.ts` (fails on the pre-fix tree, passes after).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the design debate, and implementation were drafted by Claude under my direction. I made the design calls (tmux keeps owning selection; fix the missing OSC 52 handler rather than rearchitect), reviewed each commit, and own the testing plan.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR restores the pre-v1.8.0 drag-to-select → auto-copy behavior in the web terminal after swapping wterm for xterm.js. It adds an xterm.js OSC 52 handler that decodes tmux clipboard escapes and writes the decoded text to the system clipboard. Because the OSC 52 escape can arrive asynchronously (over the WebSocket after mouseup), the implementation pre-arms a gesture-bound clipboard write on drag release and resolves it when the OSC 52 arrives; a timeout and a fallback path reduce silent failures. Documentation, unit tests, and a Playwright live test were added. No tmux or server changes are required.

What changed (non-technical)
- Restores automatic copy-on-select (plain drag, no modifier keys).
- Preserves existing scrollback behavior (wheel scrollback, drag-to-scroll into scrollback, touch/pinch, "Back to live", reconnect).
- Adds user-facing docs describing terminal copy/scroll behavior and browser secure-context constraints.
- Adds automated tests (unit + live) and a coverage-matrix entry.
- Closes issue `#1499`.

Benefits
- Restores the seamless select→copy UX from v1.7.1.
- Keeps scrollback and scrolling UX intact while enabling copy.
- Reduces silent copy failures via arming, timeouts, and fallbacks.
- Covered by unit and live tests; no server-side changes required.

Technical Details
- Registers an xterm.js OSC 52 handler that base64-decodes payloads (ignores paste-query frames and invalid payloads) and writes the decoded text to the clipboard.
- On mouseup after a genuine drag (movement > threshold), armClipboardCopy() pre-arms a user-gesture-authorized ClipboardItem write (for browsers with promise-valued ClipboardItem) and awaits the OSC 52 payload to resolve it.
- On browsers without promise-valued ClipboardItem (Firefox), falls back to navigator.clipboard.writeText.
- Uses timeouts to disarm pending writes if OSC 52 doesn't arrive; handles write rejections to avoid unhandled errors.
- Files touched: web/src/hooks/useTerminal.ts (implementation), web/src/hooks/useTerminal.lifecycle.test.ts (unit tests), web/tests/live/terminal-copy-select.spec.ts (Playwright live test), docs/guides/web-dashboard.md (docs), web/tests/coverage-matrix.json (coverage entry).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->