### PR TITLE
feat(cockpit): first-class event type for diff-comments prompts

### DIFF
--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -824,6 +824,7 @@ fn event_kind(event: &crate::cockpit::Event) -> &'static str {
         Event::AgentStartupError { .. } => "agent_startup_error",
         Event::IncompatibleAgent { .. } => "incompatible_agent",
         Event::UserPromptSent { .. } => "user_prompt_sent",
+        Event::UserDiffCommentsPrompt { .. } => "user_diff_comments_prompt",
         Event::AcpSessionAssigned { .. } => "acp_session_assigned",
         Event::SessionContextReset { .. } => "session_context_reset",
         Event::SessionCleared => "session_cleared",

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2393,6 +2393,7 @@ fn is_transcript_event(event: &Event) -> bool {
             | Event::ThinkingStarted
             | Event::ThinkingEnded
             | Event::UserPromptSent { .. }
+            | Event::UserDiffCommentsPrompt { .. }
             | Event::ApprovalRequested { .. }
             | Event::ApprovalResolved { .. }
             | Event::RawAgentUpdate { .. }
@@ -2415,6 +2416,7 @@ fn transcript_event_kind(event: &Event) -> &'static str {
         Event::ThinkingStarted => "thinking_started",
         Event::ThinkingEnded => "thinking_ended",
         Event::UserPromptSent { .. } => "user_prompt_sent",
+        Event::UserDiffCommentsPrompt { .. } => "user_diff_comments_prompt",
         Event::ApprovalRequested { .. } => "approval_requested",
         Event::ApprovalResolved { .. } => "approval_resolved",
         Event::RawAgentUpdate { .. } => "raw_agent_update",

--- a/src/cockpit/context_primer.rs
+++ b/src/cockpit/context_primer.rs
@@ -162,6 +162,22 @@ pub fn build_context_primer(events: &[(u64, Event)], opts: PrimerOptions) -> Con
                 // unsent prompt is no longer the trailing state.
                 ended_non_success = false;
             }
