### PR TITLE
feat(web): add per-session cockpit toggle to the session wizard

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -29,7 +29,11 @@ Gemini CLI, etc.) is the *server*. Any ACP-conformant agent works.
 
 aoe ships a registry entry for each tool whose ACP server we've verified
 against [agentclientprotocol.com](https://agentclientprotocol.com/get-started/agents.md).
-The wizard greys out the cockpit option for tools not in this set.
+When the cockpit master switch is on, the web wizard shows a per-session
+**Cockpit** toggle (on by default) for tools in this set, so you can opt
+a single session down to a plain tmux session without flipping the global
+switch. Tools not in this set, and custom agents, have no toggle and
+always fall back to tmux.
 
 | aoe tool   | Substrate B (cockpit)                                      | Auth                                   |
 |------------|------------------------------------------------------------|----------------------------------------|

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -190,6 +190,11 @@ export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnable
   const handleSubmit = async () => {
     dispatch({ type: "SUBMIT_START" });
     const d = state.data;
+    // Custom agents have no ACP adapter, so they can never run in
+    // cockpit even if their name collides with a built-in entry in
+    // ACP_CAPABLE_TOOLS. Mirror AgentStep's guard here.
+    const selectedCustomAgent =
+      state.agents.find((a) => a.name === d.tool)?.kind === "custom";
     // Scratch sessions: server provisions the working directory and
     // ignores `path`. Force-omit every worktree-related field so a
     // stale reducer state cannot make the server return 400 on the
@@ -217,12 +222,18 @@ export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnable
       command_override: d.commandOverride || undefined,
       custom_instruction: d.customInstruction || undefined,
       profile: d.profile || undefined,
-      // Cockpit is auto-on for ACP-capable tools when the master
-      // switch is on; non-ACP tools and a disabled master switch
-      // both fall back to tmux. The server re-applies the master
-      // switch (see src/server/api/sessions.rs), so a tampered
-      // client request can't escalate cockpit on.
-      cockpit_mode: cockpitMasterEnabled && ACP_CAPABLE_TOOLS.has(d.tool),
+      // Cockpit runs only when the master switch is on, the tool is
+      // ACP-capable, and the user kept the per-session toggle on
+      // (default). Turning it off launches a tmux session even with
+      // the master switch enabled. Non-ACP tools, custom agents, and a
+      // disabled master switch all fall back to tmux. The server
+      // re-applies the master switch (see src/server/api/sessions.rs),
+      // so a tampered client request can't escalate cockpit on.
+      cockpit_mode:
+        cockpitMasterEnabled &&
+        !selectedCustomAgent &&
+        ACP_CAPABLE_TOOLS.has(d.tool) &&
+        d.useCockpit,
       scratch: d.scratch || undefined,
     };
     const result = await createSession(body);
@@ -260,7 +271,7 @@ export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnable
           />
         );
       case "review":
-        return <ReviewStep data={state.data} onChange={handleChange} agents={state.agents} isSubmitting={state.isSubmitting} error={state.error} onSubmit={handleSubmit} onJumpTo={jumpTo} steps={steps} />;
+        return <ReviewStep data={state.data} onChange={handleChange} agents={state.agents} isSubmitting={state.isSubmitting} error={state.error} onSubmit={handleSubmit} onJumpTo={jumpTo} steps={steps} cockpitMasterEnabled={cockpitMasterEnabled} />;
       default:
         return null;
     }

--- a/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
+++ b/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
@@ -114,12 +114,15 @@ describe("AgentStep custom-agent selection (#1252)", () => {
     ).toBeTruthy();
   });
 
