### PR TITLE
feat(web): render user-defined groups as a sidebar axis

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -254,6 +254,15 @@ A sort toggle next to the filter button in the sidebar header switches to **Rece
 
 The toggle's state is per-browser (localStorage), not synced across devices and not tied to your profile. Toggling back to manual restores the stored manual order and re-enables drag. The multi-repo group stays pinned at the bottom in both modes.
 
+### Sidebar grouping: by repo or by group
+
+A grouping toggle (the layers icon) next to the sort toggle switches the axis the sidebar organises sessions by:
+
+- **By repo** (default) groups workspaces by their git repository, the original behavior.
+- **By group** groups sessions by the user-defined group you assigned in the TUI rename dialog or with `aoe group move`, mirroring the TUI's group headers. Sessions with no group fall into an **Ungrouped** bucket pinned to the bottom. A session whose worktree hosts agents in different groups shows up under each of those groups.
+
+The choice is per-browser (localStorage). Collapse state is tracked separately for each axis, so collapsing a group in **By group** does not collapse a repo in **By repo**. The group axis is read-only in v1: group rename, color, and drag-reorder live on the repo axis only, and groups themselves are not yet reorderable.
+
 ### Triage: pin, archive, snooze
 
 The sidebar exposes three triage primitives via the right-click (long-press on touch) context menu on any session row:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,7 +8,10 @@ import { CockpitPrefsProvider } from "./lib/cockpitPrefs";
 import { safeGetItem, safeSetItem } from "./lib/safeStorage";
 import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
+import { useSessionGroups } from "./hooks/useSessionGroups";
 import { useSidebarSortMode } from "./hooks/useSidebarSortMode";
+import { useSidebarAxis } from "./hooks/useSidebarAxis";
+import { repoGroupToSidebarGroup } from "./lib/sidebarGroups";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useResolvedTheme } from "./hooks/useResolvedTheme";
 import { useWebSettings } from "./hooks/useWebSettings";
@@ -232,9 +235,30 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   }, [sessionsLoaded, sessions]);
 
   const [sidebarSortMode, setSidebarSortMode] = useSidebarSortMode();
+  const [sidebarAxis, setSidebarAxis] = useSidebarAxis();
 
-  const { groups, toggleRepoCollapsed, updateRepoAppearance, reorderRepoGroups } =
-    useRepoGroups(workspaces, workspaceOrdering, sidebarSortMode);
+  const {
+    groups: repoGroups,
+    toggleRepoCollapsed,
+    updateRepoAppearance,
+    reorderRepoGroups,
+  } = useRepoGroups(workspaces, workspaceOrdering, sidebarSortMode);
+  const { groups: sessionGroups, toggleGroupCollapsed } =
+    useSessionGroups(workspaces);
+
+  // The sidebar render path consumes one honest model (SidebarGroup): the
+  // repo axis maps in via an adapter, the user-group axis is already in
+  // that shape. Collapse routing follows the active axis so the two
+  // axes keep independent collapse state. See #1234.
+  const sidebarGroups = useMemo(
+    () =>
+      sidebarAxis === "group"
+        ? sessionGroups
+        : repoGroups.map(repoGroupToSidebarGroup),
+    [sidebarAxis, sessionGroups, repoGroups],
+  );
+  const toggleSidebarGroup =
+    sidebarAxis === "group" ? toggleGroupCollapsed : toggleRepoCollapsed;
 
   // Drag-end handler for the sidebar. Optimistically applies the new
   // order locally so the row snaps into place, then persists to the
