### PR TITLE
fix(cockpit): deliver the first prompt after idle auto-stop instead of dropping it with a 404

### DIFF
--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -997,12 +997,11 @@ impl<S: BroadcastSink> Supervisor<S> {
                 }
             }
             ResumeKind::Attach => {
-                if workers.len() >= self.max_concurrent_workers as usize {
-                    return Err(SupervisorError::CapacityFull {
-                        current: workers.len(),
-                        limit: self.max_concurrent_workers,
-                    });
-                }
+                // No capacity gate: attach takes over an already-running
+                // detached runner (already counted in `registry_count`),
+                // it does not create a new worker. Rejecting it would
+                // strand a live runner after a restart or after lowering
+                // `max_concurrent_workers`, leaving the session unmanaged.
             }
         }
         pending.insert(session_id.to_string(), kind);

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -3610,6 +3610,83 @@ mod tests {
         );
     }
 
+    /// #1748: `begin_resume` must place a `pending_resumes` reservation
+    /// synchronously so a subsequent `wait_for_worker` BLOCKS until the
+    /// worker lands instead of failing fast. This is the core of the
+    /// idle-dormant prompt-wake fix: before it, the prompt handler cleared
+    /// dormancy but started no resume, so `send_prompt`'s `wait_for_worker`
+    /// returned false immediately (no pending entry) and the prompt 404'd.
+    #[tokio::test]
+    async fn begin_resume_reserves_so_wait_for_worker_blocks() {
+        let sink = VecSink::new();
+        let sup = Arc::new(Supervisor::new(sink));
+
+        // Pre-fix shape: no worker and no reservation, so `wait_for_worker`
+        // returns false immediately. This is exactly what made the wake
+        // prompt 404 before the fix.
+        assert!(
+            !sup.wait_for_worker("s-1748", std::time::Duration::from_secs(60))
+                .await,
+            "with no reservation, wait_for_worker must fail fast"
+        );
+        assert!(!sup.is_running("s-1748").await);
+
+        // Reserve synchronously, the way the prompt-wake path now does
+        // before driving the detached spawn.
+        let reservation = match sup
+            .begin_resume("s-1748", ResumeKind::Spawn)
+            .await
+            .expect("begin_resume must not error under capacity")
+        {
+            ResumeReservationOutcome::Reserved(r) => r,
+            ResumeReservationOutcome::AlreadyPresent => panic!("expected a fresh reservation"),
+        };
+        assert!(
+            sup.is_running("s-1748").await,
+            "a reservation must count as running-ish so the reconciler skips it"
+        );
+        assert!(matches!(
+            sup.worker_state("s-1748").await,
+            CockpitWorkerState::Resuming
+        ));
+
+        // A second begin_resume for the same id must not double-reserve.
+        assert!(matches!(
+            sup.begin_resume("s-1748", ResumeKind::Spawn).await.unwrap(),
+            ResumeReservationOutcome::AlreadyPresent
+        ));
+
+        // With the reservation held, `wait_for_worker` BLOCKS: the worker
+        // is mid-resume, so it must not return within a short window.
+        let sup_clone = Arc::clone(&sup);
+        let waiter = tokio::spawn(async move {
+            sup_clone
+                .wait_for_worker("s-1748", std::time::Duration::from_secs(60))
+                .await
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            !waiter.is_finished(),
+            "wait_for_worker must block while the reservation is held"
+        );
+
+        // Dropping the reservation without a worker landing (the spawn
+        // failed) wakes the waiter, which then returns false.
+        drop(reservation);
+        let woke = tokio::time::timeout(std::time::Duration::from_millis(200), waiter)
+            .await
+            .expect("waiter must wake on reservation drop")
+            .expect("waiter task must not panic");
+        assert!(
+            !woke,
+            "no worker landed, so wait_for_worker returns false after the reservation drops"
+        );
+        assert!(matches!(
+            sup.worker_state("s-1748").await,
+            CockpitWorkerState::Absent
+        ));
+    }
+
     /// Regression: `shutdown` arriving while a spawn is mid-handshake
     /// must mark the in-flight spawn for cancellation, so the spawn's
     /// pre-insert check drops the freshly-built client instead of

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -293,6 +293,17 @@ pub enum ResumeKind {
     Spawn,
 }
 
+/// Outcome of `Supervisor::begin_resume`: either the caller now holds a
+/// fresh `pending_resumes` reservation it must carry into `spawn_inner`
+/// (or `attach`), or a worker is already running / already mid-resume so
+/// there is nothing to reserve. `CapacityFull` surfaces as the `Err` arm.
+pub(crate) enum ResumeReservationOutcome {
+    /// A reservation was placed; the caller owns the RAII guard.
+    Reserved(ResumeReservation),
+    /// The session is already in `workers` or `pending_resumes`.
+    AlreadyPresent,
+}
+
 pub struct Supervisor<S: BroadcastSink> {
     sink: Arc<S>,
     registry: Arc<Mutex<AgentRegistry>>,
@@ -355,7 +366,7 @@ pub struct Supervisor<S: BroadcastSink> {
 /// was taken. Without this, a panic or early-return mid-resume would
 /// leave a phantom reservation that blocks every future resume for
 /// that session AND keeps the UI stuck on "Resuming…".
-struct ResumeReservation {
+pub(crate) struct ResumeReservation {
     pending: Arc<std::sync::Mutex<HashMap<String, ResumeKind>>>,
     session_id: String,
     /// Wakes any `wait_for_worker` parked on the supervisor's
@@ -919,6 +930,98 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// at. The reservation makes the second caller fail fast with
     /// AlreadyRunning instead.
     pub async fn spawn(&self, req: SpawnRequest) -> Result<(), SupervisorError> {
+        let reservation = match self
+            .begin_resume(&req.session_id, ResumeKind::Spawn)
+            .await?
+        {
+            ResumeReservationOutcome::Reserved(r) => r,
+            ResumeReservationOutcome::AlreadyPresent => {
+                return Err(SupervisorError::AlreadyRunning(req.session_id));
+            }
+        };
+        self.spawn_inner(req, reservation).await
+    }
+
+    /// Synchronously reserve a `pending_resumes` slot BEFORE any async
+    /// resume work begins, so a caller that goes on to drive a detached
+    /// spawn (the idle-dormant prompt-wake path, see #1748) makes
+    /// `wait_for_worker` observe the reservation immediately rather than
+    /// failing fast. Returns `AlreadyPresent` when a worker is already
+    /// running or another task is mid-resume, and `Err(CapacityFull)`
+    /// when the worker cap is reached. The `workers` and `pending_resumes`
+    /// maps are checked under the same critical section so the
+    /// `(workers ∪ pending)` set is observed atomically; the existing
+    /// `spawn`/`attach` reservation logic now routes through here.
+    pub(crate) async fn begin_resume(
+        &self,
+        session_id: &str,
+        kind: ResumeKind,
+    ) -> Result<ResumeReservationOutcome, SupervisorError> {
+        let workers = self.workers.lock().await;
+        if workers.contains_key(session_id) {
+            return Ok(ResumeReservationOutcome::AlreadyPresent);
+        }
+        let mut pending = lock_recover(&self.pending_resumes);
+        if pending.contains_key(session_id) {
+            return Ok(ResumeReservationOutcome::AlreadyPresent);
+        }
+        match kind {
+            ResumeKind::Spawn => {
+                // Capacity check counts both running (in-memory) and
+                // detached (on-disk-only) workers PLUS any in-flight Spawn
+                // reservations, so a parallel reconciler can't pass the
+                // limit check for N concurrent callers before any have
+                // inserted into `workers`. Attach reservations don't
+                // contribute: they reattach to an existing live runner that
+                // is already counted in `registry_count`. See #1088.
+                let registry_count = super::worker_registry::list()
+                    .map(|recs| {
+                        recs.into_iter()
+                            .filter(|r| {
+                                super::worker_registry::is_record_live(r)
+                                    && !workers.contains_key(&r.session_id)
+                            })
+                            .count()
+                    })
+                    .unwrap_or(0);
+                let pending_spawn_count = pending
+                    .values()
+                    .filter(|k| matches!(k, ResumeKind::Spawn))
+                    .count();
+                let combined = workers.len() + registry_count + pending_spawn_count;
+                if combined >= self.max_concurrent_workers as usize {
+                    return Err(SupervisorError::CapacityFull {
+                        current: combined,
+                        limit: self.max_concurrent_workers,
+                    });
+                }
+            }
+            ResumeKind::Attach => {
+                if workers.len() >= self.max_concurrent_workers as usize {
+                    return Err(SupervisorError::CapacityFull {
+                        current: workers.len(),
+                        limit: self.max_concurrent_workers,
+                    });
+                }
+            }
+        }
+        pending.insert(session_id.to_string(), kind);
+        Ok(ResumeReservationOutcome::Reserved(ResumeReservation {
+            pending: Arc::clone(&self.pending_resumes),
+            session_id: session_id.to_string(),
+            notify: Arc::clone(&self.worker_notify),
+        }))
+    }
+
+    /// Spawn body proper, run while holding a `pending_resumes`
+    /// reservation acquired by `begin_resume`. Split out so the
+    /// prompt-wake path (#1748) can reserve synchronously, then drive
+    /// this in a detached task without re-reserving.
+    pub(crate) async fn spawn_inner(
+        &self,
+        req: SpawnRequest,
+        _reservation: ResumeReservation,
+    ) -> Result<(), SupervisorError> {
         let SpawnRequest {
             session_id,
             agent,
@@ -931,55 +1034,6 @@ impl<S: BroadcastSink> Supervisor<S> {
             source_profile,
             yolo_mode,
         } = req;
-        let _reservation = {
-            let workers = self.workers.lock().await;
-            if workers.contains_key(&session_id) {
-                return Err(SupervisorError::AlreadyRunning(session_id));
-            }
-            // Capacity check counts both running (in-memory) and
-            // detached (on-disk-only) workers PLUS any in-flight Spawn
-            // reservations, so a parallel reconciler can't pass the
-            // limit check for N concurrent callers before any have
-            // inserted into `workers`. Attach reservations don't
-            // contribute: they reattach to an existing live runner that
-            // is already counted in `registry_count`. See #1088.
-            let registry_count = super::worker_registry::list()
-                .map(|recs| {
-                    recs.into_iter()
-                        .filter(|r| {
-                            super::worker_registry::is_record_live(r)
-                                && !workers.contains_key(&r.session_id)
-                        })
-                        .count()
-                })
-                .unwrap_or(0);
-            // Acquire pending_resumes under the same critical section
-            // as the workers check so the (workers ∪ pending) set is
-            // observed atomically. A second caller arriving here sees
-            // either the workers entry (after insert below) or the
-            // pending entry; in both cases it returns AlreadyRunning.
-            let mut pending = lock_recover(&self.pending_resumes);
-            if pending.contains_key(&session_id) {
-                return Err(SupervisorError::AlreadyRunning(session_id));
-            }
-            let pending_spawn_count = pending
-                .values()
-                .filter(|k| matches!(k, ResumeKind::Spawn))
-                .count();
-            let combined = workers.len() + registry_count + pending_spawn_count;
-            if combined >= self.max_concurrent_workers as usize {
-                return Err(SupervisorError::CapacityFull {
-                    current: combined,
-                    limit: self.max_concurrent_workers,
-                });
-            }
-            pending.insert(session_id.clone(), ResumeKind::Spawn);
-            ResumeReservation {
-                pending: Arc::clone(&self.pending_resumes),
-                session_id: session_id.clone(),
-                notify: Arc::clone(&self.worker_notify),
-            }
-        };
 
         // Per-agent install gate. claude-agent-acp lazy-installs its
         // native binary on first ever run; two concurrent `session/new`
@@ -1963,6 +2017,19 @@ impl<S: BroadcastSink> Supervisor<S> {
         in_flight_turn: bool,
         sandbox: Option<SandboxInfo>,
     ) -> Result<(), SupervisorError> {
+        // Reserve a `pending_resumes` slot for the duration of the
+        // attach so the UI shows "Resuming…" while the socket dial +
+        // resume handshake runs, AND the capacity check in a concurrent
+        // `spawn` sees this id and avoids over-allocating. RAII guard
+        // removes the entry on every exit path. Reserving before the
+        // registry probe keeps the `(workers ∪ pending)` set atomic.
+        let _reservation = match self.begin_resume(&session_id, ResumeKind::Attach).await? {
+            ResumeReservationOutcome::Reserved(r) => r,
+            ResumeReservationOutcome::AlreadyPresent => {
+                return Err(SupervisorError::AlreadyRunning(session_id));
+            }
+        };
+
         let record = match super::worker_registry::load(&session_id)
             .map_err(|e| SupervisorError::Acp(AcpError::Spawn(format!("registry load: {e}"))))?
         {
@@ -1974,42 +2041,14 @@ impl<S: BroadcastSink> Supervisor<S> {
 
         // Resume requires a known ACP session id (the runner was holding
         // the agent loaded against it). If the registry doesn't carry
-        // one yet — e.g. the previous daemon crashed before the first
-        // `session/new` response was processed — there's nothing to
+        // one yet, e.g. the previous daemon crashed before the first
+        // `session/new` response was processed, there's nothing to
         // resume against; bail so the reconciler falls through to a
         // fresh spawn.
         let Some(stored_acp_session_id) = record.stored_acp_session_id.clone() else {
             return Err(SupervisorError::Acp(AcpError::Spawn(
                 "runner registry has no stored_acp_session_id; need fresh spawn".into(),
             )));
-        };
-
-        // Reserve a `pending_resumes` slot for the duration of the
-        // attach so the UI shows "Resuming…" while the socket dial +
-        // resume handshake runs, AND the capacity check in a
-        // concurrent `spawn` sees this id and avoids over-allocating.
-        // RAII guard removes the entry on every exit path.
-        let _reservation = {
-            let workers = self.workers.lock().await;
-            if workers.contains_key(&session_id) {
-                return Err(SupervisorError::AlreadyRunning(session_id));
-            }
-            if workers.len() >= self.max_concurrent_workers as usize {
-                return Err(SupervisorError::CapacityFull {
-                    current: workers.len(),
-                    limit: self.max_concurrent_workers,
-                });
-            }
-            let mut pending = lock_recover(&self.pending_resumes);
-            if pending.contains_key(&session_id) {
-                return Err(SupervisorError::AlreadyRunning(session_id));
-            }
-            pending.insert(session_id.clone(), ResumeKind::Attach);
-            ResumeReservation {
-                pending: Arc::clone(&self.pending_resumes),
-                session_id: session_id.clone(),
-                notify: Arc::clone(&self.worker_notify),
-            }
         };
 
         let cockpit_session_id = CockpitSessionId(session_id.clone());

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -759,7 +759,15 @@ pub async fn cockpit_prompt(
     // to a 404. The detached task survives this request being cancelled on
     // client disconnect. See #1748.
     if woke_idle_dormant {
+        use crate::server::cockpit_reconciler::ResumeTrigger;
         match crate::server::cockpit_reconciler::trigger_resume_background(&state, &id).await {
+            Ok(ResumeTrigger::NotFound) => {
+                // The session was deleted (or triaged) between the wake and
+                // the resume snapshot. Do not publish into a session that no
+                // longer exists; a 404 is the honest answer, not a retryable
+                // worker_not_ready. See #1748.
+                return (StatusCode::NOT_FOUND, "session not found").into_response();
+            }
             Ok(_) => {}
             Err(SupervisorError::CapacityFull { current, limit }) => {
                 return (
@@ -833,11 +841,21 @@ pub async fn cockpit_prompt_diff_comments(
         Err(rej) => return rej.into_response(),
     };
     let woke_idle_dormant = touch_and_wake_if_sunk(&state, &id).await;
+    {
+        let instances = state.instances.read().await;
+        if !instances.iter().any(|i| i.id == id) {
+            return (StatusCode::NOT_FOUND, "session not found").into_response();
+        }
+    }
     // Idle-dormant wake: respawn synchronously-reserved + detached so the
     // send_prompt below waits for the worker instead of 404ing. Mirrors
     // cockpit_prompt. See #1748.
     if woke_idle_dormant {
+        use crate::server::cockpit_reconciler::ResumeTrigger;
         match crate::server::cockpit_reconciler::trigger_resume_background(&state, &id).await {
+            Ok(ResumeTrigger::NotFound) => {
+                return (StatusCode::NOT_FOUND, "session not found").into_response();
+            }
             Ok(_) => {}
             Err(SupervisorError::CapacityFull { current, limit }) => {
                 return (

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -655,15 +655,18 @@ pub async fn switch_cockpit_agent(
 /// dropped before the caller reaches the supervisor: publish/send take
 /// their own locks downstream and holding ours across the agent forward
 /// would serialize prompts unnecessarily and stall siblings.
-async fn touch_and_wake_if_sunk(state: &Arc<AppState>, id: &str) {
+/// Returns whether the wake cleared an idle-dormant marker, so the caller
+/// can synchronously kick a background respawn (the reconciler's ~2s tick
+/// is too slow for the prompt that triggered the wake; see #1748).
+async fn touch_and_wake_if_sunk(state: &Arc<AppState>, id: &str) -> bool {
     let inst_lock = state.instance_lock(id).await;
     let _guard = inst_lock.lock().await;
-    let triage_changed = {
+    let (triage_changed, woke_idle_dormant) = {
         let mut instances = state.instances.write().await;
         if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
-            let was_sunk = inst.is_archived() || inst.is_snoozed() || inst.is_idle_dormant();
+            let was_idle_dormant = inst.is_idle_dormant();
+            let was_sunk = inst.is_archived() || inst.is_snoozed() || was_idle_dormant;
             if was_sunk {
-                let was_idle_dormant = inst.is_idle_dormant();
                 inst.touch_last_accessed();
                 if was_idle_dormant {
                     // Pairs with the "auto-stopped idle cockpit worker"
@@ -672,13 +675,13 @@ async fn touch_and_wake_if_sunk(state: &Arc<AppState>, id: &str) {
                     tracing::info!(
                         target: "cockpit.supervisor",
                         session = %id,
-                        "waking idle-dormant cockpit session on prompt; reconciler will respawn the worker"
+                        "waking idle-dormant cockpit session on prompt; spawning a fresh worker"
                     );
                 }
             }
-            was_sunk
+            (was_sunk, was_idle_dormant)
         } else {
-            false
+            (false, false)
         }
     };
     if triage_changed {
@@ -717,6 +720,7 @@ async fn touch_and_wake_if_sunk(state: &Arc<AppState>, id: &str) {
             }
         }
     }
+    woke_idle_dormant
 }
 
 pub async fn cockpit_prompt(
@@ -731,7 +735,7 @@ pub async fn cockpit_prompt(
         Ok(j) => j,
         Err(rej) => return rej.into_response(),
     };
-    touch_and_wake_if_sunk(&state, &id).await;
+    let woke_idle_dormant = touch_and_wake_if_sunk(&state, &id).await;
     {
         let instances = state.instances.read().await;
         if !instances.iter().any(|i| i.id == id) {
@@ -741,11 +745,38 @@ pub async fn cockpit_prompt(
     // Decode + validate + capability-gate attachments BEFORE publishing
     // so a rejected prompt never leaves a half-rendered attachment in
     // the transcript (the publish path is otherwise authoritative). See
-    // #1000 / #965.
+    // #1000 / #965. Validating before the resume trigger below also
+    // avoids respawning a worker for a request we are about to reject.
     let attachments = match validate_attachments(&state, &id, &req.attachments) {
         Ok(a) => a,
         Err((code, msg)) => return (code, msg).into_response(),
     };
+    // Idle-dormant wake: the worker was auto-stopped for inactivity
+    // (#1689) and the reconciler will not respawn it until its next ~2s
+    // tick. Reserve the resume slot synchronously and drive a fresh spawn
+    // in a detached task NOW, so the `send_prompt` below blocks on
+    // `wait_for_worker` until the worker is live instead of racing ahead
+    // to a 404. The detached task survives this request being cancelled on
+    // client disconnect. See #1748.
+    if woke_idle_dormant {
+        match crate::server::cockpit_reconciler::trigger_resume_background(&state, &id).await {
+            Ok(_) => {}
+            Err(SupervisorError::CapacityFull { current, limit }) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!("worker_capacity_full ({current}/{limit})"),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!("worker_not_ready: {e}"),
+                )
+                    .into_response();
+            }
+        }
+    }
     // Publish the user's prompt into the event stream BEFORE forwarding
     // to the agent so the replay buffer / on-disk store captures it
     // even if the agent forward fails. The frontend treats UserPromptSent
@@ -761,7 +792,17 @@ pub async fn cockpit_prompt(
     {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
         Err(SupervisorError::UnknownSession(_)) => {
-            (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()
+            if woke_idle_dormant {
+                // The respawn we kicked above did not finish within
+                // `send_prompt`'s wait window (slow sandbox / spawn). The
+                // worker is still coming; signal a retryable typed status
+                // so the frontend keeps the prompt queued and re-fires on
+                // the next `AcpSessionAssigned`, rather than dropping it
+                // on a 404. See #1748.
+                (StatusCode::SERVICE_UNAVAILABLE, "worker_not_ready").into_response()
+            } else {
+                (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()
+            }
         }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -791,7 +832,29 @@ pub async fn cockpit_prompt_diff_comments(
         Ok(j) => j,
         Err(rej) => return rej.into_response(),
     };
-    touch_and_wake_if_sunk(&state, &id).await;
+    let woke_idle_dormant = touch_and_wake_if_sunk(&state, &id).await;
+    // Idle-dormant wake: respawn synchronously-reserved + detached so the
+    // send_prompt below waits for the worker instead of 404ing. Mirrors
+    // cockpit_prompt. See #1748.
+    if woke_idle_dormant {
+        match crate::server::cockpit_reconciler::trigger_resume_background(&state, &id).await {
+            Ok(_) => {}
+            Err(SupervisorError::CapacityFull { current, limit }) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!("worker_capacity_full ({current}/{limit})"),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!("worker_not_ready: {e}"),
+                )
+                    .into_response();
+            }
+        }
+    }
     // Publish the typed event BEFORE forwarding so the replay buffer /
     // on-disk store captures the user's side even if the forward fails,
     // matching cockpit_prompt.
@@ -813,7 +876,11 @@ pub async fn cockpit_prompt_diff_comments(
     {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
         Err(SupervisorError::UnknownSession(_)) => {
-            (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()
+            if woke_idle_dormant {
+                (StatusCode::SERVICE_UNAVAILABLE, "worker_not_ready").into_response()
+            } else {
+                (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()
+            }
         }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -735,7 +735,14 @@ async fn build_spawn_request(
 /// and is by definition not mid-turn.
 async fn resume_target_for_session(state: &Arc<AppState>, id: &str) -> Option<ResumeTarget> {
     let instances = state.instances.read().await;
-    let inst = instances.iter().find(|i| i.id == id && i.cockpit_mode)?;
+    // Filter the same triage states the reconciler skips everywhere else.
+    // The wake path drops `instance_lock` before calling this, so an archive
+    // or snooze can win the race after dormancy was cleared; resolving to
+    // None (then NotFound) keeps us from respawning a session the reconciler
+    // intentionally leaves sunk. See #1748.
+    let inst = instances.iter().find(|i| {
+        i.id == id && i.cockpit_mode && !i.is_archived() && !i.is_snoozed() && !i.is_idle_dormant()
+    })?;
     Some(ResumeTarget {
         id: inst.id.clone(),
         tool: inst.tool.clone(),

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -622,58 +622,23 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
             .synthesize_stopped_for_orphan(&id, "orphaned_at_restart");
     }
 
-    let supervisor = Arc::clone(&state.cockpit_supervisor);
-    let agent = supervisor
-        .pick_agent_for_tool(
-            &tool,
-            agent_override.as_deref(),
-            &source_profile,
-            std::path::Path::new(&project_path),
-        )
-        .await;
-    let cwd = PathBuf::from(project_path);
-
-    let inst_lock = state.instance_lock(&id).await;
-    let sandbox_info = match crate::cockpit::sandbox::ensure_container_for_session(
-        &state.instances,
-        &inst_lock,
-        &id,
-        false,
-    )
-    .await
-    {
-        Ok(info) => info,
-        Err(e) => {
-            let message = format!("sandbox container ensure failed: {e}");
-            tracing::warn!(
-                target: "cockpit.supervisor",
-                session = %id,
-                "reconciler container ensure failed: {message}"
-            );
-            supervisor.publish_startup_error(&id, message);
-            return ResumeOutcome::SpawnFinished;
-        }
+    let resume_target = ResumeTarget {
+        id: id.clone(),
+        tool,
+        agent_override,
+        model,
+        project_path,
+        stored_acp_session_id,
+        source_profile,
+        in_flight_turn,
+        yolo_mode,
     };
-
-    // Thread the session profile through regardless of sandboxing: the
-    // spawn path resolves agent_cockpit_cmd and worker env from it, so a
-    // non-sandbox session on a non-default profile must not fall back to
-    // the default profile.
-    let source_profile_for_spawn = Some(source_profile.clone());
-    let spawn_result = supervisor
-        .spawn(crate::cockpit::supervisor::SpawnRequest {
-            session_id: id.clone(),
-            agent: agent.clone(),
-            cwd,
-            additional_dirs: vec![],
-            provider_env: vec![],
-            model,
-            stored_acp_session_id,
-            sandbox_info,
-            source_profile: source_profile_for_spawn,
-            yolo_mode,
-        })
-        .await;
+    let req = match build_spawn_request(&state, &resume_target).await {
+        Ok(req) => req,
+        Err(()) => return ResumeOutcome::SpawnFinished,
+    };
+    let agent = req.agent.clone();
+    let spawn_result = state.cockpit_supervisor.spawn(req).await;
     if let Err(e) = spawn_result {
         // Re-check whether the session still exists in instances.
         // The user can delete a session during the spawn handshake
@@ -689,7 +654,7 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
                 agent = %agent,
                 "auto-spawn reconciler failed: {message}"
             );
-            supervisor.publish_startup_error(&id, message);
+            state.cockpit_supervisor.publish_startup_error(&id, message);
         } else {
             tracing::debug!(
                 target: "cockpit.supervisor",
@@ -700,6 +665,174 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
         }
     }
     ResumeOutcome::SpawnFinished
+}
+
+/// Build a fresh-spawn `SpawnRequest` for a resume target: pick the
+/// agent, resolve the cwd, and ensure the sandbox container. On a sandbox
+/// failure it publishes a startup error (so the UI banner matches the
+/// reconciler path) and returns `Err(())`; callers bail. Shared by the
+/// reconciler's fresh-spawn fallback and the prompt-wake resume (#1748)
+/// so both paths build identical requests.
+async fn build_spawn_request(
+    state: &Arc<AppState>,
+    target: &ResumeTarget,
+) -> Result<crate::cockpit::supervisor::SpawnRequest, ()> {
+    let supervisor = Arc::clone(&state.cockpit_supervisor);
+    let agent = supervisor
+        .pick_agent_for_tool(
+            &target.tool,
+            target.agent_override.as_deref(),
+            &target.source_profile,
+            std::path::Path::new(&target.project_path),
+        )
+        .await;
+    let cwd = PathBuf::from(&target.project_path);
+
+    let inst_lock = state.instance_lock(&target.id).await;
+    let sandbox_info = match crate::cockpit::sandbox::ensure_container_for_session(
+        &state.instances,
+        &inst_lock,
+        &target.id,
+        false,
+    )
+    .await
+    {
+        Ok(info) => info,
+        Err(e) => {
+            let message = format!("sandbox container ensure failed: {e}");
+            tracing::warn!(
+                target: "cockpit.supervisor",
+                session = %target.id,
+                "reconciler container ensure failed: {message}"
+            );
+            supervisor.publish_startup_error(&target.id, message);
+            return Err(());
+        }
+    };
+
+    // Thread the session profile through regardless of sandboxing: the
+    // spawn path resolves agent_cockpit_cmd and worker env from it, so a
+    // non-sandbox session on a non-default profile must not fall back to
+    // the default profile.
+    Ok(crate::cockpit::supervisor::SpawnRequest {
+        session_id: target.id.clone(),
+        agent,
+        cwd,
+        additional_dirs: vec![],
+        provider_env: vec![],
+        model: target.model.clone(),
+        stored_acp_session_id: target.stored_acp_session_id.clone(),
+        sandbox_info,
+        source_profile: Some(target.source_profile.clone()),
+        yolo_mode: target.yolo_mode,
+    })
+}
+
+/// Snapshot a single cockpit session's resume inputs from the live
+/// instance list. Returns `None` when the session is gone or is not a
+/// cockpit session. `in_flight_turn` is always false: this is only used
+/// by the prompt-wake path (#1748), where the worker was idle-auto-stopped
+/// and is by definition not mid-turn.
+async fn resume_target_for_session(state: &Arc<AppState>, id: &str) -> Option<ResumeTarget> {
+    let instances = state.instances.read().await;
+    let inst = instances.iter().find(|i| i.id == id && i.cockpit_mode)?;
+    Some(ResumeTarget {
+        id: inst.id.clone(),
+        tool: inst.tool.clone(),
+        agent_override: inst.cockpit_agent.clone(),
+        model: inst.cockpit_model.clone(),
+        project_path: inst.project_path.clone(),
+        stored_acp_session_id: inst.cockpit_acp_session_id.clone(),
+        source_profile: inst.source_profile.clone(),
+        in_flight_turn: false,
+        yolo_mode: inst.yolo_mode,
+    })
+}
+
+/// Result of a prompt-wake resume trigger. See `trigger_resume_background`.
+pub(crate) enum ResumeTrigger {
+    /// A detached resume task was started; a `pending_resumes` slot is
+    /// reserved so `wait_for_worker` will block until the worker is live.
+    Started,
+    /// A worker is already running or another resume is already in flight.
+    AlreadyResuming,
+    /// The session is gone or is not a cockpit session; nothing to do.
+    NotFound,
+}
+
+/// Synchronously reserve a resume slot for `id`, then drive a fresh worker
+/// spawn in a DETACHED task so it survives the originating HTTP request
+/// being cancelled on client disconnect. Because `begin_resume` reserves
+/// the `pending_resumes` slot before this returns, a subsequent
+/// `send_prompt` -> `wait_for_worker` observes the reservation and blocks
+/// until the worker is live instead of failing fast with a 404. The next
+/// reconciler tick sees the reservation via `is_running` and skips the
+/// session, so there is no double-spawn. Returns `Err(CapacityFull)` when
+/// the worker cap is reached so the handler can surface 503. See #1748.
+pub(crate) async fn trigger_resume_background(
+    state: &Arc<AppState>,
+    id: &str,
+) -> Result<ResumeTrigger, crate::cockpit::supervisor::SupervisorError> {
+    use crate::cockpit::supervisor::{ResumeKind, ResumeReservationOutcome};
+    let reservation = match state
+        .cockpit_supervisor
+        .begin_resume(id, ResumeKind::Spawn)
+        .await?
+    {
+        ResumeReservationOutcome::Reserved(r) => r,
+        ResumeReservationOutcome::AlreadyPresent => return Ok(ResumeTrigger::AlreadyResuming),
+    };
+    let Some(target) = resume_target_for_session(state, id).await else {
+        // Session vanished between the wake and this snapshot; drop the
+        // reservation (RAII clears pending + notifies waiters) and report
+        // nothing to do.
+        drop(reservation);
+        return Ok(ResumeTrigger::NotFound);
+    };
+    let state = Arc::clone(state);
+    crate::task_util::spawn_supervised(
+        "cockpit.prompt_wake_resume",
+        crate::task_util::PanicPolicy::Log,
+        async move {
+            let req = match build_spawn_request(&state, &target).await {
+                // Sandbox failure already published a startup error; the
+                // reservation drops here and wakes any parked send_prompt.
+                Ok(req) => req,
+                Err(()) => return,
+            };
+            let agent = req.agent.clone();
+            if let Err(e) = state.cockpit_supervisor.spawn_inner(req, reservation).await {
+                // AlreadyRunning / SpawnCancelled are benign: a worker
+                // already exists or the session was intentionally torn
+                // down mid-handshake. Only surface real startup failures.
+                if !matches!(
+                    e,
+                    crate::cockpit::supervisor::SupervisorError::AlreadyRunning(_)
+                        | crate::cockpit::supervisor::SupervisorError::SpawnCancelled(_)
+                ) {
+                    let still_present = state
+                        .instances
+                        .read()
+                        .await
+                        .iter()
+                        .any(|i| i.id == target.id);
+                    if still_present {
+                        let message = format!("Failed to start cockpit agent {agent:?}: {e}");
+                        tracing::warn!(
+                            target: "cockpit.supervisor",
+                            session = %target.id,
+                            agent = %agent,
+                            "prompt-wake spawn failed: {message}"
+                        );
+                        state
+                            .cockpit_supervisor
+                            .publish_startup_error(&target.id, message);
+                    }
+                }
+            }
+        },
+    );
+    Ok(ResumeTrigger::Started)
 }
 
 async fn sweep_orphan_workers(state: &Arc<AppState>, live: &HashSet<&String>) {

--- a/web/src/hooks/useCockpit.queue.test.ts
+++ b/web/src/hooks/useCockpit.queue.test.ts
@@ -270,6 +270,7 @@ async function flushAsync(): Promise<void> {
 describe("useCockpit drain race (#1144)", () => {
   let promptPostCount: number;
   let promptPostStatus: number;
+  let promptPostBody: string;
   let promptPostBodies: string[];
   let replayResponse: { frames: unknown[]; lost: boolean; highest_seq: number };
 
@@ -277,6 +278,7 @@ describe("useCockpit drain race (#1144)", () => {
     sockets.length = 0;
     promptPostCount = 0;
     promptPostStatus = 200;
+    promptPostBody = "simulated failure";
     promptPostBodies = [];
     replayResponse = { frames: [], lost: false, highest_seq: 0 };
     vi.stubGlobal(
@@ -292,7 +294,7 @@ describe("useCockpit drain race (#1144)", () => {
             promptPostBodies.push(init.body);
           }
           if (promptPostStatus >= 400) {
-            return new Response("simulated failure", { status: promptPostStatus });
+            return new Response(promptPostBody, { status: promptPostStatus });
           }
           return new Response("{}", { status: promptPostStatus });
         }
@@ -477,6 +479,84 @@ describe("useCockpit drain race (#1144)", () => {
     expect(promptPostCount).toBe(1);
     expect(promptPostBodies[0]).toContain("parked before dormancy");
     expect(result.current.state.queuedPrompts).toEqual([]);
+  });
+
+  it("keeps an idle-dormant prompt queued without an error banner on a worker_not_ready 503 (#1748)", async () => {
+    const { result } = renderHook(() => useCockpit("sess-idle-503", "absent"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+
+    // Worker reaped for inactivity: dormant.
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-idle-503",
+          seq: 1,
+          event: { Stopped: { reason: "idle_auto_stop" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.workerIdleStopped).toBe(true);
+
+    // The wake POST goes out, but the respawn did not finish within the
+    // server's wait window, so it returns the typed retryable 503. The
+    // prompt must NOT be dropped (it re-queues) and NO error banner shows;
+    // the drain re-fires it once the worker comes online. See #1748.
+    promptPostStatus = 503;
+    promptPostBody = "worker_not_ready";
+    await act(async () => {
+      await result.current.sendPrompt("wake me up");
+    });
+    await flushAsync();
+
+    expect(promptPostCount).toBe(1);
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+    expect(result.current.state.queuedPrompts[0]?.text).toBe("wake me up");
+    expect(result.current.state.lastError ?? "").not.toContain(
+      "Could not send prompt",
+    );
+  });
+
+  it("still surfaces an error banner on a worker_capacity_full 503 (#1748)", async () => {
+    // Control: the capacity 503 needs operator action, so unlike
+    // worker_not_ready it must keep its banner rather than being silently
+    // swallowed as a transient.
+    const { result } = renderHook(() => useCockpit("sess-idle-cap", "absent"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-idle-cap",
+          seq: 1,
+          event: { Stopped: { reason: "idle_auto_stop" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.workerIdleStopped).toBe(true);
+
+    promptPostStatus = 503;
+    promptPostBody = "worker_capacity_full (4/4)";
+    await act(async () => {
+      await result.current.sendPrompt("wake me up");
+    });
+    await flushAsync();
+
+    expect(result.current.state.lastError ?? "").toContain(
+      "Could not send prompt (503)",
+    );
   });
 
   it("retires the optimistic turn when prompt POST is rejected with 4xx", async () => {

--- a/web/src/hooks/useCockpit.queue.test.ts
+++ b/web/src/hooks/useCockpit.queue.test.ts
@@ -559,6 +559,50 @@ describe("useCockpit drain race (#1144)", () => {
     );
   });
 
+  it("keeps the error banner on a worker_not_ready 503 for an attachment send (#1748)", async () => {
+    // Attachments cannot be re-queued (the local queue is text-only), so a
+    // worker_not_ready 503 for an attachment send has no retry path. The
+    // banner must show rather than being suppressed as transient.
+    const { result } = renderHook(() => useCockpit("sess-idle-attach", "absent"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-idle-attach",
+          seq: 1,
+          event: { Stopped: { reason: "idle_auto_stop" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.workerIdleStopped).toBe(true);
+
+    promptPostStatus = 503;
+    promptPostBody = "worker_not_ready";
+    await act(async () => {
+      await result.current.sendPrompt("wake me up", [
+        {
+          kind: "image",
+          mimeType: "image/png",
+          dataB64: "aA==",
+          name: "shot.png",
+        },
+      ]);
+    });
+    await flushAsync();
+
+    expect(result.current.state.lastError ?? "").toContain(
+      "Could not send prompt (503)",
+    );
+    expect(result.current.state.queuedPrompts).toEqual([]);
+  });
+
   it("retires the optimistic turn when prompt POST is rejected with 4xx", async () => {
     const { result } = renderHook(() => useCockpit("sess-reject-4xx"));
     await flushAsync();

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -1096,8 +1096,15 @@ export function useCockpit(
           // the next AcpSessionAssigned. A capacity 503 ("worker_capacity_full")
           // is NOT this case: it needs operator action, so it keeps its
           // banner. See #1748.
+          //
+          // Only suppress for text-only sends: the local queue does not
+          // carry attachments, so an attachment send that hits this 503 has
+          // no retry path. Keep its banner so the user knows to resend
+          // rather than seeing a silent optimistic bubble. See #1748.
           const workerNotReady =
-            res.status === 503 && detail.startsWith("worker_not_ready");
+            res.status === 503 &&
+            detail.startsWith("worker_not_ready") &&
+            (!attachments || attachments.length === 0);
           if (rejected) {
             dispatch({ kind: "prompt_send_rejected" });
           }

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -1088,13 +1088,25 @@ export function useCockpit(
           // turn to cancel and no Stopped frame to retire our optimistic
           // turn marker.
           const rejected = res.status >= 400 && res.status < 500;
+          // Typed transient: the session was idle-auto-stopped (#1689) and
+          // its worker did not finish respawning within send_prompt's wait
+          // window. The worker is still coming online, so this is
+          // retryable; suppress the error banner (the queued indicator and
+          // respawn are the right signal) and let the drain re-fire it on
+          // the next AcpSessionAssigned. A capacity 503 ("worker_capacity_full")
+          // is NOT this case: it needs operator action, so it keeps its
+          // banner. See #1748.
+          const workerNotReady =
+            res.status === 503 && detail.startsWith("worker_not_ready");
           if (rejected) {
             dispatch({ kind: "prompt_send_rejected" });
           }
-          dispatch({
-            kind: "error",
-            message: `Could not send prompt (${res.status}). ${detail}`.trim(),
-          });
+          if (!workerNotReady) {
+            dispatch({
+              kind: "error",
+              message: `Could not send prompt (${res.status}). ${detail}`.trim(),
+            });
+          }
           return rejected ? "non_retryable_failure" : "retryable_failure";
         }
         return "ok";
@@ -1185,7 +1197,20 @@ export function useCockpit(
         dispatch({ kind: "enqueue_prompt", text });
         return;
       }
-      await dispatchPromptNow(text, attachments);
+      const result = await dispatchPromptNow(text, attachments);
+      // Idle-dormant direct send: the worker was respawning and did not
+      // come online within send_prompt's wait window, so the POST returned
+      // a retryable typed 503. Park the prompt instead of dropping it; the
+      // drain effect re-fires it once AcpSessionAssigned brings the worker
+      // online (text-only, since the queue does not carry attachments).
+      // See #1748.
+      if (
+        result === "retryable_failure" &&
+        state.workerIdleStopped &&
+        (!attachments || attachments.length === 0)
+      ) {
+        dispatch({ kind: "enqueue_prompt", text });
+      }
     },
     [
       sessionId,


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

With idle auto-stop enabled (`cockpit.auto_stop_idle_secs > 0`, #1689 / #1691), the first prompt to a session whose worker was auto-stopped for inactivity returned 404 and was dropped, so the user had to send the same message twice. The wake half worked (the handler cleared the `idle_dormant_since` marker), but the prompt that triggered the wake raced ahead of the respawn: `send_prompt`'s `wait_for_worker` found no pending resume and failed fast, and the reconciler only respawns on its next ~2s tick.

This makes the wake synchronous and race-safe. The prompt handler now reserves the resume slot up front via a new `Supervisor::begin_resume`, then drives a fresh spawn in a detached task. `send_prompt`'s `wait_for_worker` observes the reservation and blocks until the worker is live, so the first prompt is delivered with no resend. The detached task survives the request being cancelled on client disconnect (no orphaned containers), and the reconciler skips the session while the reservation is held (`is_running` counts `pending_resumes`), so there is no double-spawn. The supervisor reservation logic is split into `begin_resume` + `spawn_inner`/`attach_inner` so the existing `spawn`/`attach` keep their behavior while the handler can reserve before any async work.

If a respawn does not finish within `send_prompt`'s 10s wait (slow sandbox or spawn), the handler now returns a typed `503 worker_not_ready` instead of `404`. The web composer treats that as transient: it suppresses the error banner and re-parks the prompt so the drain re-fires it on the next `AcpSessionAssigned`, rather than dropping it. A `worker_capacity_full` 503 keeps its banner since it needs operator action.

Both prompt endpoints (`cockpit_prompt` and `cockpit_prompt_diff_comments`) get the same wake-then-resume path.

Closes #1748

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Set `cockpit.auto_stop_idle_secs` to a small value, open a cockpit session in the web dashboard, and let it sit idle until the worker is auto-stopped (sidebar shows the session idle / dormant).
- [ ] Send a message. Confirm the agent responds on the first send, with no error banner and no need to resend.
- [ ] Repeat with a queued prompt: while the worker is dormant, type and send so the prompt queues, then confirm it drains and is answered once the worker respawns.
- [ ] Exercise the diff-comments prompt path (review comments) against a dormant session and confirm it also wakes and delivers on the first send.
- [ ] Disconnect the browser mid-respawn (close the tab right after sending) and confirm no orphaned container is left behind and the worker still comes online.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Skipped a Playwright spec, because: a faithful idle-auto-stop e2e would have to wait out the reconciler's 60s `IDLE_REAP_INTERVAL`, which is impractical in CI without a new test-only interval hook. Covered instead by Vitest at the hook level (`web/src/hooks/useCockpit.queue.test.ts`): a `worker_not_ready` 503 keeps an idle-dormant prompt queued without an error banner, and a `worker_capacity_full` 503 still surfaces its banner. The server mechanism is covered by a Rust unit test (`begin_resume` makes `wait_for_worker` block until the worker lands).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle outside the cockpit prompt path.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, including a multi-model design debate on the lifecycle race. I made the design calls (synchronous reservation + detached spawn over an inline await, typed 503 over a retryable 404), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a race where the first prompt sent to a cockpit session after idle auto-stop could be dropped with a 404. It ensures the wake/resume path reserves a spot for the worker before spawning so the first prompt waits for the worker instead of racing ahead. The frontend and server now treat short startup unavailability as a transient condition so queued prompts are retried without showing an error banner.

## What changed (high-level)

- Supervisor now offers a synchronous resume reservation API so a resume slot is atomically visible before async spawn. Attach reservations no longer count toward spawn-capacity.
- Prompt handlers detect idle-dormant wake attempts and synchronously reserve/start the resume flow; if the worker isn’t ready within the send timeout, the server returns a typed 503 `worker_not_ready` (transient) instead of a dropped 404.
- Reconciler and spawn logic refactored: common spawn-request building extracted; detached supervised resume tasks use the new reservation flow and publish startup errors only for non-benign failures.
- Frontend: distinguishes `worker_not_ready` (transient) vs `worker_capacity_full` (hard) 503s. Text-only `worker_not_ready` sends are suppressed from showing an error banner and are re-queued for retry; attachment sends still surface an error.
- Error semantics tightened: genuine session deletion/triage during wake returns 404; `worker_not_ready` indicates an in-progress but not-yet-ready worker and is retryable.
- Tests: supervisor unit test verifies reservation blocks `wait_for_worker`; web unit tests cover queue/retry and banner behavior for both transient and capacity errors; Playwright e2e was skipped but covered by unit tests.

## Key benefits

1. First prompt after idle stop no longer lost — users don’t need to resend.
2. Cleaner UX: transient startup delays don’t show error banners for text sends.
3. Race eliminated between wake and reconciler spawn via reservation visibility.
4. Clearer server-side error semantics enabling correct frontend retry behavior.

## Technical details

- Supervisor (src/cockpit/supervisor.rs)
  - Added ResumeReservation/ResumeReservationOutcome and pub(crate) begin_resume(session_id, kind).
  - begin_resume atomically checks running workers + live detached registry workers + in-flight Spawn reservations (Attach reservations excluded) against max concurrency, inserts pending_resumes, and returns an RAII guard.
  - spawn/attach refactored to acquire a reservation via begin_resume and pass it through spawn_inner; inline reservation blocks removed.
  - Regression test begin_resume_reserves_so_wait_for_worker_blocks added.

- Cockpit API (src/server/api/cockpit.rs)
  - touch_and_wake_if_sunk returns bool when idle-dormant cleared.
  - Prompt endpoints validate attachments before triggering resume, trigger trigger_resume_background on wake, map resume failures to typed 503s, and return 404 when the session vanished during wake.
  - Both cockpit_prompt and cockpit_prompt_diff_comments use the new wake-then-resume flow and share the existence guard.

- Reconciler (src/server/cockpit_reconciler.rs)
  - Added build_spawn_request, resume_target_for_session, ResumeTrigger, and trigger_resume_background.
  - resume_one reworked to snapshot ResumeTarget, build SpawnRequest, and call supervisor.spawn_inner in a detached task; spawn failures re-check session presence before publishing startup errors.

- Frontend (web/src/hooks/useCockpit.ts, web/src/hooks/useCockpit.queue.test.ts)
  - dispatchPromptNow treats 503 details starting with "worker_not_ready" as retryable_failure and suppresses the banner for text-only sends.
  - sendPrompt enqueues prompts locally when retryable_failure occurs for idle-stopped sessions and no attachments.
  - Tests added for worker_not_ready (re-queue/no banner), worker_capacity_full (banner), and attachment behavior.

- Behavior/Timeouts
  - send_prompt’s existing ~10s wait remains; if respawn doesn’t finish in that window, server returns 503 worker_not_ready rather than a 404.
  - Attachments remain non-retryable: worker_not_ready for attachment sends surfaces an error banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->