### PR TITLE
feat(cockpit): always-available agent switcher (CLI + web)

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -77,6 +77,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe cockpit cancel`↴](#aoe-cockpit-cancel)
 * [`aoe cockpit tail`↴](#aoe-cockpit-tail)
 * [`aoe cockpit attach`↴](#aoe-cockpit-attach)
+* [`aoe cockpit switch-agent`↴](#aoe-cockpit-switch-agent)
 * [`aoe uninstall`↴](#aoe-uninstall)
 * [`aoe update`↴](#aoe-update)
 * [`aoe completion`↴](#aoe-completion)
@@ -983,6 +984,7 @@ Cockpit (ACP-based native agent rendering) management
 * `cancel` — Cancel the in-flight prompt for a cockpit session
 * `tail` — Stream the cockpit broadcast for a session to stdout as JSON lines (one frame per line). Press Ctrl-C to stop
 * `attach` — Open the TUI cockpit view directly for a known session id. Combine with `AOE_DAEMON_URL` (+ `AOE_DAEMON_TOKEN`) to attach across machines without going through the home session list
+* `switch-agent` — Switch a cockpit session to a different ACP agent, keeping the transcript. The new agent starts fresh; use `aoe cockpit agents` to list valid targets. Handy for returning to claude after a rate-limit handoff to codex
 
 
 
@@ -1180,6 +1182,23 @@ Open the TUI cockpit view directly for a known session id. Combine with `AOE_DAE
 ###### **Arguments:**
 
 * `<SESSION>` — Cockpit session id
+
+
+
+## `aoe cockpit switch-agent`
+
+Switch a cockpit session to a different ACP agent, keeping the transcript. The new agent starts fresh; use `aoe cockpit agents` to list valid targets. Handy for returning to claude after a rate-limit handoff to codex
+
+**Usage:** `aoe cockpit switch-agent [OPTIONS] <SESSION> <TARGET>`
+
+###### **Arguments:**
+
+* `<SESSION>` — Cockpit session id
+* `<TARGET>` — Registry key of the target agent (e.g. `claude`, `codex`)
+
+###### **Options:**
+
+* `--model <MODEL>` — Optional model override forwarded to the new agent
 
 
 

--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -91,6 +91,15 @@ The cockpit then renders the generic tool card, which is the right
 fallback. The user can file a PR adding the alias once they've used the
 agent and confirmed the wire shape.
 
+## Switching Agents on a Live Session
+
+A cockpit session is not pinned to the agent it started with. You can hand it off to any other installed ACP backend at any time, keeping the transcript. The new agent starts fresh (a new ACP session) and is primed with a recap of the recent turns so it can pick up where the last one left off.
+
+- **Web dashboard:** use the "Switch agent" control in the composer toolbar. The rate-limit recovery banner exposes the same picker via "Continue in another agent" when an agent is over its limit.
+- **CLI:** `aoe cockpit switch-agent <session> <target>`, where `<target>` is a registry key from `aoe cockpit agents`. Add `--model <name>` to override the model.
+
+This is what you reach for after a rate-limit hand-off: switch claude to codex when claude is limited, then `aoe cockpit switch-agent <session> claude` (or the toolbar control) to return once the window resets. The transcript records each switch with its reason (`manual` or `rate_limited`) on a divider.
+
 ## Known Limitations
 
 - Codex / opencode / gemini cockpit support has been built from adapter

--- a/docs/cockpit/troubleshooting.md
+++ b/docs/cockpit/troubleshooting.md
@@ -148,6 +148,15 @@ The rate-limit banner offers a primary "Continue in another agent" CTA. Clicking
 
 After the switch, the modal fetches the context primer and pre-fills the composer with a framed recap of the prior conversation. If the user's last prompt is what triggered the rate-limit (it was published to the event log before the adapter rejected it), the primer endpoint surfaces it separately as `unprocessed_prompt`; the modal drops it into the composer as the user's pending request so they don't have to retype it. The composer is NOT auto-sent; review and submit manually.
 
+### Switching agents manually
+
+The same hand-off is available at any time, not just when an agent is rate-limited. This matters when you handed a session off (say, claude to codex during a rate limit) and later want to return to the original agent once the limit clears.
+
+- **Web dashboard:** the composer toolbar carries a "Switch agent" control. Clicking it opens the same picker, lists the cockpit ACP registry, and switches on confirm. The composer is pre-filled with a recap so the new agent has context; review and send manually.
+- **CLI:** `aoe cockpit switch-agent <session> <target>` (run `aoe cockpit agents` to list valid target keys). Pass `--model <name>` to override the model the new agent starts with.
+
+Both paths hit `POST /api/sessions/{id}/cockpit/switch-agent` with `reason: "manual"`, so the transcript divider reads `Switched cockpit agent from <from> to <to> (manual)`, distinct from the `(rate_limited)` divider the recovery flow emits.
+
 ### Native binary launch failure
 
 When the cockpit banner shows an error of the form

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -130,6 +130,19 @@ pub enum CockpitCommands {
         /// Cockpit session id.
         session: String,
     },
