### PR TITLE
fix(cockpit): disarm resume-idle watchdog on first inbound notification

### DIFF
--- a/cockpit-worker/test-shim/shim.mjs
+++ b/cockpit-worker/test-shim/shim.mjs
@@ -35,6 +35,38 @@ class ShimAgent {
     // to elapse.
     this._silentOrphanResolve = null;
     this._installDeleteHandlerIfRequested();
+    this._emitUnsolicitedNotifIfRequested();
+  }
+
+  // SHIM_EMIT_UNSOLICITED_NOTIF reproduces a still-alive runner
+  // forwarding a single mid-turn notification shortly after the daemon
+  // reattaches in Resume mode, with no prompt issued. Used by the #1216
+  // test to confirm the resume-idle watchdog disarms on the first
+  // inbound notification (instead of firing after normal mid-turn
+  // silence). The value is the delay in ms before the emit (default
+  // 150); after this one notification the shim stays silent so the test
+  // can assert no synthetic Stopped follows. Requires
+  // SHIM_PRESEED_SESSION_ID so the notification carries a known session.
+  _emitUnsolicitedNotifIfRequested() {
+    const raw = process.env.SHIM_EMIT_UNSOLICITED_NOTIF;
+    if (raw === undefined) return;
+    const sessionId = process.env.SHIM_PRESEED_SESSION_ID;
+    if (!sessionId) return;
+    const delayMs = Number.parseInt(raw, 10);
+    setTimeout(
+      () => {
+        this.connection
+          .sessionUpdate({
+            sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "mid-turn chunk after reattach" },
+            },
+          })
+          .catch(() => {});
+      },
+      Number.isFinite(delayMs) ? delayMs : 150,
+    );
   }
 
   async initialize(params) {

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -492,9 +492,16 @@ Practical implications:
   to the orphaned in-flight `session/prompt` is dropped silently by
   the transport because its request id was issued by the previous
   daemon; to keep the UI from staying stuck on "thinking" forever,
-  the daemon arms a resume-idle watchdog that emits a synthetic
-  `Stopped { reason: "reattach_idle" }` event after 10s of inbound
-  silence. Sessions that the runner cannot reattach to (dead PID,
+  the daemon arms a resume-idle watchdog. It disarms on the first
+  inbound notification the runner forwards after reattach: once any
+  event arrives the turn is observable, and later gaps are normal
+  mid-turn silence (Task subagents, slow Bash, reasoning between tool
+  calls), not an orphan. It synthesizes a
+  `Stopped { reason: "reattach_idle" }` event only when the runner
+  forwards no notification at all within 30s of reattach. The narrow
+  residual, a turn that completes after reattach whose lost response
+  leaves a stale spinner, is rare and clears via Force end turn or the
+  next prompt. Sessions that the runner cannot reattach to (dead PID,
   missing socket, etc.) fall through to a fresh spawn; if the on-disk
   event log shows that fresh spawn's session was mid-prompt at the
   moment the daemon died, the reconciler publishes a

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -338,13 +338,18 @@ enum ConnectMode {
     },
 }
 
-/// Time without any inbound notification, after a `Resume`-mode attach
-/// with `in_flight_turn = true`, before the watchdog synthesizes a
-/// `Stopped { reason: "reattach_idle" }` event. LLM streams rarely have
-/// intra-turn silence near this duration so the false-positive risk
-/// (UI flips to Idle then back to Streaming on the next chunk) is
-/// bounded.
-const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from_secs(10);
+/// Time after a `Resume`-mode attach with `in_flight_turn = true`,
+/// during which the runner forwards NO inbound notification, before the
+/// watchdog synthesizes a `Stopped { reason: "reattach_idle" }` event.
+/// The watchdog disarms permanently on the first inbound notification
+/// (see `first_event_after_attach`): once the runner forwards anything,
+/// the turn is observable and later silence is normal mid-turn
+/// reasoning, not an orphan. So this grace only bounds the fully-silent
+/// reattach case (the orphaned `session/prompt` response was lost and
+/// no notification ever arrives). 30s leaves headroom for a slow first
+/// post-attach event (model reasoning before its first chunk) while
+/// still clearing a truly-dead reattach quickly. See #1216.
+const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Grace window between the first `session/cancel` notification (sent
 /// during an in-flight `session/prompt`) and the daemon declaring the
@@ -3325,15 +3330,21 @@ async fn run_connection_task<W, R>(
     //     Updated by the notification handler below. Initialized to "now"
     //     so a session that never receives a single notification still
     //     fires Stopped after RESUME_IDLE_GRACE rather than immediately.
+    //   - `first_event_after_attach`: set true on the first inbound
+    //     notification after attach. Once the runner forwards any
+    //     notification the turn is observable, so the watchdog disarms;
+    //     it exists only for the case where the runner stays silent.
     //   - `prompt_sent_since_attach`: set when the user issues a prompt
     //     after attach; the user's real PromptRequest will own the next
     //     Stopped, so the watchdog must stand down.
     //   - `watchdog_fired`: ensures we synthesize Stopped at most once.
     let now_ms = chrono::Utc::now().timestamp_millis();
     let last_event_at = Arc::new(AtomicI64::new(now_ms));
+    let first_event_after_attach = Arc::new(AtomicBool::new(false));
     let prompt_sent_since_attach = Arc::new(AtomicBool::new(false));
     let watchdog_fired = Arc::new(AtomicBool::new(false));
     let last_event_at_for_notif = last_event_at.clone();
+    let first_event_after_attach_for_notif = first_event_after_attach.clone();
 
     let result = Client
         .builder()
@@ -3344,11 +3355,18 @@ async fn run_connection_task<W, R>(
                 let suppress = suppress_for_notif.clone();
                 let session_label = session_label_for_notif.clone();
                 let last_event_at = last_event_at_for_notif.clone();
+                let first_event_after_attach =
+                    first_event_after_attach_for_notif.clone();
                 let lifecycle_signal_tx = lifecycle_signal_tx_for_notif.clone();
                 let current_prompt_epoch = current_prompt_epoch_for_notif.clone();
                 async move {
                     last_event_at
                         .store(chrono::Utc::now().timestamp_millis(), Ordering::Relaxed);
+                    // Disarm the resume-idle watchdog: the runner is
+                    // forwarding notifications, so the in-flight turn is
+                    // observable and any further silence is normal mid-turn
+                    // reasoning, not an orphaned turn whose response was lost.
+                    first_event_after_attach.store(true, Ordering::Relaxed);
                     let suppressing = suppress.load(Ordering::Relaxed);
                     // Snapshot the prompt epoch ONCE per notification so
                     // every signal derived from this update shares the
@@ -3795,6 +3813,7 @@ async fn run_connection_task<W, R>(
             if arm_resume_watchdog {
                 let event_tx_for_watchdog = event_tx_for_block.clone();
                 let last_event_at = last_event_at.clone();
+                let first_event_after_attach = first_event_after_attach.clone();
                 let prompt_sent_since_attach = prompt_sent_since_attach.clone();
                 let watchdog_fired = watchdog_fired.clone();
                 let session_label_for_watchdog = session_label.clone();
@@ -3809,6 +3828,24 @@ async fn run_connection_task<W, R>(
                         if prompt_sent_since_attach.load(Ordering::Relaxed) {
                             // User sent a new prompt; its real
                             // PromptRequest will own the next Stopped.
+                            return;
+                        }
+                        if first_event_after_attach.load(Ordering::Relaxed) {
+                            // The runner forwarded at least one notification
+                            // for the in-flight turn, so the turn is
+                            // observable; any further silence is normal
+                            // mid-turn reasoning (Task subagents, slow Bash,
+                            // long reads) rather than an orphaned turn. Disarm
+                            // permanently. The narrow residual (the turn
+                            // completes after attach and its PromptResponse is
+                            // lost, leaving a stale spinner) is rare and
+                            // recoverable via force-end-turn / a new prompt.
+                            // See #1216.
+                            info!(
+                                target: "cockpit.acp",
+                                session = %session_label_for_watchdog,
+                                "resume-idle watchdog: disarming, in-flight turn is observable"
+                            );
                             return;
                         }
                         let last = last_event_at.load(Ordering::Relaxed);

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2521,6 +2521,26 @@ fn wakeup_lifecycle_signal_from_update(
     }
 }
 
+/// Classify a notification for both watchdog lanes. Returns
+/// `(lifecycle_signal, wakeup_signal)`.
+///
+/// During post-load history replay suppression we intentionally surface no
+/// signal, so stale replay frames cannot suppress or disarm watchdogs for a
+/// new prompt epoch.
+fn classify_watchdog_notification_signals(
+    update: &agent_client_protocol::schema::SessionUpdate,
+    profile: &agent_profiles::AgentProfile,
+    suppressing_history_replay: bool,
+) -> (Option<LifecycleSignal>, Option<LifecycleSignal>) {
+    if suppressing_history_replay {
+        return (None, None);
+    }
+    (
+        classify_lifecycle_signal(update),
+        wakeup_lifecycle_signal_from_update(update, profile),
+    )
+}
+
 /// Parse Claude's ExitPlanMode tool input into a structured `Plan`.
 /// Claude ships the plan markdown in `raw_input.plan`; we extract its
 /// bullet- or number-prefixed lines as `PlanStep`s with status=Pending,
@@ -3331,9 +3351,10 @@ async fn run_connection_task<W, R>(
     //     so a session that never receives a single notification still
     //     fires Stopped after RESUME_IDLE_GRACE rather than immediately.
     //   - `first_event_after_attach`: set true on the first inbound
-    //     notification after attach. Once the runner forwards any
-    //     notification the turn is observable, so the watchdog disarms;
-    //     it exists only for the case where the runner stays silent.
+    //     lifecycle-bearing notification after attach (progress, tool
+    //     lifecycle, terminal usage, wakeup). Ambient updates like mode
+    //     or available-command refreshes do not prove turn progress, so
+    //     they must not disarm the watchdog.
     //   - `prompt_sent_since_attach`: set when the user issues a prompt
     //     after attach; the user's real PromptRequest will own the next
     //     Stopped, so the watchdog must stand down.
@@ -3362,11 +3383,6 @@ async fn run_connection_task<W, R>(
                 async move {
                     last_event_at
                         .store(chrono::Utc::now().timestamp_millis(), Ordering::Relaxed);
-                    // Disarm the resume-idle watchdog: the runner is
-                    // forwarding notifications, so the in-flight turn is
-                    // observable and any further silence is normal mid-turn
-                    // reasoning, not an orphaned turn whose response was lost.
-                    first_event_after_attach.store(true, Ordering::Relaxed);
                     let suppressing = suppress.load(Ordering::Relaxed);
                     // Snapshot the prompt epoch ONCE per notification so
                     // every signal derived from this update shares the
@@ -3378,31 +3394,24 @@ async fn run_connection_task<W, R>(
                     // started racing it.
                     let envelope_epoch =
                         current_prompt_epoch.load(Ordering::Relaxed);
-                    // Classify before consuming `notification.update` in
-                    // the event mapping below; emit only when we're not
-                    // in the post-load history-replay window so stale
-                    // chunks from a prior turn can't influence the
-                    // current prompt's silent-orphan state machine.
-                    let lifecycle_signal = if suppressing {
-                        None
-                    } else {
-                        classify_lifecycle_signal(&notification.update)
-                    };
-                    // Derive `WakeupPending` directly from the source
-                    // update so it only fires on a successful
-                    // `ToolCallUpdate { status: Completed, title:
-                    // ScheduleWakeup }`. Scanning `mapped_events` for
-                    // `Event::WakeupScheduled` instead would let the
-                    // initial `ToolCall` frame (tool not yet completed)
-                    // and any in-progress / failed completion trip
-                    // suppression for `delay + base_grace`, masking a
-                    // real adapter wedge. See CodeRabbit review on
-                    // PR #1406.
-                    let wakeup_signal = if suppressing {
-                        None
-                    } else {
-                        wakeup_lifecycle_signal_from_update(&notification.update, profile)
-                    };
+                    // Classify watchdog signals before consuming
+                    // `notification.update` in the event mapping below.
+                    // During post-load replay suppression this returns no
+                    // signal so stale chunks from a prior turn cannot
+                    // influence the current prompt's watchdog state.
+                    let (lifecycle_signal, wakeup_signal) =
+                        classify_watchdog_notification_signals(
+                            &notification.update,
+                            profile,
+                            suppressing,
+                        );
+                    // Disarm resume-idle only on lifecycle-bearing
+                    // notifications (progress/tool/terminal/wakeup). Pure
+                    // ambient updates (mode, command list, metadata) are
+                    // not proof of in-flight turn progress.
+                    if lifecycle_signal.is_some() || wakeup_signal.is_some() {
+                        first_event_after_attach.store(true, Ordering::Relaxed);
+                    }
                     let mapped_events = map_update_to_events(notification.update, profile);
                     // Deliver lifecycle signals BEFORE publishing the
                     // user-visible event vector. The watchdog uses
@@ -6189,6 +6198,52 @@ mod tests {
             &agent_profiles::CLAUDE,
         );
         assert!(matches!(sig, Some(LifecycleSignal::WakeupPending { .. })));
+    }
+
+    #[test]
+    fn classify_watchdog_notification_signals_ignores_ambient_updates() {
+        use agent_client_protocol::schema::{
+            AvailableCommand as AcpAvailableCommand, AvailableCommandsUpdate,
+        };
+        let update = SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(vec![
+            AcpAvailableCommand::new("review", "Review changes"),
+        ]));
+        let (lifecycle, wakeup) =
+            classify_watchdog_notification_signals(&update, &agent_profiles::CLAUDE, false);
+        assert!(
+            lifecycle.is_none() && wakeup.is_none(),
+            "ambient updates must not count as watchdog activity"
+        );
+    }
+
+    #[test]
+    fn classify_watchdog_notification_signals_marks_lifecycle_updates() {
+        use agent_client_protocol::schema::{ToolCallUpdate, ToolCallUpdateFields};
+        let update = SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            "tc-lifecycle-1",
+            ToolCallUpdateFields::new(),
+        ));
+        let (lifecycle, wakeup) =
+            classify_watchdog_notification_signals(&update, &agent_profiles::CLAUDE, false);
+        assert!(
+            lifecycle.is_some() && wakeup.is_none(),
+            "tool lifecycle updates must disarm the resume-idle watchdog"
+        );
+    }
+
+    #[test]
+    fn classify_watchdog_notification_signals_suppresses_during_history_replay() {
+        use agent_client_protocol::schema::{ToolCallUpdate, ToolCallUpdateFields};
+        let update = SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            "tc-suppressed-1",
+            ToolCallUpdateFields::new(),
+        ));
+        let (lifecycle, wakeup) =
+            classify_watchdog_notification_signals(&update, &agent_profiles::CLAUDE, true);
+        assert!(
+            lifecycle.is_none() && wakeup.is_none(),
+            "post-load replay suppression must block watchdog signals"
+        );
     }
 
     #[test]

--- a/tests/integration/cockpit_midturn_resume.rs
+++ b/tests/integration/cockpit_midturn_resume.rs
@@ -88,6 +88,51 @@ async fn spawn_shim_socket_bridge() -> (PathBuf, tempfile::TempDir) {
     spawn_shim_socket_bridge_with_preseed(None).await
 }
 
+/// Variant for the watchdog-disarm test: preseeds `session_id` AND tells
+/// the shim to emit one unsolicited `agent_message_chunk` after
+/// `emit_delay_ms`, then stay silent. Mimics a still-alive runner
+/// forwarding a single mid-turn notification right after reattach.
+async fn spawn_shim_socket_bridge_emitting_unsolicited(
+    session_id: &str,
+    emit_delay_ms: u64,
+) -> (PathBuf, tempfile::TempDir) {
+    let shim = shim_path();
+    let temp = tempfile::tempdir().unwrap();
+    let socket_path = temp.path().join("runner.sock");
+
+    let mut cmd = Command::new("node");
+    cmd.arg(&shim);
+    cmd.env("SHIM_PRESEED_SESSION_ID", session_id);
+    cmd.env("SHIM_EMIT_UNSOLICITED_NOTIF", emit_delay_ms.to_string());
+    let mut shim_proc = cmd
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn shim");
+    let shim_stdin = shim_proc.stdin.take().expect("shim stdin");
+    let shim_stdout = shim_proc.stdout.take().expect("shim stdout");
+
+    let listener = UnixListener::bind(&socket_path).expect("bind listener");
+
+    tokio::spawn(async move {
+        let _shim_proc = shim_proc;
+        let (stream, _) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+        let (mut sock_read, mut sock_write) = stream.into_split();
+        let mut shim_in = shim_stdin;
+        let mut shim_out = shim_stdout;
+        let to_shim = async move { tokio::io::copy(&mut sock_read, &mut shim_in).await.ok() };
+        let from_shim = async move { tokio::io::copy(&mut shim_out, &mut sock_write).await.ok() };
+        let _ = tokio::join!(to_shim, from_shim);
+    });
+
+    (socket_path, temp)
+}
+
 async fn drain_for_stopped_reason(client: &mut AcpClient, deadline: Instant) -> Option<String> {
     while Instant::now() < deadline {
         match tokio::time::timeout(Duration::from_millis(200), client.next_event()).await {
@@ -170,6 +215,53 @@ async fn attach_idle_session_does_not_synthesize_stopped() {
     assert!(
         stopped.is_none(),
         "watchdog must stay disarmed when in_flight_turn=false; got Stopped reason={stopped:?}"
+    );
+}
+
+/// #1216: once the runner forwards any notification after reattach, the
+/// in-flight turn is observable, so normal mid-turn silence (Task
+/// subagents, slow Bash, reasoning gaps) must NOT trip the watchdog. The
+/// shim emits one unsolicited chunk early, then goes silent well past
+/// the grace; the watchdog must disarm on that first notification rather
+/// than synthesize a spurious `reattach_idle` Stopped.
+#[tokio::test]
+async fn attach_in_flight_disarms_after_first_inbound_notification() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+
+    // Grace 800ms; the shim emits its single chunk at 200ms. Without the
+    // disarm-on-first-event fix the watchdog would fire ~800ms after that
+    // chunk (around t=1s); we drain for 2.5s to catch it. With the fix it
+    // disarms on the chunk and never fires.
+    std::env::set_var("AOE_RESUME_IDLE_GRACE_MS", "800");
+
+    let session_id = "test-acp-session-id";
+    let (socket_path, _tmp) = spawn_shim_socket_bridge_emitting_unsolicited(session_id, 200).await;
+
+    let mut client = AcpClient::attach(
+        socket_path,
+        std::env::temp_dir(),
+        vec![],
+        session_id.into(),
+        true, // in_flight_turn
+        CockpitSessionId("midturn-disarm".into()),
+        None,
+        "claude".into(),
+        None,
+    )
+    .await
+    .expect("attach in_flight=true");
+
+    let stopped =
+        drain_for_stopped_reason(&mut client, Instant::now() + Duration::from_millis(2500)).await;
+    let _ = client.shutdown().await;
+
+    assert_ne!(
+        stopped.as_deref(),
+        Some("reattach_idle"),
+        "watchdog must disarm after the first inbound notification; mid-turn silence is not an orphan"
     );
 }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

After `aoe serve --stop && aoe serve` (a daemon restart) while a cockpit session is mid-turn, the new daemon reattaches the still-alive ACP runner in Resume mode and arms a resume-idle watchdog. That watchdog synthesized `Stopped { reason: "reattach_idle" }` after 10s of inbound silence, bumping its idle timer on every notification. The problem: normal intra-turn silence (the model reasoning for ~11s between a Bash result and the next TodoWrite, very common during Task subagents, slow Bash, and large reads) exceeded the 10s grace and tripped the watchdog, flipping the sidebar to Idle while the agent was unambiguously still streaming tool calls.

The fix is daemon-only. Once the runner forwards any notification after reattach, the in-flight turn is observable, so further silence is normal mid-turn behavior, not an orphaned turn whose response was lost. The watchdog now disarms permanently on the first inbound notification and fires only when the runner stays completely silent after reattach. The grace is bumped from 10s to 30s so a slow first post-attach event (the model reasoning before emitting its first chunk) cannot trip it before that first notification arrives.

The narrow residual, a turn that completes after reattach whose lost `PromptResponse` leaves a stale spinner, is rare and recoverable via Force end turn or the next prompt. I deliberately kept the fix in the daemon rather than adding client-side reanimation in the reducer: a multi-model design review flagged that retracting a stop in the reducer (decrementing the monotonic `lastStoppedSeq`) breaks the reducer's invariant, races when `Stopped` and activity events cross in the stream, and can desync two browsers sharing one daemon. Status correction belongs in the daemon, which keeps every client consistent.

Closes #1216

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a cockpit session and send a prompt that triggers a long Task subagent or a slow Bash step (something that produces >30s of silence between tool cards mid-turn).
- [ ] While that turn is streaming, run `aoe serve --stop && aoe serve` to restart the daemon.
- [ ] Confirm the sidebar seeds Running on reattach and STAYS Running through the mid-turn silence (before this fix it flipped to Idle within ~10s while tool cards kept landing).
- [ ] Confirm a genuinely dead reattach (runner forwards no notification at all) still clears the spinner: the watchdog fires `reattach_idle` after 30s of total silence.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The fix is entirely backend (Rust daemon watchdog); no `web/` source changed. The sidebar behavior is driven by the daemon's event stream, so the regression test lives where the bug is: a new shim-backed integration test in `tests/integration/cockpit_midturn_resume.rs` that reattaches in Resume mode, lets the runner forward one mid-turn notification, then asserts no spurious `reattach_idle` Stopped is synthesized. It fails on the pre-fix tree and passes with the disarm.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Covered by the Rust integration test above rather than a `tests/e2e/` TUI test, since the change is in the serve daemon's ACP reattach path.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, including a multi-model design review that steered the fix to a daemon-only approach. I made the design calls, reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes a daemon-side bug where a reattached cockpit runner in Resume mode could arm a "resume-idle" watchdog and incorrectly flip the sidebar to Idle during normal mid-turn silence. The daemon now permanently disarms that watchdog as soon as the first inbound lifecycle notification the runner forwards arrives, and the initial silence grace period is increased from 10s to 30s to avoid premature firing on slow first events. The change is daemon-only and preserves reducer invariants and cross-client consistency; a rare residual case (a completed turn whose lost PromptResponse leaves a stale spinner) is noted as recoverable via Force end turn or the next prompt.

## What changed (high level)
- Daemon: Modified resume-idle watchdog logic so it disarms permanently on the first forwarded inbound lifecycle/wakeup notification after reattach; increased grace from 10s → 30s.
- Tests: Added a Rust integration test that reattaches in Resume mode, makes the shim emit a single mid-turn notification, and asserts no spurious Stopped { reason: "reattach_idle" } is produced.
- Shim: Extended the test shim to optionally emit one unsolicited mid-turn agent_message_chunk after reattach to exercise the new behavior.
- Docs: Updated cockpit.md to document the revised mid-turn reattach/watchdog behavior and the rare recoverable residual case.

## Benefits
- Prevents spurious "stuck thinking" / Idle transitions during legitimate mid-turn reasoning or streaming.
- Maintains daemon-side invariants and consistent behavior across clients.
- Provides a larger safety margin (30s) to avoid premature watchdog firing on slow first post-attach events.
- Covered by an integration test to catch regressions.

## Technical details (short)
- RESUME_IDLE_GRACE_DEFAULT increased from 10s to 30s.
- Introduced an atomic flag first_event_after_attach tracked by the notification handler and cloned into the watchdog task.
- Added classify_watchdog_notification_signals helper to narrow which notifications count as lifecycle/wakeup signals (ignores ambient/history-replay-only updates).
- Watchdog polling loop short-circuits and permanently disarms when the flag is set.
- Shim adds SHIM_EMIT_UNSOLICITED_NOTIF / SHIM_PRESEED_SESSION_ID to emit a delayed agent_message_chunk; integration test uses this to validate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->