+            Event::UserDiffCommentsPrompt {
+                assembled_markdown, ..
+            } => {
+                // Same turn-boundary semantics as UserPromptSent: the
+                // assembled markdown is the text the agent actually saw.
+                if let Some(t) = current.take() {
+                    turns.push(t);
+                }
+                current = Some(Turn {
+                    user_text: assembled_markdown.clone(),
+                    event_count: 1,
+                    ..Turn::default()
+                });
+                included_event_count += 1;
+                ended_non_success = false;
+            }
             Event::AgentMessageChunk { text } => {
                 let turn = current.get_or_insert_with(Turn::default);
                 turn.assistant_text.push_str(text);

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -934,6 +934,7 @@ fn event_kind(event: &Event) -> &'static str {
         Event::AgentStartupError { .. } => "agent_startup_error",
         Event::IncompatibleAgent { .. } => "incompatible_agent",
         Event::UserPromptSent { .. } => "user_prompt_sent",
+        Event::UserDiffCommentsPrompt { .. } => "user_diff_comments_prompt",
         Event::AcpSessionAssigned { .. } => "acp_session_assigned",
         Event::SessionContextReset { .. } => "session_context_reset",
         Event::SessionCleared => "session_cleared",
@@ -1114,6 +1115,91 @@ mod tests {
         } else {
             panic!("expected UserPromptSent");
         }
+    }
+
+    #[test]
+    fn diff_comments_prompt_round_trips_structured_fields() {
+        use super::super::state::DiffComment;
+        let (_tmp, store) = open_store(1000);
+        let comment = DiffComment {
+            id: "c-1".into(),
+            repo_name: Some("repoA".into()),
+            file_path: "src/main.rs".into(),
+            side: "new".into(),
+            start_line: 42,
+            end_line: 45,
+            body: "rename this".into(),
+            captured_snippet: "fn main() {}".into(),
+            language: Some("rust".into()),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: None,
+        };
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::UserDiffCommentsPrompt {
+                    intro: "Hey:".into(),
+                    outro: "Please address these comments.".into(),
+                    is_multi_repo: true,
+                    comments: vec![comment],
+                    assembled_markdown: "## Diff comments\n\n...".into(),
+                },
+            )
+            .unwrap();
+        let replay = store.replay_from("s-1", 0);
+        assert_eq!(replay.len(), 1);
+        match &replay[0].1 {
+            Event::UserDiffCommentsPrompt {
+                intro,
+                is_multi_repo,
+                comments,
+                assembled_markdown,
+                ..
+            } => {
+                assert_eq!(intro, "Hey:");
+                assert!(*is_multi_repo);
+                assert_eq!(comments.len(), 1);
+                assert_eq!(comments[0].repo_name.as_deref(), Some("repoA"));
+                assert_eq!(comments[0].start_line, 42);
+                assert!(assembled_markdown.starts_with("## Diff comments"));
+            }
+            other => panic!("expected UserDiffCommentsPrompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn diff_comments_prompt_serialises_camel_case() {
+        use super::super::state::DiffComment;
+        let event = Event::UserDiffCommentsPrompt {
+            intro: String::new(),
+            outro: "Please address these comments.".into(),
+            is_multi_repo: false,
+            comments: vec![DiffComment {
+                id: "c-1".into(),
+                repo_name: None,
+                file_path: "a.rs".into(),
+                side: "old".into(),
+                start_line: 1,
+                end_line: 1,
+                body: "b".into(),
+                captured_snippet: "s".into(),
+                language: None,
+                created_at: "2026-01-01T00:00:00Z".into(),
+                updated_at: None,
+            }],
+            assembled_markdown: "m".into(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        // Event payload fields and comment fields are both camelCase on
+        // the wire so the frontend union mirrors them one-for-one.
+        assert!(json.contains("\"isMultiRepo\""));
+        assert!(json.contains("\"assembledMarkdown\""));
+        assert!(json.contains("\"filePath\""));
+        assert!(json.contains("\"startLine\""));
+        // repo_name / updated_at are skipped when None.
+        assert!(!json.contains("\"repoName\""));
+        assert!(!json.contains("\"updatedAt\""));
     }
 
     #[test]

--- a/src/cockpit/protocol.rs
+++ b/src/cockpit/protocol.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use super::approvals::ApprovalDecision;
-use super::state::Event;
+use super::state::{DiffComment, Event};
 
 /// One frame on the per-AppState cockpit broadcast channel: the cockpit
 /// session id plus the typed cockpit Event. Subscribed WebSocket
@@ -68,6 +68,26 @@ impl<'de> Deserialize<'de> for CockpitBroadcastFrame {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PromptRequest {
     pub text: String,
+}
+
+/// `POST /api/sessions/{id}/cockpit/prompt/diff-comments` body.
+///
+/// The "Send diff comments" dialog sends the structured review (so the
+/// transcript can re-render the rich card) alongside `assembled_markdown`,
+/// the exact WYSIWYG prompt the user approved in the preview. The server
+/// forwards `assembled_markdown` to the agent verbatim and records both
+/// in an `Event::UserDiffCommentsPrompt`. The frontend owns markdown
+/// assembly (sort, headings, code-fence sizing, repo prefixes); the
+/// server does not re-derive it, so the card payload and the agent-visible
+/// text can never disagree.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffCommentsPromptRequest {
+    pub intro: String,
+    pub outro: String,
+    pub is_multi_repo: bool,
+    pub comments: Vec<DiffComment>,
+    pub assembled_markdown: String,
 }
 
 /// `POST /api/sessions/{id}/cockpit/approvals/{nonce}` body.

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -374,6 +374,34 @@ pub enum StateError {
     ApprovalAlreadyResolved(Nonce),
 }
 
+/// A single user-authored diff-line review comment, carried verbatim
+/// in `Event::UserDiffCommentsPrompt` so the cockpit transcript can
+/// re-render the rich review card on replay without parsing the
+/// assembled markdown. Field names mirror the frontend `DiffComment`
+/// type (`web/src/components/diff/comments/types.ts`) one-for-one; the
+/// server never interprets these, it only stores and replays them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffComment {
+    pub id: String,
+    /// Workspace member name. Absent for single-repo sessions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_name: Option<String>,
+    pub file_path: String,
+    /// `"old"` or `"new"`. Stored as a string so an unrecognised side
+    /// from a future frontend never fails replay of the whole log.
+    pub side: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub body: String,
+    pub captured_snippet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
 /// Discriminated union of state mutations. ACP `session/update`
 /// notifications become specific variants; client approval taps also
 /// become variants and flow through the same path.
@@ -567,6 +595,26 @@ pub enum Event {
     /// every turn collapses into one assistant blob.
     UserPromptSent {
         text: String,
+    },
+    /// Echo of a "Send diff comments" submission, published by the
+    /// `POST /cockpit/prompt/diff-comments` handler before
+    /// `assembled_markdown` is forwarded to the agent. The agent only
+    /// ever sees `assembled_markdown` (no sentinel); the structured
+    /// fields exist so the cockpit transcript re-renders the rich
+    /// `DiffCommentsUserCard` on replay without parsing the markdown.
+    /// `intro`/`outro` are the effective values the user approved in the
+    /// dialog (trimmed intro, defaulted outro), so replay matches what
+    /// the agent received. Replaces the legacy
+    /// `<!-- aoe:diff-comments:v1 ... -->` sentinel carried inside an
+    /// ordinary `UserPromptSent`; older persisted sentinel events keep
+    /// rendering via the frontend decode fallback.
+    #[serde(rename_all = "camelCase")]
+    UserDiffCommentsPrompt {
+        intro: String,
+        outro: String,
+        is_multi_repo: bool,
+        comments: Vec<DiffComment>,
+        assembled_markdown: String,
     },
     /// A user prompt arrived at the daemon while another `session/prompt`
     /// was still in flight. The daemon refused to forward it (claude-agent-acp
@@ -763,6 +811,10 @@ impl CockpitState {
                 self.startup_error = Some(detail);
             }
             Event::UserPromptSent { .. } => {}
+            // Like UserPromptSent, the diff-comments prompt doesn't mutate
+            // persistent CockpitState; it bumps seq so the replay buffer
+            // and on-disk store capture the user's side of the turn.
+            Event::UserDiffCommentsPrompt { .. } => {}
             Event::AcpSessionAssigned { .. } => {
                 // A fresh agent that passed the compatibility check
                 // has come online; heal any sticky startup error so a

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -692,6 +692,36 @@ impl<S: BroadcastSink> Supervisor<S> {
         }
     }
 
+    /// Publish a "Send diff comments" submission as a typed
+    /// `Event::UserDiffCommentsPrompt`. Unlike `publish_user_prompt`
+    /// this skips the `/clear` detection: assembled diff-comment
+    /// markdown is never a clear command, and treating it as one would
+    /// wrongly fold the transcript. The caller forwards
+    /// `assembled_markdown` to the agent separately, exactly as it does
+    /// the plain text of a normal prompt.
+    pub async fn publish_user_diff_comments_prompt(
+        &self,
+        session_id: &str,
+        intro: String,
+        outro: String,
+        is_multi_repo: bool,
+        comments: Vec<super::state::DiffComment>,
+        assembled_markdown: String,
+    ) {
+        let seq = next_seq(&self.next_seqs, session_id);
+        self.sink.publish(
+            session_id,
+            seq,
+            &Event::UserDiffCommentsPrompt {
+                intro,
+                outro,
+                is_multi_repo,
+                comments,
+                assembled_markdown,
+            },
+        );
+    }
+
     /// Resolve the agent registry key for a session. Reads the live
     /// `Runner` handle's `SpawnConfig` directly when available;
     /// otherwise loads the on-disk record so an `Attached` worker (or

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::cockpit::approvals::Nonce;
 use crate::cockpit::protocol::{
-    ContextPrimerQuery, ContextPrimerResponse, PromptRequest, ReplayQuery, ReplayResponse,
-    ResolveApprovalRequest, SwitchAgentRequest, SwitchAgentResponse,
+    ContextPrimerQuery, ContextPrimerResponse, DiffCommentsPromptRequest, PromptRequest,
+    ReplayQuery, ReplayResponse, ResolveApprovalRequest, SwitchAgentRequest, SwitchAgentResponse,
 };
 use crate::cockpit::supervisor::SupervisorError;
 use crate::server::AppState;
@@ -432,37 +432,28 @@ pub async fn switch_cockpit_agent(
     .into_response()
 }
 
-pub async fn cockpit_prompt(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-    req: Result<Json<PromptRequest>, axum::extract::rejection::JsonRejection>,
-) -> impl IntoResponse {
-    if let Some(resp) = read_only_block(&state) {
-        return resp;
-    }
-    let Json(req) = match req {
-        Ok(j) => j,
-        Err(rej) => return rej.into_response(),
-    };
-    // Touch the instance before forwarding so an archived or
-    // currently-snoozed session auto-wakes the same way the tmux send
-    // path does (`/api/sessions/{id}/send`). `touch_last_accessed`
-    // clears `archived_at`, `snoozed_until`, and `idle_dormant_since` so
-    // the cockpit reconciler stops skipping the session on its next ~2s
-    // tick and respawns the worker; the frontend's queue drains as soon
-    // as the fresh `AcpSessionAssigned` lands. The idle_dormant_since
-    // clear is the wake path for auto-stopped idle workers (#1689); a
-    // worker reaped for inactivity respawns on the next prompt. See #1581.
-    //
-    // The in-memory mutation and the disk persistence are both held
-    // under `state.instance_lock(&id)` so they serialize against
-    // other session-mutating endpoints (archive / snooze / pin /
-    // rename) on the same id. Without this guard, a concurrent
-    // archive PATCH could interleave with the touch and produce a
-    // lost write (archive sets archived_at = Some, touch clears it,
-    // archive's persist lands first, touch's persist lands second
-    // and overwrites the archive).
-    let inst_lock = state.instance_lock(&id).await;
+/// Auto-wake an archived, snoozed, or idle-dormant session before a
+/// prompt is forwarded, matching the tmux send path
+/// (`/api/sessions/{id}/send`). `touch_last_accessed` clears
+/// `archived_at`, `snoozed_until`, and `idle_dormant_since` so the
+/// cockpit reconciler stops skipping the session on its next ~2s tick and
+/// respawns the worker; the frontend's queue drains as soon as the fresh
+/// `AcpSessionAssigned` lands. The idle_dormant clear is the wake path for
+/// auto-stopped idle workers (#1689); a worker reaped for inactivity
+/// respawns on the next prompt. See #1581.
+///
+/// The in-memory mutation and the disk persistence are both held under
+/// `state.instance_lock(&id)` so they serialize against other
+/// session-mutating endpoints (archive / snooze / pin / rename) on the
+/// same id. Without this guard, a concurrent archive PATCH could
+/// interleave with the touch and produce a lost write (archive sets
+/// archived_at = Some, touch clears it, archive's persist lands first,
+/// touch's persist lands second and overwrites the archive). The lock is
+/// dropped before the caller reaches the supervisor: publish/send take
+/// their own locks downstream and holding ours across the agent forward
+/// would serialize prompts unnecessarily and stall siblings.
+async fn touch_and_wake_if_sunk(state: &Arc<AppState>, id: &str) {
+    let inst_lock = state.instance_lock(id).await;
     let _guard = inst_lock.lock().await;
     let triage_changed = {
         let mut instances = state.instances.write().await;
@@ -497,8 +488,8 @@ pub async fn cockpit_prompt(
                 .unwrap_or_default()
         };
         if let Ok(storage) = crate::session::Storage::new(&profile) {
-            let id_clone = id.clone();
-            let session_id_for_log = id.clone();
+            let id_clone = id.to_string();
+            let session_id_for_log = id.to_string();
             match tokio::task::spawn_blocking(move || {
                 storage.update(|instances, _groups| {
                     if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
@@ -523,11 +514,21 @@ pub async fn cockpit_prompt(
             }
         }
     }
-    // Drop the per-session lock before reaching out to the
-    // supervisor. publish_user_prompt and send_prompt take their own
-    // locks downstream; holding ours across the agent forward would
-    // serialize prompts unnecessarily and stall siblings.
-    drop(_guard);
+}
+
+pub async fn cockpit_prompt(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    req: Result<Json<PromptRequest>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if let Some(resp) = read_only_block(&state) {
+        return resp;
+    }
+    let Json(req) = match req {
+        Ok(j) => j,
+        Err(rej) => return rej.into_response(),
+    };
+    touch_and_wake_if_sunk(&state, &id).await;
     // Publish the user's prompt into the event stream BEFORE forwarding
     // to the agent so the replay buffer / on-disk store captures it
     // even if the agent forward fails. The frontend treats UserPromptSent
@@ -537,6 +538,58 @@ pub async fn cockpit_prompt(
         .publish_user_prompt(&id, req.text.clone())
         .await;
     match state.cockpit_supervisor.send_prompt(&id, &req.text).await {
+        Ok(()) => StatusCode::ACCEPTED.into_response(),
+        Err(SupervisorError::UnknownSession(_)) => {
+            (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("prompt failed: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /api/sessions/{id}/cockpit/prompt/diff-comments`: the typed
+/// successor to the diff-comments sentinel hack. The frontend sends the
+/// structured review plus the `assembled_markdown` it previewed; the
+/// server records a typed `Event::UserDiffCommentsPrompt` (so the
+/// transcript re-renders the rich card on replay) and forwards only
+/// `assembled_markdown` to the agent, so the agent never sees the old
+/// base64 sentinel noise. Mirrors `cockpit_prompt`'s auto-wake +
+/// publish-before-forward ordering.
+pub async fn cockpit_prompt_diff_comments(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    req: Result<Json<DiffCommentsPromptRequest>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if let Some(resp) = read_only_block(&state) {
+        return resp;
+    }
+    let Json(req) = match req {
+        Ok(j) => j,
+        Err(rej) => return rej.into_response(),
+    };
+    touch_and_wake_if_sunk(&state, &id).await;
+    // Publish the typed event BEFORE forwarding so the replay buffer /
+    // on-disk store captures the user's side even if the forward fails,
+    // matching cockpit_prompt.
+    state
+        .cockpit_supervisor
+        .publish_user_diff_comments_prompt(
+            &id,
+            req.intro,
+            req.outro,
+            req.is_multi_repo,
+            req.comments,
+            req.assembled_markdown.clone(),
+        )
+        .await;
+    match state
+        .cockpit_supervisor
+        .send_prompt(&id, &req.assembled_markdown)
+        .await
+    {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
         Err(SupervisorError::UnknownSession(_)) => {
             (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -23,9 +23,9 @@ mod system;
 #[cfg(feature = "serve")]
 pub use cockpit::{
     cockpit_cancel, cockpit_context_primer, cockpit_disable, cockpit_enable, cockpit_files,
-    cockpit_force_end_turn, cockpit_prompt, cockpit_replay, cockpit_set_config_option,
-    cockpit_set_mode, cockpit_worker_log, list_cockpit_agents, resolve_approval,
-    set_cockpit_master, shutdown_cockpit, spawn_cockpit, switch_cockpit_agent,
+    cockpit_force_end_turn, cockpit_prompt, cockpit_prompt_diff_comments, cockpit_replay,
+    cockpit_set_config_option, cockpit_set_mode, cockpit_worker_log, list_cockpit_agents,
+    resolve_approval, set_cockpit_master, shutdown_cockpit, spawn_cockpit, switch_cockpit_agent,
 };
 
 #[cfg(feature = "serve")]
@@ -287,6 +287,7 @@ mod tests {
                     "spawn_cockpit",
                     "shutdown_cockpit",
                     "cockpit_prompt",
+                    "cockpit_prompt_diff_comments",
                     "cockpit_cancel",
                     "cockpit_force_end_turn",
                     "cockpit_enable",
@@ -417,6 +418,7 @@ mod tests {
                     "spawn_cockpit",
                     "shutdown_cockpit",
                     "cockpit_prompt",
+                    "cockpit_prompt_diff_comments",
                     "cockpit_cancel",
                     "cockpit_force_end_turn",
                     "cockpit_enable",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1202,6 +1202,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             post(api::cockpit_prompt),
         )
         .route(
+            "/api/sessions/{id}/cockpit/prompt/diff-comments",
+            post(api::cockpit_prompt_diff_comments),
+        )
+        .route(
             "/api/sessions/{id}/cockpit/cancel",
             post(api::cockpit_cancel),
         )

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -185,6 +185,17 @@ impl CockpitTranscript {
                 // Sending a prompt dismisses any context-primer hint.
                 self.context_primer_pending = false;
             }
+            Event::UserDiffCommentsPrompt {
+                assembled_markdown, ..
+            } => {
+                // The TUI has no rich diff-comments card; render the
+                // assembled markdown (exactly what the agent received) as
+                // a plain user prompt row, same as UserPromptSent.
+                self.flush_pending_chunk();
+                self.rows
+                    .push(ActivityRow::UserPrompt(assembled_markdown.clone()));
+                self.context_primer_pending = false;
+            }
             Event::ThinkingStarted => {
                 self.flush_pending_chunk();
                 self.status_text = Some("thinking…".to_string());

--- a/web/src/components/cockpit/CockpitRuntime.test.ts
+++ b/web/src/components/cockpit/CockpitRuntime.test.ts
@@ -444,6 +444,62 @@ describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
   });
 });
 
+describe("activityToThreadMessages; diff-comments user card (#1123)", () => {
+  it("emits a user message with the structured payload on metadata.custom", () => {
+    const row: ActivityRow = {
+      id: "user-seq-1",
+      kind: "user_diff_comments",
+      text: "Take a look:\n\n## Diff comments\n\n...\n",
+      diffComments: {
+        intro: "Take a look:",
+        outro: "Please address these comments.",
+        isMultiRepo: true,
+        comments: [
+          {
+            id: "c-1",
+            repoName: "repoA",
+            filePath: "src/main.rs",
+            side: "new",
+            startLine: 42,
+            endLine: 45,
+            body: "rename this",
+            capturedSnippet: "fn main() {}",
+            language: "rust",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      },
+      at: "2026-05-12T00:00:00Z",
+    };
+    const messages = activityToThreadMessages([row], false);
+    const user = messages.find((m) => m.role === "user")!;
+    // The text part stays the assembled markdown so copy / fallback work.
+    const parts = user.content as Array<{ type: string; text?: string }>;
+    expect(parts[0]!.type).toBe("text");
+    expect(parts[0]!.text).toContain("## Diff comments");
+    // The structured payload rides on metadata.custom.diffComments for
+    // UserText to render the rich card without parsing any sentinel.
+    const custom = (
+      user.metadata as
+        | { custom?: { diffComments?: { comments?: unknown[] } } }
+        | undefined
+    )?.custom;
+    expect(custom?.diffComments?.comments).toHaveLength(1);
+  });
+
+  it("omits metadata when the structured payload is absent", () => {
+    const row: ActivityRow = {
+      id: "user-seq-2",
+      kind: "user_diff_comments",
+      text: "plain body\n",
+      at: "2026-05-12T00:00:00Z",
+    };
+    const messages = activityToThreadMessages([row], false);
+    const user = messages.find((m) => m.role === "user")!;
+    expect(user.metadata).toBeUndefined();
+  });
+});
+
 function toolStopped(id: string, text = ""): ActivityRow {
   return {
     id: `stopped-${id}-9`,

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -247,6 +247,25 @@ export function activityToThreadMessages(
       continue;
     }
 
+    if (row.kind === "user_diff_comments") {
+      // A typed diff-comments prompt. The assembled markdown is the
+      // user-visible / agent body (and the fallback if the card can't
+      // render); the structured payload rides on the message metadata
+      // so UserText can render the rich DiffCommentsUserCard without
+      // parsing any sentinel. See #1123.
+      flushAssistant();
+      messages.push({
+        id: row.id,
+        role: "user",
+        content: [{ type: "text", text: row.text }],
+        metadata: row.diffComments
+          ? { custom: { diffComments: row.diffComments } }
+          : undefined,
+        createdAt: parseDate(row.at),
+      });
+      continue;
+    }
+
     if (row.kind === "context_reset") {
       // `session/load` fallback after an `aoe serve` restart: model's
       // window is empty even though we replay the prior transcript.

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -57,6 +57,7 @@ import {
 } from "./ToolCards";
 import { DiffCommentsUserCard } from "../diff/comments/DiffCommentsUserCard";
 import { parseDiffCommentsSentinel } from "../diff/comments/buildPrompt";
+import type { DiffCommentsCardPayload } from "../diff/comments/buildPrompt";
 import {
   SPINNER_FRAMES,
   SPINNER_INTERVAL_MS,
@@ -492,11 +493,23 @@ function UserMessage() {
   );
 }
 
-/** Text-part renderer for user messages. Detects the diff-comments
- *  sentinel header (prepended by `buildFullPrompt`) and swaps in the
- *  structured `DiffCommentsUserCard`; falls back to the classic chat
- *  bubble otherwise. */
+/** Text-part renderer for user messages. Renders the structured
+ *  `DiffCommentsUserCard` for diff-comments prompts: from the typed
+ *  event payload carried on the message metadata (see #1123) for new
+ *  prompts, or from the decoded base64 sentinel for legacy persisted
+ *  prompts. Falls back to the classic chat bubble otherwise. */
 function UserText({ text }: { text: string }) {
+  const typedPayload = useMessage(
+    (m) =>
+      (m.metadata?.custom as { diffComments?: DiffCommentsCardPayload } | undefined)
+        ?.diffComments,
+  );
+  if (typedPayload) {
+    return <DiffCommentsUserCard payload={typedPayload} />;
+  }
+  // Legacy fallback: older prompts carry the structured data in a
+  // base64 sentinel at the top of the text body. Decode + render the
+  // same card. Kept until those persisted events age out of the log.
   const payload = parseDiffCommentsSentinel(text);
   if (payload) {
     return <DiffCommentsUserCard payload={payload} />;

--- a/web/src/components/diff/comments/DiffCommentsUserCard.tsx
+++ b/web/src/components/diff/comments/DiffCommentsUserCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { CommentMarkdown } from "./CommentMarkdown";
-import type { DiffCommentsSentinelPayload } from "./buildPrompt";
+import type { DiffCommentsCardPayload } from "./buildPrompt";
 import type { DiffComment } from "./types";
 import {
   ensureThemeLoaded,
@@ -11,13 +11,14 @@ import {
 import { useShikiTheme } from "../../../hooks/useShikiTheme";
 
 interface Props {
-  payload: DiffCommentsSentinelPayload;
+  payload: DiffCommentsCardPayload;
 }
 
 /** Rich rendering of a diff-comments prompt in the cockpit user-message
- *  slot. Built from the sentinel payload that `buildFullPrompt`
- *  prepends to the prompt body. Falls back to the raw text rendering
- *  upstream when the sentinel is missing or malformed. */
+ *  slot. Built from the typed `UserDiffCommentsPrompt` event (carried on
+ *  the assistant-ui message metadata) or, for legacy prompts, from the
+ *  decoded sentinel payload. Falls back to raw text rendering upstream
+ *  when neither is present. */
 export function DiffCommentsUserCard({ payload }: Props) {
   const { intro, outro, isMultiRepo, comments } = payload;
   const sorted = [...comments].sort(compareComments);

--- a/web/src/components/diff/comments/SendCommentsDialog.tsx
+++ b/web/src/components/diff/comments/SendCommentsDialog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CommentMarkdown } from "./CommentMarkdown";
-import { buildCommentsMarkdown, buildFullPrompt } from "./buildPrompt";
+import { buildCommentsMarkdown, buildDiffCommentsPrompt } from "./buildPrompt";
 import type { DiffComment } from "./types";
 
 interface Props {
@@ -63,16 +63,16 @@ export function SendCommentsDialog({
     if (busy || comments.length === 0 || !sendEnabled) return;
     setBusy(true);
     setError(null);
-    const body = buildFullPrompt(comments, introDraft, outroDraft, {
+    const built = buildDiffCommentsPrompt(comments, introDraft, outroDraft, {
       isMultiRepo,
     });
     try {
       const res = await fetch(
-        `/api/sessions/${encodeURIComponent(sessionId)}/cockpit/prompt`,
+        `/api/sessions/${encodeURIComponent(sessionId)}/cockpit/prompt/diff-comments`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ text: body }),
+          body: JSON.stringify(built),
         },
       );
       if (!res.ok) {

--- a/web/src/components/diff/comments/buildPrompt.test.ts
+++ b/web/src/components/diff/comments/buildPrompt.test.ts
@@ -1,11 +1,28 @@
 import { describe, it, expect } from "vitest";
 import {
   buildCommentsMarkdown,
-  buildFullPrompt,
+  buildDiffCommentsPrompt,
   parseDiffCommentsSentinel,
   stripDiffCommentsSentinel,
 } from "./buildPrompt";
 import type { DiffComment } from "./types";
+
+/** Reproduce the legacy `<!-- aoe:diff-comments:v1 <base64> -->`
+ *  encoder (removed from the send path in #1123) so the decode-fallback
+ *  tests can still exercise `parseDiffCommentsSentinel` against the
+ *  shape older persisted prompts carry. */
+function legacySentinel(payload: {
+  intro: string;
+  outro: string;
+  isMultiRepo: boolean;
+  comments: DiffComment[];
+}): string {
+  const json = JSON.stringify(payload);
+  const bytes = new TextEncoder().encode(json);
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
+  return `<!-- aoe:diff-comments:v1 ${btoa(bin)} -->\nbody\n`;
+}
 
 function mk(partial: Partial<DiffComment>): DiffComment {
   return {
@@ -104,65 +121,88 @@ describe("buildCommentsMarkdown", () => {
   });
 });
 
-describe("buildFullPrompt", () => {
+describe("buildDiffCommentsPrompt", () => {
   it("uses default outro when blank", () => {
-    const prompt = buildFullPrompt([mk({})], "", "", { isMultiRepo: false });
-    expect(prompt).toMatch(/Please address these comments\.\n$/);
+    const built = buildDiffCommentsPrompt([mk({})], "", "", {
+      isMultiRepo: false,
+    });
+    expect(built.outro).toBe("Please address these comments.");
+    expect(built.assembledMarkdown).toMatch(/Please address these comments\.\n$/);
   });
 
   it("uses provided outro when set", () => {
-    const prompt = buildFullPrompt([mk({})], "", "Custom outro", {
+    const built = buildDiffCommentsPrompt([mk({})], "", "Custom outro", {
       isMultiRepo: false,
     });
-    expect(prompt).toMatch(/Custom outro\n$/);
-    expect(prompt).not.toContain("Please address these comments.");
+    expect(built.outro).toBe("Custom outro");
+    expect(built.assembledMarkdown).toMatch(/Custom outro\n$/);
+    expect(built.assembledMarkdown).not.toContain("Please address these comments.");
   });
 
   it("prepends intro when set", () => {
-    const prompt = buildFullPrompt([mk({})], "Hey:", "", { isMultiRepo: false });
-    const body = stripDiffCommentsSentinel(prompt);
-    expect(body.startsWith("Hey:\n\n## Diff comments")).toBe(true);
+    const built = buildDiffCommentsPrompt([mk({})], "Hey:", "", {
+      isMultiRepo: false,
+    });
+    expect(built.intro).toBe("Hey:");
+    expect(built.assembledMarkdown.startsWith("Hey:\n\n## Diff comments")).toBe(
+      true,
+    );
   });
 
   it("trims surrounding whitespace from intro/outro", () => {
-    const prompt = buildFullPrompt(
-      [mk({})],
-      "  intro  \n",
-      "   outro   ",
-      { isMultiRepo: false },
-    );
-    const body = stripDiffCommentsSentinel(prompt);
-    expect(body.startsWith("intro\n")).toBe(true);
-    expect(body).toMatch(/outro\n$/);
+    const built = buildDiffCommentsPrompt([mk({})], "  intro  \n", "   outro   ", {
+      isMultiRepo: false,
+    });
+    expect(built.intro).toBe("intro");
+    expect(built.outro).toBe("outro");
+    expect(built.assembledMarkdown.startsWith("intro\n")).toBe(true);
+    expect(built.assembledMarkdown).toMatch(/outro\n$/);
   });
 
   it("omits the comments section when no comments", () => {
-    const prompt = buildFullPrompt([], "intro", "outro", { isMultiRepo: false });
-    expect(prompt).not.toContain("## Diff comments");
-    expect(prompt).not.toContain("aoe:diff-comments");
-    expect(prompt).toContain("intro");
-    expect(prompt).toContain("outro");
+    const built = buildDiffCommentsPrompt([], "intro", "outro", {
+      isMultiRepo: false,
+    });
+    expect(built.assembledMarkdown).not.toContain("## Diff comments");
+    expect(built.assembledMarkdown).toContain("intro");
+    expect(built.assembledMarkdown).toContain("outro");
+    expect(built.comments).toHaveLength(0);
   });
 
-  it("prepends a sentinel header when comments are present", () => {
-    const prompt = buildFullPrompt([mk({})], "", "", { isMultiRepo: false });
-    expect(prompt.startsWith("<!-- aoe:diff-comments:v1 ")).toBe(true);
-    expect(prompt).toContain("\n## Diff comments\n");
+  it("never emits a sentinel header (typed-event send path)", () => {
+    const built = buildDiffCommentsPrompt([mk({})], "", "", {
+      isMultiRepo: false,
+    });
+    expect(built.assembledMarkdown).not.toContain("aoe:diff-comments");
+    expect(built.assembledMarkdown).not.toContain("<!--");
+    expect(built.assembledMarkdown).toContain("## Diff comments");
+  });
+
+  it("carries the structured comments and multi-repo flag verbatim", () => {
+    const comment = mk({ repoName: "repoA" });
+    const built = buildDiffCommentsPrompt([comment], "", "", {
+      isMultiRepo: true,
+    });
+    expect(built.isMultiRepo).toBe(true);
+    expect(built.comments).toEqual([comment]);
   });
 });
 
-describe("parseDiffCommentsSentinel", () => {
+describe("parseDiffCommentsSentinel (legacy decode fallback)", () => {
   it("returns null when no sentinel", () => {
     expect(parseDiffCommentsSentinel("hello world")).toBeNull();
   });
 
-  it("round-trips a payload built by buildFullPrompt", () => {
+  it("round-trips a legacy sentinel payload", () => {
     const comment = mk({
       body: "needs error handling",
       capturedSnippet: "let x = 1;",
     });
-    const prompt = buildFullPrompt([comment], "Take a look:", "Thanks.", {
+    const prompt = legacySentinel({
+      intro: "Take a look:",
+      outro: "Thanks.",
       isMultiRepo: false,
+      comments: [comment],
     });
     const payload = parseDiffCommentsSentinel(prompt);
     expect(payload).not.toBeNull();
@@ -176,7 +216,12 @@ describe("parseDiffCommentsSentinel", () => {
 
   it("survives snippets that contain `-->`", () => {
     const c = mk({ capturedSnippet: "<!-- not allowed -->\nlet x = 1;" });
-    const prompt = buildFullPrompt([c], "", "", { isMultiRepo: false });
+    const prompt = legacySentinel({
+      intro: "",
+      outro: "Please address these comments.",
+      isMultiRepo: false,
+      comments: [c],
+    });
     const payload = parseDiffCommentsSentinel(prompt);
     expect(payload).not.toBeNull();
     expect(payload!.comments[0]!.capturedSnippet).toContain("-->");
@@ -187,12 +232,14 @@ describe("parseDiffCommentsSentinel", () => {
     expect(parseDiffCommentsSentinel(broken)).toBeNull();
   });
 
-  it("preserves the visible body for the agent", () => {
-    const prompt = buildFullPrompt([mk({})], "Intro:", "Outro.", {
+  it("strips the sentinel to recover the visible body", () => {
+    const prompt = legacySentinel({
+      intro: "Intro:",
+      outro: "Outro.",
       isMultiRepo: false,
+      comments: [mk({})],
     });
     const body = stripDiffCommentsSentinel(prompt);
-    expect(body.startsWith("Intro:\n\n## Diff comments")).toBe(true);
-    expect(body).toMatch(/Outro\.\n$/);
+    expect(body).toBe("body\n");
   });
 });

--- a/web/src/components/diff/comments/buildPrompt.ts
+++ b/web/src/components/diff/comments/buildPrompt.ts
@@ -12,26 +12,24 @@ const DEFAULT_OUTRO = "Please address these comments.";
 const SENTINEL_PREFIX = "<!-- aoe:diff-comments:v1 ";
 const SENTINEL_SUFFIX = " -->";
 
-/** Structured payload embedded as an HTML comment at the top of the
- *  prompt body. The cockpit `UserMessage` parses it back out and
- *  renders a structured card; the agent ignores the HTML comment and
- *  reads the assembled markdown below. Base64-encoded JSON avoids any
- *  `-->` collision with snippet/body content. */
-export interface DiffCommentsSentinelPayload {
+/** Structured fields the cockpit transcript needs to render the rich
+ *  `DiffCommentsUserCard`. Produced two ways: freshly by
+ *  `buildDiffCommentsPrompt` (the typed-event send path), and by
+ *  `parseDiffCommentsSentinel` when decoding legacy prompts that still
+ *  carry the old `<!-- aoe:diff-comments:v1 ... -->` sentinel. */
+export interface DiffCommentsCardPayload {
   intro: string;
   outro: string;
   isMultiRepo: boolean;
   comments: DiffComment[];
 }
 
-function encodeSentinel(payload: DiffCommentsSentinelPayload): string {
-  const json = JSON.stringify(payload);
-  const bytes = new TextEncoder().encode(json);
-  let bin = "";
-  for (let i = 0; i < bytes.length; i++) {
-    bin += String.fromCharCode(bytes[i]!);
-  }
-  return SENTINEL_PREFIX + btoa(bin) + SENTINEL_SUFFIX;
+/** The single build artifact for the typed diff-comments send path:
+ *  the card payload plus `assembledMarkdown`, the exact text forwarded
+ *  to the agent. Built once and used for the dialog preview, the POST
+ *  body, and the transcript card so the three can never disagree. */
+export interface BuiltDiffCommentsPrompt extends DiffCommentsCardPayload {
+  assembledMarkdown: string;
 }
 
 /** Returns the structured payload when `text` begins with our sentinel,
@@ -39,7 +37,7 @@ function encodeSentinel(payload: DiffCommentsSentinelPayload): string {
  *  falls back to plain-text rendering. */
 export function parseDiffCommentsSentinel(
   text: string,
-): DiffCommentsSentinelPayload | null {
+): DiffCommentsCardPayload | null {
   if (!text.startsWith(SENTINEL_PREFIX)) return null;
   const end = text.indexOf(SENTINEL_SUFFIX, SENTINEL_PREFIX.length);
   if (end < 0) return null;
@@ -97,15 +95,19 @@ export function buildCommentsMarkdown(
   return sections.join("\n\n---\n\n");
 }
 
-/** Assemble the full prompt body: intro + comments preview + outro.
+/** Build the typed diff-comments prompt artifact: intro + comments
+ *  preview + outro assembled into `assembledMarkdown` (the exact text
+ *  the agent receives, no sentinel), alongside the effective
+ *  intro/outro and the structured comments for the transcript card.
  *  `outro` falls back to a default if blank so the agent sees an
- *  actionable nudge. */
-export function buildFullPrompt(
+ *  actionable nudge; the returned `intro`/`outro` are these effective
+ *  values, so the persisted event matches what the agent saw. */
+export function buildDiffCommentsPrompt(
   comments: DiffComment[],
   intro: string,
   outro: string,
   opts: BuildOpts,
-): string {
+): BuiltDiffCommentsPrompt {
   const introText = intro.trim();
   const outroText = (outro.trim() || DEFAULT_OUTRO).trim();
   const sections: string[] = [];
@@ -116,15 +118,14 @@ export function buildFullPrompt(
     sections.push(commentsBlock);
   }
   sections.push(outroText);
-  const body = sections.join("\n\n") + "\n";
-  if (comments.length === 0) return body;
-  const sentinel = encodeSentinel({
+  const assembledMarkdown = sections.join("\n\n") + "\n";
+  return {
     intro: introText,
     outro: outroText,
     isMultiRepo: opts.isMultiRepo,
     comments,
-  });
-  return `${sentinel}\n${body}`;
+    assembledMarkdown,
+  };
 }
 
 function renderComment(c: DiffComment, isMultiRepo: boolean): string {

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -337,6 +337,108 @@ describe("applyEvent / UserPromptSent", () => {
   });
 });
 
+describe("applyEvent / UserDiffCommentsPrompt (#1123)", () => {
+  function diffCommentsFrame(seq: number): CockpitFrame {
+    return {
+      session_id: "s-1",
+      seq,
+      event: {
+        UserDiffCommentsPrompt: {
+          intro: "Take a look:",
+          outro: "Please address these comments.",
+          isMultiRepo: true,
+          comments: [
+            {
+              id: "c-1",
+              repoName: "repoA",
+              filePath: "src/main.rs",
+              side: "new",
+              startLine: 42,
+              endLine: 45,
+              body: "rename this",
+              capturedSnippet: "fn main() {}",
+              language: "rust",
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+          assembledMarkdown: "Take a look:\n\n## Diff comments\n\n...\n",
+        },
+      },
+    };
+  }
+
+  it("appends a typed user_diff_comments row carrying the structured payload", () => {
+    const next = applyEvent(emptyCockpitState(), diffCommentsFrame(1));
+    expect(next.activity).toHaveLength(1);
+    const row = next.activity[0]!;
+    expect(row.id).toBe("user-seq-1");
+    expect(row.kind).toBe("user_diff_comments");
+    // text is the assembled markdown (agent-visible body / fallback),
+    // never a base64 sentinel.
+    expect(row.text).toContain("## Diff comments");
+    expect(row.text).not.toContain("aoe:diff-comments");
+    expect(row.diffComments).toEqual({
+      intro: "Take a look:",
+      outro: "Please address these comments.",
+      isMultiRepo: true,
+      comments: [
+        {
+          id: "c-1",
+          repoName: "repoA",
+          filePath: "src/main.rs",
+          side: "new",
+          startLine: 42,
+          endLine: 45,
+          body: "rename this",
+          capturedSnippet: "fn main() {}",
+          language: "rust",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+    expect(next.lastSeq).toBe(1);
+    expect(next.turnActive).toBe(true);
+  });
+
+  it("applies the same per-turn resets as a plain prompt", () => {
+    const stale: CockpitState = {
+      ...emptyCockpitState(),
+      assistantMessage: "stale partial reply",
+      startupError: "old error",
+      lastError: "old action error",
+      workerStopped: true,
+      workerRestarting: true,
+      agentUnresponsive: true,
+      turnActive: false,
+    };
+    const next = applyEvent(stale, diffCommentsFrame(1));
+    expect(next.assistantMessage).toBe("");
+    expect(next.startupError).toBeNull();
+    expect(next.lastError).toBeNull();
+    expect(next.workerStopped).toBe(false);
+    expect(next.workerRestarting).toBe(false);
+    expect(next.agentUnresponsive).toBe(false);
+    expect(next.turnActive).toBe(true);
+  });
+
+  it("reconstructs the diff-comments turn on replay (no optimistic row)", () => {
+    // The send dialog posts directly, so there is never a placeholder to
+    // promote; the server echo simply appends the typed row.
+    const final = [
+      diffCommentsFrame(1),
+      {
+        session_id: "s-1",
+        seq: 2,
+        event: { AgentMessageChunk: { text: "On it." } },
+      } as CockpitFrame,
+    ].reduce((state, f) => applyEvent(state, f), emptyCockpitState());
+    const rows = final.activity.filter((a) => a.kind === "user_diff_comments");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.diffComments?.comments).toHaveLength(1);
+    expect(final.lastSeq).toBe(2);
+  });
+});
+
 describe("applyEvent / AvailableCommandsUpdated", () => {
   it("populates availableCommands and replaces the prior list", () => {
     const f1: CockpitFrame = {

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -421,6 +421,23 @@ describe("applyEvent / UserDiffCommentsPrompt (#1123)", () => {
     expect(next.turnActive).toBe(true);
   });
 
+  it("counts as a prior user turn for SessionContextReset (#1123)", () => {
+    // A session whose only turn is a diff-comments prompt must still
+    // surface the context-reset row + arm the primer; otherwise it is
+    // wrongly treated as a 0-message session.
+    let state = applyEvent(emptyCockpitState(), diffCommentsFrame(1));
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { SessionContextReset: { reason: "session/load failed: bad id" } },
+    });
+    expect(state.activity.some((r) => r.kind === "context_reset")).toBe(true);
+    expect(state.contextPrimerAvailable).toEqual({
+      resetSeq: 2,
+      reason: "session/load failed: bad id",
+    });
+  });
+
   it("reconstructs the diff-comments turn on replay (no optimistic row)", () => {
     // The send dialog posts directly, so there is never a placeholder to
     // promote; the server echo simply appends the typed row.

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -4,6 +4,8 @@
 // side can add new variants without breaking the UI as long as the
 // component renders unknown frames gracefully.
 
+import type { DiffComment } from "../components/diff/comments/types";
+
 export type ApprovalDecision =
   | "Allow"
   | "AllowAlways"
@@ -281,6 +283,15 @@ export type CockpitEvent =
   | { AgentStartupError: { message: string } }
   | { IncompatibleAgent: { detail: IncompatibleAgentDetail } }
   | { UserPromptSent: { text: string } }
+  | {
+      UserDiffCommentsPrompt: {
+        intro: string;
+        outro: string;
+        isMultiRepo: boolean;
+        comments: DiffComment[];
+        assembledMarkdown: string;
+      };
+    }
   | { AcpSessionAssigned: { acp_session_id: string } }
   | { SessionContextReset: { reason: string } }
   | { WakeupScheduled: { at: string; reason: string | null } }
@@ -528,6 +539,7 @@ export interface ActivityRow {
     | "message"
     | "thinking"
     | "user_prompt"
+    | "user_diff_comments"
     | "empty_output"
     | "context_reset"
     | "session_cleared"
@@ -538,6 +550,16 @@ export interface ActivityRow {
    *  pick a per-kind renderer without needing to look the call up by
    *  toolCallId. */
   tool?: ToolCall;
+  /** Structured payload on `user_diff_comments` rows. The runtime
+   *  attaches it to the assistant-ui message metadata so the
+   *  transcript renders the rich `DiffCommentsUserCard`; `text` holds
+   *  the assembled markdown as the fallback / agent-visible body. */
+  diffComments?: {
+    intro: string;
+    outro: string;
+    isMultiRepo: boolean;
+    comments: DiffComment[];
+  };
   at: string; // ISO-8601
 }
 
@@ -601,6 +623,47 @@ export function emptyCockpitState(): CockpitState {
     configOptionSwitchFailed: null,
     pendingConfigOption: null,
   };
+}
+
+/** Per-turn state resets shared by every "a new user turn started"
+ *  event (a plain `UserPromptSent` and a `UserDiffCommentsPrompt`).
+ *  Mutates `next` in place; the caller has already appended the
+ *  activity row and bumped `pendingUserPromptSeq`. */
+function applyNewTurnResets(next: CockpitState): void {
+  next.assistantMessage = "";
+  next.startupError = null;
+  next.lastError = null;
+  next.turnActive = isTurnActive(next);
+  // New turn; reset the no-output detector so Stopped fires the
+  // empty-output notice if the agent produces nothing.
+  next.turnHasOutput = false;
+  // A fresh prompt means the worker is alive again; clear the
+  // user_stopped banner without waiting for AcpSessionAssigned.
+  next.workerStopped = false;
+  next.workerRestarting = false;
+  // The user is moving on. Clear any pending Retry pills and the
+  // agent-unresponsive banner; if the rejection was legitimate the
+  // new prompt will end up rejected too and a fresh pill will land.
+  // See #1196.
+  next.rejectedPrompts = [];
+  next.agentUnresponsive = false;
+  next.agentOrphaned = false;
+  // /loop dynamic mode self-fires a prompt on wake, but a user-typed
+  // follow-up during the wait is NOT the wake firing; only clear when
+  // the scheduled time has already elapsed. The countdown UI continues
+  // counting down through a mid-wait user prompt; the next
+  // ScheduleWakeup turn (or the wake itself) overrides it cleanly.
+  // See #1091.
+  if (next.nextWakeupAt) {
+    const wakeAt = new Date(next.nextWakeupAt).getTime();
+    if (!Number.isNaN(wakeAt) && Date.now() >= wakeAt) {
+      next.nextWakeupAt = null;
+      next.nextWakeupReason = null;
+    }
+  }
+  // Any pending context-primer offer is consumed once the user submits
+  // a new prompt; the recovery affordance is one-shot.
+  next.contextPrimerAvailable = null;
 }
 
 /** Pure reducer. Returns a new state; never mutates the input.
@@ -1105,40 +1168,30 @@ export function applyEvent(
       });
       next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;
     }
-    next.assistantMessage = "";
-    next.startupError = null;
-    next.lastError = null;
-    next.turnActive = isTurnActive(next);
-    // New turn; reset the no-output detector so Stopped fires the
-    // empty-output notice if the agent produces nothing.
-    next.turnHasOutput = false;
-    // A fresh prompt means the worker is alive again; clear the
-    // user_stopped banner without waiting for AcpSessionAssigned.
-    next.workerStopped = false;
-    next.workerRestarting = false;
-    // The user is moving on. Clear any pending Retry pills and the
-    // agent-unresponsive banner; if the rejection was legitimate the
-    // new prompt will end up rejected too and a fresh pill will land.
-    // See #1196.
-    next.rejectedPrompts = [];
-    next.agentUnresponsive = false;
-    next.agentOrphaned = false;
-    // /loop dynamic mode self-fires a UserPromptSent on wake, but a
-    // user-typed follow-up during the wait is NOT the wake firing;
-    // only clear when the scheduled time has already elapsed. The
-    // countdown UI continues counting down through a mid-wait user
-    // prompt; the next ScheduleWakeup turn (or the wake itself)
-    // overrides it cleanly. See #1091.
-    if (next.nextWakeupAt) {
-      const wakeAt = new Date(next.nextWakeupAt).getTime();
-      if (!Number.isNaN(wakeAt) && Date.now() >= wakeAt) {
-        next.nextWakeupAt = null;
-        next.nextWakeupReason = null;
-      }
-    }
-    // Any pending context-primer offer is consumed once the user
-    // submits a new prompt; the recovery affordance is one-shot.
-    next.contextPrimerAvailable = null;
+    applyNewTurnResets(next);
+    return next;
+  }
+  if ("UserDiffCommentsPrompt" in event) {
+    // The "Send diff comments" dialog posts directly (no optimistic
+    // row), so there is never a placeholder to promote: always append a
+    // typed `user_diff_comments` row. `text` carries the assembled
+    // markdown (agent-visible body / fallback); `diffComments` carries
+    // the structured payload the runtime hands to the transcript card.
+    const p = event.UserDiffCommentsPrompt;
+    next.activity = pushActivity(next.activity, {
+      id: `user-seq-${frame.seq}`,
+      kind: "user_diff_comments",
+      text: p.assembledMarkdown,
+      diffComments: {
+        intro: p.intro,
+        outro: p.outro,
+        isMultiRepo: p.isMultiRepo,
+        comments: p.comments,
+      },
+      at: new Date().toISOString(),
+    });
+    next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;
+    applyNewTurnResets(next);
     return next;
   }
   if ("AcpSessionAssigned" in event) {

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -1243,7 +1243,9 @@ export function applyEvent(
     // order, so checking `activity` here captures "any prompt with a
     // lower seq than this reset"; later prompts won't retroactively
     // surface the suppressed row.
-    const hasPriorPrompt = next.activity.some((r) => r.kind === "user_prompt");
+    const hasPriorPrompt = next.activity.some(
+      (r) => r.kind === "user_prompt" || r.kind === "user_diff_comments",
+    );
     if (!hasPriorPrompt) {
       return next;
     }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -838,6 +838,35 @@
       ]
     },
     {
+      "id": "diff-comments.send-flow",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/diff-comments.spec.ts"
+      ],
+      "components": [
+        "web/src/components/diff/comments/SendCommentsDialog.tsx",
+        "web/src/components/diff/comments/CommentsBanner.tsx",
+        "web/src/components/diff/comments/CommentForm.tsx",
+        "web/src/components/diff/comments/CommentCard.tsx"
+      ]
+    },
+    {
+      "id": "diff-comments.typed-event",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/components/diff/comments/buildPrompt.test.ts",
+        "src/lib/cockpitTypes.test.ts",
+        "src/components/cockpit/CockpitRuntime.test.ts"
+      ],
+      "components": [
+        "web/src/components/diff/comments/DiffCommentsUserCard.tsx",
+        "web/src/components/cockpit/CockpitRuntime.tsx",
+        "web/src/components/cockpit/CockpitView.tsx"
+      ]
+    },
+    {
       "id": "right-panel.mobile-picker",
       "kind": "mocked-playwright",
       "risk": "high",

--- a/web/tests/diff-comments.spec.ts
+++ b/web/tests/diff-comments.spec.ts
@@ -7,7 +7,8 @@ import { clickSidebarSession } from "./helpers/sidebar";
 //   `+` gutter button or the banner.
 // - Click `+` to comment on a single line; save; card renders.
 // - Open the send dialog, edit intro, send; comments clear; POST
-//   reaches /cockpit/prompt with the assembled body.
+//   reaches /cockpit/prompt/diff-comments with the structured body
+//   (intro/outro/comments/isMultiRepo/assembledMarkdown). See #1123.
 // - Comments persist to localStorage and reload back into the UI.
 
 const FILE_PATH = "src/example.ts";
@@ -229,15 +230,25 @@ test.describe("Diff comments (#928)", () => {
     await expect(page.getByText("nit").first()).toBeVisible();
   });
 
-  test("send dialog POSTs to /cockpit/prompt and clears comments on success", async ({
+  test("send dialog POSTs structured body to /cockpit/prompt/diff-comments and clears comments on success", async ({
     page,
   }) => {
     await setup(page);
-    let captured: { text?: string } | null = null;
-    await page.route("**/api/sessions/*/cockpit/prompt", (r) => {
-      captured = JSON.parse(r.request().postData() || "{}");
-      return r.fulfill({ json: {} });
-    });
+    interface CapturedBody {
+      intro?: string;
+      outro?: string;
+      isMultiRepo?: boolean;
+      comments?: Array<{ body?: string }>;
+      assembledMarkdown?: string;
+    }
+    let captured: CapturedBody | null = null;
+    await page.route(
+      "**/api/sessions/*/cockpit/prompt/diff-comments",
+      (r) => {
+        captured = JSON.parse(r.request().postData() || "{}");
+        return r.fulfill({ json: {} });
+      },
+    );
     await openSessionAndFile(page);
     await startSingleLineComment(page, "new", 3);
     await page
@@ -251,11 +262,21 @@ test.describe("Diff comments (#928)", () => {
     await page.getByPlaceholder(/Anything you want to say/).fill("Hey:");
     // Confirm send (dialog's own Send button is the last one in the DOM).
     await page.getByRole("button", { name: /^Send$/ }).last().click();
-    await expect.poll(() => captured?.text).toBeTruthy();
-    expect(captured?.text).toContain("Hey:");
-    expect(captured?.text).toContain("## Diff comments");
-    expect(captured?.text).toContain("rename");
-    expect(captured?.text).toContain("Please address these comments.");
+    await expect.poll(() => captured?.assembledMarkdown).toBeTruthy();
+    // Structured fields the transcript card renders from.
+    expect(captured?.intro).toBe("Hey:");
+    expect(captured?.outro).toBe("Please address these comments.");
+    expect(captured?.isMultiRepo).toBe(false);
+    expect(captured?.comments).toHaveLength(1);
+    expect(captured?.comments?.[0]?.body).toContain("rename");
+    // assembledMarkdown is the agent-visible body, no base64 sentinel.
+    expect(captured?.assembledMarkdown).toContain("Hey:");
+    expect(captured?.assembledMarkdown).toContain("## Diff comments");
+    expect(captured?.assembledMarkdown).toContain("rename");
+    expect(captured?.assembledMarkdown).toContain(
+      "Please address these comments.",
+    );
+    expect(captured?.assembledMarkdown).not.toContain("aoe:diff-comments");
     // Banner cleared.
     await expect(page.getByText(/^1 comment$/)).toHaveCount(0);
   });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to #1122. The "Send diff comments" flow shipped as a sentinel-in-text hack: the dialog prepended an HTML comment `<!-- aoe:diff-comments:v1 <base64-json> -->` to a normal user prompt, the frontend parsed it back out to render a card, and the agent saw the base64 blob as noise at the top of every diff-comment prompt.

This makes it a first-class cockpit event.

- New REST endpoint `POST /api/sessions/:id/cockpit/prompt/diff-comments` accepting the structured review (`intro`, `outro`, `isMultiRepo`, `comments`) plus `assembledMarkdown`, the exact WYSIWYG prompt the user approved in the dialog.
- New typed event `Event::UserDiffCommentsPrompt { intro, outro, is_multi_repo, comments, assembled_markdown }`. The server forwards only `assembled_markdown` to the ACP agent, so the agent no longer sees the sentinel; the structured fields are what the cockpit transcript re-renders.
- The frontend owns markdown assembly (sort, headings, code-fence sizing, repo prefixes). The server stores it verbatim rather than re-deriving it in Rust, so the card payload and the agent-visible text can never disagree (a `/debate` between gemini-3.1-pro and gpt-5.5 settled this; both also flagged that `is_multi_repo` belongs on the event for deterministic replay).
- Frontend renders the card from the typed event: the reducer produces a `user_diff_comments` activity row, the runtime attaches the structured payload to the assistant-ui message via `metadata.custom.diffComments`, and `UserText` renders `DiffCommentsUserCard` from it. The sentinel encode path is removed; the decode fallback stays so older persisted prompts still render.

No data migration: the event is additive to the JSON event log, and old sentinel-bearing `UserPromptSent` events keep replaying through the retained decode fallback.

Closes #1123

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] `cargo build --features serve`, run `aoe serve`, open a cockpit session against an ACP agent (`claude`).
- [x] Make an agent edit, open the diff in the right panel, add a line comment, open the Send dialog, send.
- [x] Confirm the agent receives and acts on the comments, and the transcript shows the diff-comments card with no `<!-- aoe:diff-comments` line.
- [x] Inspect the forwarded prompt (worker log / agent side): it starts with the intro and `## Diff comments`, with no base64 sentinel line at the top.
- [x] Reload the page: the diff-comments card re-renders from the persisted typed event.
- [x] Open a session that already has an old sentinel-bearing diff-comments prompt in its log (authored before this change): the card still renders via the legacy decode fallback.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

(No visual change: the rendered card is identical; this swaps the data path behind it.)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Updated the mocked send spec (`tests/diff-comments.spec.ts`) to assert the new endpoint and structured body, plus Vitest for prompt assembly (`buildPrompt.test.ts`), the reducer's typed-event arm (`cockpitTypes.test.ts`), and the runtime's metadata wiring (`CockpitRuntime.test.ts`). Two new coverage-matrix surfaces registered.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the new TUI/CLI arms only render a web-only event (diff comments are authored in the web cockpit, never in the TUI), and are covered by unit tests in `src/tui/cockpit_view/reducer.rs` and `src/cli/cockpit.rs`. No TUI user flow emits `UserDiffCommentsPrompt`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Opus 4.8, 1M context) via Claude Code, `/aoe-implement` skill.

**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction. The two design calls (client-supplied `assembled_markdown`; assistant-ui `metadata.custom` over a side map) were settled by a `/debate` between gemini-3.1-pro and gpt-5.5, then I made the final call. A local CodeRabbit pass caught one real bug (context-reset misclassifying a diff-comments-only session as 0-message), fixed in a follow-up commit with a regression test.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR replaces the previous sentinel-in-text hack for sending diff-comment prompts with a proper, first-class typed flow: a new REST endpoint and a new strongly-typed cockpit event. Frontend now assembles the markdown and sends structured data; the server persists the structured event but forwards only the assembled markdown to the agent. Legacy sentinel decoding is retained as a replay fallback.

## What changed (high-level)

- Added a dedicated endpoint: POST /api/sessions/{id}/cockpit/prompt/diff-comments.
- Introduced a new typed event: UserDiffCommentsPrompt (intro, outro, is_multi_repo, comments, assembled_markdown).
- Frontend builds and sends a structured payload (no more hidden sentinel markers).
- Frontend reducer/runtime attach structured diff-comments payload to message metadata for rendering; UI renders a typed DiffCommentsUserCard.
- Server persists the typed event and forwards only assembled_markdown to the ACP agent (removes base64 sentinel from agent-visible text).
- Legacy sentinel encode path removed; legacy decode fallback kept for old persisted prompts.
- Tests added/updated across Rust and web (Playwright, Vitest) and coverage entries updated.
- No data migration required; change is additive to event log.

## What moved / added / removed

Added:
- New wire/type: DiffCommentsPromptRequest and BuiltDiffCommentsPrompt structures.
- New state type: DiffComment and Event::UserDiffCommentsPrompt.
- New supervisor API: publish_user_diff_comments_prompt.
- New server handler and router route for the diff-comments endpoint.
- Frontend: buildDiffCommentsPrompt, updated SendCommentsDialog, ActivityRow kind "user_diff_comments", metadata plumbing, and DiffCommentsUserCard typing.
- Tests: unit and integration tests for serialization, reducer/runtime behavior, and e2e send-flow.

Changed:
- Context primer, transcript classification, reducer and runtime logic to treat diff-comments prompts as user turns and to include them in context/reset logic.
- Cockpit CLI/log breadcrumbing to recognize the new event kind.

Removed:
- Frontend sentinel encode path (no longer embeds aoe:diff-comments markers in sent prompts).

Legacy:
- Sentinel decode fallback retained for replaying older persisted prompts.

## Benefits

- Clearer API contract and intent (no hidden markers).
- Stronger type safety and reliable round-trip persistence.
- Agent receives only the visible assembled markdown (no sentinel noise).
- Easier rendering and replay from structured data.
- Backwards compatible for existing stored prompts; no migration needed.

## Technical details (brief)

- Server: new DiffCommentsPromptRequest struct, cockpit_prompt_diff_comments handler, touch-and-wake helper reused, supervisor publishes Event::UserDiffCommentsPrompt, send_prompt receives only assembled_markdown.
- State/store: DiffComment struct added; event variant serialized in camelCase; event store tests ensure round-trip and field preservation.
- Runtime/context: context_primer and acp_client classify UserDiffCommentsPrompt as a user turn/transcript event; it closes/starts turns and counts toward history/truncation logic.
- Frontend: buildDiffCommentsPrompt returns structured BuiltDiffCommentsPrompt (intro, outro, isMultiRepo, comments, assembledMarkdown); SendCommentsDialog POSTs that object to the new endpoint; reducer appends ActivityRow kind "user_diff_comments" with optional diffComments payload; activityToThreadMessages wires metadata.custom.diffComments for user messages; CockpitView.UserText renders DiffCommentsUserCard from typed metadata, falling back to legacy sentinel parse when needed.
- Tests: updated Rust unit tests, Vitest for reducer/runtime, Playwright/Vitest for send-flow interception and payload assertions; coverage matrix updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->