### PR TITLE
feat(cockpit): slash-command picker in the TUI composer

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -55,7 +55,11 @@ status banner at the bottom of the screen shows the current focus.
 | Composer    | `Enter`         | Send the buffered text, or queue it if a turn is active |
 | Composer    | `Shift+Enter`   | Insert a newline (multi-line prompts)                 |
 | Composer    | `Enter` (empty) | Retry draining the queue when idle (e.g. after a failed send) |
-| Composer    | `Esc`           | Return focus to the transcript                        |
+| Composer    | `/`             | Type a slash at the start of an empty line to open the command picker |
+| Composer    | `↑` / `↓`       | Move the picker highlight (picker open)               |
+| Composer    | `Ctrl+n` / `Ctrl+p` | Move the picker highlight down / up (picker open) |
+| Composer    | `Enter` / `Tab` | Insert the highlighted command (picker open)          |
+| Composer    | `Esc`           | Dismiss the picker, or return focus to the transcript |
 | Transcript  | `j` / `↓`       | Scroll down one line                                  |
 | Transcript  | `k` / `↑`       | Scroll up one line                                    |
 | Transcript  | `PgDn` / `PgUp` | Scroll ten lines                                      |
@@ -71,6 +75,18 @@ status banner at the bottom of the screen shows the current focus.
 | Any         | `Ctrl+C`        | Cancel the in-flight prompt                           |
 | Any         | `Ctrl+O`        | Open the session in the web dashboard                 |
 | Any         | `Ctrl+X`        | Clear every queued (not-yet-sent) prompt              |
+
+**Slash-command picker.** When the composer holds a single-word
+slash query (`/comp`, no spaces yet), a picker floats above the
+composer listing the agent's advertised commands ranked against what
+you typed, the same ranking the web composer uses. Navigate with the
+arrows or `Ctrl+n` / `Ctrl+p`, then press `Enter` or `Tab` to insert
+`/{command} ` into the composer (it does not auto-send, so you can
+add arguments first). `Esc` dismisses the picker without inserting;
+it stays closed until the query text changes, so cursor movement
+won't reopen it. A slash query with no matching command is left
+alone: `Enter` sends it verbatim. The picker only appears once the
+agent has advertised commands over the ACP stream.
 
 **Focus isolation.** Approval keys (`a`/`Shift+A`/`d`) only resolve
 when the approval card itself has focus. Typing "always allow" into

--- a/src/tui/cockpit_view/input.rs
+++ b/src/tui/cockpit_view/input.rs
@@ -39,16 +39,32 @@ pub enum Intent {
     OpenInBrowser,
     /// Move focus to the named region.
     SetFocus(Focus),
+    /// Move the slash-picker highlight by one row (positive = down).
+    SlashMove(i32),
+    /// Insert the highlighted slash command into the composer.
+    SlashAccept,
+    /// Dismiss the slash picker without inserting, latching the query.
+    SlashDismiss,
     /// Exit the cockpit view; return to the home screen.
     Exit,
     /// Nothing to do (unhandled key).
     Ignore,
 }
 
+/// Ambient state the dispatcher needs beyond the raw key: whether an
+/// approval is pending (gates Tab routing) and whether the slash picker
+/// is currently open (claims navigation keys in the composer). Passed
+/// as a struct instead of positional bools so call sites stay readable.
+#[derive(Debug, Clone, Copy)]
+pub struct InputContext {
+    pub has_pending_approval: bool,
+    pub slash_picker_open: bool,
+}
+
 /// Translate a key event into an [`Intent`] based on the current
 /// focus. Pure function so the entire focus model is unit-testable
 /// without instantiating a real ratatui surface.
-pub fn dispatch(focus: Focus, key: &KeyEvent, has_pending_approval: bool) -> Intent {
+pub fn dispatch(focus: Focus, key: &KeyEvent, ctx: InputContext) -> Intent {
     // Universal: Ctrl-C cancels any in-flight prompt (matches the web
     // composer's stop button). We intentionally do NOT exit the view
     // on Ctrl-C because the user's natural reflex from a tmux session
@@ -71,13 +87,29 @@ pub fn dispatch(focus: Focus, key: &KeyEvent, has_pending_approval: bool) -> Int
     }
 
     match focus {
-        Focus::Composer => composer_keys(key),
-        Focus::Transcript => transcript_keys(key, has_pending_approval),
+        Focus::Composer => composer_keys(key, ctx.slash_picker_open),
+        Focus::Transcript => transcript_keys(key, ctx.has_pending_approval),
         Focus::Approval => approval_keys(key),
     }
 }
 