+    /// Switch a cockpit session to a different ACP agent, keeping the
+    /// transcript. The new agent starts fresh; use `aoe cockpit agents`
+    /// to list valid targets. Handy for returning to claude after a
+    /// rate-limit handoff to codex.
+    SwitchAgent {
+        /// Cockpit session id.
+        session: String,
+        /// Registry key of the target agent (e.g. `claude`, `codex`).
+        target: String,
+        /// Optional model override forwarded to the new agent.
+        #[arg(long)]
+        model: Option<String>,
+    },
 }
 
 #[tracing::instrument(target = "cli.cockpit", skip_all)]
@@ -162,6 +175,11 @@ pub async fn run(command: CockpitCommands) -> Result<()> {
         CockpitCommands::Cancel { session } => cancel(&session).await,
         CockpitCommands::Tail { session, since } => tail(&session, since).await,
         CockpitCommands::Attach { session } => attach(&session).await,
+        CockpitCommands::SwitchAgent {
+            session,
+            target,
+            model,
+        } => switch_agent(&session, &target, model.as_deref()).await,
     }
 }
 
@@ -752,6 +770,17 @@ async fn cancel(session: &str) -> Result<()> {
     let client = HttpClient::new(endpoint)?;
     client.cancel(session).await.map_err(map_http)?;
     println!("cancel sent");
+    Ok(())
+}
+
+async fn switch_agent(session: &str, target: &str, model: Option<&str>) -> Result<()> {
+    let endpoint = require_daemon().await?;
+    let client = HttpClient::new(endpoint)?;
+    let resp = client
+        .switch_agent(session, target, model, Some("manual"))
+        .await
+        .map_err(map_http)?;
+    println!("switched cockpit agent for {session} -> {}", resp.agent);
     Ok(())
 }
 

--- a/src/cockpit/client/http.rs
+++ b/src/cockpit/client/http.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use super::discovery::DaemonEndpoint;
 use crate::cockpit::protocol::{
     ApprovalDecisionWire, ContextPrimerResponse, PromptRequest, ReplayResponse,
-    ResolveApprovalRequest,
+    ResolveApprovalRequest, SwitchAgentRequest, SwitchAgentResponse,
 };
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -109,6 +109,31 @@ impl HttpClient {
         let res = self.auth(self.http.post(&url)).send().await?;
         check_status(res, session_id).await?;
         Ok(())
+    }
+
+    /// `POST /api/sessions/{id}/cockpit/switch-agent`. Hands the session
+    /// off to another ACP backend, keeping the transcript. Returns the
+    /// daemon's response (before/switch seqs) so callers can fetch a
+    /// context primer if they want a handoff recap.
+    pub async fn switch_agent(
+        &self,
+        session_id: &str,
+        target: &str,
+        model: Option<&str>,
+        reason: Option<&str>,
+    ) -> Result<SwitchAgentResponse, HttpError> {
+        let url = format!(
+            "{}/api/sessions/{}/cockpit/switch-agent",
+            self.endpoint.base_url, session_id
+        );
+        let body = SwitchAgentRequest {
+            target: target.to_string(),
+            model: model.map(str::to_string),
+            reason: reason.map(str::to_string),
+        };
+        let res = self.auth(self.http.post(&url)).json(&body).send().await?;
+        let res = check_status(res, session_id).await?;
+        Ok(res.json::<SwitchAgentResponse>().await?)
     }
 
     /// `POST /api/sessions/{id}/cockpit/approvals/{nonce}`.

--- a/src/cockpit/protocol.rs
+++ b/src/cockpit/protocol.rs
@@ -228,6 +228,13 @@ pub struct SwitchAgentRequest {
     /// back to the instance's existing `cockpit_model`.
     #[serde(default)]
     pub model: Option<String>,
+    /// Why the switch happened, recorded verbatim in the `AgentSwitched`
+    /// event and surfaced in the transcript divider. The rate-limit
+    /// recovery flow sends `"rate_limited"`; an explicit user-initiated
+    /// switch (composer control, `aoe cockpit switch-agent`) sends
+    /// `"manual"`. Defaults to `"manual"` when omitted.
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 /// `POST /api/sessions/{id}/cockpit/switch-agent` response.
@@ -246,7 +253,9 @@ pub struct SwitchAgentResponse {
     /// recovery composer prefill so the divider, state-clear, and
     /// primer prefill all land in order.
     pub switch_seq: u64,
-    pub status: &'static str,
+    /// Owned so the client side can deserialize the response (a
+    /// `&'static str` field is not `DeserializeOwned`).
+    pub status: String,
 }
 
 #[cfg(test)]
@@ -303,5 +312,23 @@ mod tests {
         let body = serde_json::json!({ "decision": "Allow" });
         let parsed: ResolveApprovalRequest = serde_json::from_value(body).unwrap();
         assert!(matches!(parsed.decision, ApprovalDecisionWire::Allow));
+    }
+
+    #[test]
+    fn switch_agent_request_optional_fields_default_to_none() {
+        // A bare body (the rate-limit recovery modal's original shape)
+        // still deserializes; model and reason are optional.
+        let body = serde_json::json!({ "target": "codex" });
+        let parsed: SwitchAgentRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(parsed.target, "codex");
+        assert!(parsed.model.is_none());
+        assert!(parsed.reason.is_none());
+    }
+
+    #[test]
+    fn switch_agent_request_carries_reason() {
+        let body = serde_json::json!({ "target": "claude", "reason": "manual" });
+        let parsed: SwitchAgentRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(parsed.reason.as_deref(), Some("manual"));
     }
 }

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -410,9 +410,11 @@ pub async fn list_cockpit_agents(State(state): State<Arc<AppState>>) -> impl Int
 }
 
 /// Atomically move a cockpit session from one ACP backend to another.
