### PR TITLE
fix(cockpit): preserve context across reversible shutdown

### DIFF
--- a/docs/cockpit/persistence.md
+++ b/docs/cockpit/persistence.md
@@ -82,9 +82,19 @@ Practical implications:
 
 ## Session deletion
 
-When you delete a cockpit session, aoe opportunistically fires the
-experimental `session/delete` ACP request against the live worker
-(bounded by a 2-second timeout) whenever a stored ACP session id
+`session/delete` fires only on **permanent** removal: deleting a
+cockpit session, or disabling cockpit mode on a session (which discards
+the conversation). Reversible teardown, `aoe cockpit stop`, snooze,
+archive, and idle auto-stop, deliberately does NOT fire it, so the
+agent's transcript stays on disk and the next respawn resumes via
+`session/load` instead of resetting the conversation. Firing it on
+those paths previously reset context on every snooze / archive /
+idle-stop. See
+[#1710](https://github.com/agent-of-empires/agent-of-empires/issues/1710).
+
+When you permanently delete a cockpit session, aoe opportunistically
+fires the experimental `session/delete` ACP request against the live
+worker (bounded by a 2-second timeout) whenever a stored ACP session id
 exists, and then proceeds with the existing kill path
 (`session/cancel` for in-flight prompts, then SIGTERM on the runner,
 then on-disk cleanup). aoe does not inspect the initialize-time

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1135,6 +1135,44 @@ impl AcpClient {
         (client, event_tx)
     }
 
+    /// Like `fake_for_test`, but wires a live `cmd_tx` whose consumer
+    /// records whether a `session/delete` RPC was issued. The returned
+    /// `AtomicBool` flips to `true` the moment a
+    /// `ClientCmd::DeleteSession` is received, and the consumer answers
+    /// it immediately so the caller's `delete_session` returns without
+    /// waiting on the timeout. Used to assert that reversible teardown
+    /// does NOT delete the agent transcript while permanent removal
+    /// does (#1710).
+    #[cfg(test)]
+    pub fn fake_for_test_recording(
+        session_id: CockpitSessionId,
+    ) -> (
+        Self,
+        mpsc::Sender<Event>,
+        std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) {
+        let (event_tx, event_rx) = mpsc::channel(64);
+        let (cmd_tx, mut cmd_rx) = mpsc::channel::<ClientCmd>(16);
+        let saw_delete = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let saw_delete_task = saw_delete.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = cmd_rx.recv().await {
+                if let ClientCmd::DeleteSession { respond_to, .. } = cmd {
+                    saw_delete_task.store(true, std::sync::atomic::Ordering::SeqCst);
+                    let _ = respond_to.send(DeleteSessionOutcome::UnsupportedMethod);
+                }
+            }
+        });
+        let client = Self {
+            session_id,
+            inbound: Some(event_rx),
+            cmd_tx: Some(cmd_tx),
+            pending_responders: Arc::new(Mutex::new(HashMap::new())),
+            _child: None,
+        };
+        (client, event_tx, saw_delete)
+    }
+
     /// Spawn an ACP agent subprocess, run the handshake + create a
     /// session, and start pumping notifications into the inbound channel.
     pub async fn spawn(

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1710,18 +1710,39 @@ impl<S: BroadcastSink> Supervisor<S> {
         Ok(())
     }
 
-    /// Shutdown a single cockpit worker.
+    /// Shutdown a single cockpit worker, preserving its agent-side
+    /// transcript so the next respawn can resume it via `session/load`.
+    ///
+    /// This is the temporary-teardown path: cockpit stop, snooze,
+    /// archive, idle auto-stop, and supersede all funnel here. They are
+    /// reversible, so we must NOT fire `session/delete` (which deletes
+    /// the agent's on-disk transcript); doing so left every snooze /
+    /// archive / idle-stop unable to resume, resetting context on the
+    /// next prompt (#1710). For permanent removal use
+    /// [`Self::shutdown_and_delete`].
     pub async fn shutdown(&self, session_id: &str) -> Result<(), SupervisorError> {
-        self.shutdown_with_reason(session_id, "user_stopped").await
+        self.shutdown_with_reason(session_id, "user_stopped", false)
+            .await
     }
 
     /// Like `shutdown`, but tags the synthetic `Stopped` event with
     /// `reason: "idle_auto_stop"` so the cockpit timeline shows the
     /// worker was reclaimed for inactivity rather than user-stopped.
     /// Used by the reconciler's idle-reap pass (#1689). Seamless: no UI
-    /// banner, the next prompt respawns the worker.
+    /// banner, the next prompt respawns the worker. Preserves the
+    /// agent transcript so that respawn resumes instead of resetting.
     pub async fn shutdown_idle(&self, session_id: &str) -> Result<(), SupervisorError> {
-        self.shutdown_with_reason(session_id, "idle_auto_stop")
+        self.shutdown_with_reason(session_id, "idle_auto_stop", false)
+            .await
+    }
+
+    /// Shutdown a worker AND release its agent-side persisted state via
+    /// the experimental `session/delete` RPC. Use only when the session
+    /// is being permanently discarded (session delete, or disabling
+    /// cockpit mode), never for reversible teardown, which must keep the
+    /// transcript resumable. See #1710 and `shutdown`.
+    pub async fn shutdown_and_delete(&self, session_id: &str) -> Result<(), SupervisorError> {
+        self.shutdown_with_reason(session_id, "user_stopped", true)
             .await
     }
 
@@ -1729,6 +1750,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         &self,
         session_id: &str,
         stop_reason: &str,
+        delete_adapter_state: bool,
     ) -> Result<(), SupervisorError> {
         // Hold workers + pending_resumes simultaneously so the spawn
         // can't observe an empty workers map, finish the handshake,
@@ -1742,13 +1764,22 @@ impl<S: BroadcastSink> Supervisor<S> {
             // Best-effort experimental `session/delete` RPC before
             // SIGTERM. Adapters that advertise
             // `sessionCapabilities.delete: {}` (claude-agent-acp >= 0.36)
-            // release adapter-side persisted state here. Other
-            // adapters return -32601 and we proceed to the existing
-            // kill path either way. Bounded by
-            // `ACP_SESSION_DELETE_TIMEOUT` inside `delete_session`
-            // (~2s) so a wedged adapter cannot stall the user's
-            // delete. See #1404.
-            try_session_delete(&handle.client, session_id).await;
+            // release adapter-side persisted state here, deleting the
+            // agent's on-disk transcript. Other adapters return -32601
+            // and we proceed to the existing kill path either way.
+            // Bounded by `ACP_SESSION_DELETE_TIMEOUT` inside
+            // `delete_session` (~2s) so a wedged adapter cannot stall
+            // the caller. See #1404.
+            //
+            // Gated on `delete_adapter_state`: only permanent removal
+            // (session delete / disabling cockpit) deletes the
+            // transcript. Reversible teardown (snooze, archive, idle
+            // auto-stop, stop, supersede) must keep it so the next
+            // respawn resumes via `session/load` instead of resetting
+            // the conversation. See #1710.
+            if delete_adapter_state {
+                try_session_delete(&handle.client, session_id).await;
+            }
             let _ = handle.client.shutdown().await;
             handle.drain_task.abort();
             // SIGTERM the runner (if there is one) so the agent
@@ -3078,6 +3109,93 @@ mod tests {
         assert!(
             sink.frames.lock().unwrap().is_empty(),
             "shutdown must not publish for stdio fixtures"
+        );
+    }
+
+    /// Reversible teardown must keep the agent transcript resumable, so
+    /// `shutdown` (snooze, archive, idle auto-stop, stop, supersede)
+    /// must NOT fire `session/delete`; only permanent removal via
+    /// `shutdown_and_delete` may. Regression test for the snooze /
+    /// archive / idle-stop context loss in #1710. Isolates HOME so the
+    /// registry record (which carries the stored ACP id that
+    /// `try_session_delete` needs) stays out of real state, and uses a
+    /// reaped, never-leader pid so the teardown's process-group SIGTERM
+    /// resolves to a harmless ESRCH.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn shutdown_skips_session_delete_permanent_delete_fires_it() {
+        use std::sync::atomic::Ordering;
+        let tmp = tempfile::TempDir::new().unwrap();
+        // SAFETY: serialised by `#[serial]`; matches the existing pattern.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+
+        // Dead pid that was never a process-group leader, so the
+        // teardown's killpg/kill signal nothing (ESRCH).
+        let dead_pid = {
+            let mut child = std::process::Command::new("/bin/sh")
+                .args(["-c", "exit 0"])
+                .spawn()
+                .expect("spawn helper");
+            let id = child.id();
+            let _ = child.wait();
+            id
+        };
+
+        async fn register(
+            sup: &Supervisor<VecSink>,
+            session: &str,
+            pid: u32,
+            socket: std::path::PathBuf,
+        ) -> std::sync::Arc<std::sync::atomic::AtomicBool> {
+            let record = crate::cockpit::worker_registry::WorkerRecord::new(
+                session.into(),
+                pid,
+                socket,
+                "claude-agent-acp".into(),
+                "claude-code".into(),
+                std::env::temp_dir(),
+                None,
+                vec![],
+                vec![],
+                Some("acp-test-id".into()),
+                None,
+            );
+            crate::cockpit::worker_registry::save(&record).unwrap();
+            let (client, _tx, saw_delete) =
+                AcpClient::fake_for_test_recording(CockpitSessionId(session.into()));
+            let mut workers = sup.workers.lock().await;
+            workers.insert(
+                session.into(),
+                WorkerHandle {
+                    client: Arc::new(client),
+                    drain_task: tokio::spawn(async {}),
+                    restart_history: vec![],
+                    kind: WorkerKind::Stdio,
+                },
+            );
+            saw_delete
+        }
+
+        let sup = Supervisor::new(VecSink::new());
+
+        let keep = register(&sup, "s-keep", dead_pid, tmp.path().join("keep.sock")).await;
+        sup.shutdown("s-keep").await.expect("shutdown ok");
+        assert!(
+            !keep.load(Ordering::SeqCst),
+            "shutdown must NOT send session/delete; the transcript must \
+             stay resumable so the next respawn restores context (#1710)"
+        );
+
+        let purge = register(&sup, "s-del", dead_pid, tmp.path().join("del.sock")).await;
+        sup.shutdown_and_delete("s-del")
+            .await
+            .expect("shutdown_and_delete ok");
+        assert!(
+            purge.load(Ordering::SeqCst),
+            "shutdown_and_delete (permanent removal) must send session/delete"
         );
     }
 

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1297,9 +1297,12 @@ pub async fn cockpit_disable(
         .into_response();
     }
 
-    // Tear down the cockpit worker. UnknownSession is fine — the
-    // supervisor may not have a worker if startup never completed.
-    match state.cockpit_supervisor.shutdown(&id).await {
+    // Tear down the cockpit worker. Disabling cockpit mode discards the
+    // conversation (we delete on-disk history and clear the stored ACP
+    // id below), so release the agent's persisted transcript too via
+    // session/delete. UnknownSession is fine, the supervisor may not
+    // have a worker if startup never completed. See #1710.
+    match state.cockpit_supervisor.shutdown_and_delete(&id).await {
         Ok(()) | Err(SupervisorError::UnknownSession(_)) => {}
         Err(e) => {
             tracing::warn!(target: "cockpit.switch", session = %id, "shutdown cockpit failed: {e}");

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1218,7 +1218,9 @@ pub async fn update_session_archive(
         // reconciler does not race to respawn it. The reconciler also
         // skips archived sessions (see cockpit_reconciler.rs), but
         // shutting down here gives an immediate teardown rather than
-        // waiting for the next poll tick.
+        // waiting for the next poll tick. `shutdown` preserves the
+        // agent transcript (no session/delete), so unarchiving resumes
+        // the conversation instead of resetting it (#1710).
         #[cfg(feature = "serve")]
         match state.cockpit_supervisor.shutdown(&id).await {
             Ok(()) | Err(crate::cockpit::supervisor::SupervisorError::UnknownSession(_)) => {}
@@ -1361,6 +1363,9 @@ pub async fn update_session_snooze(
     // worker stays down until the snooze expires; the next reconciler
     // tick after expiry brings it back. Unsnooze just lets the
     // reconciler re-pick the session naturally, no explicit respawn.
+    // `shutdown` preserves the agent transcript (no session/delete), so
+    // that respawn resumes the conversation instead of resetting it
+    // (#1710).
     #[cfg(feature = "serve")]
     if was_cockpit_mode && minutes.is_some() {
         match state.cockpit_supervisor.shutdown(&id).await {
@@ -1460,7 +1465,9 @@ pub async fn delete_session(
     // return UnknownSession, which we ignore.
     #[cfg(feature = "serve")]
     if instance.cockpit_mode {
-        match state.cockpit_supervisor.shutdown(&id).await {
+        // Permanent removal: release the agent's persisted transcript
+        // too, since the session is going away for good. See #1710.
+        match state.cockpit_supervisor.shutdown_and_delete(&id).await {
             Ok(()) | Err(crate::cockpit::supervisor::SupervisorError::UnknownSession(_)) => {}
             Err(e) => {
                 tracing::warn!(


### PR DESCRIPTION
## Description
Fixes #1710.

This change preserves cockpit conversation context across reversible worker teardown.

- `Supervisor::shutdown` and `shutdown_idle` now preserve adapter-side transcript state
- Added `Supervisor::shutdown_and_delete` for permanent teardown paths
- Switched permanent delete paths to `shutdown_and_delete`:
  - delete session
  - disable cockpit mode
- Added regression coverage to assert reversible shutdown does not issue `session/delete`, while permanent delete does
- Updated persistence docs to describe the new `session/delete` behavior

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: behavior change is in backend teardown/resume gating; covered with a Rust supervisor regression test in this PR. Local test execution was intentionally skipped per request, CI will run checks.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this change targets cockpit supervisor/server behavior and adds focused Rust unit coverage; no TUI/CLI e2e changes were added in this PR.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex (GPT-5)

**Any Additional AI Details you'd like to share:**

Implemented code changes and documentation updates under direct user instruction.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes the loss of cockpit conversation context that occurs after reversible worker teardowns (like snoozing or stopping conversations). Previously, these temporary stops were permanently deleting the conversation history stored in the AI adapter, forcing a fresh start on resume. The fix separates reversible shutdowns from permanent deletions, ensuring conversation history is preserved when appropriate.

## What Changed

**Architecture & API:**
- Introduced a new permanent shutdown method (`shutdown_and_delete`) alongside the existing reversible shutdown method
- The reversible shutdown now explicitly preserves adapter-side conversation transcripts
- Only permanent deletion scenarios (deleting a session or disabling cockpit mode entirely) now trigger the session deletion RPC

**Code Changes Across Files:**
- **supervisor.rs**: Added the new `shutdown_and_delete` method; refactored existing shutdown methods to accept a parameter controlling whether to delete adapter state; only permanent deletions trigger the session/delete RPC
- **sessions.rs**: Updated the session delete operation to use the new permanent deletion method; archive and snooze operations updated with clarifying comments that they preserve conversations
- **cockpit.rs**: When disabling cockpit mode, now uses the permanent deletion method instead of the reversible one
- **acp_client.rs**: Added a test helper for recording whether session deletion was attempted
- **persistence.md**: Updated documentation to clarify when session deletion occurs

**Test Coverage:**
- Added regression tests verifying that reversible shutdown does not send session/delete, while permanent deletion does

## Benefits

- **Conversation continuity**: Users no longer lose their conversation history when temporarily pausing work (snoozing, archiving, idle auto-stop)
- **Proper state cleanup**: Session history is only deleted when truly permanent (session deletion, cockpit mode disabled)
- **Clear semantics**: The distinction between reversible and permanent operations is now explicit in the code
- **Regression prevention**: New tests ensure this behavior is maintained in future changes

## Technical Details

The key change is a boolean flag (`delete_adapter_state`) added to the internal `shutdown_with_reason` implementation:
- **Reversible operations** (stop, snooze, archive, idle auto-stop, supersede): pass `false`, preserving the Claude transcript
- **Permanent operations** (session deletion, disabling cockpit): call `shutdown_and_delete` which passes `true`, triggering the `session/delete` RPC to release persisted adapter state
- The `session/load` RPC on resume can now restore conversation context instead of returning a not-found error and forcing a reset

<!-- end of auto-generated comment: release notes by coderabbit.ai -->