-fn composer_keys(key: &KeyEvent) -> Intent {
+fn composer_keys(key: &KeyEvent, slash_picker_open: bool) -> Intent {
+    // When the picker is open it claims navigation + accept/dismiss keys
+    // so the user can drive it without the textarea swallowing them.
+    // Everything else (typing, cursor motion the picker doesn't use)
+    // falls through to the normal composer rules below.
+    if slash_picker_open {
+        match (key.modifiers, key.code) {
+            (m, KeyCode::Down) if m.is_empty() => return Intent::SlashMove(1),
+            (m, KeyCode::Up) if m.is_empty() => return Intent::SlashMove(-1),
+            (m, KeyCode::Char('n')) if m == KeyModifiers::CONTROL => return Intent::SlashMove(1),
+            (m, KeyCode::Char('p')) if m == KeyModifiers::CONTROL => return Intent::SlashMove(-1),
+            (m, KeyCode::Enter) if m.is_empty() => return Intent::SlashAccept,
+            (m, KeyCode::Tab) if m.is_empty() => return Intent::SlashAccept,
+            (m, KeyCode::Esc) if m.is_empty() => return Intent::SlashDismiss,
+            _ => {}
+        }
+    }
     match (key.modifiers, key.code) {
         // Plain Enter submits.
         (m, KeyCode::Enter) if m.is_empty() => Intent::SubmitPrompt,
@@ -152,13 +184,36 @@ mod tests {
         KeyEvent::new(code, m)
     }
 
+    /// No pending approval, picker closed: the common case for the
+    /// pre-existing focus tests.
+    fn ctx() -> InputContext {
+        InputContext {
+            has_pending_approval: false,
+            slash_picker_open: false,
+        }
+    }
+
+    fn ctx_pending() -> InputContext {
+        InputContext {
+            has_pending_approval: true,
+            slash_picker_open: false,
+        }
+    }
+
+    fn ctx_picker() -> InputContext {
+        InputContext {
+            has_pending_approval: false,
+            slash_picker_open: true,
+        }
+    }
+
     #[test]
     fn composer_swallows_approval_letters() {
         // Regression test for the composer-eats-approval bug: typing
         // "always allow" with a pending approval must NOT fire any
         // approval intent.
         for ch in "always allow deny".chars() {
-            let intent = dispatch(Focus::Composer, &key(KeyCode::Char(ch)), true);
+            let intent = dispatch(Focus::Composer, &key(KeyCode::Char(ch)), ctx_pending());
             match intent {
                 Intent::Compose(_) => {}
                 other => panic!("char {ch:?} produced {other:?} from composer focus"),
@@ -180,7 +235,7 @@ mod tests {
                         KeyModifiers::NONE
                     },
                 ),
-                true,
+                ctx_pending(),
             );
             assert!(
                 !matches!(intent, Intent::ResolveApproval(_)),
@@ -189,32 +244,32 @@ mod tests {
         }
         // But the same letters DO resolve under approval focus.
         assert!(matches!(
-            dispatch(Focus::Approval, &key(KeyCode::Char('a')), true),
+            dispatch(Focus::Approval, &key(KeyCode::Char('a')), ctx_pending()),
             Intent::ResolveApproval(ApprovalDecisionWire::Allow)
         ));
         assert!(matches!(
             dispatch(
                 Focus::Approval,
                 &key_mod(KeyCode::Char('A'), KeyModifiers::SHIFT),
-                true
+                ctx_pending()
             ),
             Intent::ResolveApproval(ApprovalDecisionWire::AllowAlways)
         ));
         assert!(matches!(
-            dispatch(Focus::Approval, &key(KeyCode::Char('d')), true),
+            dispatch(Focus::Approval, &key(KeyCode::Char('d')), ctx_pending()),
             Intent::ResolveApproval(ApprovalDecisionWire::Deny)
         ));
     }
 
     #[test]
     fn esc_from_composer_returns_focus_to_transcript() {
-        let intent = dispatch(Focus::Composer, &key(KeyCode::Esc), false);
+        let intent = dispatch(Focus::Composer, &key(KeyCode::Esc), ctx());
         assert_eq!(intent, Intent::SetFocus(Focus::Transcript));
     }
 
     #[test]
     fn esc_from_transcript_exits() {
-        let intent = dispatch(Focus::Transcript, &key(KeyCode::Esc), false);
+        let intent = dispatch(Focus::Transcript, &key(KeyCode::Esc), ctx());
         assert_eq!(intent, Intent::Exit);
     }
 
@@ -224,7 +279,7 @@ mod tests {
             let intent = dispatch(
                 focus,
                 &key_mod(KeyCode::Char('c'), KeyModifiers::CONTROL),
-                true,
+                ctx_pending(),
             );
             assert_eq!(intent, Intent::CancelInFlight);
         }
@@ -236,13 +291,13 @@ mod tests {
             let intent = dispatch(
                 focus,
                 &key_mod(KeyCode::Char('x'), KeyModifiers::CONTROL),
-                false,
+                ctx(),
             );
             assert_eq!(intent, Intent::ClearQueue);
         }
         // Plain 'x' in the composer is still a typed character.
         assert!(matches!(
-            dispatch(Focus::Composer, &key(KeyCode::Char('x')), false),
+            dispatch(Focus::Composer, &key(KeyCode::Char('x')), ctx()),
             Intent::Compose(_)
         ));
     }
@@ -250,16 +305,16 @@ mod tests {
     #[test]
     fn plain_o_opens_browser_only_from_transcript() {
         // Composer focus must pass through.
-        let composer = dispatch(Focus::Composer, &key(KeyCode::Char('o')), false);
+        let composer = dispatch(Focus::Composer, &key(KeyCode::Char('o')), ctx());
         assert!(matches!(composer, Intent::Compose(_)));
         // Transcript focus opens browser.
-        let transcript = dispatch(Focus::Transcript, &key(KeyCode::Char('o')), false);
+        let transcript = dispatch(Focus::Transcript, &key(KeyCode::Char('o')), ctx());
         assert_eq!(transcript, Intent::OpenInBrowser);
     }
 
     #[test]
     fn enter_in_composer_submits() {
-        let intent = dispatch(Focus::Composer, &key(KeyCode::Enter), false);
+        let intent = dispatch(Focus::Composer, &key(KeyCode::Enter), ctx());
         assert_eq!(intent, Intent::SubmitPrompt);
     }
 
@@ -268,29 +323,89 @@ mod tests {
         let intent = dispatch(
             Focus::Composer,
             &key_mod(KeyCode::Enter, KeyModifiers::SHIFT),
-            false,
+            ctx(),
         );
         assert!(matches!(intent, Intent::Compose(_)));
     }
 
     #[test]
     fn tab_from_transcript_routes_to_approval_when_pending() {
-        let with_pending = dispatch(Focus::Transcript, &key(KeyCode::Tab), true);
+        let with_pending = dispatch(Focus::Transcript, &key(KeyCode::Tab), ctx_pending());
         assert_eq!(with_pending, Intent::SetFocus(Focus::Approval));
-        let without = dispatch(Focus::Transcript, &key(KeyCode::Tab), false);
+        let without = dispatch(Focus::Transcript, &key(KeyCode::Tab), ctx());
         assert_eq!(without, Intent::SetFocus(Focus::Composer));
     }
 
     #[test]
     fn vim_scroll_keys_only_active_in_transcript() {
         assert_eq!(
-            dispatch(Focus::Transcript, &key(KeyCode::Char('j')), false),
+            dispatch(Focus::Transcript, &key(KeyCode::Char('j')), ctx()),
             Intent::Scroll(1)
         );
         // 'j' in composer is a typed character, not a scroll.
         assert!(matches!(
-            dispatch(Focus::Composer, &key(KeyCode::Char('j')), false),
+            dispatch(Focus::Composer, &key(KeyCode::Char('j')), ctx()),
             Intent::Compose(_)
         ));
+    }
+
+    #[test]
+    fn picker_open_claims_navigation_and_accept_keys() {
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Down), ctx_picker()),
+            Intent::SlashMove(1)
+        );
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Up), ctx_picker()),
+            Intent::SlashMove(-1)
+        );
+        assert_eq!(
+            dispatch(
+                Focus::Composer,
+                &key_mod(KeyCode::Char('n'), KeyModifiers::CONTROL),
+                ctx_picker()
+            ),
+            Intent::SlashMove(1)
+        );
+        assert_eq!(
+            dispatch(
+                Focus::Composer,
+                &key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL),
+                ctx_picker()
+            ),
+            Intent::SlashMove(-1)
+        );
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Enter), ctx_picker()),
+            Intent::SlashAccept
+        );
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Tab), ctx_picker()),
+            Intent::SlashAccept
+        );
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Esc), ctx_picker()),
+            Intent::SlashDismiss
+        );
+    }
+
+    #[test]
+    fn picker_open_still_passes_typed_chars_through() {
+        // Typing a letter while the picker is open narrows the query;
+        // it must NOT be stolen as a picker command.
+        assert!(matches!(
+            dispatch(Focus::Composer, &key(KeyCode::Char('a')), ctx_picker()),
+            Intent::Compose(_)
+        ));
+    }
+
+    #[test]
+    fn picker_closed_enter_still_submits() {
+        // Focus-isolation regression: with the picker closed, Enter must
+        // submit even if an approval is pending.
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Enter), ctx_pending()),
+            Intent::SubmitPrompt
+        );
     }
 }

