### PR TITLE
feat: one-command hot-reload dev workflow for the web dashboard (cargo xtask dev)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@
 - Stack: React 19, TypeScript, Vite, Tailwind v4, xterm.js v6. Installable as a PWA ("Install Agent of Empires" in Chrome; "Add to Home Screen" on iOS).
 - Build: `cargo build --features serve` (build.rs runs `npm install && npm run build` in `web/` when inputs change).
 - Run: `aoe serve --host 0.0.0.0` (token-based auth by default).
-- Frontend dev: `cd web && npm run dev` for Vite HMR; the Rust server must also be running for API/WebSocket requests.
+- Frontend dev: `cargo xtask dev` (Unix) builds the serve binary, then runs `aoe serve` (8081) and the Vite dev server (5173, HMR) together, pointing Vite at the backend via `VITE_PROXY` so `/api` and the `/sessions/*/ws` relays resolve; open `:5173`, Ctrl-C stops both. Or run them by hand: `cd web && npm run dev` plus a separate `cargo run --features serve -- serve`.
 - TUI-only `cargo build` (without `--features serve`) needs no JS tooling.
 
 ## Settings & Configuration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +822,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +974,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -5303,6 +5335,8 @@ dependencies = [
  "agent-of-empires",
  "clap",
  "clap-markdown",
+ "ctrlc",
+ "nix 0.31.3",
  "regex",
 ]
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,6 +29,20 @@ aoe logs --path                # Print the resolved log file path
 
 Requires `tmux` to be installed.
 