-/// Used by the rate-limit recovery flow (#1282) so the user can
-/// continue a Claude-rate-limited session in `codex` (or another
-/// installed ACP backend) without losing the transcript.
+/// Two callers drive this: the rate-limit recovery flow (#1282), which
+/// hands a Claude-rate-limited session off to `codex` (or another
+/// installed backend), and explicit user-initiated switches from the
+/// composer control or `aoe cockpit switch-agent`. Both keep the
+/// transcript; only the recorded `reason` differs.
 ///
 /// Sequence:
 ///   1. Validate `target` exists in the cockpit registry.
@@ -590,11 +592,18 @@ pub async fn switch_cockpit_agent(
         }
     }
 
+    let reason = req
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|r| !r.is_empty())
+        .unwrap_or("manual")
+        .to_string();
     let switch_seq = state.cockpit_supervisor.publish_agent_switched(
         &id,
         from_agent.clone(),
         target.clone(),
-        "rate_limited".into(),
+        reason,
     );
 
     Json(SwitchAgentResponse {
@@ -602,7 +611,7 @@ pub async fn switch_cockpit_agent(
         agent: target,
         before_seq,
         switch_seq,
-        status: "running",
+        status: "running".to_string(),
     })
     .into_response()
 }

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -41,7 +41,7 @@ import {
 import { Composer } from "./Composer";
 import { ConfigOptionSwitchFailedNotice } from "./SessionConfigControls";
 import { ContextPrimerBanner } from "./ContextPrimerBanner";
-import { RateLimitRecoveryModal } from "./RateLimitRecoveryModal";
+import { SwitchAgentModal } from "./SwitchAgentModal";
 import { Markdown } from "./Markdown";
 import {
   isQueuedPromptLong,
@@ -462,6 +462,7 @@ function CockpitChrome({
 
           <Composer
             sessionId={sessionId}
+            currentAgent={state.agent}
             availableModes={state.availableModes}
             currentModeId={state.currentModeId}
             legacyMode={state.mode}
@@ -1200,12 +1201,13 @@ export function RateLimitRecoverySection({
   return (
     <>
       {children({ onSwitchAgent: () => setOpen(true) })}
-      <RateLimitRecoveryModal
+      <SwitchAgentModal
         open={open}
         sessionId={sessionId}
         currentAgent={currentAgent}
         onClose={() => setOpen(false)}
         onPrefill={onPrefill}
+        trigger="rate_limit"
       />
     </>
   );

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -20,6 +20,7 @@ import {
 } from "@assistant-ui/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  ArrowLeftRight,
   AtSign,
   ChevronUp,
   Paperclip,
@@ -30,6 +31,7 @@ import {
 
 import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import { SessionConfigControls } from "./SessionConfigControls";
+import { SwitchAgentModal } from "./SwitchAgentModal";
 import type {
   CockpitState,
   PromptAttachmentInput,
@@ -195,6 +197,9 @@ function fileToBase64(file: File): Promise<string> {
 
 interface Props {
   sessionId: string;
+  /** Registry key of the agent the session currently runs. Drives the
+   *  "Switch agent" control's filtered target list and handoff copy. */
+  currentAgent: CockpitState["agent"];
   availableModes: CockpitState["availableModes"];
   currentModeId: CockpitState["currentModeId"];
   /** Legacy enum-based mode used as fallback when the agent does not
@@ -264,6 +269,7 @@ interface Props {
 
 export function Composer({
   sessionId,
+  currentAgent,
   availableModes,
   currentModeId,
   legacyMode,
@@ -430,6 +436,12 @@ export function Composer({
       () => setPendingAttachments([]),
     );
   }, [composerRuntime, enqueuePrompt, pendingAttachments, setPendingAttachments]);
+
+  // Manual agent switch dialog, opened from the toolbar control. Unlike
+  // the rate-limit recovery path (which lives up in CockpitView), this
+  // is available at any time so a user can hand back to, say, claude
+  // after a rate-limit handoff to codex.
+  const [switchAgentOpen, setSwitchAgentOpen] = useState(false);
 
   // iOS Safari native dictation (#1431): WebKit fires `beforeinput` /
   // `input` with `inputType: "insertReplacementText"` per partial
@@ -855,6 +867,12 @@ export function Composer({
                   pendingConfigOption={pendingConfigOption}
                   onSetConfigOption={setConfigOption}
                 />
+                <span className="mx-1 h-4 w-px bg-surface-700" aria-hidden />
+                <ToolbarButton
+                  icon={<ArrowLeftRight className="h-3.5 w-3.5" />}
+                  label="Switch agent"
+                  onClick={() => setSwitchAgentOpen(true)}
+                />
               </div>
 
               <div className="flex items-center gap-2">
@@ -876,6 +894,17 @@ export function Composer({
           </ComposerPrimitive.Root>
         </ComposerPrimitive.Unstable_TriggerPopoverRoot>
       </div>
+      <SwitchAgentModal
+        open={switchAgentOpen}
+        sessionId={sessionId}
+        currentAgent={currentAgent}
+        onClose={() => setSwitchAgentOpen(false)}
+        onPrefill={(text) => {
+          composerRuntime.setText(text);
+          requestAnimationFrame(() => taRef.current?.focus());
+        }}
+        trigger="manual"
+      />
     </div>
   );
 }

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -901,7 +901,19 @@ export function Composer({
         onClose={() => setSwitchAgentOpen(false)}
         onPrefill={(text) => {
           composerRuntime.setText(text);
-          requestAnimationFrame(() => taRef.current?.focus());
+          requestAnimationFrame(() => {
+            const el = taRef.current;
+            if (!el) return;
+            el.focus();
+            const len = el.value.length;
+            try {
+              el.setSelectionRange(len, len);
+            } catch {
+              // ignore: non-text inputs can throw here
+            }
+            el.style.height = "auto";
+            el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+          });
         }}
         trigger="manual"
       />

--- a/web/src/components/cockpit/SwitchAgentModal.test.tsx
+++ b/web/src/components/cockpit/SwitchAgentModal.test.tsx
@@ -1,14 +1,17 @@
 // @vitest-environment jsdom
 //
-// Modal-side contract for the rate-limit recovery flow (#1281 / #1282).
-// The component fans out to three API helpers in lib/api; the test
-// mocks them so each assertion pins one slice of behaviour:
+// Modal-side contract for the agent-switch flow (#1281 / #1282). The
+// same dialog drives two triggers: the rate-limit recovery path
+// ("rate_limit") and an explicit user-initiated switch ("manual"). The
+// component fans out to three API helpers in lib/api; the test mocks
+// them so each assertion pins one slice of behaviour:
 //   - confirm fires switchCockpitAgent then fetchContextPrimer, in
 //     that order, then onPrefill with the framed handoff text;
-//   - cancel does NOT touch switchCockpitAgent;
-//   - Escape closes the modal (and likewise leaves switch untouched);
+//   - the recorded reason matches the trigger (rate_limited vs manual);
+//   - cancel / Escape do NOT touch switchCockpitAgent;
 //   - the recap and unprocessed_prompt slots show up in the prefill in
-//     the expected positions.
+//     the expected positions;
+//   - the manual trigger swaps the copy and drops the codex preference.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -18,7 +21,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 
-import { RateLimitRecoveryModal } from "./RateLimitRecoveryModal";
+import { SwitchAgentModal } from "./SwitchAgentModal";
 
 vi.mock("../../lib/api", () => ({
   fetchCockpitAgents: vi.fn(),
@@ -64,23 +67,24 @@ afterEach(() => {
   cleanup();
 });
 
-function mount(props?: Partial<React.ComponentProps<typeof RateLimitRecoveryModal>>) {
+function mount(props?: Partial<React.ComponentProps<typeof SwitchAgentModal>>) {
   const onClose = vi.fn();
   const onPrefill = vi.fn();
   const utils = render(
-    <RateLimitRecoveryModal
+    <SwitchAgentModal
       open
       sessionId="s-1"
       currentAgent="claude"
       onClose={onClose}
       onPrefill={onPrefill}
+      trigger="rate_limit"
       {...props}
     />,
   );
   return { onClose, onPrefill, ...utils };
 }
 
-describe("RateLimitRecoveryModal", () => {
+describe("SwitchAgentModal (rate_limit)", () => {
   it("filters out the current agent and preselects codex", async () => {
     const { container, findByText } = mount();
     await findByText(/Continue in codex/);
@@ -110,7 +114,8 @@ describe("RateLimitRecoveryModal", () => {
     const confirm = await findByText(/Continue in codex/);
     fireEvent.click(confirm);
     await waitFor(() => expect(mockSwitch).toHaveBeenCalledTimes(1));
-    expect(mockSwitch).toHaveBeenCalledWith("s-1", "codex");
+    // reason "rate_limited" so the transcript divider reads correctly.
+    expect(mockSwitch).toHaveBeenCalledWith("s-1", "codex", null, "rate_limited");
     await waitFor(() => expect(mockPrimer).toHaveBeenCalledTimes(1));
     // Primer must be invoked with before_seq from the switch response
     // (41), not switch_seq, so the recap excludes the AgentSwitched
@@ -120,6 +125,7 @@ describe("RateLimitRecoveryModal", () => {
     await waitFor(() => expect(onPrefill).toHaveBeenCalledTimes(1));
     const prefilled = onPrefill.mock.calls[0]?.[0] as string;
     expect(prefilled).toContain("CONTEXT HANDOFF");
+    expect(prefilled).toContain("rate-limited");
     expect(prefilled).toContain("claude");
     expect(prefilled).toContain("codex");
     expect(prefilled).toContain("user: hi");
@@ -196,5 +202,46 @@ describe("RateLimitRecoveryModal", () => {
     ]);
     const { findByText } = mount();
     await findByText(/No alternative cockpit agents are registered/i);
+  });
+});
+
+describe("SwitchAgentModal (manual)", () => {
+  it("uses 'Switch to' copy and no codex preference", async () => {
+    // Manual trigger has no preferred direction: it preselects the first
+    // remaining entry (claude filtered out -> codex is first here, but
+    // the label proves the manual copy path, not a rate-limit fallback).
+    const { container, findByText, queryByText } = mount({ trigger: "manual" });
+    await findByText(/Switch to/);
+    expect(queryByText(/Continue in/)).toBeNull();
+    const checked = Array.from(
+      container.querySelectorAll<HTMLInputElement>(
+        "input[name=cockpit-agent-target]",
+      ),
+    ).find((r) => r.checked);
+    // First remaining agent after filtering out the current one.
+    expect(checked?.value).toBe("codex");
+  });
+
+  it("records reason 'manual' and frames the recap as a plain switch", async () => {
+    const { findByText, onPrefill } = mount({ trigger: "manual" });
+    fireEvent.click(await findByText(/Switch to codex/));
+    await waitFor(() => expect(mockSwitch).toHaveBeenCalledTimes(1));
+    expect(mockSwitch).toHaveBeenCalledWith("s-1", "codex", null, "manual");
+    await waitFor(() => expect(onPrefill).toHaveBeenCalledTimes(1));
+    const prefilled = onPrefill.mock.calls[0]?.[0] as string;
+    expect(prefilled).toContain("switched from claude to codex");
+    expect(prefilled).not.toContain("rate-limited");
+  });
+
+  it("preselects the first remaining agent (no codex bias) on manual switch", async () => {
+    mockFetchAgents.mockResolvedValue([
+      { name: "claude", description: "Claude", command: "claude-agent-acp" },
+      { name: "opencode", description: "OpenCode", command: "opencode-acp" },
+      { name: "codex", description: "OpenAI Codex", command: "codex-acp" },
+    ]);
+    const { findByText } = mount({ trigger: "manual" });
+    // opencode comes before codex in the list, so it wins without the
+    // rate-limit codex preference.
+    await findByText(/Switch to opencode/);
   });
 });

--- a/web/src/components/cockpit/SwitchAgentModal.tsx
+++ b/web/src/components/cockpit/SwitchAgentModal.tsx
@@ -91,10 +91,13 @@ export function SwitchAgentModal({
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
+    // Only flag this load as stale. abortRef belongs to the primer
+    // fetch in handleConfirm; aborting it here would cancel an in-flight
+    // handoff when an unrelated dep (currentAgent, rateLimited) changes.
+    // The agents fetch itself takes no signal, so there is nothing else
+    // to cancel.
     return () => {
       cancelled = true;
-      abortRef.current?.abort();
-      abortRef.current = null;
     };
   }, [open, currentAgent, rateLimited]);
 
@@ -246,8 +249,11 @@ export function SwitchAgentModal({
         <div className="mt-5 flex justify-end gap-2">
           <button
             type="button"
-            onClick={onClose}
-            className="rounded border border-surface-700 px-3 py-1 text-xs font-medium hover:bg-surface-800"
+            onClick={() => {
+              if (!submitting) onClose();
+            }}
+            disabled={submitting}
+            className="rounded border border-surface-700 px-3 py-1 text-xs font-medium hover:bg-surface-800 disabled:cursor-not-allowed disabled:opacity-60"
           >
             Cancel
           </button>

--- a/web/src/components/cockpit/SwitchAgentModal.tsx
+++ b/web/src/components/cockpit/SwitchAgentModal.tsx
@@ -7,39 +7,51 @@ import {
 } from "../../lib/api";
 
 /**
- * Rate-limit recovery dialog. Surfaces from the cockpit rate-limit
- * banner when the user clicks "Continue in another agent". Lists the
- * cockpit ACP registry, preselects `codex` when present (otherwise
- * the first non-current entry), and hands off the session via
+ * Agent-switch dialog. Lists the cockpit ACP registry, preselects a
+ * sensible target, and hands the session off via
  * `POST /api/sessions/:id/cockpit/switch-agent`.
+ *
+ * Two triggers drive it, distinguished by `trigger`:
+ *   - "rate_limit": surfaced from the rate-limit banner's "Continue in
+ *     another agent" CTA. Preselects `codex` and frames the recap as a
+ *     rate-limit handoff.
+ *   - "manual": surfaced from the composer toolbar at any time (e.g. to
+ *     return to claude after a rate-limit handoff). Preselects the first
+ *     available agent and frames the recap as a plain switch.
  *
  * After a successful switch:
  *   1. Fetch the context primer using `before_seq` so the recap
  *      excludes the AgentSwitched event itself.
  *   2. Compose a framed handoff message that prepends the recap and
- *      appends `unprocessed_prompt` (the user's last prompt that the
- *      rate-limited agent never processed) as the body the user is
- *      about to send.
- *   3. Call `onPrefill` so the parent drops the text into the
- *      composer. The composer is NOT auto-sent; the user reviews and
- *      sends manually. See #1282.
+ *      appends `unprocessed_prompt` (a prompt the prior agent never
+ *      processed, only present on the rate-limit path) as the body the
+ *      user is about to send.
+ *   3. Call `onPrefill` so the parent drops the text into the composer.
+ *      The composer is NOT auto-sent; the user reviews and sends
+ *      manually. See #1282.
  */
+type SwitchTrigger = "rate_limit" | "manual";
+
 interface Props {
   open: boolean;
   sessionId: string;
   currentAgent: string | null;
   onClose: () => void;
   onPrefill: (text: string) => void;
+  /** What opened the dialog. Drives copy and the recorded switch
+   *  reason. Defaults to "manual". */
+  trigger?: SwitchTrigger;
 }
 
 const PREFERRED_FALLBACK = "codex";
 
-export function RateLimitRecoveryModal({
+export function SwitchAgentModal({
   open,
   sessionId,
   currentAgent,
   onClose,
   onPrefill,
+  trigger = "manual",
 }: Props) {
   const [agents, setAgents] = useState<CockpitAgentInfo[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
@@ -49,6 +61,8 @@ export function RateLimitRecoveryModal({
   const abortRef = useRef<AbortController | null>(null);
   const confirmRef = useRef<HTMLButtonElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const rateLimited = trigger === "rate_limit";
 
   useEffect(() => {
     if (!open) return;
@@ -60,10 +74,12 @@ export function RateLimitRecoveryModal({
         if (cancelled) return;
         const filtered = list.filter((a) => a.name !== currentAgent);
         setAgents(filtered);
-        // Preferred fallback: codex when installed; otherwise first
-        // remaining entry. The user can change the pick before
-        // confirming.
-        const preferred = filtered.find((a) => a.name === PREFERRED_FALLBACK);
+        // On the rate-limit path, prefer codex when installed. On a
+        // manual switch we have no preferred direction, so just pick the
+        // first remaining entry. The user can change the pick either way.
+        const preferred = rateLimited
+          ? filtered.find((a) => a.name === PREFERRED_FALLBACK)
+          : undefined;
         setSelected(preferred?.name ?? filtered[0]?.name ?? null);
       })
       .catch((e) => {
@@ -80,7 +96,7 @@ export function RateLimitRecoveryModal({
       abortRef.current?.abort();
       abortRef.current = null;
     };
-  }, [open, currentAgent]);
+  }, [open, currentAgent, rateLimited]);
 
   // Escape closes; while submitting we don't dismiss so a half-completed
   // switch can finish without leaving the UI in an unknown state.
@@ -94,7 +110,7 @@ export function RateLimitRecoveryModal({
   }, [open, submitting, onClose]);
 
   // Focus the confirm button on open, return focus to whatever was
-  // focused before (typically the banner button that triggered us).
+  // focused before (typically the control that triggered us).
   useEffect(() => {
     if (!open) return;
     previousFocusRef.current = document.activeElement as HTMLElement | null;
@@ -112,7 +128,12 @@ export function RateLimitRecoveryModal({
     setSubmitting(true);
     setError(null);
     try {
-      const result = await switchCockpitAgent(sessionId, selected);
+      const result = await switchCockpitAgent(
+        sessionId,
+        selected,
+        null,
+        rateLimited ? "rate_limited" : "manual",
+      );
       if (!result) {
         setError("Switch failed: server returned no response.");
         return;
@@ -132,6 +153,7 @@ export function RateLimitRecoveryModal({
         to: selected,
         recap,
         unprocessed,
+        rateLimited,
       });
       onPrefill(prefill);
       onClose();
@@ -142,25 +164,38 @@ export function RateLimitRecoveryModal({
     }
   };
 
+  const title = rateLimited ? "Continue in another agent?" : "Switch agent?";
+
   return (
     <div
       role="dialog"
       aria-modal="true"
-      aria-labelledby="rate-limit-recovery-title"
+      aria-labelledby="switch-agent-title"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4"
       onClick={(e) => {
         if (e.target === e.currentTarget && !submitting) onClose();
       }}
     >
       <div className="w-full max-w-lg rounded-lg border border-surface-700 bg-surface-900 p-5 shadow-xl text-text-primary">
-        <h2 id="rate-limit-recovery-title" className="text-base font-semibold">
-          Continue in another agent?
+        <h2 id="switch-agent-title" className="text-base font-semibold">
+          {title}
         </h2>
         <p className="mt-1 text-xs text-text-muted">
-          The current agent ({currentAgent ?? "unknown"}) is rate-limited.
-          Hand the session off to a different installed ACP backend; we
-          will pre-fill the composer with a recap of the recent turns
-          for you to review before sending.
+          {rateLimited ? (
+            <>
+              The current agent ({currentAgent ?? "unknown"}) is rate-limited.
+              Hand the session off to a different installed ACP backend; we
+              will pre-fill the composer with a recap of the recent turns
+              for you to review before sending.
+            </>
+          ) : (
+            <>
+              Hand this session off from {currentAgent ?? "the current agent"}{" "}
+              to a different installed ACP backend, keeping the transcript. We
+              will pre-fill the composer with a recap of the recent turns for
+              you to review before sending.
+            </>
+          )}
         </p>
 
         {loading ? (
@@ -223,7 +258,9 @@ export function RateLimitRecoveryModal({
             disabled={!selected || submitting || agents.length === 0}
             className="rounded border border-brand-700 bg-brand-900/40 px-3 py-1 text-xs font-medium text-brand-100 hover:bg-brand-900/60 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {submitting ? "Switching..." : `Continue in ${selected ?? ""}`}
+            {submitting
+              ? "Switching..."
+              : `${rateLimited ? "Continue in" : "Switch to"} ${selected ?? ""}`}
           </button>
         </div>
       </div>
@@ -236,6 +273,7 @@ interface PrefillInputs {
   to: string;
   recap: string;
   unprocessed: string;
+  rateLimited: boolean;
 }
 
 function buildHandoffPrefill({
@@ -243,10 +281,13 @@ function buildHandoffPrefill({
   to,
   recap,
   unprocessed,
+  rateLimited,
 }: PrefillInputs): string {
   const parts: string[] = [];
   parts.push(
-    `[CONTEXT HANDOFF: ${from} was rate-limited; continuing with ${to}.]`,
+    rateLimited
+      ? `[CONTEXT HANDOFF: ${from} was rate-limited; continuing with ${to}.]`
+      : `[CONTEXT HANDOFF: switched from ${from} to ${to}.]`,
   );
   parts.push("");
   parts.push(

--- a/web/src/components/cockpit/SystemNotices.test.tsx
+++ b/web/src/components/cockpit/SystemNotices.test.tsx
@@ -2,7 +2,7 @@
 //
 // Wiring contract for the rate-limit recovery handoff button. CockpitView
 // passes `onSwitchAgent={() => setRecoveryOpen(true)}` and the only way
-// the user reaches the RateLimitRecoveryModal is by clicking the button
+// the user reaches the SwitchAgentModal from here is by clicking the button
 // SystemNotices conditionally renders below the rate-limit banner. This
 // test pins:
 //   1. The button shows up exactly when both `rateLimit` and

--- a/web/src/lib/api.cockpit.test.ts
+++ b/web/src/lib/api.cockpit.test.ts
@@ -100,6 +100,16 @@ describe("switchCockpitAgent", () => {
     expect(body).toEqual({ target: "codex", model: "opus-4.7" });
   });
 
+  it("includes the reason field only when provided", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      ok({ session_id: "s-1", agent: "claude", before_seq: 0, switch_seq: 1, status: "ok" }),
+    );
+    await switchCockpitAgent("s-1", "claude", null, "manual");
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({ target: "claude", reason: "manual" });
+  });
+
   it("returns null when fetchJson reports a non-2xx", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       new Response("conflict", { status: 409 }),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -442,14 +442,18 @@ export interface SwitchAgentResponse {
  *  `target` (registry key, e.g. "codex"). Backend stops the old
  *  worker, spawns the new one, persists the agent change, and emits
  *  an AgentSwitched event. On failure (unknown target, spawn error)
- *  the instance is left untouched. See #1282. */
+ *  the instance is left untouched. `reason` is recorded on the event
+ *  and shown in the transcript divider: "rate_limited" for the
+ *  recovery flow, "manual" for an explicit user switch. See #1282. */
 export async function switchCockpitAgent(
   sessionId: string,
   target: string,
   model?: string | null,
+  reason?: string | null,
 ): Promise<SwitchAgentResponse | null> {
-  const body: { target: string; model?: string } = { target };
+  const body: { target: string; model?: string; reason?: string } = { target };
   if (model) body.model = model;
+  if (reason) body.reason = reason;
   return fetchJson<SwitchAgentResponse>(
     `/api/sessions/${encodeURIComponent(sessionId)}/cockpit/switch-agent`,
     {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1121,10 +1121,24 @@
       "risk": "high",
       "specs": [
         "src/lib/cockpitTypes.test.ts",
-        "src/components/cockpit/RateLimitRecoveryModal.test.tsx"
+        "src/components/cockpit/SwitchAgentModal.test.tsx"
       ],
       "components": [
-        "web/src/components/cockpit/RateLimitRecoveryModal.tsx"
+        "web/src/components/cockpit/SwitchAgentModal.tsx"
+      ]
+    },
+    {
+      "id": "cockpit.switch-agent-manual",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/SwitchAgentModal.test.tsx",
+        "src/lib/api.cockpit.test.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/SwitchAgentModal.tsx",
+        "web/src/components/cockpit/Composer.tsx",
+        "web/src/lib/api.ts"
       ]
     },
     {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A cockpit session could only switch its ACP agent from the rate-limit recovery banner. The "Continue in another agent" control renders only while `rateLimit` is set, so once the limit cleared (or the session reset) there was no way to switch again. If you ran claude, hit the limit, handed off to codex, and then the rate-limit state went away, you were stuck on codex with no path back to claude.

The backend already did all the work: `POST /api/sessions/{id}/cockpit/switch-agent` stops the old worker, spawns the target, persists the change, and emits an `AgentSwitched` event. This PR adds two always-available front doors and makes the recorded reason honest.

- **Web:** a "Switch agent" control in the composer toolbar, available at any time. The rate-limit recovery banner keeps its own entry point.
- **CLI:** `aoe cockpit switch-agent <session> <target> [--model <name>]`, mirroring the existing `prompt` / `cancel` client commands. Run `aoe cockpit agents` to list valid targets.
- **Reason:** `SwitchAgentRequest` gains an optional `reason` field (defaults to `manual`). The endpoint no longer hardcodes `rate_limited`, so the transcript divider reads `(manual)` for an explicit switch and `(rate_limited)` for recovery.

Implementation notes: `RateLimitRecoveryModal` is generalized into `SwitchAgentModal` with a `trigger` prop driving copy and reason; the rate-limit path is unchanged in behavior. `SwitchAgentResponse.status` became an owned `String` so the new CLI client can deserialize the response.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a cockpit session on claude (`aoe add --cockpit --cmd claude`), open it in the web dashboard, and confirm a "Switch agent" button sits in the composer toolbar with no rate limit active.
- [ ] Click it, pick codex, confirm: the session switches, the composer pre-fills a recap, and the transcript shows a divider reading `Switched cockpit agent from claude to codex (manual)`.
- [ ] From the CLI, run `aoe cockpit switch-agent <session> claude` and confirm it prints `switched cockpit agent for <session> -> claude` and the session is back on claude.
- [ ] Trigger a rate limit (or simulate one) and confirm the banner's "Continue in another agent" still works and its divider reads `(rate_limited)`.
- [ ] Run `aoe cockpit switch-agent --help` and confirm the command is documented; `aoe cockpit agents` lists valid targets.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

<!-- Detail: covered via Vitest (SwitchAgentModal both triggers, api reason payload) and the coverage matrix was updated for the rename and the new manual flow, mirroring how the rate-limit modal was already covered. -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the new `switch-agent` subcommand is a thin daemon client mirroring the existing `prompt` / `cancel` commands; the endpoint and request shape are covered by Rust unit tests, and a full e2e would need a live daemon plus two installed ACP agents.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (manual reason default, modal generalization, CLI verb name) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR makes agent switching in Cockpit always available. Users can now hand off an active cockpit session to another ACP agent at any time via the web UI or CLI; each switch is recorded with an explicit reason (manual or rate_limited).

## What changed (high level)

- Web UI: added a persistent "Switch agent" control in the composer toolbar and replaced the rate-limit-only modal with a unified SwitchAgentModal that supports both manual and rate-limit triggers and shows context-appropriate messaging and prefill behavior.
- CLI: added aoe cockpit switch-agent <session> <target> [--model <name>] to perform switches and aoe cockpit agents to list valid targets.
- API/backend: SwitchAgentRequest accepts an optional reason (defaults to "manual"); the switch handler now records and emits the provided reason instead of hardcoding "rate_limited". SwitchAgentResponse.status is now an owned String to support client deserialization.
- UX/transcripts: transcript divider now shows the switch reason (e.g., Switched… (manual) or (rate_limited)).
- Docs/tests: CLI docs, troubleshooting and multi-agent docs updated; unit tests and coverage matrix updated; e2e testing skipped with rationale.

## Benefits

- Better UX: on-demand agent handoffs without losing transcript context.
- Clearer audit trail: explicit reasons recorded for each switch.
- Multi-surface support: available via web, CLI and API.
- Backwards compatible: existing rate-limit recovery flow preserved.
- Improved documentation and tests for the new flows.

## Technical details (short)

- Web: Composer now receives currentAgent; SwitchAgentModal replaces RateLimitRecoveryModal and takes a trigger ("manual" | "rate_limit"); modal chooses defaults (e.g., prefer codex only for rate-limit trigger), sends reason with API call, and can prefill composer text and focus/caret.
- CLI: new CockpitCommands::SwitchAgent variant and switch_agent handler; HttpClient::switch_agent performs POST /api/sessions/{id}/cockpit/switch-agent with optional model/reason.
- Protocol/API: SwitchAgentRequest gains pub reason: Option<String> with serde default; SwitchAgentResponse.status changed from &'static str to String; server trims/Defaults reason to "manual" when missing and emits AgentSwitched with that reason.
- Tests: new/updated unit tests for modal behavior, API request body including reason, protocol deserialization tests, and coverage-matrix entries updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->