--- a/src/tui/cockpit_view/mod.rs
+++ b/src/tui/cockpit_view/mod.rs
@@ -12,6 +12,7 @@ pub mod input;
 pub mod queue;
 pub mod reducer;
 pub mod render;
+pub mod slash;
 pub mod state;
 
 use std::io::Stdout;
@@ -24,7 +25,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use tokio::time::Instant;
 
-use self::input::{Focus, Intent};
+use self::input::{Focus, InputContext, Intent};
 use self::state::{CockpitViewState, ToastBanner, ToastKind};
 use crate::cockpit::client::{
     require_daemon, ws_connect, DaemonEndpoint, HttpClient, ManagerError, WsError, WsMessage,
@@ -196,6 +197,7 @@ pub async fn run_for_endpoint(
                 state.transcript.apply(frame);
             }
             state.reconcile_selection();
+            state.reconcile_slash_selection();
             None
         }
         Err(e) => {
@@ -247,6 +249,7 @@ pub async fn run_for_endpoint(
                         let was_active = state.transcript.turn_active;
                         state.transcript.apply(&frame);
                         state.reconcile_selection();
+                        state.reconcile_slash_selection();
                         let now_active = state.transcript.turn_active;
                         if !was_active && now_active {
                             // Turn started (our own prompt echoed back, or
@@ -274,6 +277,7 @@ pub async fn run_for_endpoint(
                                     state.transcript.apply(frame);
                                 }
                                 state.reconcile_selection();
+                                state.reconcile_slash_selection();
                                 // Re-derived turn state from the rebuilt
                                 // transcript; the lock no longer reflects
                                 // anything observable. Drain if idle.
@@ -355,7 +359,11 @@ async fn handle_terminal_event(
     }
 
     let has_pending = !state.transcript.pending_approvals.is_empty();
-    let intent = input::dispatch(state.focus, &key, has_pending);
+    let ctx = InputContext {
+        has_pending_approval: has_pending,
+        slash_picker_open: state.slash_picker_open(),
+    };
+    let intent = input::dispatch(state.focus, &key, ctx);
     match intent {
         Intent::Ignore => Ok(false),
         Intent::Exit => Ok(true),
@@ -372,8 +380,27 @@ async fn handle_terminal_event(
         }
         Intent::Compose(k) => {
             // ratatui_textarea consumes raw crossterm KeyEvent through
-            // its `Input` conversion.
+            // its `Input` conversion. Snapshot the slash query first so
+            // we can detect a query-text change (vs. mere cursor motion)
+            // and reset the picker highlight only when the text shifts.
+            let before = state.slash_query();
             state.composer.input(k);
+            if state.slash_query() != before {
+                state.slash_selected = 0;
+            }
+            state.reconcile_slash_selection();
+            Ok(false)
+        }
+        Intent::SlashMove(delta) => {
+            state.move_slash_selection(delta);
+            Ok(false)
+        }
+        Intent::SlashAccept => {
+            state.accept_selected_slash();
+            Ok(false)
+        }
+        Intent::SlashDismiss => {
+            state.dismiss_slash();
             Ok(false)
         }
         Intent::SubmitPrompt => {

--- a/src/tui/cockpit_view/render.rs
+++ b/src/tui/cockpit_view/render.rs
@@ -113,13 +113,22 @@ fn render_slash_picker(
     if matches.is_empty() {
         return;
     }
-    let lines = picker_lines(&matches, state.slash_selected, SLASH_PICKER_MAX_ROWS);
-    // border rows (2) + content; width matches the composer so the
-    // popup lines up with the input it completes.
+    // Cap the visible rows to the space above the composer (minus the 2
+    // border rows) before windowing, so on a short terminal the window
+    // can't hand back more rows than will paint and hide the selection
+    // at the bottom. width matches the composer so the popup lines up
+    // with the input it completes.
+    let max_rows = (composer_area.y as usize)
+        .saturating_sub(2)
+        .min(SLASH_PICKER_MAX_ROWS);
+    if max_rows == 0 {
+        return;
+    }
+    let lines = picker_lines(&matches, state.slash_selected, max_rows);
     let desired = lines.len() as u16 + 2;
     // Anchor the popup's bottom edge to the composer's top edge, growing
-    // upward; clamp the top to row 0 so a tall list never underflows.
-    // When clamped, the visible height shrinks to the space available.
+    // upward. max_rows already guarantees the list fits above the
+    // composer, so the height below won't truncate the windowed rows.
     let y = composer_area.y.saturating_sub(desired);
     let area = Rect {
         x: composer_area.x,
@@ -940,5 +949,48 @@ mod tests {
         assert!(dump.contains("Commands"), "picker title missing");
         assert!(dump.contains("/compact"), "command label missing");
         assert!(dump.contains('▶'), "selection marker missing");
+    }
+
+    #[test]
+    fn short_terminal_keeps_selected_row_visible() {
+        // Regression: on a short terminal the popup's drawable height is
+        // tiny, but the window was sized to SLASH_PICKER_MAX_ROWS, so a
+        // bottom selection painted above the fold and vanished. Render a
+        // 9-row terminal with many commands, select the last, and assert
+        // the selected label + marker actually paint.
+        let endpoint = DaemonEndpoint {
+            base_url: "http://127.0.0.1:8080".to_string(),
+            token: None,
+            source: Source::LocalDaemon,
+        };
+        let http = HttpClient::new(endpoint.clone()).expect("http client");
+        let mut state = CockpitViewState::new("sess".to_string(), endpoint, http, None);
+        state.focus = Focus::Composer;
+        state.transcript.available_commands =
+            (0..12).map(|i| cmd(&format!("cmd{i:02}"), "")).collect();
+        state.composer.insert_str("/cmd");
+        assert!(state.slash_picker_open());
+        // Drive the highlight to the last match.
+        let last = state.slash_matches().len() - 1;
+        state.move_slash_selection(last as i32);
+        let last_name = state.slash_matches()[last].name.clone();
+
+        let theme = crate::tui::styles::load_theme_with_mode("empire", false);
+        let backend = TestBackend::new(40, 9);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|f| render(f, f.area(), &theme, &state))
+            .expect("draw");
+
+        let buf = terminal.backend().buffer().clone();
+        let dump: String = buf.content().iter().map(|c| c.symbol()).collect();
+        assert!(
+            dump.contains('▶'),
+            "selection marker missing on short terminal"
+        );
+        assert!(
+            dump.contains(&format!("/{last_name}")),
+            "selected row /{last_name} scrolled off-screen: {dump:?}"
+        );
     }
 }

--- a/src/tui/cockpit_view/render.rs
+++ b/src/tui/cockpit_view/render.rs
@@ -8,7 +8,7 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Padding, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
 use ratatui::Frame;
 
 use super::input::Focus;
@@ -35,6 +35,12 @@ pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, state: &CockpitViewS
         render_queue(frame, chunks[2], theme, state);
     }
     render_composer(frame, chunks[3], theme, state);
+    // Picker floats above the composer (the composer sits at the screen
+    // bottom, so a dropdown below it would render off-screen). Drawn
+    // last so it overlays the transcript's lower rows.
+    if state.slash_picker_open() {
+        render_slash_picker(frame, chunks[3], theme, state);
+    }
 }
 
 /// Up to this many queued prompts are previewed in the strip; the rest
@@ -90,6 +96,88 @@ fn render_queue(frame: &mut Frame, area: Rect, theme: &Theme, state: &CockpitVie
         )));
     }
     frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// Most picker rows visible at once before the list windows around the
