### PR TITLE
fix(cockpit): show tool state in WorkingSpinner during tool execution

### DIFF
--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -62,6 +62,7 @@ import {
   SPINNER_INTERVAL_MS,
   VERB_INTERVAL_MS,
   chooseVerb,
+  deriveSpinnerState,
 } from "../../lib/cockpitRattle";
 import { useCockpitPrefs } from "../../lib/cockpitPrefs";
 import {
@@ -999,16 +1000,7 @@ export function WorkingSpinner({
     return () => window.clearInterval(t);
   }, [lastActivityRef]);
 
-  // tool is the more specific, I/O-bound signal: a tool in flight means
-  // the agent is blocked waiting on its result, which the user needs to
-  // see over the compute-bound "thinking" state. Prefer it when both are
-  // set (the claude-agent-acp adapter can leave `thinking` latched true
-  // through a tool run by skipping ThinkingEnded). See #1213.
-  const state: "thinking" | "tool" | "working" = tool
-    ? "tool"
-    : thinking
-      ? "thinking"
-      : "working";
+  const state = deriveSpinnerState(thinking, tool);
   // Swap the rattle verb for an explicit "waiting on model" badge
   // with a live elapsed counter once the inactivity gap is clearly
   // longer than normal TTFT. The user can then distinguish "model

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -999,10 +999,15 @@ export function WorkingSpinner({
     return () => window.clearInterval(t);
   }, [lastActivityRef]);
 
-  const state: "thinking" | "tool" | "working" = thinking
-    ? "thinking"
-    : tool
-      ? "tool"
+  // tool is the more specific, I/O-bound signal: a tool in flight means
+  // the agent is blocked waiting on its result, which the user needs to
+  // see over the compute-bound "thinking" state. Prefer it when both are
+  // set (the claude-agent-acp adapter can leave `thinking` latched true
+  // through a tool run by skipping ThinkingEnded). See #1213.
+  const state: "thinking" | "tool" | "working" = tool
+    ? "tool"
+    : thinking
+      ? "thinking"
       : "working";
   // Swap the rattle verb for an explicit "waiting on model" badge
   // with a live elapsed counter once the inactivity gap is clearly

--- a/web/src/components/cockpit/__tests__/WorkingSpinner.test.tsx
+++ b/web/src/components/cockpit/__tests__/WorkingSpinner.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, screen } from "@testing-library/react";
 
 import { WorkingSpinner } from "../CockpitView";
+import { THINKING_VERBS } from "../../../lib/cockpitRattle";
 
 function makeRef(initial: number): React.RefObject<number> {
   return { current: initial } as React.RefObject<number>;
@@ -82,5 +83,17 @@ describe("WorkingSpinner force-end-turn gate (#1176)", () => {
       screen.queryByRole("button", { name: /force end turn/i }),
     ).toBeNull();
     expect(screen.getByText(/waiting on tool… 3m \d{2}s/i)).toBeTruthy();
+  });
+});
+
+describe("WorkingSpinner state precedence (#1213)", () => {
+  it("shows the tool verb, not a thinking verb, when both thinking and tool are set", () => {
+    // The adapter can leave `thinking` latched true through a tool run
+    // (it skips ThinkingEnded). Tool is the more specific signal and
+    // must win, so the user sees "Dispatching Terminal…" rather than a
+    // mystical thinking verb while a shell command is in flight.
+    renderSpinner({ stalledSecs: 1, tool: "Terminal", thinking: true });
+    expect(screen.getByText(/Terminal…/)).toBeTruthy();
+    expect(THINKING_VERBS.some((v) => screen.queryByText(`${v}…`))).toBe(false);
   });
 });

--- a/web/src/lib/cockpitRattle.test.ts
+++ b/web/src/lib/cockpitRattle.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   chooseVerb,
+  deriveSpinnerState,
   pickIndex,
   SPINNER_FRAMES,
   SPINNER_INTERVAL_MS,
@@ -87,6 +88,24 @@ describe("chooseVerb", () => {
     expect(chooseVerb("tool", 42, "Read")).toBe(
       chooseVerb("tool", 42, "Read"),
     );
+  });
+});
+
+describe("deriveSpinnerState (#1213)", () => {
+  it("prefers tool over thinking when both are set", () => {
+    expect(deriveSpinnerState(true, "Terminal")).toBe("tool");
+  });
+
+  it("returns tool when only a tool is in flight", () => {
+    expect(deriveSpinnerState(false, "Terminal")).toBe("tool");
+  });
+
+  it("returns thinking when thinking and no tool", () => {
+    expect(deriveSpinnerState(true, null)).toBe("thinking");
+  });
+
+  it("returns working when neither thinking nor tool", () => {
+    expect(deriveSpinnerState(false, null)).toBe("working");
   });
 });
 

