### PR TITLE
feat(web): move "Switch agent" from composer toolbar to sidebar context menu

### DIFF
--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -95,10 +95,10 @@ agent and confirmed the wire shape.
 
 A cockpit session is not pinned to the agent it started with. You can hand it off to any other installed ACP backend at any time, keeping the transcript. The new agent starts fresh (a new ACP session) and is primed with a recap of the recent turns so it can pick up where the last one left off.
 
-- **Web dashboard:** use the "Switch agent" control in the composer toolbar. The rate-limit recovery banner exposes the same picker via "Continue in another agent" when an agent is over its limit.
+- **Web dashboard:** right-click a cockpit session in the sidebar and pick "Switch agent". The rate-limit recovery banner exposes the same picker via "Continue in another agent" when an agent is over its limit.
 - **CLI:** `aoe cockpit switch-agent <session> <target>`, where `<target>` is a registry key from `aoe cockpit agents`. Add `--model <name>` to override the model.
 
-This is what you reach for after a rate-limit hand-off: switch claude to codex when claude is limited, then `aoe cockpit switch-agent <session> claude` (or the toolbar control) to return once the window resets. The transcript records each switch with its reason (`manual` or `rate_limited`) on a divider.
+This is what you reach for after a rate-limit hand-off: switch claude to codex when claude is limited, then `aoe cockpit switch-agent <session> claude` (or the sidebar "Switch agent" item) to return once the window resets. The transcript records each switch with its reason (`manual` or `rate_limited`) on a divider.
 
 ## Known Limitations
 

--- a/docs/cockpit/troubleshooting.md
+++ b/docs/cockpit/troubleshooting.md
@@ -152,7 +152,7 @@ After the switch, the modal fetches the context primer and pre-fills the compose
 
 The same hand-off is available at any time, not just when an agent is rate-limited. This matters when you handed a session off (say, claude to codex during a rate limit) and later want to return to the original agent once the limit clears.
 