-  it("renders the ACP substrate notice when the selected agent is a built-in with ACP support", () => {
-    const { getByText } = renderAgentStep({
+  it("renders the interactive cockpit toggle when the selected agent is a built-in with ACP support", () => {
+    const { getByRole, getByText } = renderAgentStep({
       tool: "claude",
       agents: [builtin, custom],
     });
-    expect(getByText(/Cockpit is enabled/)).toBeTruthy();
+    // The ACP-capable case now renders CockpitSubstrateCard (an
+    // interactive switch defaulting on) rather than a read-only notice.
+    expect(getByRole("switch", { name: "Use cockpit" })).toBeTruthy();
+    expect(getByText(/Renders the agent's plan/)).toBeTruthy();
   });
 
   it("clicking an agent button calls onChange with the agent name", () => {
@@ -282,6 +285,7 @@ describe("ReviewStep agent row (#1252)", () => {
         onSubmit={() => {}}
         onJumpTo={() => {}}
         steps={[{ id: "agent", label: "Agent" }] as Parameters<typeof ReviewStep>[0]["steps"]}
+        cockpitMasterEnabled={false}
       />,
     );
   }

--- a/web/src/components/session-wizard/__tests__/cockpitToggle.test.tsx
+++ b/web/src/components/session-wizard/__tests__/cockpitToggle.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+//
+// Covers the per-session cockpit opt-out added in #1580: when the
+// cockpit master switch is on, the wizard now lets the user create a
+// plain tmux/terminal session for an ACP-capable tool instead of being
+// force-routed into cockpit. Two surfaces:
+//
+//   - AgentStep renders an interactive CockpitSubstrateCard (a switch,
+//     default on) for ACP-capable built-ins; non-ACP tools and custom
+//     agents keep the read-only fallback notice and show no switch.
+//   - SessionWizard's submit payload sets `cockpit_mode` from
+//     `cockpitMasterEnabled && acpCapable && useCockpit`, so toggling
+//     the switch off sends `cockpit_mode: false` (the server then
+//     creates a tmux session even with the master switch on).
+//
+// The payload assertions are the request-permutation coverage the
+// AGENTS.md mandate calls for; the live persistence path stays in the
+// Playwright suite.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, fireEvent, waitFor } from "@testing-library/react";
+
+import { AgentStep } from "../steps/AgentStep";
+import { SessionWizard } from "../SessionWizard";
+import { initialData } from "../wizardReducer";
+import type { AgentInfo, ProfileInfo } from "../../../lib/types";
+
+const createSession = vi.fn();
+
+vi.mock("../../../lib/api", () => ({
+  fetchSettings: vi.fn().mockResolvedValue({}),
+  fetchAgents: vi.fn().mockResolvedValue([]),
+  fetchGroups: vi.fn().mockResolvedValue([]),
+  fetchDockerStatus: vi.fn().mockResolvedValue({ available: false }),
+  fetchProfiles: vi.fn().mockResolvedValue([]),
+  createSession: (...args: unknown[]) => createSession(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+const claude: AgentInfo = {
+  kind: "builtin",
+  name: "claude",
+  binary: "claude",
+  host_only: false,
+  installed: true,
+  install_hint: "",
+};
+
+const nonAcpBuiltin: AgentInfo = {
+  kind: "builtin",
+  name: "aider",
+  binary: "aider",
+  host_only: false,
+  installed: true,
+  install_hint: "",
+};
+
+const custom: AgentInfo = {
+  kind: "custom",
+  name: "remote-helper",
+  binary: "remote-helper",
+  host_only: false,
+  installed: true,
+  install_hint: "Configured custom agent",
+};
+
+function renderAgentStep(overrides: {
+  tool?: string;
+  agents?: AgentInfo[];
+  cockpitMasterEnabled?: boolean;
+  useCockpit?: boolean;
+}) {
+  const onChange = vi.fn();
+  const utils = render(
+    <AgentStep
+      data={{
+        ...initialData,
+        tool: overrides.tool ?? "claude",
+        useCockpit: overrides.useCockpit ?? true,
+      }}
+      onChange={onChange}
+      agents={overrides.agents ?? [claude, nonAcpBuiltin, custom]}
+      profiles={[] as ProfileInfo[]}
+      dockerAvailable={false}
+      onApplyProfileDefaults={() => {}}
+      cockpitMasterEnabled={overrides.cockpitMasterEnabled ?? true}
+    />,
+  );
+  return { onChange, ...utils };
+}
+
+describe("AgentStep cockpit substrate card (#1580)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders an interactive switch (default on) for an ACP-capable built-in when the master switch is on", () => {
+    const { getByRole } = renderAgentStep({ tool: "claude" });
+    const toggle = getByRole("switch", { name: "Use cockpit" });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("toggling the switch off calls onChange('useCockpit', false)", () => {
+    const { onChange, getByRole } = renderAgentStep({ tool: "claude" });
+    fireEvent.click(getByRole("switch", { name: "Use cockpit" }));
+    expect(onChange).toHaveBeenCalledWith("useCockpit", false);
+  });
+
+  it("reflects useCockpit=false as an unchecked switch", () => {
+    const { getByRole } = renderAgentStep({ tool: "claude", useCockpit: false });
+    expect(getByRole("switch", { name: "Use cockpit" }).getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("shows no switch for a non-ACP built-in, only the terminal fallback notice", () => {
+    const { queryByRole, getByText } = renderAgentStep({ tool: "aider" });
+    expect(queryByRole("switch", { name: "Use cockpit" })).toBeNull();
+    expect(getByText(/has no ACP adapter yet/)).toBeTruthy();
+  });
+
+  it("shows no switch for a custom agent, only the fallback notice", () => {
+    const { queryByRole, getByText } = renderAgentStep({ tool: "remote-helper" });
+    expect(queryByRole("switch", { name: "Use cockpit" })).toBeNull();
+    expect(
+      getByText(
+        "Custom agents run in the terminal. Cockpit is available for built-in agents with ACP support.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("shows neither switch nor notice when the master switch is off", () => {
+    const { queryByRole, queryByText } = renderAgentStep({
+      tool: "claude",
+      cockpitMasterEnabled: false,
+    });
+    expect(queryByRole("switch", { name: "Use cockpit" })).toBeNull();
+    expect(queryByText(/Renders the agent's plan/)).toBeNull();
+  });
+});
+
+describe("SessionWizard cockpit_mode payload (#1580)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createSession.mockResolvedValue({ ok: true, session: { warnings: [] } });
+  });
+
+  function renderWizard(cockpitMasterEnabled: boolean) {
+    return render(
+      <SessionWizard
+        onClose={() => {}}
+        onCreated={() => {}}
+        prefill={{ skipToReview: true, path: "/tmp/proj", tool: "claude" }}
+        cockpitMasterEnabled={cockpitMasterEnabled}
+      />,
+    );
+  }
+
+  it("sends cockpit_mode: true for an ACP tool when master on and the toggle is left on (default)", async () => {
+    const { getByText } = renderWizard(true);
+    fireEvent.click(getByText(/Launch session/));
+    await waitFor(() => expect(createSession).toHaveBeenCalled());
+    expect(createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: "claude", cockpit_mode: true }),
+    );
+  });
+
+  it("sends cockpit_mode: false when master on but the user opts out via the toggle", async () => {
+    const { getByText, getByRole } = renderWizard(true);
+    // Jump from review back to the agent step via the Interface row,
+    // flip the cockpit switch off, return to review, and launch.
+    fireEvent.click(getByText("Interface"));
+    fireEvent.click(getByRole("switch", { name: "Use cockpit" }));
+    fireEvent.click(getByText("Next"));
+    fireEvent.click(getByText(/Launch session/));
+    await waitFor(() => expect(createSession).toHaveBeenCalled());
+    expect(createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: "claude", cockpit_mode: false }),
+    );
+  });
+
+  it("sends cockpit_mode: false when the master switch is off", async () => {
+    const { getByText } = renderWizard(false);
+    fireEvent.click(getByText(/Launch session/));
+    await waitFor(() => expect(createSession).toHaveBeenCalled());
+    expect(createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: "claude", cockpit_mode: false }),
+    );
+  });
+});

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -18,6 +18,7 @@ interface WizardData {
   customInstruction: string;
   extraArgs: string;
   commandOverride: string;
+  useCockpit: boolean;
   [key: string]: unknown;
 }
 
@@ -35,53 +36,80 @@ interface Props {
   cockpitMasterEnabled: boolean;
 }
 
+/** Read-only callout for the cases where cockpit is impossible even
+ *  though the master switch is on: a custom agent or a built-in tool
+ *  with no ACP adapter. Both fall back to the tmux terminal, so there
+ *  is nothing to toggle. The ACP-capable case renders
+ *  `CockpitSubstrateCard` instead. */
 function SubstrateNotice({
   tool,
-  acpCapable,
   customAgent,
-  sandboxEnabled,
 }: {
   tool: string;
-  acpCapable: boolean;
   customAgent: boolean;
-  sandboxEnabled: boolean;
 }) {
-  const sandboxedCockpit = acpCapable && sandboxEnabled;
   return (
     <div className="mb-5 rounded-lg border border-surface-700 bg-surface-950 px-3 py-2.5">
       <div className="flex items-center gap-2">
-        <span className="text-sm font-semibold text-text-primary">
-          {acpCapable ? "Cockpit" : "Terminal"}
-        </span>
-        <span
-          className={`rounded px-1.5 py-px text-[10px] font-mono uppercase tracking-wide ${
-            acpCapable
-              ? "bg-brand-700/40 text-brand-400"
-              : "bg-surface-700 text-text-dim"
-          }`}
-        >
-          {acpCapable ? "Beta" : "Fallback"}
+        <span className="text-sm font-semibold text-text-primary">Terminal</span>
+        <span className="rounded px-1.5 py-px text-[10px] font-mono uppercase tracking-wide bg-surface-700 text-text-dim">
+          Fallback
         </span>
       </div>
       <p className="mt-1 text-xs text-text-dim leading-snug">
-        {sandboxedCockpit
-          ? "Cockpit + container: the agent runs inside the sandbox container, so its file and terminal access stay inside the container's mounts."
-          : customAgent
+        {customAgent
           ? "Custom agents run in the terminal. Cockpit is available for built-in agents with ACP support."
-          : acpCapable
-          ? "Cockpit is enabled, so this session will run in the structured cockpit UI. Switch to terminal substrate from the session view if needed."
           : `${tool} has no ACP adapter yet, so this session falls back to the tmux terminal. Pick a tool with cockpit support (e.g. claude, opencode, gemini) to use the structured UI.`}
       </p>
     </div>
   );
 }
 
-function Toggle({ checked, onChange, disabled }: { checked: boolean; onChange: (v: boolean) => void; disabled?: boolean }) {
+/** Interactive substrate picker shown when the cockpit master switch is
+ *  on and the selected tool is ACP-capable. Defaults on (so the master
+ *  switch keeps its current behavior); turning it off launches a tmux
+ *  session even with the master switch enabled (see #1580). */
+function CockpitSubstrateCard({
+  checked,
+  onChange,
+  sandboxEnabled,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  sandboxEnabled: boolean;
+}) {
+  const sandboxedCockpit = checked && sandboxEnabled;
+  return (
+    <div className="mb-5 rounded-lg border border-surface-700 bg-surface-900 px-3 py-2.5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-text-primary">Cockpit</span>
+            <span className="rounded px-1.5 py-px text-[10px] font-mono uppercase tracking-wide bg-brand-700/40 text-brand-400">
+              Beta
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-text-dim leading-snug">
+            {sandboxedCockpit
+              ? "Cockpit + container: the agent runs inside the sandbox container, so its file and terminal access stay inside the container's mounts. Turn off to run this session in the tmux terminal instead."
+              : checked
+              ? "Renders the agent's plan, tool calls, and diffs in the structured cockpit UI. Turn off to run this session in the tmux terminal instead."
+              : "This session will run in the tmux terminal. Turn on to use the structured cockpit UI; you can also switch substrates from the session view later."}
+          </p>
+        </div>
+        <Toggle checked={checked} onChange={onChange} label="Use cockpit" />
+      </div>
+    </div>
+  );
+}
+
+function Toggle({ checked, onChange, disabled, label }: { checked: boolean; onChange: (v: boolean) => void; disabled?: boolean; label?: string }) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={checked}
+      aria-label={label}
       disabled={disabled}
       onClick={() => !disabled && onChange(!checked)}
       className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 ${
@@ -103,6 +131,7 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
   );
   const selectedAgent = agents.find((a) => a.name === data.tool);
   const selectedCustomAgent = selectedAgent?.kind === "custom";
+  const acpCapable = !selectedCustomAgent && ACP_CAPABLE_TOOLS.has(data.tool);
   const isHostOnly = selectedAgent?.host_only ?? false;
   const [showAdvanced, setShowAdvanced] = useState(data.advancedEnabled);
   const showProfilePicker = profiles.length > 1;
@@ -190,21 +219,23 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
         ))}
       </div>
 
-      {/* Substrate notice. Cockpit mode is auto-selected for ACP-capable
-          tools when the master switch is on; non-ACP tools fall back to
-          tmux silently. The notice tells the user which one they'll get
-          without giving them a per-session toggle (the master switch is
-          the opt-in, and the session view has a post-creation switch if
-          they need to flip). When the master switch is off, every new
-          session is tmux and no notice is shown. */}
-      {cockpitMasterEnabled && (
-        <SubstrateNotice
-          tool={data.tool}
-          acpCapable={ACP_CAPABLE_TOOLS.has(data.tool)}
-          customAgent={selectedCustomAgent}
-          sandboxEnabled={data.sandboxEnabled}
-        />
-      )}
+      {/* Substrate picker. When the master switch is on and the tool is
+          ACP-capable, the user gets a per-session cockpit toggle
+          (default on, see #1580) so they can opt down to a tmux session
+          without flipping the global switch. Non-ACP tools and custom
+          agents can't run in cockpit, so they show a read-only fallback
+          notice instead. When the master switch is off, every new
+          session is tmux and nothing is shown. */}
+      {cockpitMasterEnabled &&
+        (acpCapable ? (
+          <CockpitSubstrateCard
+            checked={data.useCockpit}
+            onChange={(v) => onChange("useCockpit", v)}
+            sandboxEnabled={data.sandboxEnabled}
+          />
+        ) : (
+          <SubstrateNotice tool={data.tool} customAgent={selectedCustomAgent} />
+        ))}
 
       {/* Profile selector. We render a card list (rather than a native
           <select>) so each profile can carry a short description beneath

--- a/web/src/components/session-wizard/steps/ReviewStep.tsx
+++ b/web/src/components/session-wizard/steps/ReviewStep.tsx
@@ -4,9 +4,10 @@ import type { StepDef, StepId } from "../StepIndicator";
 import { getReviewSummary } from "../sessionNames";
 import { useServerDown, OFFLINE_TITLE } from "../../../lib/connectionState";
 import type { AgentInfo } from "../../../lib/types";
+import { ACP_CAPABLE_TOOLS } from "../../../lib/acpCapableTools";
 
-interface WizardData { path: string; title: string; worktreeBranch: string; useWorktree: boolean; attachExisting: boolean; baseBranch: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; scratch: boolean; [key: string]: unknown; }
-interface Props { data: WizardData; onChange: (field: string, value: unknown) => void; agents: AgentInfo[]; isSubmitting: boolean; error: string | null; onSubmit: () => void; onJumpTo: (stepId: StepId) => void; steps: StepDef[]; }
+interface WizardData { path: string; title: string; worktreeBranch: string; useWorktree: boolean; attachExisting: boolean; baseBranch: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; scratch: boolean; useCockpit: boolean; [key: string]: unknown; }
+interface Props { data: WizardData; onChange: (field: string, value: unknown) => void; agents: AgentInfo[]; isSubmitting: boolean; error: string | null; onSubmit: () => void; onJumpTo: (stepId: StepId) => void; steps: StepDef[]; cockpitMasterEnabled: boolean; }
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
 
@@ -108,7 +109,7 @@ function EditableRow({ label, value, displayValue, placeholder, onChange, accent
   );
 }
 
-export function ReviewStep({ data, onChange, agents, isSubmitting, error, onSubmit, onJumpTo, steps }: Props) {
+export function ReviewStep({ data, onChange, agents, isSubmitting, error, onSubmit, onJumpTo, steps, cockpitMasterEnabled }: Props) {
   const hasStep = (id: StepId) => steps.some((s) => s.id === id);
   const offline = useServerDown();
   // Scratch sessions intentionally carry no path until the server
@@ -119,6 +120,14 @@ export function ReviewStep({ data, onChange, agents, isSubmitting, error, onSubm
   const summary = getReviewSummary(data.title, data.worktreeBranch);
   const selectedAgent = agents.find((agent) => agent.name === data.tool);
   const selectedCustomAgent = selectedAgent?.kind === "custom";
+  // Mirror the submit-path computation in SessionWizard.handleSubmit so
+  // the review reflects the substrate the session will actually launch
+  // with, including the per-session opt-out (#1580).
+  const willUseCockpit =
+    cockpitMasterEnabled &&
+    !selectedCustomAgent &&
+    ACP_CAPABLE_TOOLS.has(data.tool) &&
+    data.useCockpit;
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -182,6 +191,9 @@ export function ReviewStep({ data, onChange, agents, isSubmitting, error, onSubm
           stepId="agent"
           onJumpTo={onJumpTo}
         />
+        {cockpitMasterEnabled && (
+          <Row label="Interface" value={willUseCockpit ? "Cockpit" : "Terminal"} stepId="agent" onJumpTo={onJumpTo} />
+        )}
         {data.profile && (
           <Row label="Profile" value={data.profileDirty ? `${data.profile} (Custom)` : data.profile} stepId="agent" onJumpTo={onJumpTo} accent />
         )}

--- a/web/src/components/session-wizard/wizardReducer.test.ts
+++ b/web/src/components/session-wizard/wizardReducer.test.ts
@@ -212,3 +212,57 @@ describe("SessionWizard reducer / APPLY_PROFILE_DEFAULTS (#1142)", () => {
     expect(late.data.yoloMode).toBe(true);
   });
 });
+
+describe("SessionWizard reducer / useCockpit (#1580)", () => {
+  it("defaults useCockpit to true so the master switch keeps its current behavior", () => {
+    expect(initialData.useCockpit).toBe(true);
+  });
+
+  it("SET_FIELD useCockpit updates the flag", () => {
+    const next = reducer(makeState(), {
+      type: "SET_FIELD",
+      field: "useCockpit",
+      value: false,
+    });
+    expect(next.data.useCockpit).toBe(false);
+  });
+
+  it("toggling useCockpit does NOT mark profileDirty", () => {
+    // useCockpit is deliberately excluded from the dirty-tracking list:
+    // the mount-time APPLY_PROFILE_DEFAULTS seeder uses skipIfDirty, so
+    // marking dirty on a cockpit toggle would suppress the profile's
+    // tool/yolo/sandbox/env defaults even though cockpit is unrelated.
+    const next = reducer(makeState(), {
+      type: "SET_FIELD",
+      field: "useCockpit",
+      value: false,
+    });
+    expect(next.data.profileDirty).toBe(false);
+
+    // A late profile-defaults fetch must still apply (not be skipped).
+    const late = reducer(next, {
+      type: "APPLY_PROFILE_DEFAULTS",
+      yoloMode: true,
+      sandboxEnabled: false,
+      tool: "claude",
+      extraEnv: [],
+      skipIfDirty: true,
+    });
+    expect(late.data.yoloMode).toBe(true);
+  });
+
+  it("switching tool preserves the user's useCockpit choice", () => {
+    const optedOut = reducer(makeState(), {
+      type: "SET_FIELD",
+      field: "useCockpit",
+      value: false,
+    });
+    const next = reducer(optedOut, {
+      type: "SET_FIELD",
+      field: "tool",
+      value: "opencode",
+    });
+    expect(next.data.tool).toBe("opencode");
+    expect(next.data.useCockpit).toBe(false);
+  });
+});

--- a/web/src/components/session-wizard/wizardReducer.ts
+++ b/web/src/components/session-wizard/wizardReducer.ts
@@ -47,6 +47,17 @@ export interface WizardData {
    *  `scratch` clears `path`/`useWorktree`/`extraRepoPaths`; setting any
    *  of those back to a non-empty value clears `scratch`. */
   scratch: boolean;
+  /** Per-session opt-in to cockpit rendering for ACP-capable tools.
+   *  Defaults true so the cockpit master switch (`cockpit.enabled`)
+   *  keeps its current "ACP tools run in cockpit" behavior; the user
+   *  can turn it off in AgentStep to launch a tmux/terminal session
+   *  even while the master switch is on. The submit path only sends
+   *  `cockpit_mode: true` when the master switch is on, the tool is
+   *  ACP-capable, and this flag is set; the server re-checks the
+   *  master switch (src/server/api/sessions.rs). Intentionally not
+   *  tracked in `profileDirty` (see SET_FIELD) and not persisted: a
+   *  remembered opt-out would silently defeat the master switch. */
+  useCockpit: boolean;
   [key: string]: unknown;
 }
 
@@ -94,6 +105,7 @@ export const initialData: WizardData = {
   advancedEnabled: false, profileDirty: false,
   customInstruction: "", extraArgs: "", commandOverride: "",
   scratch: false,
+  useCockpit: true,
 };
 
 export function reducer(state: WizardState, action: Action): WizardState {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -389,6 +389,21 @@
       ]
     },
     {
+      "id": "wizard.cockpit-opt-out",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/components/session-wizard/__tests__/cockpitToggle.test.tsx",
+        "src/components/session-wizard/wizardReducer.test.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/steps/AgentStep.tsx",
+        "web/src/components/session-wizard/steps/ReviewStep.tsx",
+        "web/src/components/session-wizard/wizardReducer.ts"
+      ]
+    },
+    {
       "id": "wizard.multi-repo-stale-base",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

With the cockpit master switch on (`cockpit.enabled = true`), the web dashboard wizard auto-routed every ACP-capable session into cockpit mode with no per-session opt-out. The only ways to get a plain tmux session were to flip the global switch off or use the CLI `--no-cockpit`. This adds a per-session **Cockpit** toggle to the wizard so a user can launch a regular terminal session for an ACP-capable tool while keeping the master switch on.

The toggle defaults **on**, so the master switch keeps its current "ACP tools run in cockpit" behavior; turning it off launches a tmux session instead. No backend change was needed: the server already computes `instance.cockpit_mode = body.cockpit_mode && cockpit_master_enabled` (it only ever downgrades, never escalates), so the frontend sending `cockpit_mode: false` already produces a tmux session. The wizard's submit payload now sends `cockpit_mode = cockpitMasterEnabled && acpCapable && useCockpit`.

Implementation notes:
- New `useCockpit` wizard field (default true). It is deliberately excluded from `profileDirty` tracking, so toggling cockpit cannot suppress the mount-time profile-default seeder, and it is not persisted, so a remembered opt-out can never silently defeat the master switch.
- `AgentStep` renders an interactive substrate card (a switch) for ACP-capable built-ins; non-ACP tools and custom agents keep the read-only terminal fallback notice and show no toggle.
- `ReviewStep` surfaces the resulting `Interface: Cockpit | Terminal` so the choice is visible before launch (and reachable for the skip-to-review fast-create flow via the existing jump-to-agent affordance).

Closes #1580

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
  - Per `AGENTS.md`, request-payload permutations (does the control emit the right JSON keys) belong in Vitest + RTL, not Playwright. Added `web/src/components/session-wizard/__tests__/cockpitToggle.test.tsx` (AgentStep substrate card + SessionWizard `cockpit_mode` payload across master / tool / toggle permutations) and reducer tests in `wizardReducer.test.ts`, plus a `wizard.cockpit-opt-out` entry in `web/tests/coverage-matrix.json`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## How to test

- [ ] Set `cockpit.enabled = true` (web settings Cockpit tab or `config.toml`), run `aoe serve`, open the dashboard
- [ ] New session wizard, pick an ACP-capable tool (e.g. claude): the Agent step shows a **Cockpit** toggle, on by default
- [ ] Leave it on and launch: the session opens in the structured cockpit UI (and shows `Interface: Cockpit` on the review step)
- [ ] Create another session, turn the **Cockpit** toggle off, launch: the session opens as a plain tmux terminal even though the master switch is still on
- [ ] Pick a non-ACP or custom agent: no toggle appears, only the terminal fallback notice
- [ ] Turn the master switch off: the toggle disappears and all new sessions are tmux, as before

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a multi-model `/debate` consult on the design (default value, toggle placement, profile-dirty interaction). I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds a per-session "Cockpit" toggle to the web session wizard so users can opt a single session out of Cockpit mode while the global Cockpit master switch remains enabled. The toggle appears only for ACP-capable built-in tools, defaults ON, and preserves existing behavior for non-ACP tools and custom agents.

## What changed (high-level)

- UI: AgentStep shows an interactive "Use Cockpit" switch for ACP-capable built-ins when the global master is enabled; non-ACP tools and custom agents show a read-only terminal fallback notice and no switch. ReviewStep shows an "Interface" row: "Cockpit" or "Terminal".
- State: Wizard data gained a new useCockpit boolean (default true). It is not persisted and is excluded from profileDirty tracking.
- Submit logic: SessionWizard now computes cockpit_mode as cockpitMasterEnabled && acpCapable && useCockpit so users can opt a session down to terminal even when the master switch is on.
- Tests & docs: Added Vitest/RTL tests for toggle behavior and reducer tests; updated coverage matrix and cockpit docs. Closes issue `#1580`.

## Technical details (concise)

- WizardData: added useCockpit: boolean; initialData.useCockpit = true.
- AgentStep: computes acpCapable, renders interactive substrate card wired to data.useCockpit for eligible tools; substrate notice simplified for fallback cases.
- ReviewStep: new cockpitMasterEnabled prop; computes willUseCockpit from master + acpCapable + !customAgent + useCockpit.
- SessionWizard: submit payload sets cockpit_mode using the three-way condition above; removed old logic that ignored custom agents/useCockpit.
- Tests: new cockpitToggle.test.tsx and wizardReducer.test.ts; coverage-matrix entry added.
- No backend changes required (server already enforces cockpit_master_enabled on creation).

## Benefits

- Allows per-session opt-out while keeping global Cockpit enabled.
- Backward-compatible default (toggle ON).
- No server changes required; frontend-only surface and tests close `#1580`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->