--- a/web/src/lib/cockpitRattle.ts
+++ b/web/src/lib/cockpitRattle.ts
@@ -94,6 +94,21 @@ export const THINKING_VERBS: readonly string[] = [
 ] as const;
 
 /**
+ * Pick the spinner sub-state from the two flags the cockpit tracks.
+ * `tool` is the more specific, I/O-bound signal: a tool in flight means
+ * the agent is blocked waiting on its result, which the user needs to
+ * see over the compute-bound "thinking" state. Prefer it when both are
+ * set (the claude-agent-acp adapter can leave `thinking` latched true
+ * through a tool run by skipping ThinkingEnded). See #1213.
+ */
+export function deriveSpinnerState(
+  thinking: boolean,
+  tool: string | null,
+): "thinking" | "tool" | "working" {
+  return tool ? "tool" : thinking ? "thinking" : "working";
+}
+
+/**
  * Pick a stable random index for a list. The same seed within one
  * turn keeps the verb stable; we generate a fresh seed each turn.
  */

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -18,6 +18,7 @@ import {
   normaliseTurnCounters,
   type CockpitFrame,
   type CockpitState,
+  type ToolCall,
 } from "./cockpitTypes";
 
 function frame(seq: number, text: string): CockpitFrame {
@@ -2094,5 +2095,91 @@ describe("applyEvent / ConfigOptions (#1403)", () => {
       event: "SessionCleared",
     });
     expect(state.configOptions).toHaveLength(2);
+  });
+});
+
+describe("applyEvent / thinking-state honesty (#1213)", () => {
+  // claude-agent-acp emits ThinkingStarted once per reasoning block but
+  // often skips ThinkingEnded when it transitions into tool calls or
+  // final text. Without these clears, `thinking` latches true through a
+  // whole turn and the WorkingSpinner shows "thinking" verbs while a
+  // Terminal command is actually running. See #1213.
+
+  function toolCall(id: string, name: string): ToolCall {
+    return {
+      id,
+      name,
+      kind: "execute",
+      args_preview: "{}",
+      started_at: "2026-01-01T00:00:00Z",
+    };
+  }
+
+  it("clears thinking when a tool call starts (no ThinkingEnded from adapter)", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: "ThinkingStarted",
+    });
+    expect(state.thinking).toBe(true);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { ToolCallStarted: { tool_call: toolCall("t1", "Terminal") } },
+    });
+    expect(state.thinking).toBe(false);
+    expect(state.inFlightTool?.name).toBe("Terminal");
+  });
+
+  it("clears thinking when assistant text starts streaming", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: "ThinkingStarted",
+    });
+    expect(state.thinking).toBe(true);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { AgentMessageChunk: { text: "Here is the answer" } },
+    });
+    expect(state.thinking).toBe(false);
+  });
+
+  it("clears thinking on Stopped so it does not leak across turns", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: "ThinkingStarted",
+    });
+    expect(state.thinking).toBe(true);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    expect(state.thinking).toBe(false);
+    expect(state.inFlightTool).toBeNull();
+  });
+
+  it("derives tool over thinking through an interleaved turn (full trace)", () => {
+    // Mirrors the affected session: ThinkingStarted, then a Terminal
+    // tool call with no intervening ThinkingEnded.
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: "ThinkingStarted",
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { ToolCallStarted: { tool_call: toolCall("t1", "Terminal") } },
+    });
+    // The WorkingSpinner derives state as tool > thinking > working.
+    expect(state.thinking).toBe(false);
+    expect(state.inFlightTool).not.toBeNull();
   });
 });

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -699,6 +699,10 @@ export function applyEvent(
   if ("ToolCallStarted" in event) {
     const tc = event.ToolCallStarted.tool_call;
     next.inFlightTool = tc;
+    // The reasoning block produced output (a tool call), so the agent is
+    // no longer thinking. The adapter often skips ThinkingEnded when it
+    // transitions into tool calls, so clear it here. See #1213.
+    next.thinking = false;
     // Skip duplicate tool_start rows. SQLite stores accumulated from
     // pre-fix runs (where post-load history-replay leaked through) can
     // contain the same tool_call_id twice; rendering both makes
@@ -915,6 +919,10 @@ export function applyEvent(
   }
   if ("AgentMessageChunk" in event) {
     next.assistantMessage = next.assistantMessage + event.AgentMessageChunk.text;
+    // Visible assistant text means the agent is answering, not thinking.
+    // A later reasoning block re-sets `thinking` via ThinkingStarted. See
+    // #1213.
+    next.thinking = false;
     next.activity = pushActivity(next.activity, {
       id: `msg-${frame.seq}`,
       kind: "message",
@@ -938,6 +946,10 @@ export function applyEvent(
     // optimistic message above any still-arriving prior-turn agent
     // chunks. See #1170.
     next.inFlightTool = null;
+    // Belt-and-suspenders against a missed ThinkingEnded leaking the
+    // thinking state into the next turn (same defensive shape as the
+    // inFlightTool reset above). See #1213.
+    next.thinking = false;
     sweepOpenToolCalls(next, frame.seq);
     next.lastStoppedSeq = Math.min(
       next.lastStoppedSeq + 1,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -954,6 +954,18 @@
       "components": []
     },
     {
+      "id": "cockpit.spinner-tool-precedence",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/__tests__/WorkingSpinner.test.tsx",
+        "src/lib/cockpitTypes.test.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx"
+      ]
+    },
+    {
       "id": "cockpit.escape-no-cancel",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -959,7 +959,8 @@
       "risk": "medium",
       "specs": [
         "src/components/cockpit/__tests__/WorkingSpinner.test.tsx",
-        "src/lib/cockpitTypes.test.ts"
+        "src/lib/cockpitTypes.test.ts",
+        "src/lib/cockpitRattle.test.ts"
       ],
       "components": [
         "web/src/components/cockpit/CockpitView.tsx"


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the cockpit web view, the `WorkingSpinner` showed mystical "thinking" verbs (`Casting bones…`, `Consulting auguries…`) while a Bash/Terminal tool was actually running. A long shell command looked identical to the model taking a while to think, so the user had no signal of "running bash" vs "thinking about the next move".

Three layered defects caused this:

1. **Precedence.** The spinner derived its state as `thinking ? "thinking" : tool ? "tool" : "working"`, so when both `thinking` and an in-flight tool were set, "thinking" won.
2. **`thinking` latched true.** The reducer set `thinking = true` on `ThinkingStarted` and only cleared it on an explicit `ThinkingEnded`. The claude-agent-acp adapter emits `ThinkingStarted` once per reasoning block but skips `ThinkingEnded` when it transitions into tool calls, so `thinking` stayed true through every tool call of the turn.
3. **Cross-turn leak.** The `Stopped` reducer arm cleared `inFlightTool` but not `thinking`, so the stale flag leaked into the next turn.

The fix swaps the spinner precedence to `tool > thinking > working` (tool is the more specific, I/O-bound signal the user needs), and makes the reducer honest by clearing `thinking` on `ToolCallStarted`, `AgentMessageChunk`, and `Stopped`. `thinking` now means strictly "reasoning, no output produced yet". User-observable impact: an in-flight `Terminal` tool now reads `Dispatching Terminal…` instead of `Casting bones…`.

The command text in the spinner (issue proposal B) was intentionally dropped: it is redundant with the tool card directly below the spinner, needs extra plumbing, and does not address the root state bug. The upstream `claude-agent-acp` `ThinkingEnded` gap (proposal D) is a separate follow-up.

Closes #1213

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] In the cockpit web view, send a prompt that runs a long Bash/Terminal command (for example a `find` over a large tree, or `npm install`).
- [x] While the command runs, confirm the spinner shows a tool verb (`Dispatching Terminal…`), not a thinking verb (`Casting bones…`, `Consulting auguries…`).
- [x] After the command completes and the model streams its final text answer, confirm the spinner no longer claims the model is "thinking".
- [x] Start a second turn in the same session; confirm the spinner does not begin in a stale "thinking" state carried over from the prior turn.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Note: the regression is pure reducer state plus component-render logic, so the tests live in Vitest (`web/src/lib/cockpitTypes.test.ts` reducer arms, `web/src/components/cockpit/__tests__/WorkingSpinner.test.tsx` precedence render), matching the existing spinner test suite and the AGENTS.md guidance that pure-logic and RTL render belong in Vitest. `web/tests/coverage-matrix.json` was updated with a `cockpit.spinner-tool-precedence` entry.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. A two-model design debate (Gemini + GPT) converged on the smallest correct fix and on dropping proposal B. I reviewed each commit, made the design calls, and the regression tests were proven to fail on the pre-fix tree and pass after.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Fixes a Cockpit UI/state bug where the WorkingSpinner could show “thinking” verbs while a tool (e.g., Terminal/Bash) was running. Spinner precedence now favors an in-flight tool, and reducer logic was tightened so the thinking flag cannot become sticky or leak across turns.

## What changed (high-level)
- Reworked spinner state derivation to prefer tool > thinking > working.
- Added deriveSpinnerState(thinking, tool) and unit tests that verify precedence.
- Updated WorkingSpinner to use deriveSpinnerState and added a render test ensuring tool verbs appear when a tool is active.
- Hardened reducer (applyEvent) to clear thinking on ToolCallStarted, AgentMessageChunk, and Stopped events.
- Added reducer tests that cover scenarios where ThinkingStarted is not followed by ThinkingEnded and verify no cross-turn leakage.
- Added a coverage-matrix entry to keep this behavior tested.

## Benefits
- UI accurately reflects ongoing tool execution instead of misleading “thinking” text.
- More robust state handling for adapters that emit ThinkingStarted without a matching ThinkingEnded.
- Eliminates cross-turn sticky thinking state and reduces regressions via tests.

## Technical details (concise)
- Spinner precedence changed from `thinking ? "thinking" : tool ? "tool" : "working"` to a deriveSpinnerState that returns `"tool"` if a tool is present, else `"thinking"` if thinking is true, else `"working"`.
- Reducer change: `next.thinking = false` is explicitly set on ToolCallStarted, AgentMessageChunk, and Stopped frames so `thinking` strictly means “reasoning with no output yet.”
- Tests added/updated: deriveSpinnerState unit tests, WorkingSpinner render test, and cockpitTypes reducer tests covering interleaved traces and clearing behavior.
- Removed the spinner command-text proposal (deemed redundant/out of scope).

Closes `#1213`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->