-- **Web dashboard:** the composer toolbar carries a "Switch agent" control. Clicking it opens the same picker, lists the cockpit ACP registry, and switches on confirm. The composer is pre-filled with a recap so the new agent has context; review and send manually.
+- **Web dashboard:** right-click a cockpit session in the sidebar and pick "Switch agent". It opens the same picker, lists the cockpit ACP registry, and switches on confirm. The composer is pre-filled with a recap so the new agent has context; review and send manually.
 - **CLI:** `aoe cockpit switch-agent <session> <target>` (run `aoe cockpit agents` to list valid target keys). Pass `--model <name>` to override the model the new agent starts with.
 
 Both paths hit `POST /api/sessions/{id}/cockpit/switch-agent` with `reason: "manual"`, so the transcript divider reads `Switched cockpit agent from <from> to <to> (manual)`, distinct from the `(rate_limited)` divider the recovery flow emits.

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -12,6 +12,7 @@ import {
 import { createPortal } from "react-dom";
 import {
   Archive,
+  ArrowLeftRight,
   Clock,
   GripVertical,
   Layers,
@@ -68,6 +69,8 @@ import {
   setSessionSnooze,
 } from "../lib/api";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
+import { requestOpenSession } from "../lib/sessionRoute";
+import { requestSwitchAgent } from "../lib/switchAgentTrigger";
 import { useClampedMenuPosition } from "../lib/menuPosition";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { useQueuedCountForSessions } from "../hooks/useCockpitQueueCount";
@@ -564,6 +567,11 @@ export const SessionRow = memo(function SessionRow({
     idleDecayWindowMs,
   );
   const firstSession = workspace.sessions[0];
+  // The cockpit session backing this row, if any. Drives the "Switch
+  // agent" context-menu item, which only makes sense for an ACP cockpit
+  // session (tmux rows have no agent to hand off). Multi-session rows are
+  // rare; pick the first cockpit session in the workspace.
+  const cockpitSession = workspace.sessions.find((s) => s.cockpit_mode);
   const runningSession = workspace.sessions.find((s) =>
     isSessionActive(s, idleDecayWindowMs),
   );
@@ -734,6 +742,19 @@ export const SessionRow = memo(function SessionRow({
   const openSnoozeModal = () => {
     setContextMenu(null);
     setSnoozeModalOpen(true);
+  };
+
+  // Open the switch-agent dialog for this row's cockpit session. The
+  // dialog lives in that session's Composer (it prefills the composer on
+  // confirm), so we navigate to the session first, then request the open.
+  // When the row is already the active session the navigation is a no-op
+  // and the dispatched event opens the dialog immediately; otherwise the
+  // Composer consumes the pending latch once it mounts.
+  const handleSwitchAgent = () => {
+    setContextMenu(null);
+    if (!cockpitSession) return;
+    requestOpenSession(cockpitSession.id);
+    requestSwitchAgent(cockpitSession.id);
   };
 
   // Effective state for rendering: optimistic overrides win until the
@@ -1065,6 +1086,16 @@ export const SessionRow = memo(function SessionRow({
           >
             Rename
           </button>
+          {!readOnly && cockpitSession && (
+            <button
+              onClick={handleSwitchAgent}
+              data-testid="sidebar-context-menu-switch-agent"
+              className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+            >
+              <ArrowLeftRight className="h-3.5 w-3.5 shrink-0" />
+              Switch agent
+            </button>
+          )}
           <div className="border-t border-surface-700/20 my-1" />
           <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">
             Notifications

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -16,6 +16,11 @@ import {
   SessionRow,
 } from "../WorkspaceSidebar";
 import type { SessionResponse, Workspace } from "../../lib/types";
+import { OPEN_SESSION_EVENT } from "../../lib/sessionRoute";
+import {
+  OPEN_SWITCH_AGENT_EVENT,
+  consumePendingSwitchAgent,
+} from "../../lib/switchAgentTrigger";
 
 function session(over: Partial<SessionResponse> = {}): SessionResponse {
   return {
@@ -90,6 +95,9 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  // Drain any switch-agent latch a click left behind so tests stay
+  // independent.
+  consumePendingSwitchAgent("sess-switch-it");
 });
 
 describe("SessionRow chips", () => {
@@ -221,8 +229,38 @@ describe("SessionRow context menu", () => {
     expect(menu.textContent).toContain("Snooze…");
   });
 
+  it("shows Switch agent for a cockpit row", () => {
+    const ws = workspace("w-cockpit", [
+      session({ id: "sess-cockpit", cockpit_mode: true }),
+    ]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    expect(
+      screen.queryByTestId("sidebar-context-menu-switch-agent"),
+    ).not.toBeNull();
+  });
+
+  it("hides Switch agent for a non-cockpit (tmux) row", () => {
+    const ws = workspace("w-tmux", [session({ cockpit_mode: false })]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    expect(
+      screen.queryByTestId("sidebar-context-menu-switch-agent"),
+    ).toBeNull();
+  });
+
   it("hides the triage section in read-only mode", () => {
-    const ws = workspace("w-live", [session({})]);
+    // cockpit_mode is set so the Switch agent gate is also exercised:
+    // it must stay hidden in read-only even on a cockpit row.
+    const ws = workspace("w-live", [session({ cockpit_mode: true })]);
     render(
       <Wrap>
         <SessionRow
@@ -239,6 +277,9 @@ describe("SessionRow context menu", () => {
     expect(menu.textContent).not.toContain("Archive");
     expect(menu.textContent).not.toContain("Snooze");
     expect(menu.textContent).not.toContain("Delete");
+    expect(
+      screen.queryByTestId("sidebar-context-menu-switch-agent"),
+    ).toBeNull();
   });
 });
 
@@ -405,5 +446,37 @@ describe("SessionRow triage actions", () => {
     const [url, init] = fetchSpy.mock.calls[0]!;
     expect(url).toBe("/api/sessions/sess-unsnooze-it/snooze");
     expect(JSON.parse(init!.body as string)).toEqual({ minutes: null });
+  });
+
+  it("Switch agent click navigates to the session and requests the dialog", () => {
+    const ws = workspace("w-cockpit", [
+      session({ id: "sess-switch-it", cockpit_mode: true }),
+    ]);
+    const opened: string[] = [];
+    const switched: string[] = [];
+    const onOpen = (e: Event) =>
+      opened.push((e as CustomEvent).detail.sessionId);
+    const onSwitch = (e: Event) =>
+      switched.push((e as CustomEvent).detail.sessionId);
+    window.addEventListener(OPEN_SESSION_EVENT, onOpen);
+    window.addEventListener(OPEN_SWITCH_AGENT_EVENT, onSwitch);
+    try {
+      render(
+        <Wrap>
+          <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        </Wrap>,
+      );
+      fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+      fireEvent.click(
+        screen.getByTestId("sidebar-context-menu-switch-agent"),
+      );
+      expect(opened).toEqual(["sess-switch-it"]);
+      expect(switched).toEqual(["sess-switch-it"]);
+      // No PATCH: switching is deferred to the dialog in the composer.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener(OPEN_SESSION_EVENT, onOpen);
+      window.removeEventListener(OPEN_SWITCH_AGENT_EVENT, onSwitch);
+    }
   });
 });

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -20,7 +20,6 @@ import {
 } from "@assistant-ui/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  ArrowLeftRight,
   AtSign,
   ChevronUp,
   Paperclip,
@@ -32,6 +31,11 @@ import {
 import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import { SessionConfigControls } from "./SessionConfigControls";
 import { SwitchAgentModal } from "./SwitchAgentModal";
+import {
+  OPEN_SWITCH_AGENT_EVENT,
+  consumePendingSwitchAgent,
+  type OpenSwitchAgentDetail,
+} from "../../lib/switchAgentTrigger";
 import type {
   CockpitState,
   PromptAttachmentInput,
@@ -453,11 +457,30 @@ export function Composer({
     );
   }, [composerRuntime, enqueuePrompt, pendingAttachments, setPendingAttachments]);
 
-  // Manual agent switch dialog, opened from the toolbar control. Unlike
-  // the rate-limit recovery path (which lives up in CockpitView), this
-  // is available at any time so a user can hand back to, say, claude
-  // after a rate-limit handoff to codex.
+  // Manual agent switch dialog. Opened from the sidebar row context menu
+  // (see WorkspaceSidebar's "Switch agent" item) via the cross-component
+  // trigger below. Unlike the rate-limit recovery path (which lives up in
+  // CockpitView), this is available at any time so a user can hand back
+  // to, say, claude after a rate-limit handoff to codex.
   const [switchAgentOpen, setSwitchAgentOpen] = useState(false);
+  // Open on a switch-agent request targeting this session. The dispatched
+  // event covers the already-open session; the pending latch (consumed on
+  // mount) covers the case where the user picked the menu item on another
+  // session and navigation mounted this Composer a tick later.
+  useEffect(() => {
+    if (consumePendingSwitchAgent(sessionId)) setSwitchAgentOpen(true);
+    const onOpen = (e: Event) => {
+      const detail = (e as CustomEvent<OpenSwitchAgentDetail>).detail;
+      if (detail?.sessionId === sessionId) {
+        // Clear the latch we also set, so a later remount of this
+        // already-open session does not reopen the dialog.
+        consumePendingSwitchAgent(sessionId);
+        setSwitchAgentOpen(true);
+      }
+    };
+    window.addEventListener(OPEN_SWITCH_AGENT_EVENT, onOpen);
+    return () => window.removeEventListener(OPEN_SWITCH_AGENT_EVENT, onOpen);
+  }, [sessionId]);
 
   // iOS Safari native dictation (#1431): WebKit fires `beforeinput` /
   // `input` with `inputType: "insertReplacementText"` per partial
@@ -882,12 +905,6 @@ export function Composer({
                   configOptions={configOptions}
                   pendingConfigOption={pendingConfigOption}
                   onSetConfigOption={setConfigOption}
-                />
-                <span className="mx-1 h-4 w-px bg-surface-700" aria-hidden />
-                <ToolbarButton
-                  icon={<ArrowLeftRight className="h-3.5 w-3.5" />}
-                  label="Switch agent"
-                  onClick={() => setSwitchAgentOpen(true)}
                 />
               </div>
 

--- a/web/src/lib/__tests__/switchAgentTrigger.test.ts
+++ b/web/src/lib/__tests__/switchAgentTrigger.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+//
+// Unit tests for the cross-component switch-agent trigger (#1747): the
+// dispatch + pending-latch helper the sidebar context menu uses to ask a
+// (possibly not-yet-mounted) cockpit Composer to open its switch-agent
+// dialog. Asserts both the dispatched event and the stashed latch.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  OPEN_SWITCH_AGENT_EVENT,
+  consumePendingSwitchAgent,
+  requestSwitchAgent,
+  type OpenSwitchAgentDetail,
+} from "../switchAgentTrigger";
+
+function captureDispatch(): () => OpenSwitchAgentDetail[] {
+  const seen: OpenSwitchAgentDetail[] = [];
+  const handler = (e: Event) => {
+    seen.push((e as CustomEvent<OpenSwitchAgentDetail>).detail);
+  };
+  window.addEventListener(OPEN_SWITCH_AGENT_EVENT, handler);
+  return () => {
+    window.removeEventListener(OPEN_SWITCH_AGENT_EVENT, handler);
+    return seen;
+  };
+}
+
+afterEach(() => {
+  // Drain any latch left over so tests stay independent.
+  consumePendingSwitchAgent("s1");
+  consumePendingSwitchAgent("s2");
+});
+
+describe("requestSwitchAgent", () => {
+  it("dispatches an event carrying the target session id", () => {
+    const done = captureDispatch();
+    requestSwitchAgent("s1");
+    const seen = done();
+    expect(seen).toEqual([{ sessionId: "s1" }]);
+  });
+
+  it("stashes the request so a later consume for the same id wins", () => {
+    requestSwitchAgent("s1");
+    expect(consumePendingSwitchAgent("s1")).toBe(true);
+    // Latch is one-shot: a second consume returns false.
+    expect(consumePendingSwitchAgent("s1")).toBe(false);
+  });
+
+  it("does not satisfy a consume for a different session", () => {
+    requestSwitchAgent("s1");
+    expect(consumePendingSwitchAgent("s2")).toBe(false);
+    // The original latch is still pending for s1.
+    expect(consumePendingSwitchAgent("s1")).toBe(true);
+  });
+
+  it("keeps only the most recent request when called twice", () => {
+    requestSwitchAgent("s1");
+    requestSwitchAgent("s2");
+    expect(consumePendingSwitchAgent("s1")).toBe(false);
+    expect(consumePendingSwitchAgent("s2")).toBe(true);
+  });
+});

--- a/web/src/lib/switchAgentTrigger.ts
+++ b/web/src/lib/switchAgentTrigger.ts
@@ -1,0 +1,44 @@
+// Cross-component trigger for the cockpit "Switch agent" dialog.
+//
+// The dialog itself lives inside the cockpit Composer (it prefills the
+// composer with a handoff recap on confirm), so the only thing that
+// relocates when the trigger moves out of the composer toolbar and into
+// the sidebar row context menu is the open signal. The sidebar requests
+// "open switch-agent for session X"; the Composer for that session flips
+// its local `switchAgentOpen` state when the signal targets it.
+//
+// Mirrors the dispatch + pending-latch shape of `terminalFocus.ts`: the
+// target Composer may not be mounted yet when the user picks the menu
+// item on a session that is not currently open (selecting it navigates,
+// and the cockpit view mounts a tick later). The caller stashes the
+// intent here; the Composer consumes it on mount. When the row is already
+// the open session the dispatched event is handled immediately.
+
+export const OPEN_SWITCH_AGENT_EVENT = "aoe:open-switch-agent";
+
+export interface OpenSwitchAgentDetail {
+  sessionId: string;
+}
+
+let pendingSwitchAgent: string | null = null;
+
+export function requestSwitchAgent(sessionId: string): void {
+  if (typeof window === "undefined") return;
+  pendingSwitchAgent = sessionId;
+  window.dispatchEvent(
+    new CustomEvent<OpenSwitchAgentDetail>(OPEN_SWITCH_AGENT_EVENT, {
+      detail: { sessionId },
+    }),
+  );
+}
+
+// Returns true (and clears the latch) when the stashed request targets
+// this session. The Composer calls it on mount so a navigation-then-open
+// request lands once the target session's cockpit view is ready.
+export function consumePendingSwitchAgent(sessionId: string): boolean {
+  if (pendingSwitchAgent === sessionId) {
+    pendingSwitchAgent = null;
+    return true;
+  }
+  return false;
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1142,6 +1142,19 @@
       ]
     },
     {
+      "id": "cockpit.switch-agent-context-menu",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/SessionRowTriage.test.tsx",
+        "src/lib/__tests__/switchAgentTrigger.test.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
       "id": "cockpit.silent-orphan-watchdog",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The manual "Switch agent" control (added in #1725) no longer lives in the cockpit composer toolbar. It now surfaces as a "Switch agent" item in the sidebar row right-click context menu, decluttering the composer and grouping the action with the other per-session controls (Rename, Pin, Archive, Snooze, Delete).

The item only appears on cockpit sessions (it makes no sense for tmux rows, which have no ACP agent to hand off) and is hidden in read-only mode. Picking it navigates to that session and asks its Composer to open the existing switch-agent dialog. The dialog itself is unchanged: it still lists the cockpit ACP registry, switches on confirm via `POST /api/sessions/:id/cockpit/switch-agent`, and pre-fills the composer with a handoff recap for the user to review before sending.

Mechanically, the trigger is decoupled from the composer via a small `switchAgentTrigger.ts` helper that mirrors the dispatch + pending-latch pattern of the existing `terminalFocus.ts`. The sidebar dispatches an open request; the target session's Composer opens the dialog immediately if already mounted, or consumes the pending latch once it mounts after navigation. The rate-limit recovery banner ("Continue in another agent") is a separate entry point and is untouched.

Closes #1747

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the web dashboard, open a cockpit session and confirm the composer toolbar no longer has a "Switch agent" button.
- [ ] Right-click a cockpit session row in the sidebar and confirm a "Switch agent" item appears (above the Notifications section).
- [ ] Right-click a non-cockpit (tmux) session row and confirm no "Switch agent" item appears.
- [ ] With a cockpit session NOT currently open, pick "Switch agent" from its context menu and confirm the app navigates to that session and opens the switch-agent dialog.
- [ ] Confirm the agent and a recap are pre-filled into that session's composer after switching, and that it is not auto-sent.
- [ ] Confirm the rate-limit banner's "Continue in another agent" path still works.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Detail: coverage is via Vitest + RTL rather than Playwright. New matrix entry `cockpit.switch-agent-context-menu` maps `src/components/__tests__/SessionRowTriage.test.tsx` (menu item appears on cockpit rows, hidden on tmux rows, hidden in read-only, click navigates + requests the dialog) and `src/lib/__tests__/switchAgentTrigger.test.ts` (the dispatch + latch primitive). A live Playwright end-to-end of the navigate-then-prefill flow is a reasonable follow-up since it needs a real ACP agent registered.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (relocate to the context menu, keep the composer-coupled dialog via a navigate-then-open trigger), reviewed each commit, and ran the test sweep.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR relocates the "Switch agent" feature from a button in the composer toolbar to a right-click context menu item on cockpit sessions in the sidebar. The feature itself remains unchanged—the dialog, behavior, and backend interaction are identical.

### What Moved
- **Removed**: "Switch agent" button from the composer toolbar
- **Added**: "Switch agent" option in the sidebar session row context menu (right-click)

### Key Behaviors
- The context menu item only appears for cockpit sessions (not tmux or terminal sessions)
- The item is hidden when the workspace is in read-only mode
- Clicking it navigates to the session (if not already open) and opens the switch-agent dialog in that session's composer
- The dialog prefills with a handoff recap as before (manual send required)

### Implementation Details
The PR introduces a new cross-component communication pattern:

**New module: `switchAgentTrigger.ts`**
- Provides `requestSwitchAgent(sessionId)` to trigger the dialog from the sidebar
- Provides `consumePendingSwitchAgent(sessionId)` for the composer to consume pending requests
- Uses a dispatch + pending-latch pattern: if the target session isn't open when the user clicks, the intent is stashed and consumed when that session's composer mounts

**Changes to sidebar (`WorkspaceSidebar.tsx`)**
- Adds "Switch agent" menu item with icon
- On click: closes menu, navigates to session, requests dialog via the trigger

**Changes to composer (`Composer.tsx`)**
- Removes toolbar button
- Listens for the `OPEN_SWITCH_AGENT_EVENT` on mount
- Opens the dialog when the event targets the current session
- Consumes any pending latch to handle navigation-then-open scenarios

### Benefits
- Cleaner composer interface (removes toolbar clutter)
- Better discoverability through right-click context menu
- Consistent with other session-level actions in the sidebar
- No changes to the underlying switch-agent logic, dialog, or backend API

### Testing & Documentation
- Added comprehensive test coverage for menu visibility, navigation, and event dispatching
- Updated Cockpit troubleshooting and multi-agent documentation to reference the new location
- Coverage matrix updated with new surface entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->