+/// selection. Keeps the popup from eating the whole transcript when the
+/// daemon advertises a long command list.
+const SLASH_PICKER_MAX_ROWS: usize = 8;
+
+fn render_slash_picker(
+    frame: &mut Frame,
+    composer_area: Rect,
+    theme: &Theme,
+    state: &CockpitViewState,
+) {
+    let matches = state.slash_matches();
+    if matches.is_empty() {
+        return;
+    }
+    let lines = picker_lines(&matches, state.slash_selected, SLASH_PICKER_MAX_ROWS);
+    // border rows (2) + content; width matches the composer so the
+    // popup lines up with the input it completes.
+    let desired = lines.len() as u16 + 2;
+    // Anchor the popup's bottom edge to the composer's top edge, growing
+    // upward; clamp the top to row 0 so a tall list never underflows.
+    // When clamped, the visible height shrinks to the space available.
+    let y = composer_area.y.saturating_sub(desired);
+    let area = Rect {
+        x: composer_area.x,
+        y,
+        width: composer_area.width,
+        height: composer_area.y - y,
+    };
+    if area.height < 3 {
+        return;
+    }
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Commands (↑/↓ or Ctrl+n/p · Enter/Tab select · Esc dismiss) ")
+        .border_style(Style::default().fg(theme.title));
+    let inner = block.inner(area);
+    frame.render_widget(Clear, area);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// Build the picker's visible rows, windowed around `selected` so a
+/// selection past the visible cap still shows. Each row is
+/// `▶ /name  description`, with the marker only on the selected row.
+fn picker_lines<'a>(
+    matches: &[&'a crate::cockpit::state::AvailableCommand],
+    selected: usize,
+    max_rows: usize,
+) -> Vec<Line<'a>> {
+    let total = matches.len();
+    let cap = max_rows.min(total).max(1);
+    // Slide the window so `selected` stays inside [start, start+cap).
+    let start = if selected >= cap {
+        (selected - cap + 1).min(total.saturating_sub(cap))
+    } else {
+        0
+    };
+    let mut out = Vec::with_capacity(cap);
+    for (offset, cmd) in matches[start..(start + cap).min(total)].iter().enumerate() {
+        let idx = start + offset;
+        let is_sel = idx == selected;
+        let marker = if is_sel { "▶ " } else { "  " };
+        let mut spans = vec![Span::styled(
+            format!("{marker}/{}", cmd.name),
+            if is_sel {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            },
+        )];
+        if !cmd.description.is_empty() {
+            spans.push(Span::styled(
+                format!("  {}", cmd.description),
+                Style::default().add_modifier(Modifier::DIM),
+            ));
+        }
+        out.push(Line::from(spans));
+    }
+    out
 }
 
 /// Top + bottom border rows wrapping the composer textarea.
