### PR TITLE
fix(cockpit): wake idle-dormant workers from the web composer

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -397,6 +397,16 @@ can't accept them yet. Two cases:
    `AcpSessionAssigned` event), the same drain effect fires the
    queue. See #1359.
 
+3. **Idle-dormant session.** If the worker was auto-stopped for
+   inactivity (`auto_stop_idle_secs`, `Stopped` reason
+   `idle_auto_stop`), the composer stays fully usable and your prompt
+   does not park indefinitely: the POST itself is the wake path. The
+   server clears the dormancy marker, the reconciler respawns the
+   worker, and the request is held until the fresh worker is ready,
+   then delivered. A prompt you had already queued before the worker
+   went dormant drains the same way the moment the dormancy event
+   lands. See #1689.
+
 Queued entries persist in the per-origin localStorage snapshot at
 `aoe:cockpit-state:v1:<sid>`, so a page reload (and closing then
 reopening the tab on the same origin) keeps them across the reconnect

--- a/web/src/hooks/useCockpit.queue.test.ts
+++ b/web/src/hooks/useCockpit.queue.test.ts
@@ -390,6 +390,95 @@ describe("useCockpit drain race (#1144)", () => {
     );
   });
 
+  it("a fresh prompt POSTs (wakes) instead of parking when the worker is idle-dormant (#1689)", async () => {
+    // workerState="absent": the reconciler reaped the worker for
+    // inactivity. The REST poll reads "absent" until the respawn lands.
+    const { result } = renderHook(() => useCockpit("sess-idle-fresh", "absent"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+
+    // Control: a plain absent worker (cold resume, no idle_auto_stop)
+    // still parks — that guard is unchanged.
+    act(() => {
+      void result.current.sendPrompt("typed during cold resume");
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(0);
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+    act(() => {
+      void result.current.removeQueuedPrompt(
+        result.current.state.queuedPrompts[0]!.id,
+      );
+    });
+    await flushAsync();
+
+    // The daemon publishes idle_auto_stop: the worker is dormant and a
+    // prompt POST is the wake path. A freshly-typed prompt must POST
+    // directly (the server clears dormancy + respawns + delivers)
+    // rather than parking in the local queue forever — the bug.
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-idle-fresh",
+          seq: 1,
+          event: { Stopped: { reason: "idle_auto_stop" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.workerIdleStopped).toBe(true);
+
+    act(() => {
+      void result.current.sendPrompt("wake me up");
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(1);
+    expect(promptPostBodies[0]).toContain("wake me up");
+    expect(result.current.state.queuedPrompts).toEqual([]);
+  });
+
+  it("drains a prompt parked before idle_auto_stop once dormancy lands (#1689)", async () => {
+    // The real stuck scenario: a prompt was queued while the worker was
+    // a cold-absent resume, then the reconciler reaped it to dormant.
+    // The dormancy signal must let the drain effect fire the parked
+    // prompt (the wake POST), otherwise it sits queued forever.
+    const { result } = renderHook(() => useCockpit("sess-idle-drain", "absent"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+
+    act(() => {
+      void result.current.sendPrompt("parked before dormancy");
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(0);
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-idle-drain",
+          seq: 1,
+          event: { Stopped: { reason: "idle_auto_stop" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.workerIdleStopped).toBe(true);
+    expect(promptPostCount).toBe(1);
+    expect(promptPostBodies[0]).toContain("parked before dormancy");
+    expect(result.current.state.queuedPrompts).toEqual([]);
+  });
+
   it("retires the optimistic turn when prompt POST is rejected with 4xx", async () => {
     const { result } = renderHook(() => useCockpit("sess-reject-4xx"));
     await flushAsync();

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -1144,7 +1144,19 @@ export function useCockpit(
       }
       const wsClosed = statusRef.current !== "open";
       const workerNotRunning = workerStateRef.current !== "running";
-      const shouldEnqueue = wsClosed || workerNotRunning || state.turnActive || state.workerStopped || state.workerRestarting;
+      // An idle-auto-stopped worker is dormant, not dead: the prompt POST
+      // itself wakes it (the server clears dormancy, the reconciler
+      // respawns, and `send_prompt`'s `wait_for_worker` holds the request
+      // until the fresh worker is ready). So a dormant worker must NOT
+      // park the prompt on `workerNotRunning` (the REST poll reads
+      // "absent" until the respawn lands); parking would leave it in the
+      // local queue forever and the worker would never come back. Only a
+      // non-dormant cold worker (genuine mid-resume) still parks. See #1689.
+      const blockedAsideFromWorker =
+        wsClosed || state.turnActive || state.workerStopped || state.workerRestarting;
+      const shouldEnqueue = state.workerIdleStopped
+        ? blockedAsideFromWorker
+        : blockedAsideFromWorker || workerNotRunning;
       if (shouldEnqueue) {
         // The local prompt queue is text-only (persisted to
         // localStorage, where megabytes of base64 would blow the
@@ -1170,6 +1182,7 @@ export function useCockpit(
       state.turnActive,
       state.workerStopped,
       state.workerRestarting,
+      state.workerIdleStopped,
       dispatchPromptNow,
     ],
   );
@@ -1195,7 +1208,14 @@ export function useCockpit(
     // came online). Park queued prompts so they don't POST into a
     // worker that's not online yet; the next REST poll flips
     // workerState to "running" and re-runs this effect. See #1088.
-    if (workerStateRef.current !== "running") return;
+    //
+    // Exception: an idle-auto-stopped (dormant) worker reads "absent"
+    // too, but here the POST is the wake path, so we must let the drain
+    // fire to issue it. The server's `touch_and_wake_if_sunk` clears
+    // dormancy and `send_prompt`'s `wait_for_worker` holds the POST
+    // until the respawned worker is ready. Without this, a prompt the
+    // user queued while the worker was dormant would never drain. #1689.
+    if (workerStateRef.current !== "running" && !state.workerIdleStopped) return;
     // Reconnect race: connect() awaits fetchReplay BEFORE opening the
     // WS, and replay can dispatch a Stopped frame that flips turnActive
     // off. If we drain here while the WS is still in "connecting",
@@ -1267,6 +1287,7 @@ export function useCockpit(
     state.turnActive,
     state.workerStopped,
     state.workerRestarting,
+    state.workerIdleStopped,
     state.queuedPrompts,
     dispatchPromptNow,
   ]);

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -819,6 +819,51 @@ describe("applyEvent / Stopped restart_pending", () => {
   });
 });
 
+describe("applyEvent / Stopped idle_auto_stop (#1689)", () => {
+  it("sets workerIdleStopped (not workerStopped) on reason=idle_auto_stop", () => {
+    const state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { Stopped: { reason: "idle_auto_stop" } },
+    });
+    expect(state.workerIdleStopped).toBe(true);
+    // Crucially NOT a user stop: no reconnect banner, composer stays open.
+    expect(state.workerStopped).toBe(false);
+    expect(state.workerRestarting).toBe(false);
+    expect(state.turnActive).toBe(false);
+  });
+
+  it("clears workerIdleStopped on the next UserPromptSent (the prompt woke it)", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { Stopped: { reason: "idle_auto_stop" } },
+    });
+    expect(state.workerIdleStopped).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { UserPromptSent: { text: "wake up" } },
+    });
+    expect(state.workerIdleStopped).toBe(false);
+  });
+
+  it("clears workerIdleStopped on AcpSessionAssigned (respawn handshake landed)", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { Stopped: { reason: "idle_auto_stop" } },
+    });
+    expect(state.workerIdleStopped).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { AcpSessionAssigned: { acp_session_id: "fresh-id" } },
+    });
+    expect(state.workerIdleStopped).toBe(false);
+  });
+});
+
 describe("applyEvent / WakeupScheduled lifecycle", () => {
   it("user-typed prompt mid-wait keeps the pending wakeup", () => {
     // Regression for #1091: a user-typed follow-up during the wait

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -482,6 +482,17 @@ export interface CockpitState {
    *  transient "Restarting…" banner appears without a reconnect button;
    *  cleared on AcpSessionAssigned or UserPromptSent. */
   workerRestarting: boolean;
+  /** Set true when the daemon publishes `Stopped { reason: "idle_auto_stop" }`,
+   *  meaning the reconciler reaped the worker for inactivity
+   *  (`cockpit.auto_stop_idle_secs`) and marked the session dormant. Unlike
+   *  `workerStopped`, this is recoverable without any explicit reconnect:
+   *  the next prompt POST wakes it (the server's `touch_and_wake_if_sunk`
+   *  clears dormancy, the reconciler respawns, and `send_prompt`'s
+   *  `wait_for_worker` holds the request until the fresh worker is ready).
+   *  `sendPrompt` and the drain effect read this so a dormant worker does
+   *  NOT park prompts in the local queue forever; instead the POST itself
+   *  is the wake path. Cleared on AcpSessionAssigned or UserPromptSent. */
+  workerIdleStopped: boolean;
   /** Follow-up prompts the user typed and submitted while a turn was
    *  already running. The composer enqueues them client-side instead
    *  of racing the agent (claude-agent-acp serialises session/prompt
@@ -670,6 +681,7 @@ export function emptyCockpitState(): CockpitState {
     turnHasOutput: false,
     workerStopped: false,
     workerRestarting: false,
+    workerIdleStopped: false,
     queuedPrompts: [],
     nextWakeupAt: null,
     nextWakeupReason: null,
@@ -701,6 +713,10 @@ function applyNewTurnResets(next: CockpitState): void {
   // user_stopped banner without waiting for AcpSessionAssigned.
   next.workerStopped = false;
   next.workerRestarting = false;
+  // A prompt also wakes an idle-dormant worker (the POST cleared
+  // dormancy server-side); drop the marker so the drain effect stops
+  // treating the worker as wakeable-but-down.
+  next.workerIdleStopped = false;
   // The user is moving on. Clear any pending Retry pills and the
   // agent-unresponsive banner; if the rejection was legitimate the
   // new prompt will end up rejected too and a fresh pill will land.
@@ -1131,6 +1147,19 @@ export function applyEvent(
       next.workerStopped = false;
       next.agentUnresponsive = false;
       next.agentOrphaned = true;
+    } else if (event.Stopped.reason === "idle_auto_stop") {
+      // The reconciler reaped the worker for inactivity and marked the
+      // session dormant (#1689). This is NOT a user stop: no reconnect
+      // banner, no composer lockdown. The next prompt POST wakes the
+      // worker server-side (`touch_and_wake_if_sunk` clears dormancy,
+      // the reconciler respawns, `send_prompt` waits for it), so the
+      // composer stays usable and `sendPrompt` / the drain effect read
+      // `workerIdleStopped` to route a queued prompt through the POST
+      // wake path instead of parking it forever. Cleared on the next
+      // UserPromptSent or AcpSessionAssigned.
+      next.workerIdleStopped = true;
+      next.workerStopped = false;
+      next.workerRestarting = false;
     }
     // Some upstream slash commands (e.g. /usage, /status, /memory in
     // claude-agent-acp) advertise via available_commands_update but
@@ -1325,6 +1354,9 @@ export function applyEvent(
     // is online; clear both transient worker banners.
     next.workerStopped = false;
     next.workerRestarting = false;
+    // The respawn may have been triggered by waking an idle-dormant
+    // worker; the fresh handshake means it is no longer dormant.
+    next.workerIdleStopped = false;
     // The respawn after an `agent_unresponsive` escalation completed;
     // clear the banner so the user can interact again. See #1196.
     next.agentUnresponsive = false;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1174,6 +1174,19 @@
       ]
     },
     {
+      "id": "cockpit.idle-dormant-wake",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/lib/cockpitTypes.test.ts",
+        "src/hooks/useCockpit.queue.test.ts"
+      ],
+      "components": [
+        "web/src/lib/cockpitTypes.ts",
+        "web/src/hooks/useCockpit.ts"
+      ]
+    },
+    {
       "id": "cockpit.files-index",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
## Description

A cockpit session auto-stopped for inactivity (`auto_stop_idle_secs`, `Stopped` reason `idle_auto_stop`, #1689) could not be resumed from the web composer: a queued message sat at **"Pending until session resumes"** forever and nothing ever respawned the worker.

Root cause is frontend-only. The backend is already built to wake a dormant worker on a prompt POST (`touch_and_wake_if_sunk` clears dormancy, the reconciler respawns, and `send_prompt`'s `wait_for_worker` holds the request until the fresh worker is ready). But the web frontend never issued that POST:

- The reducer (`cockpitTypes.ts`) had no `idle_auto_stop` case, so the only signal that the worker was gone was the REST worker-state poll reading `absent`.
- `sendPrompt` and the drain effect (`useCockpit.ts`) both park on the `workerNotRunning` guard, so the prompt went into the local queue and never reached the server. The dormancy marker is deliberately hidden from the UI, so the archived/snoozed auto-wake path never fired either.

### Fix

Track dormancy in reducer state as `workerIdleStopped` (set on the `idle_auto_stop` `Stopped` frame; cleared on `UserPromptSent` / `AcpSessionAssigned`) and treat it as *wakeable-but-down*:

- `sendPrompt` POSTs instead of parking when dormant (the POST is the wake path).
- The drain effect fires a prompt that was parked *before* dormancy landed.
- The plain cold-resume `absent` guard (#1088) is unchanged: only dormancy bypasses it.

Frontend-only; no backend changes.

Related: #1689 (the idle auto-stop feature this gap lives in). Not a `Closes` since #1689 itself shipped.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit**
- [x] Added/updated Vitest specs and updated `web/tests/coverage-matrix.json` (`cockpit.idle-dormant-wake`)
  - `web/src/lib/cockpitTypes.test.ts`: reducer sets `workerIdleStopped` on `idle_auto_stop` (not `workerStopped`), clears it on `UserPromptSent` / `AcpSessionAssigned`.
  - `web/src/hooks/useCockpit.queue.test.ts`: a fresh prompt POSTs (wakes) while dormant; a prompt parked before dormancy drains once the dormancy frame lands; the plain cold-`absent` control still parks.
- Per the matrix guidance, this state-machine / request-routing logic belongs in Vitest. A live Playwright test would need to wait out a real idle-reap timeout, which is impractical and non-deterministic.

**TUI / CLI**
- [x] N/A: no TUI rendering, CLI subcommand, or session-lifecycle change.

### How to verify manually

- [ ] Set `cockpit.auto_stop_idle_secs` to a small value (e.g. `30`) and start `aoe serve`.
- [ ] Open a cockpit session in the web dashboard, send a prompt, let it finish.
- [ ] Leave it idle past the threshold; the timeline shows `Stopped (idle_auto_stop)`.
- [ ] Type and send a new prompt. It should POST and wake the worker (no "Pending until session resumes" that never clears).
- [ ] Repeat, but queue a prompt while the worker is still spinning up, then let it go dormant; the parked prompt should drain and wake the worker once dormancy lands.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request fixes a bug where sessions that were automatically stopped due to inactivity (idle-dormant workers) could not be resumed from the web composer. Prompts would get stuck in "Pending until session resumes" state instead of triggering a worker wake-up.

## What Changed

**Added:**
- New state flag `workerIdleStopped` to track when a worker has been auto-stopped due to inactivity
- Logic to detect idle-dormant sessions and treat them as "wakeable-but-down" instead of permanently absent
- Two regression test cases to verify idle-dormancy wake behavior
- Test suite covering the `idle_auto_stop` stopped reason
- Documentation update explaining the idle-dormant session scenario

**Updated:**
- Prompt sending logic: now issues a server POST request to wake the dormant worker instead of parking the prompt locally
- Drain effect: allows queued prompts to be sent even when the worker isn't running, if it's idle-dormant
- Test coverage matrix with new idle-dormancy test entry

**No Changes:**
- No public API changes or exported entity modifications
- The existing cold-resume behavior for truly absent workers remains unchanged
- No TUI/CLI changes

## Benefits

- **Improved user experience**: Users can resume dormant sessions directly from the web composer without manual intervention
- **Automatic wake-up**: Prompts now properly trigger the backend's worker respawn mechanism (`touch_and_wake_if_sunk`, reconciler respawn)
- **Queued prompts handled correctly**: Prompts that were queued before dormancy now drain normally once the worker is back
- **Aligned with backend capability**: Leverages existing backend support for waking workers that was previously inaccessible from the frontend
- **Better testing**: Regression tests prevent future regressions of this specific scenario

## Technical Details

The fix introduces a new `CockpitState.workerIdleStopped` boolean flag that:
- Is set to `true` when the reducer receives a `Stopped` frame with reason `idle_auto_stop`
- Is cleared when a `UserPromptSent` or `AcpSessionAssigned` event occurs
- Allows the `sendPrompt` function to bypass the `workerNotRunning` guard and proceed to the wake-and-send path
- Allows the drain effect to post queued prompts even when `workerStateRef.current !== "running"`

The `idle_auto_stop` stopped reason is distinguished from other stop conditions (`workerStopped`, `workerRestarting`) to enable wake-up behavior while maintaining the existing behavior for other dormancy scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->