### PR TITLE
feat(update): document shell completions and hint to refresh them on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ In the TUI, press `?` for help. The bottom information bar shows all available k
 - **[tmux Status Bar](https://www.agent-of-empires.com/guides/tmux-status-bar/)**: integrated session monitoring
 - **[Sound Effects](https://www.agent-of-empires.com/docs/sounds/)**: audible agent status notifications
 - **[Configuration Reference](https://www.agent-of-empires.com/docs/guides/configuration/)**: all config options
+- **[Shell Completions](https://www.agent-of-empires.com/guides/shell-completions/)**: tab-completion for bash, zsh, fish, PowerShell, and elvish
 - **[CLI Reference](https://www.agent-of-empires.com/docs/cli/reference/)**: complete command documentation
 - **[HTTP API Reference](https://www.agent-of-empires.com/docs/api/)**: REST endpoints for external orchestrators
 - **[Development](https://www.agent-of-empires.com/docs/development/)**: contributing and local setup

--- a/docs/guides/shell-completions.md
+++ b/docs/guides/shell-completions.md
@@ -62,10 +62,14 @@ aoe completion zsh > ~/.zfunc/_aoe
 aoe completion fish > ~/.config/fish/completions/aoe.fish
 ```
 
-**PowerShell:**
+**PowerShell** (write to a dedicated file, then dot-source it from your profile; redirecting straight into `$PROFILE` would overwrite the profile script itself):
 
 ```powershell
-aoe completion powershell > $PROFILE.CurrentUserAllHosts
+$dir = Split-Path -Parent $PROFILE.CurrentUserAllHosts
+New-Item -ItemType Directory -Force -Path $dir | Out-Null
+aoe completion powershell > "$dir\aoe.completion.ps1"
+# Add this line to $PROFILE.CurrentUserAllHosts:
+#   . "$PSScriptRoot\aoe.completion.ps1"
 ```
 
 **Elvish:**

--- a/docs/guides/shell-completions.md
+++ b/docs/guides/shell-completions.md
@@ -1,0 +1,87 @@
+# Shell Completions
+
+`aoe completion <shell>` prints a tab-completion script for your shell. It supports `bash`, `zsh`, `fish`, `powershell`, and `elvish`. The script is rendered from the binary's command tree at the moment you run the command, so it always matches the version of `aoe` that produced it.
+
+There are two ways to wire it up. Pick one per shell.
+
+## Recommended: eval on shell startup
+
+Source the completions every time your shell starts. The script is regenerated from the current binary on each launch, so it never goes stale after an `aoe update`. The cost is a few milliseconds added to shell startup.
+
+This is the pattern `gh`, `rustup`, and `kubectl` recommend.
+
+**Bash** (add to `~/.bashrc`):
+
+```bash
+eval "$(aoe completion bash)"
+```
+
+**Zsh** (add to `~/.zshrc`, before any `compinit` call):
+
+```zsh
+eval "$(aoe completion zsh)"
+```
+
+**Fish** (add to `~/.config/fish/config.fish`):
+
+```fish
+aoe completion fish | source
+```
+
+**PowerShell** (add to your `$PROFILE`):
+
+```powershell
+aoe completion powershell | Out-String | Invoke-Expression
+```
+
+**Elvish** (add to `~/.config/elvish/rc.elv`):
+
+```elvish
+eval (aoe completion elvish | slurp)
+```
+
+## Alternative: static file
+
+Write the script to a file your shell loads at startup. This avoids the per-launch cost, but the file is a snapshot: after an `aoe update` adds or renames a subcommand or flag, the file is stale until you regenerate it (see [Keeping static completions fresh](#keeping-static-completions-fresh)).
+
+**Bash:**
+
+```bash
+aoe completion bash > ~/.local/share/bash-completion/completions/aoe
+```
+
+**Zsh** (ensure `~/.zfunc` is on your `fpath` in `~/.zshrc` before `compinit`):
+
+```zsh
+aoe completion zsh > ~/.zfunc/_aoe
+```
+
+**Fish:**
+
+```fish
+aoe completion fish > ~/.config/fish/completions/aoe.fish
+```
+
+**PowerShell:**
+
+```powershell
+aoe completion powershell > $PROFILE.CurrentUserAllHosts
+```
+
+**Elvish:**
+
+```elvish
+aoe completion elvish > ~/.elvish/lib/aoe.elv
+```
+
+Restart your shell, or re-source the relevant file, after installing.
+
+## Keeping static completions fresh
+
+A static completion file does not update itself. Each time you run `aoe update`, regenerate the file so it reflects any new subcommands or flags:
+
+```bash
+aoe completion zsh > ~/.zfunc/_aoe   # adjust shell and path to match your install
+```
+
+`aoe update` prints a reminder about this after a successful update. If you would rather not think about it, use the eval-on-startup method above; it is always in sync with the installed binary.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,6 +58,8 @@ The `aoe update` command detects how aoe was installed (Homebrew, the curl insta
 
 Inside the TUI, press `u` when the update bar is visible to run the same flow without leaving the app. Press `Ctrl+x` to dismiss the bar for the current session.
 
+If you installed shell completions as a static file, regenerate it after an update so it picks up new commands and flags. See [Shell Completions](guides/shell-completions.md) for both the static and the always-fresh eval-on-startup setup.
+
 ## Uninstall
 
 To remove Agent of Empires:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -156,7 +156,7 @@ main() {
     echo ""
     success "Run 'aoe' to get started!"
     echo ""
-    info "For shell completions, run: aoe completion --help"
+    info "For shell completions, see: https://www.agent-of-empires.com/guides/shell-completions/"
 }
 
 main "$@"

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -108,8 +108,35 @@ pub async fn run(args: UpdateArgs) -> Result<()> {
             "✓ Updated to v{}. Restart `aoe` to use the new version.",
             info.latest_version
         );
+        println!("{}", completion_refresh_hint());
     } else if matches!(&method, InstallMethod::Homebrew) {
         println!("✓ brew upgrade complete.");
     }
     Ok(())
+}
+
+/// Reminder printed after a successful in-place update. A static completion
+/// file does not refresh itself, so it goes stale once the new binary adds or
+/// renames commands. We deliberately do not rewrite the file: aoe does not
+/// track which paths the user installed completions to, and overwriting files
+/// it does not own (dotfile-managed symlinks, system paths) is unsafe. The
+/// eval-on-startup setup avoids the problem entirely.
+fn completion_refresh_hint() -> &'static str {
+    "  If you use static shell completions, regenerate them so they pick up new\n  \
+     commands, e.g. `aoe completion zsh > ~/.zfunc/_aoe`. Eval-on-startup setups\n  \
+     stay in sync automatically: https://www.agent-of-empires.com/guides/shell-completions/"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::completion_refresh_hint;
+
+    #[test]
+    fn hint_points_at_regen_and_eval_alternative() {
+        let hint = completion_refresh_hint();
+        assert!(hint.contains("aoe completion"));
+        assert!(hint.contains("guides/shell-completions"));
+        // Mentions the always-fresh alternative so users can avoid manual refresh.
+        assert!(hint.to_lowercase().contains("eval"));
+    }
 }

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -20,6 +20,13 @@ const PAGES_DIR = join(__dirname, "..", "src", "pages");
 const PAGES = [
   // --- Guides (docs/guides/ → pages/guides/) ---
   {
+    source: "docs/guides/shell-completions.md",
+    dest: "guides/shell-completions.md",
+    title: "Shell Completions",
+    description:
+      "Install and refresh tab-completion for the aoe CLI in bash, zsh, fish, PowerShell, and elvish.",
+  },
+  {
     source: "docs/guides/diff-view.md",
     dest: "guides/diff-view.md",
     title: "Diff View",
@@ -252,6 +259,7 @@ const URL_MAP = {
   "docs/cockpit/multi-agent.md": "/docs/cockpit/multi-agent/",
   "docs/api.md": "/docs/api/",
   // Guides
+  "docs/guides/shell-completions.md": "/guides/shell-completions/",
   "docs/guides/diff-view.md": "/guides/diff-view/",
   "docs/guides/repo-config.md": "/guides/repo-config/",
   "docs/guides/sandbox.md": "/guides/sandbox/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -37,6 +37,7 @@ export const docsNav: NavSection[] = [
       { title: "Agent Command Overrides", href: "/guides/agent-override/" },
       { title: "Tool Sessions", href: "/guides/tool-sessions/" },
       { title: "Session Resume (Claude)", href: "/guides/session-resume/" },
+      { title: "Shell Completions", href: "/guides/shell-completions/" },
       { title: "Sound Effects", href: "/docs/sounds/" },
       { title: "Push Notifications", href: "/docs/push-notifications/" },
     ],

--- a/website/src/pages/guides/index.astro
+++ b/website/src/pages/guides/index.astro
@@ -10,6 +10,7 @@ const guides = [
   { title: "Diff View", href: "/guides/diff-view/", description: "Review git changes and edit files from the TUI." },
   { title: "tmux Status Bar", href: "/guides/tmux-status-bar/", description: "Display session info in your tmux status bar." },
   { title: "Web Dashboard", href: "/guides/web-dashboard/", description: "Remote access to sessions from any browser." },
+  { title: "Shell Completions", href: "/guides/shell-completions/", description: "Install and refresh tab-completion for the aoe CLI." },
 ];
 ---
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`aoe completion <shell>` has existed since #261, but it had no user-facing docs and no story for staying current after `aoe update`. This PR closes both gaps.

It adds `docs/guides/shell-completions.md` covering all five shells (bash, zsh, fish, PowerShell, elvish) with two install styles each: eval-on-startup (recommended, regenerated on every shell launch so it never goes stale) and a static file (with a note to regenerate after an update). The guide is wired into the website sync map, docs nav, and guides index, and README, the install-script hint, and the installation docs now point at it.

On the binary side, after a successful in-place tarball update, `aoe update` now prints a short reminder: static-completion users should regenerate, or switch to eval-on-startup which stays in sync on its own.

I deliberately did not auto-rewrite completion files on update. `aoe` does not track which paths a user installed completions to, and overwriting files it does not own is unsafe: dotfile managers like GNU Stow symlink parent directories (so the target reads as a regular file while actually living in a git-tracked repo), and system paths need sudo. The principled version of auto-refresh is a manifest of aoe-owned paths populated by an explicit `aoe completion install`, which is left as a follow-up. The eval-on-startup method documented here removes the staleness problem without any of that risk.

Closes #972

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open `docs/guides/shell-completions.md`; confirm install snippets for bash, zsh, fish, PowerShell, and elvish, each with an eval-on-startup and a static-file variant.
- [ ] Run the website sync (`node website/scripts/sync-docs.mjs`) and confirm the guide appears in the nav and the guides index, reachable at `/guides/shell-completions/`.
- [ ] Add `eval "$(aoe completion zsh)"` to `~/.zshrc`, restart the shell, and confirm `aoe <Tab>` completes subcommands.
- [ ] After a real `aoe update` that swaps the binary (tarball install), confirm the output includes the "regenerate static completions / use eval-on-startup" reminder.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the only runtime change is a reminder line printed after a successful in-place update, which requires a real release download and binary swap to reach. The hint text itself is covered by a unit test in `src/cli/update.rs`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan (vetted with a two-model design debate), and implementation were drafted by Claude under my direction. I made the design calls, including dropping the auto-refresh-on-update approach in favor of docs plus a hint, and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds user-facing documentation for shell completions and a small runtime hint after in-place updates to help users keep static completion files current. Changes touch documentation, website metadata, install messaging, and the CLI update flow.

## What changed (non-technical)

- New user guide documenting how to install and refresh shell completions for five shells: bash, zsh, fish, PowerShell, elvish.
  - Each shell includes two install styles: recommended "eval-on-startup" (auto-regenerates each shell launch) and "static-file" (requires regeneration after updates).
- Guide linked from README, installation docs, website navigation, and the site sync map so it's discoverable.
- Install script messaging updated to point to the new guide.
- After a successful tarball-style self-update, aoe now prints a short reminder for users who use static completion files to regenerate them or switch to eval-on-startup.
- Deliberately avoids auto-overwriting user files on update; leaves manifest/opt-in auto-refresh as a follow-up.

## Technical notes (short)

- New file: docs/guides/shell-completions.md (copy-pastable snippets + guidance).
- Website updates: website/scripts/sync-docs.mjs, website/src/data/docsNav.ts, website/src/pages/guides/index.astro to include the guide.
- CLI change: added fn completion_refresh_hint() in src/cli/update.rs and integrated it into the tarball InstallMethod success message; unit test added for the hint text.
- Install script: scripts/install.sh updated to surface the guide URL.
- Small docs tweak in docs/installation.md and README.md.

## Key benefits

- Closes the documentation gap for shell completions across supported shells.
- Makes completion setup discoverable and easy to follow.
- Surfaces the staleness risk for static completions and gives simple, low-risk remediation (regenerate or use eval-on-startup).
- Avoids unsafe behavior by not auto-overwriting user files; provides a clear path for a safer, opt-in future enhancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->