@@ -584,7 +672,9 @@ fn border_style(theme: &Theme, state: &CockpitViewState, this_focus: Focus) -> S
 
 fn help_hint(focus: Focus) -> &'static str {
     match focus {
-        Focus::Composer => " Enter=send · Shift+Enter=newline · Esc=back · Ctrl-C=cancel ",
+        Focus::Composer => {
+            " Enter=send · Shift+Enter=newline · /=commands · Esc=back · Ctrl-C=cancel "
+        }
         Focus::Transcript => " j/k=scroll · i=compose · Tab=approvals · o=browser · Esc=exit ",
         Focus::Approval => " a=allow · A=always · d=deny · Esc=back ",
     }
@@ -770,6 +860,18 @@ mod tests {
         }
     }
 
+    use crate::cockpit::state::AvailableCommand;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn cmd(name: &str, desc: &str) -> AvailableCommand {
+        AvailableCommand {
+            name: name.to_string(),
+            description: desc.to_string(),
+            accepts_input: false,
+        }
+    }
+
     #[test]
     fn agent_message_renders_list_markers_without_dashes() {
         let lines = render_agent_message_lines("- one\n- two\n\n1. first\n2. second");
@@ -795,5 +897,48 @@ mod tests {
             assert_eq!(lines.len(), 1, "input {input:?}");
             assert_eq!(line_text(&lines[0]), format!("{AGENT_GUTTER}…"));
         }
+    }
+
+    #[test]
+    fn picker_lines_window_follows_selection_past_cap() {
+        let cmds: Vec<AvailableCommand> = (0..10).map(|i| cmd(&format!("c{i}"), "")).collect();
+        let refs: Vec<&AvailableCommand> = cmds.iter().collect();
+        // Selecting row 9 with a 3-row cap must keep it inside the window.
+        let lines = picker_lines(&refs, 9, 3);
+        assert_eq!(lines.len(), 3);
+        // Window should be rows 7,8,9; row 9 is the last visible line.
+        let last = &lines[2];
+        let text: String = last.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("/c9"), "expected /c9 in {text:?}");
+        assert!(text.starts_with("▶"), "selected row marked: {text:?}");
+    }
+
+    #[test]
+    fn render_shows_slash_picker_overlay() {
+        let endpoint = DaemonEndpoint {
+            base_url: "http://127.0.0.1:8080".to_string(),
+            token: None,
+            source: Source::LocalDaemon,
+        };
+        let http = HttpClient::new(endpoint.clone()).expect("http client");
+        let mut state = CockpitViewState::new("sess".to_string(), endpoint, http, None);
+        state.focus = Focus::Composer;
+        state.transcript.available_commands =
+            vec![cmd("compact", "shrink context"), cmd("clear", "wipe")];
+        state.composer.insert_str("/comp");
+        assert!(state.slash_picker_open());
+
+        let theme = crate::tui::styles::load_theme_with_mode("empire", false);
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|f| render(f, f.area(), &theme, &state))
+            .expect("draw");
+
+        let buf = terminal.backend().buffer().clone();
+        let dump: String = buf.content().iter().map(|c| c.symbol()).collect();
+        assert!(dump.contains("Commands"), "picker title missing");
+        assert!(dump.contains("/compact"), "command label missing");
+        assert!(dump.contains('▶'), "selection marker missing");
     }
 }

--- a/src/tui/cockpit_view/slash.rs
+++ b/src/tui/cockpit_view/slash.rs
@@ -1,0 +1,145 @@
+//! Slash-command picker helpers: detect when the composer holds a
+//! slash query and filter the daemon-advertised command list against
+//! it. Pure functions so the picker logic is unit-testable without a
+//! ratatui surface or a live daemon.
+//!
+//! Mirrors the web composer's `fuzzyFilter` scoring (prefix beats
+//! substring beats description match), lowercased on both sides so the
+//! TUI and web rank the same way.
+
+use crate::cockpit::state::AvailableCommand;
+
+/// Largest number of matches the picker will surface. The render layer
+/// windows around the selection, so this is a sanity bound, not a
+/// display cap.
+const MAX_MATCHES: usize = 30;
+
+/// If `text` is a single-line slash query (`/word`, no whitespace
+/// after the slash), return the query portion **without** the leading
+/// slash. Returns `None` when the composer holds anything else: empty,
+/// multi-line, not slash-prefixed, or a slash followed by whitespace
+/// (which means the user already finished the command name and is
+/// typing arguments).
+pub fn slash_query(text: &str) -> Option<&str> {
+    if text.contains('\n') {
+        return None;
+    }
+    let rest = text.strip_prefix('/')?;
+    if rest.chars().any(char::is_whitespace) {
+        return None;
+    }
+    Some(rest)
+}
+
+/// Filter + rank `commands` against a slash `query` (the text after the
+/// leading slash, possibly empty). Empty query returns every command in
+/// declaration order. Otherwise scores case-insensitively: name prefix
+/// (3) beats name substring (2) beats description substring (1); zero
+/// scores drop out. Ties break on shorter name first, then name order.
+pub fn filter_commands<'a>(
+    query: &str,
+    commands: &'a [AvailableCommand],
+) -> Vec<&'a AvailableCommand> {
+    if query.is_empty() {
+        return commands.iter().take(MAX_MATCHES).collect();
+    }
+    let q = query.to_lowercase();
+    let mut scored: Vec<(i32, &'a AvailableCommand)> = commands
+        .iter()
+        .filter_map(|cmd| {
+            let name = cmd.name.to_lowercase();
+            let score = if name.starts_with(&q) {
+                3
+            } else if name.contains(&q) {
+                2
+            } else if cmd.description.to_lowercase().contains(&q) {
+                1
+            } else {
+                0
+            };
+            (score > 0).then_some((score, cmd))
+        })
+        .collect();
+    scored.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| a.1.name.len().cmp(&b.1.name.len()))
+            .then_with(|| a.1.name.cmp(&b.1.name))
+    });
+    scored
+        .into_iter()
+        .take(MAX_MATCHES)
+        .map(|(_, c)| c)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cmd(name: &str, desc: &str) -> AvailableCommand {
+        AvailableCommand {
+            name: name.to_string(),
+            description: desc.to_string(),
+            accepts_input: false,
+        }
+    }
+
+    #[test]
+    fn slash_query_extracts_word_after_slash() {
+        assert_eq!(slash_query("/com"), Some("com"));
+        assert_eq!(slash_query("/"), Some(""));
+    }
+
+    #[test]
+    fn slash_query_rejects_non_slash_and_whitespace_and_multiline() {
+        assert_eq!(slash_query("hello"), None);
+        assert_eq!(slash_query(""), None);
+        // Slash followed by a space = command name finished, typing args.
+        assert_eq!(slash_query("/compact now"), None);
+        assert_eq!(slash_query("/multi\nline"), None);
+    }
+
+    #[test]
+    fn filter_empty_query_returns_all_in_order() {
+        let commands = vec![cmd("compact", ""), cmd("clear", "")];
+        let got = filter_commands("", &commands);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].name, "compact");
+        assert_eq!(got[1].name, "clear");
+    }
+
+    #[test]
+    fn filter_prefix_outranks_substring_and_description() {
+        let commands = vec![
+            cmd("recompact", "rebuild"),    // substring of "comp"
+            cmd("compact", "shrink"),       // prefix
+            cmd("noop", "compact the log"), // description only
+        ];
+        let got = filter_commands("comp", &commands);
+        assert_eq!(got[0].name, "compact");
+        assert_eq!(got[1].name, "recompact");
+        assert_eq!(got[2].name, "noop");
+    }
+
+    #[test]
+    fn filter_is_case_insensitive() {
+        let commands = vec![cmd("Compact", "")];
+        assert_eq!(filter_commands("comp", &commands).len(), 1);
+        assert_eq!(filter_commands("COMP", &commands).len(), 1);
+    }
+
+    #[test]
+    fn filter_drops_zero_scores() {
+        let commands = vec![cmd("compact", "shrink"), cmd("clear", "wipe")];
+        let got = filter_commands("xyz", &commands);
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn filter_ties_break_on_shorter_name() {
+        let commands = vec![cmd("compactor", ""), cmd("compact", "")];
+        let got = filter_commands("compact", &commands);
+        assert_eq!(got[0].name, "compact");
+        assert_eq!(got[1].name, "compactor");
+    }
+}