+### Web dashboard dev server
+
+```bash
+cargo xtask dev    # Unix only
+```
+
+Builds the serve-enabled binary, then runs `aoe serve` (8081) and the Vite dev
+server (5173) together with hot module reload. Open
+[http://localhost:5173](http://localhost:5173); Vite proxies `/api` and the
+`/sessions/*/ws` relays to the backend (via `VITE_PROXY`). One Ctrl-C stops
+both. Ports are overridable with `--serve-port` / `--web-port`. See the
+[web dashboard guide](guides/web-dashboard.md#frontend-development) for the
+manual two-shell alternative.
+
 ### Dev namespace
 
 Debug builds use an isolated namespace so a local `cargo run` shares no

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -250,7 +250,22 @@ The terminal disconnect banner surfaces a WebSocket close code when it can't rea
 
 ## Frontend development
 
-The React frontend lives in `web/`:
+The React frontend lives in `web/`. One command from the repo root builds the
+serve-enabled binary, then runs the backend and the Vite dev server together:
+
+```bash
+cargo xtask dev
+```
+
+This starts `aoe serve --no-auth` on port 8081 and the Vite dev server on
+[http://localhost:5173](http://localhost:5173), pointing Vite at the backend via
+`VITE_PROXY`. Open the `:5173` URL (not `:8081`): Vite serves the app with hot
+module reload and proxies `/api` and the `/sessions/*/ws` relays to the backend,
+so edits to `.tsx` files reload instantly while API and terminal traffic keep
+working. One Ctrl-C stops both processes. Override ports with `--serve-port` /
+`--web-port`. Unix only.
+
+To run the two halves by hand instead:
 
 ```bash
 cd web

--- a/web/src/viteConfig.test.ts
+++ b/web/src/viteConfig.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Guards the dev-server proxy contract that `cargo xtask dev` relies on: when
+// VITE_PROXY points at a running `aoe serve`, the Vite dev server must forward
+// REST (/api) and every WebSocket relay (/sessions/{id}/...ws) there, with the
+// WS target switched to the ws:// scheme. See vite.config.ts.
+
+type ProxyEntry = { target: string; ws?: boolean };
+
+async function loadProxy(
+  env: Record<string, string | undefined>,
+): Promise<Record<string, ProxyEntry> | undefined> {
+  vi.resetModules();
+  const prev = { ...process.env };
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    const mod = await import("../vite.config");
+    const factory = mod.default as (e: {
+      command: string;
+      mode: string;
+    }) => { server: { proxy?: Record<string, ProxyEntry> } };
+    const cfg = await factory({ command: "serve", mode: "development" });
+    return cfg.server.proxy;
+  } finally {
+    process.env = prev;
+  }
+}
+
+describe("vite dev server proxy", () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("has no proxy when VITE_PROXY is unset", async () => {
+    const proxy = await loadProxy({ VITE_PROXY: undefined });
+    expect(proxy).toBeUndefined();
+  });
+
+  it("forwards /api and the /sessions WebSockets to VITE_PROXY", async () => {
+    const proxy = await loadProxy({ VITE_PROXY: "http://127.0.0.1:8081" });
+    expect(proxy?.["/api"].target).toBe("http://127.0.0.1:8081");
+    const ws = proxy?.["^/sessions/.+/ws"];
+    expect(ws?.target).toBe("ws://127.0.0.1:8081");
+    expect(ws?.ws).toBe(true);
+  });
+
+  it("defaults a bare host:port to http and derives the ws target", async () => {
+    const proxy = await loadProxy({ VITE_PROXY: "localhost:50106" });
+    expect(proxy?.["/api"].target).toBe("http://localhost:50106");
+    expect(proxy?.["^/sessions/.+/ws"].target).toBe("ws://localhost:50106");
+  });
+});

--- a/web/src/viteConfig.test.ts
+++ b/web/src/viteConfig.test.ts
@@ -11,10 +11,8 @@ async function loadProxy(
   env: Record<string, string | undefined>,
 ): Promise<Record<string, ProxyEntry> | undefined> {
   vi.resetModules();
-  const prev = { ...process.env };
   for (const [k, v] of Object.entries(env)) {
-    if (v === undefined) delete process.env[k];
-    else process.env[k] = v;
+    vi.stubEnv(k, v as string | undefined);
   }
   try {
     const mod = await import("../vite.config");
@@ -25,13 +23,14 @@ async function loadProxy(
     const cfg = await factory({ command: "serve", mode: "development" });
     return cfg.server.proxy;
   } finally {
-    process.env = prev;
+    vi.unstubAllEnvs();
   }
 }
 
 describe("vite dev server proxy", () => {
   afterEach(() => {
     vi.resetModules();
+    vi.unstubAllEnvs();
   });
 
   it("has no proxy when VITE_PROXY is unset", async () => {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,3 +9,7 @@ agent-of-empires = { path = "..", features = ["serve"] }
 clap = { version = "4.6", features = ["derive"] }
 clap-markdown = "0.1"
 regex = "1"
+
+[target.'cfg(unix)'.dependencies]
+ctrlc = "3"
+nix = { version = "0.31", features = ["signal"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,6 @@
 //! xtask - Development tasks for agent-of-empires
 
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
@@ -19,6 +19,18 @@ enum Commands {
     GenDocs,
     /// Check that contrib skill files reference valid CLI commands
     CheckSkill,
+    /// Run the web dashboard backend and Vite dev server together (Ctrl-C stops both)
+    Dev(DevArgs),
+}
+
+#[derive(Args)]
+struct DevArgs {
+    /// Port for the `aoe serve` backend (matches the debug-build default)
+    #[arg(long, default_value_t = 8081)]
+    serve_port: u16,
+    /// Port for the Vite dev server
+    #[arg(long, default_value_t = 5173)]
+    web_port: u16,
 }
 
 fn main() {
@@ -26,7 +38,120 @@ fn main() {
     match args.command {
         Commands::GenDocs => generate_cli_docs(),
         Commands::CheckSkill => check_skill(),
+        Commands::Dev(dev) => run_dev(dev),
     }
+}
+
+#[cfg(not(unix))]
+fn run_dev(_args: DevArgs) {
+    eprintln!("`cargo xtask dev` is unix-only (it relies on POSIX process groups).");
+    std::process::exit(1);
+}
+
+/// Build the serve-enabled binary, then run it alongside the Vite dev server.
+/// Vite proxies `/api` and the `/sessions/*/ws` relays to the backend via the
+/// `VITE_PROXY` env var it already honors. Each child runs in its own process
+/// group so a single Ctrl-C tears the whole tree down (npm spawns vite, vite
+/// may spawn esbuild) with no orphans.
+#[cfg(unix)]
+fn run_dev(args: DevArgs) {
+    use nix::sys::signal::{killpg, Signal};
+    use nix::unistd::Pid;
+    use std::os::unix::process::CommandExt;
+    use std::process::{Child, Command};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    // Build up front so build output doesn't interleave with Vite's startup
+    // and a broken build fails fast before either server comes up.
+    eprintln!("[xtask dev] building aoe (--features serve)...");
+    let built = Command::new("cargo")
+        .args(["build", "--features", "serve"])
+        .status()
+        .expect("failed to run cargo build");
+    if !built.success() {
+        std::process::exit(built.code().unwrap_or(1));
+    }
+
+    // Honor CARGO_TARGET_DIR; cargo wrote the debug binary under it.
+    let target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+    let bin = Path::new(&target_dir).join("debug").join("aoe");
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    {
+        let shutdown = shutdown.clone();
+        ctrlc::set_handler(move || shutdown.store(true, Ordering::SeqCst))
+            .expect("failed to install Ctrl-C handler");
+    }
+
+    let mut serve = Command::new(&bin)
+        .args(["serve", "--no-auth", "--port", &args.serve_port.to_string()])
+        .process_group(0)
+        .spawn()
+        .expect("failed to spawn `aoe serve`");
+
+    let mut vite = Command::new("npm")
+        .args([
+            "--prefix",
+            "web",
+            "run",
+            "dev",
+            "--",
+            "--port",
+            &args.web_port.to_string(),
+        ])
+        .env(
+            "VITE_PROXY",
+            format!("http://127.0.0.1:{}", args.serve_port),
+        )
+        .process_group(0)
+        .spawn()
+        .expect("failed to spawn `npm run dev`");
+
+    eprintln!(
+        "[xtask dev] aoe serve on :{} | open http://localhost:{}",
+        args.serve_port, args.web_port
+    );
+
+    let exited = |child: &mut Child| matches!(child.try_wait(), Ok(Some(_)));
+
+    // Supervise: stop when Ctrl-C arrives or either child dies on its own.
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            break;
+        }
+        if exited(&mut serve) {
+            eprintln!("[xtask dev] `aoe serve` exited; stopping vite");
+            break;
+        }
+        if exited(&mut vite) {
+            eprintln!("[xtask dev] vite exited; stopping `aoe serve`");
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    // Signal each process group: SIGTERM, brief grace, then SIGKILL so the
+    // ports are always freed even if a child ignores the term.
+    let groups = [serve.id() as i32, vite.id() as i32];
+    for pid in groups {
+        let _ = killpg(Pid::from_raw(pid), Signal::SIGTERM);
+    }
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if exited(&mut serve) && exited(&mut vite) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    if !(exited(&mut serve) && exited(&mut vite)) {
+        for pid in groups {
+            let _ = killpg(Pid::from_raw(pid), Signal::SIGKILL);
+        }
+    }
+    let _ = serve.wait();
+    let _ = vite.wait();
 }
 
 fn generate_cli_docs() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -58,7 +58,7 @@ fn run_dev(args: DevArgs) {
     use nix::sys::signal::{killpg, Signal};
     use nix::unistd::Pid;
     use std::os::unix::process::CommandExt;
-    use std::process::{Child, Command};
+    use std::process::{Child, Command, Stdio};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -85,13 +85,19 @@ fn run_dev(args: DevArgs) {
             .expect("failed to install Ctrl-C handler");
     }
 
+    // Detach stdin from both children: each runs in its own (background)
+    // process group, so a TTY-driven raw-mode setup (Vite installs keypress
+    // shortcuts when stdin is a TTY) would raise SIGTTOU and suspend the
+    // child. Shutdown is driven by signals here, not per-server keystrokes,
+    // so neither child needs the terminal.
     let mut serve = Command::new(&bin)
         .args(["serve", "--no-auth", "--port", &args.serve_port.to_string()])
+        .stdin(Stdio::null())
         .process_group(0)
         .spawn()
         .expect("failed to spawn `aoe serve`");
 
-    let mut vite = Command::new("npm")
+    let mut vite = match Command::new("npm")
         .args([
             "--prefix",
             "web",
@@ -105,9 +111,20 @@ fn run_dev(args: DevArgs) {
             "VITE_PROXY",
             format!("http://127.0.0.1:{}", args.serve_port),
         )
+        .stdin(Stdio::null())
         .process_group(0)
         .spawn()
-        .expect("failed to spawn `npm run dev`");
+    {
+        Ok(child) => child,
+        Err(e) => {
+            // serve is already up; tear its group down before bailing so we
+            // don't orphan a backend on the serve port.
+            eprintln!("[xtask dev] failed to spawn `npm run dev`: {e}");
+            let _ = killpg(Pid::from_raw(serve.id() as i32), Signal::SIGTERM);
+            let _ = serve.wait();
+            std::process::exit(1);
+        }
+    };
 
     eprintln!(
         "[xtask dev] aoe serve on :{} | open http://localhost:{}",


### PR DESCRIPTION
## Description

Adds a one-command hot-reload dev workflow for the web dashboard. `cargo xtask dev` builds the serve-enabled binary, then runs `aoe serve` (`--no-auth`, port 8081) and the Vite dev server (port 5173, HMR) together. It points Vite at the backend through the `VITE_PROXY` env var the dev server already honors, so `/api` (REST) and `/sessions/*/ws` (PTY/cockpit WebSocket relays) proxy to the backend and editing a `.tsx` hot-reloads in the browser while API and terminal traffic keep resolving.

Both child processes run in their own POSIX process groups; a single Ctrl-C tears the whole tree down (npm -> vite -> esbuild) via SIGTERM, a short grace, then SIGKILL, so ports are always freed with no orphans. Ports are overridable with `--serve-port` / `--web-port`.

Unix only: a from-source dev workflow already needs tmux, and there is no Windows process module, so a cross-platform process-group dep would be dead weight. The subcommand prints a clear error on non-Unix.

Builds on the existing `VITE_PROXY` mechanism (#1771) rather than inventing a parallel one. Design was settled via `/debate` (two models converged on `cargo xtask dev` over a `concurrently` + root `package.json` approach; build-first over `cargo run`; honor `CARGO_TARGET_DIR`).

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

This is build/dev tooling, not a runtime dashboard surface. The proxy contract this command relies on (`VITE_PROXY` -> `/api` + `/sessions/*/ws` targets, ws:// scheme) is guarded by a vitest at `web/src/viteConfig.test.ts`. The orchestrator itself is process supervision in xtask, which has no test harness and is not cleanly unit-testable.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

`xtask` is the dev-task runner, not the `aoe` CLI; no `aoe` subcommand or session lifecycle changed.

## How to test

- [ ] From a clean checkout, run `cargo xtask dev` from the repo root. Confirm it builds, then `aoe serve` comes up on 8081 and Vite on 5173, with interleaved logs.
- [ ] Open http://localhost:5173 (not :8081). The dashboard loads, sessions list (`/api/*`) populates, and opening a terminal (`/sessions/*/ws`) works with no 404s.
- [ ] Edit a `.tsx` under `web/src/` and save. Browser hot-reloads without a full refresh.
- [ ] Press Ctrl-C once. Both processes exit; confirm no orphaned `aoe`, `node`, or `vite` (`pgrep -fl 'aoe serve|vite'` returns nothing) and ports 8081/5173 are free.
- [ ] Run `cargo xtask dev --serve-port 9000 --web-port 4000` and confirm both servers bind the overridden ports and the proxy still resolves `/api`.
- [ ] `cd web && npx vitest run src/viteConfig.test.ts` passes.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (1M context) via agent-of-empires cockpit

**Any Additional AI Details you'd like to share:** Design fork resolved with a multi-model `/debate`; implementation and docs by the agent.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR introduces a streamlined one-command developer workflow for the web dashboard via `cargo xtask dev`, eliminating the need for manual multi-shell setups. The command automatically builds the backend, runs the Rust server and Vite dev server together with proper proxy configuration, and gracefully shuts down both processes on exit.

## What Changed

### New Features Added
- **`cargo xtask dev` subcommand**: A single entry point that orchestrates the entire development environment
  - Builds the `aoe` binary with the `serve` feature
  - Spawns the backend server (`aoe serve`) on port 8081
  - Spawns the Vite dev server on port 5173 with hot module reload
  - Automatically proxies API requests and WebSocket traffic from frontend to backend
  - Configurable ports via `--serve-port` and `--web-port` flags
  - Unified Ctrl-C shutdown that gracefully stops both processes (SIGTERM → SIGKILL after 2 seconds if needed)
  - Unix-only with clear error messages on non-Unix systems

### Documentation Updates
- **AGENTS.md**: Updated "Frontend dev" section to recommend the new `cargo xtask dev` command
- **docs/development.md**: Added "Web dashboard dev server" subsection documenting the new workflow
- **docs/guides/web-dashboard.md**: Rewrote "Frontend development" section with new command details; retained manual two-shell workflow as fallback

### Testing & Quality
- **web/src/viteConfig.test.ts**: Added Vitest module to validate the Vite proxy configuration contract, ensuring `/api` and `/sessions/*/ws` are properly proxied

### Dependencies
- **xtask/Cargo.toml**: Added Unix-only dependencies (`ctrlc` for Ctrl-C handling, `nix` with `signal` feature for process group management)

## Benefits
- **Reduced friction**: Developers no longer need to manually coordinate multiple terminals or remember complex commands
- **Hot reload**: Frontend changes immediately reflect without manual recompilation
- **Unified lifecycle**: Single Ctrl-C cleanly stops both processes, preventing orphaned processes and port conflicts
- **Consistent environment**: Automatic proxy setup ensures API and WebSocket traffic routes correctly without manual configuration
- **Flexible ports**: Override defaults when needed without shell manipulation

## Technical Details
The implementation uses POSIX process groups to ensure both child processes (backend and frontend servers) are grouped together. A signal handler catches Ctrl-C and initiates graceful shutdown with SIGTERM, followed by SIGKILL if processes don't terminate within 2 seconds. The frontend server is configured via the `VITE_PROXY` environment variable to proxy backend traffic, with test coverage ensuring this contract remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->