### PR TITLE
fix(session): close cross-instance race on Claude session-id capture

### DIFF
--- a/docs/development/adding-agents.md
+++ b/docs/development/adding-agents.md
@@ -288,6 +288,15 @@ cargo build
 
 Set `hook_config: Some(AgentHookConfig { ... })` in the agent def; the generic `install_hooks()` handles it.
 
+#### `HookEvent` flags
+
+Each entry in `events: &[HookEvent]` carries:
+
+- `name` — the agent's event name (e.g., `"PreToolUse"`).
+- `matcher` — optional pattern for events that need it (e.g., Claude's `Notification` matcher).
+- `status` — `Some("running" | "waiting" | "idle")` to install a status-writer command on this event, or `None` if the event is purely lifecycle.
+- `session_id_capture` — `true` to install an additional command that extracts the active `session_id` from the agent's stdin JSON and writes it atomically to `/tmp/aoe-hooks/<AOE_INSTANCE_ID>/session_id`. Read by [`session-resume`](../guides/session-resume.md)'s poller as the primary capture source. Currently used only by Claude on `SessionStart` and `UserPromptSubmit`; other agents either don't pre-mint UUIDs (so capture is post-launch from disk) or use a different payload schema (Cursor, Codex). Setting both `status: Some(...)` and `session_id_capture: true` emits two commands under the same matcher block; the session-id command is placed first so it consumes stdin before the status writer.
+
 ### Codex (custom TOML)
 
 Codex stores AoE status hooks in the `[hooks]` table in `.codex/config.toml`:

--- a/docs/guides/session-resume.md
+++ b/docs/guides/session-resume.md
@@ -6,9 +6,12 @@ Agent of Empires can persist Claude Code conversation IDs so sessions resume the
 
 When you launch a Claude session through AoE, AoE generates a UUID and passes it to `claude --session-id <uuid>`. Claude uses that UUID for the conversation; AoE records it in `sessions.json`. On every subsequent launch of the same instance, AoE invokes `claude --resume <uuid>` so the conversation picks up where it left off.
 
-A background poller checks `~/.claude/projects/<project>/` every 2 seconds for the most recently modified session file. If the session ID rotates at runtime — for example after `/clear`, `--fork-session`, or starting a fresh `claude` invocation in the same tmux pane — the poller catches the new ID and AoE persists it transparently. Next launch resumes the new conversation, not the stale one.
+AoE tracks the active session ID via two converging sources:
 
-For sandboxed (Docker) sessions, the poller runs the same scan inside the container via `docker exec`, since Claude writes its session files to the container's filesystem rather than the host's.
+1. **Hook sidecar (primary, near-instant).** AoE installs `SessionStart` and `UserPromptSubmit` hooks into `~/.claude/settings.json`. These hooks extract the active `session_id` from Claude's stdin payload and write it atomically to `/tmp/aoe-hooks/<instance-id>/session_id`. The poller reads this file before scanning the filesystem, so runtime rotations via `/clear`, `--fork-session`, or `--continue` are picked up within one poll tick (~2 s).
+2. **Filesystem scan (fallback).** If the sidecar is absent, stale (> 5 min), or invalid, the poller falls back to scanning `~/.claude/projects/<project>/` for the most recent `.jsonl`. Sibling AoE instances sharing the same project path are filtered out via tmux env (`AOE_CAPTURED_SESSION_ID`) so each session keeps its own UUID.
+
+For sandboxed (Docker) sessions, the filesystem scan runs inside the container via `docker exec` (capped at 5 seconds per call). The hook sidecar is host-only today; sandboxed `/clear` adoption falls back to the filesystem scan and resolves within one poll tick.
 
 ## What's covered
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -63,7 +63,7 @@ In the TUI, press `Ctrl+P` on the Worktree field and toggle **Attach to existing
 
 When you later remove the session, AoE only cleans up worktrees it created; attached ones are left alone.
 
-**Resume an existing Claude Code conversation.** After attaching, run `/resume` inside the Claude pane and pick the conversation you want. AoE's session-id poller watches `~/.claude/projects/<project>/` and persists the new id so the next launch reattaches to the same conversation automatically. Details in [Session Resume](guides/session-resume.md), including the `aoe session set-session-id` command for setting the Claude UUID explicitly.
+**Resume an existing Claude Code conversation.** After attaching, run `/resume` inside the Claude pane and pick the conversation you want. AoE installs hooks into `~/.claude/settings.json` to capture the active session ID and persists it so the next launch reattaches to the same conversation automatically. Details in [Session Resume](guides/session-resume.md), including the `aoe session set-session-id` command for setting the Claude UUID explicitly.
 
 ## Create a Sandboxed Session
 

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -52,6 +52,10 @@ pub struct HookEvent {
     pub matcher: Option<&'static str>,
     /// AoE status to write when this event fires (`"running"`, `"idle"`, `"waiting"`).
     pub status: Option<&'static str>,
+    /// When `true`, install an additional hook command that extracts
+    /// `session_id` from the agent's stdin JSON payload and writes it to
+    /// `/tmp/aoe-hooks/<AOE_INSTANCE_ID>/session_id`.
+    pub session_id_capture: bool,
 }
 
 /// Configuration for installing status-detection hooks into an agent's settings file.
@@ -103,32 +107,85 @@ pub struct AgentDef {
     pub install_hint: &'static str,
 }
 
-/// Hook events shared by Claude Code and Cursor CLI.
-const CLAUDE_CURSOR_HOOK_EVENTS: &[HookEvent] = &[
+/// Claude Code hook events. `SessionStart` and `UserPromptSubmit` carry
+/// `session_id_capture: true` so the per-instance sidecar
+/// (`/tmp/aoe-hooks/<id>/session_id`) is updated whenever Claude rotates
+/// its session UUID (`/clear`, `/new`, `--fork-session`, resume, compact).
+/// `claude_poll_fn` reads this sidecar before falling back to its disk
+/// scan.
+const CLAUDE_HOOK_EVENTS: &[HookEvent] = &[
+    HookEvent {
+        name: "SessionStart",
+        matcher: None,
+        status: None,
+        session_id_capture: true,
+    },
     HookEvent {
         name: "PreToolUse",
         matcher: None,
         status: Some("running"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
         status: Some("running"),
+        session_id_capture: true,
     },
     HookEvent {
         name: "Stop",
         matcher: None,
         status: Some("idle"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "Notification",
         matcher: Some("permission_prompt|elicitation_dialog"),
         status: Some("waiting"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "ElicitationResult",
         matcher: None,
         status: Some("running"),
+        session_id_capture: false,
+    },
+];
+
+/// Cursor CLI hook events. No `session_id_capture`: Cursor's session id is
+/// not consumed by AoE pollers, and Cursor's hook payload uses a different
+/// schema, so installing the capture command would do useless work on every
+/// `UserPromptSubmit`.
+const CURSOR_HOOK_EVENTS: &[HookEvent] = &[
+    HookEvent {
+        name: "PreToolUse",
+        matcher: None,
+        status: Some("running"),
+        session_id_capture: false,
+    },
+    HookEvent {
+        name: "UserPromptSubmit",
+        matcher: None,
+        status: Some("running"),
+        session_id_capture: false,
+    },
+    HookEvent {
+        name: "Stop",
+        matcher: None,
+        status: Some("idle"),
+        session_id_capture: false,
+    },
+    HookEvent {
+        name: "Notification",
+        matcher: Some("permission_prompt|elicitation_dialog"),
+        status: Some("waiting"),
+        session_id_capture: false,
+    },
+    HookEvent {
+        name: "ElicitationResult",
+        matcher: None,
+        status: Some("running"),
+        session_id_capture: false,
     },
 ];
 
@@ -141,26 +198,31 @@ const QWEN_HOOK_EVENTS: &[HookEvent] = &[
         name: "PreToolUse",
         matcher: None,
         status: Some("running"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
         status: Some("running"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "PostToolUse",
         matcher: None,
         status: Some("running"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "Stop",
         matcher: None,
         status: Some("idle"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "Notification",
         matcher: Some("permission_prompt|elicitation_dialog"),
         status: Some("waiting"),
+        session_id_capture: false,
     },
 ];
 
@@ -171,31 +233,37 @@ const CODEX_HOOK_EVENTS: &[HookEvent] = &[
         name: "SessionStart",
         matcher: None,
         status: Some("idle"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
         status: Some("running"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "PreToolUse",
         matcher: None,
         status: Some("running"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "PermissionRequest",
         matcher: None,
         status: Some("waiting"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "PostToolUse",
         matcher: None,
         status: Some("running"),
+        session_id_capture: false,
     },
     HookEvent {
         name: "Stop",
         matcher: None,
         status: Some("idle"),
+        session_id_capture: false,
     },
 ];
 
@@ -212,7 +280,7 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[("CLAUDE_CONFIG_DIR", "/root/.claude")],
         hook_config: Some(AgentHookConfig {
             settings_rel_path: ".claude/settings.json",
-            events: CLAUDE_CURSOR_HOOK_EVENTS,
+            events: CLAUDE_HOOK_EVENTS,
         }),
         resume_strategy: ResumeStrategy::FlagPair {
             existing: "--resume",
@@ -295,21 +363,25 @@ pub const AGENTS: &[AgentDef] = &[
                     name: "BeforeTool",
                     matcher: None,
                     status: Some("running"),
+                    session_id_capture: false,
                 },
                 HookEvent {
                     name: "BeforeAgent",
                     matcher: None,
                     status: Some("running"),
+                    session_id_capture: false,
                 },
                 HookEvent {
                     name: "AfterAgent",
                     matcher: None,
                     status: Some("idle"),
+                    session_id_capture: false,
                 },
                 HookEvent {
                     name: "Notification",
                     matcher: Some("ToolPermission"),
                     status: Some("waiting"),
+                    session_id_capture: false,
                 },
             ],
         }),
@@ -330,7 +402,7 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[("CURSOR_CONFIG_DIR", "/root/.cursor")],
         hook_config: Some(AgentHookConfig {
             settings_rel_path: ".cursor/settings.json",
-            events: CLAUDE_CURSOR_HOOK_EVENTS,
+            events: CURSOR_HOOK_EVENTS,
         }),
         resume_strategy: ResumeStrategy::Unsupported,
         host_only: false,

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -680,8 +680,8 @@ mod tests {
 
     #[test]
     fn test_supports_named_volumes_flags() {
-        assert!(RuntimeBase::DOCKER.supports_named_volumes);
-        assert!(RuntimeBase::PODMAN.supports_named_volumes);
-        assert!(!RuntimeBase::APPLE_CONTAINER.supports_named_volumes);
+        const { assert!(RuntimeBase::DOCKER.supports_named_volumes) };
+        const { assert!(RuntimeBase::PODMAN.supports_named_volumes) };
+        const { assert!(!RuntimeBase::APPLE_CONTAINER.supports_named_volumes) };
     }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -16,7 +16,8 @@ use fs2::FileExt as _;
 use serde_json::Value;
 
 pub use status_file::{
-    cleanup_hook_status_dir, hook_status_dir, read_hook_status, read_hook_urgent,
+    cleanup_hook_status_dir, hook_status_dir, read_hook_session_id, read_hook_status,
+    read_hook_urgent,
 };
 
 /// Base directory for all AoE hook status files.
@@ -91,31 +92,81 @@ fn hook_command_with_base(status: &str, base: &str) -> String {
     )
 }
 
+/// Build the shell command for a hook that extracts `session_id` from the
+/// agent's stdin JSON payload and writes it to a sidecar file.
+///
+/// **Schema requirement**: the payload's top-level `session_id` must
+/// appear textually before any nested object that uses the same key. If
+/// the inner copy is emitted first, `head -1` captures the wrong UUID.
+///
+/// The pipeline:
+///   1. `tr -d '\n'` collapses pretty-printed multi-line JSON onto a
+///      single line so the line-oriented `grep` can match `"session_id"
+///      :"<UUID>"` even when key/value are split across lines.
+///   2. `grep -oE` matches `[{,] "session_id":"<UUID>"`. The leading
+///      `[{,]` anchors the field to a JSON-structural boundary so a user
+///      prompt containing the literal substring `"session_id":"<uuid>"`
+///      cannot be captured (a JSON serializer escapes inner quotes as
+///      `\"`, breaking the structural prefix). `[0-9a-fA-F]` accepts
+///      either case for parity with `Uuid::parse_str`.
+///   3. `head -1` keeps the first match.
+///   4. The second `grep -oE` strips the framing, leaving the bare UUID.
+///   5. `printf > $D/.session_id.$$.tmp && mv ... $D/session_id`:
+///      PID-suffixed tempfile + atomic POSIX `rename(2)` makes concurrent
+///      hook invocations race-free.
+fn hook_command_session_id(base: &str) -> String {
+    format!(
+        "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; \
+         D={base}/$AOE_INSTANCE_ID; mkdir -p \"$D\" 2>/dev/null; \
+         SID=$(tr -d \"\\n\" | grep -oE \"[{{,][[:space:]]*\\\"session_id\\\"[[:space:]]*:[[:space:]]*\\\"[0-9a-fA-F]{{8}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{12}}\\\"\" | head -1 | grep -oE \"[0-9a-fA-F]{{8}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{12}}\"); \
+         [ -n \"$SID\" ] && printf \"%s\" \"$SID\" > \"$D/.session_id.$$.tmp\" 2>/dev/null && mv \"$D/.session_id.$$.tmp\" \"$D/session_id\" 2>/dev/null; \
+         exit 0'"
+    )
+}
+
 fn is_aoe_hook_command(cmd: &str) -> bool {
     cmd.contains(AOE_HOOK_MARKER)
 }
 
 /// Build the AoE hooks JSON structure from agent-defined events.
 ///
-/// Events with `status: None` (lifecycle-only) are skipped since shell
-/// one-liners can only write a status string.
+/// For each event, emit one entry per active behaviour:
+/// - `event.session_id_capture` → session-id-extractor command (placed
+///   first so it gets stdin first if the agent only delivers stdin to the
+///   leading command in a matcher block).
+/// - `event.status.is_some()` → status-writer command (does not read
+///   stdin).
+///
+/// An event with both produces two `hooks` array entries under the same
+/// matcher block. An event with neither is skipped.
 fn build_aoe_hooks(events: &[crate::agents::HookEvent]) -> Value {
     let mut hooks_obj = serde_json::Map::new();
     for event in events {
-        let Some(status) = event.status else {
+        let mut commands: Vec<String> = Vec::new();
+        if event.session_id_capture {
+            commands.push(hook_command_session_id(HOOK_STATUS_BASE));
+        }
+        if let Some(status) = event.status {
+            commands.push(hook_command(status));
+        }
+        if commands.is_empty() {
             continue;
-        };
+        }
+
         let mut entry = serde_json::Map::new();
         if let Some(m) = event.matcher {
             entry.insert("matcher".to_string(), Value::String(m.to_string()));
         }
-        entry.insert(
-            "hooks".to_string(),
-            Value::Array(vec![serde_json::json!({
-                "type": "command",
-                "command": hook_command(status)
-            })]),
-        );
+        let hook_entries: Vec<Value> = commands
+            .into_iter()
+            .map(|cmd| {
+                serde_json::json!({
+                    "type": "command",
+                    "command": cmd,
+                })
+            })
+            .collect();
+        entry.insert("hooks".to_string(), Value::Array(hook_entries));
         hooks_obj.insert(
             event.name.to_string(),
             Value::Array(vec![Value::Object(entry)]),
@@ -2512,5 +2563,155 @@ hooks_auto_accept: false
         let config_path = tmp.path().join("nonexistent.json");
         let modified = uninstall_kiro_hooks(&config_path).unwrap();
         assert!(!modified);
+    }
+
+    fn run_session_id_hook(payload: &str, instance_id: &str, base: &Path) -> std::process::Output {
+        let cmd = hook_command_session_id(base.to_str().unwrap());
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", &cmd])
+            .env("AOE_INSTANCE_ID", instance_id)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn sh");
+        use std::io::Write;
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(payload.as_bytes())
+            .unwrap();
+        child.wait_with_output().expect("wait sh")
+    }
+
+    #[test]
+    fn test_hook_command_session_id_extracts_from_compact_payload() {
+        let tmp = TempDir::new().unwrap();
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payload = format!(r#"{{"session_id":"{uuid}","cwd":"/x"}}"#);
+        let output = run_session_id_hook(&payload, "extract_compact", tmp.path());
+        assert!(output.status.success());
+        let written =
+            std::fs::read_to_string(tmp.path().join("extract_compact").join("session_id"))
+                .expect("sidecar file");
+        assert_eq!(written, uuid);
+    }
+
+    #[test]
+    fn test_hook_command_session_id_ignores_user_prompt_injection() {
+        let tmp = TempDir::new().unwrap();
+        let real = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let fake = "11111111-2222-3333-4444-555555555555";
+        let payload = format!(r#"{{"session_id":"{real}","prompt":"\"session_id\":\"{fake}\""}}"#);
+        let output = run_session_id_hook(&payload, "prompt_injection", tmp.path());
+        assert!(output.status.success());
+        let written =
+            std::fs::read_to_string(tmp.path().join("prompt_injection").join("session_id"))
+                .expect("sidecar file");
+        assert_eq!(written, real);
+    }
+
+    #[test]
+    fn test_hook_command_session_id_extracts_from_multi_line_payload() {
+        let tmp = TempDir::new().unwrap();
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payload = format!("{{\n  \"session_id\":\"{uuid}\",\n  \"cwd\":\"/x\"\n}}");
+        let output = run_session_id_hook(&payload, "multi_line", tmp.path());
+        assert!(output.status.success());
+        let written = std::fs::read_to_string(tmp.path().join("multi_line").join("session_id"))
+            .expect("sidecar file");
+        assert_eq!(written, uuid);
+    }
+
+    #[test]
+    fn test_hook_command_session_id_accepts_uppercase_uuid() {
+        let tmp = TempDir::new().unwrap();
+        let uuid = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+        let payload = format!(r#"{{"session_id":"{uuid}"}}"#);
+        let output = run_session_id_hook(&payload, "uppercase_uuid", tmp.path());
+        assert!(output.status.success());
+        let written = std::fs::read_to_string(tmp.path().join("uppercase_uuid").join("session_id"))
+            .expect("sidecar file");
+        assert_eq!(written, uuid);
+    }
+
+    #[test]
+    fn test_hook_command_session_id_skips_when_no_session_id() {
+        let tmp = TempDir::new().unwrap();
+        let payload = r#"{"cwd":"/x","other":"value"}"#;
+        let output = run_session_id_hook(payload, "no_sid", tmp.path());
+        assert!(output.status.success());
+        let path = tmp.path().join("no_sid").join("session_id");
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_hook_command_session_id_uses_pid_suffixed_tempfile() {
+        let cmd = hook_command_session_id("/tmp/aoe-hooks");
+        assert!(
+            cmd.contains(".session_id.$$.tmp"),
+            "expected PID-suffixed tempfile in command, got: {cmd}"
+        );
+        assert!(cmd.contains("mv"));
+    }
+
+    #[test]
+    fn test_build_aoe_hooks_emits_session_id_capture_for_session_start() {
+        let events = claude_events();
+        let hooks = build_aoe_hooks(events);
+        let session_start = hooks
+            .get("SessionStart")
+            .expect("SessionStart matcher block")
+            .as_array()
+            .unwrap();
+        assert_eq!(session_start.len(), 1);
+        let entries = session_start[0]["hooks"].as_array().unwrap();
+        assert_eq!(entries.len(), 1, "SessionStart should emit 1 hook command");
+        let cmd = entries[0]["command"].as_str().unwrap();
+        assert!(cmd.contains("session_id"));
+        assert!(cmd.contains(AOE_HOOK_MARKER));
+    }
+
+    #[test]
+    fn test_build_aoe_hooks_emits_both_for_user_prompt_submit() {
+        let events = claude_events();
+        let hooks = build_aoe_hooks(events);
+        let user_prompt = hooks
+            .get("UserPromptSubmit")
+            .expect("UserPromptSubmit matcher block")
+            .as_array()
+            .unwrap();
+        let entries = user_prompt[0]["hooks"].as_array().unwrap();
+        assert_eq!(
+            entries.len(),
+            2,
+            "UserPromptSubmit should emit status + session_id_capture"
+        );
+        let commands: Vec<&str> = entries
+            .iter()
+            .map(|e| e["command"].as_str().unwrap())
+            .collect();
+        assert!(commands.iter().any(|c| c.contains("printf running")));
+        assert!(commands.iter().any(|c| c.contains("session_id")));
+    }
+
+    #[test]
+    fn test_build_aoe_hooks_status_only_events_unchanged() {
+        let events = claude_events();
+        let hooks = build_aoe_hooks(events);
+        for event_name in &["PreToolUse", "Stop", "Notification", "ElicitationResult"] {
+            let block = hooks
+                .get(*event_name)
+                .unwrap_or_else(|| panic!("expected {event_name}"))
+                .as_array()
+                .unwrap();
+            let entries = block[0]["hooks"].as_array().unwrap();
+            assert_eq!(
+                entries.len(),
+                1,
+                "status-only event {event_name} should emit 1 hook"
+            );
+        }
     }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -2613,6 +2613,31 @@ hooks_auto_accept: false
     }
 
     #[test]
+    fn test_hook_command_session_id_locks_top_level_first_contract() {
+        // The grep regex `[{,]"session_id":"<UUID>"` cannot distinguish a
+        // nested object literal from the top-level field: a nested copy
+        // emitted textually before the top-level one is captured by
+        // `head -1`. This test pins the resulting behavior so any drift in
+        // the upstream payload schema (or in the extractor) shows up as a
+        // test failure rather than as silent wrong-UUID capture.
+        let tmp = TempDir::new().unwrap();
+        let nested = "11111111-2222-3333-4444-555555555555";
+        let top_level = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payload =
+            format!(r#"{{"context":{{"session_id":"{nested}"}},"session_id":"{top_level}"}}"#);
+        let output = run_session_id_hook(&payload, "nested_first", tmp.path());
+        assert!(output.status.success());
+        let written = std::fs::read_to_string(tmp.path().join("nested_first").join("session_id"))
+            .expect("sidecar file");
+        assert_eq!(
+            written, nested,
+            "current extractor returns the nested UUID; replace with a JSON-aware \
+             parser if Claude ever emits a payload where a nested `session_id` \
+             precedes the top-level field"
+        );
+    }
+
+    #[test]
     fn test_hook_command_session_id_extracts_from_multi_line_payload() {
         let tmp = TempDir::new().unwrap();
         let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -5,10 +5,16 @@
 //! still reconcile agent-specific hook gaps from pane text.
 
 use std::path::PathBuf;
+use std::time::Duration;
+
+use uuid::Uuid;
 
 use crate::session::Status;
 
 use super::HOOK_STATUS_BASE;
+
+/// Maximum age before a sidecar `session_id` file is considered stale.
+pub(crate) const SESSION_ID_SIDECAR_MAX_AGE: Duration = Duration::from_secs(5 * 60);
 
 /// Return the directory for a given instance's hook status file.
 pub fn hook_status_dir(instance_id: &str) -> PathBuf {
@@ -34,6 +40,27 @@ pub fn read_hook_status(instance_id: &str) -> Option<Status> {
             tracing::warn!(target: "hooks.status", "Unexpected hook status value: {:?}", other);
             None
         }
+    }
+}
+
+/// Read a Claude session UUID from the hook-written `session_id` sidecar.
+///
+/// Returns `None` when the file is absent, malformed (non-UUID), or older
+/// than [`SESSION_ID_SIDECAR_MAX_AGE`]. Filesystems that report
+/// `mtime > now` (clock skew) are treated as stale.
+pub fn read_hook_session_id(instance_id: &str) -> Option<String> {
+    let path = hook_status_dir(instance_id).join("session_id");
+    let metadata = std::fs::metadata(&path).ok()?;
+    let mtime = metadata.modified().ok()?;
+    if mtime.elapsed().ok()? > SESSION_ID_SIDECAR_MAX_AGE {
+        return None;
+    }
+    let content = std::fs::read_to_string(&path).ok()?;
+    let id = content.trim().to_string();
+    if Uuid::parse_str(&id).is_ok() {
+        Some(id)
+    } else {
+        None
     }
 }
 
@@ -238,6 +265,63 @@ mod tests {
         let body = format!(r#"{{"urgent":true,"urgent_expires_at":{}}}"#, future);
         let dir = write_attention_json(id, &body);
         assert!(read_hook_urgent(id));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    fn write_session_id_sidecar(instance_id: &str, content: &str) -> PathBuf {
+        let dir = hook_status_dir(instance_id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("session_id"), content).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_read_hook_session_id_returns_some_when_fresh_uuid() {
+        let id = "test_session_id_fresh";
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let dir = write_session_id_sidecar(id, uuid);
+        assert_eq!(read_hook_session_id(id), Some(uuid.to_string()));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_hook_session_id_returns_none_when_absent() {
+        assert_eq!(
+            read_hook_session_id("nonexistent_session_id_instance"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_read_hook_session_id_rejects_non_uuid() {
+        let id = "test_session_id_garbage";
+        let dir = write_session_id_sidecar(id, "not-a-uuid");
+        assert_eq!(read_hook_session_id(id), None);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_hook_session_id_rejects_stale_file() {
+        let id = "test_session_id_stale";
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let dir = write_session_id_sidecar(id, uuid);
+        let stale = std::time::SystemTime::now() - Duration::from_secs(10 * 60);
+        fs::File::options()
+            .write(true)
+            .open(dir.join("session_id"))
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(stale))
+            .unwrap();
+        assert_eq!(read_hook_session_id(id), None);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_hook_session_id_trims_trailing_whitespace() {
+        let id = "test_session_id_trim";
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let dir = write_session_id_sidecar(id, &format!("{uuid}\n"));
+        assert_eq!(read_hook_session_id(id), Some(uuid.to_string()));
         fs::remove_dir_all(dir).ok();
     }
 }

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -82,14 +82,13 @@ fn encode_claude_project_path(project_path: &str) -> String {
 pub(crate) fn capture_claude_session_id(
     project_path: &str,
     known_session_id: Option<&str>,
+    exclusion: &HashSet<String>,
 ) -> Result<String> {
     let claude_home = resolve_agent_home(Some("CLAUDE_CONFIG_DIR"), ".claude")?;
     let canonical = canonicalize_or_raw(project_path);
 
-    // Source 1: this poller's own known session if its .jsonl is still fresh,
-    // otherwise the most recently modified .jsonl in the project dir.
     if let Some((id, modified)) =
-        scan_claude_project_dir(&claude_home, &canonical, known_session_id)?
+        scan_claude_project_dir(&claude_home, &canonical, known_session_id, exclusion)?
     {
         let age = modified.elapsed().unwrap_or(Duration::from_secs(u64::MAX));
         if age <= Duration::from_secs(5 * 60) {
@@ -97,8 +96,13 @@ pub(crate) fn capture_claude_session_id(
         }
     }
 
-    // Source 2: lastSessionId from ~/.claude.json (same staleness threshold)
     if let Some(id) = read_claude_json_session_id(&canonical) {
+        if exclusion.contains(&id) {
+            return Err(anyhow::anyhow!(
+                "claude.json lastSessionId {} is excluded (claimed by another instance)",
+                id
+            ));
+        }
         let claude_json = dirs::home_dir()
             .map(|h| h.join(".claude.json"))
             .and_then(|p| std::fs::metadata(&p).ok())
@@ -114,24 +118,20 @@ pub(crate) fn capture_claude_session_id(
     anyhow::bail!("No active Claude session found for {}", project_path)
 }
 
-/// Scan `~/.claude/projects/{encoded-path}/` for the session this poller should
-/// report.
+/// Scan `~/.claude/projects/{encoded-path}/` and pick this poller's session.
 ///
-/// When several AoE sessions share one `project_path` (a fleet rooted at a
-/// single repo), the bare "most recently modified `.jsonl`" heuristic makes
-/// every session's poller report whichever session most recently wrote — so
-/// they all steal one another's session ids and resume the same conversation
-/// (issue #1522). To prevent that, if the caller's own `known` session still
-/// has a fresh `.jsonl` here, return it: each session sticks to its own
-/// transcript rather than racing for the global most-recent.
-///
-/// Falls back to the most-recent file when `known` is `None`, absent, or stale
-/// (e.g. the session genuinely moved to a new conversation), preserving the
-/// original behaviour for the single-session-per-repo case.
+/// Tie-break:
+/// 1. anchor stale or absent → return `best` (most-recent unexcluded jsonl).
+/// 2. `best` exists, fresh, and strictly newer than the anchor → return
+///    `best`. The caller promotes `last_known` so the poller adopts the new
+///    UUID after `/clear` / `/new` / `--fork-session` mints a new jsonl.
+/// 3. otherwise → return the anchor (covers steady-state and the case where
+///    a sibling's most-recent write was filtered out by `exclusion`).
 fn scan_claude_project_dir(
     claude_home: &Path,
     project_path: &Path,
     known: Option<&str>,
+    exclusion: &HashSet<String>,
 ) -> Result<Option<(String, std::time::SystemTime)>> {
     let dir_name = encode_claude_project_path(&project_path.to_string_lossy());
     let project_dir = claude_home.join("projects").join(&dir_name);
@@ -161,25 +161,37 @@ fn scan_claude_project_dir(
             .and_then(|m| m.modified())
             .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
 
+        if known == Some(stem) && !exclusion.contains(stem) {
+            known_hit = Some((stem.to_string(), modified));
+        }
+
+        if exclusion.contains(stem) {
+            continue;
+        }
+
         if best.as_ref().is_none_or(|(_, t)| modified > *t) {
             best = Some((stem.to_string(), modified));
         }
-        if known == Some(stem) {
-            known_hit = Some((stem.to_string(), modified));
-        }
     }
 
-    // issue #1522: anchor to our own session while its file is fresh, so
-    // sessions sharing a project_path don't cross-assign. The freshness bound
-    // mirrors the caller's staleness gate in `capture_claude_session_id`.
     if let Some((kid, kmt)) = known_hit {
-        let fresh = kmt
+        let known_fresh = kmt
             .elapsed()
             .map(|age| age <= Duration::from_secs(5 * 60))
             .unwrap_or(false);
-        if fresh {
-            return Ok(Some((kid, kmt)));
+        if !known_fresh {
+            return Ok(best);
         }
+        if let Some((_, bmt)) = best.as_ref() {
+            let best_fresh = bmt
+                .elapsed()
+                .map(|age| age <= Duration::from_secs(5 * 60))
+                .unwrap_or(false);
+            if best_fresh && *bmt > kmt {
+                return Ok(best);
+            }
+        }
+        return Ok(Some((kid, kmt)));
     }
 
     Ok(best)
@@ -208,55 +220,51 @@ fn read_claude_json_session_id(project_path: &Path) -> Option<String> {
 
 /// Polling closure for Claude Code session tracking on the host filesystem.
 ///
-/// Unlike other agents' poll factories, this closure does not take an
-/// `extra_excludes` set. Claude is protected from re-importing the sid
-/// `start_with_resume_fallback` just cleared by a layered chain:
-///
-/// 1. `acquire_session_id` mints a fresh UUID for Claude and assigns it
-///    to `agent_session_id` BEFORE `maybe_start_poller` runs, so the
-///    poller's `initial_known` is the new UUID, not the stale one.
-/// 2. The poller's `last_known` dedupes once Claude writes
-///    `<new_uuid>.jsonl` and the disk scan returns it.
-/// 3. The defense-in-depth guard in `apply_session_id_updates`
-///    (`tui/home/mod.rs`) drops any poller report whose sid is in
-///    `retroactive_capture_excludes`. The cascade pre-loads that set
-///    before respawning, so a race where the immediate first poll fires
-///    before Claude writes the new `.jsonl` (and therefore returns the
-///    still-fresh stale `<stale_sid>.jsonl`) is caught here.
-///
-/// The 5-minute mtime check inside `capture_claude_session_id` is an
-/// upper bound on staleness, not a stale-sid filter; a just-crashed
-/// `<stale_sid>.jsonl` has a fresh mtime and passes that check.
-///
-/// Serve-only mode never drains `result_rx` (the only consumer of
-/// `try_recv_session_update` is the TUI tick path), so the stale sid
-/// cannot reach in-memory `agent_session_id` or `sessions.json` via the
-/// poller in that mode either. The only residual effect is that
-/// `on_change` may briefly write the stale sid into the tmux env's
-/// `AOE_CAPTURED_SESSION_ID_KEY`; the next poll cycle overwrites it.
-///
-/// If you ever add a second consumer of the poller channel that
-/// bypasses `apply_session_id_updates`, replicate the
-/// `retroactive_capture_excludes` filter at the consumer or thread an
-/// `extra_excludes` set into this closure mirroring the other agents.
+/// Per tick, in order:
+/// 1. Read `/tmp/aoe-hooks/<instance_id>/session_id` (written by Claude's
+///    `SessionStart` / `UserPromptSubmit` hooks). When present and ≤ 5 min
+///    old, return it and skip the disk scan.
+/// 2. Otherwise scan `~/.claude/projects/<encoded-path>/`. The scan uses
+///    `compose_exclusion(instance_id, extra_excludes)` to skip UUIDs claimed
+///    by peers via tmux env, and the `last_known` mutex to anchor this
+///    closure to its own session even when a peer's jsonl is more recent.
+///    Each successful capture promotes `last_known` so subsequent ticks see
+///    the new anchor.
 pub(crate) fn claude_poll_fn(
     project_path: String,
     known_session_id: Option<String>,
+    instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
-    // issue #1522: promote the last successfully captured sid to the anchor
-    // for subsequent polls. Without this, the closure keeps the startup
-    // `known_session_id` forever; once that file goes stale the scan drops
-    // back to global-most-recent and shared-repo fleets can resume
-    // cross-assigning on the next /clear or fork.
     let last_known = std::sync::Mutex::new(known_session_id);
     move || {
+        // Sidecar reads are scoped per-instance: the file lives under
+        // `/tmp/aoe-hooks/<instance_id>/` so a sibling instance's hook
+        // writes cannot reach this path, which is why the read skips
+        // `compose_exclusion`. `extra_excludes` is still honored so a
+        // sidecar value matching one of this instance's cleared sids does
+        // not leak through.
+        if let Some(id) = crate::hooks::read_hook_session_id(&instance_id) {
+            if !extra_excludes.contains(&id) {
+                if let Some(validated) = validated_session_id(id) {
+                    if let Ok(mut guard) = last_known.lock() {
+                        *guard = Some(validated.clone());
+                    }
+                    return Some(validated);
+                }
+            }
+        }
+
         let current_known = last_known.lock().ok().and_then(|g| g.clone());
-        let captured = capture_claude_session_id(&project_path, current_known.as_deref())
-            .map_err(
-                |e| tracing::debug!(target: "session.capture", "Claude disk scan failed: {}", e),
-            )
-            .ok()
-            .and_then(validated_session_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
+        let captured = capture_claude_session_id(
+            &project_path,
+            current_known.as_deref(),
+            &exclusion,
+        )
+        .map_err(|e| tracing::debug!(target: "session.capture", "Claude disk scan failed: {}", e))
+        .ok()
+        .and_then(validated_session_id);
 
         if let Some(id) = captured.as_ref() {
             if let Ok(mut guard) = last_known.lock() {
@@ -270,71 +278,126 @@ pub(crate) fn claude_poll_fn(
 
 /// Capture Claude Code session ID inside a Docker container.
 ///
-/// Claude in a sandboxed AoE session writes its `.jsonl` files to the
-/// container's `~/.claude/projects/{encoded-cwd}/` directory, not the host's.
-/// This shells `docker exec` into the running container to find the most
-/// recently modified UUID-named jsonl in that directory, with a 5-minute
-/// staleness guard.
+/// Lists every fresh (≤ 5 min mtime) UUID-named jsonl in
+/// `$CLAUDE_CONFIG_DIR/projects/<encoded-cwd>/` newest-first via
+/// `docker exec`, wrapped in [`run_with_timeout`] (5 s) so a hung exec
+/// cannot block the poller thread, then delegates per-pane attribution to
+/// [`select_claude_session_in_container`].
 pub(crate) fn capture_claude_session_id_in_container(
     container_name: &str,
     container_cwd: &str,
+    exclusion: &HashSet<String>,
+    known_session_id: Option<&str>,
 ) -> Result<String> {
     let dir_name = encode_claude_project_path(container_cwd);
 
-    // Shell snippet:
-    //   - resolve $CLAUDE_CONFIG_DIR or $HOME/.claude
-    //   - walk projects/<encoded>/ for *.jsonl files
-    //   - keep ones with mtime within 5 minutes
-    //   - emit basename (without .jsonl) of the most recent
-    //
-    // Using POSIX `find -mmin -5` and `ls -t` to avoid GNU-only `printf '%T@ %f'`.
     let snippet = format!(
         r#"
 CLAUDE_HOME="${{CLAUDE_CONFIG_DIR:-$HOME/.claude}}"
 DIR="$CLAUDE_HOME/projects/{dir_name}"
 [ -d "$DIR" ] || exit 0
-NEWEST=$(ls -t "$DIR"/*.jsonl 2>/dev/null | head -1)
-[ -z "$NEWEST" ] && exit 0
-[ -n "$(find "$NEWEST" -mmin -5 2>/dev/null)" ] || exit 0
-basename "$NEWEST" .jsonl
+for f in $(ls -t "$DIR"/*.jsonl 2>/dev/null); do
+  [ -n "$(find "$f" -mmin -5 2>/dev/null)" ] || continue
+  basename "$f" .jsonl
+done
 "#
     );
 
-    let output = std::process::Command::new("docker")
-        .args(["exec", container_name, "sh", "-c", &snippet])
-        .output()
-        .map_err(|e| anyhow::anyhow!("docker exec failed: {}", e))?;
+    let mut cmd = std::process::Command::new("docker");
+    cmd.args(["exec", container_name, "sh", "-c", &snippet]);
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("docker exec returned non-zero: {}", stderr.trim());
+    let stdout_bytes = run_with_timeout(
+        cmd,
+        Duration::from_secs(5),
+        "docker exec sh (claude jsonl scan)",
+    )
+    .map_err(|e| anyhow::anyhow!("{} (container {})", e, container_name))?;
+
+    select_claude_session_in_container(&stdout_bytes, exclusion, known_session_id)
+        .map_err(|e| anyhow::anyhow!("{} (container {})", e, container_name))
+}
+
+/// Pick the active Claude session UUID from the container shell snippet's
+/// stdout.
+///
+/// Stdout is UUID basenames in newest-first order. Tie-break (mirrors
+/// [`scan_claude_project_dir`]):
+/// 1. anchor absent → return first unexcluded.
+/// 2. anchor present, an unexcluded candidate appears before it → return
+///    that candidate (active newer wins).
+/// 3. otherwise → return the anchor.
+fn select_claude_session_in_container(
+    stdout_bytes: &[u8],
+    exclusion: &HashSet<String>,
+    known: Option<&str>,
+) -> Result<String> {
+    let text = String::from_utf8_lossy(stdout_bytes);
+    let candidates: Vec<String> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && Uuid::parse_str(l).is_ok())
+        .map(String::from)
+        .collect();
+
+    if candidates.is_empty() {
+        anyhow::bail!("No active Claude session found in container");
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let id = stdout.trim();
-    if id.is_empty() {
-        anyhow::bail!(
-            "No active Claude session found in container {}",
-            container_name
-        );
-    }
-    if Uuid::parse_str(id).is_err() {
-        anyhow::bail!("Container returned non-UUID session ID: {:?}", id);
-    }
+    let known_pos = known.and_then(|k| {
+        if exclusion.contains(k) {
+            None
+        } else {
+            candidates.iter().position(|c| c == k)
+        }
+    });
+    let best_pos = candidates.iter().position(|c| !exclusion.contains(c));
 
-    Ok(id.to_string())
+    match (known_pos, best_pos) {
+        (None, None) => {
+            anyhow::bail!("All Claude session candidates in container are excluded")
+        }
+        (None, Some(p)) => Ok(candidates[p].clone()),
+        (Some(kp), Some(bp)) if bp < kp => Ok(candidates[bp].clone()),
+        (Some(kp), _) => Ok(candidates[kp].clone()),
+    }
 }
 
 /// Polling closure for sandboxed (Docker) Claude Code session tracking.
+///
+/// Mirrors [`claude_poll_fn`] but does not read the host hook sidecar (the
+/// in-container hook would write to the container's `/tmp/aoe-hooks/`,
+/// which the host poller cannot see without bind-mounting). Sandboxed
+/// `/clear` adoption therefore takes ≤ 1 poll tick.
 pub(crate) fn claude_poll_fn_sandboxed(
     container_name: String,
     container_cwd: String,
+    known_session_id: Option<String>,
+    instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
+    let last_known = std::sync::Mutex::new(known_session_id);
     move || {
-        capture_claude_session_id_in_container(&container_name, &container_cwd)
-            .map_err(|e| tracing::debug!(target: "session.capture", "Claude container scan failed: {}", e))
-            .ok()
-            .and_then(validated_session_id)
+        let current_known = last_known.lock().ok().and_then(|g| g.clone());
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
+        let captured = capture_claude_session_id_in_container(
+            &container_name,
+            &container_cwd,
+            &exclusion,
+            current_known.as_deref(),
+        )
+        .map_err(
+            |e| tracing::debug!(target: "session.capture", "Claude container scan failed: {}", e),
+        )
+        .ok()
+        .and_then(validated_session_id);
+
+        if let Some(id) = captured.as_ref() {
+            if let Ok(mut guard) = last_known.lock() {
+                *guard = Some(id.clone());
+            }
+        }
+
+        captured
     }
 }
 
@@ -2101,7 +2164,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject", None);
+        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new());
         assert_eq!(result.unwrap(), uuid_new);
 
         match old_val {
@@ -2112,10 +2175,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_capture_claude_session_prefers_known_when_shared() {
-        // issue #1522: two sessions share a project_path and both .jsonl files
-        // are fresh. Without an anchor the poller returns the most-recent for
-        // BOTH, cross-assigning ids. With `known`, each sticks to its own file.
+    fn test_capture_claude_session_prefers_known_when_excluded() {
         let tmp = tempfile::tempdir().unwrap();
         let project_dir = tmp.path().join("projects").join("-tmp-myproject");
         std::fs::create_dir_all(&project_dir).unwrap();
@@ -2123,7 +2183,6 @@ mod tests {
         let uuid_a = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
         let uuid_b = "11111111-2222-3333-4444-555555555555";
         std::fs::write(project_dir.join(format!("{uuid_a}.jsonl")), "a\n").unwrap();
-        // Nudge A 30s into the past so B is unambiguously the most-recent.
         let a_time = std::time::SystemTime::now() - Duration::from_secs(30);
         std::fs::File::options()
             .write(true)
@@ -2136,25 +2195,30 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        // No anchor -> most recent (B): original behaviour preserved.
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", None).unwrap(),
+            capture_claude_session_id("/tmp/myproject", None, &HashSet::new()).unwrap(),
             uuid_b
         );
-        // Anchor to A (fresh) -> stays on A despite B being newer.
+
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(uuid_a)).unwrap(),
+            capture_claude_session_id("/tmp/myproject", Some(uuid_a), &HashSet::new()).unwrap(),
+            uuid_b
+        );
+
+        let exclusion: HashSet<String> = std::iter::once(uuid_b.to_string()).collect();
+        assert_eq!(
+            capture_claude_session_id("/tmp/myproject", Some(uuid_a), &exclusion).unwrap(),
             uuid_a
         );
-        // Anchor to B -> B.
+
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(uuid_b)).unwrap(),
+            capture_claude_session_id("/tmp/myproject", Some(uuid_b), &HashSet::new()).unwrap(),
             uuid_b
         );
-        // Anchor to an id with no file here -> fall back to most-recent (B).
+
         let absent = "99999999-9999-9999-9999-999999999999";
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(absent)).unwrap(),
+            capture_claude_session_id("/tmp/myproject", Some(absent), &HashSet::new()).unwrap(),
             uuid_b
         );
 
@@ -2189,7 +2253,7 @@ mod tests {
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
         assert_eq!(
-            capture_claude_session_id("/tmp/myproject", Some(uuid_known)).unwrap(),
+            capture_claude_session_id("/tmp/myproject", Some(uuid_known), &HashSet::new()).unwrap(),
             uuid_fresh
         );
 
@@ -2202,12 +2266,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_claude_poll_fn_promotes_last_known_across_polls() {
-        // issue #1522: once a stale anchor falls back to the disk's most-recent,
-        // the closure must adopt that sid as its new anchor so a later sibling
-        // write (think: another session in the same fleet) cannot steal it
-        // back on the next poll. Without promotion, the closure stays anchored
-        // to its startup sid forever, and shared-repo cross-assignment returns
-        // the moment a session forks (/clear, /new, --fork-session).
         let tmp = tempfile::tempdir().unwrap();
         let project_dir = tmp.path().join("projects").join("-tmp-myproject");
         std::fs::create_dir_all(&project_dir).unwrap();
@@ -2216,7 +2274,6 @@ mod tests {
         let uuid_post_fork = "11111111-2222-3333-4444-555555555555";
         let uuid_sibling = "99999999-8888-7777-6666-555555555555";
 
-        // Startup anchor's file is stale; the post-fork file is fresh.
         std::fs::write(project_dir.join(format!("{uuid_startup}.jsonl")), "s\n").unwrap();
         let stale = std::time::SystemTime::now() - Duration::from_secs(600);
         std::fs::File::options()
@@ -2230,17 +2287,18 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let poll = claude_poll_fn("/tmp/myproject".to_string(), Some(uuid_startup.to_string()));
+        let extra_excludes: HashSet<String> = std::iter::once(uuid_sibling.to_string()).collect();
+        let poll = claude_poll_fn(
+            "/tmp/myproject".to_string(),
+            Some(uuid_startup.to_string()),
+            "test-instance-promote-last-known".to_string(),
+            extra_excludes,
+        );
 
-        // First poll: anchor is stale, fall back to most-recent (post-fork).
         assert_eq!(poll().as_deref(), Some(uuid_post_fork));
 
-        // A sibling session in the same dir writes its transcript with a newer
-        // mtime than the post-fork file.
         std::fs::write(project_dir.join(format!("{uuid_sibling}.jsonl")), "x\n").unwrap();
 
-        // Second poll: closure must now anchor to the post-fork sid (still
-        // fresh) and refuse to drift onto the sibling's newer file.
         assert_eq!(poll().as_deref(), Some(uuid_post_fork));
 
         match old_val {
@@ -2265,7 +2323,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject", None);
+        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new());
         assert!(result.is_err(), "Agent files should not be picked up");
 
         match old_val {
@@ -2297,7 +2355,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject", None);
+        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new());
         assert!(result.is_err(), "Stale session file should be rejected");
         assert!(
             result
@@ -2323,7 +2381,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject", None);
+        let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new());
         assert!(result.is_err(), "Empty dir should return error");
 
         match old_val {
@@ -2337,6 +2395,8 @@ mod tests {
         let result = capture_claude_session_id_in_container(
             "aoe-test-nonexistent-container-xyz",
             "/workspace/test",
+            &HashSet::new(),
+            None,
         );
         assert!(result.is_err());
     }
@@ -4043,6 +4103,186 @@ mod tests {
         match old_xdg {
             Some(v) => std::env::set_var("XDG_DATA_HOME", v),
             None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_anchor_at_position_zero() {
+        let uuid_a = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let uuid_b = "11111111-2222-3333-4444-555555555555";
+        let stdout = format!("{uuid_a}\n{uuid_b}\n");
+        let id =
+            select_claude_session_in_container(stdout.as_bytes(), &HashSet::new(), Some(uuid_a))
+                .unwrap();
+        assert_eq!(id, uuid_a);
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_active_newer_wins_over_anchor() {
+        let uuid_anchor = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let uuid_newer = "11111111-2222-3333-4444-555555555555";
+        let stdout = format!("{uuid_newer}\n{uuid_anchor}\n");
+        let id = select_claude_session_in_container(
+            stdout.as_bytes(),
+            &HashSet::new(),
+            Some(uuid_anchor),
+        )
+        .unwrap();
+        assert_eq!(id, uuid_newer);
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_excluded_newest_falls_to_anchor() {
+        let uuid_anchor = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let uuid_sibling = "11111111-2222-3333-4444-555555555555";
+        let stdout = format!("{uuid_sibling}\n{uuid_anchor}\n");
+        let exclusion: HashSet<String> = std::iter::once(uuid_sibling.to_string()).collect();
+        let id =
+            select_claude_session_in_container(stdout.as_bytes(), &exclusion, Some(uuid_anchor))
+                .unwrap();
+        assert_eq!(id, uuid_anchor);
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_no_candidates_errors() {
+        let result = select_claude_session_in_container(b"", &HashSet::new(), None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_all_candidates_excluded_errors() {
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let exclusion: HashSet<String> = std::iter::once(uuid.to_string()).collect();
+        let stdout = format!("{uuid}\n");
+        let result = select_claude_session_in_container(stdout.as_bytes(), &exclusion, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_no_anchor_picks_first_unexcluded() {
+        let uuid_a = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let uuid_b = "11111111-2222-3333-4444-555555555555";
+        let exclusion: HashSet<String> = std::iter::once(uuid_a.to_string()).collect();
+        let stdout = format!("{uuid_a}\n{uuid_b}\n");
+        let id = select_claude_session_in_container(stdout.as_bytes(), &exclusion, None).unwrap();
+        assert_eq!(id, uuid_b);
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_ignores_non_uuid_lines() {
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let stdout = format!("\n  \nnot-a-uuid\n{uuid}\nstill-not-a-uuid\n");
+        let id =
+            select_claude_session_in_container(stdout.as_bytes(), &HashSet::new(), None).unwrap();
+        assert_eq!(id, uuid);
+    }
+
+    #[test]
+    #[serial]
+    fn test_claude_poll_fn_reads_hook_sidecar_first() {
+        let instance_id = "test_sidecar_first_path";
+        let hook_dir = std::path::PathBuf::from("/tmp/aoe-hooks").join(instance_id);
+        std::fs::create_dir_all(&hook_dir).unwrap();
+        let sidecar_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        std::fs::write(hook_dir.join("session_id"), sidecar_uuid).unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("projects").join("-tmp-myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let disk_uuid = "11111111-2222-3333-4444-555555555555";
+        std::fs::write(project_dir.join(format!("{disk_uuid}.jsonl")), "d\n").unwrap();
+
+        let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
+
+        let poll = claude_poll_fn(
+            "/tmp/myproject".to_string(),
+            None,
+            instance_id.to_string(),
+            HashSet::new(),
+        );
+        assert_eq!(poll().as_deref(), Some(sidecar_uuid));
+
+        match old_val {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+        std::fs::remove_dir_all(&hook_dir).ok();
+    }
+
+    #[test]
+    #[serial]
+    fn test_claude_poll_fn_skips_stale_sidecar_falls_through_to_disk() {
+        let instance_id = "test_sidecar_stale_falls_through";
+        let hook_dir = std::path::PathBuf::from("/tmp/aoe-hooks").join(instance_id);
+        std::fs::create_dir_all(&hook_dir).unwrap();
+        let stale_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let sidecar_path = hook_dir.join("session_id");
+        std::fs::write(&sidecar_path, stale_uuid).unwrap();
+        let stale = std::time::SystemTime::now() - Duration::from_secs(10 * 60);
+        std::fs::File::options()
+            .write(true)
+            .open(&sidecar_path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(stale))
+            .unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("projects").join("-tmp-myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let disk_uuid = "11111111-2222-3333-4444-555555555555";
+        std::fs::write(project_dir.join(format!("{disk_uuid}.jsonl")), "d\n").unwrap();
+
+        let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
+
+        let poll = claude_poll_fn(
+            "/tmp/myproject".to_string(),
+            None,
+            instance_id.to_string(),
+            HashSet::new(),
+        );
+        assert_eq!(poll().as_deref(), Some(disk_uuid));
+
+        match old_val {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+        std::fs::remove_dir_all(&hook_dir).ok();
+    }
+
+    #[test]
+    #[serial]
+    fn test_capture_claude_session_active_newer_wins_over_anchor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("projects").join("-tmp-myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let uuid_anchor = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let uuid_active = "11111111-2222-3333-4444-555555555555";
+
+        std::fs::write(project_dir.join(format!("{uuid_anchor}.jsonl")), "k\n").unwrap();
+        let anchor_time = std::time::SystemTime::now() - Duration::from_secs(60);
+        std::fs::File::options()
+            .write(true)
+            .open(project_dir.join(format!("{uuid_anchor}.jsonl")))
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(anchor_time))
+            .unwrap();
+        std::fs::write(project_dir.join(format!("{uuid_active}.jsonl")), "a\n").unwrap();
+
+        let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
+
+        assert_eq!(
+            capture_claude_session_id("/tmp/myproject", Some(uuid_anchor), &HashSet::new())
+                .unwrap(),
+            uuid_active
+        );
+
+        match old_val {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
         }
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1434,6 +1434,12 @@ impl Instance {
                 super::environment::redact_env_values(v)
             })
         );
+
+        if self.tool == "claude" {
+            let sidecar = crate::hooks::hook_status_dir(&self.id).join("session_id");
+            let _ = std::fs::remove_file(&sidecar);
+        }
+
         session.create_with_size(&self.project_path, cmd.as_deref(), size)?;
 
         self.finalize_launch(session.name(), &profile);
@@ -1723,12 +1729,28 @@ impl Instance {
 
     /// Post-launch setup: persist state, start pollers, and apply tmux options.
     fn finalize_launch(&mut self, session_name: &str, profile: &str) {
-        if let Err(e) = crate::tmux::env::set_hidden_env(
+        let claude_sid: Option<String> = if self.tool == "claude" {
+            self.agent_session_id.clone()
+        } else {
+            None
+        };
+
+        let mut entries: Vec<(&str, &str, &str)> = vec![(
             session_name,
             crate::tmux::env::AOE_INSTANCE_ID_KEY,
             &self.id,
-        ) {
-            tracing::warn!(target: "session.store", "Failed to set AOE_INSTANCE_ID in tmux env: {}", e);
+        )];
+        if let Some(ref sid) = claude_sid {
+            entries.push((
+                session_name,
+                crate::tmux::env::AOE_CAPTURED_SESSION_ID_KEY,
+                sid.as_str(),
+            ));
+        }
+        if let Err(e) = crate::tmux::env::set_hidden_env_batch(&entries) {
+            let keys: Vec<&str> = entries.iter().map(|(_, k, _)| *k).collect();
+            tracing::warn!(target: "session.store",
+                "Failed to set tmux env keys [{}] at finalize_launch: {}", keys.join(", "), e);
         }
 
         self.persist_session_id(profile);
@@ -1870,11 +1892,16 @@ impl Instance {
                     Box::new(claude_poll_fn_sandboxed(
                         container_name,
                         self.container_workdir(),
+                        initial_known.clone(),
+                        instance_id.clone(),
+                        extra_excludes.clone(),
                     ))
                 } else {
                     Box::new(claude_poll_fn(
                         self.project_path.clone(),
                         initial_known.clone(),
+                        instance_id.clone(),
+                        extra_excludes.clone(),
                     ))
                 }
             }

--- a/tests/integration/parallel_capture.rs
+++ b/tests/integration/parallel_capture.rs
@@ -164,9 +164,10 @@ fn test_parallel_launch_unique_session_ids() {
         );
     }
 
-    // In a tight parallel race, threads may see the same (empty) exclusion set
-    // and pick the same candidate. This is inherent to the optimistic approach.
-    // The sequential test below validates strict uniqueness.
+    // Strict uniqueness is not asserted: agents that discover their session
+    // id post-launch (vibe/codex/etc.) can produce duplicates when racing
+    // pollers observe an empty exclusion set. Per-agent capture tests cover
+    // the agent-specific paths.
     let unique: HashSet<String> = captured.into_iter().flatten().collect();
     assert!(!unique.is_empty(), "No session IDs were captured at all");
 }


### PR DESCRIPTION
## Description

Multiple AoE Claude sessions sharing one project path or container volume could cross-assign each other's session UUIDs at launch and after `/clear`, `/new`, or `--fork-session`.

Replaces the anchor-only approach in #1572 with three converging mechanisms in `claude_poll_fn` / `claude_poll_fn_sandboxed`:

1. **Synchronous `AOE_CAPTURED_SESSION_ID` publish at `finalize_launch`** (batched with `AOE_INSTANCE_ID`), so peers' `build_exclusion_set` sees this session's claim before the first poll tick.

2. **Per-tick `compose_exclusion` + revised tie-break** in `scan_claude_project_dir` and `select_claude_session_in_container`: excluded UUIDs are filtered out of candidates; the anchor wins unless an unexcluded candidate is strictly newer. Aligns Claude with the exclusion contract the other agents already use.

3. **Hook-driven sidecar** `/tmp/aoe-hooks/<id>/session_id`, written by Claude's `SessionStart` / `UserPromptSubmit` hooks via a POSIX pipeline with PID-suffixed tempfile + atomic `mv`. Read by the host poller before the disk scan; honors per-instance `extra_excludes`; pre-launch cleanup wipes stale values.

Sandboxed parity: `claude_poll_fn_sandboxed` now threads `instance_id` + `extra_excludes` + `last_known` anchor; `capture_claude_session_id_in_container` runs under `run_with_timeout(5s)` like the other sandboxed scanners.

`CLAUDE_CURSOR_HOOK_EVENTS` is split into `CLAUDE_HOOK_EVENTS` (with `session_id_capture`) and `CURSOR_HOOK_EVENTS` (status writers only) so Cursor does not install a capture command with no consumer.

Related to #1522 (host-side cross-assignment fix landed in #1523; this PR adds the sandboxed-fleet parity and the hook-based fast path). Supersedes #1572 (anchor-only attempt that the maintainer rejected as treating a symptom).

Overlap with #1731 (broader observation/intent split + CAS guards on writers): this PR's synchronous publish at `finalize_launch` and the Claude-specific exclusion plumbing are independent of #1731's `ResumeIntent` refactor; either can land first, with conflict-resolution at the call sites in `instance.rs`.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass (`cargo test --lib`: 2501 passed, 0 failed)
- [x] Documentation was updated where necessary (rustdoc on changed functions)
- [x] For UI changes: included screenshot or recording (N/A — internal session tracking)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: regression coverage lives at the unit layer where the race occurs. 18 new tests in `src/session/capture.rs` and `src/hooks/*` cover the scanner tie-break (anchor-vs-best, exclusion filtering), sidecar reader (mtime gate, UUID validation), hook command extraction (compact, multi-line, nested, prompt-injection, uppercase UUID, atomic write), and `build_aoe_hooks` restructure. End-to-end coverage of two Claude sessions sharing a project path requires a fake-hook harness; filed as follow-up.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (Claude Code), reviewed by @jerome-benoit.

**Any Additional AI Details you'd like to share:** Diff went through four adversarial review rounds (oracle architecture critic + behavioral truth-table + plan critic). Issues raised (regex prompt injection, multi-line JSON, sidecar leak past `extra_excludes`, exclusion-leak via anchor in tie-break, uppercase UUIDs, dead match arm) are closed with regression tests.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a race where multiple Claude sessions sharing the same project path or container volume could capture and assign each other’s session UUIDs, causing wrong-session resume and clobbered resume targets.

High-level changes (non-technical)
- Prevents cross-instance session-id theft with three coordinated mechanisms: immediate publish-at-launch, per-poll exclusion + stronger tie-breaks, and a hook-driven per-instance sidecar that surfaces session IDs quickly and atomically.
- Adds per-instance bookkeeping (instance ID + exclusion sets) so pollers avoid adopting IDs claimed by peers.
- Brings parity between host and sandbox/container flows so the fix applies to both local and containerized Claude sessions.
- Adds sidecar read/write logic, hook-generation changes, and ~18 unit tests covering tie-breaks, sidecar behavior, extraction robustness, atomic writes, and related edge cases.

What changed / moved / added / removed (concise)
- Added hook-driven session-id sidecar: hooks write /tmp/aoe-hooks/<instance_id>/session_id via a PID-suffixed tempfile + atomic mv; the host poller reads this before filesystem scanning.
- Replaced the previous anchor-only approach with three converging measures:
  1) synchronous publish of AOE_CAPTURED_SESSION_ID at finalize_launch (batched with AOE_INSTANCE_ID) so peers see claims before the first poll tick;
  2) per-tick compose_exclusion and exclusion-aware scanning with a stricter anchor-vs-newest tie-break (excluded UUIDs filtered out);
  3) sidecar-first capture via hook-written per-instance session_id files with freshness and UUID validation.
- Threaded instance_id, extra_excludes, and last_known anchor through poller and sandboxed/container capture APIs.
- Split hook constants: CLAUDE_HOOK_EVENTS (session_id_capture true for SessionStart and UserPromptSubmit) and CURSOR_HOOK_EVENTS (no capture).
- Added read_hook_session_id with freshness/UUID validation and SESSION_ID_SIDECAR_MAX_AGE.
- Instance lifecycle: pre-launch sidecar cleanup for Claude; Instance::finalize_launch now atomically publishes AOE_INSTANCE_ID and conditionally AOE_CAPTURED_SESSION_ID.
- Tests: ~18 new unit tests; cargo lib tests passed in CI.

Benefits
- Eliminates cross-assignment of session IDs when multiple sessions share paths/volumes.
- Ensures sessions resume their intended conversations and prevents accidental mass reassignment.
- Faster, more reliable capture (hook sidecar) and robust fallback (filesystem scan) that work in both host and sandboxed environments.
- Resilient to malformed/nested payloads, stale sidecars, and concurrent hook invocations.

Technical details (concise)
- HookEvent gained session_id_capture: bool; per-agent hook arrays updated (src/agents.rs).
- New public function read_hook_session_id(instance_id: &str) -> Option<String) and constant SESSION_ID_SIDECAR_MAX_AGE (src/hooks/status_file.rs).
- New hook_command_session_id() generator and build_aoe_hooks now emit session-id extractor commands when session_id_capture is set; extractor collapses JSON, finds the first top-level session_id via UUID-matching, writes via PID-suffixed tempfile, then atomic mv (src/hooks/mod.rs).
- capture_claude_session_id, scan_claude_project_dir, and related functions now accept exclusion sets and honor them; excluded lastSessionId causes rejection.
- Added select_claude_session_in_container and updated capture_claude_session_id_in_container to accept exclusion and known anchor; sandboxed capture runs with a short timeout and threads instance_id/extra_excludes through claude_poll_fn_sandboxed.
- Instance::start_with_size_opts removes stale per-instance session_id sidecar before launch for Claude.
- Documentation updated (guides, quick-start, rustdoc). PR supersedes `#1572` and addresses `#1522`; AI-assisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
