### PR TITLE
feat(cockpit): real attachment support in composer (image / audio / resource, paste & drop)

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -323,6 +323,53 @@ pointer is not invalidated mid-utterance, then drains the final text
 into the composer state on blur (typically when you tap Send) or
 after a brief idle period. See #1431.
 
+### Composer attachments (images, audio, files)
+
+The web composer can send attachments alongside the prompt text when
+the active agent advertises support for them. Three ways to add one:
+
+- the paperclip button in the composer toolbar opens a file picker;
+- paste an image (for example a screenshot) with Cmd/Ctrl+V while the
+  composer is focused;
+- drag and drop files onto the composer.
+
+Staged attachments show as removable chips above the text area; images
+render a thumbnail. A prompt can be attachment-only (no text), which is
+handy for "what is wrong here?" screenshots.
+
+Support is gated on the agent's ACP `prompt_capabilities`, reported
+during the `initialize` handshake. The paperclip is disabled (with a
+tooltip explaining why) when the current agent does not accept
+attachments, and the file picker only offers the kinds it does accept:
+
+- `image` for images,
+- `audio` for audio,
+- `embedded_context` for embedded resources (text / markdown / JSON /
+  PDF).
+
+`claude-agent-acp` advertises `image` and `embedded_context`; other
+agents vary, so the button reflects whichever agent is running.
+
+The server is the authority: it re-checks the agent capability, enforces
+a per-attachment size limit (10 MiB), a total-per-prompt limit (20 MiB),
+a count cap (8), a MIME allowlist (`image/svg+xml` and HTML are
+excluded), and sniffs image magic bytes so a mislabeled file is
+rejected. Oversize or unsupported attachments come back as an error
+instead of reaching the agent.
+
+Attachments are persisted with the transcript so they re-render on
+reload. The bytes live in a dedicated store keyed to the prompt and are
+pruned in lockstep with it (and dropped when the session is deleted), so
+the event log stays lean. Replayed images are fetched lazily from
+`GET /api/sessions/{id}/cockpit/attachments/{attachment_id}`.
+
+Attachments require an idle, connected agent. Unlike text, they are not
+held in the offline prompt queue (which is stored locally in the
+browser); sending an attachment while the agent is mid-turn or
+disconnected surfaces an error rather than silently dropping it. Audio
+and embedded resources are sent and stored, but render as a labelled
+chip rather than an inline player or preview for now.
+
 ### Queued prompts (mid-turn + inactive session)
 
 The web composer keeps your messages around even when the session

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -825,6 +825,7 @@ fn event_kind(event: &crate::cockpit::Event) -> &'static str {
         Event::IncompatibleAgent { .. } => "incompatible_agent",
         Event::UserPromptSent { .. } => "user_prompt_sent",
         Event::UserDiffCommentsPrompt { .. } => "user_diff_comments_prompt",
