### PR TITLE
fix(web): align wizard custom-agent Playwright assertion with updated notice copy

### DIFF
--- a/web/tests/wizard-custom-agent.spec.ts
+++ b/web/tests/wizard-custom-agent.spec.ts
@@ -139,7 +139,9 @@ test.describe("wizard custom agent picker", () => {
 
     await page.getByRole("button", { name: /remote-helper/ }).click();
     await expect(
-      page.getByText(/Custom agents run in the terminal\./),
+      page.getByText(
+        /Custom agents run in the terminal unless they define agent_cockpit_cmd/,
+      ),
     ).toBeVisible();
     await expect(page.locator("body")).not.toContainText(hiddenBinary);
     await expect(page.locator("body")).not.toContainText(hiddenCommand);


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an AI agent (Claude) on behalf of the maintainer.

## Description

The mocked Playwright spec `web/tests/wizard-custom-agent.spec.ts` asserted the custom-agent substrate notice with the stale regex `/Custom agents run in the terminal\./`. The notice copy on `cockpit-main` is now:

> Custom agents run in the terminal unless they define agent_cockpit_cmd in config or TUI settings.

There is no period after "terminal", so the old regex never matched and the test failed deterministically on every `cockpit-main`-based run (it surfaced as a "flaky" mocked failure on PR #1706). The Vitest unit test (`AgentStep.customAgent.test.tsx`) had already been updated to the new copy; this brings the Playwright spec in line.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

No matrix change needed: this fixes a stale assertion in an existing spec; no flow coverage changes.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)

## How I tested

```
cd web && npx playwright test --config=playwright.config.ts wizard-custom-agent
# PASS (1) FAIL (0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a failing Playwright test for the custom agent picker UI by updating the assertion to match the updated notice copy displayed to users. The notice text was expanded to provide more detailed information about how custom agents behave, but the test was still checking for the old, shorter version.

## What Changed
The Playwright test in `web/tests/wizard-custom-agent.spec.ts` was updated to assert that the custom agent notice message now includes additional guidance about the `agent_cockpit_cmd` configuration option. Previously, the test was looking for the message "Custom agents run in the terminal." — the assertion has been updated to match the new expanded message that includes information about how agents can define `agent_cockpit_cmd` in their config or TUI settings.

## Why This Fix Was Needed
The underlying UI notice text had been updated on the main branch, but the Playwright test still checked for the old text, causing the test to fail reliably. A related Vitest unit test had already been corrected to match the new notice text, so this PR brings the Playwright test into alignment with both the updated UI and the existing unit tests.

## Benefits
- **Test Reliability**: Eliminates deterministic test failures caused by outdated assertions
- **Consistency**: Brings the Playwright test suite in sync with the already-updated unit tests and actual UI content
- **Improved Documentation**: The updated notice copy provides users with clearer information about custom agent behavior and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->