### PR TITLE
feat(cockpit): auto-stop idle workers past a configurable timeout

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -468,6 +468,17 @@ Practical implications:
   next `aoe serve` reattaches.
 - To actually terminate a worker, run `aoe cockpit stop <session>` or
   `aoe cockpit stop --all`. To force-kill, `aoe cockpit kill <session>`.
+- **No orphaned agents on teardown.** Every termination path (idle
+  auto-stop, `aoe cockpit stop|kill|restart`, snooze/archive, daemon
+  `shutdown_all`, and a fresh spawn that supersedes a stale runner)
+  signals the runner's whole process group, so the agent subprocess and
+  its own children (the node ACP wrapper and the SDK child it execs) die
+  with the runner instead of reparenting to PID 1. Earlier releases
+  signalled only the runner pid, so superseded or torn-down runners
+  leaked `node` / `claude` processes that accumulated across daemon
+  restarts and e2e runs (#1689). A runner that is hard-killed with
+  `SIGKILL` (which cannot run its own cleanup) can still leak; prefer
+  the verbs above over `kill -9`.
 - During the detach window (between `aoe serve --stop` and the next
   `aoe serve`), the runner buffers up to 256 agent → daemon
   notification lines so per-stream chunks emitted while the daemon was

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -162,6 +162,7 @@ queue_drain_mode = "combined"  # how the composer drains client-side queued prom
 force_end_turn_threshold_secs = 30  # seconds of streaming silence before the spinner offers a "Force end turn" button (#1100)
 silent_orphan_grace_secs = 120  # daemon-side watchdog grace when the adapter stops talking with no in-flight tool; 0 disables (#1240); bumped from 60 in #1360 for async-agent flows; nonzero values below 120 clamp up at runtime
 silent_orphan_fast_grace_secs = 20  # accelerated grace used once a cost-populated UsageUpdate has arrived for the current prompt (#1240); ignored while an async-agent wait is active (#1360)
+auto_stop_idle_secs = 0  # auto-stop cockpit workers idle this many seconds; 0 disables (default); the next prompt respawns the worker (#1689)
 ```
 
 `max_concurrent_resumes` bounds how many cockpit workers the reconciler
@@ -175,6 +176,19 @@ race is safe even at high parallelism (#1088).
 `enabled = false` is a master kill switch; cockpit refuses to spawn
 even if a session has `--cockpit`. `default_for_claude = true` makes
 new Claude sessions cockpit-mode by default on mobile clients.
+
+`auto_stop_idle_secs` reclaims resources from abandoned sessions. When
+set to a positive value, the daemon stops any cockpit worker that has
+seen no events and has no in-flight turn for that many seconds, freeing
+its claude-agent-acp subprocess. The stop is seamless: the session keeps
+its place in the sidebar, the timeline shows a `Stopped` event with
+reason `idle_auto_stop`, and the next prompt you send respawns a fresh
+worker (resuming the agent-side transcript) within a couple of seconds.
+A mid-turn worker is never stopped. The check runs about once a minute,
+so the effective stop can lag the threshold by up to a minute. Default
+`0` disables the feature; no worker is ever stopped for inactivity. This
+covers cockpit workers only; plain TUI/tmux sessions are not affected
+(#1689).
 
 Migration v005 seeds these defaults on upgrade so the section already
 exists if you came from 1.4.x. Migration v006 then flips the v005-seeded

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -512,11 +512,10 @@ fn kill_now(session: &str) -> Result<()> {
     // on `stop`: the running daemon's drain task uses the registry-gone
     // signal to skip respawn on user-initiated termination.
     worker_registry::delete(session).ok();
-    #[cfg(unix)]
+    // Group-SIGKILL so the agent's node/SDK grandchildren die with the
+    // runner instead of orphaning under PID 1 (#1689).
     if worker_registry::is_pid_alive(record.pid) {
-        use nix::sys::signal::{kill, Signal};
-        use nix::unistd::Pid;
-        let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGKILL);
+        worker_registry::kill_runner_group(record.pid);
     }
     println!(
         "Killed cockpit worker for {} (PID {}).",
@@ -530,26 +529,20 @@ async fn signal_and_wait(
     timeout_secs: u64,
 ) {
     use crate::cockpit::worker_registry;
-    #[cfg(unix)]
-    {
-        use nix::sys::signal::{kill, Signal};
-        use nix::unistd::Pid;
-        let pid = Pid::from_raw(record.pid as i32);
+    if !worker_registry::is_pid_alive(record.pid) {
+        return;
+    }
+    // Group signals so the whole agent tree (runner + node + SDK child)
+    // goes down together, not just the runner pid. See #1689.
+    worker_registry::terminate_runner_group(record.pid);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    while std::time::Instant::now() < deadline {
         if !worker_registry::is_pid_alive(record.pid) {
             return;
         }
-        let _ = kill(pid, Signal::SIGTERM);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
-        while std::time::Instant::now() < deadline {
-            if !worker_registry::is_pid_alive(record.pid) {
-                return;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        }
-        let _ = kill(pid, Signal::SIGKILL);
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
-    #[cfg(not(unix))]
-    let _ = (record, timeout_secs);
+    worker_registry::kill_runner_group(record.pid);
 }
 
 fn logs(session: Option<String>, follow: bool) -> Result<()> {
@@ -624,11 +617,10 @@ fn restart(session: &str) -> Result<()> {
     // Reconnect" affordance.
     worker_registry::mark_restart_pending(session);
     worker_registry::delete(session).ok();
-    #[cfg(unix)]
+    // Group-SIGTERM so the agent's node/SDK grandchildren die with the
+    // runner rather than orphaning under PID 1 before respawn (#1689).
     if worker_registry::is_pid_alive(record.pid) {
-        use nix::sys::signal::{kill, Signal};
-        use nix::unistd::Pid;
-        let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGTERM);
+        worker_registry::terminate_runner_group(record.pid);
     }
     println!(
         "Stopped runner for {} (PID {}). `aoe serve` will respawn on its next reconciler tick.",

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -513,10 +513,12 @@ fn kill_now(session: &str) -> Result<()> {
     // signal to skip respawn on user-initiated termination.
     worker_registry::delete(session).ok();
     // Group-SIGKILL so the agent's node/SDK grandchildren die with the
-    // runner instead of orphaning under PID 1 (#1689).
-    if worker_registry::is_pid_alive(record.pid) {
-        worker_registry::kill_runner_group(record.pid);
-    }
+    // runner instead of orphaning under PID 1 (#1689). Unconditional: the
+    // process group can outlive its leader pid, so gating on leader
+    // liveness would skip the killpg and leak surviving descendants.
+    // killpg ignores ESRCH, so signaling an already-empty group is a
+    // harmless no-op.
+    worker_registry::kill_runner_group(record.pid);
     println!(
         "Killed cockpit worker for {} (PID {}).",
         session, record.pid
@@ -529,11 +531,10 @@ async fn signal_and_wait(
     timeout_secs: u64,
 ) {
     use crate::cockpit::worker_registry;
-    if !worker_registry::is_pid_alive(record.pid) {
-        return;
-    }
     // Group signals so the whole agent tree (runner + node + SDK child)
-    // goes down together, not just the runner pid. See #1689.
+    // goes down together, not just the runner pid. Sent unconditionally:
+    // the group can outlive its leader pid, so gating on leader liveness
+    // would skip the SIGTERM and leak surviving descendants. See #1689.
     worker_registry::terminate_runner_group(record.pid);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
     while std::time::Instant::now() < deadline {
@@ -619,9 +620,9 @@ fn restart(session: &str) -> Result<()> {
     worker_registry::delete(session).ok();
     // Group-SIGTERM so the agent's node/SDK grandchildren die with the
     // runner rather than orphaning under PID 1 before respawn (#1689).
-    if worker_registry::is_pid_alive(record.pid) {
-        worker_registry::terminate_runner_group(record.pid);
-    }
+    // Unconditional: the group can outlive its leader pid, so gating on
+    // leader liveness would skip the killpg and leak descendants.
+    worker_registry::terminate_runner_group(record.pid);
     println!(
         "Stopped runner for {} (PID {}). `aoe serve` will respawn on its next reconciler tick.",
         session, record.pid

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1173,6 +1173,14 @@ impl AcpClient {
         let install_binary = config.spec.command.clone();
         let source_profile_for_task = config.source_profile.clone();
         if let Some(socket_path) = config.socket_path.clone() {
+            // Supersede guard: a fresh spawn overwrites this session's
+            // registry entry, so any runner already registered for it would
+            // be orphaned (its agent's node/SDK children reparent to PID 1
+            // and leak, accumulating across restarts). Reap the prior
+            // runner's whole process group and clear its stale entry/socket
+            // before binding the replacement. No-op when there is no live
+            // prior runner. See #1689.
+            super::worker_registry::terminate(&session_id.0);
             spawn_runner_detached(&config, &socket_path, session_id.0.clone(), runner_sandbox)?;
             return Self::connect_via_socket(
                 socket_path,

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -95,7 +95,9 @@ impl EventStore {
                 PRIMARY KEY (session_id, seq)
             );
             CREATE INDEX IF NOT EXISTS idx_cockpit_events_session_seq
-                ON cockpit_events(session_id, seq);",
+                ON cockpit_events(session_id, seq);
+            CREATE INDEX IF NOT EXISTS idx_cockpit_events_session_created_at
+                ON cockpit_events(session_id, created_at);",
         )
         .context("create cockpit_events schema")?;
         debug!(
@@ -779,6 +781,56 @@ impl EventStore {
             }
         };
         terminator.is_none()
+    }
+
+    /// Latest `created_at` (ms since epoch) per session for the given
+    /// ids, in a single grouped query. Sessions with no events are
+    /// absent from the returned map. Backed by the
+    /// `(session_id, created_at)` index. Used by the reconciler's
+    /// idle-reap pass (#1689) to find cockpit workers that have seen no
+    /// activity for longer than `cockpit.auto_stop_idle_secs`, without a
+    /// per-session round trip.
+    pub fn last_event_at_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> std::collections::HashMap<String, i64> {
+        let mut out = std::collections::HashMap::new();
+        if session_ids.is_empty() {
+            return out;
+        }
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let placeholders = std::iter::repeat("?")
+            .take(session_ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT session_id, MAX(created_at) FROM cockpit_events
+             WHERE session_id IN ({placeholders}) GROUP BY session_id"
+        );
+        let mut stmt = match conn.prepare(&sql) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(target: "cockpit.event_store", "last_event_at_for_sessions prepare: {e}");
+                return out;
+            }
+        };
+        let rows = stmt.query_map(rusqlite::params_from_iter(session_ids.iter()), |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        });
+        match rows {
+            Ok(iter) => {
+                for r in iter.flatten() {
+                    out.insert(r.0, r.1);
+                }
+            }
+            Err(e) => {
+                warn!(target: "cockpit.event_store", "last_event_at_for_sessions query: {e}");
+            }
+        }
+        out
     }
 
     /// Drop every event for a session. Called when the session is

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -833,8 +833,15 @@ impl EventStore {
         });
         match rows {
             Ok(iter) => {
-                for r in iter.flatten() {
-                    out.insert(r.0, r.1);
+                for r in iter {
+                    match r {
+                        Ok((session_id, created_at)) => {
+                            out.insert(session_id, created_at);
+                        }
+                        Err(e) => {
+                            warn!(target: "cockpit.event_store", "last_event_at_for_sessions row: {e}");
+                        }
+                    }
                 }
             }
             Err(e) => {

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -806,9 +806,20 @@ impl EventStore {
             .take(session_ids.len())
             .collect::<Vec<_>>()
             .join(",");
+        // Exclude non-substantive lifecycle/metadata events so they do not
+        // reset the idle clock. AcpSessionAssigned in particular is emitted
+        // on every cold-start resume (acp_client.rs), so counting it would
+        // make a daemon restart look like fresh activity for every worker
+        // and the idle-reap (#1689) would never fire across restarts. Mirrors
+        // the not-substantive set the retention prune protects.
         let sql = format!(
             "SELECT session_id, MAX(created_at) FROM cockpit_events
-             WHERE session_id IN ({placeholders}) GROUP BY session_id"
+             WHERE session_id IN ({placeholders})
+               AND event_json NOT LIKE '{{\"AvailableCommandsUpdated\":%'
+               AND event_json NOT LIKE '{{\"ModesAvailable\":%'
+               AND event_json NOT LIKE '{{\"CurrentModeChanged\":%'
+               AND event_json NOT LIKE '{{\"AcpSessionAssigned\":%'
+             GROUP BY session_id"
         );
         let mut stmt = match conn.prepare(&sql) {
             Ok(s) => s,
@@ -923,6 +934,55 @@ mod tests {
         let replay = store.replay_from("s-1", 2);
         let seqs: Vec<u64> = replay.iter().map(|(s, _)| *s).collect();
         assert_eq!(seqs, vec![3, 4, 5]);
+    }
+
+    #[test]
+    fn last_event_at_ignores_non_substantive_events() {
+        // #1689: the idle clock must reflect real activity, not lifecycle /
+        // metadata events. A session whose only events are AcpSessionAssigned
+        // (emitted on every cold-start resume), ModesAvailable, etc. must NOT
+        // register a recent activity timestamp, otherwise a daemon restart
+        // would reset every worker's idle timer and the reap would never fire.
+        let (_tmp, store) = open_store(1000);
+        store
+            .record(
+                "s-lifecycle",
+                1,
+                &Event::AcpSessionAssigned {
+                    acp_session_id: "acp-1".into(),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-lifecycle",
+                2,
+                &Event::ModesAvailable {
+                    current_mode_id: "default".into(),
+                    modes: vec![],
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-real",
+                1,
+                &Event::UserPromptSent {
+                    text: "hello".into(),
+                },
+            )
+            .unwrap();
+
+        let map =
+            store.last_event_at_for_sessions(&["s-lifecycle".to_string(), "s-real".to_string()]);
+        assert!(
+            !map.contains_key("s-lifecycle"),
+            "non-substantive-only session must not register activity: {map:?}"
+        );
+        assert!(
+            map.contains_key("s-real"),
+            "session with a real event must register activity: {map:?}"
+        );
     }
 
     #[test]

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -57,6 +57,30 @@ use tracing::{debug, trace, warn};
 use super::approvals::Nonce;
 use super::state::{Event, Plan};
 
+/// Externally-tagged JSON discriminants for non-substantive cockpit
+/// events: lifecycle and metadata snapshots the agent emits once per
+/// session (or on every cold-start resume) that must not count as session
+/// activity. Two SQL predicates depend on this set staying in sync: the
+/// retention prune exempts them from eviction (#1049) and the idle-reap
+/// idle clock ignores them (#1689). Centralized so the two cannot silently
+/// desync.
+const NON_SUBSTANTIVE_EVENT_DISCRIMINANTS: &[&str] = &[
+    "AvailableCommandsUpdated",
+    "ModesAvailable",
+    "CurrentModeChanged",
+    "AcpSessionAssigned",
+];
+
+/// Build the `AND event_json NOT LIKE '{"Name":%'` SQL fragment for every
+/// non-substantive discriminant, newline-joined for readable queries.
+fn non_substantive_not_like_clauses() -> String {
+    NON_SUBSTANTIVE_EVENT_DISCRIMINANTS
+        .iter()
+        .map(|name| format!("AND event_json NOT LIKE '{{\"{name}\":%'"))
+        .collect::<Vec<_>>()
+        .join("\n               ")
+}
+
 /// SQLite-backed cockpit event log. One row per (session_id, seq).
 pub struct EventStore {
     conn: Mutex<Connection>,
@@ -172,7 +196,7 @@ impl EventStore {
         // See #1049. The `event_json NOT LIKE` clauses match the
         // externally-tagged JSON discriminant for each pinned variant.
         if self.max_events_per_session > 0 {
-            match conn.execute(
+            let prune_sql = format!(
                 "DELETE FROM cockpit_events
                  WHERE session_id = ?1
                    AND seq <= (
@@ -181,10 +205,11 @@ impl EventStore {
                      ORDER BY seq DESC
                      LIMIT 1 OFFSET ?2
                    )
-                   AND event_json NOT LIKE '{\"AvailableCommandsUpdated\":%'
-                   AND event_json NOT LIKE '{\"ModesAvailable\":%'
-                   AND event_json NOT LIKE '{\"CurrentModeChanged\":%'
-                   AND event_json NOT LIKE '{\"AcpSessionAssigned\":%'",
+                   {clauses}",
+                clauses = non_substantive_not_like_clauses()
+            );
+            match conn.execute(
+                &prune_sql,
                 params![session_id, self.max_events_per_session as i64],
             ) {
                 Ok(0) => {}
@@ -810,16 +835,15 @@ impl EventStore {
         // reset the idle clock. AcpSessionAssigned in particular is emitted
         // on every cold-start resume (acp_client.rs), so counting it would
         // make a daemon restart look like fresh activity for every worker
-        // and the idle-reap (#1689) would never fire across restarts. Mirrors
-        // the not-substantive set the retention prune protects.
+        // and the idle-reap (#1689) would never fire across restarts. Shares
+        // NON_SUBSTANTIVE_EVENT_DISCRIMINANTS with the retention prune so the
+        // two predicates cannot desync.
         let sql = format!(
             "SELECT session_id, MAX(created_at) FROM cockpit_events
              WHERE session_id IN ({placeholders})
-               AND event_json NOT LIKE '{{\"AvailableCommandsUpdated\":%'
-               AND event_json NOT LIKE '{{\"ModesAvailable\":%'
-               AND event_json NOT LIKE '{{\"CurrentModeChanged\":%'
-               AND event_json NOT LIKE '{{\"AcpSessionAssigned\":%'
-             GROUP BY session_id"
+               {clauses}
+             GROUP BY session_id",
+            clauses = non_substantive_not_like_clauses()
         );
         let mut stmt = match conn.prepare(&sql) {
             Ok(s) => s,
@@ -990,6 +1014,50 @@ mod tests {
             map.contains_key("s-real"),
             "session with a real event must register activity: {map:?}"
         );
+    }
+
+    /// Insert a substantive event with an explicit `created_at` (ms) so
+    /// tests can pin MAX(created_at) deterministically. `"ThinkingStarted"`
+    /// serializes to a bare JSON string, so it never matches the
+    /// non-substantive `{"Name":%` predicates.
+    fn insert_at(store: &EventStore, session_id: &str, seq: u64, created_at: i64) {
+        let conn = store.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO cockpit_events (session_id, seq, event_json, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![session_id, seq as i64, "\"ThinkingStarted\"", created_at],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn last_event_at_empty_input_is_empty() {
+        let (_tmp, store) = open_store(1000);
+        insert_at(&store, "s-1", 1, 1000);
+        assert!(store.last_event_at_for_sessions(&[]).is_empty());
+    }
+
+    #[test]
+    fn last_event_at_skips_missing_sessions() {
+        let (_tmp, store) = open_store(1000);
+        insert_at(&store, "s-present", 1, 5000);
+        let map =
+            store.last_event_at_for_sessions(&["s-present".to_string(), "s-missing".to_string()]);
+        assert_eq!(map.get("s-present"), Some(&5000));
+        assert!(!map.contains_key("s-missing"));
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn last_event_at_returns_max_per_session() {
+        let (_tmp, store) = open_store(1000);
+        insert_at(&store, "s-a", 1, 100);
+        insert_at(&store, "s-a", 2, 900);
+        insert_at(&store, "s-a", 3, 400);
+        insert_at(&store, "s-b", 1, 7000);
+        let map = store.last_event_at_for_sessions(&["s-a".to_string(), "s-b".to_string()]);
+        assert_eq!(map.get("s-a"), Some(&900));
+        assert_eq!(map.get("s-b"), Some(&7000));
     }
 
     #[test]

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1533,6 +1533,24 @@ impl<S: BroadcastSink> Supervisor<S> {
 
     /// Shutdown a single cockpit worker.
     pub async fn shutdown(&self, session_id: &str) -> Result<(), SupervisorError> {
+        self.shutdown_with_reason(session_id, "user_stopped").await
+    }
+
+    /// Like `shutdown`, but tags the synthetic `Stopped` event with
+    /// `reason: "idle_auto_stop"` so the cockpit timeline shows the
+    /// worker was reclaimed for inactivity rather than user-stopped.
+    /// Used by the reconciler's idle-reap pass (#1689). Seamless: no UI
+    /// banner, the next prompt respawns the worker.
+    pub async fn shutdown_idle(&self, session_id: &str) -> Result<(), SupervisorError> {
+        self.shutdown_with_reason(session_id, "idle_auto_stop")
+            .await
+    }
+
+    async fn shutdown_with_reason(
+        &self,
+        session_id: &str,
+        stop_reason: &str,
+    ) -> Result<(), SupervisorError> {
         // Hold workers + pending_resumes simultaneously so the spawn
         // can't observe an empty workers map, finish the handshake,
         // and insert a WorkerHandle while we're walking through this
@@ -1575,7 +1593,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                     session_id,
                     seq,
                     &Event::Stopped {
-                        reason: "user_stopped".into(),
+                        reason: stop_reason.into(),
                     },
                 );
             }

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1665,14 +1665,12 @@ impl<S: BroadcastSink> Supervisor<S> {
             handle.drain_task.abort();
         }
 
-        // SIGTERM every runner we knew about, so detached agents that
-        // outlived a previous daemon are also taken down by an explicit
-        // "kill them all" request.
-        #[cfg(unix)]
+        // Group-SIGTERM every runner we knew about, so detached agents that
+        // outlived a previous daemon (and their node/SDK grandchildren) are
+        // also taken down by an explicit "kill them all" request, not left
+        // orphaned under PID 1. See #1689.
         for (session_id, pid) in registry_pids {
-            use nix::sys::signal::{kill, Signal};
-            use nix::unistd::Pid;
-            let _ = kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
+            super::worker_registry::terminate_runner_group(pid);
             super::worker_registry::delete(&session_id).ok();
         }
         #[cfg(not(unix))]
@@ -2030,17 +2028,10 @@ impl<S: BroadcastSink> Supervisor<S> {
 /// then delete the entry. Used by `shutdown` and `shutdown_all` to take
 /// down detached workers explicitly.
 fn terminate_runner_for_session(session_id: &str) {
-    if let Ok(Some(record)) = super::worker_registry::load(session_id) {
-        #[cfg(unix)]
-        if super::worker_registry::is_pid_alive(record.pid) {
-            use nix::sys::signal::{kill, Signal};
-            use nix::unistd::Pid;
-            let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGTERM);
-        }
-        #[cfg(not(unix))]
-        let _ = record;
-    }
-    super::worker_registry::delete(session_id).ok();
+    // Group-kill (runner + agent + grandchildren) then delete the entry.
+    // Single-pid SIGTERM here used to orphan the agent's node/SDK children
+    // under PID 1; see worker_registry::terminate and #1689.
+    super::worker_registry::terminate(session_id);
 }
 
 #[derive(Debug)]

--- a/src/cockpit/worker_registry.rs
+++ b/src/cockpit/worker_registry.rs
@@ -409,6 +409,58 @@ fn socket_exists(path: &Path) -> bool {
     }
 }
 
+/// Signal the runner's entire process group, then the runner pid itself.
+///
+/// The runner is spawned `setsid` (a fresh session, so it is the leader of
+/// a process group whose id equals its pid), and the agent subprocess plus
+/// the agent's own children (e.g. the node ACP wrapper and the SDK child it
+/// execs) inherit that group. Signalling the group reaps the whole tree in
+/// one shot. Signalling only the runner pid leaves the agent and its
+/// grandchildren orphaned under PID 1, which is the cockpit-runner /
+/// `node` / `claude` process leak that accumulated across daemon restarts
+/// and superseded spawns (#1689). The trailing single-pid signal is a
+/// belt-and-suspenders for the unlikely case `setsid` failed and the
+/// runner is not a group leader. Best-effort; errors are ignored.
+#[cfg(unix)]
+fn signal_runner_group(pid: u32, sig: nix::sys::signal::Signal) {
+    use nix::sys::signal::{kill, killpg};
+    use nix::unistd::Pid;
+    let p = Pid::from_raw(pid as i32);
+    let _ = killpg(p, sig);
+    let _ = kill(p, sig);
+}
+
+/// SIGTERM the runner's process group (runner + agent + grandchildren).
+pub fn terminate_runner_group(pid: u32) {
+    #[cfg(unix)]
+    signal_runner_group(pid, nix::sys::signal::Signal::SIGTERM);
+    #[cfg(not(unix))]
+    let _ = pid;
+}
+
+/// SIGKILL the runner's process group; the escalation path when SIGTERM
+/// does not take.
+pub fn kill_runner_group(pid: u32) {
+    #[cfg(unix)]
+    signal_runner_group(pid, nix::sys::signal::Signal::SIGKILL);
+    #[cfg(not(unix))]
+    let _ = pid;
+}
+
+/// Reap the runner for `session_id`: SIGTERM its whole process group (if
+/// the registry entry exists and its pid is alive), then remove the
+/// registry entry and socket. The canonical teardown used by the
+/// supervisor's shutdown paths and by a fresh spawn that supersedes a
+/// stale runner, so no prior agent tree is left orphaned. See #1689.
+pub fn terminate(session_id: &str) {
+    if let Ok(Some(record)) = load(session_id) {
+        if is_pid_alive(record.pid) {
+            terminate_runner_group(record.pid);
+        }
+    }
+    delete(session_id).ok();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -643,6 +695,42 @@ mod tests {
             let after = load("x").unwrap().unwrap();
             assert!(after.last_attached_at.is_some());
             assert!(after.detached_at.is_none());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn terminate_deletes_entry_for_dead_pid() {
+        with_temp_home(|| {
+            // 2e9 is not a live pid (see is_pid_alive_unlikely_pid), so
+            // terminate sends no signal and just clears the stale entry.
+            let rec = WorkerRecord::new(
+                "term-dead".into(),
+                2_000_000_000,
+                PathBuf::from("/tmp/term-dead.sock"),
+                "aoe-agent".into(),
+                "aoe-agent".into(),
+                PathBuf::from("/repo"),
+                None,
+                vec![],
+                vec![],
+                None,
+                None,
+            );
+            save(&rec).unwrap();
+            assert!(record_path("term-dead").unwrap().exists());
+            terminate("term-dead");
+            assert!(!record_path("term-dead").unwrap().exists());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn terminate_missing_entry_is_noop() {
+        with_temp_home(|| {
+            // No entry, no panic, nothing to delete.
+            terminate("does-not-exist");
+            assert!(!record_path("does-not-exist").unwrap().exists());
         });
     }
 

--- a/src/cockpit/worker_registry.rs
+++ b/src/cockpit/worker_registry.rs
@@ -448,15 +448,16 @@ pub fn kill_runner_group(pid: u32) {
 }
 
 /// Reap the runner for `session_id`: SIGTERM its whole process group (if
-/// the registry entry exists and its pid is alive), then remove the
-/// registry entry and socket. The canonical teardown used by the
-/// supervisor's shutdown paths and by a fresh spawn that supersedes a
-/// stale runner, so no prior agent tree is left orphaned. See #1689.
+/// the registry entry exists), then remove the registry entry and socket.
+/// The canonical teardown used by the supervisor's shutdown paths and by a
+/// fresh spawn that supersedes a stale runner, so no prior agent tree is
+/// left orphaned. The SIGTERM is sent unconditionally: the process group
+/// can outlive its leader pid, so gating on leader liveness would skip the
+/// killpg and leak surviving descendants. `killpg` ignores ESRCH, so an
+/// already-empty group is a harmless no-op. See #1689.
 pub fn terminate(session_id: &str) {
     if let Ok(Some(record)) = load(session_id) {
-        if is_pid_alive(record.pid) {
-            terminate_runner_group(record.pid);
-        }
+        terminate_runner_group(record.pid);
     }
     delete(session_id).ok();
 }

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -447,10 +447,12 @@ pub async fn cockpit_prompt(
     // Touch the instance before forwarding so an archived or
     // currently-snoozed session auto-wakes the same way the tmux send
     // path does (`/api/sessions/{id}/send`). `touch_last_accessed`
-    // clears `archived_at` and `snoozed_until` so the cockpit
-    // reconciler stops skipping the session on its next ~2s tick and
-    // respawns the worker; the frontend's queue drains as soon as the
-    // fresh `AcpSessionAssigned` lands. See #1581.
+    // clears `archived_at`, `snoozed_until`, and `idle_dormant_since` so
+    // the cockpit reconciler stops skipping the session on its next ~2s
+    // tick and respawns the worker; the frontend's queue drains as soon
+    // as the fresh `AcpSessionAssigned` lands. The idle_dormant_since
+    // clear is the wake path for auto-stopped idle workers (#1689); a
+    // worker reaped for inactivity respawns on the next prompt. See #1581.
     //
     // The in-memory mutation and the disk persistence are both held
     // under `state.instance_lock(&id)` so they serialize against
@@ -465,9 +467,20 @@ pub async fn cockpit_prompt(
     let triage_changed = {
         let mut instances = state.instances.write().await;
         if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
-            let was_sunk = inst.is_archived() || inst.is_snoozed();
+            let was_sunk = inst.is_archived() || inst.is_snoozed() || inst.is_idle_dormant();
             if was_sunk {
+                let was_idle_dormant = inst.is_idle_dormant();
                 inst.touch_last_accessed();
+                if was_idle_dormant {
+                    // Pairs with the "auto-stopped idle cockpit worker"
+                    // info log in the reconciler's reap pass (#1689) so the
+                    // stop/resume cycle is traceable in the daemon log.
+                    tracing::info!(
+                        target: "cockpit.supervisor",
+                        session = %id,
+                        "waking idle-dormant cockpit session on prompt; reconciler will respawn the worker"
+                    );
+                }
             }
             was_sunk
         } else {

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -79,6 +79,13 @@ pub(super) const ALLOWED_GLOBAL_SETTINGS_SECTIONS: &[&str] = &[
     // No shell commands, no binary paths. Values are validated against the
     // EnvFilter parser before being written back to disk.
     "logging",
+    // cockpit: bools, numeric tuning knobs, and a queue-drain enum. The one
+    // binary-path field (`node_path`) is stripped via COCKPIT_BLOCKED_FIELDS
+    // below, mirroring the session allowlist+blocklist pattern, so the web
+    // surface carries no shell command or binary override. Without this the
+    // dashboard cockpit settings (durations, queue mode, resume/grace/idle
+    // knobs) silently failed to save. See #1689.
+    "cockpit",
 ];
 
 /// Sections that PATCH /api/settings/profile/:name may write.
@@ -97,8 +104,16 @@ pub(super) const ALLOWED_PROFILE_SETTINGS_SECTIONS: &[&str] = &[
     "worktree",
     "web",
     "logging",
+    "cockpit",
     "description",
 ];
+
+/// Cockpit fields stripped from any web settings PATCH before it is
+/// written, mirroring `SESSION_BLOCKED_FIELDS`. `node_path` overrides the
+/// Node.js binary the cockpit runner launches, an arbitrary-binary / RCE
+/// surface that must stay local-only; the rest of the cockpit section
+/// (bools, numbers, queue-drain enum) is safe to set from the dashboard.
+pub(super) const COCKPIT_BLOCKED_FIELDS: &[&str] = &["node_path"];
 
 pub(super) const SESSION_BLOCKED_FIELDS: &[&str] = &[
     "agent_command_override",
@@ -553,6 +568,10 @@ mod tests {
             // logging: persistent tracing filter. EnvFilter parser
             // validates every value before save_config writes it back.
             "logging",
+            // cockpit: audited for #1689. Safe knobs (bools, numbers, enum);
+            // the binary-path field node_path is stripped via
+            // COCKPIT_BLOCKED_FIELDS before write.
+            "cockpit",
         ];
         assert_eq!(
             ALLOWED_GLOBAL_SETTINGS_SECTIONS.len(),
@@ -599,6 +618,9 @@ mod tests {
             "worktree",
             "web",
             "logging",
+            // cockpit: see global allowlist note; node_path stripped via
+            // COCKPIT_BLOCKED_FIELDS. #1689.
+            "cockpit",
             // description: optional string surfaced in the wizard profile
             // picker (#949). Plain text, no shell metacharacters.
             "description",
@@ -778,6 +800,29 @@ mod tests {
             assert!(
                 SESSION_BLOCKED_FIELDS.contains(field),
                 "SESSION_BLOCKED_FIELDS lost field {:?}",
+                field
+            );
+        }
+    }
+
+    #[test]
+    fn cockpit_blocked_fields_are_pinned() {
+        // node_path overrides the Node.js binary the cockpit runner launches,
+        // an arbitrary-binary / RCE surface that must stay local-only even
+        // though the rest of the cockpit section is API-writable. Renaming
+        // the Rust field must update this list in the same commit.
+        let expected: &[&str] = &["node_path"];
+        assert_eq!(
+            COCKPIT_BLOCKED_FIELDS.len(),
+            expected.len(),
+            "COCKPIT_BLOCKED_FIELDS size changed — this strips the binary-path \
+             override from incoming web cockpit settings and must be reviewed \
+             as a security change."
+        );
+        for field in expected {
+            assert!(
+                COCKPIT_BLOCKED_FIELDS.contains(field),
+                "COCKPIT_BLOCKED_FIELDS lost field {:?}",
                 field
             );
         }

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use super::AppState;
 use super::{
     body_requires_elevation, validate_profile_name, ALLOWED_GLOBAL_SETTINGS_SECTIONS,
-    ALLOWED_PROFILE_SETTINGS_SECTIONS, SESSION_BLOCKED_FIELDS,
+    ALLOWED_PROFILE_SETTINGS_SECTIONS, COCKPIT_BLOCKED_FIELDS, SESSION_BLOCKED_FIELDS,
 };
 use crate::server::auth::AuthenticatedSession;
 
@@ -160,6 +160,14 @@ pub async fn update_settings(
                     if let Some(session_obj) = value.as_object_mut() {
                         for blocked in SESSION_BLOCKED_FIELDS {
                             session_obj.remove(*blocked);
+                        }
+                    }
+                }
+                // Strip blocked fields from cockpit section (node_path).
+                if key == "cockpit" {
+                    if let Some(cockpit_obj) = value.as_object_mut() {
+                        for blocked in COCKPIT_BLOCKED_FIELDS {
+                            cockpit_obj.remove(*blocked);
                         }
                     }
                 }
@@ -1043,6 +1051,13 @@ pub async fn update_profile_settings(
                     if let Some(session_obj) = value.as_object_mut() {
                         for blocked in SESSION_BLOCKED_FIELDS {
                             session_obj.remove(*blocked);
+                        }
+                    }
+                }
+                if key == "cockpit" {
+                    if let Some(cockpit_obj) = value.as_object_mut() {
+                        for blocked in COCKPIT_BLOCKED_FIELDS {
+                            cockpit_obj.remove(*blocked);
                         }
                     }
                 }

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -77,7 +77,11 @@ type RawTargetTuple = (
     bool,
 );
 
-pub async fn reconcile_cockpit_workers(state: &Arc<AppState>, attempted: &mut HashSet<String>) {
+pub async fn reconcile_cockpit_workers(
+    state: &Arc<AppState>,
+    attempted: &mut HashSet<String>,
+    last_idle_reap: &mut Option<std::time::Instant>,
+) {
     // Honor `cockpit.enabled = false` from config.toml — the persistent
     // master switch. Mirrored as an atomic; `PATCH /api/cockpit/master`
     // flips it live without restarting `aoe serve`.
@@ -103,6 +107,21 @@ pub async fn reconcile_cockpit_workers(state: &Arc<AppState>, attempted: &mut Ha
         attempted.remove(id);
     }
 
+    // Idle auto-stop (#1689). Cadence-gated to IDLE_REAP_INTERVAL so the
+    // batched activity query does not run on every 2s tick. Runs BEFORE
+    // the resume snapshot below: a worker marked dormant here is excluded
+    // from this same tick's respawn pass by the `!i.is_idle_dormant()`
+    // filter. `auto_stop_idle_secs == 0` (default) disables the feature.
+    let auto_stop_idle_secs =
+        crate::session::profile_config::resolve_config_or_warn(&state.profile)
+            .cockpit
+            .auto_stop_idle_secs;
+    if auto_stop_idle_secs > 0 && last_idle_reap.map_or(true, |t| t.elapsed() >= IDLE_REAP_INTERVAL)
+    {
+        reap_idle_workers(state, auto_stop_idle_secs).await;
+        *last_idle_reap = Some(std::time::Instant::now());
+    }
+
     // Snapshot per-target resume inputs under the instances read lock.
     // We then drop the lock so the parallel resume tasks (each ~3s for
     // a fresh spawn) don't pin it.
@@ -118,7 +137,9 @@ pub async fn reconcile_cockpit_workers(state: &Arc<AppState>, attempted: &mut Ha
         let instances = state.instances.read().await;
         instances
             .iter()
-            .filter(|i| i.cockpit_mode && !i.is_archived() && !i.is_snoozed())
+            .filter(|i| {
+                i.cockpit_mode && !i.is_archived() && !i.is_snoozed() && !i.is_idle_dormant()
+            })
             .map(|i| {
                 (
                     i.id.clone(),
@@ -285,6 +306,161 @@ pub async fn reconcile_cockpit_workers(state: &Arc<AppState>, attempted: &mut Ha
                     "resume task panicked: {e}"
                 );
             }
+        }
+    }
+}
+
+/// How often the idle-reap pass actually runs. The reconciler ticks
+/// every 2s, but the idle threshold is measured in hours, so reaping on
+/// every tick would hammer SQLite for no benefit; this gates the batched
+/// activity query to a coarse cadence. See #1689.
+const IDLE_REAP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Pure idle-reap decision. A cockpit worker is auto-stopped only when the
+/// feature is enabled (`threshold_secs > 0`), it is not mid-turn, and its
+/// last recorded event is at least `threshold_secs` old. A session with no
+/// events (`last_event_ms == None`) is never reaped, so a freshly-spawned
+/// worker without history survives. Extracted from `reap_idle_workers` so
+/// the policy is unit-testable without a live supervisor or DB. See #1689.
+fn should_auto_stop(
+    now_ms: i64,
+    last_event_ms: Option<i64>,
+    threshold_secs: u32,
+    in_flight: bool,
+) -> bool {
+    if threshold_secs == 0 || in_flight {
+        return false;
+    }
+    match last_event_ms {
+        Some(ms) => now_ms.saturating_sub(ms) >= i64::from(threshold_secs) * 1000,
+        None => false,
+    }
+}
+
+/// Idle auto-stop pass (#1689). Shuts down cockpit workers that have seen
+/// no activity for `idle_secs` and are not mid-turn, marking their
+/// session dormant so the resume pass does not respawn them. The next
+/// user prompt clears dormancy (via `Instance::touch_last_accessed`) and
+/// the following reconciler tick spawns a fresh worker.
+///
+/// Ordering and races: dormancy is persisted BEFORE the worker is shut
+/// down, so a persist failure leaves the worker alive instead of orphaning
+/// a still-running worker the next tick would respawn. `has_in_flight_turn`
+/// is re-checked immediately before shutdown to avoid killing a worker a
+/// prompt started in the gap since the candidate snapshot.
+async fn reap_idle_workers(state: &Arc<AppState>, idle_secs: u32) {
+    // Candidates: cockpit sessions not already sunk/dormant. Snapshot
+    // (id, profile) under the read lock so we don't hold it across awaits.
+    let candidates: Vec<(String, String)> = {
+        let instances = state.instances.read().await;
+        instances
+            .iter()
+            .filter(|i| {
+                i.cockpit_mode && !i.is_archived() && !i.is_snoozed() && !i.is_idle_dormant()
+            })
+            .map(|i| (i.id.clone(), i.source_profile.clone()))
+            .collect()
+    };
+    if candidates.is_empty() {
+        return;
+    }
+    // Keep only sessions with a live worker; nothing to reap otherwise.
+    let mut live: Vec<(String, String)> = Vec::new();
+    for (id, profile) in candidates {
+        if state.cockpit_supervisor.is_running(&id).await {
+            live.push((id, profile));
+        }
+    }
+    if live.is_empty() {
+        return;
+    }
+    // One batched query for the latest event timestamp per candidate.
+    let ids: Vec<String> = live.iter().map(|(id, _)| id.clone()).collect();
+    let store = Arc::clone(&state.cockpit_event_store);
+    let latest = match tokio::task::spawn_blocking(move || store.last_event_at_for_sessions(&ids))
+        .await
+    {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(target: "cockpit.supervisor", error = %e, "idle-reap activity query failed");
+            return;
+        }
+    };
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    for (id, profile) in live {
+        // Cheap pre-check (no in-flight probe yet): skips sessions with no
+        // history or still within the idle window. Sessions with no events
+        // are never reaped, so a freshly-spawned worker is safe.
+        let last_ms = latest.get(&id).copied();
+        if !should_auto_stop(now_ms, last_ms, idle_secs, false) {
+            continue;
+        }
+        // Re-check mid-turn right before stopping: a turn may have started
+        // since the snapshot. spawn_blocking matches the SQLite-on-tokio
+        // pattern used by the resume pass above.
+        let store = Arc::clone(&state.cockpit_event_store);
+        let id_probe = id.clone();
+        let in_flight = tokio::task::spawn_blocking(move || store.has_in_flight_turn(&id_probe))
+            .await
+            .unwrap_or(false);
+        if !should_auto_stop(now_ms, last_ms, idle_secs, in_flight) {
+            continue;
+        }
+        // Mark dormant in-memory so this tick's resume snapshot skips it.
+        {
+            let mut instances = state.instances.write().await;
+            match instances.iter_mut().find(|i| i.id == id) {
+                Some(inst) => inst.mark_idle_dormant(),
+                None => continue,
+            }
+        }
+        // Persist BEFORE shutdown: a daemon restart must keep the worker
+        // stopped, and if persistence fails we must not orphan a killed
+        // worker that the next tick would respawn.
+        let persisted = if let Ok(storage) = crate::session::Storage::new(&profile) {
+            let id_persist = id.clone();
+            tokio::task::spawn_blocking(move || {
+                storage.update(|instances, _groups| {
+                    if let Some(inst) = instances.iter_mut().find(|i| i.id == id_persist) {
+                        inst.mark_idle_dormant();
+                    }
+                    Ok(())
+                })
+            })
+            .await
+            .map(|r| r.is_ok())
+            .unwrap_or(false)
+        } else {
+            false
+        };
+        if !persisted {
+            // Roll back the in-memory mark and leave the worker alive; retry
+            // on the next interval.
+            let mut instances = state.instances.write().await;
+            if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+                inst.idle_dormant_since = None;
+            }
+            tracing::warn!(
+                target: "cockpit.supervisor",
+                session = %id,
+                "idle-reap persist failed; leaving worker alive"
+            );
+            continue;
+        }
+        match state.cockpit_supervisor.shutdown_idle(&id).await {
+            Ok(()) | Err(crate::cockpit::supervisor::SupervisorError::UnknownSession(_)) => {
+                tracing::info!(
+                    target: "cockpit.supervisor",
+                    session = %id,
+                    idle_secs,
+                    "auto-stopped idle cockpit worker"
+                );
+            }
+            Err(e) => tracing::warn!(
+                target: "cockpit.supervisor",
+                session = %id,
+                "idle-reap shutdown failed: {e}"
+            ),
         }
     }
 }
@@ -497,5 +673,50 @@ async fn sweep_orphan_workers(state: &Arc<AppState>, live: &HashSet<&String>) {
             let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGTERM);
         }
         crate::cockpit::worker_registry::delete(&record.session_id).ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_auto_stop;
+
+    const HOUR_MS: i64 = 3_600_000;
+
+    #[test]
+    fn disabled_threshold_never_stops() {
+        // threshold 0 = feature off; even a worker idle for a day survives.
+        assert!(!should_auto_stop(HOUR_MS * 24, Some(0), 0, false));
+    }
+
+    #[test]
+    fn in_flight_worker_is_never_stopped() {
+        // Idle far past the threshold, but mid-turn: do not kill.
+        assert!(!should_auto_stop(HOUR_MS * 24, Some(0), 3600, true));
+    }
+
+    #[test]
+    fn idle_past_threshold_stops() {
+        // Last event 2h ago, threshold 1h, not mid-turn: reap.
+        assert!(should_auto_stop(HOUR_MS * 2, Some(0), 3600, false));
+    }
+
+    #[test]
+    fn idle_within_threshold_survives() {
+        // Last event 30min ago, threshold 1h: too soon.
+        let now = HOUR_MS;
+        let last = HOUR_MS / 2;
+        assert!(!should_auto_stop(now, Some(last), 3600, false));
+    }
+
+    #[test]
+    fn no_events_never_stops() {
+        // A worker with no recorded events (fresh spawn) is never reaped.
+        assert!(!should_auto_stop(HOUR_MS * 24, None, 3600, false));
+    }
+
+    #[test]
+    fn exactly_at_threshold_stops() {
+        // Boundary: elapsed == threshold reaps (>= comparison).
+        assert!(should_auto_stop(3600 * 1000, Some(0), 3600, false));
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1604,6 +1604,8 @@ async fn status_poll_loop(state: Arc<AppState>) {
     #[cfg(feature = "serve")]
     let mut attempted_cockpit_spawns: std::collections::HashSet<String> =
         std::collections::HashSet::new();
+    #[cfg(feature = "serve")]
+    let mut last_idle_reap: Option<std::time::Instant> = None;
     loop {
         interval.tick().await;
 
@@ -1732,8 +1734,12 @@ async fn status_poll_loop(state: Arc<AppState>) {
             }
 
             #[cfg(feature = "serve")]
-            cockpit_reconciler::reconcile_cockpit_workers(&state, &mut attempted_cockpit_spawns)
-                .await;
+            cockpit_reconciler::reconcile_cockpit_workers(
+                &state,
+                &mut attempted_cockpit_spawns,
+                &mut last_idle_reap,
+            )
+            .await;
         }
     }
 }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -303,6 +303,19 @@ pub struct CockpitConfig {
     /// has no effect. See #1240.
     #[serde(default = "default_silent_orphan_fast_grace_secs")]
     pub silent_orphan_fast_grace_secs: u32,
+    /// Auto-stop idle cockpit workers: seconds of inactivity (no cockpit
+    /// events and no in-flight turn) after which the daemon shuts a
+    /// worker down and marks its session dormant so the reconciler does
+    /// not respawn it. The next user prompt wakes the session and the
+    /// reconciler spawns a fresh worker. `0` (default) disables the
+    /// feature entirely; no worker is ever stopped for inactivity. See
+    /// #1689.
+    #[serde(default = "default_auto_stop_idle_secs")]
+    pub auto_stop_idle_secs: u32,
+}
+
+fn default_auto_stop_idle_secs() -> u32 {
+    0
 }
 
 fn default_max_concurrent_resumes() -> u32 {
@@ -370,6 +383,7 @@ impl Default for CockpitConfig {
             force_end_turn_threshold_secs: default_force_end_turn_threshold_secs(),
             silent_orphan_grace_secs: default_silent_orphan_grace_secs(),
             silent_orphan_fast_grace_secs: default_silent_orphan_fast_grace_secs(),
+            auto_stop_idle_secs: default_auto_stop_idle_secs(),
         }
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -325,6 +325,19 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snoozed_until: Option<DateTime<Utc>>,
 
+    /// Internal cockpit idle-dormancy marker. Set by the reconciler's
+    /// idle-reap pass when a cockpit worker is shut down for inactivity
+    /// (`cockpit.auto_stop_idle_secs`); while set, the reconciler skips
+    /// respawning the worker, so the session stays stopped until the
+    /// user comes back. Cleared by `touch_last_accessed()` (the same
+    /// wake path that clears archive/snooze), so the next prompt revives
+    /// the worker on the following reconciler tick. Distinct from
+    /// `snoozed_until` (user-facing, deadline-based, sorts to tier 99)
+    /// and `archived_at` (user-facing hide): dormancy is invisible to
+    /// the UI sort and exists only to suppress auto-respawn. See #1689.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_dormant_since: Option<DateTime<Utc>>,
+
     /// Web-only pin marker. Distinct from `favorited_at`: favorite is the
     /// TUI attention-sort within-tier pin, while pin is a hard top-of-sort
     /// surfacing primitive surfaced through the web sidebar (where the TUI's
@@ -672,6 +685,7 @@ impl Instance {
             archived_at: None,
             favorited_at: None,
             snoozed_until: None,
+            idle_dormant_since: None,
             pinned_at: None,
             scratch: false,
             worktree_info: None,
@@ -718,6 +732,20 @@ impl Instance {
         self.last_accessed_at = Some(Utc::now());
         self.archived_at = None;
         self.snoozed_until = None;
+        self.idle_dormant_since = None;
+    }
+
+    /// Whether this session's cockpit worker was auto-stopped for
+    /// inactivity and should not be respawned by the reconciler until the
+    /// user wakes it. See `idle_dormant_since` and #1689.
+    pub fn is_idle_dormant(&self) -> bool {
+        self.idle_dormant_since.is_some()
+    }
+
+    /// Mark the session dormant after its cockpit worker was auto-stopped
+    /// for inactivity. Idempotent: re-marking refreshes the timestamp.
+    pub fn mark_idle_dormant(&mut self) {
+        self.idle_dormant_since = Some(Utc::now());
     }
 
     /// Mutates: `status`, `sandbox_info`. Field set must match what
@@ -3111,6 +3139,24 @@ mod tests {
         assert!(inst.is_snoozed());
         inst.touch_last_accessed();
         assert!(!inst.is_snoozed());
+    }
+
+    #[test]
+    fn test_touch_last_accessed_clears_idle_dormant() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.mark_idle_dormant();
+        assert!(inst.is_idle_dormant());
+        inst.touch_last_accessed();
+        assert!(!inst.is_idle_dormant());
+    }
+
+    #[test]
+    fn test_mark_idle_dormant_sets_marker() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        assert!(!inst.is_idle_dormant());
+        inst.mark_idle_dormant();
+        assert!(inst.is_idle_dormant());
+        assert!(inst.idle_dormant_since.is_some());
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -852,12 +852,15 @@ impl Instance {
             self.archived_at = None;
             self.snoozed_until = None;
         }
-        // touch_last_accessed(): clears archived + snoozed. Does NOT clear
-        // favorite or pin (both are explicit user-surfacing signals, not
-        // sink states).
+        // touch_last_accessed(): clears archived + snoozed + idle-dormant.
+        // Does NOT clear favorite or pin (both are explicit user-surfacing
+        // signals, not sink states). Mirrors touch_last_accessed() so the
+        // wake-from-dormancy invariant holds on the concurrent-writer merge
+        // path too, not just direct touches (#1689).
         if touched {
             self.archived_at = None;
             self.snoozed_until = None;
+            self.idle_dormant_since = None;
         }
         // Final-state invariant: archive is the strongest dismiss and
         // wins over snooze. The per-mutation rules above clear other

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -96,6 +96,8 @@ pub struct CockpitConfigOverride {
     pub silent_orphan_grace_secs: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub silent_orphan_fast_grace_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_stop_idle_secs: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -639,6 +641,9 @@ pub fn merge_configs(mut global: Config, profile: &ProfileConfig) -> Config {
         }
         if let Some(v) = cockpit_override.silent_orphan_fast_grace_secs {
             global.cockpit.silent_orphan_fast_grace_secs = v;
+        }
+        if let Some(v) = cockpit_override.auto_stop_idle_secs {
+            global.cockpit.auto_stop_idle_secs = v;
         }
     }
 

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -158,6 +158,7 @@ pub enum FieldKey {
     CockpitForceEndTurnThresholdSecs,
     CockpitSilentOrphanGraceSecs,
     CockpitSilentOrphanFastGraceSecs,
+    CockpitAutoStopIdleSecs,
     // Logging
     LoggingDefaultLevel,
     /// Per-target override; carries an index into `crate::logging::KNOWN_SUB_TARGETS`
@@ -664,6 +665,11 @@ fn build_cockpit_fields(
         global.cockpit.silent_orphan_fast_grace_secs,
         p.and_then(|c| c.silent_orphan_fast_grace_secs),
     );
+    let (auto_stop_idle_secs, asis_override) = resolve_value(
+        scope,
+        global.cockpit.auto_stop_idle_secs,
+        p.and_then(|c| c.auto_stop_idle_secs),
+    );
 
     vec![
         SettingField {
@@ -796,6 +802,15 @@ fn build_cockpit_fields(
             value: FieldValue::Number(u64::from(silent_orphan_fast_grace_secs)),
             category: SettingsCategory::Cockpit,
             has_override: sofg_override,
+            inherited_display: None,
+        },
+        SettingField {
+            key: FieldKey::CockpitAutoStopIdleSecs,
+            label: "Auto-stop idle workers (s)",
+            description: "Seconds of inactivity (no cockpit events, no in-flight turn) after which the daemon stops an idle cockpit worker and frees its resources. The session stays stopped until the next prompt, which respawns the worker seamlessly. Default 0 disables the feature; no worker is ever auto-stopped for inactivity. Evaluated roughly once a minute, so the effective stop time can lag the threshold by up to a minute. See #1689.",
+            value: FieldValue::Number(u64::from(auto_stop_idle_secs)),
+            category: SettingsCategory::Cockpit,
+            has_override: asis_override,
             inherited_display: None,
         },
     ]
@@ -2817,6 +2832,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
             let raw = (*v).min(u32::MAX as u64) as u32;
             config.cockpit.silent_orphan_fast_grace_secs = if raw == 0 { 0 } else { raw.max(5) };
         }
+        (FieldKey::CockpitAutoStopIdleSecs, FieldValue::Number(v)) => {
+            config.cockpit.auto_stop_idle_secs = (*v).min(u32::MAX as u64) as u32;
+        }
         // Logging
         (FieldKey::LoggingDefaultLevel, FieldValue::Select { selected, options }) => {
             if let Some(level) = options.get(*selected) {
@@ -3349,6 +3367,12 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 s.silent_orphan_fast_grace_secs = val
             });
         }
+        (FieldKey::CockpitAutoStopIdleSecs, FieldValue::Number(v)) => {
+            let clamped = (*v).min(u32::MAX as u64) as u32;
+            set_profile_override(clamped, &mut config.cockpit, |s, val| {
+                s.auto_stop_idle_secs = val
+            });
+        }
         (FieldKey::HostEnvironment, FieldValue::List(v)) => {
             // Empty list clears the override (no env entries); otherwise store
             // the list as the profile-scope replacement of the global list.
@@ -3751,6 +3775,7 @@ mod tests {
             FieldKey::CockpitForceEndTurnThresholdSecs,
             FieldKey::CockpitSilentOrphanGraceSecs,
             FieldKey::CockpitSilentOrphanFastGraceSecs,
+            FieldKey::CockpitAutoStopIdleSecs,
         ];
         for k in advanced_keys {
             let pos = fields.iter().position(|f| f.key == k).unwrap();

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -3388,6 +3388,35 @@ mod tests {
     use crate::session::{Config, ProfileConfig};
 
     #[test]
+    fn test_cockpit_auto_stop_idle_secs_applies_to_global_and_profile() {
+        let mut global = Config::default();
+        let mut profile = ProfileConfig::default();
+
+        // Pull the real field from the builder so the test tracks the
+        // production definition (label/category), then pin the value.
+        let mut field = build_fields_for_category(
+            SettingsCategory::Cockpit,
+            SettingsScope::Global,
+            &global,
+            &profile,
+        )
+        .into_iter()
+        .find(|f| f.key == FieldKey::CockpitAutoStopIdleSecs)
+        .expect("CockpitAutoStopIdleSecs field must exist in the Cockpit category");
+        field.value = FieldValue::Number(28800);
+
+        apply_field_to_config(&field, SettingsScope::Global, &mut global, &mut profile);
+        assert_eq!(global.cockpit.auto_stop_idle_secs, 28800);
+
+        apply_field_to_config(&field, SettingsScope::Profile, &mut global, &mut profile);
+        assert_eq!(
+            profile.cockpit.as_ref().and_then(|c| c.auto_stop_idle_secs),
+            Some(28800),
+            "profile scope must store the value as an override"
+        );
+    }
+
+    #[test]
     fn test_profile_field_has_no_override_after_global_change() {
         use crate::session::config::UpdateCheckMode;
         // Start with default configs

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -1052,6 +1052,11 @@ impl SettingsView {
                     c.silent_orphan_fast_grace_secs = None;
                 }
             }
+            FieldKey::CockpitAutoStopIdleSecs => {
+                if let Some(c) = config.cockpit.as_mut() {
+                    c.auto_stop_idle_secs = None;
+                }
+            }
             // Logging is global-only for v1 (no profile overrides); the
             // "clear override" gesture is a no-op for these keys.
             // SessionIdPollerMaxThreads and ConfirmBeforeQuit are also

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -810,6 +810,17 @@ function CockpitSettings({
           min={0}
           onChange={(v) => onSaveField("cockpit", "silent_orphan_fast_grace_secs", v)}
         />
+        <NumberField
+          label="Auto-stop idle workers (s)"
+          description="Seconds of inactivity (no cockpit events, no in-flight turn) after which the daemon stops an idle cockpit worker and frees its resources. The session stays put; the next prompt respawns the worker seamlessly. 0 disables (default); no worker is ever stopped for inactivity. Checked about once a minute, so the stop can lag the threshold by up to a minute. Cockpit workers only. Persists to config.toml as cockpit.auto_stop_idle_secs; cross-device. See #1689."
+          value={
+            typeof cockpit.auto_stop_idle_secs === "number"
+              ? (cockpit.auto_stop_idle_secs as number)
+              : 0
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "auto_stop_idle_secs", v)}
+        />
       </CollapsibleSection>
 
       {error && <div className="text-xs text-rose-400">{error}</div>}

--- a/web/src/components/__tests__/SettingsView.folds.test.tsx
+++ b/web/src/components/__tests__/SettingsView.folds.test.tsx
@@ -196,6 +196,10 @@ describe("Settings Advanced fold", () => {
       fieldInputByLabel(container, "Silent-orphan fast grace (s)", "number"),
       "30",
     );
+    commit(
+      fieldInputByLabel(container, "Auto-stop idle workers (s)", "number"),
+      "28800",
+    );
 
     await waitFor(() =>
       expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith(
@@ -205,6 +209,9 @@ describe("Settings Advanced fold", () => {
     );
     expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
       cockpit: { silent_orphan_fast_grace_secs: 30 },
+    });
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      cockpit: { auto_stop_idle_secs: 28800 },
     });
   });
 

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -195,6 +195,17 @@
       "components": []
     },
     {
+      "id": "settings.cockpit-persistence",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/settings-persistence-cockpit.spec.ts"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx"
+      ]
+    },
+    {
       "id": "settings.theme-payload",
       "kind": "vitest",
       "risk": "low",

--- a/web/tests/live/settings-persistence-cockpit.spec.ts
+++ b/web/tests/live/settings-persistence-cockpit.spec.ts
@@ -1,0 +1,61 @@
+// Settings persistence round-trip for the cockpit panel.
+//
+// Sibling of settings-persistence-tmux.spec.ts. Guards #1689: the cockpit
+// section was missing from the web settings allowlist, so every cockpit
+// field (including the new idle auto-stop) silently failed to save with
+// validation_failed. The mocked folds Vitest masked it because it stubs
+// the API. This drives the REAL server: a cockpit PATCH must persist a
+// safe knob (auto_stop_idle_secs) and must strip the node_path binary
+// override (COCKPIT_BLOCKED_FIELDS, an RCE surface that stays local-only).
+
+import { test, expect } from "../helpers/liveTest";
+
+test("cockpit settings persist through PATCH + reload, node_path is stripped", async ({
+  serve,
+  page,
+}) => {
+  const before = await fetch(`${serve.baseUrl}/api/settings`).then((r) =>
+    r.json(),
+  );
+  const baselineCockpit = (before?.cockpit ?? {}) as Record<string, unknown>;
+  const baselineNodePath =
+    typeof baselineCockpit.node_path === "string"
+      ? (baselineCockpit.node_path as string)
+      : "";
+  const newIdle =
+    baselineCockpit.auto_stop_idle_secs === 28800 ? 14400 : 28800;
+
+  // PATCH a safe knob plus a malicious node_path through the same endpoint
+  // the dashboard hits. The section must be accepted (regression) and
+  // node_path must be ignored (security).
+  const patchRes = await fetch(`${serve.baseUrl}/api/settings`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      cockpit: {
+        ...baselineCockpit,
+        auto_stop_idle_secs: newIdle,
+        node_path: "/tmp/evil-node",
+      },
+    }),
+  });
+  expect(patchRes.ok).toBeTruthy();
+
+  // Server-side: the safe knob persisted, node_path was stripped (still
+  // the baseline, never the injected /tmp/evil-node).
+  const after = await fetch(`${serve.baseUrl}/api/settings`).then((r) =>
+    r.json(),
+  );
+  expect(after?.cockpit?.auto_stop_idle_secs).toBe(newIdle);
+  expect(after?.cockpit?.node_path).toBe(baselineNodePath);
+  expect(after?.cockpit?.node_path).not.toBe("/tmp/evil-node");
+
+  // Frontend-side: reload and the persisted value is what the page reads.
+  await page.goto(serve.baseUrl);
+  const fetched = await page.evaluate(async (url) => {
+    const r = await fetch(`${url}/api/settings`);
+    return r.json();
+  }, serve.baseUrl);
+  expect(fetched?.cockpit?.auto_stop_idle_secs).toBe(newIdle);
+  expect(fetched?.cockpit?.node_path).not.toBe("/tmp/evil-node");
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds opt-in auto-stop for idle cockpit workers (#1689). When `cockpit.auto_stop_idle_secs` is set to a positive value, the daemon stops any cockpit worker that has seen no events and has no in-flight turn for that long, freeing its `claude-agent-acp` subprocess. The default is `0`, which disables the feature entirely, so behavior is unchanged unless a user opts in.

The stop is seamless. There is no banner or sidebar change: a dormant session keeps its place in the list, its cockpit timeline shows a `Stopped` event with reason `idle_auto_stop`, and the next prompt revives the worker (resuming the agent-side transcript) within a couple of seconds. A mid-turn worker is never stopped.

Mechanism: a new persisted `Instance::idle_dormant_since` marker suppresses the reconciler's auto-respawn while a worker is dormant (the reconciler respawns any worker-less cockpit session every 2s otherwise). The reap runs as a cadence-gated phase inside the existing reconciler, before the resume snapshot, so a worker marked dormant in a tick is excluded from that same tick's respawn pass. Idle is measured from the last cockpit event (`MAX(created_at)`, batched and indexed) plus an in-flight-turn guard, so a worker is not killed right after a long autonomous turn finishes. Dormancy is persisted so a daemon restart does not respawn a storm of idle workers; it is cleared by `touch_last_accessed()`, the same wake path that clears archive/snooze, so the next prompt revives the session. Persist happens before shutdown and the in-flight check is re-run under the write lock to avoid orphaning a just-prompted worker.

Design was vetted via a three-model debate (persist vs in-memory, idle signal, placement, race safety); the synthesized decisions are reflected above. Scope is cockpit workers only. Plain TUI/tmux sessions are a separate surface and a follow-up.

Closes #1689

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In `config.toml` under `[cockpit]`, set `auto_stop_idle_secs = 60`, start `aoe serve`, open a cockpit session, send one prompt, then leave it idle. After about a minute the worker stops; the cockpit timeline shows a `Stopped` event with reason `idle_auto_stop` and `aoe cockpit ps` no longer lists the worker.
- [ ] Send a new prompt to that dormant session and confirm it respawns within a couple of seconds and the prompt is answered (transcript resumed), with no banner or sidebar change.
- [ ] Start a long-running turn (a task that keeps the agent busy past the threshold) and confirm the worker is NOT stopped while mid-turn.
- [ ] Set `auto_stop_idle_secs = 0` (default), leave a worker idle well past any timeout, and confirm it is never auto-stopped.
- [ ] Open the settings TUI, find "Auto-stop idle workers (s)" under Cockpit > Advanced, set a value, save, and confirm it persists to `config.toml` and round-trips (including clearing a profile override).
- [ ] Check the daemon log shows a paired `auto-stopped idle cockpit worker` (with `idle_secs`) on stop and `waking idle-dormant cockpit session on prompt` on resume.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The wake is transparent (no new UI surface, no sidebar/composer change), so no dashboard flow in the coverage matrix is affected.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The feature is daemon-side (`aoe serve` reconciler). The idle-stop decision and the dormancy state machine are covered by Rust unit tests instead: `should_auto_stop` (disabled, in-flight, past/within threshold, no-events, boundary) in `cockpit_reconciler.rs`, and `is_idle_dormant` / `mark_idle_dormant` / `touch_last_accessed` clearing in `instance.rs`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill); design debate via Gemini, GPT-5.5, and Claude Opus.

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. I made the design calls (seamless vs banner, cockpit-only scope, default-off), ran the debate, and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
High-level summary:
This PR adds an opt-in auto-stop for idle cockpit workers to prevent accumulation of orphaned agent subprocesses. A new setting, cockpit.auto_stop_idle_secs (0 = disabled), makes the reconciler periodically stop any cockpit worker that has had no substantive events and no in-flight turn for longer than the configured timeout. Stopped sessions remain visible and the timeline records a Stopped event with reason idle_auto_stop. Dormancy is persisted so the reconciler won’t immediately respawn the worker and survives daemon restarts; the next user prompt clears dormancy and transparently revives the worker. The setting is exposed in TUI and web settings (with per-profile overrides), includes logging, and is covered by unit and integration tests. Closes `#1689`.

Benefits:
- Reclaims claude-agent-acp subprocesses and prevents runaway idle processes.
- Transparent UX: sessions resume on first prompt after auto-stop.
- Safe operations: mid-turn workers are never stopped and in-flight checks are re-run under lock to avoid races.
- Configurable per-profile via UI; server-side sanitization protects sensitive cockpit fields.

What changed (what moved/added/removed):
- New behavior: idle auto-stop sweep in the cockpit reconciler (cadence-gated).
- New config: cockpit.auto_stop_idle_secs (u32, default 0) and per-profile override.
- Persistence: Instance gains idle_dormant_since (persisted); touch_last_accessed() clears it.
- EventStore: new last_event_at_for_sessions(session_ids) returns MAX(created_at) per session while excluding non-substantive lifecycle/metadata events.
- Supervisor: new shutdown_idle(session_id) that emits Stopped events with reason idle_auto_stop; shutdown refactored to thread stop reasons.
- Worker registry / runner teardown: process-group-aware termination (terminate_runner_group / kill_runner_group) to avoid leaking subprocess trees.
- CLI/UI/API: TUI and web settings add the auto-stop field; server sanitizes cockpit patches (blocks node_path); tests and live integration test added/updated.
- Tests & docs: unit tests for idle-stop logic, dormancy, event filtering; docs updated and a Playwright live test added.
- Minor refactors: logging for stop/resume and supervisor shutdown helper.

Technical summary:
- Reconciler: reconcile_cockpit_workers gains an IDLE_REAP_INTERVAL gated phase that:
  - collects live cockpit sessions,
  - batch-queries EventStore::last_event_at_for_sessions to get last substantive activity,
  - evaluates should_auto_stop (threshold, mid-turn exclusion),
  - re-checks has_in_flight_turn under write lock,
  - marks sessions idle_dormant_since (persisted) and calls Supervisor::shutdown_idle.
- Instance changes: added idle_dormant_since: Option<DateTime<Utc>> with is_idle_dormant(), mark_idle_dormant(), and touch_last_accessed() clearing dormancy.
- Event store: new grouped SQL query to compute per-session MAX(created_at) excluding metadata events; unit test ensures excluded events don't reset idle timers.
- Worker termination: terminate/kil­l now target the runner's process group (killpg) and fall back to PID kill to avoid orphaned child processes across restarts and supersedes.
- Settings surface: cockpit.auto_stop_idle_secs implemented in global/profile configs, merged with profile overrides; web/TUI fields added; server strips blocked cockpit fields (COCKPIT_BLOCKED_FIELDS).
- Tests: unit tests for should_auto_stop behaviors, dormancy persistence/clearing, event filtering; live test verifies settings persistence and blocked-field stripping.

Areas for potential enhancement:
- Extend auto-stop behavior to TUI/tmux sessions if desired.
- Consider non-zero default or adaptive defaults based on deployment size.
- Add telemetry/metrics for auto-stop/resume counts and reclaimed resources.
- Provide admin UI visibility into currently dormant sessions and recent auto-stop activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->