+        Event::PromptCapabilities { .. } => "prompt_capabilities",
         Event::AcpSessionAssigned { .. } => "acp_session_assigned",
         Event::SessionContextReset { .. } => "session_context_reset",
         Event::SessionCleared => "session_cleared",

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -18,8 +18,9 @@ use std::sync::Arc;
 
 use agent_client_protocol::schema::ErrorCode;
 use agent_client_protocol::schema::{
-    CancelNotification, ClientCapabilities, ContentBlock, CreateTerminalRequest,
-    CreateTerminalResponse, FileSystemCapabilities, InitializeRequest, KillTerminalRequest,
+    AudioContent, BlobResourceContents, CancelNotification, ClientCapabilities, ContentBlock,
+    CreateTerminalRequest, CreateTerminalResponse, EmbeddedResource, EmbeddedResourceResource,
+    FileSystemCapabilities, ImageContent, InitializeRequest, KillTerminalRequest,
     KillTerminalResponse, LoadSessionRequest, NewSessionRequest, PermissionOptionKind,
     PromptRequest, ProtocolVersion, ReadTextFileRequest, ReadTextFileResponse,
     ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
@@ -42,13 +43,14 @@ use super::agent_compat::{self, ExpectedAgent};
 use super::agent_profiles;
 use super::agent_registry::AgentSpec;
 use super::approvals::{is_destructive, ApprovalDecision, Nonce};
+use super::event_store::AttachmentBlob;
 use super::fs_handler::{self, FsPolicy, SandboxPathMap};
 use super::permissions::build_approval;
 use super::state::{
     AvailableCommand, CockpitSessionId, ConfigOptionCategory, ConfigOptionChoice,
     ConfigOptionDescriptor, DiffPreview, Event, MemoryRecall, ModeInfo, Plan, PlanStep,
-    PlanStepStatus, RateLimitInfo, SessionMode, SessionUsage, StartupErrorDetail, ToolCall,
-    UsageCost,
+    PlanStepStatus, PromptAttachmentKind, RateLimitInfo, SessionMode, SessionUsage,
+    StartupErrorDetail, ToolCall, UsageCost,
 };
 use super::terminal_handler::TerminalManager;
 use crate::session::SandboxInfo;
@@ -285,7 +287,10 @@ pub struct SpawnConfig {
 
 /// Commands sent from `AcpClient` methods to the background connection task.
 enum ClientCmd {
-    Prompt(String),
+    /// The fully-built prompt content blocks (text first, then any
+    /// attachments). Built in `send_prompt` so the connection task just
+    /// forwards them to `session/prompt`. See #1000.
+    Prompt(Vec<ContentBlock>),
     Cancel,
     SetMode(String),
     /// Send `session/set_config_option` for the given (`config_id`,
@@ -1466,11 +1471,50 @@ impl AcpClient {
         .await
     }
 
-    /// Send a user message to the agent (ACP `session/prompt`).
-    pub async fn send_prompt(&self, text: &str) -> Result<(), AcpError> {
+    /// Send a user message to the agent (ACP `session/prompt`). The
+    /// `attachments` are mapped to the matching ACP `ContentBlock`
+    /// (`Image` / `Audio` / `Resource`) and appended after the text
+    /// block. Callers are responsible for gating attachment kinds on
+    /// the agent's advertised `prompt_capabilities`; this method does
+    /// not re-check them. See #1000 / #965.
+    pub async fn send_prompt(
+        &self,
+        text: &str,
+        attachments: &[AttachmentBlob],
+    ) -> Result<(), AcpError> {
+        use base64::Engine as _;
         let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
+        let mut blocks: Vec<ContentBlock> = Vec::with_capacity(1 + attachments.len());
+        blocks.push(ContentBlock::Text(TextContent::new(text)));
+        for att in attachments {
+            let data_b64 = base64::engine::general_purpose::STANDARD.encode(&att.data);
+            let block = match att.kind {
+                PromptAttachmentKind::Image => {
+                    ContentBlock::Image(ImageContent::new(data_b64, att.mime_type.clone()))
+                }
+                PromptAttachmentKind::Audio => {
+                    ContentBlock::Audio(AudioContent::new(data_b64, att.mime_type.clone()))
+                }
+                PromptAttachmentKind::Resource => {
+                    // Embedded binary resource. ACP requires a uri; the
+                    // bytes never leave the daemon so a synthetic
+                    // `attachment://` uri is enough for the agent to
+                    // refer to it.
+                    let uri = format!(
+                        "attachment:///{}",
+                        att.name.clone().unwrap_or_else(|| att.id.clone())
+                    );
+                    let blob =
+                        BlobResourceContents::new(data_b64, uri).mime_type(att.mime_type.clone());
+                    ContentBlock::Resource(EmbeddedResource::new(
+                        EmbeddedResourceResource::BlobResourceContents(blob),
+                    ))
+                }
+            };
+            blocks.push(block);
+        }
         cmd_tx
-            .send(ClientCmd::Prompt(text.to_string()))
+            .send(ClientCmd::Prompt(blocks))
             .await
             .map_err(|_| AcpError::AgentExited)
     }
@@ -3607,6 +3651,21 @@ async fn run_connection_task<W, R>(
             }
 
             let load_session_capable = init.agent_capabilities.load_session;
+            // Surface the agent's prompt capabilities to the cockpit so
+            // the web composer can gate the attachment button on the
+            // current agent, and the server prompt handler can reject
+            // attachments the agent cannot accept. `initialize` runs on
+            // both Fresh and Resume connects, so this re-emits on every
+            // reconnect and replay always carries a current copy. See
+            // #1000 / #965.
+            let prompt_caps = &init.agent_capabilities.prompt_capabilities;
+            let _ = event_tx_for_block
+                .send(Event::PromptCapabilities {
+                    image: prompt_caps.image,
+                    audio: prompt_caps.audio,
+                    embedded_context: prompt_caps.embedded_context,
+                })
+                .await;
             // Snapshot the watchdog-arming flag before `mode` is moved
             // into the match below.
             let arm_resume_watchdog = matches!(
@@ -3883,7 +3942,7 @@ async fn run_connection_task<W, R>(
             loop {
                 let cmd = cmd_rx.recv().await;
                 match cmd {
-                    Some(ClientCmd::Prompt(text)) => {
+                    Some(ClientCmd::Prompt(blocks)) => {
                         // First user prompt after session/load: stop
                         // dropping notifications. The agent's history-
                         // replay window is over; everything from now on
@@ -3900,7 +3959,7 @@ async fn run_connection_task<W, R>(
                         // transition, so we no longer need to synthesize
                         // one for the orphaned prior turn.
                         prompt_sent_since_attach.store(true, Ordering::Relaxed);
-                        info!(target: "cockpit.acp", "sending prompt ({} chars)", text.len());
+                        info!(target: "cockpit.acp", "sending prompt ({} content blocks)", blocks.len());
                         // Drive the prompt request concurrently with the
                         // command channel so out-of-band notifications
                         // (Cancel, SetMode) can be delivered to the agent
@@ -3960,10 +4019,7 @@ async fn run_connection_task<W, R>(
                         tokio::pin!(silent_orphan_check);
 
                         let prompt_fut = connection
-                            .send_request(PromptRequest::new(
-                                acp_session_id.clone(),
-                                vec![ContentBlock::Text(TextContent::new(text))],
-                            ))
+                            .send_request(PromptRequest::new(acp_session_id.clone(), blocks))
                             .block_task();
                         tokio::pin!(prompt_fut);
 
@@ -4306,7 +4362,7 @@ async fn run_connection_task<W, R>(
                                                 respond_to,
                                             );
                                         }
-                                        Some(ClientCmd::Prompt(rejected_text)) => {
+                                        Some(ClientCmd::Prompt(rejected_blocks)) => {
                                             // Surface the dropped prompt
                                             // to the UI so the user can
                                             // retry from a Rejected pill
@@ -4318,6 +4374,18 @@ async fn run_connection_task<W, R>(
                                             // server-side gap when a prompt
                                             // does make it to the daemon
                                             // while another is in flight.
+                                            // Recover the text from the
+                                            // first text block; attachments
+                                            // aren't carried back into the
+                                            // retry pill (rare agent-busy
+                                            // edge, text is the retry hook).
+                                            let rejected_text = rejected_blocks
+                                                .iter()
+                                                .find_map(|b| match b {
+                                                    ContentBlock::Text(t) => Some(t.text.clone()),
+                                                    _ => None,
+                                                })
+                                                .unwrap_or_default();
                                             warn!(
                                                 target: "cockpit.acp",
                                                 "received Prompt while one is in flight; rejecting"

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1500,10 +1500,7 @@ impl AcpClient {
                     // bytes never leave the daemon so a synthetic
                     // `attachment://` uri is enough for the agent to
                     // refer to it.
-                    let uri = format!(
-                        "attachment:///{}",
-                        att.name.clone().unwrap_or_else(|| att.id.clone())
-                    );
+                    let uri = format!("attachment:///{}", att.id);
                     let blob =
                         BlobResourceContents::new(data_b64, uri).mime_type(att.mime_type.clone());
                     ContentBlock::Resource(EmbeddedResource::new(

--- a/src/cockpit/client/http.rs
+++ b/src/cockpit/client/http.rs
@@ -93,6 +93,7 @@ impl HttpClient {
         );
         let body = PromptRequest {
             text: text.to_string(),
+            attachments: Vec::new(),
         };
         let res = self.auth(self.http.post(&url)).json(&body).send().await?;
         check_status(res, session_id).await?;

--- a/src/cockpit/context_primer.rs
+++ b/src/cockpit/context_primer.rs
@@ -146,7 +146,7 @@ pub fn build_context_primer(events: &[(u64, Event)], opts: PrimerOptions) -> Con
         }
 
         match event {
-            Event::UserPromptSent { text } => {
+            Event::UserPromptSent { text, .. } => {
                 if let Some(t) = current.take() {
                     turns.push(t);
                 }
@@ -715,6 +715,7 @@ mod tests {
             seq,
             Event::UserPromptSent {
                 text: text.to_string(),
+                attachments: Vec::new(),
             },
         )
     }

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -121,7 +121,20 @@ impl EventStore {
             CREATE INDEX IF NOT EXISTS idx_cockpit_events_session_seq
                 ON cockpit_events(session_id, seq);
             CREATE INDEX IF NOT EXISTS idx_cockpit_events_session_created_at
-                ON cockpit_events(session_id, created_at);",
+                ON cockpit_events(session_id, created_at);
+            CREATE TABLE IF NOT EXISTS cockpit_attachments (
+                session_id    TEXT    NOT NULL,
+                seq           INTEGER NOT NULL,
+                attachment_id TEXT    NOT NULL,
+                kind          TEXT    NOT NULL,
+                mime_type     TEXT    NOT NULL,
+                name          TEXT,
+                data          BLOB    NOT NULL,
+                created_at    INTEGER NOT NULL,
+                PRIMARY KEY (session_id, attachment_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_cockpit_attachments_session_seq
+                ON cockpit_attachments(session_id, seq);",
         )
         .context("create cockpit_events schema")?;
         debug!(
@@ -196,38 +209,64 @@ impl EventStore {
         // See #1049. The `event_json NOT LIKE` clauses match the
         // externally-tagged JSON discriminant for each pinned variant.
         if self.max_events_per_session > 0 {
-            let prune_sql = format!(
-                "DELETE FROM cockpit_events
-                 WHERE session_id = ?1
-                   AND seq <= (
-                     SELECT seq FROM cockpit_events
+            // Compute the prune cutoff seq once so the events delete and
+            // the attachments delete agree on the same threshold. Doing
+            // the events delete first would shift the OFFSET row out from
+            // under the attachments delete and leave orphaned blobs.
+            let cutoff: Option<i64> = conn
+                .query_row(
+                    "SELECT seq FROM cockpit_events
                      WHERE session_id = ?1
                      ORDER BY seq DESC
-                     LIMIT 1 OFFSET ?2
-                   )
-                   {clauses}",
-                clauses = non_substantive_not_like_clauses()
-            );
-            match conn.execute(
-                &prune_sql,
-                params![session_id, self.max_events_per_session as i64],
-            ) {
-                Ok(0) => {}
-                Ok(pruned) => {
-                    trace!(
-                        target: "cockpit.event_store",
-                        session = %session_id,
-                        pruned,
-                        cap = self.max_events_per_session,
-                        "pruned oldest events past retention cap"
-                    );
+                     LIMIT 1 OFFSET ?2",
+                    params![session_id, self.max_events_per_session as i64],
+                    |row| row.get(0),
+                )
+                .optional()
+                .unwrap_or(None);
+            if let Some(cutoff) = cutoff {
+                // The `non_substantive_not_like_clauses()` helper pins the
+                // snapshot variants (slash-command list, mode list, ACP
+                // session id) so a long session can't evict them. See #1049.
+                let prune_sql = format!(
+                    "DELETE FROM cockpit_events
+                     WHERE session_id = ?1
+                       AND seq <= ?2
+                       {clauses}",
+                    clauses = non_substantive_not_like_clauses()
+                );
+                match conn.execute(&prune_sql, params![session_id, cutoff]) {
+                    Ok(0) => {}
+                    Ok(pruned) => {
+                        trace!(
+                            target: "cockpit.event_store",
+                            session = %session_id,
+                            pruned,
+                            cap = self.max_events_per_session,
+                            "pruned oldest events past retention cap"
+                        );
+                    }
+                    Err(e) => {
+                        // Prune failure isn't fatal; the row is recorded,
+                        // we just exceed the cap until the next prune
+                        // succeeds. Log + swallow so callers don't have to
+                        // distinguish "record failed" from "trim failed".
+                        warn!(target: "cockpit.event_store", "prune {session_id}: {e}");
+                    }
                 }
-                Err(e) => {
-                    // Prune failure isn't fatal; the row is recorded,
-                    // we just exceed the cap until the next prune
-                    // succeeds. Log + swallow so callers don't have to
-                    // distinguish "record failed" from "trim failed".
-                    warn!(target: "cockpit.event_store", "prune {session_id}: {e}");
+                // Drop attachment blobs whose owning UserPromptSent has
+                // (or is about to be) pruned. Attachments only ever hang
+                // off prompts, never the pinned snapshot variants, so a
+                // flat `seq <= cutoff` delete cannot strand a blob whose
+                // event survived. This is what keeps the attachment table
+                // bounded alongside the event log rather than growing
+                // without limit as screenshots accumulate.
+                if let Err(e) = conn.execute(
+                    "DELETE FROM cockpit_attachments
+                     WHERE session_id = ?1 AND seq <= ?2",
+                    params![session_id, cutoff],
+                ) {
+                    warn!(target: "cockpit.event_store", "prune attachments {session_id}: {e}");
                 }
             }
         }
@@ -875,6 +914,104 @@ impl EventStore {
         out
     }
 
+    /// Persist one decoded attachment blob, keyed to the seq of the
+    /// `UserPromptSent` event it rides with so the retention prune and
+    /// `delete_session` can drop it in lockstep with that event. Called
+    /// from the prompt handler before the event is published, so a
+    /// client that receives the `UserPromptSent` can immediately fetch
+    /// the blob over the GET endpoint. Idempotent on
+    /// `(session_id, attachment_id)`.
+    pub fn record_attachment(&self, session_id: &str, seq: u64, blob: &AttachmentBlob) {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if let Err(e) = conn.execute(
+            "INSERT OR IGNORE INTO cockpit_attachments
+                (session_id, seq, attachment_id, kind, mime_type, name, data, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                session_id,
+                seq as i64,
+                blob.id,
+                blob.kind.as_str(),
+                blob.mime_type,
+                blob.name,
+                blob.data,
+                now_ms,
+            ],
+        ) {
+            warn!(
+                target: "cockpit.event_store",
+                session = %session_id,
+                attachment = %blob.id,
+                "insert attachment failed: {e}"
+            );
+        }
+    }
+
+    /// Fetch one attachment's MIME type and bytes for the replay GET
+    /// endpoint. Scoped by `session_id` so a valid token for one session
+    /// can't read another session's blob by guessing ids.
+    pub fn load_attachment(
+        &self,
+        session_id: &str,
+        attachment_id: &str,
+    ) -> Option<(String, Vec<u8>)> {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        conn.query_row(
+            "SELECT mime_type, data FROM cockpit_attachments
+             WHERE session_id = ?1 AND attachment_id = ?2",
+            params![session_id, attachment_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        )
+        .optional()
+        .unwrap_or_else(|e| {
+            warn!(
+                target: "cockpit.event_store",
+                session = %session_id,
+                attachment = %attachment_id,
+                "load attachment failed: {e}"
+            );
+            None
+        })
+    }
+
+    /// Latest prompt capabilities the agent advertised for this session,
+    /// or `None` if no `PromptCapabilities` event is on disk yet. Read by
+    /// the prompt handler to reject attachments the agent cannot accept,
+    /// mirroring `latest_plan`. Returns `(image, audio, embedded_context)`.
+    pub fn latest_prompt_capabilities(&self, session_id: &str) -> Option<(bool, bool, bool)> {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let json: String = conn
+            .query_row(
+                "SELECT event_json FROM cockpit_events
+                 WHERE session_id = ?1
+                   AND event_json LIKE '{\"PromptCapabilities\":%'
+                 ORDER BY seq DESC LIMIT 1",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .ok()
+            .flatten()?;
+        match serde_json::from_str::<Event>(&json).ok()? {
+            Event::PromptCapabilities {
+                image,
+                audio,
+                embedded_context,
+            } => Some((image, audio, embedded_context)),
+            _ => None,
+        }
+    }
+
     /// Drop every event for a session. Called when the session is
     /// deleted or its substrate is switched away from cockpit, so the
     /// next cockpit_enable starts fresh from seq=1.
@@ -899,7 +1036,27 @@ impl EventStore {
                 warn!(target: "cockpit.event_store", "delete {session_id}: {e}");
             }
         }
+        // Cascade to attachment blobs so a deleted session leaves no
+        // orphaned bytes behind.
+        if let Err(e) = conn.execute(
+            "DELETE FROM cockpit_attachments WHERE session_id = ?1",
+            params![session_id],
+        ) {
+            warn!(target: "cockpit.event_store", "delete attachments {session_id}: {e}");
+        }
     }
+}
+
+/// A decoded attachment ready to persist: the storage-side counterpart
+/// of the wire `PromptAttachmentUpload`. Holds raw bytes (not base64) so
+/// the GET endpoint serves them directly. The matching metadata-only
+/// `PromptAttachmentRef` is what rides in the event log.
+pub struct AttachmentBlob {
+    pub id: String,
+    pub kind: crate::cockpit::state::PromptAttachmentKind,
+    pub mime_type: String,
+    pub name: Option<String>,
+    pub data: Vec<u8>,
 }
 
 /// Cheap discriminant string for `Event` so debug logs don't dump the
@@ -935,6 +1092,7 @@ fn event_kind(event: &Event) -> &'static str {
         Event::IncompatibleAgent { .. } => "incompatible_agent",
         Event::UserPromptSent { .. } => "user_prompt_sent",
         Event::UserDiffCommentsPrompt { .. } => "user_diff_comments_prompt",
+        Event::PromptCapabilities { .. } => "prompt_capabilities",
         Event::AcpSessionAssigned { .. } => "acp_session_assigned",
         Event::SessionContextReset { .. } => "session_context_reset",
         Event::SessionCleared => "session_cleared",
@@ -1103,14 +1261,21 @@ mod tests {
     fn duplicate_seq_is_idempotent() {
         let (_tmp, store) = open_store(1000);
         store
-            .record("s-1", 1, &Event::UserPromptSent { text: "hi".into() })
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "hi".into(),
+                    attachments: Vec::new(),
+                },
+            )
             .unwrap();
         // Second insert at the same seq must not double-count.
         store.record("s-1", 1, &Event::ThinkingStarted).unwrap();
         let replay = store.replay_from("s-1", 0);
         assert_eq!(replay.len(), 1);
         // The first write wins (INSERT OR IGNORE).
-        if let Event::UserPromptSent { text } = &replay[0].1 {
+        if let Event::UserPromptSent { text, .. } = &replay[0].1 {
             assert_eq!(text, "hi");
         } else {
             panic!("expected UserPromptSent");
@@ -1399,7 +1564,14 @@ mod tests {
     fn has_in_flight_turn_true_when_chunks_unterminated() {
         let (_tmp, store) = open_store(1000);
         store
-            .record("s-1", 1, &Event::UserPromptSent { text: "go".into() })
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "go".into(),
+                    attachments: Vec::new(),
+                },
+            )
             .unwrap();
         store
             .record(
@@ -1417,7 +1589,14 @@ mod tests {
     fn has_in_flight_turn_false_when_stopped_after_prompt() {
         let (_tmp, store) = open_store(1000);
         store
-            .record("s-1", 1, &Event::UserPromptSent { text: "go".into() })
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "go".into(),
+                    attachments: Vec::new(),
+                },
+            )
             .unwrap();
         store
             .record(
@@ -1444,7 +1623,14 @@ mod tests {
     fn has_in_flight_turn_false_when_agent_startup_error_after_prompt() {
         let (_tmp, store) = open_store(1000);
         store
-            .record("s-1", 1, &Event::UserPromptSent { text: "go".into() })
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "go".into(),
+                    attachments: Vec::new(),
+                },
+            )
             .unwrap();
         store
             .record(
@@ -1468,6 +1654,7 @@ mod tests {
                 1,
                 &Event::UserPromptSent {
                     text: "first".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();
@@ -1486,6 +1673,7 @@ mod tests {
                 3,
                 &Event::UserPromptSent {
                     text: "second".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();
@@ -1511,6 +1699,7 @@ mod tests {
                 1,
                 &Event::UserPromptSent {
                     text: "schedule a wake in 2m".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();
@@ -1531,6 +1720,7 @@ mod tests {
                 3,
                 &Event::UserPromptSent {
                     text: "btw, ping me when you wake".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();
@@ -1599,6 +1789,7 @@ mod tests {
                 1,
                 &Event::UserPromptSent {
                     text: "schedule a wake".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();
@@ -1619,6 +1810,7 @@ mod tests {
                 3,
                 &Event::UserPromptSent {
                     text: "ping me when you wake".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();
@@ -1648,6 +1840,7 @@ mod tests {
                 2,
                 &Event::UserPromptSent {
                     text: "Wake-up fired. Confirm.".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();
@@ -1672,6 +1865,7 @@ mod tests {
                 2,
                 &Event::UserPromptSent {
                     text: "first prompt past at".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();
@@ -1681,6 +1875,7 @@ mod tests {
                 3,
                 &Event::UserPromptSent {
                     text: "second prompt past at".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();
@@ -1703,6 +1898,7 @@ mod tests {
                     1,
                     &Event::UserPromptSent {
                         text: "hello".into(),
+                        attachments: Vec::new(),
                     },
                 )
                 .unwrap();
@@ -1731,7 +1927,14 @@ mod tests {
     fn latest_status_event_returns_most_recent_lifecycle_event() {
         let (_tmp, store) = open_store(1000);
         store
-            .record("s-1", 1, &Event::UserPromptSent { text: "hi".into() })
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "hi".into(),
+                    attachments: Vec::new(),
+                },
+            )
             .unwrap();
         store.record("s-1", 2, &Event::ThinkingStarted).unwrap();
         store.record("s-1", 3, &Event::ThinkingEnded).unwrap();
@@ -1739,7 +1942,7 @@ mod tests {
         let latest = store.latest_status_event("s-1");
         assert!(matches!(
             latest,
-            Some(Event::UserPromptSent { text }) if text == "hi"
+            Some(Event::UserPromptSent { text, .. }) if text == "hi"
         ));
 
         // Stopped at seq 4 takes over as the most recent lifecycle event.

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -1115,6 +1115,136 @@ mod tests {
         (tmp, store)
     }
 
+    fn img_blob(id: &str) -> AttachmentBlob {
+        AttachmentBlob {
+            id: id.to_string(),
+            kind: crate::cockpit::state::PromptAttachmentKind::Image,
+            mime_type: "image/png".into(),
+            name: Some("shot.png".into()),
+            data: vec![0x89, 0x50, 0x4E, 0x47, 1, 2, 3],
+        }
+    }
+
+    fn prompt_with_attachment(id: &str) -> Event {
+        Event::UserPromptSent {
+            text: "look at this".into(),
+            attachments: vec![crate::cockpit::state::PromptAttachmentRef {
+                id: id.to_string(),
+                kind: crate::cockpit::state::PromptAttachmentKind::Image,
+                mime_type: "image/png".into(),
+                name: Some("shot.png".into()),
+                size: 7,
+            }],
+        }
+    }
+
+    #[test]
+    fn attachment_record_and_load_roundtrip() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record("s-1", 1, &prompt_with_attachment("a1"))
+            .unwrap();
+        store.record_attachment("s-1", 1, &img_blob("a1"));
+        let (mime, bytes) = store.load_attachment("s-1", "a1").expect("blob present");
+        assert_eq!(mime, "image/png");
+        assert_eq!(bytes, vec![0x89, 0x50, 0x4E, 0x47, 1, 2, 3]);
+        // Wrong session must not read another session's blob by id.
+        assert!(store.load_attachment("s-2", "a1").is_none());
+        // Unknown id is None.
+        assert!(store.load_attachment("s-1", "nope").is_none());
+    }
+
+    #[test]
+    fn attachment_pruned_with_owning_prompt() {
+        // The user's explicit requirement: the attachment table must
+        // not grow without bound. When the retention cap evicts the
+        // prompt event an attachment rode with, the blob must go too.
+        let (_tmp, store) = open_store(3);
+        store
+            .record("s-1", 1, &prompt_with_attachment("a1"))
+            .unwrap();
+        store.record_attachment("s-1", 1, &img_blob("a1"));
+        assert!(store.load_attachment("s-1", "a1").is_some());
+        // Blow past the cap so seq 1 is pruned.
+        for i in 2..=20 {
+            store.record("s-1", i, &Event::ThinkingStarted).unwrap();
+        }
+        assert!(
+            store.load_attachment("s-1", "a1").is_none(),
+            "attachment blob outlived its pruned prompt event",
+        );
+    }
+
+    #[test]
+    fn delete_session_clears_attachments() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record("s-1", 1, &prompt_with_attachment("a1"))
+            .unwrap();
+        store.record_attachment("s-1", 1, &img_blob("a1"));
+        store
+            .record("s-2", 1, &prompt_with_attachment("b1"))
+            .unwrap();
+        store.record_attachment("s-2", 1, &img_blob("b1"));
+        store.delete_session("s-1");
+        assert!(store.load_attachment("s-1", "a1").is_none());
+        // Sibling session untouched.
+        assert!(store.load_attachment("s-2", "b1").is_some());
+    }
+
+    #[test]
+    fn latest_prompt_capabilities_reads_most_recent() {
+        let (_tmp, store) = open_store(1000);
+        assert_eq!(store.latest_prompt_capabilities("s-1"), None);
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::PromptCapabilities {
+                    image: true,
+                    audio: false,
+                    embedded_context: true,
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            store.latest_prompt_capabilities("s-1"),
+            Some((true, false, true))
+        );
+        // A later capabilities event (e.g. after agent switch) wins.
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::PromptCapabilities {
+                    image: false,
+                    audio: false,
+                    embedded_context: false,
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            store.latest_prompt_capabilities("s-1"),
+            Some((false, false, false))
+        );
+    }
+
+    #[test]
+    fn user_prompt_event_deserialises_without_attachments_field() {
+        // Back-compat: events written before this feature have no
+        // `attachments` key. `#[serde(default)]` must hydrate them as
+        // text-only rather than failing the whole replay.
+        let json = r#"{"UserPromptSent":{"text":"legacy"}}"#;
+        let event: Event = serde_json::from_str(json).expect("legacy event deserialises");
+        match event {
+            Event::UserPromptSent { text, attachments } => {
+                assert_eq!(text, "legacy");
+                assert!(attachments.is_empty());
+            }
+            other => panic!("expected UserPromptSent, got {other:?}"),
+        }
+    }
+
     #[test]
     fn record_and_replay_roundtrip() {
         let (_tmp, store) = open_store(1000);

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -951,6 +951,27 @@ impl EventStore {
         }
     }
 
+    /// Drop all attachment blobs owned by one prompt seq. Used as a
+    /// rollback when `UserPromptSent` could not be durably persisted, so
+    /// attachment refs and blobs stay in sync.
+    pub fn delete_attachments_for_seq(&self, session_id: &str, seq: u64) {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if let Err(e) = conn.execute(
+            "DELETE FROM cockpit_attachments WHERE session_id = ?1 AND seq = ?2",
+            params![session_id, seq as i64],
+        ) {
+            warn!(
+                target: "cockpit.event_store",
+                session = %session_id,
+                seq,
+                "rollback attachments failed: {e}"
+            );
+        }
+    }
+
     /// Fetch one attachment's MIME type and bytes for the replay GET
     /// endpoint. Scoped by `session_id` so a valid token for one session
     /// can't read another session's blob by guessing ids.
@@ -1289,6 +1310,7 @@ mod tests {
                 1,
                 &Event::UserPromptSent {
                     text: "hello".into(),
+                    attachments: Vec::new(),
                 },
             )
             .unwrap();

--- a/src/cockpit/protocol.rs
+++ b/src/cockpit/protocol.rs
@@ -254,6 +254,29 @@ mod tests {
     use super::*;
 
     #[test]
+    fn prompt_request_defaults_attachments_when_absent() {
+        // Text-only clients (and the CLI/TUI cockpit HTTP client) send
+        // `{"text":"..."}` with no attachments key; it must deserialise.
+        let req: PromptRequest = serde_json::from_str(r#"{"text":"hello"}"#).unwrap();
+        assert_eq!(req.text, "hello");
+        assert!(req.attachments.is_empty());
+    }
+
+    #[test]
+    fn prompt_attachment_upload_roundtrips() {
+        let req: PromptRequest = serde_json::from_str(
+            r#"{"text":"see this","attachments":[{"kind":"image","mime_type":"image/png","data":"aGk=","name":"a.png"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(req.attachments.len(), 1);
+        let att = &req.attachments[0];
+        assert_eq!(att.kind, PromptAttachmentKind::Image);
+        assert_eq!(att.mime_type, "image/png");
+        assert_eq!(att.data, "aGk=");
+        assert_eq!(att.name.as_deref(), Some("a.png"));
+    }
+
+    #[test]
     fn broadcast_frame_roundtrips_through_json() {
         let frame = CockpitBroadcastFrame {
             session_id: "s-1".into(),

--- a/src/cockpit/protocol.rs
+++ b/src/cockpit/protocol.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use super::approvals::ApprovalDecision;
-use super::state::{DiffComment, Event};
+use super::state::{DiffComment, Event, PromptAttachmentKind};
 
 /// One frame on the per-AppState cockpit broadcast channel: the cockpit
 /// session id plus the typed cockpit Event. Subscribed WebSocket
@@ -64,10 +64,32 @@ impl<'de> Deserialize<'de> for CockpitBroadcastFrame {
     }
 }
 
+/// One attachment as the web composer uploads it: the raw base64 bytes
+/// inline in the prompt POST. This is the untrusted request shape; the
+/// server decodes it, sniffs the magic bytes, enforces size/MIME/count
+/// caps and the agent's capability gate, then maps it to an ACP
+/// `ContentBlock` for the agent and a metadata-only
+/// `PromptAttachmentRef` for replay. Bytes never reach the event log.
+/// See #1000 / #965.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptAttachmentUpload {
+    pub kind: PromptAttachmentKind,
+    pub mime_type: String,
+    /// Standard base64 (no `data:` URL prefix). The client strips the
+    /// prefix before sending.
+    pub data: String,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
 /// `POST /api/sessions/{id}/cockpit/prompt` body.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PromptRequest {
     pub text: String,
+    /// `#[serde(default)]` so text-only clients (and the TUI cockpit
+    /// verb) keep working unchanged.
+    #[serde(default)]
+    pub attachments: Vec<PromptAttachmentUpload>,
 }
 
 /// `POST /api/sessions/{id}/cockpit/prompt/diff-comments` body.

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -402,6 +402,49 @@ pub struct DiffComment {
     pub updated_at: Option<String>,
 }
 
+/// Which ACP `ContentBlock` an attachment maps to. The string form
+/// (`"image"` / `"audio"` / `"resource"`) is the wire contract shared
+/// with the web composer and the prompt-request DTO in `protocol.rs`,
+/// so renaming a variant breaks the build on both sides rather than
+/// silently dropping attachments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PromptAttachmentKind {
+    Image,
+    Audio,
+    Resource,
+}
+
+impl PromptAttachmentKind {
+    /// Stable lowercase tag, matching the serde wire form. Used by the
+    /// attachment store to persist the kind as a TEXT column.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PromptAttachmentKind::Image => "image",
+            PromptAttachmentKind::Audio => "audio",
+            PromptAttachmentKind::Resource => "resource",
+        }
+    }
+}
+
+/// Replay-side view of one prompt attachment. Carries metadata only,
+/// never the bytes: the decoded blob lives in the `cockpit_attachments`
+/// table keyed by `(session_id, id)` and is fetched lazily over
+/// `GET /cockpit/attachments/{id}`. Keeping bytes out of the event log
+/// is what stops `event_json` (and every WS replay frame) from bloating
+/// to megabytes per screenshot. See #1000 / #965.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PromptAttachmentRef {
+    pub id: String,
+    pub kind: PromptAttachmentKind,
+    pub mime_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Decoded byte length, for the UI to show a size hint without
+    /// fetching the blob.
+    pub size: u64,
+}
+
 /// Discriminated union of state mutations. ACP `session/update`
 /// notifications become specific variants; client approval taps also
 /// become variants and flow through the same path.
@@ -595,6 +638,26 @@ pub enum Event {
     /// every turn collapses into one assistant blob.
     UserPromptSent {
         text: String,
+        /// Attachments the user sent alongside the text (images, audio,
+        /// embedded resources). Metadata only; bytes live in the
+        /// `cockpit_attachments` store. `#[serde(default)]` keeps
+        /// pre-attachment events on disk deserialising as text-only, so
+        /// no migration is needed. See #1000 / #965.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attachments: Vec<PromptAttachmentRef>,
+    },
+    /// The agent's prompt capabilities, captured from the ACP
+    /// `initialize` response right after the handshake (and re-emitted
+    /// on every connect, since `initialize` runs in both Fresh and
+    /// Resume modes). Persisted + replayed so the web composer can gate
+    /// the attachment button on the current agent without a round-trip,
+    /// and so a reconnecting client reconstructs the gate from history.
+    /// The server prompt handler reads the latest one to reject
+    /// attachments an agent cannot accept. See #1000.
+    PromptCapabilities {
+        image: bool,
+        audio: bool,
+        embedded_context: bool,
     },
     /// Echo of a "Send diff comments" submission, published by the
     /// `POST /cockpit/prompt/diff-comments` handler before
@@ -815,6 +878,11 @@ impl CockpitState {
             // persistent CockpitState; it bumps seq so the replay buffer
             // and on-disk store capture the user's side of the turn.
             Event::UserDiffCommentsPrompt { .. } => {}
+            // Surfaced to the web composer via replay and read by the
+            // server prompt handler from the event store; no persistent
+            // CockpitState field consumes it, so this arm only bumps
+            // seq/updated_at like the streaming events above.
+            Event::PromptCapabilities { .. } => {}
             Event::AcpSessionAssigned { .. } => {
                 // A fresh agent that passed the compatibility check
                 // has come online; heal any sticky startup error so a

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -179,6 +179,18 @@ pub trait BroadcastSink: Send + Sync + 'static {
     fn unresolved_approval_nonces(&self, _session_id: &str) -> Vec<Nonce> {
         Vec::new()
     }
+    /// Persist one prompt attachment blob keyed to the seq of the
+    /// `UserPromptSent` it rides with, so the retention prune and
+    /// session delete drop it in lockstep. Default no-op so test sinks
+    /// without an event store opt out cleanly, mirroring
+    /// `unresolved_approval_nonces`. See #1000 / #965.
+    fn record_attachment(
+        &self,
+        _session_id: &str,
+        _seq: u64,
+        _blob: &crate::cockpit::event_store::AttachmentBlob,
+    ) {
+    }
 }
 
 /// How this supervisor acquired the worker. Drives both reap (which
@@ -680,12 +692,44 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// is text-based but routed through the session's `AgentProfile`
     /// so each agent's aliases match the right surface. See #1101.
     pub async fn publish_user_prompt(&self, session_id: &str, text: String) {
+        self.publish_user_prompt_with_attachments(session_id, text, &[])
+            .await;
+    }
+
+    /// Like `publish_user_prompt` but also persists the prompt's
+    /// attachment blobs (keyed to the same seq as the `UserPromptSent`)
+    /// and records metadata-only refs on the event so replay can render
+    /// them. The bytes never enter the event JSON; only the refs do.
+    /// See #1000 / #965.
+    pub async fn publish_user_prompt_with_attachments(
+        &self,
+        session_id: &str,
+        text: String,
+        attachments: &[crate::cockpit::event_store::AttachmentBlob],
+    ) {
         let agent_key = self.agent_key_for_session(session_id).await;
         let profile = super::agent_profiles::resolve(&agent_key);
         let is_clear = profile.is_clear_command(&text);
         let seq = next_seq(&self.next_seqs, session_id);
-        self.sink
-            .publish(session_id, seq, &Event::UserPromptSent { text });
+        let mut refs = Vec::with_capacity(attachments.len());
+        for blob in attachments {
+            self.sink.record_attachment(session_id, seq, blob);
+            refs.push(crate::cockpit::state::PromptAttachmentRef {
+                id: blob.id.clone(),
+                kind: blob.kind,
+                mime_type: blob.mime_type.clone(),
+                name: blob.name.clone(),
+                size: blob.data.len() as u64,
+            });
+        }
+        self.sink.publish(
+            session_id,
+            seq,
+            &Event::UserPromptSent {
+                text,
+                attachments: refs,
+            },
+        );
         if is_clear {
             let seq = next_seq(&self.next_seqs, session_id);
             self.sink.publish(session_id, seq, &Event::SessionCleared);
@@ -1483,12 +1527,18 @@ impl<S: BroadcastSink> Supervisor<S> {
             .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
     }
 
-    /// Send a user prompt to a running cockpit worker.
-    pub async fn send_prompt(&self, session_id: &str, text: &str) -> Result<(), SupervisorError> {
+    /// Send a user prompt (with optional attachments) to a running
+    /// cockpit worker.
+    pub async fn send_prompt(
+        &self,
+        session_id: &str,
+        text: &str,
+        attachments: &[crate::cockpit::event_store::AttachmentBlob],
+    ) -> Result<(), SupervisorError> {
         self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
             .await;
         let client = self.client_for_session(session_id).await?;
-        client.send_prompt(text).await?;
+        client.send_prompt(text, attachments).await?;
         Ok(())
     }
 
@@ -2265,6 +2315,15 @@ impl BroadcastSink for ChannelSink {
     fn unresolved_approval_nonces(&self, session_id: &str) -> Vec<Nonce> {
         self.event_store.unresolved_approval_nonces(session_id)
     }
+
+    fn record_attachment(
+        &self,
+        session_id: &str,
+        seq: u64,
+        blob: &crate::cockpit::event_store::AttachmentBlob,
+    ) {
+        self.event_store.record_attachment(session_id, seq, blob);
+    }
 }
 
 #[cfg(test)]
@@ -2932,7 +2991,7 @@ mod tests {
         assert_eq!(frames.len(), 2);
         assert!(matches!(
             &frames[0].2,
-            Event::UserPromptSent { text } if text == "/clear"
+            Event::UserPromptSent { text, .. } if text == "/clear"
         ));
         assert!(matches!(&frames[1].2, Event::SessionCleared));
         assert_eq!(frames[1].1, 2, "SessionCleared must use the next seq");
@@ -3095,13 +3154,13 @@ mod tests {
         assert_eq!(*seq, 1);
         assert!(matches!(
             event,
-            Event::UserPromptSent { text } if text == "first prompt"
+            Event::UserPromptSent { text, .. } if text == "first prompt"
         ));
         let (_, seq2, event2) = &frames[1];
         assert_eq!(*seq2, 2);
         assert!(matches!(
             event2,
-            Event::UserPromptSent { text } if text == "second prompt"
+            Event::UserPromptSent { text, .. } if text == "second prompt"
         ));
     }
 
@@ -3495,6 +3554,7 @@ mod tests {
             1,
             &Event::UserPromptSent {
                 text: "hello world".into(),
+                attachments: Vec::new(),
             },
         );
         sink.publish(
@@ -3518,7 +3578,7 @@ mod tests {
         assert_eq!(stored[0].0, 1);
         assert!(matches!(
             stored[0].1,
-            Event::UserPromptSent { ref text } if text == "hello world"
+            Event::UserPromptSent { ref text, .. } if text == "hello world"
         ));
         assert_eq!(stored[1].0, 2);
         assert!(matches!(
@@ -3583,7 +3643,7 @@ mod tests {
         let texts: Vec<String> = stored
             .iter()
             .filter_map(|(_, ev)| match ev {
-                Event::UserPromptSent { text } => Some(text.clone()),
+                Event::UserPromptSent { text, .. } => Some(text.clone()),
                 _ => None,
             })
             .collect();

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -171,6 +171,13 @@ pub enum SupervisorError {
 /// See #1038.
 pub trait BroadcastSink: Send + Sync + 'static {
     fn publish(&self, session_id: &str, seq: u64, event: &Event);
+    /// Like `publish`, but reports whether the event write reached the
+    /// durable event store. Default assumes success for sinks that don't
+    /// persist (tests / in-memory fixtures).
+    fn publish_persisted(&self, session_id: &str, seq: u64, event: &Event) -> bool {
+        self.publish(session_id, seq, event);
+        true
+    }
     /// Approval nonces from `ApprovalRequested` events on disk with no
     /// matching `ApprovalResolved`. Used by `Supervisor::attach` to
     /// cancel approvals whose responder died with the previous daemon.
@@ -191,6 +198,10 @@ pub trait BroadcastSink: Send + Sync + 'static {
         _blob: &crate::cockpit::event_store::AttachmentBlob,
     ) {
     }
+    /// Roll back blobs for one prompt seq. Used when publishing the
+    /// matching `UserPromptSent` fails durability, so refs and blobs
+    /// never diverge on disk.
+    fn delete_attachments_for_seq(&self, _session_id: &str, _seq: u64) {}
 }
 
 /// How this supervisor acquired the worker. Drives both reap (which
@@ -722,7 +733,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                 size: blob.data.len() as u64,
             });
         }
-        self.sink.publish(
+        let persisted = self.sink.publish_persisted(
             session_id,
             seq,
             &Event::UserPromptSent {
@@ -730,6 +741,10 @@ impl<S: BroadcastSink> Supervisor<S> {
                 attachments: refs,
             },
         );
+        if !persisted {
+            self.sink.delete_attachments_for_seq(session_id, seq);
+            return;
+        }
         if is_clear {
             let seq = next_seq(&self.next_seqs, session_id);
             self.sink.publish(session_id, seq, &Event::SessionCleared);
@@ -2262,6 +2277,10 @@ pub struct ChannelSink {
 
 impl BroadcastSink for ChannelSink {
     fn publish(&self, session_id: &str, seq: u64, event: &Event) {
+        let _ = self.publish_persisted(session_id, seq, event);
+    }
+
+    fn publish_persisted(&self, session_id: &str, seq: u64, event: &Event) -> bool {
         // Persist FIRST so a disk failure can be surfaced before
         // broadcast subscribers see an event the on-disk log doesn't
         // have. If the write fails the seq is already burned (the
@@ -2288,6 +2307,7 @@ impl BroadcastSink for ChannelSink {
             }
             _ => self.event_store.record(session_id, seq, event),
         };
+        let persisted = record_result.is_ok();
         let event_ref: &Event = match record_result {
             Ok(()) => event,
             Err(e) => {
@@ -2310,6 +2330,7 @@ impl BroadcastSink for ChannelSink {
             event: Arc::new(event_ref.clone()),
         };
         let _ = self.tx.send(frame);
+        persisted
     }
 
     fn unresolved_approval_nonces(&self, session_id: &str) -> Vec<Nonce> {
@@ -2322,7 +2343,25 @@ impl BroadcastSink for ChannelSink {
         seq: u64,
         blob: &crate::cockpit::event_store::AttachmentBlob,
     ) {
-        self.event_store.record_attachment(session_id, seq, blob);
+        match tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()) {
+            Ok(tokio::runtime::RuntimeFlavor::MultiThread) => {
+                tokio::task::block_in_place(|| {
+                    self.event_store.record_attachment(session_id, seq, blob)
+                });
+            }
+            _ => self.event_store.record_attachment(session_id, seq, blob),
+        }
+    }
+
+    fn delete_attachments_for_seq(&self, session_id: &str, seq: u64) {
+        match tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()) {
+            Ok(tokio::runtime::RuntimeFlavor::MultiThread) => {
+                tokio::task::block_in_place(|| {
+                    self.event_store.delete_attachments_for_seq(session_id, seq)
+                });
+            }
+            _ => self.event_store.delete_attachments_for_seq(session_id, seq),
+        }
     }
 }
 

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1619,6 +1619,38 @@ mod tests {
     use std::io::Write;
 
     #[test]
+    fn mime_allowlist_gates_by_kind() {
+        assert!(mime_allowed(PromptAttachmentKind::Image, "image/png"));
+        assert!(mime_allowed(PromptAttachmentKind::Image, "image/webp"));
+        // SVG is excluded on purpose (scriptable XML).
+        assert!(!mime_allowed(PromptAttachmentKind::Image, "image/svg+xml"));
+        // Cross-kind MIME is rejected.
+        assert!(!mime_allowed(PromptAttachmentKind::Image, "audio/mpeg"));
+        assert!(mime_allowed(PromptAttachmentKind::Audio, "audio/mpeg"));
+        assert!(mime_allowed(
+            PromptAttachmentKind::Resource,
+            "application/pdf"
+        ));
+        assert!(!mime_allowed(PromptAttachmentKind::Resource, "text/html"));
+    }
+
+    #[test]
+    fn image_magic_bytes_sniff() {
+        assert!(looks_like_image(&[
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+        ]));
+        assert!(looks_like_image(&[0xFF, 0xD8, 0xFF, 0xE0]));
+        assert!(looks_like_image(b"GIF89a....."));
+        let mut webp = b"RIFF".to_vec();
+        webp.extend_from_slice(&[0, 0, 0, 0]);
+        webp.extend_from_slice(b"WEBP");
+        assert!(looks_like_image(&webp));
+        // A text blob mislabeled as PNG must not pass.
+        assert!(!looks_like_image(b"<svg>not an image</svg>"));
+        assert!(!looks_like_image(b""));
+    }
+
+    #[test]
     fn read_log_tail_missing_file_returns_empty_not_error() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("missing.log");

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -15,9 +15,9 @@ use serde::{Deserialize, Serialize};
 use crate::cockpit::approvals::Nonce;
 use crate::cockpit::event_store::AttachmentBlob;
 use crate::cockpit::protocol::{
-    ContextPrimerQuery, ContextPrimerResponse, PromptAttachmentUpload, PromptRequest, ReplayQuery,
-    ReplayResponse, ResolveApprovalRequest, SwitchAgentRequest, SwitchAgentResponse,
-    DiffCommentsPromptRequest,
+    ContextPrimerQuery, ContextPrimerResponse, DiffCommentsPromptRequest, PromptAttachmentUpload,
+    PromptRequest, ReplayQuery, ReplayResponse, ResolveApprovalRequest, SwitchAgentRequest,
+    SwitchAgentResponse,
 };
 use crate::cockpit::state::PromptAttachmentKind;
 use crate::cockpit::supervisor::SupervisorError;
@@ -57,12 +57,18 @@ fn mime_allowed(kind: PromptAttachmentKind, mime: &str) -> bool {
 /// True if `bytes` start with a magic-number signature for a supported
 /// raster image. Guards against a client mislabeling arbitrary bytes as
 /// `image/png` to smuggle them past the allowlist.
-fn looks_like_image(bytes: &[u8]) -> bool {
-    let png = bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
-    let jpeg = bytes.starts_with(&[0xFF, 0xD8, 0xFF]);
-    let gif = bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a");
-    let webp = bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP";
-    png || jpeg || gif || webp
+fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        Some("image/png")
+    } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg")
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some("image/gif")
+    } else if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        Some("image/webp")
+    } else {
+        None
+    }
 }
 
 /// Decode, size-check, MIME-check, magic-byte-sniff and capability-gate
@@ -144,11 +150,19 @@ fn validate_attachments(
                 ),
             ));
         }
-        if up.kind == PromptAttachmentKind::Image && !looks_like_image(&bytes) {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "attachment bytes are not a supported image".to_string(),
-            ));
+        if up.kind == PromptAttachmentKind::Image {
+            let Some(sniffed_mime) = sniff_image_mime(&bytes) else {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "attachment bytes are not a supported image".to_string(),
+                ));
+            };
+            if sniffed_mime != up.mime_type {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "attachment MIME does not match declared content-type".to_string(),
+                ));
+            }
         }
         total += bytes.len();
         if total > MAX_TOTAL_ATTACHMENT_BYTES {
@@ -680,6 +694,12 @@ pub async fn cockpit_prompt(
         Err(rej) => return rej.into_response(),
     };
     touch_and_wake_if_sunk(&state, &id).await;
+    {
+        let instances = state.instances.read().await;
+        if !instances.iter().any(|i| i.id == id) {
+            return (StatusCode::NOT_FOUND, "session not found").into_response();
+        }
+    }
     // Decode + validate + capability-gate attachments BEFORE publishing
     // so a rejected prompt never leaves a half-rendered attachment in
     // the transcript (the publish path is otherwise authoritative). See
@@ -1636,18 +1656,31 @@ mod tests {
 
     #[test]
     fn image_magic_bytes_sniff() {
-        assert!(looks_like_image(&[
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
-        ]));
-        assert!(looks_like_image(&[0xFF, 0xD8, 0xFF, 0xE0]));
-        assert!(looks_like_image(b"GIF89a....."));
+        assert_eq!(
+            sniff_image_mime(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+            Some("image/png")
+        );
+        assert_eq!(
+            sniff_image_mime(&[0xFF, 0xD8, 0xFF, 0xE0]),
+            Some("image/jpeg")
+        );
+        assert_eq!(sniff_image_mime(b"GIF89a....."), Some("image/gif"));
         let mut webp = b"RIFF".to_vec();
         webp.extend_from_slice(&[0, 0, 0, 0]);
         webp.extend_from_slice(b"WEBP");
-        assert!(looks_like_image(&webp));
+        assert_eq!(sniff_image_mime(&webp), Some("image/webp"));
         // A text blob mislabeled as PNG must not pass.
-        assert!(!looks_like_image(b"<svg>not an image</svg>"));
-        assert!(!looks_like_image(b""));
+        assert_eq!(sniff_image_mime(b"<svg>not an image</svg>"), None);
+        assert_eq!(sniff_image_mime(b""), None);
+    }
+
+    #[test]
+    fn image_magic_bytes_predicate() {
+        assert!(sniff_image_mime(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]).is_some());
+        assert!(sniff_image_mime(&[0xFF, 0xD8, 0xFF, 0xE0]).is_some());
+        assert!(sniff_image_mime(b"GIF89a.....").is_some());
+        assert!(sniff_image_mime(b"<svg>not an image</svg>").is_none());
+        assert!(sniff_image_mime(b"").is_none());
     }
 
     #[test]

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -13,12 +13,163 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use crate::cockpit::approvals::Nonce;
+use crate::cockpit::event_store::AttachmentBlob;
 use crate::cockpit::protocol::{
-    ContextPrimerQuery, ContextPrimerResponse, DiffCommentsPromptRequest, PromptRequest,
-    ReplayQuery, ReplayResponse, ResolveApprovalRequest, SwitchAgentRequest, SwitchAgentResponse,
+    ContextPrimerQuery, ContextPrimerResponse, PromptAttachmentUpload, PromptRequest, ReplayQuery,
+    ReplayResponse, ResolveApprovalRequest, SwitchAgentRequest, SwitchAgentResponse,
+    DiffCommentsPromptRequest,
 };
+use crate::cockpit::state::PromptAttachmentKind;
 use crate::cockpit::supervisor::SupervisorError;
 use crate::server::AppState;
+
+/// Maximum attachments per prompt.
+const MAX_ATTACHMENTS: usize = 8;
+/// Maximum decoded size of a single attachment (10 MiB).
+const MAX_ATTACHMENT_BYTES: usize = 10 * 1024 * 1024;
+/// Maximum decoded size of all attachments on one prompt (20 MiB).
+const MAX_TOTAL_ATTACHMENT_BYTES: usize = 20 * 1024 * 1024;
+
+/// MIME types accepted per attachment kind. Conservative on purpose:
+/// `image/svg+xml` is excluded (scriptable XML), and embedded resources
+/// are limited to inert text/document types. The image kind is also
+/// magic-byte sniffed; a declared MIME that the bytes don't back is
+/// rejected. See #1000 / #965 and the design debate.
+fn mime_allowed(kind: PromptAttachmentKind, mime: &str) -> bool {
+    match kind {
+        PromptAttachmentKind::Image => {
+            matches!(
+                mime,
+                "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+            )
+        }
+        PromptAttachmentKind::Audio => matches!(
+            mime,
+            "audio/mpeg" | "audio/wav" | "audio/x-wav" | "audio/webm" | "audio/ogg" | "audio/mp4"
+        ),
+        PromptAttachmentKind::Resource => matches!(
+            mime,
+            "text/plain" | "text/markdown" | "application/json" | "application/pdf"
+        ),
+    }
+}
+
+/// True if `bytes` start with a magic-number signature for a supported
+/// raster image. Guards against a client mislabeling arbitrary bytes as
+/// `image/png` to smuggle them past the allowlist.
+fn looks_like_image(bytes: &[u8]) -> bool {
+    let png = bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+    let jpeg = bytes.starts_with(&[0xFF, 0xD8, 0xFF]);
+    let gif = bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a");
+    let webp = bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP";
+    png || jpeg || gif || webp
+}
+
+/// Decode, size-check, MIME-check, magic-byte-sniff and capability-gate
+/// the uploaded attachments. Returns the decoded blobs ready to persist
+/// and forward, or an HTTP `(status, message)` to return verbatim.
+/// Runs entirely before the prompt is published so a rejected prompt
+/// never leaves a half-rendered attachment in the transcript.
+fn validate_attachments(
+    state: &AppState,
+    session_id: &str,
+    uploads: &[PromptAttachmentUpload],
+) -> Result<Vec<AttachmentBlob>, (StatusCode, String)> {
+    use base64::Engine as _;
+    if uploads.is_empty() {
+        return Ok(Vec::new());
+    }
+    if uploads.len() > MAX_ATTACHMENTS {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("too many attachments (max {MAX_ATTACHMENTS})"),
+        ));
+    }
+    // Capability gate: the agent must advertise the matching prompt
+    // capability. `None` means the handshake hasn't reported caps yet;
+    // reject rather than forward bytes the agent may not accept.
+    let caps = state
+        .cockpit_event_store
+        .latest_prompt_capabilities(session_id);
+    let (image_ok, audio_ok, embedded_ok) = match caps {
+        Some(c) => c,
+        None => {
+            return Err((
+                StatusCode::CONFLICT,
+                "agent capabilities not known yet; cannot accept attachments".to_string(),
+            ))
+        }
+    };
+
+    let mut blobs = Vec::with_capacity(uploads.len());
+    let mut total = 0usize;
+    for up in uploads {
+        let kind_ok = match up.kind {
+            PromptAttachmentKind::Image => image_ok,
+            PromptAttachmentKind::Audio => audio_ok,
+            PromptAttachmentKind::Resource => embedded_ok,
+        };
+        if !kind_ok {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "the current agent does not accept {} attachments",
+                    up.kind.as_str()
+                ),
+            ));
+        }
+        if !mime_allowed(up.kind, &up.mime_type) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("unsupported attachment type: {}", up.mime_type),
+            ));
+        }
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(up.data.as_bytes())
+            .map_err(|_| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "attachment is not valid base64".to_string(),
+                )
+            })?;
+        if bytes.is_empty() {
+            return Err((StatusCode::BAD_REQUEST, "empty attachment".to_string()));
+        }
+        if bytes.len() > MAX_ATTACHMENT_BYTES {
+            return Err((
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!(
+                    "attachment exceeds {} MiB limit",
+                    MAX_ATTACHMENT_BYTES / (1024 * 1024)
+                ),
+            ));
+        }
+        if up.kind == PromptAttachmentKind::Image && !looks_like_image(&bytes) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "attachment bytes are not a supported image".to_string(),
+            ));
+        }
+        total += bytes.len();
+        if total > MAX_TOTAL_ATTACHMENT_BYTES {
+            return Err((
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!(
+                    "attachments exceed {} MiB total limit",
+                    MAX_TOTAL_ATTACHMENT_BYTES / (1024 * 1024)
+                ),
+            ));
+        }
+        blobs.push(AttachmentBlob {
+            id: uuid::Uuid::new_v4().to_string(),
+            kind: up.kind,
+            mime_type: up.mime_type.clone(),
+            name: up.name.clone(),
+            data: bytes,
+        });
+    }
+    Ok(blobs)
+}
 
 #[derive(Debug, Deserialize)]
 pub struct SpawnCockpitRequest {
@@ -529,15 +680,27 @@ pub async fn cockpit_prompt(
         Err(rej) => return rej.into_response(),
     };
     touch_and_wake_if_sunk(&state, &id).await;
+    // Decode + validate + capability-gate attachments BEFORE publishing
+    // so a rejected prompt never leaves a half-rendered attachment in
+    // the transcript (the publish path is otherwise authoritative). See
+    // #1000 / #965.
+    let attachments = match validate_attachments(&state, &id, &req.attachments) {
+        Ok(a) => a,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
     // Publish the user's prompt into the event stream BEFORE forwarding
     // to the agent so the replay buffer / on-disk store captures it
     // even if the agent forward fails. The frontend treats UserPromptSent
     // as authoritative and dedupes against its own optimistic row.
     state
         .cockpit_supervisor
-        .publish_user_prompt(&id, req.text.clone())
+        .publish_user_prompt_with_attachments(&id, req.text.clone(), &attachments)
         .await;
-    match state.cockpit_supervisor.send_prompt(&id, &req.text).await {
+    match state
+        .cockpit_supervisor
+        .send_prompt(&id, &req.text, &attachments)
+        .await
+    {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
         Err(SupervisorError::UnknownSession(_)) => {
             (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()
@@ -587,7 +750,7 @@ pub async fn cockpit_prompt_diff_comments(
         .await;
     match state
         .cockpit_supervisor
-        .send_prompt(&id, &req.assembled_markdown)
+        .send_prompt(&id, &req.assembled_markdown, &[])
         .await
     {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
@@ -599,6 +762,37 @@ pub async fn cockpit_prompt_diff_comments(
             format!("prompt failed: {e}"),
         )
             .into_response(),
+    }
+}
+
+/// Serve one persisted prompt attachment's bytes for transcript replay.
+/// Scoped by session id so a token valid for one session can't read
+/// another's blob by guessing the attachment id. Inherits the global
+/// auth middleware. See #1000 / #965.
+pub async fn cockpit_attachment(
+    State(state): State<Arc<AppState>>,
+    Path((id, attachment_id)): Path<(String, String)>,
+) -> impl IntoResponse {
+    match state
+        .cockpit_event_store
+        .load_attachment(&id, &attachment_id)
+    {
+        Some((mime, bytes)) => (
+            [
+                (axum::http::header::CONTENT_TYPE, mime),
+                (
+                    axum::http::header::X_CONTENT_TYPE_OPTIONS,
+                    "nosniff".to_string(),
+                ),
+                (
+                    axum::http::header::CACHE_CONTROL,
+                    "private, max-age=31536000, immutable".to_string(),
+                ),
+            ],
+            bytes,
+        )
+            .into_response(),
+        None => (StatusCode::NOT_FOUND, "attachment not found").into_response(),
     }
 }
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -24,9 +24,9 @@ mod system;
 pub use cockpit::{
     cockpit_attachment, cockpit_cancel, cockpit_context_primer, cockpit_disable, cockpit_enable,
     cockpit_files, cockpit_force_end_turn, cockpit_prompt, cockpit_prompt_diff_comments,
-    cockpit_replay,
-    cockpit_set_config_option, cockpit_set_mode, cockpit_worker_log, list_cockpit_agents,
-    resolve_approval, set_cockpit_master, shutdown_cockpit, spawn_cockpit, switch_cockpit_agent,
+    cockpit_replay, cockpit_set_config_option, cockpit_set_mode, cockpit_worker_log,
+    list_cockpit_agents, resolve_approval, set_cockpit_master, shutdown_cockpit, spawn_cockpit,
+    switch_cockpit_agent,
 };
 
 #[cfg(feature = "serve")]

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -22,8 +22,9 @@ mod system;
 
 #[cfg(feature = "serve")]
 pub use cockpit::{
-    cockpit_cancel, cockpit_context_primer, cockpit_disable, cockpit_enable, cockpit_files,
-    cockpit_force_end_turn, cockpit_prompt, cockpit_prompt_diff_comments, cockpit_replay,
+    cockpit_attachment, cockpit_cancel, cockpit_context_primer, cockpit_disable, cockpit_enable,
+    cockpit_files, cockpit_force_end_turn, cockpit_prompt, cockpit_prompt_diff_comments,
+    cockpit_replay,
     cockpit_set_config_option, cockpit_set_mode, cockpit_worker_log, list_cockpit_agents,
     resolve_approval, set_cockpit_master, shutdown_cockpit, spawn_cockpit, switch_cockpit_agent,
 };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1199,7 +1199,17 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route(
             "/api/sessions/{id}/cockpit/prompt",
-            post(api::cockpit_prompt),
+            // Prompt bodies carry inline base64 attachments, which blow
+            // past the global 1 MiB cap. Raise the limit on this route
+            // only; the server-side decoded-size caps in
+            // `validate_attachments` are the real guard. 28 MiB leaves
+            // headroom for the 20 MiB total decoded cap plus base64's
+            // ~33% overhead and JSON framing. See #1000 / #965.
+            post(api::cockpit_prompt).layer(axum::extract::DefaultBodyLimit::max(28 * 1024 * 1024)),
+        )
+        .route(
+            "/api/sessions/{id}/cockpit/attachments/{attachment_id}",
+            get(api::cockpit_attachment),
         )
         .route(
             "/api/sessions/{id}/cockpit/prompt/diff-comments",
@@ -2444,7 +2454,10 @@ mod tests {
             memory_recall: None,
         };
         assert_eq!(
-            derive_cockpit_status(&Event::UserPromptSent { text: "hi".into() }),
+            derive_cockpit_status(&Event::UserPromptSent {
+                text: "hi".into(),
+                attachments: Vec::new(),
+            }),
             Some(StatusIntent::Set(Status::Running))
         );
         assert_eq!(

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -179,9 +179,17 @@ impl CockpitTranscript {
                 self.rows.push(ActivityRow::AgentMessage(text.clone()));
                 self.pending_message_idx = Some(self.rows.len() - 1);
             }
-            Event::UserPromptSent { text } => {
+            Event::UserPromptSent { text, attachments } => {
                 self.flush_pending_chunk();
-                self.rows.push(ActivityRow::UserPrompt(text.clone()));
+                // The TUI cockpit view renders text only; note the
+                // attachment count inline so a prompt sent from the web
+                // composer with images doesn't look empty here.
+                let row = if attachments.is_empty() {
+                    text.clone()
+                } else {
+                    format!("{text} [{} attachment(s)]", attachments.len())
+                };
+                self.rows.push(ActivityRow::UserPrompt(row));
                 // Sending a prompt dismisses any context-primer hint.
                 self.context_primer_pending = false;
             }
@@ -397,6 +405,7 @@ impl CockpitTranscript {
             | Event::RawAgentUpdate { .. }
             | Event::WakeupScheduled { .. }
             | Event::PromptRejected { .. }
+            | Event::PromptCapabilities { .. }
             | Event::AgentSwitched { .. }
             | Event::ModeSwitchFailed { .. }
             | Event::ConfigOptionsUpdated { .. }
@@ -443,7 +452,13 @@ mod tests {
     #[test]
     fn user_prompt_creates_row() {
         let mut t = CockpitTranscript::new("s-1");
-        t.apply(&frame(1, Event::UserPromptSent { text: "hi".into() }));
+        t.apply(&frame(
+            1,
+            Event::UserPromptSent {
+                text: "hi".into(),
+                attachments: Vec::new(),
+            },
+        ));
         assert_eq!(t.rows.len(), 1);
         match &t.rows[0] {
             ActivityRow::UserPrompt(text) => assert_eq!(text, "hi"),
@@ -563,13 +578,20 @@ mod tests {
     #[test]
     fn duplicate_seq_is_ignored() {
         let mut t = CockpitTranscript::new("s-1");
-        t.apply(&frame(1, Event::UserPromptSent { text: "hi".into() }));
+        t.apply(&frame(
+            1,
+            Event::UserPromptSent {
+                text: "hi".into(),
+                attachments: Vec::new(),
+            },
+        ));
         // Replay-vs-live overlap can deliver the same seq twice; the
         // reducer must dedupe.
         t.apply(&frame(
             1,
             Event::UserPromptSent {
                 text: "ignored".into(),
+                attachments: Vec::new(),
             },
         ));
         assert_eq!(t.rows.len(), 1);
@@ -586,7 +608,13 @@ mod tests {
         ));
         assert!(t.context_primer_pending);
         // Sending a prompt clears the hint.
-        t.apply(&frame(2, Event::UserPromptSent { text: "go".into() }));
+        t.apply(&frame(
+            2,
+            Event::UserPromptSent {
+                text: "go".into(),
+                attachments: Vec::new(),
+            },
+        ));
         assert!(!t.context_primer_pending);
     }
 
@@ -642,7 +670,13 @@ mod tests {
     #[test]
     fn reset_clears_state_but_preserves_session_id() {
         let mut t = CockpitTranscript::new("s-1");
-        t.apply(&frame(1, Event::UserPromptSent { text: "hi".into() }));
+        t.apply(&frame(
+            1,
+            Event::UserPromptSent {
+                text: "hi".into(),
+                attachments: Vec::new(),
+            },
+        ));
         t.reset();
         assert_eq!(t.session_id, "s-1");
         assert_eq!(t.last_seq, 0);

--- a/tests/integration/cockpit_acp_smoke.rs
+++ b/tests/integration/cockpit_acp_smoke.rs
@@ -49,7 +49,7 @@ async fn shim_agent_round_trips_prompt() {
         .expect("spawn shim agent");
 
     client
-        .send_prompt("hello smoke")
+        .send_prompt("hello smoke", &[])
         .await
         .expect("send_prompt");
 
@@ -169,7 +169,7 @@ async fn shim_agent_round_trips_approval_allow() {
         .expect("spawn shim agent");
 
     client
-        .send_prompt("REQUEST_PERMISSION please")
+        .send_prompt("REQUEST_PERMISSION please", &[])
         .await
         .expect("send_prompt");
 
@@ -265,7 +265,7 @@ async fn shim_agent_round_trips_fs() {
         .expect("spawn shim");
 
     client
-        .send_prompt("FS_READ_WRITE please")
+        .send_prompt("FS_READ_WRITE please", &[])
         .await
         .expect("send_prompt");
 
@@ -335,7 +335,7 @@ async fn shim_agent_round_trips_terminal() {
         .expect("spawn shim");
 
     client
-        .send_prompt("TERMINAL_RUN please")
+        .send_prompt("TERMINAL_RUN please", &[])
         .await
         .expect("send_prompt");
 
@@ -483,7 +483,7 @@ async fn shim_agent_emits_rate_limit_event() {
         .expect("spawn shim agent");
 
     client
-        .send_prompt("trigger RATE_LIMIT now")
+        .send_prompt("trigger RATE_LIMIT now", &[])
         .await
         .expect("send_prompt");
 

--- a/tests/integration/cockpit_midturn_resume.rs
+++ b/tests/integration/cockpit_midturn_resume.rs
@@ -300,7 +300,7 @@ async fn socket_transport_round_trips_prompt_via_attach() {
     .expect("attach to bridge");
 
     client
-        .send_prompt("hello over socket")
+        .send_prompt("hello over socket", &[])
         .await
         .expect("send_prompt");
 

--- a/tests/integration/cockpit_session_delete.rs
+++ b/tests/integration/cockpit_session_delete.rs
@@ -48,7 +48,7 @@ async fn drive_handshake_and_capture_session_id(
     deadline: std::time::Instant,
 ) -> Option<String> {
     client
-        .send_prompt("hello")
+        .send_prompt("hello", &[])
         .await
         .expect("send_prompt should reach the shim");
     let mut acp_session_id: Option<String> = None;

--- a/tests/integration/cockpit_silent_orphan.rs
+++ b/tests/integration/cockpit_silent_orphan.rs
@@ -153,7 +153,7 @@ async fn silent_orphan_fires_on_cost_then_silence() {
 
     let mut client = client;
     client
-        .send_prompt("SILENT_ORPHAN trigger")
+        .send_prompt("SILENT_ORPHAN trigger", &[])
         .await
         .expect("send prompt");
 
@@ -218,7 +218,7 @@ async fn silent_orphan_suppressed_during_normal_turn() {
     // and returns stopReason=end_turn. The watchdog must stay silent
     // and the natural prompt_complete must win.
     client
-        .send_prompt("normal turn")
+        .send_prompt("normal turn", &[])
         .await
         .expect("send prompt");
 
@@ -276,7 +276,7 @@ async fn silent_orphan_disabled_by_zero_grace() {
 
     let mut client = client;
     client
-        .send_prompt("SILENT_ORPHAN trigger")
+        .send_prompt("SILENT_ORPHAN trigger", &[])
         .await
         .expect("send prompt");
 
@@ -334,7 +334,7 @@ async fn silent_orphan_suppressed_during_async_agent_wait() {
 
     let mut client = client;
     client
-        .send_prompt("ASYNC_AGENT_ORPHAN trigger")
+        .send_prompt("ASYNC_AGENT_ORPHAN trigger", &[])
         .await
         .expect("send prompt");
 
@@ -393,7 +393,7 @@ async fn silent_orphan_suppressed_during_background_bash() {
 
     let mut client = client;
     client
-        .send_prompt("BACKGROUND_BASH_ORPHAN trigger")
+        .send_prompt("BACKGROUND_BASH_ORPHAN trigger", &[])
         .await
         .expect("send prompt");
 
@@ -446,7 +446,7 @@ async fn silent_orphan_suppressed_during_scheduled_wakeup() {
 
     let mut client = client;
     client
-        .send_prompt("WAKEUP_ORPHAN trigger")
+        .send_prompt("WAKEUP_ORPHAN trigger", &[])
         .await
         .expect("send prompt");
 

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -264,25 +264,25 @@ export function activityToThreadMessages(
     }
     if (row.kind === "user_prompt") {
       flushAssistant();
-      const content: ThreadMessageLike["content"] = [];
-      if (row.text) content.push({ type: "text", text: row.text });
-      for (const att of row.attachments ?? []) {
-        if (att.kind === "image") {
-          content.push({ type: "image", image: att.url });
-        } else {
-          // Audio / embedded resources have no inline player here yet;
-          // surface them as a labelled chip line so the turn isn't empty.
-          content.push({
-            type: "text",
-            text: `📎 ${att.name ?? att.kind} (${att.mimeType})`,
-          });
-        }
-      }
-      if (content.length === 0) content.push({ type: "text", text: "" });
+      // `ThreadMessageLike["content"]` is a readonly array, so build the
+      // parts via spreads rather than push. Images become image parts;
+      // audio / embedded resources have no inline player here yet, so
+      // surface them as a labelled chip line.
+      const parts = [
+        ...(row.text ? [{ type: "text" as const, text: row.text }] : []),
+        ...(row.attachments ?? []).map((att) =>
+          att.kind === "image"
+            ? { type: "image" as const, image: att.url }
+            : {
+                type: "text" as const,
+                text: `📎 ${att.name ?? att.kind} (${att.mimeType})`,
+              },
+        ),
+      ];
       messages.push({
         id: row.id,
         role: "user",
-        content,
+        content: parts.length > 0 ? parts : [{ type: "text", text: "" }],
         createdAt: parseDate(row.at),
       });
       continue;

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -31,13 +31,14 @@ import {
   useExternalStoreRuntime,
   type ThreadMessageLike,
 } from "@assistant-ui/react";
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { useCockpit } from "../../hooks/useCockpit";
 import type {
   ActivityRow,
   ApprovalDecision,
   CockpitState,
+  PromptAttachmentInput,
   ToolCall,
 } from "../../lib/cockpitTypes";
 
@@ -81,7 +82,18 @@ export interface CockpitContext {
     nonce: string,
     decision: ApprovalDecision,
   ) => Promise<void>;
-  sendPrompt: (text: string) => Promise<void>;
+  sendPrompt: (
+    text: string,
+    attachments?: PromptAttachmentInput[],
+  ) => Promise<void>;
+  /** Attachments the composer has staged for the next send. Owned here
+   *  (above the assistant-ui runtime) so `onNew` can attach them when
+   *  the user submits via Enter / the assistant-ui Send path, and the
+   *  composer can render + clear them. See #1000 / #965. */
+  pendingAttachments: PromptAttachmentInput[];
+  setPendingAttachments: React.Dispatch<
+    React.SetStateAction<PromptAttachmentInput[]>
+  >;
   forceEndTurn: () => Promise<void>;
   lastActivityRef: ReturnType<typeof useCockpit>["lastActivityRef"];
   dismissError: () => void;
@@ -110,6 +122,16 @@ export function CockpitRuntime({
   children,
 }: Props) {
   const cockpit = useCockpit(sessionId, cockpitWorkerState, archivedAt, snoozedUntil);
+  // Staged attachments for the next prompt. A ref mirror keeps `onNew`
+  // (recreated each render by useExternalStoreRuntime) reading the
+  // latest value without going stale. See #1000 / #965.
+  const [pendingAttachments, setPendingAttachments] = useState<
+    PromptAttachmentInput[]
+  >([]);
+  const pendingAttachmentsRef = useRef<PromptAttachmentInput[]>([]);
+  useEffect(() => {
+    pendingAttachmentsRef.current = pendingAttachments;
+  }, [pendingAttachments]);
   // Memoise the activity → ThreadMessageLike conversion. The function
   // walks the entire activity array, allocates a new AssistantBuilder
   // per turn, and produces brand-new message objects. Without
@@ -131,16 +153,18 @@ export function CockpitRuntime({
     isRunning: cockpit.state.turnActive,
     convertMessage: (m) => m,
     onNew: async (msg) => {
-      // assistant-ui hands us an AppendMessage with mixed parts. The
-      // cockpit only accepts plain text prompts today, so flatten any
-      // text parts into a single string. Attachments / images are not
-      // supported by ACP yet.
+      // assistant-ui hands us an AppendMessage with mixed parts. Flatten
+      // text parts into one string; the composer stages attachments
+      // separately (assistant-ui's own attachment system is unused), so
+      // pull them from the pending ref and clear it on send. See #1000.
       const text = msg.content
         .map((c) => (c.type === "text" ? c.text : ""))
         .join("")
         .trim();
-      if (!text) return;
-      await cockpit.sendPrompt(text);
+      const attachments = pendingAttachmentsRef.current;
+      if (!text && attachments.length === 0) return;
+      setPendingAttachments([]);
+      await cockpit.sendPrompt(text, attachments);
     },
     onCancel: async () => {
       await cockpit.cancelPrompt();
@@ -160,6 +184,8 @@ export function CockpitRuntime({
         manualReconnect: cockpit.manualReconnect,
         resolveApproval: cockpit.resolveApproval,
         sendPrompt: cockpit.sendPrompt,
+        pendingAttachments,
+        setPendingAttachments,
         forceEndTurn: cockpit.forceEndTurn,
         lastActivityRef: cockpit.lastActivityRef,
         dismissError: cockpit.dismissError,
@@ -238,10 +264,25 @@ export function activityToThreadMessages(
     }
     if (row.kind === "user_prompt") {
       flushAssistant();
+      const content: ThreadMessageLike["content"] = [];
+      if (row.text) content.push({ type: "text", text: row.text });
+      for (const att of row.attachments ?? []) {
+        if (att.kind === "image") {
+          content.push({ type: "image", image: att.url });
+        } else {
+          // Audio / embedded resources have no inline player here yet;
+          // surface them as a labelled chip line so the turn isn't empty.
+          content.push({
+            type: "text",
+            text: `📎 ${att.name ?? att.kind} (${att.mimeType})`,
+          });
+        }
+      }
+      if (content.length === 0) content.push({ type: "text", text: "" });
       messages.push({
         id: row.id,
         role: "user",
-        content: [{ type: "text", text: row.text }],
+        content,
         createdAt: parseDate(row.at),
       });
       continue;

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -168,6 +168,8 @@ function CockpitChrome({
   manualReconnect,
   resolveApproval,
   sendPrompt,
+  pendingAttachments,
+  setPendingAttachments,
   forceEndTurn,
   lastActivityRef,
   dismissError,
@@ -472,6 +474,9 @@ function CockpitChrome({
             turnActive={state.turnActive}
             queuedCount={state.queuedPrompts.length}
             enqueuePrompt={sendPrompt}
+            promptCapabilities={state.promptCapabilities}
+            pendingAttachments={pendingAttachments}
+            setPendingAttachments={setPendingAttachments}
             primerPrefill={primerPrefill}
           />
         </div>

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -582,16 +582,15 @@ export function Composer({
         {...tourAnchor(TOUR_ANCHORS.composer)}
         className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl"
         onDragOver={(e) => {
-          // Allow drops only when the agent accepts attachments; the
-          // browser default is to navigate to the dropped file. See #965.
-          if (!attachmentsEnabled) return;
+          const hasFiles = Array.from(e.dataTransfer?.types ?? []).includes("Files");
+          if (!hasFiles) return;
           e.preventDefault();
         }}
         onDrop={(e) => {
-          if (!attachmentsEnabled) return;
           const dropped = e.dataTransfer?.files;
           if (!dropped || dropped.length === 0) return;
           e.preventDefault();
+          if (!attachmentsEnabled) return;
           void addFiles(dropped);
         }}
       >

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -18,17 +18,24 @@ import {
   type Unstable_TriggerAdapter,
   type Unstable_TriggerItem,
 } from "@assistant-ui/core";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AtSign,
   ChevronUp,
+  Paperclip,
   Slash,
   Square,
+  X,
 } from "lucide-react";
 
 import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import { SessionConfigControls } from "./SessionConfigControls";
-import type { CockpitState } from "../../lib/cockpitTypes";
+import type {
+  CockpitState,
+  PromptAttachmentInput,
+  PromptAttachmentKind,
+  PromptCapabilities,
+} from "../../lib/cockpitTypes";
 import { getDraft, setDraft } from "../../lib/cockpitDrafts";
 import { TOUR_ANCHORS, tourAnchor } from "../../lib/tourSteps";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
@@ -141,6 +148,51 @@ function detectMobileInput(): boolean {
   return coarse && !anyFine;
 }
 
+/** Client-side mirror of the server's per-prompt attachment cap. */
+const MAX_ATTACHMENTS = 8;
+
+/** Map a file's MIME type to the ACP attachment kind. */
+function mimeToKind(mime: string): PromptAttachmentKind {
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("audio/")) return "audio";
+  return "resource";
+}
+
+/** Whether the current agent accepts the given attachment kind. */
+function kindSupported(
+  kind: PromptAttachmentKind,
+  caps: PromptCapabilities | null,
+): boolean {
+  if (!caps) return false;
+  if (kind === "image") return caps.image;
+  if (kind === "audio") return caps.audio;
+  return caps.embeddedContext;
+}
+
+/** The `accept` attribute for the file picker, narrowed to the kinds
+ *  the agent advertises so the OS dialog only offers usable files. */
+function acceptForCaps(caps: PromptCapabilities | null): string {
+  const parts: string[] = [];
+  if (caps?.image) parts.push("image/*");
+  if (caps?.audio) parts.push("audio/*");
+  if (caps?.embeddedContext) parts.push(".txt,.md,.json,.pdf");
+  return parts.join(",");
+}
+
+/** Read a File into standard base64 (no `data:` prefix). */
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      // `data:<mime>;base64,<b64>` → keep only the base64 tail.
+      resolve(result.slice(result.indexOf(",") + 1));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
 interface Props {
   sessionId: string;
   availableModes: CockpitState["availableModes"];
@@ -188,7 +240,20 @@ interface Props {
    *  the ComposerPrimitive.Send path (which assistant-ui hard-disables
    *  while `thread.isRunning && !capabilities.queue`). Used by the
    *  mid-turn Send button + the Enter-while-running handler. */
-  enqueuePrompt: (text: string) => void | Promise<void>;
+  enqueuePrompt: (
+    text: string,
+    attachments?: PromptAttachmentInput[],
+  ) => void | Promise<void>;
+  /** Attachment kinds the current agent accepts, gating the paperclip
+   *  / paste / drop affordances. Null until the handshake reports it.
+   *  See #1000 / #965. */
+  promptCapabilities: PromptCapabilities | null;
+  /** Attachments staged for the next send, owned by CockpitRuntime so
+   *  the assistant-ui Enter / Send path can read them on submit. */
+  pendingAttachments: PromptAttachmentInput[];
+  setPendingAttachments: React.Dispatch<
+    React.SetStateAction<PromptAttachmentInput[]>
+  >;
   /** When set, replace the current composer text with `text` and
    *  focus the textarea (cursor at end). Used by the context-primer
    *  banner to prefill a transcript recap before send. The `id` is
@@ -211,10 +276,54 @@ export function Composer({
   turnActive,
   queuedCount,
   enqueuePrompt,
+  promptCapabilities,
+  pendingAttachments,
+  setPendingAttachments,
   primerPrefill,
 }: Props) {
   const taRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const { files } = useFilesIndex(sessionId);
+
+  const attachmentsEnabled =
+    !!promptCapabilities &&
+    (promptCapabilities.image ||
+      promptCapabilities.audio ||
+      promptCapabilities.embeddedContext);
+
+  // Stage files dropped, pasted, or picked. Filters to kinds the agent
+  // accepts and respects the per-prompt count cap; oversize / type
+  // rejection beyond this is enforced authoritatively server-side.
+  const addFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const list = Array.from(files);
+      const accepted: PromptAttachmentInput[] = [];
+      for (const file of list) {
+        const kind = mimeToKind(file.type || "application/octet-stream");
+        if (!kindSupported(kind, promptCapabilities)) continue;
+        const dataB64 = await fileToBase64(file);
+        if (!dataB64) continue;
+        accepted.push({
+          kind,
+          mimeType: file.type || "application/octet-stream",
+          name: file.name || undefined,
+          dataB64,
+        });
+      }
+      if (accepted.length === 0) return;
+      setPendingAttachments((prev) =>
+        prev.concat(accepted).slice(0, MAX_ATTACHMENTS),
+      );
+    },
+    [promptCapabilities, setPendingAttachments],
+  );
+
+  const removeAttachment = useCallback(
+    (index: number) => {
+      setPendingAttachments((prev) => prev.filter((_, i) => i !== index));
+    },
+    [setPendingAttachments],
+  );
 
   // When the soft keyboard is up the App root's safe-area-inset-bottom
   // padding reserves space for the iOS home indicator that the keyboard
@@ -305,6 +414,22 @@ export function Composer({
   );
 
   const composerRuntime = useComposerRuntime();
+
+  // Unified submit for the custom Send / QueueSend buttons and the
+  // mid-turn Enter path: drains the textarea text + staged attachments
+  // through `enqueuePrompt` (which is the cockpit `sendPrompt`), then
+  // clears both. The idle assistant-ui Enter path submits via the
+  // runtime's `onNew`, which reads the same staged attachments from
+  // CockpitRuntime. See #1000 / #965.
+  const submitComposer = useCallback(() => {
+    void sendFromTextarea(
+      taRef,
+      composerRuntime,
+      enqueuePrompt,
+      pendingAttachments,
+      () => setPendingAttachments([]),
+    );
+  }, [composerRuntime, enqueuePrompt, pendingAttachments, setPendingAttachments]);
 
   // iOS Safari native dictation (#1431): WebKit fires `beforeinput` /
   // `input` with `inputType: "insertReplacementText"` per partial
@@ -453,7 +578,23 @@ export function Composer({
   const wrapperLayout = composerWrapperLayout({ keyboardOpen });
   return (
     <div className={wrapperLayout.className} style={wrapperLayout.style}>
-      <div {...tourAnchor(TOUR_ANCHORS.composer)} className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl">
+      <div
+        {...tourAnchor(TOUR_ANCHORS.composer)}
+        className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl"
+        onDragOver={(e) => {
+          // Allow drops only when the agent accepts attachments; the
+          // browser default is to navigate to the dropped file. See #965.
+          if (!attachmentsEnabled) return;
+          e.preventDefault();
+        }}
+        onDrop={(e) => {
+          if (!attachmentsEnabled) return;
+          const dropped = e.dataTransfer?.files;
+          if (!dropped || dropped.length === 0) return;
+          e.preventDefault();
+          void addFiles(dropped);
+        }}
+      >
         <ComposerPrimitive.Unstable_TriggerPopoverRoot>
           <ComposerPrimitive.Root
             className={[
@@ -602,7 +743,21 @@ export function Composer({
                 // action === "send"
                 e.preventDefault();
                 e.stopPropagation();
-                void sendFromTextarea(taRef, composerRuntime, enqueuePrompt);
+                submitComposer();
+              }}
+              onPaste={(e) => {
+                // Cmd/Ctrl+V of an image (screenshot) lands here as a
+                // clipboard file item. Capture supported files and stage
+                // them; let text paste fall through untouched. See #965.
+                if (!attachmentsEnabled) return;
+                const items = Array.from(e.clipboardData?.items ?? []);
+                const files = items
+                  .filter((it) => it.kind === "file")
+                  .map((it) => it.getAsFile())
+                  .filter((f): f is File => f != null);
+                if (files.length === 0) return;
+                e.preventDefault();
+                void addFiles(files);
               }}
               autoFocus={!isMobile}
               className={[
@@ -611,6 +766,43 @@ export function Composer({
                 "placeholder:text-text-dim focus:outline-none",
               ].join(" ")}
             />
+
+            {/* Staged attachments — thumbnails for images, labelled
+                chips for audio / resources. Removable before send. */}
+            {pendingAttachments.length > 0 && (
+              <div className="flex flex-wrap gap-2 px-3 pt-1">
+                {pendingAttachments.map((att, i) => (
+                  <div
+                    key={`${att.name ?? att.kind}-${i}`}
+                    className="group/att relative flex items-center gap-2 rounded-md border border-surface-700 bg-surface-800 py-1 pl-1 pr-2 text-[11px] text-text-secondary"
+                  >
+                    {att.kind === "image" ? (
+                      <img
+                        src={`data:${att.mimeType};base64,${att.dataB64}`}
+                        alt={att.name ?? "attachment"}
+                        className="h-8 w-8 rounded object-cover"
+                      />
+                    ) : (
+                      <span className="flex h-8 w-8 items-center justify-center rounded bg-surface-700">
+                        <Paperclip className="h-3.5 w-3.5" />
+                      </span>
+                    )}
+                    <span className="max-w-[120px] truncate">
+                      {att.name ?? att.kind}
+                    </span>
+                    <button
+                      type="button"
+                      aria-label={`Remove ${att.name ?? "attachment"}`}
+                      title="Remove attachment"
+                      onClick={() => removeAttachment(i)}
+                      className="rounded p-0.5 text-text-dim hover:bg-surface-700 hover:text-text-secondary"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
 
             {/* Footer strip — affordances on the left, send/stop on the right */}
             <div className="flex items-center justify-between gap-2 border-t border-surface-800/60 px-2 pb-2 pt-1.5">
@@ -626,6 +818,31 @@ export function Composer({
                   label="Slash command (/)"
                   hint="/"
                   onClick={() => insertAtCaret(taRef, "/")}
+                />
+                <ToolbarButton
+                  icon={<Paperclip className="h-3.5 w-3.5" />}
+                  label={
+                    attachmentsEnabled
+                      ? "Attach files (image / audio / resource)"
+                      : promptCapabilities
+                        ? "This agent does not accept attachments"
+                        : "Waiting for agent capabilities…"
+                  }
+                  disabled={!attachmentsEnabled}
+                  onClick={() => fileInputRef.current?.click()}
+                />
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  accept={acceptForCaps(promptCapabilities)}
+                  className="hidden"
+                  onChange={(e) => {
+                    const picked = e.target.files;
+                    if (picked && picked.length > 0) void addFiles(picked);
+                    // Reset so re-picking the same file fires onChange.
+                    e.target.value = "";
+                  }}
                 />
                 <span className="mx-1 h-4 w-px bg-surface-700" aria-hidden />
                 <ModePicker
@@ -649,11 +866,11 @@ export function Composer({
                     <QueueSendButton
                       connected={connected}
                       queuedCount={queuedCount}
-                      onSend={() => sendFromTextarea(taRef, composerRuntime, enqueuePrompt)}
+                      onSend={submitComposer}
                     />
                   </>
                 ) : (
-                  <SendButton connected={connected} />
+                  <SendButton connected={connected} onSend={submitComposer} />
                 )}
               </div>
             </div>
@@ -1059,33 +1276,39 @@ function formatCost(amount: number, currency: string): string {
 
 /* ── Send / Stop ─────────────────────────────────────────────────── */
 
-function SendButton({ connected = true }: { connected?: boolean }) {
+function SendButton({
+  connected = true,
+  onSend,
+}: {
+  connected?: boolean;
+  onSend: () => void;
+}) {
   // When the session is inactive (WS closed, worker stopped, worker
   // restarting) we leave the button clickable: `sendPrompt` routes the
   // text into the local queue and the drain effect fires it on resume.
   // The tooltip swaps so users can tell the click queued rather than
-  // sent. ComposerPrimitive.Send still drives the assistant-ui submit
-  // flow; it does not look at our `connected` flag. See #1359.
+  // sent. A custom button (not ComposerPrimitive.Send) drives submit so
+  // the staged attachments ride along and an attachment-only prompt can
+  // send even with empty text. See #1359 / #1000.
   const title = connected
     ? "Send, Enter"
     : "Session not active, will send on resume";
   const label = connected ? "Send message" : "Queue message until session resumes";
   return (
-    <ComposerPrimitive.Send asChild>
-      <button
-        type="submit"
-        aria-label={label}
-        title={title}
-        className={[
-          "group/send inline-flex items-center justify-center gap-1",
-          "rounded-lg bg-brand-600 px-2.5 py-1.5 text-white shadow-sm",
-          "hover:bg-brand-500 active:scale-[0.98]",
-          "transition-all duration-100",
-        ].join(" ")}
-      >
-        <PaperPlaneIcon />
-      </button>
-    </ComposerPrimitive.Send>
+    <button
+      type="button"
+      aria-label={label}
+      title={title}
+      onClick={onSend}
+      className={[
+        "group/send inline-flex items-center justify-center gap-1",
+        "rounded-lg bg-brand-600 px-2.5 py-1.5 text-white shadow-sm",
+        "hover:bg-brand-500 active:scale-[0.98]",
+        "transition-all duration-100",
+      ].join(" ")}
+    >
+      <PaperPlaneIcon />
+    </button>
   );
 }
 
@@ -1172,13 +1395,21 @@ function QueueSendButton({
 function sendFromTextarea(
   taRef: React.RefObject<HTMLTextAreaElement | null>,
   composerRuntime: ReturnType<typeof useComposerRuntime>,
-  enqueuePrompt: (text: string) => void | Promise<void>,
+  enqueuePrompt: (
+    text: string,
+    attachments?: PromptAttachmentInput[],
+  ) => void | Promise<void>,
+  attachments: PromptAttachmentInput[] = [],
+  clearAttachments?: () => void,
 ): void {
   if (!composerRuntime) return;
   const text = composerRuntime.getState().text.trim();
-  if (!text) return;
-  void enqueuePrompt(text);
+  // Allow an attachment-only prompt (e.g. a pasted screenshot with no
+  // text); otherwise require some text.
+  if (!text && attachments.length === 0) return;
+  void enqueuePrompt(text, attachments.length > 0 ? attachments : undefined);
   composerRuntime.setText("");
+  clearAttachments?.();
   // Manually reset the textarea height; auto-grow runs on input events
   // and we cleared the value without firing one.
   const el = taRef.current;

--- a/web/src/hooks/useCockpit.queue.test.ts
+++ b/web/src/hooks/useCockpit.queue.test.ts
@@ -269,14 +269,14 @@ async function flushAsync(): Promise<void> {
 
 describe("useCockpit drain race (#1144)", () => {
   let promptPostCount: number;
-  let promptPostShouldFail: boolean;
+  let promptPostStatus: number;
   let promptPostBodies: string[];
   let replayResponse: { frames: unknown[]; lost: boolean; highest_seq: number };
 
   beforeEach(() => {
     sockets.length = 0;
     promptPostCount = 0;
-    promptPostShouldFail = false;
+    promptPostStatus = 200;
     promptPostBodies = [];
     replayResponse = { frames: [], lost: false, highest_seq: 0 };
     vi.stubGlobal(
@@ -291,10 +291,10 @@ describe("useCockpit drain race (#1144)", () => {
           if (typeof init?.body === "string") {
             promptPostBodies.push(init.body);
           }
-          if (promptPostShouldFail) {
-            return new Response("simulated failure", { status: 500 });
+          if (promptPostStatus >= 400) {
+            return new Response("simulated failure", { status: promptPostStatus });
           }
-          return new Response("{}", { status: 200 });
+          return new Response("{}", { status: promptPostStatus });
         }
         return new Response("{}", { status: 200 });
       }),
@@ -390,6 +390,38 @@ describe("useCockpit drain race (#1144)", () => {
     );
   });
 
+  it("retires the optimistic turn when prompt POST is rejected with 4xx", async () => {
+    const { result } = renderHook(() => useCockpit("sess-reject-4xx"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+
+    promptPostStatus = 400;
+    await act(async () => {
+      await result.current.sendPrompt("send bad attachment", [
+        {
+          kind: "image",
+          mimeType: "image/x-xcf",
+          dataB64: "aA==",
+          name: "bad.xcf",
+        },
+      ]);
+    });
+    await flushAsync();
+
+    expect(promptPostCount).toBe(1);
+    expect(result.current.state.pendingUserPromptSeq).toBe(1);
+    expect(result.current.state.lastStoppedSeq).toBe(1);
+    expect(result.current.state.turnActive).toBe(false);
+    expect(result.current.state.lastError).toContain(
+      "Could not send prompt (400)",
+    );
+  });
+
   it("combined-mode drain leaves the queue intact when the prompt POST fails", async () => {
     const { result } = renderHook(() => useCockpit("sess-drain-2"));
     await flushAsync();
@@ -426,7 +458,7 @@ describe("useCockpit drain race (#1144)", () => {
 
     // Configure the prompt POST to fail, then end the turn so the drain
     // fires.
-    promptPostShouldFail = true;
+    promptPostStatus = 500;
     act(() => {
       ws.onmessage?.({
         data: JSON.stringify({

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -15,8 +15,10 @@ import {
   normaliseTurnCounters,
   setActivityLimit,
   type ApprovalDecision,
+  type CockpitAttachment,
   type CockpitFrame,
   type CockpitState,
+  type PromptAttachmentInput,
   type QueuedPrompt,
 } from "../lib/cockpitTypes";
 import { useCockpitPrefs } from "../lib/cockpitPrefs";
@@ -38,7 +40,7 @@ export type Action =
   | { kind: "frame"; frame: CockpitFrame }
   | { kind: "frames"; frames: CockpitFrame[] }
   | { kind: "lagged"; skipped: number }
-  | { kind: "user_prompt"; text: string }
+  | { kind: "user_prompt"; text: string; attachments?: CockpitAttachment[] }
   | { kind: "error"; message: string }
   | { kind: "clear_error" }
   | { kind: "lagged_resolved" }
@@ -372,6 +374,10 @@ function reducer(state: CockpitState, action: Action): CockpitState {
         id: `user-${Date.now()}-${state.activity.length}`,
         kind: "user_prompt",
         text: action.text,
+        attachments:
+          action.attachments && action.attachments.length > 0
+            ? action.attachments
+            : undefined,
         at: new Date().toISOString(),
       }),
       assistantMessage: "",
@@ -988,7 +994,10 @@ export function useCockpit(
   // the items it just sent; false on any disconnect / non-OK response /
   // network error so the queue stays intact for the next turn-end retry.
   const dispatchPromptNow = useCallback(
-    async (text: string): Promise<boolean> => {
+    async (
+      text: string,
+      attachments?: PromptAttachmentInput[],
+    ): Promise<boolean> => {
       if (!sessionId) return false;
       if (statusRef.current !== "open") {
         dispatch({
@@ -997,22 +1006,49 @@ export function useCockpit(
         });
         return false;
       }
+      // Optimistic preview rows: render the attachment inline from a
+      // local data URL so the bubble shows immediately, before the
+      // server confirms and replay would otherwise back it with the
+      // GET endpoint. See #1000 / #965.
+      const previews: CockpitAttachment[] = (attachments ?? []).map(
+        (a, i) => ({
+          id: `local-${Date.now()}-${i}`,
+          kind: a.kind,
+          mimeType: a.mimeType,
+          name: a.name,
+          size: Math.floor((a.dataB64.length * 3) / 4),
+          url: `data:${a.mimeType};base64,${a.dataB64}`,
+        }),
+      );
       // Optimistically echo the user's message; the agent reply
       // streams back as session/update events on the WS. If the POST
       // fails we'll surface a banner and the user can retry; the
       // optimistic row stays so they see what they tried to send.
-      dispatch({ kind: "user_prompt", text });
+      dispatch({
+        kind: "user_prompt",
+        text,
+        attachments: previews.length > 0 ? previews : undefined,
+      });
       // Submit counts as activity so the force-end-turn watchdog
       // doesn't surface the escape hatch immediately on a fresh prompt
       // (the agent's first chunk can be a few seconds out).
       lastActivityRef.current = Date.now();
       try {
+        const body = {
+          text,
+          attachments: (attachments ?? []).map((a) => ({
+            kind: a.kind,
+            mime_type: a.mimeType,
+            data: a.dataB64,
+            name: a.name,
+          })),
+        };
         const res = await fetch(
           `/api/sessions/${encodeURIComponent(sessionId)}/cockpit/prompt`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ text }),
+            body: JSON.stringify(body),
           },
         );
         if (!res.ok) {
@@ -1048,7 +1084,7 @@ export function useCockpit(
   // its own status guard for the drain effect, which can race the WS
   // reopen window (see #1144).
   const sendPrompt = useCallback(
-    async (text: string) => {
+    async (text: string, attachments?: PromptAttachmentInput[]) => {
       if (!sessionId) return;
       // Auto-wake an archived or actively-snoozed session before
       // routing. The tmux send path runs this via
@@ -1082,10 +1118,24 @@ export function useCockpit(
       const workerNotRunning = workerStateRef.current !== "running";
       const shouldEnqueue = wsClosed || workerNotRunning || state.turnActive || state.workerStopped || state.workerRestarting;
       if (shouldEnqueue) {
+        // The local prompt queue is text-only (persisted to
+        // localStorage, where megabytes of base64 would blow the
+        // quota). Attachments must go through the immediate POST, so
+        // surface why rather than silently dropping them. The composer
+        // keeps the text + attachments so the user can resend once the
+        // agent is idle. See #1000 / #965.
+        if (attachments && attachments.length > 0) {
+          dispatch({
+            kind: "error",
+            message:
+              "Attachments can only be sent while the agent is idle and connected. Your message was not sent; try again in a moment.",
+          });
+          return;
+        }
         dispatch({ kind: "enqueue_prompt", text });
         return;
       }
-      await dispatchPromptNow(text);
+      await dispatchPromptNow(text, attachments);
     },
     [
       sessionId,

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -41,6 +41,7 @@ export type Action =
   | { kind: "frames"; frames: CockpitFrame[] }
   | { kind: "lagged"; skipped: number }
   | { kind: "user_prompt"; text: string; attachments?: CockpitAttachment[] }
+  | { kind: "prompt_send_rejected" }
   | { kind: "error"; message: string }
   | { kind: "clear_error" }
   | { kind: "lagged_resolved" }
@@ -389,6 +390,26 @@ function reducer(state: CockpitState, action: Action): CockpitState {
       turnActive: isTurnActive({
         pendingUserPromptSeq,
         lastStoppedSeq: state.lastStoppedSeq,
+      }),
+    };
+  }
+  if (action.kind === "prompt_send_rejected") {
+    // Optimistic submit already bumped pendingUserPromptSeq. When the
+    // prompt POST is rejected client-side (for example unsupported
+    // attachments), retire exactly one pending turn so Stop unlocks and
+    // the composer returns to idle without waiting for a Stopped frame
+    // that will never arrive.
+    const lastStoppedSeq = Math.min(
+      state.lastStoppedSeq + 1,
+      state.pendingUserPromptSeq,
+    );
+    return {
+      ...state,
+      inFlightTool: null,
+      lastStoppedSeq,
+      turnActive: isTurnActive({
+        pendingUserPromptSeq: state.pendingUserPromptSeq,
+        lastStoppedSeq,
       }),
     };
   }
@@ -1053,6 +1074,13 @@ export function useCockpit(
         );
         if (!res.ok) {
           const detail = await safeText(res);
+          // 4xx means the server rejected the prompt (validation,
+          // capability gate, unknown session), so there is no in-flight
+          // turn to cancel and no Stopped frame to retire our optimistic
+          // turn marker.
+          if (res.status >= 400 && res.status < 500) {
+            dispatch({ kind: "prompt_send_rejected" });
+          }
           dispatch({
             kind: "error",
             message: `Could not send prompt (${res.status}). ${detail}`.trim(),

--- a/web/src/lib/cockpitAttachments.test.ts
+++ b/web/src/lib/cockpitAttachments.test.ts
@@ -1,0 +1,107 @@
+// Reducer tests for cockpit attachment support (#1000 / #965).
+//
+// Cover the wire-protocol contract the composer and replay depend on:
+// the PromptCapabilities event drives the composer's attachment gate,
+// and a UserPromptSent carrying attachment refs maps each ref to a
+// render-ready attachment backed by the replay GET endpoint. If either
+// regresses, the paperclip silently disables or replayed screenshots
+// fail to render.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyEvent,
+  emptyCockpitState,
+  type CockpitFrame,
+} from "./cockpitTypes";
+
+describe("cockpit attachments reducer", () => {
+  it("stores prompt capabilities from the PromptCapabilities event", () => {
+    const frame: CockpitFrame = {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        PromptCapabilities: {
+          image: true,
+          audio: false,
+          embedded_context: true,
+        },
+      },
+    };
+    const next = applyEvent(emptyCockpitState(), frame);
+    expect(next.promptCapabilities).toEqual({
+      image: true,
+      audio: false,
+      embeddedContext: true,
+    });
+  });
+
+  it("re-emits supersede earlier capabilities (agent switch)", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        PromptCapabilities: { image: true, audio: true, embedded_context: true },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        PromptCapabilities: {
+          image: false,
+          audio: false,
+          embedded_context: false,
+        },
+      },
+    });
+    expect(state.promptCapabilities).toEqual({
+      image: false,
+      audio: false,
+      embeddedContext: false,
+    });
+  });
+
+  it("maps server attachment refs to a GET-backed url on the user row", () => {
+    const frame: CockpitFrame = {
+      session_id: "sess-42",
+      seq: 5,
+      event: {
+        UserPromptSent: {
+          text: "what is wrong here?",
+          attachments: [
+            {
+              id: "att-abc",
+              kind: "image",
+              mime_type: "image/png",
+              name: "shot.png",
+              size: 1234,
+            },
+          ],
+        },
+      },
+    };
+    const next = applyEvent(emptyCockpitState(), frame);
+    const row = next.activity.find((r) => r.kind === "user_prompt");
+    expect(row).toBeDefined();
+    expect(row?.attachments).toHaveLength(1);
+    expect(row?.attachments?.[0]).toEqual({
+      id: "att-abc",
+      kind: "image",
+      mimeType: "image/png",
+      name: "shot.png",
+      size: 1234,
+      url: "/api/sessions/sess-42/cockpit/attachments/att-abc",
+    });
+  });
+
+  it("leaves attachments undefined on a text-only prompt", () => {
+    const next = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "plain" } },
+    });
+    const row = next.activity.find((r) => r.kind === "user_prompt");
+    expect(row?.attachments).toBeUndefined();
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -282,7 +282,7 @@ export type CockpitEvent =
   | { Stopped: { reason: string } }
   | { AgentStartupError: { message: string } }
   | { IncompatibleAgent: { detail: IncompatibleAgentDetail } }
-  | { UserPromptSent: { text: string } }
+  | { UserPromptSent: { text: string; attachments?: PromptAttachmentRefWire[] } }
   | {
       UserDiffCommentsPrompt: {
         intro: string;
@@ -292,11 +292,62 @@ export type CockpitEvent =
         assembledMarkdown: string;
       };
     }
+  | {
+      PromptCapabilities: {
+        image: boolean;
+        audio: boolean;
+        embedded_context: boolean;
+      };
+    }
   | { AcpSessionAssigned: { acp_session_id: string } }
   | { SessionContextReset: { reason: string } }
   | { WakeupScheduled: { at: string; reason: string | null } }
   | { PromptRejected: { reason: string; text: string } }
   | { AgentSwitched: { from: string; to: string; reason: string } };
+
+/** Metadata-only attachment ref as it rides on a `UserPromptSent`
+ *  event from the server (mirrors Rust `PromptAttachmentRef`). The
+ *  bytes are fetched lazily from the replay GET endpoint. See #1000. */
+export interface PromptAttachmentRefWire {
+  id: string;
+  kind: PromptAttachmentKind;
+  mime_type: string;
+  name?: string;
+  size: number;
+}
+
+export type PromptAttachmentKind = "image" | "audio" | "resource";
+
+/** What the agent will accept on a prompt, from the ACP `initialize`
+ *  handshake. Drives the composer's attachment button gating. */
+export interface PromptCapabilities {
+  image: boolean;
+  audio: boolean;
+  embeddedContext: boolean;
+}
+
+/** One attachment as the composer hands it to `sendPrompt`: the raw
+ *  base64 bytes plus metadata. The hook turns this into both the POST
+ *  upload body and the optimistic preview row. See #1000 / #965. */
+export interface PromptAttachmentInput {
+  kind: PromptAttachmentKind;
+  mimeType: string;
+  name?: string;
+  /** Standard base64, no `data:` URL prefix. */
+  dataB64: string;
+}
+
+/** One attachment as the composer and transcript render it. `url` is
+ *  the replay GET endpoint for server-confirmed rows, or a local
+ *  object URL for the optimistic echo before the server confirms. */
+export interface CockpitAttachment {
+  id: string;
+  kind: PromptAttachmentKind;
+  mimeType: string;
+  name?: string;
+  size: number;
+  url: string;
+}
 
 export interface CockpitFrame {
   session_id: string;
@@ -308,6 +359,10 @@ export interface CockpitState {
   agent: string | null;
   model: string | null;
   mode: SessionMode;
+  /** Attachment kinds the current agent accepts, from the latest
+   *  `PromptCapabilities` event. Null until the handshake reports it;
+   *  the composer keeps the attachment button disabled while null. */
+  promptCapabilities: PromptCapabilities | null;
   plan: Plan | null;
   inFlightTool: ToolCall | null;
   pendingApprovals: Approval[];
@@ -560,6 +615,10 @@ export interface ActivityRow {
     isMultiRepo: boolean;
     comments: DiffComment[];
   };
+  /** Attachments on a `user_prompt` row (images / audio / resources).
+   *  Set from the optimistic local preview on send, or from the
+   *  server `UserPromptSent` refs on replay. See #1000 / #965. */
+  attachments?: CockpitAttachment[];
   at: string; // ISO-8601
 }
 
@@ -585,6 +644,7 @@ export function emptyCockpitState(): CockpitState {
     agent: null,
     model: null,
     mode: "Default",
+    promptCapabilities: null,
     plan: null,
     inFlightTool: null,
     pendingApprovals: [],
@@ -1135,8 +1195,32 @@ export function applyEvent(
     next.turnActive = isTurnActive(next);
     return next;
   }
+  if ("PromptCapabilities" in event) {
+    const c = event.PromptCapabilities;
+    next.promptCapabilities = {
+      image: c.image,
+      audio: c.audio,
+      embeddedContext: c.embedded_context,
+    };
+    return next;
+  }
   if ("UserPromptSent" in event) {
     const text = event.UserPromptSent.text;
+    // Map server attachment refs to render-ready attachments backed by
+    // the replay GET endpoint. Used on the replay/no-optimistic path;
+    // the optimistic row already carries local preview URLs. See #1000.
+    const serverAttachments: CockpitAttachment[] = (
+      event.UserPromptSent.attachments ?? []
+    ).map((a) => ({
+      id: a.id,
+      kind: a.kind,
+      mimeType: a.mime_type,
+      name: a.name,
+      size: a.size,
+      url: `/api/sessions/${encodeURIComponent(
+        frame.session_id,
+      )}/cockpit/attachments/${encodeURIComponent(a.id)}`,
+    }));
     // Dedupe against the optimistic row that useCockpit's sendPrompt
     // dispatched a moment ago: find the OLDEST matching un-promoted
     // user_prompt with the same text and promote it to the
@@ -1161,7 +1245,18 @@ export function applyEvent(
       const match = next.activity[matchIdx];
       if (match) {
         const updated = next.activity.slice();
-        updated[matchIdx] = { ...match, id: `user-seq-${frame.seq}` };
+        // Keep the optimistic local previews if present (no refetch);
+        // otherwise adopt the server refs so the bubble still renders.
+        updated[matchIdx] = {
+          ...match,
+          id: `user-seq-${frame.seq}`,
+          attachments:
+            match.attachments && match.attachments.length > 0
+              ? match.attachments
+              : serverAttachments.length > 0
+                ? serverAttachments
+                : undefined,
+        };
         next.activity = updated;
       }
     } else {
@@ -1176,6 +1271,7 @@ export function applyEvent(
         id: `user-seq-${frame.seq}`,
         kind: "user_prompt",
         text,
+        attachments: serverAttachments.length > 0 ? serverAttachments : undefined,
         at: new Date().toISOString(),
       });
       next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -989,6 +989,19 @@
       ]
     },
     {
+      "id": "cockpit.attachments",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-attachment.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/Composer.tsx",
+        "web/src/components/cockpit/CockpitRuntime.tsx",
+        "web/src/components/cockpit/CockpitView.tsx"
+      ]
+    },
+    {
       "id": "cockpit.approval",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -347,9 +347,25 @@ async function handleRequest(msg) {
   }
 
   switch (method) {
-    case "initialize":
-      sendResult(id, INITIALIZE_RESULT);
+    case "initialize": {
+      // A script may advertise prompt capabilities (image / audio /
+      // embeddedContext) so attachment specs can exercise the gate
+      // without a real agent. Defaults stay all-false. See #1000 / #965.
+      const result = script.promptCapabilities
+        ? {
+            ...INITIALIZE_RESULT,
+            agentCapabilities: {
+              ...INITIALIZE_RESULT.agentCapabilities,
+              promptCapabilities: {
+                ...INITIALIZE_RESULT.agentCapabilities.promptCapabilities,
+                ...script.promptCapabilities,
+              },
+            },
+          }
+        : INITIALIZE_RESULT;
+      sendResult(id, result);
       return;
+    }
 
     case "session/new":
     case "session/load": {

--- a/web/tests/live/cockpit-attachment.spec.ts
+++ b/web/tests/live/cockpit-attachment.spec.ts
@@ -1,0 +1,136 @@
+// Cockpit composer attachment round-trip (#1000 / #965).
+//
+// Boots `aoe serve` with the fake ACP agent advertising the `image`
+// prompt capability (via a FAKE_ACP_SCRIPT), enables cockpit, then
+// drives the backend the composer drives: POST a prompt carrying an
+// inline base64 image. Asserts the prompt persists with an attachment
+// ref, the stored blob serves back over the replay GET endpoint with
+// the right content type, and the capability gate / magic-byte sniff
+// reject the cases they should.
+
+import { test as base, expect } from "@playwright/test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+import { enableCockpitAndWait } from "../helpers/cockpit";
+
+// A valid 1x1 PNG. The leading bytes (89 50 4E 47) satisfy the server's
+// image magic-byte sniff in validate_attachments.
+const PNG_1X1_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+base("cockpit prompt carries an image attachment end to end", async ({}, testInfo) => {
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-acp-attach-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(
+    scriptPath,
+    JSON.stringify({ promptCapabilities: { image: true } }),
+  );
+
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    fakeAcpScript: scriptPath,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "cockpit-attach" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const sessionId: string = sessions[0]!.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    const promptUrl = `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/prompt`;
+
+    // Happy path: text + one image attachment is accepted.
+    const okRes = await fetch(promptUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: "what is in this image?",
+        attachments: [
+          { kind: "image", mime_type: "image/png", data: PNG_1X1_B64, name: "shot.png" },
+        ],
+      }),
+    });
+    expect(okRes.status).toBeGreaterThanOrEqual(200);
+    expect(okRes.status).toBeLessThan(300);
+
+    // The persisted UserPromptSent carries a metadata-only ref; pull the
+    // attachment id out of replay so we can fetch the stored blob.
+    let attachmentId = "";
+    await expect
+      .poll(async () => {
+        const replay = await fetch(
+          `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+        ).then((r) => r.json());
+        const frames: Array<{ event?: Record<string, unknown> }> = Array.isArray(
+          replay,
+        )
+          ? replay
+          : (replay?.frames ?? []);
+        for (const f of frames) {
+          const ups = f.event?.UserPromptSent as
+            | { attachments?: Array<{ id: string; kind: string }> }
+            | undefined;
+          const att = ups?.attachments?.[0];
+          if (att) {
+            attachmentId = att.id;
+            return att.kind;
+          }
+        }
+        return null;
+      })
+      .toBe("image");
+
+    // The stored blob serves back over the replay GET endpoint with the
+    // right content type and bytes (PNG magic number preserved).
+    const blobRes = await fetch(
+      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/attachments/${attachmentId}`,
+    );
+    expect(blobRes.status).toBe(200);
+    expect(blobRes.headers.get("content-type")).toContain("image/png");
+    const bytes = new Uint8Array(await blobRes.arrayBuffer());
+    expect(Array.from(bytes.slice(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47]);
+
+    // Capability gate: the agent advertises image only, so an audio
+    // attachment is rejected with 400.
+    const audioRes = await fetch(promptUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: "listen",
+        attachments: [
+          { kind: "audio", mime_type: "audio/mpeg", data: PNG_1X1_B64, name: "a.mp3" },
+        ],
+      }),
+    });
+    expect(audioRes.status).toBe(400);
+
+    // Magic-byte sniff: text bytes mislabeled as image/png are rejected.
+    const spoofRes = await fetch(promptUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: "sneaky",
+        attachments: [
+          {
+            kind: "image",
+            mime_type: "image/png",
+            data: Buffer.from("<svg>not an image</svg>").toString("base64"),
+            name: "x.png",
+          },
+        ],
+      }),
+    });
+    expect(spoofRes.status).toBe(400);
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds real attachment support to the cockpit composer: images, audio, and embedded resources can be sent alongside a prompt, gated on the agent's ACP `prompt_capabilities`. Combines two issues into one pipeline, since #965 (paste/drop a screenshot) is the clipboard capture path that #1000 explicitly left as a follow-up.

Capture is three ways: the paperclip file picker, Cmd/Ctrl+V paste, and drag-and-drop onto the composer. Staged files show as removable chips (image thumbnails inline); an attachment-only prompt with no text is allowed. The paperclip is disabled with an explanatory tooltip when the active agent does not advertise the matching capability, and the file picker only offers the kinds it accepts.

Backend: `PromptRequest` gains an optional inline-base64 `attachments` array; `send_prompt` maps each to an ACP `ContentBlock` (`Image` / `Audio` / `Resource`). A new persisted `PromptCapabilities` event is captured from the `initialize` handshake (and re-emitted on every connect) so the UI gate survives replay, and the server reads the latest one to authoritatively reject attachments an agent cannot accept. The prompt handler validates count / per-attachment size (10 MiB) / total size (20 MiB) / a MIME allowlist (`image/svg+xml` and HTML excluded) and sniffs image magic bytes before publishing, so a rejected prompt never leaves a half-rendered attachment in the transcript.

Persistence is reference-out: decoded bytes live in a dedicated `cockpit_attachments` SQLite table keyed to the owning prompt's seq, the event log carries metadata-only refs, and the bytes serve back lazily over `GET /api/sessions/{id}/cockpit/attachments/{id}` for replay (browser-cacheable). Blobs are pruned in lockstep with their owning prompt event (retention cap) and cascade on session delete, so the table stays bounded.

The design (transport, persistence boundary, scope, capability surface) was worked through a multi-model debate before implementation.

Closes #1000
Closes #965

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] In the web cockpit with an agent that supports images (e.g. claude-agent-acp), click the paperclip, pick a PNG, send, and confirm it renders inline in your message bubble and the agent sees it.
- [ ] Take a screenshot, focus the composer, Cmd/Ctrl+V, and confirm a thumbnail chip appears; send and confirm it round-trips.
- [ ] Drag an image file onto the composer and confirm it stages as a chip.
- [ ] Send an image-only prompt (no text) via the Send button and confirm it works.
- [ ] Reload mid-transcript and confirm previously attached images re-render.
- [ ] Switch to an agent without image support and confirm the paperclip is disabled with a tooltip.
- [ ] Drop a non-image file mislabeled as an image (or an oversize file) and confirm the server rejects it with a clear error.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (reference-out persistence with pruning, all-three-kinds scope, capability gating) via a multi-model debate, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR adds end-to-end attachment support to the Cockpit composer. Users can attach images, audio, and embedded resources via the paperclip/file picker, paste, or drag-and-drop. Staged attachments render as removable chips (images show thumbnails); prompts may be attachment-only. The composer UI and picker are capability-gated by the active agent’s advertised prompt_capabilities.

Frontend highlights
- Restores capability-gated paperclip/file picker and adds paste & drag-and-drop capture.
- Stages attachments with removable preview chips and thumbnails for images.
- Composer send/queue/Enter flows carry attachments; optimistic UI shows attachments and server-confirmed prompts reference replayable attachment URLs.
- Exposes promptCapabilities and pendingAttachments through CockpitRuntime and hooks; types and reducers updated.

Backend & persistence
- PromptRequest now supports inline base64 attachments; server decodes, validates, and persists blobs by-reference.
- New cockpit_attachments SQLite table and AttachmentBlob struct store decoded bytes keyed by (session_id, seq); event log stores metadata-only refs.
- New GET /api/sessions/{id}/cockpit/attachments/{id} endpoint serves blobs with Cache-Control and nosniff headers.
- Attachments are pruned alongside their owning prompt and on session deletion.

Validation & capability gating
- Server enforces per-file (10 MiB), total-per-prompt (20 MiB), max count (8), kind-specific MIME allowlist (excludes image/svg+xml and HTML), and image magic-byte sniffing to prevent mislabeled/malformed images.
- Agent attachment capability (image/audio/embedded_context) is captured from the ACP initialize handshake and re-emitted as Event::PromptCapabilities so the UI can gate features and survive replay. Agents lacking capability cause authoritative rejection.

Protocol, API, and plumbing
- Protocol: PromptRequest gains attachments: Vec<PromptAttachmentUpload> (kind, mime_type, base64 data, optional name).
- Events/state: Event::UserPromptSent now includes attachments (PromptAttachmentRef metadata); new Event::PromptCapabilities persisted/replayed.
- AcpClient::send_prompt accepts attachments and maps them to ACP ContentBlock variants (Image/Audio/Resource).
- Supervisor, BroadcastSink, and ChannelSink extended to record/delete attachments and publish persisted prompts with attachments.
- Route POST /api/sessions/{id}/cockpit/prompt body limit increased to accept inline base64 payloads.

Testing and docs
- Playwright e2e test for attachment submit, persistence, retrieval, and negative cases.
- Unit tests for server validation, image sniffing, storage/pruning, protocol deserialization/backcompat, prompt capability selection, and frontend reducers.
- docs/cockpit.md updated with a new Composer attachments section and behavior.

Benefits
- Enables richer, multimedia prompts to ACP-capable agents.
- Multiple convenient input methods (paste/drop/picker) and inline previews improve UX.
- Server-side validation and stored-by-reference persistence keep transcripts safe and compact.
- UI capability gating prevents unsupported uploads and surfaces clear errors.

Technical details (concise)
- New types: PromptAttachmentKind, PromptAttachmentRef, PromptAttachmentUpload, AttachmentBlob, CockpitAttachment (frontend).
- EventStore APIs: record_attachment, delete_attachments_for_seq, load_attachment, latest_prompt_capabilities; new cockpit_attachments table.
- AcpClient/send_prompt signature changed to accept attachments and sends Vec<ContentBlock>.
- New endpoint: GET /api/sessions/{id}/cockpit/attachments/{id}; POST prompt accepts attachments in JSON payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->