### PR TITLE
feat(web): measure keystroke-to-echo latency in the dashboard terminal

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -40,6 +40,18 @@ All settings below can also be edited from the TUI settings screen (press `s` or
 | `AOE_ACP_TRACE` | Add the ACP framework's raw JSON-RPC firehose to `debug.log` (`1` to enable). Very chatty; useful for chasing schema mismatches. |
 | `AOE_TERMINAL_TRACE` | Add per-message byte tracing for the web terminal WebSocket relay to `debug.log` (`1` to enable). Bumps the `terminal` target to `trace`, surfacing every PTY read/write and every WS send/recv. Spammy under load (a busy claude session emits thousands of frames/min); use only when chasing terminal disconnect bugs. |
 
+### Terminal latency instrumentation
+
+The web dashboard can attribute keystroke-to-echo lag (the gap between pressing a key and seeing the character) to network versus server and PTY hops. Append `?debug=terminal-timing` to the dashboard URL. This is a measurement aid only; it changes no behavior and is entirely inert without the flag, so normal sessions pay nothing.
+
+When the flag is set, the terminal:
+
+- Measures **Idle-TTFB**: when you type after a quiet moment, it stamps the keystroke and resolves on the next inbound frame, recording both socket arrival and xterm render completion. It does not match echoed bytes (shells, TUIs, autosuggestions and password prompts make the echo unrelated to what you typed), so the number reflects the real key-to-screen path without parsing the echo.
+- Sends a small control-channel ping every 500ms that the server bounces back without touching the PTY. This is the **WS control RTT**: network plus WebSocket transit with no PTY in the loop. The server includes its own recv-to-send duration so no clock sync is needed.
+- Logs a rolling p50/p95 summary to the browser console every 10s, including the active renderer (`webgl` or `dom`).
+
+Call `window.__aoeTiming.dump()` in the browser console to pull the raw samples as JSON for offline analysis. Interpretation: if WS control RTT is close to Idle-TTFB, the network dominates; if Idle-TTFB is well above WS control RTT, the server, PTY, tmux, or agent echo path dominates; if socket arrival is fast but render is slow, the renderer or main thread dominates.
+
 ## Theme
 
 ```toml

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -885,6 +885,10 @@ async fn handle_terminal_ws(
                     .await;
                 }
                 Message::Text(text) => {
+                    // Stamp arrival before parse so a timing_ping can report
+                    // the server's own parse-to-enqueue cost. Cheap, and text
+                    // control frames are rare (not per-keystroke).
+                    let text_recv = Instant::now();
                     // JSON control messages (resize, activate) are always allowed
                     if let Ok(control) = serde_json::from_str::<ControlMessage>(&text) {
                         match control {
@@ -999,6 +1003,22 @@ async fn handle_terminal_ws(
                                     &this_ws_paused_for_recv,
                                 )
                                 .await;
+                            }
+                            ControlMessage::TimingPing { seq, client_t } => {
+                                // Bounce straight back over the control
+                                // channel. Never touches the PTY, never
+                                // logs (a sub-second cadence would flood the
+                                // log). server_busy_us captures parse +
+                                // dispatch + serialize on this task.
+                                let pong = TimingPong {
+                                    kind: "timing_pong",
+                                    seq,
+                                    client_t,
+                                    server_busy_us: text_recv.elapsed().as_micros() as u64,
+                                };
+                                if let Ok(text) = serde_json::to_string(&pong) {
+                                    let _ = ctrl_tx_for_recv.send(text).await;
+                                }
                             }
                         }
                     } else if !read_only {
@@ -1360,6 +1380,27 @@ enum ControlMessage {
     /// `pause_output`. SIGCONT to a non-stopped process is a no-op.
     #[serde(rename = "resume_output")]
     ResumeOutput,
+    /// Latency probe from the web terminal under `?debug=terminal-timing`.
+    /// Bounced straight back as a `timing_pong` over the control channel,
+    /// never reaching the PTY. `client_t` is an opaque client timestamp
+    /// echoed unchanged so the browser can compute the round trip. The
+    /// variant is always parseable but only exercised by debug clients, so
+    /// normal sessions pay nothing beyond one extra serde tag. See #1453.
+    #[serde(rename = "timing_ping")]
+    TimingPing { seq: u64, client_t: f64 },
+}
+
+/// Server reply to a [`ControlMessage::TimingPing`]. `server_busy_us` is
+/// this handler's own parse-to-enqueue duration, so the client can
+/// subtract it from the observed round trip to isolate network plus
+/// WebSocket transit without any client/server clock sync. See #1453.
+#[derive(serde::Serialize)]
+struct TimingPong {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    seq: u64,
+    client_t: f64,
+    server_busy_us: u64,
 }
 
 #[cfg(test)]
@@ -1464,6 +1505,35 @@ mod tests {
     #[test]
     fn parse_pane_dead_all_dead_is_dead() {
         assert_eq!(parse_pane_dead_output("1\n1\n1\n"), PaneReadiness::Dead);
+    }
+
+    #[test]
+    fn timing_ping_deserializes() {
+        let msg: ControlMessage =
+            serde_json::from_str(r#"{"type":"timing_ping","seq":7,"client_t":1234.5}"#).unwrap();
+        match msg {
+            ControlMessage::TimingPing { seq, client_t } => {
+                assert_eq!(seq, 7);
+                assert_eq!(client_t, 1234.5);
+            }
+            _ => panic!("expected TimingPing"),
+        }
+    }
+
+    #[test]
+    fn timing_pong_serializes_with_type_tag() {
+        let pong = TimingPong {
+            kind: "timing_pong",
+            seq: 7,
+            client_t: 1234.5,
+            server_busy_us: 42,
+        };
+        let json = serde_json::to_string(&pong).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["type"], "timing_pong");
+        assert_eq!(parsed["seq"], 7);
+        assert_eq!(parsed["client_t"], 1234.5);
+        assert_eq!(parsed["server_busy_us"], 42);
     }
 
     #[tokio::test]

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -13,6 +13,8 @@ import type {
 import { getOrCreateDeviceBindingSecret } from "../lib/deviceBinding";
 import { getToken } from "../lib/token";
 import { useWebSettings } from "./useWebSettings";
+import { TerminalTiming } from "../lib/terminalTiming";
+import type { TimingPingMessage, TimingPongMessage } from "../lib/types";
 
 // Client-side terminal WS debug logging is gated behind a runtime flag
 // so production users don't get a console full of lifecycle chatter.
@@ -46,6 +48,26 @@ const twarn = (...args: unknown[]) => {
   // can surface terminal-specific issues quickly.
   console.warn("[terminal.ws]", ...args);
 };
+
+// Keystroke-to-echo latency instrumentation, gated on its own
+// `?debug=terminal-timing` flag (separate from the `?debug=1` logging
+// gate above). When off, none of the timing code runs and no probe
+// traffic is sent, so normal sessions pay nothing. See #1453.
+const TERMINAL_TIMING_ENABLED = (() => {
+  if (typeof window === "undefined") return false;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("debug") === "terminal-timing";
+  } catch {
+    return false;
+  }
+})();
+// Cadence of the WS control-path ping while timing is enabled. 500ms
+// gives ~120 samples/min, enough for p90 over a debug session without
+// looking abusive on metered links.
+const TIMING_PING_INTERVAL_MS = 500;
+// How often the rolling p50/p95 summary is logged to the console.
+const TIMING_SUMMARY_INTERVAL_MS = 10000;
 
 // Fast-start retry schedule: 200ms, 400ms, 800ms, 1.5s, 3s, 6s, 10s. Total
 // to exhaustion ~22s vs the old exponential ladder's ~91s. The old 1s/30s
@@ -223,6 +245,18 @@ export function useTerminal(
     const container = containerRef.current;
     container.innerHTML = "";
 
+    // Latency instrumentation lives for the lifetime of this terminal and
+    // is exposed on `window.__aoeTiming` so an operator can call
+    // `window.__aoeTiming.dump()` to pull raw samples for offline
+    // analysis. Null (and entirely inert) unless the flag is set.
+    const timing = TERMINAL_TIMING_ENABLED ? new TerminalTiming() : null;
+    let timingPingTimer: ReturnType<typeof setInterval> | null = null;
+    let timingSummaryTimer: ReturnType<typeof setInterval> | null = null;
+    if (timing) {
+      (window as Window & { __aoeTiming?: TerminalTiming }).__aoeTiming =
+        timing;
+    }
+
     const isMobileViewport = () => window.innerWidth < MOBILE_BREAKPOINT_PX;
     const readFontSize = () =>
       isMobileViewport() ? settings.mobileFontSize : settings.desktopFontSize;
@@ -320,9 +354,14 @@ export function useTerminal(
     // so the terminal still works there.
     try {
       const webgl = new WebglAddon();
-      webgl.onContextLoss(() => webgl.dispose());
+      webgl.onContextLoss(() => {
+        timing?.setRenderer("dom");
+        webgl.dispose();
+      });
       term.loadAddon(webgl);
+      timing?.setRenderer("webgl");
     } catch (err) {
+      timing?.setRenderer("dom");
       tdbg("webgl addon unavailable, using DOM renderer", err);
     }
 
@@ -603,11 +642,29 @@ export function useTerminal(
           setState((prev) => ({ ...prev, retryCount: 0, retryCountdown: 0 }));
         }
         if (event.data instanceof ArrayBuffer) {
-          term.write(new Uint8Array(event.data));
+          const bytes = new Uint8Array(event.data);
+          const token = timing?.onBinaryFrame(performance.now());
+          if (token) {
+            // This frame resolved an armed keystroke; capture the time
+            // through xterm's render completion as well as socket arrival.
+            term.write(bytes, () => timing!.onRender(token, performance.now()));
+          } else {
+            term.write(bytes);
+          }
         } else if (typeof event.data === "string") {
           // Check for server control messages before writing to terminal
           try {
             const msg = JSON.parse(event.data) as { type?: string };
+            if (msg.type === "timing_pong") {
+              const pong = msg as TimingPongMessage;
+              timing?.onPong(
+                pong.seq,
+                pong.client_t,
+                pong.server_busy_us,
+                performance.now(),
+              );
+              return;
+            }
             if (msg.type === "primary_status") {
               const status = msg as PrimaryStatusMessage;
               setState((prev) => ({ ...prev, isPrimary: status.is_primary }));
@@ -705,6 +762,10 @@ export function useTerminal(
       // Ctrl equivalents (Ctrl+A = 0x01, Ctrl+U = 0x15, etc.).
       term.onData((data: string) => {
         if (ws.readyState !== WebSocket.OPEN) return;
+        // Arm an Idle-TTFB sample for this keystroke. Arming (not the
+        // exact byte) is all the tracker needs; it only records when the
+        // terminal was idle and resolves on the next inbound frame.
+        timing?.onKeystroke(performance.now());
         if (ctrlActiveRef.current && data.length === 1) {
           const code = data.toUpperCase().charCodeAt(0);
           if (code >= 65 && code <= 90) {
@@ -721,6 +782,34 @@ export function useTerminal(
     // Kick off the connection. xterm.js's open() is synchronous so we
     // can dial the WS immediately after construction.
     connect();
+
+    // Drive the control-path ping and the periodic console summary. Both
+    // exist only when timing is enabled. The ping measures pure WS round
+    // trip (never reaches the PTY); the summary logs rolling percentiles
+    // so an operator watching the console sees attribution without
+    // dumping. makePing skips while a keystroke sample is armed so the
+    // probe never contends with the experiential measurement.
+    if (timing) {
+      timingPingTimer = setInterval(() => {
+        const ws = wsRef.current;
+        timing.pruneTimeouts(performance.now());
+        if (ws?.readyState !== WebSocket.OPEN) return;
+        const ping = timing.makePing(performance.now());
+        if (ping) {
+          ws.send(
+            JSON.stringify({
+              type: "timing_ping",
+              seq: ping.seq,
+              client_t: ping.client_t,
+            } as TimingPingMessage),
+          );
+        }
+      }, TIMING_PING_INTERVAL_MS);
+      timingSummaryTimer = setInterval(() => {
+        timing.pruneTimeouts(performance.now());
+        console.info(timing.summaryLine());
+      }, TIMING_SUMMARY_INTERVAL_MS);
+    }
 
     // Touch swipe emits SGR mouse-wheel escape sequences to the PTY
     // so tmux mouse-mode enters copy-mode and scrolls.
@@ -1304,6 +1393,12 @@ export function useTerminal(
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);
+      if (timingPingTimer) clearInterval(timingPingTimer);
+      if (timingSummaryTimer) clearInterval(timingSummaryTimer);
+      if (timing) {
+        const w = window as Window & { __aoeTiming?: TerminalTiming };
+        if (w.__aoeTiming === timing) delete w.__aoeTiming;
+      }
       // Detach handlers BEFORE closing so the soon-to-fire onclose closure
       // can't schedule a retry that races the next session's connect path.
       // Without this, the old onclose runs after cleanup, calls setTimeout

--- a/web/src/lib/__tests__/terminalTiming.test.ts
+++ b/web/src/lib/__tests__/terminalTiming.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { TerminalTiming } from "../terminalTiming";
+
+describe("TerminalTiming Idle-TTFB", () => {
+  it("arms when idle and resolves on the next binary frame", () => {
+    const t = new TerminalTiming();
+    // lastBinaryRx starts at 0, so a keystroke at 200ms is idle.
+    t.onKeystroke(200);
+    const token = t.onBinaryFrame(250);
+    expect(token).not.toBeNull();
+    const snap = t.snapshot();
+    expect(snap.ttfbSocketMs.count).toBe(1);
+    expect(snap.ttfbSocketMs.p50).toBe(50);
+  });
+
+  it("does not arm when the terminal is busy (recent output)", () => {
+    const t = new TerminalTiming();
+    t.onBinaryFrame(100); // lastBinaryRx = 100
+    t.onKeystroke(150); // 50ms gap <= 100ms idle threshold, not idle
+    const token = t.onBinaryFrame(200);
+    expect(token).toBeNull();
+    expect(t.snapshot().ttfbSocketMs.count).toBe(0);
+  });
+
+  it("discards a sample whose echo arrives after the timeout", () => {
+    const t = new TerminalTiming();
+    t.onKeystroke(200);
+    const token = t.onBinaryFrame(200 + 1001); // > 1000ms TTFB timeout
+    expect(token).toBeNull();
+    const snap = t.snapshot();
+    expect(snap.ttfbSocketMs.count).toBe(0);
+    expect(snap.discarded).toBe(1);
+  });
+
+  it("discards when a second keystroke arrives before the echo", () => {
+    const t = new TerminalTiming();
+    t.onKeystroke(200);
+    t.onKeystroke(250); // overlapping, ambiguous
+    expect(t.snapshot().outstandingKey).toBe(false);
+    expect(t.snapshot().discarded).toBe(1);
+    // The next frame resolves nothing.
+    expect(t.onBinaryFrame(300)).toBeNull();
+    expect(t.snapshot().ttfbSocketMs.count).toBe(0);
+  });
+
+  it("records render completion via the token", () => {
+    const t = new TerminalTiming();
+    t.onKeystroke(200);
+    const token = t.onBinaryFrame(250);
+    expect(token).not.toBeNull();
+    t.onRender(token!, 260);
+    expect(t.snapshot().ttfbRenderMs.p50).toBe(60);
+  });
+
+  it("prunes an armed sample that times out", () => {
+    const t = new TerminalTiming();
+    t.onKeystroke(200);
+    t.pruneTimeouts(200 + 1001);
+    const snap = t.snapshot();
+    expect(snap.outstandingKey).toBe(false);
+    expect(snap.discarded).toBe(1);
+  });
+});
+
+describe("TerminalTiming WS control RTT", () => {
+  it("computes round trip and server busy from a pong", () => {
+    const t = new TerminalTiming();
+    const ping = t.makePing(1000);
+    expect(ping).not.toBeNull();
+    t.onPong(ping!.seq, ping!.client_t, 2000, 1050);
+    const snap = t.snapshot();
+    expect(snap.wsControlRttMs.p50).toBe(50);
+    expect(snap.serverBusyMs.p50).toBe(2); // 2000us -> 2ms
+  });
+
+  it("allows only one outstanding ping at a time", () => {
+    const t = new TerminalTiming();
+    expect(t.makePing(1000)).not.toBeNull();
+    expect(t.makePing(1001)).toBeNull();
+  });
+
+  it("skips a ping while a keystroke sample is armed", () => {
+    const t = new TerminalTiming();
+    t.onKeystroke(200);
+    expect(t.makePing(300)).toBeNull();
+  });
+
+  it("ignores a pong with a stale seq", () => {
+    const t = new TerminalTiming();
+    const ping = t.makePing(1000);
+    t.onPong(ping!.seq + 99, 1000, 0, 1050);
+    const snap = t.snapshot();
+    expect(snap.wsControlRttMs.count).toBe(0);
+    expect(snap.outstandingPing).toBe(true);
+  });
+
+  it("drops an outstanding ping that exceeds the timeout", () => {
+    const t = new TerminalTiming();
+    t.makePing(1000);
+    t.pruneTimeouts(1000 + 2001);
+    expect(t.snapshot().outstandingPing).toBe(false);
+  });
+});
+
+describe("TerminalTiming percentiles and derived", () => {
+  it("computes p50/p90/p95 over a known set", () => {
+    const t = new TerminalTiming();
+    for (let i = 1; i <= 10; i++) {
+      const ping = t.makePing(0);
+      t.onPong(ping!.seq, ping!.client_t, 0, i * 10);
+    }
+    const p = t.snapshot().wsControlRttMs;
+    expect(p.count).toBe(10);
+    expect(p.p50).toBe(50);
+    expect(p.p90).toBe(90);
+    expect(p.p95).toBe(100);
+  });
+
+  it("derives the stack delta as socket p50 minus ws-rtt p50", () => {
+    const t = new TerminalTiming();
+    // One socket sample of 80ms.
+    t.onKeystroke(200);
+    t.onBinaryFrame(280);
+    // One ws rtt of 30ms.
+    const ping = t.makePing(1000);
+    t.onPong(ping!.seq, ping!.client_t, 0, 1030);
+    expect(t.snapshot().derived.stackP50).toBe(50);
+  });
+
+  it("reports null stack delta until both metrics have samples", () => {
+    const t = new TerminalTiming();
+    t.onKeystroke(200);
+    t.onBinaryFrame(280);
+    expect(t.snapshot().derived.stackP50).toBeNull();
+  });
+
+  it("resets all accumulated state", () => {
+    const t = new TerminalTiming();
+    t.onKeystroke(200);
+    t.onBinaryFrame(250);
+    t.reset();
+    const snap = t.snapshot();
+    expect(snap.ttfbSocketMs.count).toBe(0);
+    expect(snap.discarded).toBe(0);
+  });
+});

--- a/web/src/lib/terminalTiming.ts
+++ b/web/src/lib/terminalTiming.ts
@@ -1,0 +1,284 @@
+/**
+ * Keystroke-to-echo latency instrumentation for the web terminal, active
+ * only under `?debug=terminal-timing`. Pure logic with no DOM or React so
+ * it can be unit tested in isolation. See #1453.
+ *
+ * Two complementary measurements:
+ *
+ *  - Idle-TTFB (time to first byte): the experiential metric. When the
+ *    user presses a key after the terminal has been quiet for at least
+ *    IDLE_GAP_MS, the send is stamped and resolved on the very next
+ *    inbound binary (PTY) frame. There is deliberately no byte-level echo
+ *    matching: shells, TUIs, autosuggestions and password prompts make
+ *    the echoed bytes unrelated to what was typed, so matching bytes
+ *    produces garbage percentiles. Gating on idle and resolving on the
+ *    first frame measures the real key-to-screen path without parsing the
+ *    echo. A render callback (fed via `onRender`) captures the extra time
+ *    xterm spends painting that frame, which is what separates a slow
+ *    WebGL/DOM renderer from a slow network.
+ *
+ *  - WS control RTT: the attribution metric. A timing_ping/timing_pong
+ *    round trip on the control channel that never touches the PTY. The
+ *    server reports its own recv-to-send duration (`server_busy_us`), so
+ *    `client_rtt - server_busy` approximates network plus WebSocket
+ *    transit with no client/server clock synchronisation. The gap between
+ *    Idle-TTFB and WS control RTT is the server plus PTY plus tmux plus
+ *    agent contribution.
+ */
+
+/** Terminal must be quiet this long before a keystroke is sampled, so
+ *  background output (a running `tail -f`) is not mistaken for an echo. */
+const IDLE_GAP_MS = 100;
+/** An armed keystroke with no inbound frame within this window is treated
+ *  as never echoed (a non-echoing key) and discarded rather than resolved
+ *  against unrelated later output. */
+const TTFB_TIMEOUT_MS = 1000;
+/** An outstanding ping with no pong within this window is dropped so the
+ *  next tick can probe again. */
+const PING_TIMEOUT_MS = 2000;
+/** Cap on retained raw samples per category. Plenty for p95 over a
+ *  multi-minute debug session while bounding memory. */
+const MAX_SAMPLES = 5000;
+
+export type TerminalRenderer = "webgl" | "dom" | "unknown";
+
+export interface Percentiles {
+  count: number;
+  p50: number;
+  p90: number;
+  p95: number;
+}
+
+export interface TerminalTimingSnapshot {
+  renderer: TerminalRenderer;
+  /** Key send to first inbound binary frame. */
+  ttfbSocketMs: Percentiles;
+  /** Key send to xterm render callback for the resolving frame. */
+  ttfbRenderMs: Percentiles;
+  /** timing_ping to timing_pong, full client-observed round trip. */
+  wsControlRttMs: Percentiles;
+  /** Server-reported recv-to-send duration of the pong. */
+  serverBusyMs: Percentiles;
+  derived: {
+    /** ttfbSocket p50 minus wsControlRtt p50: rough server + PTY + stack
+     *  share of the key-to-screen latency. Null until both have samples. */
+    stackP50: number | null;
+  };
+  outstandingKey: boolean;
+  outstandingPing: boolean;
+  discarded: number;
+}
+
+export interface TerminalTimingDump extends TerminalTimingSnapshot {
+  raw: {
+    ttfbSocketMs: number[];
+    ttfbRenderMs: number[];
+    wsControlRttMs: number[];
+    serverBusyMs: number[];
+  };
+  connection: { effectiveType?: string; rtt?: number; downlink?: number } | null;
+}
+
+/** Token returned by `onBinaryFrame` when that frame resolved an armed
+ *  keystroke. Pass it to `onRender` from the xterm write callback. */
+export interface RenderToken {
+  tSend: number;
+}
+
+/** Outbound ping descriptor. The client sends `{type:"timing_ping",seq,
+ *  client_t}` and echoes `client_t` back through the pong unchanged. */
+export interface PingFrame {
+  seq: number;
+  client_t: number;
+}
+
+function percentile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(q * sorted.length) - 1),
+  );
+  return sorted[idx]!;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+function summarize(samples: number[]): Percentiles {
+  const sorted = [...samples].sort((a, b) => a - b);
+  return {
+    count: sorted.length,
+    p50: round1(percentile(sorted, 0.5)),
+    p90: round1(percentile(sorted, 0.9)),
+    p95: round1(percentile(sorted, 0.95)),
+  };
+}
+
+export class TerminalTiming {
+  private renderer: TerminalRenderer = "unknown";
+  private lastBinaryRx = 0;
+  private armed: { tSend: number } | null = null;
+  private pendingPing: PingFrame | null = null;
+  private pingSeq = 0;
+  private discarded = 0;
+
+  private ttfbSocket: number[] = [];
+  private ttfbRender: number[] = [];
+  private wsRtt: number[] = [];
+  private serverBusy: number[] = [];
+
+  setRenderer(renderer: TerminalRenderer): void {
+    this.renderer = renderer;
+  }
+
+  /** Call on every outbound keystroke (`term.onData`). Arms a sample only
+   *  when the terminal is idle and nothing is already in flight. */
+  onKeystroke(now: number): void {
+    if (this.armed) {
+      // A second key before the first echo returned: the clean
+      // single-outstanding measurement is gone. Drop it and stay disarmed
+      // (the terminal is now busy with overlapping echoes).
+      this.armed = null;
+      this.discarded += 1;
+      return;
+    }
+    if (now - this.lastBinaryRx <= IDLE_GAP_MS) return;
+    this.armed = { tSend: now };
+  }
+
+  /** Call on every inbound binary (PTY) frame, before writing it to xterm.
+   *  Returns a token to feed `onRender` when this frame resolved an armed
+   *  keystroke, otherwise null. */
+  onBinaryFrame(now: number): RenderToken | null {
+    const armed = this.armed;
+    this.lastBinaryRx = now;
+    if (!armed) return null;
+    this.armed = null;
+    const elapsed = now - armed.tSend;
+    if (elapsed > TTFB_TIMEOUT_MS) {
+      // Too late to be this key's echo (the key likely did not echo);
+      // discard rather than record a bogus multi-second TTFB.
+      this.discarded += 1;
+      return null;
+    }
+    push(this.ttfbSocket, elapsed);
+    return { tSend: armed.tSend };
+  }
+
+  /** Call from the xterm write callback for a frame that `onBinaryFrame`
+   *  flagged, to record the time through render completion. */
+  onRender(token: RenderToken, now: number): void {
+    push(this.ttfbRender, now - token.tSend);
+  }
+
+  /** Build the next ping, or null if one is already outstanding or a
+   *  keystroke sample is armed (skipped to keep the experiential metric
+   *  free of self-induced head-of-line contention). */
+  makePing(now: number): PingFrame | null {
+    if (this.pendingPing || this.armed) return null;
+    const ping: PingFrame = { seq: this.pingSeq++, client_t: now };
+    this.pendingPing = ping;
+    return ping;
+  }
+
+  /** Resolve a pong. `clientT` is the value echoed back unchanged;
+   *  `serverBusyUs` is the server's own recv-to-send duration. */
+  onPong(seq: number, clientT: number, serverBusyUs: number, now: number): void {
+    if (!this.pendingPing || this.pendingPing.seq !== seq) return;
+    this.pendingPing = null;
+    push(this.wsRtt, now - clientT);
+    push(this.serverBusy, serverBusyUs / 1000);
+  }
+
+  /** Discard an armed keystroke or outstanding ping that has exceeded its
+   *  timeout. Call periodically (the ping and summary intervals do). */
+  pruneTimeouts(now: number): void {
+    if (this.armed && now - this.armed.tSend > TTFB_TIMEOUT_MS) {
+      this.armed = null;
+      this.discarded += 1;
+    }
+    if (this.pendingPing && now - this.pendingPing.client_t > PING_TIMEOUT_MS) {
+      this.pendingPing = null;
+      this.discarded += 1;
+    }
+  }
+
+  snapshot(): TerminalTimingSnapshot {
+    const ttfbSocketMs = summarize(this.ttfbSocket);
+    const wsControlRttMs = summarize(this.wsRtt);
+    const stackP50 =
+      ttfbSocketMs.count > 0 && wsControlRttMs.count > 0
+        ? round1(ttfbSocketMs.p50 - wsControlRttMs.p50)
+        : null;
+    return {
+      renderer: this.renderer,
+      ttfbSocketMs,
+      ttfbRenderMs: summarize(this.ttfbRender),
+      wsControlRttMs,
+      serverBusyMs: summarize(this.serverBusy),
+      derived: { stackP50 },
+      outstandingKey: this.armed !== null,
+      outstandingPing: this.pendingPing !== null,
+      discarded: this.discarded,
+    };
+  }
+
+  dump(): TerminalTimingDump {
+    return {
+      ...this.snapshot(),
+      raw: {
+        ttfbSocketMs: [...this.ttfbSocket],
+        ttfbRenderMs: [...this.ttfbRender],
+        wsControlRttMs: [...this.wsRtt],
+        serverBusyMs: [...this.serverBusy],
+      },
+      connection: readConnection(),
+    };
+  }
+
+  summaryLine(): string {
+    const s = this.snapshot();
+    const stack = s.derived.stackP50 === null ? "n/a" : `${s.derived.stackP50}ms`;
+    return (
+      `[terminal.timing] renderer=${s.renderer} ` +
+      `key-socket p50/p95=${s.ttfbSocketMs.p50}/${s.ttfbSocketMs.p95}ms ` +
+      `key-render p50/p95=${s.ttfbRenderMs.p50}/${s.ttfbRenderMs.p95}ms ` +
+      `ws-rtt p50/p95=${s.wsControlRttMs.p50}/${s.wsControlRttMs.p95}ms ` +
+      `server-busy p50=${s.serverBusyMs.p50}ms ` +
+      `stack(socket-rtt) p50=${stack} ` +
+      `samples=${s.ttfbSocketMs.count} discarded=${s.discarded}`
+    );
+  }
+
+  reset(): void {
+    this.lastBinaryRx = 0;
+    this.armed = null;
+    this.pendingPing = null;
+    this.discarded = 0;
+    this.ttfbSocket = [];
+    this.ttfbRender = [];
+    this.wsRtt = [];
+    this.serverBusy = [];
+  }
+}
+
+function push(arr: number[], value: number): void {
+  arr.push(value);
+  if (arr.length > MAX_SAMPLES) arr.shift();
+}
+
+function readConnection(): TerminalTimingDump["connection"] {
+  if (typeof navigator === "undefined") return null;
+  const conn = (
+    navigator as Navigator & {
+      connection?: { effectiveType?: string; rtt?: number; downlink?: number };
+    }
+  ).connection;
+  if (!conn) return null;
+  return {
+    effectiveType: conn.effectiveType,
+    rtt: conn.rtt,
+    downlink: conn.downlink,
+  };
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -163,6 +163,25 @@ export interface PrimaryStatusMessage {
   is_primary: boolean;
 }
 
+/** Client → server latency probe, sent only under
+ *  `?debug=terminal-timing`. `client_t` is a `performance.now()` stamp
+ *  echoed back unchanged in the pong. Never touches the PTY. See #1453. */
+export interface TimingPingMessage {
+  type: "timing_ping";
+  seq: number;
+  client_t: number;
+}
+
+/** Server → client reply to {@link TimingPingMessage}. `server_busy_us`
+ *  is the server's own recv-to-send duration, so the client can subtract
+ *  it from the round trip without clock synchronisation. See #1453. */
+export interface TimingPongMessage {
+  type: "timing_pong";
+  seq: number;
+  client_t: number;
+  server_busy_us: number;
+}
+
 /** Rich diff file info with addition/deletion stats */
 export interface RichDiffFile {
   path: string;


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds opt-in instrumentation to measure what dominates keystroke-to-echo latency in the web dashboard terminal (xterm.js over the WebSocket PTY relay). This is measurement first: the deliverable attributes the lag to network versus the server and PTY path, gated behind `?debug=terminal-timing` so normal sessions pay nothing.

When the flag is set, the terminal hook records two complementary metrics. **Idle-TTFB** stamps a keystroke sent after a quiet moment and resolves it on the next inbound frame, capturing both socket arrival and the xterm render callback. It deliberately does not match echoed bytes, because shells, TUIs, autosuggestions and password prompts make the echo unrelated to the keypress, so byte matching would produce garbage percentiles. A 500ms control-path **timing_ping** that the server bounces back without touching the PTY gives the WS control RTT (network plus WebSocket transit), with the server reporting its own busy time so no clock sync is needed. The gap between Idle-TTFB and WS control RTT is the server plus PTY plus tmux plus agent contribution.

The numbers are logged as a rolling p50/p95 console summary every 10s (including the active renderer), and `window.__aoeTiming.dump()` exposes the raw samples as JSON for offline analysis. There is no on-screen overlay: an overlay's own paint work would compete for the same main-thread budget the render metric is trying to measure.

Per the issue, Mosh-style local-echo prediction and a PTY-sentinel probe to split tmux versus agent time are left as follow-ups; the Idle-TTFB minus WS-RTT delta should already say whether the addressable portion is worth optimizing.

Closes #1453

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a session terminal in the dashboard with `?debug=terminal-timing` appended to the URL, type a few characters, wait ~10s, and confirm a `[terminal.timing]` summary line appears in the browser console showing key-socket, key-render, ws-rtt, server-busy, and the stack delta.
- [ ] In the console, run `window.__aoeTiming.dump()` and confirm it returns a JSON object with `renderer`, percentiles per metric, and a `raw` block of sample arrays.
- [ ] Confirm the summary reports `renderer=webgl` on a WebGL-capable browser (and `renderer=dom` where WebGL is unavailable, e.g. Safari private mode).
- [ ] Load the same terminal WITHOUT the flag, open the Network tab, and confirm no `timing_ping` frames are sent and `window.__aoeTiming` is undefined (zero overhead).
- [ ] Type at the prompt and confirm normal terminal behavior is unchanged in both modes.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Skipped a test, because: the change is debug-only and flag-gated with no UI component; the pure timing logic is covered by vitest unit tests (`web/src/lib/__tests__/terminalTiming.test.ts`) and the server control message by Rust unit tests in `src/server/ws.rs`. The normal (flag-off) dashboard flow is unchanged.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a three-model design debate, implementation, and prose were drafted by Claude under my direction. I made the design calls (no overlay, app-level ping with server busy time, Idle-TTFB over byte correlation), reviewed each commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds optional keystroke-to-echo latency measurement instrumentation to the web dashboard terminal. When enabled via the `?debug=terminal-timing` query flag, the system records detailed timing metrics to help identify which component of the terminal pipeline dominates typing latency. The feature is completely inert when disabled, imposing zero overhead on normal sessions.

### What Was Added

**New client-side timing module** (`web/src/lib/terminalTiming.ts`): A comprehensive timing tracker that measures three types of latency:
- **Idle-TTFB**: Time from keystroke to first inbound PTY frame (captures network + xterm render)
- **WebSocket control RTT**: Periodic control-channel ping/pong exchanges to measure pure network transit time
- **Server busy time**: Server-reported processing delay to help isolate server+PTY contribution

**Server-side ping/pong support** (`src/server/ws.rs`): New `timing_ping`/`timing_pong` control messages that allow the client to measure WebSocket round-trip time with server processing delays included in the response.

**Client integration** (`web/src/hooks/useTerminal.ts`): Wired the timing tracker into the terminal hook, automatically arming keystroke measurements on user input and resolving them when frames arrive. Also enables periodic control-channel pings and logs aggregated metrics (p50/p95 percentiles) to the console every 10 seconds.

**TypeScript message types** (`web/src/lib/types.ts`): New message interfaces for the timing ping/pong protocol.

**Documentation** (`docs/guides/configuration.md`): Explains the feature, the metrics collected, and how to access raw timing samples via `window.__aoeTiming.dump()`.

**Comprehensive tests** (`web/src/lib/__tests__/terminalTiming.test.ts`): Unit tests covering idle-based arming, frame resolution, ping/pong exchanges, percentile calculations, timeout handling, and edge cases.

### What Was Removed

Nothing.

---

## Technical Details

The implementation provides fine-grained attribution across the keystroke pipeline:

- **Idle-TTFB**: Stamped on keystroke after a quiet period; resolved on next binary frame arrival. A `RenderToken` propagates the frame timestamp to xterm's render callback, capturing both socket arrival and render completion.
  
- **WebSocket control RTT**: Client sends `timing_ping` messages with sequence number and client timestamp; server echoes back in `timing_pong` with original values plus `serverBusyUs` (server parse-to-enqueue time). This eliminates clock-sync requirements and isolates network latency.

- **Stack delta**: Computed as Idle-TTFB p50 minus WS-RTT p50, attributing the remainder to server+PTY+tmux/agent processing.

- **Metrics aggregation**: Rolling p50/p90/p95 percentiles over multiple samples; samples are capped at a configurable limit per category. Raw sample dumps include connection state from `navigator.connection` for offline correlation with network conditions.

- **Renderer tracking**: Detects WebGL vs DOM renderer and logs the active renderer in summaries.

- **Zero-cost when disabled**: All instrumentation code is gated behind the query flag check; disabled instances create no hooks, timers, or allocations.

### Benefits

- **Measurement-first attribution**: Developers can now see exactly where typing latency is spent (network, server, PTY, xterm render), unblocking targeted optimization work.
- **Offline analysis**: Raw sample dumps with network connection metadata enable correlation with LAN vs remote conditions, renderer variants, and system load.
- **Production-safe**: Opt-in flag avoids impacting normal users; aggregated console logging and memory-capped sample retention prevent overhead accumulation.
- **Cross-environment comparison**: Can compare latency profiles across different network transports (LAN, Tailscale, Funnel), renderers (WebGL, DOM), and agent load states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->