--- a/src/tui/cockpit_view/slash.rs
+++ b/src/tui/cockpit_view/slash.rs
@@ -61,8 +61,14 @@ pub fn filter_commands<'a>(
         })
         .collect();
     scored.sort_by(|a, b| {
+        // Tie-break case-insensitively so mixed-case names sort the same
+        // way the (case-insensitive) scoring ranks them, matching web
+        // parity; fall back to raw bytes only to keep the order total.
+        let a_lc = a.1.name.to_lowercase();
+        let b_lc = b.1.name.to_lowercase();
         b.0.cmp(&a.0)
             .then_with(|| a.1.name.len().cmp(&b.1.name.len()))
+            .then_with(|| a_lc.cmp(&b_lc))
             .then_with(|| a.1.name.cmp(&b.1.name))
     });
     scored

--- a/src/tui/cockpit_view/state.rs
+++ b/src/tui/cockpit_view/state.rs
@@ -9,7 +9,9 @@ use ratatui_textarea::TextArea;
 use super::input::Focus;
 use super::queue::PromptQueue;
 use super::reducer::CockpitTranscript;
+use super::slash;
 use crate::cockpit::client::{DaemonEndpoint, HttpClient, WsHandle};
+use crate::cockpit::state::AvailableCommand;
 use crate::session::config::QueueDrainMode;
 
 pub struct CockpitViewState {
@@ -42,6 +44,25 @@ pub struct CockpitViewState {
     /// between the POST returning and the `UserPromptSent` echo would see
     /// a stale-idle reducer and fire a duplicate concurrent prompt.
     pub in_flight: bool,
+    /// Highlighted row in the slash-command picker. Meaningful only
+    /// while the picker is open; clamped against the live match count.
+    pub slash_selected: usize,
+    /// The exact slash query the user dismissed with Esc. The picker
+    /// stays closed while the composer text still maps to this query,
+    /// so cursor movement (which the textarea reports as edits) can't
+    /// reopen it; the picker reappears only once the query text
+    /// actually changes.
+    pub dismissed_slash_query: Option<String>,
+}
+
+/// Build a composer textarea with the shared placeholder + cursor
+/// styling. ratatui-textarea has no public "clear", so resetting the
+/// composer means swapping in a fresh one from here.
+fn new_composer_textarea() -> TextArea<'static> {
+    let mut ta = TextArea::default();
+    ta.set_placeholder_text(" Message the agent…");
+    ta.set_cursor_line_style(ratatui::style::Style::default());
+    ta
 }
 
 #[derive(Debug, Clone)]
