### PR TITLE
feat(cockpit): observable, force-stoppable cancel that kills runaway loops

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -188,6 +188,14 @@ reopening the tab on the same origin) keeps them across the reconnect
 window. Server-side durability is not currently implemented; clearing
 site data wipes the queue.
 
+## Stopping a turn
+
+While an agent turn is running, the composer shows a **Stop** button. Clicking it sends a graceful cancel to the agent and the working spinner switches to **Stopping...** with a short countdown to the escalation deadline.
+
+Some tools the agent runs internally (a monitor or `until` loop, a long blocking command) do not honor a graceful cancel. When that happens a **Force stop** button appears next to the spinner, even while a tool is in flight. Force stop ends the turn immediately: it restarts the agent worker and kills the whole command tree the agent had running, so a runaway loop actually stops instead of waiting out the grace window. Clicking **Stop** again while it already reads "Stopping..." does the same thing.
+
+Force stop is a hard interrupt. The agent resumes from its saved transcript on the next prompt, but any partial output from the tool that was in flight is lost. Reach for **Force stop** only when a turn is genuinely wedged; the graceful **Stop** is enough for a turn that is merely taking a while.
+
 ## Timeline card grouping
 
 To keep the timeline readable, cockpit folds two kinds of runs into

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -849,6 +849,7 @@ fn event_kind(event: &crate::cockpit::Event) -> &'static str {
         Event::ConfigOptionSwitchFailed { .. } => "config_option_switch_failed",
         Event::RawAgentUpdate { .. } => "raw_agent_update",
         Event::AgentMessageChunk { .. } => "agent_message_chunk",