@@ -1062,14 +1086,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       <div className="flex flex-1 min-h-0">
         {!showSettings && !showProjects && (
           <WorkspaceSidebar
-            groups={groups}
+            groups={sidebarGroups}
             onReorderWorkspaces={handleReorderWorkspaces}
             onReorderGroups={reorderRepoGroups}
             activeId={activeWorkspace?.id ?? null}
             open={sidebarOpen}
             onToggle={() => setSidebarOpen(false)}
             onSelect={handleSelectWorkspace}
-            onToggleRepo={toggleRepoCollapsed}
+            onToggleGroup={toggleSidebarGroup}
             onUpdateRepoAppearance={updateRepoAppearance}
             onNew={() => { setWizardPrefill(undefined); setShowSessionWizard(true); }}
             onCreateSession={handleCreateSession}
@@ -1079,6 +1103,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             readOnly={serverAbout?.read_only}
             sortMode={sidebarSortMode}
             onSortModeChange={setSidebarSortMode}
+            axis={sidebarAxis}
+            onAxisChange={setSidebarAxis}
           />
         )}
 

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -14,6 +14,7 @@ import {
   Archive,
   Clock,
   GripVertical,
+  Layers,
   ListOrdered,
   Moon,
   Pencil,
@@ -37,12 +38,15 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type {
-  RepoGroup,
   SessionResponse,
   SessionStatus,
   Workspace,
 } from "../lib/types";
-import { MULTI_REPO_GROUP_ID, SCRATCH_GROUP_ID } from "../hooks/useRepoGroups";
+import type { SidebarAxis } from "../lib/sidebarAxis";
+import {
+  sidebarGroupHasLiveWorkspace,
+  type SidebarGroup,
+} from "../lib/sidebarGroups";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import {
   REPO_COLOR_OPTIONS,
@@ -69,7 +73,6 @@ import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { useQueuedCountForSessions } from "../hooks/useCockpitQueueCount";
 import { reportError } from "../lib/toastBus";
 import {
-  repoGroupHasLiveWorkspace,
   resolveEffectiveSnoozedUntil,
   snoozeTimestampCloseEnough,
   triageMenuShape,
@@ -133,14 +136,14 @@ const typedClosestCenter: CollisionDetection = (args) => {
 };
 
 interface Props {
-  groups: RepoGroup[];
+  groups: SidebarGroup[];
   onReorderWorkspaces: (newOrder: string[]) => void;
   onReorderGroups: (orderedGroupIds: string[]) => void;
   activeId: string | null;
   open: boolean;
   onToggle: () => void;
   onSelect: (workspaceId: string) => void;
-  onToggleRepo: (repoId: string) => void;
+  onToggleGroup: (groupId: string) => void;
   onUpdateRepoAppearance: (repoId: string, update: RepoAppearanceUpdate) => void;
   onNew: () => void;
   onCreateSession: (repoPath: string) => void;
@@ -150,6 +153,8 @@ interface Props {
   readOnly?: boolean;
   sortMode: SidebarSortMode;
   onSortModeChange: (mode: SidebarSortMode) => void;
+  axis: SidebarAxis;
+  onAxisChange: (axis: SidebarAxis) => void;
 }
 
 function bestSession(
@@ -402,7 +407,11 @@ function useSuppressClickAfterDrag(ref: MutableRefObject<number>) {
   }, [ref]);
 }
 
-function SortableSessionRow(props: {
+function SortableSessionRow({
+  rowKey,
+  ...props
+}: {
+  rowKey?: string;
   workspace: Workspace;
   isActive: boolean;
   onClick: () => void;
@@ -420,7 +429,7 @@ function SortableSessionRow(props: {
   const dragOff = !!props.readOnly || !!props.dragDisabled;
   const { listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({
-      id: props.workspace.id,
+      id: rowKey ?? props.workspace.id,
       disabled: dragOff,
       data: { type: "workspace" },
     });
@@ -1430,7 +1439,7 @@ export function SnoozeModal({
   );
 }
 
-const RepoGroupHeader = memo(function RepoGroupHeader({
+const SidebarGroupHeader = memo(function SidebarGroupHeader({
   group,
   hasActiveChild,
   onClick,
@@ -1439,7 +1448,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
   offline,
   dragHandle,
 }: {
-  group: RepoGroup;
+  group: SidebarGroup;
   hasActiveChild: boolean;
   onClick: () => void;
   onNewSession: () => void;
@@ -1447,6 +1456,11 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
   offline: boolean;
   dragHandle?: DragHandleProps;
 }) {
+  // Appearance (rename/alias/color) and its context menu are repo-axis
+  // only. The user-group axis has no per-group appearance in v1, so the
+  // menu trigger and rename input are gated off rather than rendered inert.
+  const canAppearance = group.capabilities.appearance;
+  const headerTitle = group.groupPath ?? group.repoPath;
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(group.alias ?? group.displayName);
@@ -1544,14 +1558,20 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
       <div
         data-testid="sidebar-group-header"
         data-group-id={group.id}
-        tabIndex={0}
-        aria-haspopup="menu"
-        aria-label={`Project actions for ${group.displayName}`}
-        onContextMenu={(e) => {
-          e.preventDefault();
-          openMenuAt(e.clientX, e.clientY);
-        }}
-        onKeyDown={handleHeaderKeyDown}
+        tabIndex={canAppearance ? 0 : undefined}
+        aria-haspopup={canAppearance ? "menu" : undefined}
+        aria-label={
+          canAppearance ? `Project actions for ${group.displayName}` : undefined
+        }
+        onContextMenu={
+          canAppearance
+            ? (e) => {
+                e.preventDefault();
+                openMenuAt(e.clientX, e.clientY);
+              }
+            : undefined
+        }
+        onKeyDown={canAppearance ? handleHeaderKeyDown : undefined}
         className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary focus:outline-none focus:ring-2 focus:ring-brand-600 ${headerHoverClass} ${
           hasActiveChild ? "border-l-2 border-brand-600" : ""
         }`}
@@ -1588,7 +1608,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
             <path d="M2 3 L5 6.5 L8 3" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
           <OwnerAvatar owner={group.remoteOwner} size={16} />
-          <span className="text-[13px] md:text-[14px] font-medium truncate flex-1" title={group.repoPath}>
+          <span className="text-[13px] md:text-[14px] font-medium truncate flex-1" title={headerTitle}>
             {group.displayName}
           </span>
         </button>
@@ -1606,7 +1626,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
           </button>
         </Tooltip>
       </div>
-      {contextMenu && createPortal(
+      {canAppearance && contextMenu && createPortal(
         <div
           ref={menuRef}
           data-testid="sidebar-group-context-menu"
@@ -1709,7 +1729,7 @@ export function WorkspaceSidebar({
   open,
   onToggle,
   onSelect,
-  onToggleRepo,
+  onToggleGroup,
   onUpdateRepoAppearance,
   onNew,
   onCreateSession,
@@ -1719,8 +1739,16 @@ export function WorkspaceSidebar({
   readOnly,
   sortMode,
   onSortModeChange,
+  axis,
+  onAxisChange,
 }: Props) {
   const dragDisabled = !!readOnly || sortMode === "lastActivity";
+  // Reorder (group drag + row drag) is also off whenever any visible group
+  // forbids it, which is the whole user-group axis: groups have no manual
+  // order in v1. Gating here keeps the shared DndContext from firing a
+  // reorder on an axis that cannot persist one.
+  const reorderDisabled =
+    dragDisabled || groups.some((g) => !g.capabilities.reorder);
   const dragSuppressRef = useRef<number>(0);
   useSuppressClickAfterDrag(dragSuppressRef);
   const offline = useServerDown();
@@ -1788,23 +1816,25 @@ export function WorkspaceSidebar({
       // (each group has its own SortableContext), so finding the active
       // group and reordering inside it is sufficient.
       const groupIndex = groups.findIndex((g) =>
-        g.workspaces.some((w) => w.id === active.id),
+        g.workspaces.some((v) => v.key === active.id),
       );
       const group = groups[groupIndex];
       if (groupIndex < 0 || !group) return;
-      const oldIndex = group.workspaces.findIndex((w) => w.id === active.id);
-      const newIndex = group.workspaces.findIndex((w) => w.id === over.id);
+      const oldIndex = group.workspaces.findIndex((v) => v.key === active.id);
+      const newIndex = group.workspaces.findIndex((v) => v.key === over.id);
       if (oldIndex < 0 || newIndex < 0) return;
 
       // Build the new full visual order by replacing the affected
       // group's local order, then concat in the existing group order.
-      // We persist the full flat list so cross-device clients can render
-      // the same layout without re-deriving per-group ordering.
+      // We persist the full flat list of workspace ids so cross-device
+      // clients can render the same layout without re-deriving per-group
+      // ordering. Reorder only ever runs on the repo axis (the user-group
+      // axis disables drag), where each view key equals its workspace id.
       const reordered = arrayMove(group.workspaces, oldIndex, newIndex);
       const flat: string[] = [];
       groups.forEach((g, i) => {
-        const ws = i === groupIndex ? reordered : g.workspaces;
-        ws.forEach((w) => flat.push(w.id));
+        const views = i === groupIndex ? reordered : g.workspaces;
+        views.forEach((v) => flat.push(v.workspace.id));
       });
       onReorderWorkspaces(flat);
     },
@@ -1817,8 +1847,8 @@ export function WorkspaceSidebar({
     ? groups
         .map((g) => ({
           ...g,
-          workspaces: g.workspaces.filter((ws) =>
-            workspaceMatchesFilter(ws, q) ||
+          workspaces: g.workspaces.filter((v) =>
+            workspaceMatchesFilter(v.workspace, q) ||
             g.displayName.toLowerCase().includes(q),
           ),
         }))
@@ -1888,8 +1918,34 @@ export function WorkspaceSidebar({
       >
         <div className="px-3 pt-3 pb-1 flex items-center">
           <span className="text-sm text-text-muted flex-1">
-            Projects
+            {axis === "group" ? "Groups" : "Projects"}
           </span>
+          <Tooltip
+            text={
+              axis === "group"
+                ? "Grouping: by user group"
+                : "Grouping: by repository"
+            }
+          >
+            <button
+              onClick={() => onAxisChange(axis === "repo" ? "group" : "repo")}
+              aria-pressed={axis === "group"}
+              aria-label={
+                axis === "group"
+                  ? "Group sessions by user group, currently pressed"
+                  : "Group sessions by repository"
+              }
+              data-testid="sidebar-axis-toggle"
+              data-axis={axis}
+              className={`w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors ${
+                axis === "group"
+                  ? "text-brand-500"
+                  : "text-text-dim hover:text-text-secondary"
+              }`}
+            >
+              <Layers className="h-3.5 w-3.5" />
+            </button>
+          </Tooltip>
           <Tooltip
             text={
               sortMode === "lastActivity"
@@ -2001,41 +2057,41 @@ export function WorkspaceSidebar({
           <DndContext
             sensors={sensors}
             collisionDetection={typedClosestCenter}
-            onDragEnd={dragDisabled ? undefined : handleDragEnd}
+            onDragEnd={reorderDisabled ? undefined : handleDragEnd}
           >
             {(() => {
               const liveGroups = filteredGroups.filter(
-                repoGroupHasLiveWorkspace,
+                sidebarGroupHasLiveWorkspace,
               );
               // Every visible group is sortable, synthetic Multi-repo /
               // Scratch included: they default to the bottom but can be
               // dragged to any position. Group drag is off while a filter
-              // is active (the visible list is a partial projection) or
+              // is active (the visible list is a partial projection),
               // whenever row drag is off (read-only or last-activity
-              // sort, where the order is computed). See #1644.
+              // sort), or on the user-group axis (no manual order). See
+              // #1644, #1234.
               const sortableGroupIds = liveGroups.map((g) => g.id);
-              const groupDragDisabled = dragDisabled || q.length > 0;
+              const groupDragDisabled = reorderDisabled || q.length > 0;
 
               const renderGroupBody = (
-                group: RepoGroup,
+                group: SidebarGroup,
                 dragHandle?: DragHandleProps,
               ) => {
                 const showExpanded = q ? true : !group.collapsed;
                 const hasActiveChild = group.workspaces.some(
-                  (ws) => ws.id === displayedActiveId,
+                  (v) => v.workspace.id === displayedActiveId,
                 );
                 return (
                   <>
-                    <RepoGroupHeader
+                    <SidebarGroupHeader
                       group={{ ...group, collapsed: !showExpanded }}
                       hasActiveChild={!showExpanded && hasActiveChild}
-                      onClick={() => !q && onToggleRepo(group.id)}
+                      onClick={() => !q && onToggleGroup(group.id)}
                       onUpdateAppearance={onUpdateRepoAppearance}
                       onNewSession={() =>
-                        group.id === MULTI_REPO_GROUP_ID ||
-                        group.id === SCRATCH_GROUP_ID
-                          ? onNew()
-                          : onCreateSession(group.repoPath)
+                        group.capabilities.create === "repo" && group.repoPath
+                          ? onCreateSession(group.repoPath)
+                          : onNew()
                       }
                       offline={offline}
                       dragHandle={dragHandle}
@@ -2049,24 +2105,27 @@ export function WorkspaceSidebar({
                         // bottom of the sidebar, rather than one footer
                         // per repo group. See #1581.
                         const liveWorkspaces = group.workspaces.filter(
-                          (ws) => !workspaceIsSunk(ws),
+                          (v) => !workspaceIsSunk(v.workspace),
                         );
                         return (
                           <SortableContext
-                            items={liveWorkspaces.map((ws) => ws.id)}
+                            items={liveWorkspaces.map((v) => v.key)}
                             strategy={verticalListSortingStrategy}
                           >
-                            {liveWorkspaces.map((ws) => (
+                            {liveWorkspaces.map((v) => (
                               <SortableSessionRow
-                                key={ws.id}
-                                workspace={ws}
-                                isActive={ws.id === displayedActiveId}
+                                key={v.key}
+                                rowKey={v.key}
+                                workspace={v.workspace}
+                                isActive={
+                                  v.workspace.id === displayedActiveId
+                                }
                                 onClick={() => {
                                   setOptimisticActive({
-                                    id: ws.id,
+                                    id: v.workspace.id,
                                     fromActiveId: activeId,
                                   });
-                                  onSelect(ws.id);
+                                  onSelect(v.workspace.id);
                                 }}
                                 onDelete={onDeleteSession}
                                 readOnly={readOnly}
@@ -2074,10 +2133,12 @@ export function WorkspaceSidebar({
                                 // comparator already controls placement:
                                 // lastActivity mode has no manual
                                 // concept, pinned rows always float to
-                                // the top of their group. See #1581.
+                                // the top of their group, and the
+                                // user-group axis has no manual order.
+                                // See #1581, #1234.
                                 dragDisabled={
-                                  sortMode === "lastActivity" ||
-                                  workspaceIsPinned(ws)
+                                  reorderDisabled ||
+                                  workspaceIsPinned(v.workspace)
                                 }
                               />
                             ))}
@@ -2126,7 +2187,7 @@ export function WorkspaceSidebar({
             // surfaces the title/branch/repo chips that anchor it to
             // its project. See #1581.
             const sunkWorkspaces = filteredGroups.flatMap((g) =>
-              g.workspaces.filter(workspaceIsSunk),
+              g.workspaces.filter((v) => workspaceIsSunk(v.workspace)),
             );
             if (sunkWorkspaces.length === 0) return null;
             return (
@@ -2160,17 +2221,17 @@ export function WorkspaceSidebar({
                   </span>
                 </button>
                 {sunkExpanded &&
-                  sunkWorkspaces.map((ws) => (
+                  sunkWorkspaces.map((v) => (
                     <SessionRow
-                      key={ws.id}
-                      workspace={ws}
-                      isActive={ws.id === displayedActiveId}
+                      key={v.key}
+                      workspace={v.workspace}
+                      isActive={v.workspace.id === displayedActiveId}
                       onClick={() => {
                         setOptimisticActive({
-                          id: ws.id,
+                          id: v.workspace.id,
                           fromActiveId: activeId,
                         });
-                        onSelect(ws.id);
+                        onSelect(v.workspace.id);
                       }}
                       onDelete={onDeleteSession}
                       readOnly={readOnly}

--- a/web/src/hooks/useSessionGroups.ts
+++ b/web/src/hooks/useSessionGroups.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Workspace } from "../lib/types";
 import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
 import { buildSessionGroups, type SidebarGroup } from "../lib/sidebarGroups";
@@ -29,18 +29,28 @@ export function useSessionGroups(workspaces: Workspace[]): {
     [workspaces, idleDecayWindowMs, collapsedMap],
   );
 
+  // The updater stays pure: it reads the current value but performs no
+  // storage IO. Writing inside the updater is unsafe under React
+  // StrictMode, which double-invokes updaters in dev: the first pass's
+  // write would make the second pass's `loadCollapsed` read see the new
+  // value and compute the opposite result, so the toggle no-ops and
+  // storage desyncs from state. Persistence runs in an effect instead.
   const toggleGroupCollapsed = useCallback((groupId: string) => {
     setCollapsedMap((prev) => {
       const current = prev[groupId] ?? loadCollapsed(groupId);
-      const next = !current;
-      if (next) {
-        safeSetItem(`${COLLAPSED_KEY_PREFIX}${groupId}`, "1");
-      } else {
-        safeRemoveItem(`${COLLAPSED_KEY_PREFIX}${groupId}`);
-      }
-      return { ...prev, [groupId]: next };
+      return { ...prev, [groupId]: !current };
     });
   }, []);
+
+  useEffect(() => {
+    for (const [id, collapsed] of Object.entries(collapsedMap)) {
+      if (collapsed) {
+        safeSetItem(`${COLLAPSED_KEY_PREFIX}${id}`, "1");
+      } else {
+        safeRemoveItem(`${COLLAPSED_KEY_PREFIX}${id}`);
+      }
+    }
+  }, [collapsedMap]);
 
   return { groups, toggleGroupCollapsed };
 }

--- a/web/src/hooks/useSessionGroups.ts
+++ b/web/src/hooks/useSessionGroups.ts
@@ -1,0 +1,46 @@
+import { useCallback, useMemo, useState } from "react";
+import type { Workspace } from "../lib/types";
+import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
+import { buildSessionGroups, type SidebarGroup } from "../lib/sidebarGroups";
+import { useIdleDecayWindowMs } from "../lib/idleDecay";
+
+// Distinct from the repo axis prefix (`aoe-repo-collapsed-`) so collapse
+// state is per-axis: collapsing a user group never changes a repo group's
+// state and vice versa. See #1234.
+const COLLAPSED_KEY_PREFIX = "aoe-group-collapsed-";
+
+function loadCollapsed(id: string): boolean {
+  return safeGetItem(`${COLLAPSED_KEY_PREFIX}${id}`) === "1";
+}
+
+export function useSessionGroups(workspaces: Workspace[]): {
+  groups: SidebarGroup[];
+  toggleGroupCollapsed: (groupId: string) => void;
+} {
+  const idleDecayWindowMs = useIdleDecayWindowMs();
+  const [collapsedMap, setCollapsedMap] = useState<Record<string, boolean>>({});
+
+  const groups = useMemo(
+    () =>
+      buildSessionGroups(workspaces, {
+        idleDecayWindowMs,
+        isCollapsed: (id) => collapsedMap[id] ?? loadCollapsed(id),
+      }),
+    [workspaces, idleDecayWindowMs, collapsedMap],
+  );
+
+  const toggleGroupCollapsed = useCallback((groupId: string) => {
+    setCollapsedMap((prev) => {
+      const current = prev[groupId] ?? loadCollapsed(groupId);
+      const next = !current;
+      if (next) {
+        safeSetItem(`${COLLAPSED_KEY_PREFIX}${groupId}`, "1");
+      } else {
+        safeRemoveItem(`${COLLAPSED_KEY_PREFIX}${groupId}`);
+      }
+      return { ...prev, [groupId]: next };
+    });
+  }, []);
+
+  return { groups, toggleGroupCollapsed };
+}

--- a/web/src/hooks/useSidebarAxis.test.ts
+++ b/web/src/hooks/useSidebarAxis.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+//
+// Contract test for the useSidebarAxis hook (#1234). The hook is a thin
+// React wrapper around sidebarAxis's load/save helpers. These tests pin
+// the public contract: defaults to "repo" when localStorage is empty,
+// restores a stored "group", and the setter persists.
+
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useSidebarAxis } from "./useSidebarAxis";
+import { SIDEBAR_AXIS_KEY } from "../lib/sidebarAxis";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("useSidebarAxis", () => {
+  it("defaults to 'repo' when localStorage is empty", () => {
+    const { result } = renderHook(() => useSidebarAxis());
+    expect(result.current[0]).toBe("repo");
+  });
+
+  it("hydrates from a stored 'group' value", () => {
+    window.localStorage.setItem(SIDEBAR_AXIS_KEY, "group");
+    const { result } = renderHook(() => useSidebarAxis());
+    expect(result.current[0]).toBe("group");
+  });
+
+  it("falls back to 'repo' for an unrecognised stored value", () => {
+    window.localStorage.setItem(SIDEBAR_AXIS_KEY, "garbage");
+    const { result } = renderHook(() => useSidebarAxis());
+    expect(result.current[0]).toBe("repo");
+  });
+
+  it("setter updates state and persists to localStorage", () => {
+    const { result } = renderHook(() => useSidebarAxis());
+
+    act(() => {
+      result.current[1]("group");
+    });
+
+    expect(result.current[0]).toBe("group");
+    expect(window.localStorage.getItem(SIDEBAR_AXIS_KEY)).toBe("group");
+  });
+
+  it("setter is stable across renders (useCallback)", () => {
+    const { result, rerender } = renderHook(() => useSidebarAxis());
+    const setter1 = result.current[1];
+    rerender();
+    expect(result.current[1]).toBe(setter1);
+  });
+});

--- a/web/src/hooks/useSidebarAxis.ts
+++ b/web/src/hooks/useSidebarAxis.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from "react";
+import {
+  loadSidebarAxis,
+  saveSidebarAxis,
+  type SidebarAxis,
+} from "../lib/sidebarAxis";
+
+export function useSidebarAxis(): readonly [
+  SidebarAxis,
+  (axis: SidebarAxis) => void,
+] {
+  const [axis, setAxis] = useState<SidebarAxis>(loadSidebarAxis);
+
+  const update = useCallback((next: SidebarAxis) => {
+    setAxis(next);
+    saveSidebarAxis(next);
+  }, []);
+
+  return [axis, update] as const;
+}

--- a/web/src/lib/__tests__/sidebarGroups.test.ts
+++ b/web/src/lib/__tests__/sidebarGroups.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment node
+//
+// Unit tests for the sidebar group view-model (#1234). The render path
+// consumes SidebarGroup; these tests pin the two builders that produce it:
+// repoGroupToSidebarGroup (repo axis adapter) and buildSessionGroups (the
+// user-group axis). The load-bearing case is the per-session split: a
+// workspace whose sessions span groups must render once per group with a
+// sliced session set, a distinct render key, and the real workspace id
+// preserved for actions.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSessionGroups,
+  repoGroupToSidebarGroup,
+  sidebarGroupHasLiveWorkspace,
+  UNGROUPED_GROUP_ID,
+} from "../sidebarGroups";
+import { MULTI_REPO_GROUP_ID } from "../../hooks/useRepoGroups";
+import { IDLE_DECAY_WINDOW_MS } from "../session";
+import type { RepoGroup, SessionResponse, Workspace } from "../types";
+
+function session(over: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: "s1",
+    title: "t",
+    project_path: "/repo-a",
+    group_path: "",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+    },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+    scratch: false,
+    ...over,
+  };
+}
+
+function workspace(
+  id: string,
+  sessions: SessionResponse[],
+  over: Partial<Workspace> = {},
+): Workspace {
+  return {
+    id,
+    branch: null,
+    projectPath: "/repo-a",
+    displayName: id,
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    sessions,
+    ...over,
+  };
+}
+
+const build = (
+  workspaces: Workspace[],
+  isCollapsed: (id: string) => boolean = () => false,
+) =>
+  buildSessionGroups(workspaces, {
+    idleDecayWindowMs: IDLE_DECAY_WINDOW_MS,
+    isCollapsed,
+  });
+
+describe("buildSessionGroups", () => {
+  it("buckets workspaces by group_path, named groups alphabetical", () => {
+    const groups = build([
+      workspace("w1", [session({ id: "s1", group_path: "refactor" })]),
+      workspace("w2", [session({ id: "s2", group_path: "feature" })]),
+    ]);
+    expect(groups.map((g) => g.id)).toEqual(["feature", "refactor"]);
+    expect(groups.every((g) => g.kind === "sessionGroup")).toBe(true);
+    expect(groups[0]!.groupPath).toBe("feature");
+  });
+
+  it("collects empty group_path into Ungrouped, pinned to the bottom", () => {
+    const groups = build([
+      workspace("w1", [session({ id: "s1", group_path: "" })]),
+      workspace("w2", [session({ id: "s2", group_path: "feature" })]),
+    ]);
+    expect(groups.map((g) => g.id)).toEqual(["feature", UNGROUPED_GROUP_ID]);
+    const ungrouped = groups.find((g) => g.id === UNGROUPED_GROUP_ID)!;
+    expect(ungrouped.displayName).toBe("Ungrouped");
+    expect(ungrouped.groupPath).toBe("");
+  });
+
+  it("splits a workspace whose sessions span groups, slicing sessions", () => {
+    const groups = build([
+      workspace("w1", [
+        session({ id: "a", group_path: "feature" }),
+        session({ id: "b", group_path: "fix" }),
+      ]),
+    ]);
+    expect(groups.map((g) => g.id)).toEqual(["feature", "fix"]);
+
+    const feature = groups.find((g) => g.id === "feature")!;
+    const fix = groups.find((g) => g.id === "fix")!;
+    expect(feature.workspaces).toHaveLength(1);
+    expect(fix.workspaces).toHaveLength(1);
+
+    // Real workspace id preserved for actions; render keys distinct.
+    expect(feature.workspaces[0]!.workspace.id).toBe("w1");
+    expect(fix.workspaces[0]!.workspace.id).toBe("w1");
+    expect(feature.workspaces[0]!.key).not.toBe(fix.workspaces[0]!.key);
+
+    // Each view carries only its group's sessions.
+    expect(feature.workspaces[0]!.workspace.sessions.map((s) => s.id)).toEqual([
+      "a",
+    ]);
+    expect(fix.workspaces[0]!.workspace.sessions.map((s) => s.id)).toEqual([
+      "b",
+    ]);
+  });
+
+  it("trims and normalizes whitespace-only group_path into Ungrouped", () => {
+    const groups = build([
+      workspace("w1", [session({ id: "s1", group_path: "   " })]),
+    ]);
+    expect(groups.map((g) => g.id)).toEqual([UNGROUPED_GROUP_ID]);
+  });
+
+  it("uses the leaf segment of a nested path as the display name", () => {
+    const groups = build([
+      workspace("w1", [session({ id: "s1", group_path: "feature/auth" })]),
+    ]);
+    expect(groups[0]!.id).toBe("feature/auth");
+    expect(groups[0]!.displayName).toBe("auth");
+  });
+
+  it("reflects collapse state from the isCollapsed lookup", () => {
+    const groups = build(
+      [workspace("w1", [session({ id: "s1", group_path: "feature" })])],
+      (id) => id === "feature",
+    );
+    expect(groups[0]!.collapsed).toBe(true);
+  });
+
+  it("session groups expose no repo-only affordances", () => {
+    const groups = build([
+      workspace("w1", [session({ id: "s1", group_path: "feature" })]),
+    ]);
+    expect(groups[0]!.capabilities).toEqual({
+      appearance: false,
+      reorder: false,
+      create: "generic",
+    });
+  });
+});
+
+describe("repoGroupToSidebarGroup", () => {
+  function repoGroup(over: Partial<RepoGroup> = {}): RepoGroup {
+    return {
+      id: "/repo-a",
+      repoPath: "/repo-a",
+      displayName: "repo-a",
+      defaultDisplayName: "repo-a",
+      alias: null,
+      color: null,
+      remoteOwner: null,
+      workspaces: [workspace("w1", [session({ id: "s1" })])],
+      status: "idle",
+      collapsed: false,
+      ...over,
+    };
+  }
+
+  it("maps a real repo group with repo capabilities and id-based keys", () => {
+    const sg = repoGroupToSidebarGroup(repoGroup());
+    expect(sg.kind).toBe("repo");
+    expect(sg.repoPath).toBe("/repo-a");
+    expect(sg.capabilities).toEqual({
+      appearance: true,
+      reorder: true,
+      create: "repo",
+    });
+    expect(sg.workspaces[0]!.key).toBe("w1");
+    expect(sg.workspaces[0]!.workspace.id).toBe("w1");
+  });
+
+  it("gives synthetic repo buckets a generic create action", () => {
+    const sg = repoGroupToSidebarGroup(
+      repoGroup({ id: MULTI_REPO_GROUP_ID, repoPath: MULTI_REPO_GROUP_ID }),
+    );
+    expect(sg.capabilities.create).toBe("generic");
+    expect(sg.capabilities.appearance).toBe(true);
+  });
+});
+
+describe("sidebarGroupHasLiveWorkspace", () => {
+  it("is false when every workspace is sunk", () => {
+    const groups = build([
+      workspace("w1", [
+        session({ id: "s1", group_path: "feature", archived_at: "2025-01-02T00:00:00Z" }),
+      ]),
+    ]);
+    expect(sidebarGroupHasLiveWorkspace(groups[0]!)).toBe(false);
+  });
+
+  it("is true when at least one workspace is live", () => {
+    const groups = build([
+      workspace("w1", [session({ id: "s1", group_path: "feature" })]),
+    ]);
+    expect(sidebarGroupHasLiveWorkspace(groups[0]!)).toBe(true);
+  });
+});

--- a/web/src/lib/sidebarAxis.ts
+++ b/web/src/lib/sidebarAxis.ts
@@ -1,0 +1,17 @@
+import { safeGetItem, safeSetItem } from "./safeStorage";
+
+/** Which organisation axis the sidebar groups sessions by: the auto-derived
+ *  repository axis (default, the original behavior) or the user-defined
+ *  group axis backed by each session's `group_path`. Per-browser, like the
+ *  sort mode. See #1234. */
+export type SidebarAxis = "repo" | "group";
+
+export const SIDEBAR_AXIS_KEY = "aoe-sidebar-axis";
+
+export function loadSidebarAxis(): SidebarAxis {
+  return safeGetItem(SIDEBAR_AXIS_KEY) === "group" ? "group" : "repo";
+}
+
+export function saveSidebarAxis(axis: SidebarAxis): void {
+  safeSetItem(SIDEBAR_AXIS_KEY, axis);
+}

--- a/web/src/lib/sidebarGroups.ts
+++ b/web/src/lib/sidebarGroups.ts
@@ -1,0 +1,190 @@
+import type { RepoColor } from "./repoAppearance";
+import type {
+  RepoGroup,
+  SessionResponse,
+  Workspace,
+  WorkspaceStatus,
+} from "./types";
+import { isSessionActive } from "./session";
+import {
+  compareWorkspacesByLastActivityDesc,
+  workspaceIsSunk,
+} from "./sidebarSort";
+import { MULTI_REPO_GROUP_ID, SCRATCH_GROUP_ID } from "../hooks/useRepoGroups";
+
+// Synthetic id for the bucket that collects sessions with no user-assigned
+// `group_path`. Distinct from any real group path (a real path is never
+// empty after trimming), so it can double as a localStorage collapse key.
+export const UNGROUPED_GROUP_ID = "__ungrouped__";
+
+// Which affordances a sidebar group header may show. The repo axis groups
+// own appearance (alias/color), manual drag-reorder, and create-in-repo;
+// the user-group axis owns none of these in v1, so they are gated here
+// instead of by scattered `kind === ...` checks in the render path.
+export interface SidebarGroupCapabilities {
+  appearance: boolean;
+  reorder: boolean;
+  create: "repo" | "generic";
+}
+
+// A single rendered workspace row inside a sidebar group. `workspace`
+// keeps its real server id for selection, routing, and delete actions; in
+// the group axis its `sessions` is a per-group slice (a workspace whose
+// sessions span groups appears once per group). `key` is a render/DnD
+// identity that stays unique across such a split, so it must never be used
+// as the workspace id for an action.
+export interface SidebarWorkspaceView {
+  key: string;
+  workspace: Workspace;
+}
+
+// The honest render model for the sidebar. Repo groups map into it via
+// `repoGroupToSidebarGroup`; user groups are built by `buildSessionGroups`.
+// `RepoGroup` stays a repo-axis-internal type and is never reused to mean
+// a user group.
+export interface SidebarGroup {
+  id: string;
+  kind: "repo" | "sessionGroup";
+  displayName: string;
+  defaultDisplayName: string;
+  alias: string | null;
+  color: RepoColor | null;
+  remoteOwner: string | null;
+  workspaces: SidebarWorkspaceView[];
+  status: WorkspaceStatus;
+  collapsed: boolean;
+  capabilities: SidebarGroupCapabilities;
+  /** Set when `kind === "repo"`. */
+  repoPath?: string;
+  /** Set when `kind === "sessionGroup"`. Empty string for Ungrouped. */
+  groupPath?: string;
+}
+
+function isSyntheticRepoGroup(id: string): boolean {
+  return id === MULTI_REPO_GROUP_ID || id === SCRATCH_GROUP_ID;
+}
+
+// Adapt a repo-axis `RepoGroup` into the shared render model without
+// changing any repo behavior. Synthetic Multi-repo / Scratch buckets keep
+// their generic create action (they route the `+` to the wizard, not to a
+// repo path); real repos create directly in their repo.
+export function repoGroupToSidebarGroup(group: RepoGroup): SidebarGroup {
+  const synthetic = isSyntheticRepoGroup(group.id);
+  return {
+    id: group.id,
+    kind: "repo",
+    displayName: group.displayName,
+    defaultDisplayName: group.defaultDisplayName,
+    alias: group.alias,
+    color: group.color,
+    remoteOwner: group.remoteOwner,
+    workspaces: group.workspaces.map((workspace) => ({
+      key: workspace.id,
+      workspace,
+    })),
+    status: group.status,
+    collapsed: group.collapsed,
+    capabilities: {
+      appearance: true,
+      reorder: true,
+      create: synthetic ? "generic" : "repo",
+    },
+    repoPath: group.repoPath,
+  };
+}
+
+function normalizeGroupPath(path: string | null | undefined): string {
+  return (path ?? "").trim();
+}
+
+function groupDisplayName(path: string): string {
+  if (path === "") return "Ungrouped";
+  // v1 renders groups flat; the leaf segment is the friendly label while
+  // the full path stays available as the header title for nested groups.
+  return path.split("/").pop() || path;
+}
+
+// Build the user-group axis from workspaces. `group_path` is per-session,
+// so a workspace whose sessions span groups is split into one view per
+// group, each carrying only that group's sessions. Sessions with an empty
+// `group_path` collect into the Ungrouped bucket. Within a group, rows
+// sort by the shared last-activity comparator (the group axis has no
+// manual order in v1); named groups sort alphabetically with Ungrouped
+// pinned to the bottom.
+export function buildSessionGroups(
+  workspaces: Workspace[],
+  opts: {
+    idleDecayWindowMs: number;
+    isCollapsed: (groupId: string) => boolean;
+  },
+): SidebarGroup[] {
+  const byGroup = new Map<string, SidebarWorkspaceView[]>();
+  const order: string[] = [];
+
+  for (const ws of workspaces) {
+    const sessionsByGroup = new Map<string, SessionResponse[]>();
+    for (const session of ws.sessions) {
+      const gp = normalizeGroupPath(session.group_path);
+      const existing = sessionsByGroup.get(gp);
+      if (existing) existing.push(session);
+      else sessionsByGroup.set(gp, [session]);
+    }
+
+    for (const [gp, sessions] of sessionsByGroup) {
+      const sliced: Workspace = {
+        ...ws,
+        sessions,
+        status: sessions.some((s) => isSessionActive(s, opts.idleDecayWindowMs))
+          ? "active"
+          : "idle",
+      };
+      const view: SidebarWorkspaceView = { key: `${gp}::${ws.id}`, workspace: sliced };
+      const bucket = byGroup.get(gp);
+      if (bucket) {
+        bucket.push(view);
+      } else {
+        byGroup.set(gp, [view]);
+        order.push(gp);
+      }
+    }
+  }
+
+  const groups: SidebarGroup[] = [];
+  for (const gp of order) {
+    const views = byGroup.get(gp)!;
+    views.sort((a, b) =>
+      compareWorkspacesByLastActivityDesc(a.workspace, b.workspace),
+    );
+    const id = gp === "" ? UNGROUPED_GROUP_ID : gp;
+    const hasActive = views.some((v) => v.workspace.status === "active");
+    groups.push({
+      id,
+      kind: "sessionGroup",
+      displayName: groupDisplayName(gp),
+      defaultDisplayName: groupDisplayName(gp),
+      alias: null,
+      color: null,
+      remoteOwner: null,
+      workspaces: views,
+      status: hasActive ? "active" : "idle",
+      collapsed: opts.isCollapsed(id),
+      capabilities: { appearance: false, reorder: false, create: "generic" },
+      groupPath: gp,
+    });
+  }
+
+  groups.sort((a, b) => {
+    if (a.id === UNGROUPED_GROUP_ID) return 1;
+    if (b.id === UNGROUPED_GROUP_ID) return -1;
+    return a.displayName.localeCompare(b.displayName);
+  });
+
+  return groups;
+}
+
+// Group-axis equivalent of `repoGroupHasLiveWorkspace`: true while a group
+// still has a row that has not dropped into the global "Snoozed & archived"
+// footer, so an all-sunk group's header is not rendered empty.
+export function sidebarGroupHasLiveWorkspace(group: SidebarGroup): boolean {
+  return group.workspaces.some((v) => !workspaceIsSunk(v.workspace));
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -730,6 +730,41 @@
       ]
     },
     {
+      "id": "sidebar.group-axis-pure",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/lib/__tests__/sidebarGroups.test.ts"
+      ],
+      "components": [
+        "web/src/lib/sidebarGroups.ts"
+      ]
+    },
+    {
+      "id": "sidebar.axis-hook",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/hooks/useSidebarAxis.test.ts"
+      ],
+      "components": [
+        "web/src/hooks/useSidebarAxis.ts"
+      ]
+    },
+    {
+      "id": "sidebar.group-axis-live",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/sidebar-groups-axis.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/hooks/useSessionGroups.ts",
+        "web/src/lib/sidebarGroups.ts"
+      ]
+    },
+    {
       "id": "session.lifecycle",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/sidebar-groups-axis.spec.ts
+++ b/web/tests/live/sidebar-groups-axis.spec.ts
@@ -1,0 +1,156 @@
+// Live coverage for the user-defined group axis in the sidebar (#1234).
+//   - Three sessions seeded in ONE repo dir but two user groups surface
+//     as a single repo group on the default "By repo" axis, then as two
+//     group headers (feature, refactor) once the axis toggle flips to
+//     "By group".
+//   - Collapse state is per-axis and persists: collapsing a group in the
+//     group axis survives a reload and does not collapse the repo group.
+//
+// The split/bucket correctness is unit-tested in
+// `src/lib/__tests__/sidebarGroups.test.ts`; this spec exercises the real
+// server -> sidebar render + the localStorage-backed axis/collapse toggles.
+//
+// Seeding runs BEFORE serve spawns so `state.instances` picks up the
+// records on boot, mirroring `sidebar-groups.spec.ts`.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  resolveAoeBinary,
+} from "../helpers/aoeServe";
+
+function seedGroupedSessions(
+  sessions: { title: string; group: string }[],
+) {
+  return ({ home, env }: { home: string; shimBin: string; env: NodeJS.ProcessEnv }) => {
+    const binary = resolveAoeBinary();
+    const projectDir = join(home, "project");
+    mkdirSync(projectDir, { recursive: true });
+    spawnSync("git", ["init", "-q"], { cwd: projectDir });
+    spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+      cwd: projectDir,
+      env: {
+        ...env,
+        GIT_AUTHOR_NAME: "t",
+        GIT_AUTHOR_EMAIL: "t@t",
+        GIT_COMMITTER_NAME: "t",
+        GIT_COMMITTER_EMAIL: "t@t",
+      },
+    });
+    for (const { title, group } of sessions) {
+      const res = spawnSync(
+        binary,
+        ["add", projectDir, "-t", title, "-c", "claude", "-g", group],
+        { env },
+      );
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed for ${title}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    }
+  };
+}
+
+const SEED = seedGroupedSessions([
+  { title: "feat-one", group: "feature" },
+  { title: "feat-two", group: "feature" },
+  { title: "refac-one", group: "refactor" },
+]);
+
+base.describe("sidebar user-group axis (#1234)", () => {
+  base("axis toggle renders user groups by group_path", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: SEED,
+    });
+
+    try {
+      expect(await listSessions(serve.baseUrl)).toHaveLength(3);
+      await page.goto(`${serve.baseUrl}/`);
+
+      // Default axis is "By repo": all three sessions live in one repo dir,
+      // so there is a single repo group and three rows.
+      const headers = page.locator("[data-testid='sidebar-group-header']");
+      await expect(headers).toHaveCount(1, { timeout: 10_000 });
+      await expect(
+        page.locator("[data-testid='sidebar-session-row']"),
+      ).toHaveCount(3);
+
+      const axisToggle = page.locator("[data-testid='sidebar-axis-toggle']");
+      await expect(axisToggle).toHaveAttribute("data-axis", "repo");
+      await axisToggle.click();
+      await expect(axisToggle).toHaveAttribute("data-axis", "group");
+
+      // Group axis: two headers, keyed by group_path. All three rows stay
+      // visible, now nested under their group.
+      await expect(headers).toHaveCount(2);
+      await expect(
+        page.locator("[data-testid='sidebar-group-header'][data-group-id='feature']"),
+      ).toBeVisible();
+      await expect(
+        page.locator("[data-testid='sidebar-group-header'][data-group-id='refactor']"),
+      ).toBeVisible();
+      await expect(
+        page.locator("[data-testid='sidebar-session-row']"),
+      ).toHaveCount(3);
+    } finally {
+      await serve.stop();
+    }
+  });
+
+  base("group-axis collapse persists across reload and is per-axis", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: SEED,
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+
+      const axisToggle = page.locator("[data-testid='sidebar-axis-toggle']");
+      await expect(axisToggle).toHaveAttribute("data-axis", "repo", {
+        timeout: 10_000,
+      });
+      await axisToggle.click();
+
+      const featureHeader = page.locator(
+        "[data-testid='sidebar-group-header'][data-group-id='feature']",
+      );
+      const featureExpand = featureHeader.locator("button[aria-expanded]");
+      await expect(featureExpand).toHaveAttribute("aria-expanded", "true");
+
+      await featureExpand.click();
+      await expect(featureExpand).toHaveAttribute("aria-expanded", "false");
+      await expect(page.getByText("feat-one")).toBeHidden();
+
+      // Reload: the axis choice and the group collapse both restore from
+      // localStorage.
+      await page.reload();
+      await expect(axisToggle).toHaveAttribute("data-axis", "group", {
+        timeout: 10_000,
+      });
+      await expect(
+        featureHeader.locator("button[aria-expanded]"),
+      ).toHaveAttribute("aria-expanded", "false");
+
+      // Switching back to the repo axis shows an independent collapse map:
+      // the repo group is not collapsed just because a user group was.
+      await axisToggle.click();
+      await expect(axisToggle).toHaveAttribute("data-axis", "repo");
+      await expect(
+        page.locator("[data-testid='sidebar-group-header'] button[aria-expanded]"),
+      ).toHaveAttribute("aria-expanded", "true");
+    } finally {
+      await serve.stop();
+    }
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web dashboard sidebar only ever grouped sessions by repository (the `RepoGroup` axis from `useRepoGroups`). User-defined groups, which the TUI renders as collapsible section headers and which are persisted in `groups.json` via each session's `group_path`, were fetched into state but never surfaced anywhere in the web sidebar. The taxonomy a user builds in the TUI was invisible in the browser.

This adds a second sidebar axis. A grouping toggle (the layers icon) next to the sort toggle switches between **By repo** (default, unchanged) and **By group**. In group mode, sessions render under collapsible headers keyed by their `group_path`, with an **Ungrouped** bucket pinned to the bottom for sessions with no group.

The render path was made honest rather than overloaded. Instead of cramming user groups into the repo-shaped `RepoGroup` type, a small view-model (`SidebarGroup` with a `kind` discriminator and a `capabilities` object, plus `SidebarWorkspaceView`) now feeds one render path. The repo axis maps into it through an adapter with no behavior change; the user-group axis is built by a new pure builder. Because `group_path` is per session and a single workspace can host agents in different groups, that builder splits such a workspace into one sliced view per group rather than guessing a single "dominant" group, so no session is hidden or shown under the wrong header. Each view keeps the real workspace id for selection and routing while carrying a distinct render key so React and dnd-kit stay happy across the split. Repo-only affordances (alias/color rename, drag-reorder, create-in-repo) are gated off on the group axis via capabilities. Collapse state is per-browser and per-axis.

Out of scope, flagged as follow-ups: server-side collapse sync to `groups.json` (a PATCH endpoint), a command-palette `group:` filter, drag-to-regroup between groups, nested-group rendering, and group rename/color.

Closes #1234

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the TUI (or via `aoe add <dir> -g feature` / `aoe group move`), assign several sessions to two or more groups and leave some ungrouped.
- [ ] Open the web dashboard. Confirm the sidebar still defaults to **By repo** (layers icon not highlighted) and looks unchanged.
- [ ] Click the layers toggle next to the sort/filter buttons. Confirm the header label flips to "Groups" and sessions now render under one collapsible header per group, with an "Ungrouped" bucket at the bottom.
- [ ] If a worktree hosts agents in two different groups, confirm that workspace appears under each group, each header showing only its own sessions.
- [ ] Collapse a group, reload the page, and confirm the group stays collapsed and the axis stays on "By group".
- [ ] Toggle back to **By repo** and confirm the repo groups are not collapsed (collapse state is independent per axis).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Live spec `web/tests/live/sidebar-groups-axis.spec.ts` (axis toggle renders user groups; per-axis collapse persists across reload). Plus vitest `web/src/lib/__tests__/sidebarGroups.test.ts` (builder + split correctness) and `web/src/hooks/useSidebarAxis.test.ts` (toggle contract).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, design debate, implementation, and tests were drafted by Claude under my direction. I made the design calls (honest view-model over an overloaded type, session-scoped splitting, localStorage-only collapse for v1) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a second sidebar "axis" to the web dashboard so users can view sessions either "By repo" (unchanged default) or "By group" (user-defined groups from sessions' group_path). A layers-icon toggle switches modes. In group mode sessions are shown under collapsible group headers (named by group_path, with an "Ungrouped" bucket pinned to the bottom). Workspaces that host sessions in multiple groups are sliced so the workspace appears under each relevant group. The chosen axis and per-axis collapse state persist locally (localStorage). Repo-only affordances (rename/color, drag-reorder, create-in-repo) are disabled in group mode. Follow-ups (server-side collapse sync, drag-to-regroup, nested groups, group rename/color, command-palette group filter) are deferred.

## What changed (high level)

- Added a second sidebar axis and a UI toggle (By repo ↔ By group).
- New view-model: SidebarGroup, SidebarWorkspaceView, and capability flags to represent both axes uniformly.
- New builder: buildSessionGroups — groups sessions by normalized group_path, creates Ungrouped bucket, sorts groups (named groups alphabetically, Ungrouped last), and slices workspaces per-group with stable render keys.
- Adapter: repoGroupToSidebarGroup — maps existing repo groups into the new model without changing repo behavior.
- Hooks:
  - useSidebarAxis — persists/restores the selected axis (aoe-sidebar-axis).
  - useSessionGroups — builds group-axis SidebarGroups and manages per-group collapse state (aoe-group-collapsed-*). Fixed StrictMode issue by keeping the collapse updater pure and moving persistence into useEffect.
- WorkspaceSidebar updated to accept SidebarGroup[], axis, and onAxisChange; UI gates repo-only affordances in group mode; added axis toggle control and accessibility adjustments.
- Tests:
  - Vitest unit tests for buildSessionGroups, repoGroupToSidebarGroup, sidebarAxis hook, and per-axis collapse behavior.
  - Playwright live spec validating axis toggle, group rendering, and per-axis collapse persistence.
- Docs: new subsection "Sidebar grouping: by repo or by group" added to the web dashboard guide.
- Small behavioral fix: made collapse persistence pure under React StrictMode to avoid double-write issues.

## Benefits

- Gives users a flexible, second perspective (group-centric) without altering the default repo view.
- Preserves data fidelity for sessions that belong to multiple groups.
- UX continuity via per-browser persistence of axis and collapse state.
- Clean separation of model, builder, and UI layers makes future features (drag-to-regroup, nested groups, server-side sync) easier to add.

## Technical notes (concise)

- New types & exports in web/src/lib/sidebarGroups.ts: UNGROUPED_GROUP_ID, SidebarGroupCapabilities, SidebarWorkspaceView, SidebarGroup, repoGroupToSidebarGroup, buildSessionGroups, sidebarGroupHasLiveWorkspace.
- Axis persistence in web/src/lib/sidebarAxis.ts using safeSetItem/safeGetItem; hook useSidebarAxis exposes readonly [axis, setAxis].
- Per-group collapse keys use prefix aoe-group-collapsed- and are managed in useSessionGroups with persistence performed in an effect to remain pure under StrictMode.
- Render keys for sliced workspaces use `${groupPath}::${workspaceId}` while actions preserve the actual workspace id.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->