@@ -63,15 +84,12 @@ impl CockpitViewState {
         http: HttpClient,
         ws: Option<WsHandle>,
     ) -> Self {
-        let mut composer = TextArea::default();
-        composer.set_placeholder_text(" Message the agent…");
-        composer.set_cursor_line_style(ratatui::style::Style::default());
         Self {
             transcript: CockpitTranscript::new(session_id.clone()),
             session_id,
             endpoint,
             http,
-            composer,
+            composer: new_composer_textarea(),
             focus: Focus::Transcript,
             scroll_offset: u16::MAX, // stick to bottom by default; render clamps to last row
             selected_approval: None,
@@ -80,6 +98,8 @@ impl CockpitViewState {
             queue: PromptQueue::default(),
             drain_mode: QueueDrainMode::default(),
             in_flight: false,
+            slash_selected: 0,
+            dismissed_slash_query: None,
         }
     }
 
@@ -98,11 +118,92 @@ impl CockpitViewState {
         let text = self.composer.lines().join("\n").trim().to_string();
         // Replace with a fresh textarea so cursor + selection state
         // also reset; ratatui-textarea has no public "clear" today.
-        let mut next = TextArea::default();
-        next.set_placeholder_text(" Message the agent…");
-        next.set_cursor_line_style(ratatui::style::Style::default());
-        self.composer = next;
+        self.composer = new_composer_textarea();
+        self.slash_selected = 0;
+        self.dismissed_slash_query = None;
         text
+    }
+
+    /// The current single-line slash query (without the leading slash),
+    /// or `None` when the composer doesn't hold one.
+    pub fn slash_query(&self) -> Option<String> {
+        let line = self.composer.lines().join("\n");
+        slash::slash_query(&line).map(str::to_string)
+    }
+
+    /// Commands matching the current slash query, ranked. Empty when
+    /// the composer isn't a slash query.
+    pub fn slash_matches(&self) -> Vec<&AvailableCommand> {
+        match self.slash_query() {
+            Some(q) => slash::filter_commands(&q, &self.transcript.available_commands),
+            None => Vec::new(),
+        }
+    }
+
+    /// The picker is open when the composer holds a slash query that has
+    /// matches and the user hasn't dismissed *this exact* query.
+    pub fn slash_picker_open(&self) -> bool {
+        let Some(query) = self.slash_query() else {
+            return false;
+        };
+        if self.dismissed_slash_query.as_deref() == Some(query.as_str()) {
+            return false;
+        }
+        !self.slash_matches().is_empty()
+    }
+
+    /// Move the picker highlight by `delta` rows, saturating at both
+    /// ends of the live match list.
+    pub fn move_slash_selection(&mut self, delta: i32) {
+        let len = self.slash_matches().len();
+        if len == 0 {
+            self.slash_selected = 0;
+            return;
+        }
+        let max = len - 1;
+        let next = self.slash_selected as i64 + delta as i64;
+        self.slash_selected = next.clamp(0, max as i64) as usize;
+    }
+
+    /// Latch the current query as dismissed so the picker closes until
+    /// the query text changes.
+    pub fn dismiss_slash(&mut self) {
+        self.dismissed_slash_query = self.slash_query();
+    }
+
+    /// Replace the composer with `/{name} ` (trailing space, ready for
+    /// arguments) for the highlighted command. Does not submit. Returns
+    /// false when there's no match to accept.
+    pub fn accept_selected_slash(&mut self) -> bool {
+        let name = match self.slash_matches().get(self.slash_selected) {
+            Some(cmd) => cmd.name.clone(),
+            None => return false,
+        };
+        let mut next = new_composer_textarea();
+        next.insert_str(format!("/{name} "));
+        self.composer = next;
+        self.slash_selected = 0;
+        self.dismissed_slash_query = None;
+        true
+    }
+
+    /// Keep `slash_selected` in bounds and reset the dismissal latch
+    /// when the query text changes. Call after every composer edit and
+    /// whenever the available-command list shifts under the cursor.
+    pub fn reconcile_slash_selection(&mut self) {
+        // A query change clears the dismissal so a freshly-typed query
+        // reopens the picker even if its text once matched a dismissed
+        // one earlier in the session.
+        let query = self.slash_query();
+        if self.dismissed_slash_query.is_some() && self.dismissed_slash_query != query {
+            self.dismissed_slash_query = None;
+        }
+        let len = self.slash_matches().len();
+        if len == 0 {
+            self.slash_selected = 0;
+        } else if self.slash_selected >= len {
+            self.slash_selected = len - 1;
+        }
     }
 
     /// Bring the selected-approval index back into bounds whenever the
@@ -128,7 +229,7 @@ impl CockpitViewState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cockpit::client::discovery::Source;
+    use crate::cockpit::client::Source;
 
     fn test_state(ws: Option<WsHandle>) -> CockpitViewState {
         let endpoint = DaemonEndpoint {
@@ -178,5 +279,95 @@ mod tests {
         assert_eq!(state.queue.len(), 2);
         let items: Vec<&String> = state.queue.iter().collect();
         assert_eq!(items, vec!["hello", "world"]);
+    }
+
+    fn cmd(name: &str) -> AvailableCommand {
+        AvailableCommand {
+            name: name.to_string(),
+            description: String::new(),
+            accepts_input: false,
+        }
+    }
+
+    fn state_with_commands(names: &[&str]) -> CockpitViewState {
+        let endpoint = DaemonEndpoint {
+            base_url: "http://127.0.0.1:8080".to_string(),
+            token: None,
+            source: Source::LocalDaemon,
+        };
+        let http = HttpClient::new(endpoint.clone()).expect("build test http client");
+        let mut state = CockpitViewState::new("test-session".to_string(), endpoint, http, None);
+        state.transcript.available_commands = names.iter().map(|n| cmd(n)).collect();
+        state
+    }
+
+    #[test]
+    fn picker_opens_on_slash_query_with_matches() {
+        let mut state = state_with_commands(&["compact", "clear"]);
+        assert!(!state.slash_picker_open());
+        state.composer.insert_str("/comp");
+        assert!(state.slash_picker_open());
+        assert_eq!(state.slash_matches()[0].name, "compact");
+    }
+
+    #[test]
+    fn picker_closed_when_no_matches() {
+        let mut state = state_with_commands(&["compact"]);
+        state.composer.insert_str("/zzz");
+        assert!(!state.slash_picker_open());
+    }
+
+    #[test]
+    fn accept_inserts_command_with_trailing_space_and_does_not_submit() {
+        let mut state = state_with_commands(&["compact", "clear"]);
+        state.composer.insert_str("/comp");
+        assert!(state.accept_selected_slash());
+        assert_eq!(state.composer.lines().join("\n"), "/compact ");
+        // Trailing space means the composer is no longer a bare slash
+        // query, so the picker closes after accepting.
+        assert!(!state.slash_picker_open());
+    }
+
+    #[test]
+    fn move_selection_clamps_at_both_ends() {
+        let mut state = state_with_commands(&["compact", "compactor", "comparable"]);
+        state.composer.insert_str("/comp");
+        assert_eq!(state.slash_selected, 0);
+        state.move_slash_selection(-1);
+        assert_eq!(state.slash_selected, 0, "clamps at top");
+        state.move_slash_selection(99);
+        assert_eq!(
+            state.slash_selected,
+            state.slash_matches().len() - 1,
+            "clamps at bottom"
+        );
+    }
+
+    #[test]
+    fn dismiss_latches_query_and_reopens_on_change() {
+        let mut state = state_with_commands(&["compact"]);
+        state.composer.insert_str("/comp");
+        assert!(state.slash_picker_open());
+        state.dismiss_slash();
+        assert!(
+            !state.slash_picker_open(),
+            "dismissed exact query stays closed"
+        );
+        // Typing more changes the query, which reconcile clears.
+        state.composer.insert_str("a");
+        state.reconcile_slash_selection();
+        assert!(state.slash_picker_open(), "query change reopens picker");
+    }
+
+    #[test]
+    fn reconcile_clamps_selection_when_matches_shrink() {
+        let mut state = state_with_commands(&["compact", "compactor"]);
+        state.composer.insert_str("/comp");
+        state.move_slash_selection(1);
+        assert_eq!(state.slash_selected, 1);
+        // The command list shrinks under the cursor.
+        state.transcript.available_commands = vec![cmd("compact")];
+        state.reconcile_slash_selection();
+        assert_eq!(state.slash_selected, 0);
     }
 }


### PR DESCRIPTION
## Description

Adds a slash-command autocomplete picker to the native TUI cockpit composer, bringing it to parity with the web composer. When the composer holds a single-word slash query (`/comp`, no spaces yet), a picker floats above the composer listing the agent's ACP-advertised commands, ranked prefix > substring > description (the same scoring the web composer's `fuzzyFilter` uses, lowercased on both sides).

Navigate with the arrows or `Ctrl+n` / `Ctrl+p`; `Enter` or `Tab` inserts `/{command} ` (trailing space, no auto-send) so arguments can follow. `Esc` dismisses the picker and latches the exact query, so cursor movement won't reopen it; the picker reappears only once the query text changes. A slash query with no matching command is left alone, so `Enter` sends it verbatim.

Design decisions on the issue's open questions: navigation = arrows **and** `Ctrl+n`/`Ctrl+p`; placement = **above** the composer (it sits at screen bottom, so a dropdown below would render off-screen); **insert-only**, no auto-submit.

Closes #1697

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (TUI-only change; the web composer picker already exists)

**TUI / CLI (e2e test)**
- [x] Added or updated a test: pure unit tests for the slash filter/query helpers (`slash.rs`), state-machine tests for picker open/dismiss/accept/clamp (`state.rs`), key-dispatch tests including a focus-isolation regression (`input.rs`), and a headless ratatui `TestBackend` render test asserting the popup border, command labels, and selection marker (`render.rs`). A live tmux e2e was intentionally skipped in favor of the deterministic `TestBackend` assertion, which covers the "picker visible on screen" story without a live daemon.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Agent of Empires cockpit (`/aoe-implement`)

- [x] I am an AI Agent filling out this form (check box if true)

## How I tested

- [ ] `cargo test --features serve --lib cockpit_view` (47 passing, including the new slash picker tests)
- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo clippy --features serve` clean on the touched files
- [ ] Manual: open `aoe cockpit attach <id>`, focus the composer, type `/`, confirm the picker lists commands, navigate with arrows + `Ctrl+n`/`Ctrl+p`, accept with `Enter`/`Tab`, dismiss with `Esc`, and confirm a non-matching `/word` still sends verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a slash-command autocomplete picker to the native TUI cockpit composer, bringing the TUI to parity with the web composer. When the composer contains a single-word slash query (e.g., `/comp`, no spaces), a floating picker appears above the composer listing agent-advertised commands and narrows/ranks results as you type. Users can navigate with arrow keys or Ctrl+n/Ctrl+p, accept a selection with Enter or Tab (which inserts `/{command} ` without sending), and dismiss with Esc (which latches the exact query so it won’t reopen until the text changes). If no commands match, the slash query is sent verbatim on Enter. The feature is documented and covered by comprehensive tests.

What changed (high level)
- New picker UI that floats above the composer and lists daemon-advertised commands.
- Single-line slash detection: picker only activates for single-word slash queries (no whitespace after slash).
- Filter & ranking: results narrow as you type; prefix matches outrank substring and description matches.
- Keyboard UX: arrow & Ctrl+n/p for navigation, Enter/Tab to insert (insert-only), Esc to dismiss and latch.
- State & input plumbing: picker state integrated across input dispatch, view state, reconciliation, and rendering so it stays consistent with composer edits and available commands.
- Tests & docs: unit tests for parsing/filtering, state-machine and input-dispatch tests (including regressions), headless render test, and docs updated with keybinds and behaviors.

Benefits
- Improves discoverability and speed of entering commands in the TUI.
- Aligns TUI behavior with web composer (consistent fuzzy-filter semantics).
- Non-intrusive: picker appears only for relevant queries and does not auto-submit inserted commands.
- Robust on small terminals (windowing/clamping) and avoids annoying reopenings via a dismissal latch.
- Well-tested and documented, easing future maintenance.

Technical notes (brief)
- New module: src/tui/cockpit_view/slash.rs implements slash_query() (single-line, no-space-after-slash) and filter_commands() with scoring: prefix=3, name-substring=2, description-substring=1; empty query returns declaration order; MAX_MATCHES (30) truncates results.
- State additions: CockpitViewState gains slash_selected and dismissed_slash_query plus methods: slash_query, slash_matches, slash_picker_open, move_slash_selection, dismiss_slash, accept_selected_slash (inserts "/{name} "), and reconcile_slash_selection.
- Input changes: input::dispatch now accepts InputContext { has_pending_approval, slash_picker_open } and Intent adds SlashMove/SlashAccept/SlashDismiss; composer key handling claims navigation/accept/dismiss keys when picker is open.
- Rendering: render::render_slash_picker draws a bordered popup anchored above the composer, uses SLASH_PICKER_MAX_ROWS (8) and picker_lines(...) to window visible rows around the selection.
- Minor API change: input dispatch previously took a bool for pending approval; replaced with InputContext to carry picker-open state so keys can be claimed by the picker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->