+        Event::CancelRequested { .. } => "cancel_requested",
         Event::Stopped { .. } => "stopped",
         Event::AgentStartupError { .. } => "agent_startup_error",
         Event::IncompatibleAgent { .. } => "incompatible_agent",

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -292,6 +292,9 @@ enum ClientCmd {
     /// forwards them to `session/prompt`. See #1000.
     Prompt(Vec<ContentBlock>),
     Cancel,
+    /// Force-stop now: end the in-flight turn with `user_forced` and let
+    /// the drain task kill the worker process group + respawn. See #1727.
+    ForceStop,
     SetMode(String),
     /// Send `session/set_config_option` for the given (`config_id`,
     /// `value`) pair. The connection task fires the request detached so
@@ -1561,6 +1564,22 @@ impl AcpClient {
         let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
         cmd_tx
             .send(ClientCmd::Cancel)
+            .await
+            .map_err(|_| AcpError::AgentExited)
+    }
+
+    /// Force-stop the in-flight turn immediately, bypassing the 10s
+    /// cancel-escalation grace. If a prompt is in flight the connection
+    /// task ends the turn with `Stopped { reason: "user_forced" }`, which
+    /// the drain task treats like `agent_unresponsive`: it kills the
+    /// worker's process group and respawns with `session/load`. This is
+    /// the only lever that reliably stops a tool the agent runs
+    /// internally (a monitor/until loop) and ignores `session/cancel` on.
+    /// Best-effort: returns Ok even if no turn is in flight. See #1727.
+    pub async fn force_cancel(&self) -> Result<(), AcpError> {
+        let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
+        cmd_tx
+            .send(ClientCmd::ForceStop)
             .await
             .map_err(|_| AcpError::AgentExited)
     }
@@ -4120,6 +4139,11 @@ async fn run_connection_task<W, R>(
                         // stop from a clean turn completion.
                         let mut prompt_cancelled = false;
                         let mut cancelling = false;
+                        // Set when the user clicked "Force stop": ends the
+                        // turn with `user_forced` so the drain task kills the
+                        // process group + respawns, instead of waiting out
+                        // the 10s grace. See #1727.
+                        let mut force_stopped = false;
                         let cancel_grace = tokio::time::sleep(CANCEL_ESCALATION_GRACE);
                         tokio::pin!(cancel_grace);
 
@@ -4284,7 +4308,40 @@ async fn run_connection_task<W, R>(
                                                     tokio::time::Instant::now()
                                                         + CANCEL_ESCALATION_GRACE,
                                                 );
+                                                // Tell the UI a cancel is in
+                                                // flight so it can show
+                                                // "Stopping..." with an honest
+                                                // escalation countdown instead
+                                                // of a silent spinner. Once per
+                                                // turn. See #1727.
+                                                let escalates_at = chrono::Utc::now()
+                                                    + chrono::Duration::from_std(
+                                                        CANCEL_ESCALATION_GRACE,
+                                                    )
+                                                    .unwrap_or_else(|_| {
+                                                        chrono::Duration::seconds(10)
+                                                    });
+                                                let _ = event_tx_for_block
+                                                    .send(Event::CancelRequested { escalates_at })
+                                                    .await;
                                             }
+                                        }
+                                        Some(ClientCmd::ForceStop) => {
+                                            warn!(
+                                                target: "cockpit.acp",
+                                                "force-stop requested during in-flight prompt; ending turn and restarting worker"
+                                            );
+                                            // Best-effort cancel notification
+                                            // first (protocol politeness); the
+                                            // real lever is ending the turn so
+                                            // the drain task kills the process
+                                            // group and respawns. See #1727.
+                                            let _ = connection.send_notification(
+                                                CancelNotification::new(acp_session_id.clone()),
+                                            );
+                                            force_stopped = true;
+                                            shutdown = true;
+                                            break;
                                         }
                                         Some(ClientCmd::SetConfigOption { config_id, value }) => {
                                             info!(
@@ -4489,6 +4546,13 @@ async fn run_connection_task<W, R>(
                             "rate_limited"
                         } else if prompt_orphaned {
                             "prompt_orphaned"
+                        } else if force_stopped {
+                            // Explicit user "Force stop": the drain task
+                            // treats this like `agent_unresponsive` (kill
+                            // process group + respawn) but the reason
+                            // string keeps the user-initiated signal
+                            // distinct in postmortems. See #1727.
+                            "user_forced"
                         } else if agent_unresponsive {
                             "agent_unresponsive"
                         } else if shutdown {
@@ -4517,6 +4581,15 @@ async fn run_connection_task<W, R>(
                         info!(target: "cockpit.acp", "sending session/cancel (no prompt in flight)");
                         connection
                             .send_notification(CancelNotification::new(acp_session_id.clone()))?;
+                    }
+                    Some(ClientCmd::ForceStop) => {
+                        // No prompt in flight: nothing to kill here. The
+                        // supervisor's force_end_turn publishes a synthetic
+                        // `Stopped` to free a wedged UI (#1100); we only send
+                        // a best-effort cancel notification. See #1727.
+                        info!(target: "cockpit.acp", "force-stop requested with no prompt in flight; best-effort cancel only");
+                        let _ = connection
+                            .send_notification(CancelNotification::new(acp_session_id.clone()));
                     }
                     Some(ClientCmd::SetMode(mode_id)) => {
                         info!(target: "cockpit.acp", "sending session/set_mode mode={mode_id}");

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -4544,15 +4544,20 @@ async fn run_connection_task<W, R>(
                         //     #1240.
                         let reason = if rate_limited {
                             "rate_limited"
+                        } else if force_stopped {
+                            // Explicit user "Force stop" wins over the
+                            // orphan/unresponsive watchdog reasons: it's the
+                            // proximate cause of THIS turn ending (we broke
+                            // the loop the moment the user clicked), so it
+                            // must not be masked by a prompt_orphaned flag
+                            // that was set earlier. The drain task treats it
+                            // like `agent_unresponsive` (kill process group +
+                            // respawn) but the reason string keeps the
+                            // user-initiated signal distinct in postmortems.
+                            // See #1727.
+                            "user_forced"
                         } else if prompt_orphaned {
                             "prompt_orphaned"
-                        } else if force_stopped {
-                            // Explicit user "Force stop": the drain task
-                            // treats this like `agent_unresponsive` (kill
-                            // process group + respawn) but the reason
-                            // string keeps the user-initiated signal
-                            // distinct in postmortems. See #1727.
-                            "user_forced"
                         } else if agent_unresponsive {
                             "agent_unresponsive"
                         } else if shutdown {

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -1108,6 +1108,7 @@ fn event_kind(event: &Event) -> &'static str {
         Event::ConfigOptionSwitchFailed { .. } => "config_option_switch_failed",
         Event::RawAgentUpdate { .. } => "raw_agent_update",
         Event::AgentMessageChunk { .. } => "agent_message_chunk",
+        Event::CancelRequested { .. } => "cancel_requested",
         Event::Stopped { .. } => "stopped",
         Event::AgentStartupError { .. } => "agent_startup_error",
         Event::IncompatibleAgent { .. } => "incompatible_agent",

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -607,6 +607,17 @@ pub enum Event {
     AgentMessageChunk {
         text: String,
     },
+    /// A cancel was requested for the in-flight turn: aoe sent the ACP
+    /// `session/cancel` notification and armed the escalation watchdog.
+    /// The turn is NOT over yet (no `Stopped`); this lets the UI show a
+    /// "Stopping..." state and reveal a force-stop affordance instead of
+    /// a silent spinner. `escalates_at` is when the watchdog will SIGTERM
+    /// the worker if the agent keeps ignoring the cancel, so the UI can
+    /// show an honest countdown without depending on a local timer for
+    /// correctness. Emitted once per turn on the first cancel. See #1727.
+    CancelRequested {
+        escalates_at: DateTime<Utc>,
+    },
     /// Final stop signal from the agent. Carries an opaque reason string
     /// so the UI can render "completed" / "ended early" / "cancelled".
     Stopped {
@@ -868,6 +879,11 @@ impl CockpitState {
             // made progress.
             Event::RawAgentUpdate { .. } => {}
             Event::AgentMessageChunk { .. } => {}
+            // No in-memory mutation: the turn is still active (turnActive
+            // stays true until a real `Stopped`). The reducer/UI derive the
+            // "Stopping..." state from the broadcast/replayed event. Bumps
+            // seq so the WS replay surfaces it to live clients. See #1727.
+            Event::CancelRequested { .. } => {}
             Event::Stopped { .. } => {}
             Event::AgentStartupError { .. } => {}
             Event::IncompatibleAgent { detail } => {

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1205,7 +1205,14 @@ impl<S: BroadcastSink> Supervisor<S> {
                     let mut rate_limited = false;
                     while let Some(event) = inbound.recv().await {
                         if let Event::Stopped { reason } = &event {
-                            if reason == "agent_unresponsive" || reason == "prompt_orphaned" {
+                            if reason == "agent_unresponsive"
+                                || reason == "prompt_orphaned"
+                                || reason == "user_forced"
+                            {
+                                // `user_forced` is the explicit "Force stop":
+                                // same recovery as a wedged agent (kill the
+                                // worker process group, respawn, session/load).
+                                // See #1727.
                                 agent_unresponsive = true;
                             } else if reason == "rate_limited" {
                                 rate_limited = true;
@@ -1300,21 +1307,28 @@ impl<S: BroadcastSink> Supervisor<S> {
                     if agent_unresponsive {
                         #[cfg(unix)]
                         {
-                            use nix::sys::signal::{kill, Signal};
+                            use nix::sys::signal::{killpg, Signal};
                             use nix::unistd::Pid;
                             let old_pid = super::worker_registry::load(&session_id)
                                 .ok()
                                 .flatten()
                                 .map(|r| r.pid);
                             if let Some(pid) = old_pid {
+                                // The runner is spawned via `setsid`, so it
+                                // leads its own process group (PGID == PID).
+                                // Signal the whole GROUP, not just the runner
+                                // PID, so a tool the agent ran internally (a
+                                // monitor/until loop spawned as a grandchild
+                                // of claude-agent-acp) dies too instead of
+                                // surviving the restart orphaned. See #1727.
                                 if super::worker_registry::is_pid_alive(pid) {
                                     info!(
                                         target: "cockpit.supervisor",
                                         session = %session_id,
                                         pid,
-                                        "SIGTERM wedged runner before respawn (agent_unresponsive)"
+                                        "SIGTERM wedged runner process group before respawn (agent_unresponsive)"
                                     );
-                                    let _ = kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
+                                    let _ = killpg(Pid::from_raw(pid as i32), Signal::SIGTERM);
                                 }
                                 // Poll for the runner to exit before
                                 // proceeding to respawn. ~3s budget, 100ms
@@ -1335,7 +1349,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                                         pid,
                                         "wedged runner survived SIGTERM grace; escalating to SIGKILL"
                                     );
-                                    let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
+                                    let _ = killpg(Pid::from_raw(pid as i32), Signal::SIGKILL);
                                     // One more brief tick for the kernel
                                     // to reap and the socket inode to
                                     // drop. We don't loop forever; spawn
@@ -1651,14 +1665,24 @@ impl<S: BroadcastSink> Supervisor<S> {
         Ok(())
     }
 
-    /// Escape hatch for the "spinner stuck because we never saw the
-    /// agent's `Stopped`" failure mode (#1100). Publishes a synthetic
-    /// `Stopped { reason: "user_forced" }` through the sink so every
-    /// connected UI flips `turnActive` off and any client-side prompt
-    /// queue can drain, then sends a best-effort `session/cancel` to
-    /// the agent in case it really is mid-turn. Idempotent: a second
-    /// call just publishes another (no-op for the reducer) Stopped.
+    /// User-initiated "Force stop". Two failure modes to cover:
+    ///
+    /// 1. A turn is genuinely in flight and the agent is ignoring
+    ///    `session/cancel` (a monitor/until loop). `force_cancel` ends the
+    ///    turn with `Stopped { reason: "user_forced" }` through the drain
+    ///    task, which kills the worker process group and respawns with
+    ///    `session/load`. This is what actually stops the runaway loop.
+    /// 2. The daemon already finished the turn but the UI is wedged on a
+    ///    `Stopped` it never saw (#1100). The synthetic `Stopped` published
+    ///    below frees `turnActive` for every connected UI immediately.
+    ///
+    /// Both are best-effort and idempotent: the synthetic `Stopped` bypasses
+    /// the drain (so it never triggers a restart on its own), and a second
+    /// `Stopped` is a capped no-op for the reducer. See #1727 / #1100.
     pub async fn force_end_turn(&self, session_id: &str) {
+        if let Ok(client) = self.client_for_session(session_id).await {
+            let _ = client.force_cancel().await;
+        }
         let seq = next_seq(&self.next_seqs, session_id);
         self.sink.publish(
             session_id,
@@ -1667,11 +1691,6 @@ impl<S: BroadcastSink> Supervisor<S> {
                 reason: "user_forced".into(),
             },
         );
-        // Best-effort cancel; ignore UnknownSession because the headline
-        // intent is "free the UI", which the publish above already did.
-        if let Ok(client) = self.client_for_session(session_id).await {
-            let _ = client.cancel_prompt().await;
-        }
     }
 
     /// Set the active session mode via ACP session/set_mode.

--- a/src/cockpit/terminal_handler.rs
+++ b/src/cockpit/terminal_handler.rs
@@ -140,7 +140,11 @@ impl TerminalManager {
                 cmd.args(&full_args)
                     .stdin(Stdio::null())
                     .stdout(Stdio::piped())
-                    .stderr(Stdio::piped());
+                    .stderr(Stdio::piped())
+                    // If the prompt task is dropped (worker teardown on a
+                    // force-stop / cancel-escalation restart), kill the child
+                    // instead of leaking it. See #1727.
+                    .kill_on_drop(true);
                 for (k, v) in inherit_pairs {
                     cmd.env(k, v);
                 }
@@ -152,6 +156,9 @@ impl TerminalManager {
                 .stdin(Stdio::null())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
+                // Kill the child if the prompt task is dropped on a
+                // force-stop / cancel-escalation worker teardown. See #1727.
+                .kill_on_drop(true)
                 .spawn()?,
         };
 

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -404,6 +404,7 @@ impl CockpitTranscript {
             | Event::UsageUpdated { .. }
             | Event::RawAgentUpdate { .. }
             | Event::WakeupScheduled { .. }
+            | Event::CancelRequested { .. }
             | Event::PromptRejected { .. }
             | Event::PromptCapabilities { .. }
             | Event::AgentSwitched { .. }

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -167,7 +167,16 @@ export function CockpitRuntime({
       await cockpit.sendPrompt(text, attachments);
     },
     onCancel: async () => {
-      await cockpit.cancelPrompt();
+      // First Stop sends a graceful cancel. If a cancel is already in
+      // flight (the agent is ignoring session/cancel on a stuck loop),
+      // a second Stop escalates to a force-stop instead of resending a
+      // no-op notification, so the user's instinct to click again
+      // actually ends the turn. See #1727.
+      if (cockpit.state.cancelling) {
+        await cockpit.forceEndTurn();
+      } else {
+        await cockpit.cancelPrompt();
+      }
     },
   });
 

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -1089,7 +1089,7 @@ export function WorkingSpinner({
           onClick={() => {
             void onForceEndTurn();
           }}
-          className="self-start text-xs not-italic px-2 py-1 rounded-md border border-surface-700 bg-surface-800 text-text-secondary hover:bg-surface-700 hover:text-text-primary cursor-pointer"
+          className="self-start h-8 text-xs not-italic px-2 py-1 rounded-md border border-surface-700 bg-surface-800 text-text-secondary hover:bg-surface-700 hover:text-text-primary transition-colors cursor-pointer"
           title="The agent is ignoring the stop request. Force stop restarts the agent now (it resumes from the saved transcript; partial in-flight tool output is lost)."
         >
           Force stop
@@ -1100,7 +1100,7 @@ export function WorkingSpinner({
           onClick={() => {
             void onForceEndTurn();
           }}
-          className="self-start text-xs not-italic px-2 py-1 rounded-md border border-surface-700 bg-surface-800 text-text-secondary hover:bg-surface-700 hover:text-text-primary cursor-pointer"
+          className="self-start h-8 text-xs not-italic px-2 py-1 rounded-md border border-surface-700 bg-surface-800 text-text-secondary hover:bg-surface-700 hover:text-text-primary transition-colors cursor-pointer"
           title={`No streaming activity for ${stalledSecs}s. Clears the spinner and sends a best-effort cancel to the agent.`}
         >
           Force end turn

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -401,6 +401,8 @@ function CockpitChrome({
                 <WorkingSpinner
                   thinking={state.thinking}
                   tool={state.inFlightTool?.name ?? null}
+                  cancelling={state.cancelling}
+                  cancelEscalatesAt={state.cancelEscalatesAt}
                   lastActivityRef={lastActivityRef}
                   onForceEndTurn={forceEndTurn}
                 />
@@ -971,11 +973,15 @@ function formatElapsed(seconds: number): string {
 export function WorkingSpinner({
   thinking,
   tool,
+  cancelling,
+  cancelEscalatesAt,
   lastActivityRef,
   onForceEndTurn,
 }: {
   thinking: boolean;
   tool: string | null;
+  cancelling: boolean;
+  cancelEscalatesAt: string | null;
   lastActivityRef: React.RefObject<number>;
   onForceEndTurn: () => Promise<void>;
 }) {
@@ -1019,6 +1025,27 @@ export function WorkingSpinner({
     return () => window.clearInterval(t);
   }, [lastActivityRef]);
 
+  // Live countdown to the cancel-escalation deadline while cancelling, so
+  // "Stopping…" shows when the worker will be force-restarted. Computed in
+  // an effect (not render) to keep the render pure. See #1727.
+  const [escalatesInSecs, setEscalatesInSecs] = useState<number | null>(null);
+  useEffect(() => {
+    if (!cancelEscalatesAt) {
+      setEscalatesInSecs(null);
+      return;
+    }
+    const target = new Date(cancelEscalatesAt).getTime();
+    if (Number.isNaN(target)) {
+      setEscalatesInSecs(null);
+      return;
+    }
+    const tick = () =>
+      setEscalatesInSecs(Math.max(0, Math.ceil((target - Date.now()) / 1000)));
+    tick();
+    const t = window.setInterval(tick, 1000);
+    return () => window.clearInterval(t);
+  }, [cancelEscalatesAt]);
+
   const state = deriveSpinnerState(thinking, tool);
   // Swap the rattle verb for an explicit "waiting on model" badge
   // with a live elapsed counter once the inactivity gap is clearly
@@ -1029,12 +1056,21 @@ export function WorkingSpinner({
   // #1112.
   const showStalled = stalledSecs >= forceEndTurnThresholdSecs;
   const toolInFlight = tool != null;
-  const label = showStalled
-    ? toolInFlight
-      ? `Waiting on tool… ${formatElapsed(stalledSecs)}`
-      : `Waiting on model… ${formatElapsed(stalledSecs)}`
-    : chooseVerb(state, seed, tool);
-  const showForceEnd = showStalled && !toolInFlight;
+  const label = cancelling
+    ? escalatesInSecs != null && escalatesInSecs > 0
+      ? `Stopping… (force in ${escalatesInSecs}s)`
+      : "Stopping…"
+    : showStalled
+      ? toolInFlight
+        ? `Waiting on tool… ${formatElapsed(stalledSecs)}`
+        : `Waiting on model… ${formatElapsed(stalledSecs)}`
+      : chooseVerb(state, seed, tool);
+  // A cancel is in flight: show the escape hatch even with a tool in
+  // flight (the runaway loop IS a tool in flight). The legacy
+  // force-end-turn button stays scoped to !toolInFlight so #1176's
+  // anti-flicker rule for normal Task-subagent gaps is untouched.
+  const showForceStop = cancelling;
+  const showForceEnd = !cancelling && showStalled && !toolInFlight;
 
   return (
     <div className="flex flex-col gap-2 text-sm italic text-text-muted">
@@ -1047,7 +1083,18 @@ export function WorkingSpinner({
         </span>
         <span>{label}</span>
       </div>
-      {showForceEnd ? (
+      {showForceStop ? (
+        <button
+          type="button"
+          onClick={() => {
+            void onForceEndTurn();
+          }}
+          className="self-start text-xs not-italic px-2 py-1 rounded-md border border-surface-700 bg-surface-800 text-text-secondary hover:bg-surface-700 hover:text-text-primary cursor-pointer"
+          title="The agent is ignoring the stop request. Force stop restarts the agent now (it resumes from the saved transcript; partial in-flight tool output is lost)."
+        >
+          Force stop
+        </button>
+      ) : showForceEnd ? (
         <button
           type="button"
           onClick={() => {

--- a/web/src/components/cockpit/__tests__/WorkingSpinner.test.tsx
+++ b/web/src/components/cockpit/__tests__/WorkingSpinner.test.tsx
@@ -31,6 +31,10 @@ function renderSpinner(opts: {
   /** In-flight tool name, or null for "model is silent". */
   tool: string | null;
   thinking?: boolean;
+  /** True once the user clicked Stop and aoe armed escalation (#1727). */
+  cancelling?: boolean;
+  /** ISO deadline for the escalation countdown, or null. */
+  cancelEscalatesAt?: string | null;
 }) {
   const now = Date.now();
   const ref = makeRef(now - opts.stalledSecs * 1000);
@@ -39,6 +43,8 @@ function renderSpinner(opts: {
     <WorkingSpinner
       thinking={opts.thinking ?? false}
       tool={opts.tool}
+      cancelling={opts.cancelling ?? false}
+      cancelEscalatesAt={opts.cancelEscalatesAt ?? null}
       lastActivityRef={ref}
       onForceEndTurn={onForceEndTurn}
     />,
@@ -95,5 +101,48 @@ describe("WorkingSpinner state precedence (#1213)", () => {
     renderSpinner({ stalledSecs: 1, tool: "Terminal", thinking: true });
     expect(screen.getByText(/Terminal…/)).toBeTruthy();
     expect(THINKING_VERBS.some((v) => screen.queryByText(`${v}…`))).toBe(false);
+  });
+});
+
+describe("WorkingSpinner cancelling / force-stop (#1727)", () => {
+  it("shows Stopping… and a Force stop button even while a tool is in flight", () => {
+    renderSpinner({ stalledSecs: 2, tool: "Terminal", cancelling: true });
+    expect(
+      screen.getByRole("button", { name: /force stop/i }),
+    ).toBeTruthy();
+    expect(screen.getByText(/stopping…/i)).toBeTruthy();
+    // The legacy "Force end turn" must not also render while cancelling.
+    expect(
+      screen.queryByRole("button", { name: /force end turn/i }),
+    ).toBeNull();
+  });
+
+  it("renders an escalation countdown when a deadline is provided", () => {
+    const at = new Date(Date.now() + 8000).toISOString();
+    renderSpinner({
+      stalledSecs: 1,
+      tool: "Terminal",
+      cancelling: true,
+      cancelEscalatesAt: at,
+    });
+    expect(screen.getByText(/stopping… \(force in \d+s\)/i)).toBeTruthy();
+  });
+
+  it("Force stop invokes the force-end-turn handler", () => {
+    const { onForceEndTurn } = renderSpinner({
+      stalledSecs: 1,
+      tool: "Terminal",
+      cancelling: true,
+    });
+    screen.getByRole("button", { name: /force stop/i }).click();
+    expect(onForceEndTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show force controls for a slow tool that is NOT being cancelled (#1176 preserved)", () => {
+    renderSpinner({ stalledSecs: 180, tool: "Task", cancelling: false });
+    expect(screen.queryByRole("button", { name: /force stop/i })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /force end turn/i }),
+    ).toBeNull();
   });
 });

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -1403,19 +1403,14 @@ export function useCockpit(
     }
   }, [sessionId]);
 
-  // Escape hatch for the "spinner stuck" failure mode (#1100). Locally
-  // dispatches a synthetic Stopped so the reducer flips `turnActive`
-  // off immediately, then POSTs to the daemon to publish a Stopped
-  // server-side and best-effort cancel any in-flight turn. The local
-  // dispatch is optimistic; the server echo (which lands as a real
-  // frame on the WS) is idempotent against the reducer.
+  // Escape hatch for the "spinner stuck" failure mode (#1100). POSTs to
+  // the daemon and relies on the server-published Stopped event to drive
+  // reducer state: either the synthetic free-the-UI Stopped or the
+  // user_forced one from the worker restart. We do NOT fabricate a
+  // client-side Stopped seq; the server echo flows back as a real frame
+  // on the WS. See #1727.
   const forceEndTurn = useCallback(async () => {
     if (!sessionId) return;
-    // No optimistic Stopped: that fabricated a client-side seq and lied to
-    // the UI while the worker stayed alive. The server now drives the real
-    // Stopped (either the synthetic free-the-UI one or the user_forced one
-    // from the worker restart), so we just POST and let it flow back
-    // through the event stream. See #1727.
     lastActivityRef.current = Date.now();
     try {
       const res = await fetch(

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -1411,14 +1411,11 @@ export function useCockpit(
   // frame on the WS) is idempotent against the reducer.
   const forceEndTurn = useCallback(async () => {
     if (!sessionId) return;
-    dispatch({
-      kind: "frame",
-      frame: {
-        session_id: sessionId,
-        seq: lastSeqRef.current + 1,
-        event: { Stopped: { reason: "user_forced" } },
-      },
-    });
+    // No optimistic Stopped: that fabricated a client-side seq and lied to
+    // the UI while the worker stayed alive. The server now drives the real
+    // Stopped (either the synthetic free-the-UI one or the user_forced one
+    // from the worker restart), so we just POST and let it flow back
+    // through the event stream. See #1727.
     lastActivityRef.current = Date.now();
     try {
       const res = await fetch(

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -905,6 +905,82 @@ describe("applyEvent / WakeupScheduled lifecycle", () => {
   });
 });
 
+describe("applyEvent / CancelRequested lifecycle (#1727)", () => {
+  function startedTurn() {
+    // A turn must be active for cancelling to be meaningful.
+    return applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "do a thing" } },
+    });
+  }
+
+  it("CancelRequested sets cancelling + the escalation deadline", () => {
+    const at = new Date(Date.now() + 10_000).toISOString();
+    const state = applyEvent(startedTurn(), {
+      session_id: "s-1",
+      seq: 2,
+      event: { CancelRequested: { escalates_at: at } },
+    });
+    expect(state.cancelling).toBe(true);
+    expect(state.cancelEscalatesAt).toBe(at);
+    // Turn is still active: CancelRequested is not a Stopped.
+    expect(state.turnActive).toBe(true);
+  });
+
+  it("any Stopped clears the cancelling state", () => {
+    const at = new Date(Date.now() + 10_000).toISOString();
+    let state = applyEvent(startedTurn(), {
+      session_id: "s-1",
+      seq: 2,
+      event: { CancelRequested: { escalates_at: at } },
+    });
+    expect(state.cancelling).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: { Stopped: { reason: "user_forced" } },
+    });
+    expect(state.cancelling).toBe(false);
+    expect(state.cancelEscalatesAt).toBeNull();
+    expect(state.turnActive).toBe(false);
+  });
+
+  it("a fresh user prompt clears a stale cancelling flag", () => {
+    const at = new Date(Date.now() + 10_000).toISOString();
+    let state = applyEvent(startedTurn(), {
+      session_id: "s-1",
+      seq: 2,
+      event: { CancelRequested: { escalates_at: at } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: { UserPromptSent: { text: "next turn" } },
+    });
+    expect(state.cancelling).toBe(false);
+    expect(state.cancelEscalatesAt).toBeNull();
+  });
+
+  it("replay reconstructs cancelling from the event stream", () => {
+    // REST replay applies the same ordered events; cancelling must
+    // survive a from-scratch rebuild, not depend on a local timer.
+    const at = new Date(Date.now() + 10_000).toISOString();
+    const frames = [
+      { session_id: "s-1", seq: 1, event: { UserPromptSent: { text: "go" } } },
+      {
+        session_id: "s-1",
+        seq: 2,
+        event: { CancelRequested: { escalates_at: at } },
+      },
+    ];
+    let state = emptyCockpitState();
+    for (const f of frames) state = applyEvent(state, f);
+    expect(state.cancelling).toBe(true);
+    expect(state.cancelEscalatesAt).toBe(at);
+  });
+});
+
 describe("applyEvent / SessionCleared", () => {
   // /clear wipes the model's memory. The reducer appends a divider row
   // so the renderer can fold pre-clear turns behind a disclosure

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -279,6 +279,7 @@ export type CockpitEvent =
     }
   | { RawAgentUpdate: { payload: unknown } }
   | { AgentMessageChunk: { text: string } }
+  | { CancelRequested: { escalates_at: string } }
   | { Stopped: { reason: string } }
   | { AgentStartupError: { message: string } }
   | { IncompatibleAgent: { detail: IncompatibleAgentDetail } }
@@ -509,6 +510,16 @@ export interface CockpitState {
   /** Reason the agent provided when scheduling the wakeup. Shown in
    *  the cockpit banner next to the countdown. */
   nextWakeupReason: string | null;
+  /** True between a `CancelRequested` event (aoe sent `session/cancel`
+   *  and armed the escalation watchdog) and the next `Stopped`. Drives
+   *  the "Stopping..." spinner label and reveals the Force-stop
+   *  affordance even while a tool is in flight. Cleared on any `Stopped`
+   *  and on a fresh `UserPromptSent`. See #1727. */
+  cancelling: boolean;
+  /** ISO-8601 timestamp at which the cancel-escalation watchdog will
+   *  SIGTERM the worker if the agent keeps ignoring the cancel. Lets the
+   *  UI show an honest countdown. Null when not cancelling. See #1727. */
+  cancelEscalatesAt: string | null;
   /** Set when the agent emitted `SessionContextReset` after a prior
    *  user prompt: the model's context is empty but the visible
    *  transcript is intact, so the user can opt in to fetching a
@@ -685,6 +696,8 @@ export function emptyCockpitState(): CockpitState {
     queuedPrompts: [],
     nextWakeupAt: null,
     nextWakeupReason: null,
+    cancelling: false,
+    cancelEscalatesAt: null,
     contextPrimerAvailable: null,
     rejectedPrompts: [],
     agentUnresponsive: false,
@@ -706,6 +719,10 @@ function applyNewTurnResets(next: CockpitState): void {
   next.startupError = null;
   next.lastError = null;
   next.turnActive = isTurnActive(next);
+  // A fresh turn supersedes any stale "Stopping..." state from a prior
+  // turn's cancel. See #1727.
+  next.cancelling = false;
+  next.cancelEscalatesAt = null;
   // New turn; reset the no-output detector so Stopped fires the
   // empty-output notice if the agent produces nothing.
   next.turnHasOutput = false;
@@ -1090,6 +1107,10 @@ export function applyEvent(
     // inFlightTool reset above). See #1213.
     next.thinking = false;
     sweepOpenToolCalls(next, frame.seq);
+    // The turn ended (cleanly, cancelled, force-stopped, or escalated):
+    // clear the "Stopping..." state regardless of reason. See #1727.
+    next.cancelling = false;
+    next.cancelEscalatesAt = null;
     next.lastStoppedSeq = Math.min(
       next.lastStoppedSeq + 1,
       next.pendingUserPromptSeq,
@@ -1412,6 +1433,15 @@ export function applyEvent(
   if ("WakeupScheduled" in event) {
     next.nextWakeupAt = event.WakeupScheduled.at;
     next.nextWakeupReason = event.WakeupScheduled.reason ?? null;
+    return next;
+  }
+  if ("CancelRequested" in event) {
+    // aoe sent session/cancel and armed the escalation watchdog; the
+    // turn is still active. Surface "Stopping..." and the escalation
+    // deadline so the user gets feedback instead of a silent spinner,
+    // and can reveal the Force-stop affordance. See #1727.
+    next.cancelling = true;
+    next.cancelEscalatesAt = event.CancelRequested.escalates_at;
     return next;
   }
   if ("AgentSwitched" in event) {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1223,6 +1223,21 @@
       ]
     },
     {
+      "id": "cockpit.cancel-force-stop",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/components/cockpit/__tests__/WorkingSpinner.test.tsx",
+        "src/lib/cockpitTypes.test.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx",
+        "web/src/components/cockpit/CockpitRuntime.tsx",
+        "web/src/hooks/useCockpit.ts",
+        "web/src/lib/cockpitTypes.ts"
+      ]
+    },
+    {
       "id": "cockpit.args",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Cockpit Stop was unobservable and, on a runaway loop, ineffective. Clicking Stop sent an ACP `session/cancel` notification that claude-agent-acp ignores while a tool is blocking (a monitor/until loop, a `block:true` bash). The UI showed a silent "Waiting on model..." spinner with no feedback, the "Force end turn" button was hidden whenever a tool was in flight, and the only thing that actually ended such a turn was a blind 10s escalation watchdog that SIGTERMed only the runner PID, so a loop the agent ran as a grandchild process could survive the restart. Users spammed Stop until the worker died.

This makes Stop observable, immediately escalatable, and actually fatal to the loop:

- A new sequenced `CancelRequested { escalates_at }` cockpit event is emitted when aoe sends `session/cancel`. The web reducer derives a `cancelling` state from it (cleared on any `Stopped` and on a fresh prompt), so the spinner shows "Stopping... (force in Ns)" instead of a silent rattle. Derived purely from the event stream, so REST replay and WS reconnect reconstruct it.
- A "Force stop" affordance appears next to the spinner even while a tool is in flight (the runaway loop IS a tool in flight). The legacy "Force end turn" button stays scoped to `!cancelling && !toolInFlight`, so #1176's anti-flicker rule for normal Task-subagent gaps is untouched. A second Stop click while already cancelling escalates too.
- Force stop ends the in-flight turn immediately (`ClientCmd::ForceStop` -> `Stopped { reason: "user_forced" }`), bypassing the 10s grace. The drain task treats `user_forced` like `agent_unresponsive`: it kills the worker and respawns with `session/load`.
- The pre-respawn kill now signals the runner's whole process GROUP (`killpg`; the runner is a `setsid` group leader) with a SIGKILL fallback, so a loop the agent spawned internally dies too instead of surviving orphaned. Terminal children opened through aoe's ACP terminal host get `kill_on_drop(true)` as cheap belt-and-suspenders.
- `force_end_turn` no longer only publishes a cosmetic `Stopped`; it drives the real `force_cancel` and keeps the synthetic `Stopped` solely as the free-the-UI fallback for the daemon-idle wedge case (#1100). The web `forceEndTurn` no longer fabricates a client-side `Stopped` seq.

Out of scope (follow-ups): reworking aoe's one-shot ACP terminal handler into a streaming/killable one, and a distinct "asleep / waiting on a background job" UI state (overlaps the existing `WakeupScheduled` banner and the silent-orphan watchdog #1240).

Closes #1727

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] In the cockpit web view, start a turn that runs a long loop (e.g. ask the agent to run a bash `until` loop or a monitor that polls for a while).
- [ ] Click **Stop**. Confirm the spinner switches to **Stopping... (force in Ns)** with a live countdown instead of a silent "Waiting on model...".
- [ ] While the loop is still running (a tool is in flight), confirm a **Force stop** button is visible. Click it and confirm the turn ends promptly (well under the 10s grace) and the looping process is gone (`ps` shows no orphaned child).
- [ ] On a stuck turn, click **Stop** twice in a row and confirm the second click force-stops rather than doing nothing.
- [ ] Start a normal turn with a Task subagent that thinks for a while WITHOUT cancelling; confirm no force controls appear (no #1176 regression).
- [ ] Reload the page mid-cancel and confirm the "Stopping..." state is reconstructed from replay.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Vitest spec under `web/src/**/__tests__/` and updated `web/tests/coverage-matrix.json` (`cockpit.cancel-force-stop`): reducer `cancelling` set/clear/replay in `cockpitTypes.test.ts`, Force-stop spinner visibility + countdown + #1176 preservation in `WorkingSpinner.test.tsx`. The full in-flight-cancel live Playwright round trip is blocked by the parked cockpit prompt path (#1237, same reason `cockpit-cancel.spec.ts` is skipped); the existing `cockpit-force-end-turn.spec.ts` still covers the endpoint and now exercises the `force_cancel` path. The process-group kill is covered by the manual steps above plus CI compile.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle (cockpit-only event + web UI).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, a multi-model design debate, and implementation drafted by Claude under my direction. I made the design calls (scope, force-stop = worker restart, process-group kill), reviewed each commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR makes Cockpit's Stop flow observable, escalatable, and effective at killing runaway loops by adding a persisted "cancel requested" state, a visible countdown, and a true force-stop path that terminates the agent worker and its process tree.

### What changed (high-level)
- UI: shows a "Stopping..." spinner with a live "force in Ns" countdown and a new "Force stop" button while cancelling. The legacy "Force end turn" button remains for the non-cancelling stalled case.
- Events/state: adds a persisted CancelRequested event (with escalates_at) so cancelling state survives reconnects and event replay; the reducer exposes a boolean cancelling and cancelEscalatesAt timestamp.
- Client/server control: adds a ForceStop client command and a client-side force_cancel() API. A second Stop click while cancelling escalates to force stop.
- Kill semantics: force stop immediately yields Stopped { reason: "user_forced" } and the supervisor kills and respawns the worker. Process-group kills (killpg + SIGKILL fallback) and kill_on_drop for terminal children ensure agent-spawned child/grandchild loops are terminated.
- Behavior change: web no longer fabricates optimistic Stopped events; it waits for server-published Stopped. force_end_turn now drives the real force-cancel path.
- Tests/docs: Vitest reducer and spinner tests added; coverage matrix updated; docs updated with "Stopping a turn" section and manual testing steps.

### Benefits
- Faster interruption of stuck or looping tools and blocking child processes.
- Reduces runaway/background process leaks by killing entire process groups and marking terminal children kill-on-drop.
- Clear, persistent feedback to users during cancellation (countdown + force affordance).
- More correct UI state reconstruction after reconnects (driven by event replay).
- Avoids regression by preserving prior force-end semantics when not cancelling.

### Technical notes (concise)
- New Event::CancelRequested { escalates_at } and corresponding wire type.
- New ClientCmd::ForceStop and AcpClient::force_cancel().
- Supervisor treats user_forced like agent_unresponsive to trigger watchdog recovery.
- Unix kill uses nix::sys::signal::killpg, with SIGKILL fallback.
- TerminalManager sets kill_on_drop(true) for spawned terminal children.
- Frontend: WorkingSpinner props extended; reducer fields cancelling/cancelEscalatesAt; tests added for reducer and spinner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->