### PR TITLE
feat(cockpit): support custom agents in web cockpit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha2 0.11.0",
+ "shell-words",
  "similar",
  "subtle",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ portable-pty = "0.9"
 # Fuzzy matching
 nucleo-matcher = "0.3"
 
+# Shell-style splitting of custom-agent ACP command strings into argv
+shell-words = "1.1"
+
 # Error handling
 thiserror = "2.0"
 anyhow = "1.0"

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -46,6 +46,8 @@ always fall back to tmux.
 | `aoe-agent`| Bundled multi-provider agent (Vercel AI SDK 6)             | Whatever provider env vars Vercel AI SDK expects |
 | *aider, cursor, copilot, droid, settl, hermes* | not yet wired into the cockpit registry; fall back to terminal mode |
 
+A **custom agent** can run in cockpit too: give it an ACP launch command via `agent_cockpit_cmd` in config (or the TUI settings screen). See [Running a custom agent in cockpit](guides/configuration.md#running-a-custom-agent-in-cockpit). The wizard reads each agent's `acp_capable` flag from the server, so a custom agent with an `agent_cockpit_cmd` offers cockpit just like a built-in; without one it stays terminal-only.
+
 The four env vars cockpit always forwards to the agent process are
 `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`,
 `CLAUDE_CONFIG_DIR`. For the others, set them in the env that runs

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -105,6 +105,7 @@ agent_status_hooks = true
 | `agent_command_override` | `{}` | Per-agent command override replacing the binary entirely (e.g., `{ claude = "my-claude-wrapper" }`). |
 | `custom_agents` | `{}` | User-defined agents: name to command mapping. Custom agent names appear in the TUI agent picker alongside built-in agents. |
 | `agent_detect_as` | `{}` | Status detection mapping: maps an agent name to a built-in agent whose status heuristics should be used. |
+| `agent_cockpit_cmd` | `{}` | ACP launch command for a custom agent, enabling it to run in cockpit (e.g., `{ "oc-superpowers" = "ocp run sp acp" }`). A custom agent with an entry here is cockpit-capable; without one it stays tmux-only. Unlike `custom_agents`, the value is split into argv and run directly, with no shell. |
 
 For Codex, AoE preserves existing `[hooks.state]` trust data and writes `~/.codex/config.toml` through `config.toml.lock` plus an atomic replace. This keeps repeated or concurrent AoE launches from duplicating hook blocks or leaving partial TOML.
 
@@ -149,13 +150,30 @@ agent_detect_as = { "lenovo-claude" = "claude" }
 
 - **`custom_agents`**: Maps a display name to the command AoE runs when that agent is selected. Custom-agent names are configured in config files or the TUI settings screen, and they appear alongside built-in agents like `claude`, `opencode`, and `codex`.
 - **`agent_detect_as`** (optional): Maps a custom agent to a built-in agent's status detection. Without this, custom agents default to `Idle` status. Setting `"lenovo-claude" = "claude"` reuses Claude's Running/Waiting/Idle detection heuristics for the remote session.
+- **`agent_cockpit_cmd`** (optional): The ACP launch command that lets a custom agent run in the structured cockpit UI instead of the tmux terminal. See the Cockpit subsection below.
 - **`default_tool`** (optional): Can point at a custom-agent name so new sessions default to that configured agent.
 
 Custom agents are always shown as available in the TUI picker because their command may target a remote host or wrapper script instead of a local binary. From the CLI, use `aoe add --tool <name>` to create a session with a configured custom agent by name. The selected custom agent still uses the command from `custom_agents`; browser or CLI input is not treated as a raw command.
 
-The Web session wizard can select configured custom agents and submit the selected name to the server. For security, the Web UI does not expose custom-agent command strings, does not expose `agent_detect_as` values, and does not edit `custom_agents` or `agent_detect_as`. Edit those fields through config files or the TUI settings screen instead.
+The Web session wizard can select configured custom agents and submit the selected name to the server. For security, the Web UI does not expose custom-agent command strings, does not expose `agent_detect_as` or `agent_cockpit_cmd` values, and does not edit any of these maps. Edit those fields through config files or the TUI settings screen instead.
 
-Both fields are editable from the TUI settings screen and support profile/repo-level overrides.
+All three fields are editable from the TUI settings screen and support profile/repo-level overrides.
+
+#### Running a custom agent in cockpit
+
+By default a custom agent runs in the tmux terminal. To run it in the structured cockpit UI, give it an ACP launch command in `agent_cockpit_cmd`. The agent must speak the [Agent Client Protocol](https://agentclientprotocol.com); the command is what AoE execs to start the ACP server.
+
+```toml
+[session.custom_agents]
+"oc-superpowers" = "ocp run sp"
+
+[session.agent_cockpit_cmd]
+"oc-superpowers" = "ocp run sp acp"
+```
+
+With the cockpit master switch on, selecting `oc-superpowers` in the web wizard now creates a cockpit session, and `aoe add --tool oc-superpowers --cockpit` launches the ACP command. A custom agent with no `agent_cockpit_cmd` keeps running in the terminal, and `aoe add --cockpit` for it now errors instead of silently launching the bundled fallback agent.
+
+Note the difference from `custom_agents`: the `custom_agents` value is a shell command run in a tmux pane, while the `agent_cockpit_cmd` value is split into argv with shell-word rules and executed directly, with no shell. For shell features, wrap explicitly, e.g. `"sh -lc 'source ~/.profile && ocp run sp acp'"`. The agent name must match a `custom_agents` entry so it appears in the picker, and it cannot shadow a built-in agent name.
 
 > **Note:** Profile and repo-level overrides fully replace the global value rather than merging with it. A profile that defines `custom_agents` replaces the entire global set, so you must redeclare any global agents you want to keep in that profile.
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -539,30 +539,62 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         // for, where missing tooling is a hard error rather than a
         // silent fallback to tmux.
         if instance.cockpit_mode && user_picked_cockpit {
+            // A custom agent explicitly opted into cockpit must declare an
+            // ACP command; otherwise we'd silently fall back to aoe-agent
+            // and launch the wrong thing. Fail loudly instead.
+            let has_override = instance
+                .cockpit_agent
+                .as_deref()
+                .is_some_and(|s| !s.is_empty());
+            let is_custom = config.session.custom_agents.contains_key(&instance.tool);
+            if is_custom
+                && !has_override
+                && !config
+                    .session
+                    .agent_cockpit_cmd
+                    .contains_key(&instance.tool)
+            {
+                bail!(
+                    "custom agent `{tool}` has no `agent_cockpit_cmd`, so it can't run in cockpit.\n\
+                     Add an ACP launch command under `[session.agent_cockpit_cmd]`, e.g.\n\
+                     {tool} = \"ocp run sp acp\"\n\
+                     Or skip cockpit: rerun with `--no-cockpit` for a tmux-backed session.",
+                    tool = instance.tool
+                );
+            }
             let registry = crate::cockpit::agent_registry::AgentRegistry::with_defaults();
             let agent_name = pick_cockpit_agent_name(
                 &registry,
+                &config.session,
                 &instance.tool,
                 instance.cockpit_agent.as_deref(),
             );
-            if let Some(spec) = registry.get(&agent_name) {
-                if !crate::cli::cockpit::command_present(&spec.command) {
-                    let hint = crate::cockpit::install_hints::install_hint_for(&spec.command)
-                        .unwrap_or("install via your package manager and re-run");
-                    bail!(
-                        "cockpit ACP adapter `{}` is not installed or not on $PATH.\n\
-                         Install: {}\n\
-                         Or run: aoe cockpit doctor --fix\n\
-                         Or use the bundled fallback: rerun with `--agent aoe-agent`\n\
-                         Or skip cockpit: rerun with `--no-cockpit` for a tmux-backed session.",
-                        spec.command,
-                        hint
-                    );
-                }
-            } else {
+            // Resolve the spec from the registry (built-in) or the custom
+            // agent's configured ACP command, then verify the binary is on
+            // PATH. A missing adapter is a hard error at add-time rather
+            // than a silent 404 on the first prompt.
+            let spec = match registry.get(&agent_name) {
+                Some(spec) => spec.clone(),
+                None => match config.session.agent_cockpit_cmd.get(&agent_name) {
+                    Some(cmd) => crate::cockpit::AgentSpec::from_cockpit_cmd(&agent_name, cmd)
+                        .map_err(|e| anyhow::anyhow!(e))?,
+                    None => bail!(
+                        "cockpit agent `{agent_name}` is not in the registry.\n\
+                         Run `aoe cockpit doctor` to see configured agents."
+                    ),
+                },
+            };
+            if !crate::cli::cockpit::command_present(&spec.command) {
+                let hint = crate::cockpit::install_hints::install_hint_for(&spec.command)
+                    .unwrap_or("install via your package manager and re-run");
                 bail!(
-                    "cockpit agent `{agent_name}` is not in the registry.\n\
-                     Run `aoe cockpit doctor` to see configured agents."
+                    "cockpit ACP adapter `{}` is not installed or not on $PATH.\n\
+                     Install: {}\n\
+                     Or run: aoe cockpit doctor --fix\n\
+                     Or use the bundled fallback: rerun with `--agent aoe-agent`\n\
+                     Or skip cockpit: rerun with `--no-cockpit` for a tmux-backed session.",
+                    spec.command,
+                    hint
                 );
             }
         }
@@ -911,10 +943,12 @@ pub fn is_duplicate_session(instances: &[Instance], title: &str, path: &str) -> 
 /// Sync mirror of `Supervisor::pick_agent_for_tool` so add-time
 /// precondition checks can resolve the agent without spinning up the
 /// async supervisor. Precedence: explicit override → tool-keyed
-/// registry entry → legacy (`claude` → `claude`, else `aoe-agent`).
+/// registry entry → custom agent with `agent_cockpit_cmd` → legacy
+/// (`claude` → `claude`, else `aoe-agent`).
 #[cfg(feature = "serve")]
 fn pick_cockpit_agent_name(
     registry: &crate::cockpit::agent_registry::AgentRegistry,
+    session: &crate::session::config::SessionConfig,
     tool: &str,
     explicit_override: Option<&str>,
 ) -> String {
@@ -924,6 +958,9 @@ fn pick_cockpit_agent_name(
         }
     }
     if registry.get(tool).is_some() {
+        return tool.to_string();
+    }
+    if session.agent_cockpit_cmd.contains_key(tool) {
         return tool.to_string();
     }
     if tool == "claude" {

--- a/src/cockpit/agent_registry.rs
+++ b/src/cockpit/agent_registry.rs
@@ -20,6 +20,28 @@ pub struct AgentSpec {
     pub env_allowlist: Option<Vec<String>>,
 }
 
+impl AgentSpec {
+    /// Build an ACP `AgentSpec` from a custom agent's `agent_cockpit_cmd`
+    /// string. The string is split with shell-word rules into argv and run
+    /// directly (no shell). Returns a user-facing error message when the
+    /// command is empty or has malformed quoting.
+    pub fn from_cockpit_cmd(name: &str, cmd: &str) -> Result<AgentSpec, String> {
+        let argv = shell_words::split(cmd)
+            .map_err(|e| format!("custom agent `{name}` has a malformed cockpit command ({e})"))?;
+        let mut argv = argv.into_iter();
+        let command = argv
+            .next()
+            .filter(|c| !c.trim().is_empty())
+            .ok_or_else(|| format!("custom agent `{name}` has an empty cockpit command"))?;
+        Ok(AgentSpec {
+            command,
+            args: argv.collect(),
+            description: format!("Custom ACP agent `{name}`"),
+            env_allowlist: None,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentRegistry {
     pub agents: HashMap<String, AgentSpec>,
@@ -167,6 +189,33 @@ mod tests {
         let reg = AgentRegistry::with_defaults();
         assert!(reg.get("claude-code").is_some());
         assert!(reg.get("aoe-agent").is_some());
+    }
+
+    #[test]
+    fn from_cockpit_cmd_splits_argv() {
+        let spec = AgentSpec::from_cockpit_cmd("oc-sp", "ocp run sp acp").unwrap();
+        assert_eq!(spec.command, "ocp");
+        assert_eq!(spec.args, vec!["run", "sp", "acp"]);
+        assert_eq!(spec.description, "Custom ACP agent `oc-sp`");
+        assert!(spec.env_allowlist.is_none());
+    }
+
+    #[test]
+    fn from_cockpit_cmd_honors_quoting() {
+        let spec = AgentSpec::from_cockpit_cmd("wrap", "sh -lc 'ocp run sp acp'").unwrap();
+        assert_eq!(spec.command, "sh");
+        assert_eq!(spec.args, vec!["-lc", "ocp run sp acp"]);
+    }
+
+    #[test]
+    fn from_cockpit_cmd_rejects_empty() {
+        assert!(AgentSpec::from_cockpit_cmd("x", "").is_err());
+        assert!(AgentSpec::from_cockpit_cmd("x", "   ").is_err());
+    }
+
+    #[test]
+    fn from_cockpit_cmd_rejects_unbalanced_quotes() {
+        assert!(AgentSpec::from_cockpit_cmd("x", "ocp run \"unterminated").is_err());
     }
 
     #[test]

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -523,12 +523,15 @@ impl<S: BroadcastSink> Supervisor<S> {
     ///      `aoe-agent` (our bundled multi-provider agent)
     ///
     /// `profile` is the session's source profile (`""` resolves the
-    /// user's default) and is only consulted for step 3.
+    /// user's default) and `project_path` is its working directory;
+    /// both are consulted for step 3 so repo-local `agent_cockpit_cmd`
+    /// overrides are honored.
     pub async fn pick_agent_for_tool(
         &self,
         tool: &str,
         explicit_override: Option<&str>,
         profile: &str,
+        project_path: &std::path::Path,
     ) -> String {
         if let Some(name) = explicit_override {
             if !name.is_empty() {
@@ -545,7 +548,10 @@ impl<S: BroadcastSink> Supervisor<S> {
         // Step 3: custom agent with a configured ACP command resolves to
         // its own name; spawn builds the spec from config (no registry
         // mutation).
-        if self.custom_agent_has_cockpit_cmd(tool, profile).await {
+        if self
+            .custom_agent_has_cockpit_cmd(tool, profile, project_path)
+            .await
+        {
             return tool.to_string();
         }
         // Step 4: legacy fallbacks.
@@ -557,12 +563,18 @@ impl<S: BroadcastSink> Supervisor<S> {
     }
 
     /// True iff `tool` is a custom agent that declares an
-    /// `agent_cockpit_cmd` in the given profile's resolved config.
-    pub async fn custom_agent_has_cockpit_cmd(&self, tool: &str, profile: &str) -> bool {
+    /// `agent_cockpit_cmd` in its profile + repo-resolved config.
+    pub async fn custom_agent_has_cockpit_cmd(
+        &self,
+        tool: &str,
+        profile: &str,
+        project_path: &std::path::Path,
+    ) -> bool {
         let tool = tool.to_string();
         let profile = profile.to_string();
+        let project_path = project_path.to_path_buf();
         tokio::task::spawn_blocking(move || {
-            crate::session::profile_config::resolve_config_or_warn(&profile)
+            crate::session::repo_config::resolve_config_with_repo_or_warn(&profile, &project_path)
                 .session
                 .agent_cockpit_cmd
                 .get(&tool)
@@ -986,12 +998,16 @@ impl<S: BroadcastSink> Supervisor<S> {
         };
 
         // Resolve the spec config-aware: built-ins come from the
-        // registry, custom agents from this session's profile-resolved
-        // `agent_cockpit_cmd`. Read off-thread; config resolution touches
-        // disk.
+        // registry, custom agents from this session's profile + repo
+        // resolved `agent_cockpit_cmd`. Read off-thread; config
+        // resolution touches disk.
         let profile_for_cfg = source_profile.clone().unwrap_or_default();
+        let cwd_for_cfg = cwd.clone();
         let resolved_cfg = tokio::task::spawn_blocking(move || {
-            crate::session::profile_config::resolve_config_or_warn(&profile_for_cfg)
+            crate::session::repo_config::resolve_config_with_repo_or_warn(
+                &profile_for_cfg,
+                &cwd_for_cfg,
+            )
         })
         .await
         .map_err(|e| {

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -143,6 +143,8 @@ pub enum SupervisorError {
     Acp(#[from] AcpError),
     #[error("agent {0:?} not in registry")]
     UnknownAgent(String),
+    #[error("{0}")]
+    InvalidAgentCommand(String),
     #[error("session {0:?} already has a running cockpit worker")]
     AlreadyRunning(String),
     /// Configured `[cockpit] max_concurrent_workers` cap is full. The
@@ -488,34 +490,86 @@ impl<S: BroadcastSink> Supervisor<S> {
             .ok_or_else(|| SupervisorError::UnknownAgent(name.into()))
     }
 
+    /// Resolve the agent spec for a cockpit session, overlaying the
+    /// session's (already profile-resolved) config onto the built-in
+    /// registry. Built-in agents resolve from the registry; a custom
+    /// agent resolves from its `agent_cockpit_cmd` entry, parsed into
+    /// argv. Never mutates the registry, so two profiles defining the
+    /// same custom name with different commands don't clobber each other
+    /// and `/cockpit/switch-agent` validation stays per-session.
+    pub async fn resolve_agent_spec(
+        &self,
+        name: &str,
+        config: &crate::session::config::SessionConfig,
+    ) -> Result<AgentSpec, SupervisorError> {
+        if let Some(spec) = self.registry.lock().await.get(name).cloned() {
+            return Ok(spec);
+        }
+        if let Some(cmd) = config.agent_cockpit_cmd.get(name) {
+            return AgentSpec::from_cockpit_cmd(name, cmd)
+                .map_err(SupervisorError::InvalidAgentCommand);
+        }
+        Err(SupervisorError::UnknownAgent(name.into()))
+    }
+
     /// Pick the agent name to spawn for an instance. Precedence:
     ///   1. explicit `cockpit_agent` override on the instance
     ///   2. registry entry keyed on the instance's tool name
     ///      (so `tool="opencode"` → registry `"opencode"` →
     ///      `opencode acp`, etc.)
-    ///   3. legacy fallback: `claude` for the claude tool, otherwise
+    ///   3. custom agent declaring an ACP command via
+    ///      `agent_cockpit_cmd` in the session's profile config
+    ///   4. legacy fallback: `claude` for the claude tool, otherwise
     ///      `aoe-agent` (our bundled multi-provider agent)
-    pub async fn pick_agent_for_tool(&self, tool: &str, explicit_override: Option<&str>) -> String {
+    ///
+    /// `profile` is the session's source profile (`""` resolves the
+    /// user's default) and is only consulted for step 3.
+    pub async fn pick_agent_for_tool(
+        &self,
+        tool: &str,
+        explicit_override: Option<&str>,
+        profile: &str,
+    ) -> String {
         if let Some(name) = explicit_override {
             if !name.is_empty() {
                 return name.to_string();
             }
         }
-        // Step 2: tool-keyed registry lookup. Done under the same
-        // lock as resolve_agent so a custom override registered via
-        // upsert_agent is honored.
+        // Step 2: tool-keyed registry lookup.
         {
             let reg = self.registry.lock().await;
             if reg.get(tool).is_some() {
                 return tool.to_string();
             }
         }
-        // Step 3: legacy fallbacks.
+        // Step 3: custom agent with a configured ACP command resolves to
+        // its own name; spawn builds the spec from config (no registry
+        // mutation).
+        if self.custom_agent_has_cockpit_cmd(tool, profile).await {
+            return tool.to_string();
+        }
+        // Step 4: legacy fallbacks.
         if tool == "claude" {
             "claude".into()
         } else {
             "aoe-agent".into()
         }
+    }
+
+    /// True iff `tool` is a custom agent that declares an
+    /// `agent_cockpit_cmd` in the given profile's resolved config.
+    pub async fn custom_agent_has_cockpit_cmd(&self, tool: &str, profile: &str) -> bool {
+        let tool = tool.to_string();
+        let profile = profile.to_string();
+        tokio::task::spawn_blocking(move || {
+            crate::session::profile_config::resolve_config_or_warn(&profile)
+                .session
+                .agent_cockpit_cmd
+                .get(&tool)
+                .is_some_and(|cmd| crate::cockpit::AgentSpec::from_cockpit_cmd(&tool, cmd).is_ok())
+        })
+        .await
+        .unwrap_or(false)
     }
 
     pub async fn registry_snapshot(&self) -> AgentRegistry {
@@ -931,7 +985,21 @@ impl<S: BroadcastSink> Supervisor<S> {
             }
         };
 
-        let mut spec = self.resolve_agent(&agent).await?;
+        // Resolve the spec config-aware: built-ins come from the
+        // registry, custom agents from this session's profile-resolved
+        // `agent_cockpit_cmd`. Read off-thread; config resolution touches
+        // disk.
+        let profile_for_cfg = source_profile.clone().unwrap_or_default();
+        let resolved_cfg = tokio::task::spawn_blocking(move || {
+            crate::session::profile_config::resolve_config_or_warn(&profile_for_cfg)
+        })
+        .await
+        .map_err(|e| {
+            SupervisorError::InvalidAgentCommand(format!("config load task failed: {e}"))
+        })?;
+        let mut spec = self
+            .resolve_agent_spec(&agent, &resolved_cfg.session)
+            .await?;
         // Apply ${aoe_data_dir} placeholder substitution against the
         // appropriate path; if the placeholder is not consumed it stays
         // as-is and the spawn will fail with a clear error.

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -284,6 +284,7 @@ pub async fn spawn_cockpit(
             &instance.tool,
             explicit.as_deref(),
             &instance.source_profile,
+            std::path::Path::new(&instance.project_path),
         )
         .await;
 
@@ -469,6 +470,7 @@ pub async fn switch_cockpit_agent(
             &instance.tool,
             instance.cockpit_agent.as_deref(),
             &instance.source_profile,
+            std::path::Path::new(&instance.project_path),
         )
         .await;
     if from_agent == target {
@@ -1135,13 +1137,22 @@ pub async fn cockpit_enable(
     // when it declares an `agent_cockpit_cmd` in its profile config.
     let agent_name = state
         .cockpit_supervisor
-        .pick_agent_for_tool(&instance.tool, instance.cockpit_agent.as_deref(), &profile)
+        .pick_agent_for_tool(
+            &instance.tool,
+            instance.cockpit_agent.as_deref(),
+            &profile,
+            std::path::Path::new(&instance.project_path),
+        )
         .await;
     let registry = state.cockpit_supervisor.registry_snapshot().await;
     let resolvable = registry.get(&agent_name).is_some()
         || state
             .cockpit_supervisor
-            .custom_agent_has_cockpit_cmd(&instance.tool, &profile)
+            .custom_agent_has_cockpit_cmd(
+                &instance.tool,
+                &profile,
+                std::path::Path::new(&instance.project_path),
+            )
             .await;
     if !resolvable {
         return (

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -280,7 +280,11 @@ pub async fn spawn_cockpit(
     let explicit = req.agent.clone().or_else(|| instance.cockpit_agent.clone());
     let agent = state
         .cockpit_supervisor
-        .pick_agent_for_tool(&instance.tool, explicit.as_deref())
+        .pick_agent_for_tool(
+            &instance.tool,
+            explicit.as_deref(),
+            &instance.source_profile,
+        )
         .await;
 
     let cwd = PathBuf::from(&instance.project_path);
@@ -461,7 +465,11 @@ pub async fn switch_cockpit_agent(
     };
     let from_agent = state
         .cockpit_supervisor
-        .pick_agent_for_tool(&instance.tool, instance.cockpit_agent.as_deref())
+        .pick_agent_for_tool(
+            &instance.tool,
+            instance.cockpit_agent.as_deref(),
+            &instance.source_profile,
+        )
         .await;
     if from_agent == target {
         return (
@@ -1121,15 +1129,21 @@ pub async fn cockpit_enable(
         .into_response();
     }
 
-    // Verify the tool has an ACP-capable registry entry. Otherwise
-    // there's no agent to spawn and the swap would just produce a
-    // dead cockpit. Falls back to "tool not in registry" → 400.
+    // Verify the tool has an ACP-capable agent. Otherwise there's no
+    // agent to spawn and the swap would just produce a dead cockpit.
+    // Built-in tools resolve from the registry; a custom agent is valid
+    // when it declares an `agent_cockpit_cmd` in its profile config.
     let agent_name = state
         .cockpit_supervisor
-        .pick_agent_for_tool(&instance.tool, instance.cockpit_agent.as_deref())
+        .pick_agent_for_tool(&instance.tool, instance.cockpit_agent.as_deref(), &profile)
         .await;
     let registry = state.cockpit_supervisor.registry_snapshot().await;
-    if registry.get(&agent_name).is_none() {
+    let resolvable = registry.get(&agent_name).is_some()
+        || state
+            .cockpit_supervisor
+            .custom_agent_has_cockpit_cmd(&instance.tool, &profile)
+            .await;
+    if !resolvable {
         return (
             StatusCode::BAD_REQUEST,
             format!("no cockpit agent registered for tool {:?}", instance.tool),

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -123,8 +123,10 @@ pub(super) const SESSION_BLOCKED_FIELDS: &[&str] = &[
     // custom_agents maps names to arbitrary shell commands (e.g., "ssh -t host claude").
     // agent_detect_as maps names to detection targets but is part of the agent config
     // surface that should only be editable locally.
+    // agent_cockpit_cmd maps names to ACP launch commands, another command-injection vector.
     "custom_agents",
     "agent_detect_as",
+    "agent_cockpit_cmd",
 ];
 
 /// Top-level settings sections whose presence in a `PATCH
@@ -790,6 +792,8 @@ mod tests {
             "custom_agents",
             // agent_detect_as: part of the agent config surface
             "agent_detect_as",
+            // agent_cockpit_cmd: maps agent names to ACP launch commands
+            "agent_cockpit_cmd",
         ];
         assert_eq!(
             SESSION_BLOCKED_FIELDS.len(),

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -104,6 +104,13 @@ pub struct SessionResponse {
     /// cockpit view. See #1088.
     #[cfg(feature = "serve")]
     pub cockpit_worker_state: crate::cockpit::supervisor::CockpitWorkerState,
+    /// True when this session's agent can run in cockpit: a built-in
+    /// with an ACP adapter, or a custom agent whose profile config
+    /// declares a valid `agent_cockpit_cmd`. The web terminal view reads
+    /// this to decide whether the "switch to cockpit" affordance is
+    /// available, replacing the hardcoded client-side tool list.
+    #[cfg(feature = "serve")]
+    pub acp_capable: bool,
     /// True when the session is a Claude Code session AND the user has
     /// enabled Claude's fullscreen renderer (`tui: "fullscreen"` in
     /// `~/.claude/settings.json`). The web client uses this to skip
@@ -255,6 +262,15 @@ impl SessionResponse {
             cockpit_mode: inst.cockpit_mode,
             #[cfg(feature = "serve")]
             cockpit_worker_state,
+            // Built-in ACP capability is resolved here from a process-wide
+            // registry (cheap, no IO). Custom agents depend on profile
+            // config; the list and create handlers overlay that without a
+            // per-row config read.
+            #[cfg(feature = "serve")]
+            acp_capable: {
+                let resolved = inst.cockpit_agent.as_deref().unwrap_or(inst.tool.as_str());
+                builtin_acp_registry().get(resolved).is_some()
+            },
             claude_fullscreen: claude_fullscreen && inst.tool == "claude",
             workspace_repos: inst
                 .workspace_info
@@ -321,6 +337,28 @@ pub struct SessionsEnvelope {
     pub workspace_ordering: Vec<String>,
 }
 
+/// Process-wide built-in ACP registry, built once. Used to compute
+/// `SessionResponse.acp_capable` for built-in agents without allocating
+/// a registry per response row.
+#[cfg(feature = "serve")]
+fn builtin_acp_registry() -> &'static crate::cockpit::AgentRegistry {
+    static REG: std::sync::OnceLock<crate::cockpit::AgentRegistry> = std::sync::OnceLock::new();
+    REG.get_or_init(crate::cockpit::AgentRegistry::with_defaults)
+}
+
+/// True iff this custom agent declares a valid `agent_cockpit_cmd` in the
+/// given profile-resolved map. Built-in capability is handled separately
+/// in the constructor, so this only covers the custom case.
+#[cfg(feature = "serve")]
+fn custom_agent_acp_capable(
+    agent_cockpit_cmd: &std::collections::HashMap<String, String>,
+    tool: &str,
+) -> bool {
+    agent_cockpit_cmd
+        .get(tool)
+        .is_some_and(|cmd| crate::cockpit::AgentSpec::from_cockpit_cmd(tool, cmd).is_ok())
+}
+
 pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsEnvelope> {
     let instances = state.instances.read().await;
     let claude_fullscreen = crate::claude_settings::read_tui_fullscreen();
@@ -363,6 +401,28 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
             )
         })
         .collect();
+
+    // Overlay custom-agent ACP capability (built-ins were resolved in the
+    // constructor). Resolve each distinct profile's config at most once.
+    #[cfg(feature = "serve")]
+    {
+        use std::collections::HashMap;
+        let mut cockpit_cmd_by_profile: HashMap<String, HashMap<String, String>> = HashMap::new();
+        for (resp, inst) in sessions.iter_mut().zip(instances.iter()) {
+            if resp.acp_capable {
+                continue;
+            }
+            let profile = inst.source_profile.clone();
+            let map = cockpit_cmd_by_profile
+                .entry(profile.clone())
+                .or_insert_with(|| {
+                    crate::session::profile_config::resolve_config_or_warn(&profile)
+                        .session
+                        .agent_cockpit_cmd
+                });
+            resp.acp_capable = custom_agent_acp_capable(map, &inst.tool);
+        }
+    }
 
     // Resolve per-profile cleanup defaults with a TTL cache on AppState
     let cache = {
@@ -1877,6 +1937,29 @@ pub async fn create_session(
             instance.cockpit_mode = body.cockpit_mode && cockpit_master_enabled;
             instance.cockpit_agent = body.cockpit_agent;
             instance.cockpit_model = body.cockpit_model;
+            // Don't trust the client's capability decision. Re-resolve
+            // whether this agent can actually run in cockpit; a custom
+            // agent without an `agent_cockpit_cmd` (or any non-ACP tool)
+            // falls back to tmux here rather than erroring at spawn time.
+            if instance.cockpit_mode {
+                let acp_registry = crate::cockpit::AgentRegistry::with_defaults();
+                let resolved = instance
+                    .cockpit_agent
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or(instance.tool.as_str());
+                let capable = acp_registry.get(resolved).is_some()
+                    || crate::session::profile_config::resolve_config_or_warn(
+                        &instance.source_profile,
+                    )
+                    .session
+                    .agent_cockpit_cmd
+                    .get(&instance.tool)
+                    .is_some_and(|cmd| {
+                        crate::cockpit::AgentSpec::from_cockpit_cmd(&instance.tool, cmd).is_ok()
+                    });
+                instance.cockpit_mode = capable;
+            }
         }
 
         // Anything that fails between here and the final `Ok(..)`
@@ -1940,6 +2023,17 @@ pub async fn create_session(
                 crate::claude_settings::read_tui_fullscreen(),
             );
             resp.warnings = warnings;
+            // Overlay custom-agent ACP capability so the wizard's redirect
+            // into the new session renders the right substrate immediately.
+            #[cfg(feature = "serve")]
+            if !resp.acp_capable {
+                let cockpit_cmd = crate::session::profile_config::resolve_config_or_warn(
+                    &instance.source_profile,
+                )
+                .session
+                .agent_cockpit_cmd;
+                resp.acp_capable = custom_agent_acp_capable(&cockpit_cmd, &instance.tool);
+            }
             #[cfg(feature = "serve")]
             let cockpit_spawn_target = if instance.cockpit_mode {
                 Some((
@@ -1973,7 +2067,7 @@ pub async fn create_session(
             {
                 let agent = state
                     .cockpit_supervisor
-                    .pick_agent_for_tool(&tool, agent_override.as_deref())
+                    .pick_agent_for_tool(&tool, agent_override.as_deref(), &source_profile)
                     .await;
                 let cwd = std::path::PathBuf::from(project_path);
                 let supervisor = state.cockpit_supervisor.clone();
@@ -4286,6 +4380,8 @@ mod workspace_ordering_tests {
             cockpit_mode: false,
             #[cfg(feature = "serve")]
             cockpit_worker_state: crate::cockpit::supervisor::CockpitWorkerState::Absent,
+            #[cfg(feature = "serve")]
+            acp_capable: false,
             claude_fullscreen: false,
             workspace_repos: Vec::new(),
             warnings: Vec::new(),

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -268,7 +268,11 @@ impl SessionResponse {
             // per-row config read.
             #[cfg(feature = "serve")]
             acp_capable: {
-                let resolved = inst.cockpit_agent.as_deref().unwrap_or(inst.tool.as_str());
+                let resolved = inst
+                    .cockpit_agent
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or(inst.tool.as_str());
                 builtin_acp_registry().get(resolved).is_some()
             },
             claude_fullscreen: claude_fullscreen && inst.tool == "claude",
@@ -403,23 +407,27 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
         .collect();
 
     // Overlay custom-agent ACP capability (built-ins were resolved in the
-    // constructor). Resolve each distinct profile's config at most once.
+    // constructor). Cache by (profile, project_path) since repo-local
+    // config can override agent_cockpit_cmd, so each distinct pair is
+    // resolved at most once.
     #[cfg(feature = "serve")]
     {
         use std::collections::HashMap;
-        let mut cockpit_cmd_by_profile: HashMap<String, HashMap<String, String>> = HashMap::new();
+        let mut cockpit_cmd_cache: HashMap<(String, String), HashMap<String, String>> =
+            HashMap::new();
         for (resp, inst) in sessions.iter_mut().zip(instances.iter()) {
             if resp.acp_capable {
                 continue;
             }
-            let profile = inst.source_profile.clone();
-            let map = cockpit_cmd_by_profile
-                .entry(profile.clone())
-                .or_insert_with(|| {
-                    crate::session::profile_config::resolve_config_or_warn(&profile)
-                        .session
-                        .agent_cockpit_cmd
-                });
+            let key = (inst.source_profile.clone(), inst.project_path.clone());
+            let map = cockpit_cmd_cache.entry(key).or_insert_with(|| {
+                crate::session::repo_config::resolve_config_with_repo_or_warn(
+                    &inst.source_profile,
+                    std::path::Path::new(&inst.project_path),
+                )
+                .session
+                .agent_cockpit_cmd
+            });
             resp.acp_capable = custom_agent_acp_capable(map, &inst.tool);
         }
     }
@@ -1949,8 +1957,9 @@ pub async fn create_session(
                     .filter(|s| !s.is_empty())
                     .unwrap_or(instance.tool.as_str());
                 let capable = acp_registry.get(resolved).is_some()
-                    || crate::session::profile_config::resolve_config_or_warn(
+                    || crate::session::repo_config::resolve_config_with_repo_or_warn(
                         &instance.source_profile,
+                        std::path::Path::new(&instance.project_path),
                     )
                     .session
                     .agent_cockpit_cmd
@@ -2027,8 +2036,9 @@ pub async fn create_session(
             // into the new session renders the right substrate immediately.
             #[cfg(feature = "serve")]
             if !resp.acp_capable {
-                let cockpit_cmd = crate::session::profile_config::resolve_config_or_warn(
+                let cockpit_cmd = crate::session::repo_config::resolve_config_with_repo_or_warn(
                     &instance.source_profile,
+                    std::path::Path::new(&instance.project_path),
                 )
                 .session
                 .agent_cockpit_cmd;
@@ -2067,7 +2077,12 @@ pub async fn create_session(
             {
                 let agent = state
                     .cockpit_supervisor
-                    .pick_agent_for_tool(&tool, agent_override.as_deref(), &source_profile)
+                    .pick_agent_for_tool(
+                        &tool,
+                        agent_override.as_deref(),
+                        &source_profile,
+                        std::path::Path::new(&project_path),
+                    )
                     .await;
                 let cwd = std::path::PathBuf::from(project_path);
                 let supervisor = state.cockpit_supervisor.clone();

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -24,9 +24,17 @@ pub struct AgentInfo {
     pub host_only: bool,
     pub installed: bool,
     pub install_hint: String,
+    /// True when this agent can run in the structured cockpit UI: a
+    /// built-in with an ACP adapter, or a custom agent that declares a
+    /// valid `agent_cockpit_cmd`. The web wizard reads this to decide
+    /// whether a session created for the agent runs in cockpit or tmux.
+    pub acp_capable: bool,
 }
 
-fn build_custom_agent_infos(custom_agents: &HashMap<String, String>) -> Vec<AgentInfo> {
+fn build_custom_agent_infos(
+    custom_agents: &HashMap<String, String>,
+    agent_cockpit_cmd: &HashMap<String, String>,
+) -> Vec<AgentInfo> {
     let mut entries: Vec<_> = custom_agents
         .iter()
         .filter(|(name, command)| {
@@ -41,6 +49,9 @@ fn build_custom_agent_infos(custom_agents: &HashMap<String, String>) -> Vec<Agen
             host_only: false,
             installed: true,
             install_hint: "Configured custom agent".to_string(),
+            acp_capable: agent_cockpit_cmd
+                .get(name)
+                .is_some_and(|cmd| crate::cockpit::AgentSpec::from_cockpit_cmd(name, cmd).is_ok()),
         })
         .collect();
     entries.sort_by(|left, right| left.name.cmp(&right.name));
@@ -52,8 +63,10 @@ pub async fn list_agents(State(state): State<Arc<AppState>>) -> Json<Vec<AgentIn
     let result = tokio::task::spawn_blocking(move || {
         let config = crate::session::profile_config::resolve_config_or_warn(&profile);
         let custom_agents = config.session.custom_agents;
+        let agent_cockpit_cmd = config.session.agent_cockpit_cmd;
         let tools = crate::tmux::AvailableTools::detect();
         let available = tools.available_list();
+        let acp_registry = crate::cockpit::AgentRegistry::with_defaults();
         let mut agents = crate::agents::AGENTS
             .iter()
             .map(|a| AgentInfo {
@@ -63,9 +76,10 @@ pub async fn list_agents(State(state): State<Arc<AppState>>) -> Json<Vec<AgentIn
                 host_only: a.host_only,
                 installed: available.iter().any(|s| s == a.name),
                 install_hint: a.install_hint.to_string(),
+                acp_capable: acp_registry.get(a.name).is_some(),
             })
             .collect::<Vec<_>>();
-        agents.extend(build_custom_agent_infos(&custom_agents));
+        agents.extend(build_custom_agent_infos(&custom_agents, &agent_cockpit_cmd));
         agents
     })
     .await
@@ -1183,10 +1197,10 @@ mod tests {
 
     #[test]
     fn custom_agent_entries_use_safe_placeholders() {
-        let entries = build_custom_agent_infos(&custom_agents(&[(
-            "remote-claude",
-            "ssh -t prod.example claude",
-        )]));
+        let entries = build_custom_agent_infos(
+            &custom_agents(&[("remote-claude", "ssh -t prod.example claude")]),
+            &HashMap::new(),
+        );
 
         assert_eq!(entries.len(), 1);
         let agent = &entries[0];
@@ -1196,14 +1210,16 @@ mod tests {
         assert!(!agent.host_only);
         assert!(agent.installed);
         assert_eq!(agent.install_hint, "Configured custom agent");
+        // No agent_cockpit_cmd configured, so it is tmux-only.
+        assert!(!agent.acp_capable);
     }
 
     #[test]
     fn custom_agent_entries_never_serialize_command_values() {
-        let entries = build_custom_agent_infos(&custom_agents(&[(
-            "remote-agent",
-            "ssh -t prod.example claude",
-        )]));
+        let entries = build_custom_agent_infos(
+            &custom_agents(&[("remote-agent", "ssh -t prod.example claude")]),
+            &HashMap::new(),
+        );
 
         let json = serde_json::to_string(&entries).unwrap();
         assert!(json.contains("remote-agent"));
@@ -1214,10 +1230,10 @@ mod tests {
 
     #[test]
     fn serialized_custom_agent_response_contains_no_command_or_detect_as_data() {
-        let entries = build_custom_agent_infos(&custom_agents(&[(
-            "remote-agent",
-            "ssh -t prod.example claude",
-        )]));
+        let entries = build_custom_agent_infos(
+            &custom_agents(&[("remote-agent", "ssh -t prod.example claude")]),
+            &HashMap::new(),
+        );
         let value = serde_json::to_value(&entries).unwrap();
 
         assert_eq!(value[0]["kind"], "custom");
@@ -1235,14 +1251,17 @@ mod tests {
 
     #[test]
     fn custom_agent_entries_filter_empty_values_and_builtin_collisions() {
-        let entries = build_custom_agent_infos(&custom_agents(&[
-            ("", "codex"),
-            ("empty-command", ""),
-            ("   ", "codex"),
-            ("whitespace-command", "   "),
-            ("claude", "ssh -t prod.example claude"),
-            ("remote-codex", "ssh -t prod.example codex"),
-        ]));
+        let entries = build_custom_agent_infos(
+            &custom_agents(&[
+                ("", "codex"),
+                ("empty-command", ""),
+                ("   ", "codex"),
+                ("whitespace-command", "   "),
+                ("claude", "ssh -t prod.example claude"),
+                ("remote-codex", "ssh -t prod.example codex"),
+            ]),
+            &HashMap::new(),
+        );
 
         let names: Vec<_> = entries.iter().map(|entry| entry.name.as_str()).collect();
         assert_eq!(names, vec!["remote-codex"]);
@@ -1251,14 +1270,36 @@ mod tests {
 
     #[test]
     fn custom_agent_entries_are_sorted_by_name() {
-        let entries = build_custom_agent_infos(&custom_agents(&[
-            ("zeta", "zeta-cmd"),
-            ("alpha", "alpha-cmd"),
-            ("middle", "middle-cmd"),
-        ]));
+        let entries = build_custom_agent_infos(
+            &custom_agents(&[
+                ("zeta", "zeta-cmd"),
+                ("alpha", "alpha-cmd"),
+                ("middle", "middle-cmd"),
+            ]),
+            &HashMap::new(),
+        );
 
         let names: Vec<_> = entries.iter().map(|entry| entry.name.as_str()).collect();
         assert_eq!(names, vec!["alpha", "middle", "zeta"]);
+    }
+
+    #[test]
+    fn custom_agent_acp_capable_tracks_agent_cockpit_cmd() {
+        let custom = custom_agents(&[("oc-sp", "ocp run sp"), ("plain", "ssh host claude")]);
+        let cockpit = custom_agents(&[
+            ("oc-sp", "ocp run sp acp"),
+            // An entry whose command is malformed must not flip capability on.
+            ("broken", "ocp run \"unterminated"),
+        ]);
+        let entries = build_custom_agent_infos(&custom, &cockpit);
+
+        let oc_sp = entries.iter().find(|e| e.name == "oc-sp").unwrap();
+        assert!(
+            oc_sp.acp_capable,
+            "agent with a valid cockpit cmd is capable"
+        );
+        let plain = entries.iter().find(|e| e.name == "plain").unwrap();
+        assert!(!plain.acp_capable, "agent with no cockpit cmd is tmux-only");
     }
 
     #[tokio::test]

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -572,7 +572,7 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
 
     let supervisor = Arc::clone(&state.cockpit_supervisor);
     let agent = supervisor
-        .pick_agent_for_tool(&tool, agent_override.as_deref())
+        .pick_agent_for_tool(&tool, agent_override.as_deref(), &source_profile)
         .await;
     let cwd = PathBuf::from(project_path);
 

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -572,7 +572,12 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
 
     let supervisor = Arc::clone(&state.cockpit_supervisor);
     let agent = supervisor
-        .pick_agent_for_tool(&tool, agent_override.as_deref(), &source_profile)
+        .pick_agent_for_tool(
+            &tool,
+            agent_override.as_deref(),
+            &source_profile,
+            std::path::Path::new(&project_path),
+        )
         .await;
     let cwd = PathBuf::from(project_path);
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -582,6 +582,18 @@ pub struct SessionConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub agent_detect_as: HashMap<String, String>,
 
+    /// ACP launch command for a custom agent, enabling it to run in the
+    /// structured cockpit UI (e.g., "oc-superpowers" = "ocp run sp acp").
+    /// A custom agent with an entry here is cockpit-capable; without one it
+    /// is tmux-only.
+    ///
+    /// Note: unlike `custom_agents` (a shell command run in a tmux pane),
+    /// this value is split into argv with shell-word rules and executed
+    /// directly, with no shell. For shell features, wrap explicitly, e.g.
+    /// `sh -lc 'source ~/.profile && ocp run sp acp'`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub agent_cockpit_cmd: HashMap<String, String>,
+
     /// Require SHIFT on letter-based TUI hotkeys (e.g. SHIFT+N for New, SHIFT+D for Delete).
     /// Guards against accidental destructive actions from dictation software, a forgotten
     /// focus, or stray keystrokes. Navigation keys (h/j/k/l, arrows, Enter, Esc), punctuation
@@ -745,6 +757,7 @@ impl Default for SessionConfig {
             mouse_capture: true,
             custom_agents: HashMap::new(),
             agent_detect_as: HashMap::new(),
+            agent_cockpit_cmd: HashMap::new(),
             strict_hotkeys: false,
             snooze_duration_minutes: 30,
             restart_wake_message: default_restart_wake_message(),
@@ -841,6 +854,40 @@ impl SessionConfig {
                     target,
                     crate::agents::agent_names().join(", ")
                 );
+            }
+        }
+        for (name, command) in &self.agent_cockpit_cmd {
+            if name.is_empty() {
+                tracing::warn!(target: "session.store", "agent_cockpit_cmd: entry with empty agent name will be ignored");
+                continue;
+            }
+            if crate::agents::get_agent(name).is_some() {
+                tracing::warn!(target: "session.store",
+                    "agent_cockpit_cmd: '{}' shadows a built-in agent; built-in agents already have a cockpit adapter and the entry will be ignored",
+                    name
+                );
+                continue;
+            }
+            if !self.custom_agents.contains_key(name) {
+                tracing::warn!(target: "session.store",
+                    "agent_cockpit_cmd: '{}' has no matching custom_agents entry; it will not appear in the agent picker",
+                    name
+                );
+            }
+            match shell_words::split(command) {
+                Ok(argv) if argv.is_empty() => {
+                    tracing::warn!(target: "session.store",
+                        "agent_cockpit_cmd: '{}' has an empty command, cockpit will be unavailable for it",
+                        name
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(target: "session.store",
+                        "agent_cockpit_cmd: '{}' has a malformed command ({}), cockpit will be unavailable for it",
+                        name, e
+                    );
+                }
             }
         }
     }
@@ -2268,6 +2315,34 @@ mod tests {
             deserialized.session.agent_detect_as.get("lenovo-claude"),
             Some(&"claude".to_string()),
         );
+    }
+
+    #[test]
+    fn test_agent_cockpit_cmd_roundtrip() {
+        let mut config = Config::default();
+        config
+            .session
+            .custom_agents
+            .insert("oc-sp".to_string(), "ocp run sp".to_string());
+        config
+            .session
+            .agent_cockpit_cmd
+            .insert("oc-sp".to_string(), "ocp run sp acp".to_string());
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let deserialized: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            deserialized.session.agent_cockpit_cmd.get("oc-sp"),
+            Some(&"ocp run sp acp".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_agent_cockpit_cmd_defaults_empty() {
+        // A config with no agent_cockpit_cmd must deserialize to an empty
+        // map (serde default), not error, so existing configs keep loading.
+        let config: Config = toml::from_str("").unwrap();
+        assert!(config.session.agent_cockpit_cmd.is_empty());
     }
 
     #[test]

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -252,6 +252,9 @@ pub struct SessionConfigOverride {
     pub agent_detect_as: Option<HashMap<String, String>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_cockpit_cmd: Option<HashMap<String, String>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strict_hotkeys: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -497,6 +500,9 @@ pub fn apply_session_overrides(
     }
     if let Some(ref detect_as) = source.agent_detect_as {
         target.agent_detect_as = detect_as.clone();
+    }
+    if let Some(ref cockpit_cmd) = source.agent_cockpit_cmd {
+        target.agent_cockpit_cmd = cockpit_cmd.clone();
     }
     if let Some(strict_hotkeys) = source.strict_hotkeys {
         target.strict_hotkeys = strict_hotkeys;

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -106,6 +106,7 @@ pub enum FieldKey {
     AgentStatusHooks,
     CustomAgents,
     AgentDetectAs,
+    AgentCockpitCmd,
     HostEnvironment,
     SessionIdPollerMaxThreads,
     LiveSendExitChord,
@@ -1890,6 +1891,30 @@ fn build_agents_fields(
         items
     };
 
+    let (cockpit_cmd_map, cockpit_cmd_override) = resolve_value(
+        scope,
+        global.session.agent_cockpit_cmd.clone(),
+        session.and_then(|s| s.agent_cockpit_cmd.clone()),
+    );
+    let cockpit_cmd_list: Vec<String> = {
+        let mut items: Vec<_> = cockpit_cmd_map
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+    let global_cockpit_cmd_list: Vec<String> = {
+        let mut items: Vec<_> = global
+            .session
+            .agent_cockpit_cmd
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+
     vec![
         SettingField {
             key: FieldKey::DefaultTool,
@@ -1957,6 +1982,19 @@ fn build_agents_fields(
             inherited_display: inherited_if(
                 detect_as_override,
                 FieldValue::List(global_detect_as_list),
+            ),
+        },
+        SettingField {
+            key: FieldKey::AgentCockpitCmd,
+            label: "Agent Cockpit Command",
+            description:
+                "ACP launch command enabling a custom agent in cockpit: agent=command (e.g. oc-sp=ocp run sp acp)",
+            value: FieldValue::List(cockpit_cmd_list),
+            category: SettingsCategory::Agents,
+            has_override: cockpit_cmd_override,
+            inherited_display: inherited_if(
+                cockpit_cmd_override,
+                FieldValue::List(global_cockpit_cmd_list),
             ),
         },
         SettingField {
@@ -2705,6 +2743,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::AgentDetectAs, FieldValue::List(v)) => {
             config.session.agent_detect_as = parse_key_value_list(v);
         }
+        (FieldKey::AgentCockpitCmd, FieldValue::List(v)) => {
+            config.session.agent_cockpit_cmd = parse_key_value_list(v);
+        }
         // Sound
         (FieldKey::SoundEnabled, FieldValue::Bool(v)) => config.sound.enabled = *v,
         (FieldKey::SoundMode, FieldValue::Select { selected, .. }) => {
@@ -3187,6 +3228,14 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 .session
                 .get_or_insert_with(SessionConfigOverride::default);
             s.agent_detect_as = Some(map);
+        }
+        (FieldKey::AgentCockpitCmd, FieldValue::List(v)) => {
+            let map = parse_key_value_list(v);
+            use crate::session::SessionConfigOverride;
+            let s = config
+                .session
+                .get_or_insert_with(SessionConfigOverride::default);
+            s.agent_cockpit_cmd = Some(map);
         }
         // Sound
         (FieldKey::SoundEnabled, FieldValue::Bool(v)) => {
@@ -3842,6 +3891,7 @@ mod tests {
             FieldKey::AgentCommandOverride,
             FieldKey::CustomAgents,
             FieldKey::AgentDetectAs,
+            FieldKey::AgentCockpitCmd,
             FieldKey::AgentStatusHooks,
         ] {
             assert!(

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -569,6 +569,7 @@ impl SettingsView {
                             }
                             FieldKey::CustomAgents => Some(validate_custom_agent_entry(&text)),
                             FieldKey::AgentDetectAs => Some(validate_detect_as_entry(&text)),
+                            FieldKey::AgentCockpitCmd => Some(validate_cockpit_cmd_entry(&text)),
                             _ => None,
                         };
                         if let Some(Err(msg)) = validation_result {
@@ -815,6 +816,11 @@ impl SettingsView {
             FieldKey::AgentDetectAs => {
                 if let Some(ref mut s) = config.session {
                     s.agent_detect_as = None;
+                }
+            }
+            FieldKey::AgentCockpitCmd => {
+                if let Some(ref mut s) = config.session {
+                    s.agent_cockpit_cmd = None;
                 }
             }
             FieldKey::AgentStatusHooks => {
@@ -1292,6 +1298,31 @@ fn validate_custom_agent_entry(text: &str) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+/// Validate an agent_cockpit_cmd entry: name=command. The command is the
+/// ACP launch line, split with shell-word rules into argv, so it must be
+/// non-empty and have balanced quoting.
+fn validate_cockpit_cmd_entry(text: &str) -> Result<(), String> {
+    let Some((key, value)) = text.split_once('=') else {
+        return Err(
+            "Must be in name=command format (e.g. oc-superpowers=ocp run sp acp)".to_string(),
+        );
+    };
+    if key.is_empty() {
+        return Err("Agent name cannot be empty".to_string());
+    }
+    if crate::agents::get_agent(key).is_some() {
+        return Err(format!(
+            "'{}' is a built-in agent, which already has a cockpit adapter.",
+            key
+        ));
+    }
+    match shell_words::split(value) {
+        Ok(argv) if argv.is_empty() => Err("Command cannot be empty".to_string()),
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!("Malformed command: {e}")),
+    }
 }
 
 /// Validate a detect_as entry: name=builtin_agent. Value must be a known built-in agent.

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -6,7 +6,7 @@ import { BackToLiveButton } from "./BackToLiveButton";
 import { KeyboardFab } from "./KeyboardFab";
 import { SwitchSubstrateAction } from "./cockpit/SwitchSubstrateAction";
 import { ensureSession } from "../lib/api";
-import { ACP_CAPABLE_TOOLS } from "../lib/acpCapableTools";
+import { isAcpCapable } from "../lib/acpCapableTools";
 import { safeSetItem } from "../lib/safeStorage";
 import type { SessionResponse } from "../lib/types";
 import {
@@ -245,7 +245,7 @@ export function TerminalView({
           <SwitchSubstrateAction
             sessionId={session.id}
             cockpitMode={false}
-            acpCapable={ACP_CAPABLE_TOOLS.has(session.tool)}
+            acpCapable={isAcpCapable(session.tool, session.acp_capable)}
             variant="icon"
           />
         </div>

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useReducer } from "react";
 import type { CreateSessionRequest, SessionResponse } from "../../lib/types";
 import { fetchAgents, fetchGroups, fetchDockerStatus, fetchProfiles, fetchSettings, createSession } from "../../lib/api";
-import { ACP_CAPABLE_TOOLS } from "../../lib/acpCapableTools";
+import { ACP_CAPABLE_TOOLS, isAcpCapable } from "../../lib/acpCapableTools";
 import { safeGetItem, safeSetItem } from "../../lib/safeStorage";
 import { toastBus } from "../../lib/toastBus";
 import { StepIndicator } from "./StepIndicator";
@@ -190,11 +190,10 @@ export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnable
   const handleSubmit = async () => {
     dispatch({ type: "SUBMIT_START" });
     const d = state.data;
-    // Custom agents have no ACP adapter, so they can never run in
-    // cockpit even if their name collides with a built-in entry in
-    // ACP_CAPABLE_TOOLS. Mirror AgentStep's guard here.
-    const selectedCustomAgent =
-      state.agents.find((a) => a.name === d.tool)?.kind === "custom";
+    const selectedAgentAcpCapable = isAcpCapable(
+      d.tool,
+      state.agents.find((a) => a.name === d.tool)?.acp_capable,
+    );
     // Scratch sessions: server provisions the working directory and
     // ignores `path`. Force-omit every worktree-related field so a
     // stale reducer state cannot make the server return 400 on the
@@ -222,17 +221,17 @@ export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnable
       command_override: d.commandOverride || undefined,
       custom_instruction: d.customInstruction || undefined,
       profile: d.profile || undefined,
-      // Cockpit runs only when the master switch is on, the tool is
+      // Cockpit runs only when the master switch is on, the agent is
       // ACP-capable, and the user kept the per-session toggle on
-      // (default). Turning it off launches a tmux session even with
-      // the master switch enabled. Non-ACP tools, custom agents, and a
-      // disabled master switch all fall back to tmux. The server
-      // re-applies the master switch (see src/server/api/sessions.rs),
-      // so a tampered client request can't escalate cockpit on.
+      // (default). Capability comes from the server's per-agent
+      // `acp_capable` flag (including custom agents with an
+      // `agent_cockpit_cmd`) with hardcoded fallback while loading. The
+      // server re-resolves capability and re-applies the master switch
+      // (see src/server/api/sessions.rs), so a tampered request can't
+      // escalate cockpit on for a non-capable agent.
       cockpit_mode:
         cockpitMasterEnabled &&
-        !selectedCustomAgent &&
-        ACP_CAPABLE_TOOLS.has(d.tool) &&
+        selectedAgentAcpCapable &&
         d.useCockpit,
       scratch: d.scratch || undefined,
     };

--- a/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
+++ b/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
@@ -122,18 +122,18 @@ describe("AgentStep custom-agent selection (#1252)", () => {
       tool: "remote-helper",
       agents: [builtin, custom],
     });
-    expect(getByText(/Custom agents run in the terminal\./)).toBeTruthy();
+    expect(getByText(/Custom agents run in the terminal unless they define agent_cockpit_cmd/)).toBeTruthy();
   });
 
-  it("renders the cockpit notice for a custom agent that is acp_capable", () => {
+  it("renders the cockpit substrate card for a custom agent that is acp_capable", () => {
     // A custom agent with agent_cockpit_cmd (acp_capable=true) must offer
-    // cockpit, not the terminal fallback. Guards the SubstrateNotice
-    // reorder where acp_capable wins over the custom branch.
-    const { getByText, queryByText } = renderAgentStep({
+    // cockpit, not the terminal fallback.
+    const { getByRole, getByText, queryByText } = renderAgentStep({
       tool: "oc-superpowers",
       agents: [builtin, cockpitCustom],
     });
-    expect(getByText(/Cockpit is enabled/)).toBeTruthy();
+    expect(getByRole("switch", { name: "Use cockpit" })).toBeTruthy();
+    expect(getByText(/Renders the agent's plan, tool calls, and diffs/)).toBeTruthy();
     expect(queryByText(/Custom agents run in the terminal/)).toBeNull();
   });
 

--- a/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
+++ b/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
@@ -37,6 +37,7 @@ const builtin: AgentInfo = {
   host_only: false,
   installed: true,
   install_hint: "",
+  acp_capable: true,
 };
 
 const custom: AgentInfo = {
@@ -46,6 +47,19 @@ const custom: AgentInfo = {
   host_only: false,
   installed: true,
   install_hint: "Configured custom agent",
+  acp_capable: false,
+};
+
+// A custom agent with an agent_cockpit_cmd configured: the server marks
+// it acp_capable, so the wizard offers cockpit instead of the terminal.
+const cockpitCustom: AgentInfo = {
+  kind: "custom",
+  name: "oc-superpowers",
+  binary: "oc-superpowers",
+  host_only: false,
+  installed: true,
+  install_hint: "Configured custom agent",
+  acp_capable: true,
 };
 
 const uninstalledBuiltin: AgentInfo = {
@@ -55,6 +69,7 @@ const uninstalledBuiltin: AgentInfo = {
   host_only: false,
   installed: false,
   install_hint: "brew install x",
+  acp_capable: false,
 };
 
 function renderAgentStep(overrides: {
@@ -102,16 +117,24 @@ describe("AgentStep custom-agent selection (#1252)", () => {
     expect(queryByText("No agents installed")).toBeNull();
   });
 
-  it("renders the custom-agent substrate notice when the selected agent is kind=custom", () => {
+  it("renders the terminal-fallback notice for a custom agent with no agent_cockpit_cmd", () => {
     const { getByText } = renderAgentStep({
       tool: "remote-helper",
       agents: [builtin, custom],
     });
-    expect(
-      getByText(
-        "Custom agents run in the terminal. Cockpit is available for built-in agents with ACP support.",
-      ),
-    ).toBeTruthy();
+    expect(getByText(/Custom agents run in the terminal\./)).toBeTruthy();
+  });
+
+  it("renders the cockpit notice for a custom agent that is acp_capable", () => {
+    // A custom agent with agent_cockpit_cmd (acp_capable=true) must offer
+    // cockpit, not the terminal fallback. Guards the SubstrateNotice
+    // reorder where acp_capable wins over the custom branch.
+    const { getByText, queryByText } = renderAgentStep({
+      tool: "oc-superpowers",
+      agents: [builtin, cockpitCustom],
+    });
+    expect(getByText(/Cockpit is enabled/)).toBeTruthy();
+    expect(queryByText(/Custom agents run in the terminal/)).toBeNull();
   });
 
   it("renders the interactive cockpit toggle when the selected agent is a built-in with ACP support", () => {

--- a/web/src/components/session-wizard/__tests__/cockpitToggle.test.tsx
+++ b/web/src/components/session-wizard/__tests__/cockpitToggle.test.tsx
@@ -6,8 +6,8 @@
 // force-routed into cockpit. Two surfaces:
 //
 //   - AgentStep renders an interactive CockpitSubstrateCard (a switch,
-//     default on) for ACP-capable built-ins; non-ACP tools and custom
-//     agents keep the read-only fallback notice and show no switch.
+//     default on) for ACP-capable tools (built-in or custom); non-ACP
+//     tools keep the read-only fallback notice and show no switch.
 //   - SessionWizard's submit payload sets `cockpit_mode` from
 //     `cockpitMasterEnabled && acpCapable && useCockpit`, so toggling
 //     the switch off sends `cockpit_mode: false` (the server then
@@ -124,7 +124,7 @@ describe("AgentStep cockpit substrate card (#1580)", () => {
     expect(queryByRole("switch", { name: "Use cockpit" })).toBeNull();
     expect(
       getByText(
-        "Custom agents run in the terminal. Cockpit is available for built-in agents with ACP support.",
+        "Custom agents run in the terminal unless they define agent_cockpit_cmd in config or TUI settings.",
       ),
     ).toBeTruthy();
   });

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import type { AgentInfo, ProfileInfo } from "../../../lib/types";
 import { fetchSettings } from "../../../lib/api";
-import { ACP_CAPABLE_TOOLS } from "../../../lib/acpCapableTools";
+import { isAcpCapable } from "../../../lib/acpCapableTools";
 
 interface WizardData {
   tool: string;
@@ -36,10 +36,9 @@ interface Props {
   cockpitMasterEnabled: boolean;
 }
 
-/** Read-only callout for the cases where cockpit is impossible even
- *  though the master switch is on: a custom agent or a built-in tool
- *  with no ACP adapter. Both fall back to the tmux terminal, so there
- *  is nothing to toggle. The ACP-capable case renders
+/** Read-only callout when the selected tool cannot run in cockpit. This
+ *  includes built-in tools without ACP support and custom agents that do
+ *  not provide `agent_cockpit_cmd`. ACP-capable tools render
  *  `CockpitSubstrateCard` instead. */
 function SubstrateNotice({
   tool,
@@ -58,7 +57,7 @@ function SubstrateNotice({
       </div>
       <p className="mt-1 text-xs text-text-dim leading-snug">
         {customAgent
-          ? "Custom agents run in the terminal. Cockpit is available for built-in agents with ACP support."
+          ? "Custom agents run in the terminal unless they define agent_cockpit_cmd in config or TUI settings."
           : `${tool} has no ACP adapter yet, so this session falls back to the tmux terminal. Pick a tool with cockpit support (e.g. claude, opencode, gemini) to use the structured UI.`}
       </p>
     </div>
@@ -131,7 +130,7 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
   );
   const selectedAgent = agents.find((a) => a.name === data.tool);
   const selectedCustomAgent = selectedAgent?.kind === "custom";
-  const acpCapable = !selectedCustomAgent && ACP_CAPABLE_TOOLS.has(data.tool);
+  const acpCapable = isAcpCapable(data.tool, selectedAgent?.acp_capable);
   const isHostOnly = selectedAgent?.host_only ?? false;
   const [showAdvanced, setShowAdvanced] = useState(data.advancedEnabled);
   const showProfilePicker = profiles.length > 1;
@@ -222,9 +221,8 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
       {/* Substrate picker. When the master switch is on and the tool is
           ACP-capable, the user gets a per-session cockpit toggle
           (default on, see #1580) so they can opt down to a tmux session
-          without flipping the global switch. Non-ACP tools and custom
-          agents can't run in cockpit, so they show a read-only fallback
-          notice instead. When the master switch is off, every new
+          without flipping the global switch. Tools that are not ACP-capable
+          show a read-only fallback notice instead. When the master switch is off, every new
           session is tmux and nothing is shown. */}
       {cockpitMasterEnabled &&
         (acpCapable ? (

--- a/web/src/lib/acpCapableTools.ts
+++ b/web/src/lib/acpCapableTools.ts
@@ -15,3 +15,17 @@ export const ACP_CAPABLE_TOOLS: ReadonlySet<string> = new Set([
   "vibe",
   "pi",
 ]);
+
+/** Authoritative cockpit-capability check. The server now reports
+ *  `acp_capable` per agent (built-ins and custom agents with an
+ *  `agent_cockpit_cmd`), so prefer that. The hardcoded set above is only
+ *  a fallback for the brief window before the agent/session list loads,
+ *  or older servers that don't yet send the field; it never reflects
+ *  custom agents. */
+export function isAcpCapable(
+  tool: string,
+  flag: boolean | undefined,
+): boolean {
+  if (typeof flag === "boolean") return flag;
+  return ACP_CAPABLE_TOOLS.has(tool);
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -78,6 +78,12 @@ export interface SessionResponse {
    *  the supervisor holds a live worker. Drives the sidebar `Resuming…`
    *  chip and the per-session banner in the cockpit view. See #1088. */
   cockpit_worker_state?: CockpitWorkerState;
+  /** True when this session's agent can run in cockpit: a built-in with
+   *  an ACP adapter, or a custom agent whose profile config declares a
+   *  valid `agent_cockpit_cmd`. The terminal view's "switch to cockpit"
+   *  affordance reads this instead of a hardcoded tool list. Absent on
+   *  builds without the cockpit feature. */
+  acp_capable?: boolean;
   /** True when this is a Claude Code session AND the user has enabled
    *  Claude's fullscreen renderer (`tui: "fullscreen"` in
    *  ~/.claude/settings.json). The mobile rendering path uses this to
@@ -284,6 +290,11 @@ export interface AgentInfo {
   host_only: boolean;
   installed: boolean;
   install_hint: string;
+  /** True when the agent can run in cockpit: a built-in with an ACP
+   *  adapter, or a custom agent that declares a valid `agent_cockpit_cmd`.
+   *  The wizard reads this to decide whether a new session runs in
+   *  cockpit or tmux, replacing the hardcoded client-side tool list. */
+  acp_capable: boolean;
 }
 
 /** Profile info returned by /api/profiles */

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -426,6 +426,19 @@
       ]
     },
     {
+      "id": "cockpit.custom-agent-acp-capable",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-custom-agent.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/steps/AgentStep.tsx",
+        "web/src/components/TerminalView.tsx"
+      ]
+    },
+    {
       "id": "wizard.profile-description",
       "kind": "mocked-playwright",
       "risk": "medium",

--- a/web/tests/live/cockpit-custom-agent.spec.ts
+++ b/web/tests/live/cockpit-custom-agent.spec.ts
@@ -1,0 +1,108 @@
+// Live spec for #1579: a custom agent that declares an `agent_cockpit_cmd`
+// can run in cockpit, both in the agent list the wizard reads and through
+// the session-create round-trip.
+//
+// We seed a config.toml with two custom agents before the server boots:
+//   - `oc-cockpit`   has an agent_cockpit_cmd  -> should be acp_capable
+//   - `oc-terminal`  has none                  -> tmux-only
+// then assert /api/agents reflects that, and that creating a cockpit
+// session for each yields the right substrate (the server re-resolves
+// capability and downgrades a non-capable agent to tmux instead of
+// trusting the client or erroring at spawn time).
+
+import { test as base, expect } from "@playwright/test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnAoeServe, appDirFor, resolveAoeBinary } from "../helpers/aoeServe";
+
+const CONFIG = `
+[cockpit]
+enabled = true
+
+[session.custom_agents]
+"oc-cockpit" = "true"
+"oc-terminal" = "true"
+
+[session.agent_cockpit_cmd]
+"oc-cockpit" = "true acp"
+`;
+
+async function createSession(
+  baseUrl: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${baseUrl}/api/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  expect(res.ok, `POST /api/sessions failed: ${res.status} ${await res.clone().text()}`).toBeTruthy();
+  const json = await res.json();
+  // The handler returns the SessionResponse directly or wrapped in
+  // `{ session }`; accept either.
+  return (json.session ?? json) as Record<string, unknown>;
+}
+
+base("custom agent with agent_cockpit_cmd runs in cockpit", async ({}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, xdg }) => {
+      const appDir = appDirFor(home, xdg, resolveAoeBinary());
+      mkdirSync(appDir, { recursive: true });
+      writeFileSync(join(appDir, "config.toml"), CONFIG);
+    },
+  });
+
+  try {
+    // Cockpit master on (config sets it, but PATCH is idempotent and
+    // guards against the atomic not seeding from config at boot).
+    await fetch(`${serve.baseUrl}/api/cockpit/master`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: true }),
+    });
+
+    // /api/agents reports acp_capable per the agent_cockpit_cmd config.
+    const agentsRes = await fetch(`${serve.baseUrl}/api/agents`);
+    expect(agentsRes.ok).toBeTruthy();
+    const agents = (await agentsRes.json()) as Array<{
+      name: string;
+      kind: string;
+      acp_capable: boolean;
+    }>;
+    const cockpitAgent = agents.find((a) => a.name === "oc-cockpit");
+    const terminalAgent = agents.find((a) => a.name === "oc-terminal");
+    expect(cockpitAgent, "oc-cockpit missing from /api/agents").toBeTruthy();
+    expect(terminalAgent, "oc-terminal missing from /api/agents").toBeTruthy();
+    expect(cockpitAgent!.acp_capable).toBe(true);
+    expect(terminalAgent!.acp_capable).toBe(false);
+
+    // Creating a cockpit session for the capable custom agent keeps
+    // cockpit_mode on and reports acp_capable.
+    const cockpitSession = await createSession(serve.baseUrl, {
+      path: "",
+      tool: "oc-cockpit",
+      title: "cockpit-custom",
+      cockpit_mode: true,
+      scratch: true,
+    });
+    expect(cockpitSession.cockpit_mode).toBe(true);
+    expect(cockpitSession.acp_capable).toBe(true);
+
+    // The non-capable custom agent is downgraded to tmux by the server
+    // even though the client asked for cockpit.
+    const terminalSession = await createSession(serve.baseUrl, {
+      path: "",
+      tool: "oc-terminal",
+      title: "terminal-custom",
+      cockpit_mode: true,
+      scratch: true,
+    });
+    expect(terminalSession.cockpit_mode).toBe(false);
+    expect(terminalSession.acp_capable).toBe(false);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/wizard-custom-agent.spec.ts
+++ b/web/tests/wizard-custom-agent.spec.ts
@@ -139,9 +139,7 @@ test.describe("wizard custom agent picker", () => {
 
     await page.getByRole("button", { name: /remote-helper/ }).click();
     await expect(
-      page.getByText(
-        "Custom agents run in the terminal. Cockpit is available for built-in agents with ACP support.",
-      ),
+      page.getByText(/Custom agents run in the terminal\./),
     ).toBeVisible();
     await expect(page.locator("body")).not.toContainText(hiddenBinary);
     await expect(page.locator("body")).not.toContainText(hiddenCommand);


### PR DESCRIPTION
## Description
Adds end-to-end support for running custom agents in cockpit sessions by introducing an `agent_cockpit_cmd` config, resolving ACP specs/config at spawn time, and wiring API/UI behavior to capability signals.

Key changes:
- add `agent_cockpit_cmd` config and ACP spec resolver for custom agents
- resolve custom-agent ACP specs/config with repo-aware overrides at spawn time
- expose `acp_capable` on agent/session APIs and redact cockpit command from API payloads
- drive web cockpit eligibility from server-side `acp_capable`
- add TUI settings field wiring for Agent Cockpit Command
- add docs and web coverage for the custom-agent cockpit flow

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: settings/parity wiring and cockpit backend behavior were covered by existing/unit/lib tests in this change set.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you'd like to share:**
Used for implementation, refactoring, and test updates in this branch.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR adds end-to-end support for running custom agents in the Cockpit (ACP) substrate by introducing a per-agent launch command setting and wiring capability checks through the server, CLI, TUI, and web UI. Custom agents can now opt into Cockpit by providing an agent_cockpit_cmd; the server validates and resolves these commands at spawn time (repo/profile-aware) and exposes a truthful acp_capable flag to clients. Server-side revalidation prevents client spoofing and downgrades sessions to tmux when an agent is not actually ACP-capable. UI and TUI surfaces were updated to show the new setting and to prefer server-provided capability info.

What changed (non-technical overview)
- Added a new configurable mapping (agent_cockpit_cmd) so custom agents can declare a Cockpit/ACP launch command.
- Commands are parsed (no shell execution) and validated; malformed/empty commands are rejected.
- Cockpit eligibility is resolved at runtime per-session using repo/profile-aware overrides — no global registry mutation.
- Server now reports agent/session acp_capable and strips agent_cockpit_cmd from dashboard PATCHes to avoid injection.
- CLI/TUI/web flows updated to surface the setting, validate it, and use server capability signals to enable/disable Cockpit UI.
- Tests and docs (Playwright/Vitest and docs updates) added to cover the new custom-agent Cockpit flow.

Benefits
- Flexibility: any custom agent can be made Cockpit-capable by providing a launch command.
- Consistency: a single authoritative source (server) determines Cockpit eligibility across clients.
- Security: cockpit commands are redacted from dashboard edits and validated server-side to reduce injection risks.
- Robustness: config is validated early (TUI) and rechecked at spawn-time to avoid silent failures.
- UX parity: TUI, CLI and web UI now consistently reflect real capabilities.

Areas for further enhancement
- Consider adding optional sandboxing / stricter env allowlists for user-supplied agent commands to reduce risk from arbitrary binaries.
- Provide a UX for testing or verifying a custom agent command from the settings UI (run a dry handshake).
- Cache invalidation tuning or telemetry for failed custom-agent resolutions to help diagnose misconfigurations.

Technical details

- Config and parsing
  - New SessionConfig.agent_cockpit_cmd: HashMap<String, String> and SessionConfigOverride.agent_cockpit_cmd: Option<...>.
  - Added AgentSpec::from_cockpit_cmd(name, cmd) using shell-words for argv splitting; returns descriptive errors for malformed quoting or empty commands.
  - session config validation warns/ignores built-in collisions and malformed entries.

- Server & supervisor
  - Supervisor::resolve_agent_spec(name, config) resolves built-in registry or constructs AgentSpec from agent_cockpit_cmd; spawn path re-resolves repo-aware config off-thread.
  - pick_agent_for_tool now accepts profile and project_path to consult repo-local overrides.
  - create_session and list_sessions recompute acp_capable server-side and downgrade cockpit_mode to tmux when not capable.
  - SESSION_BLOCKED_FIELDS updated to redact "agent_cockpit_cmd" from dashboard PATCH payloads.
  - New SupervisorError::InvalidAgentCommand variant surfaced for bad custom-agent commands.

- API & types
  - AgentInfo.acp_capable: bool added to /api/agents.
  - SessionResponse.acp_capable: bool (served behind serve feature) added to session listing/creation responses.
  - Server logic overlays acp_capable for custom agents by parsing repo-local configs.

- UI / TUI / CLI
  - Web: introduced isAcpCapable(tool, flag) helper to prefer server-provided flag with legacy set fallback; SessionWizard, AgentStep, TerminalView and types updated to consume acp_capable.
  - TUI: settings fields added for Agent Cockpit Command with validators; profile override clearing supported.
  - CLI: session add flow enforces that explicitly-selected custom agents provide a cockpit command; cockpit preflight keeps checking for ACP adapter binary.

- Tests & docs
  - Added Playwright/Vitest coverage for custom-agent Cockpit flows (including live test that asserts server downgrades for non-capable agents).
  - docs/guides and docs/cockpit updated to document agent_cockpit_cmd behavior and override semantics.
  - Added shell-words = "1.1" dependency for argv parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->