### PR TITLE
test(e2e): prove cockpit focus isolation against a live daemon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ Full-binary e2e tests live in `tests/e2e/`, exercising `aoe` through tmux (TUI) 
 
 The harness (`tests/e2e/harness.rs`) exposes `TuiTestHarness` with `spawn_tui()`/`spawn(args)`, `send_keys(keys)`/`type_text(text)`, `wait_for(text)` (10s timeout), `capture_screen()`/`assert_screen_contains(text)`, and `run_cli(args)`. TUI tests auto-skip without tmux; Docker tests use `#[ignore]`; all use `#[serial]` for tmux isolation.
 
+Cockpit live-daemon e2e (`tests/e2e/cockpit_focus_isolation_e2e.rs`) stands up a real `aoe serve --daemon` and attaches the native TUI cockpit view against it. It reuses the shared Node fake-ACP agent (`web/tests/helpers/fakeAcpAgent.mjs`) to drive a deterministic pending approval, so it needs `--features serve` and Node on `PATH` (it auto-skips via `require_node!` otherwise). The harness installs the fake as the `claude` / `claude-agent-acp` / `aoe-agent` shims (`install_acp_shim`), roots `$HOME` under `/tmp` (`new_in_tmp`, keeping the worker unix socket under the macOS `sun_path` limit), and stops the worker plus daemon on `Drop` (`stop_daemon_on_drop`).
+
 Recording (for PR reviews): `RECORD_E2E=1 cargo test --test e2e -- --nocapture` locally (needs `asciinema` + `agg`, outputs to `target/e2e-recordings/`), or add the `needs-recording` label in CI.
 
 ### Web Dashboard Playwright Tests

--- a/tests/e2e/cockpit_focus_isolation_e2e.rs
+++ b/tests/e2e/cockpit_focus_isolation_e2e.rs
@@ -1,0 +1,203 @@
+//! Full-stack e2e: TUI cockpit focus isolation against a live daemon.
+//!
+//! The cockpit focus model (composer swallows approval letters; approval
+//! letters only resolve under approval focus) is unit-tested in isolation
+//! at `src/tui/cockpit_view/input.rs`. This test proves the same guarantee
+//! end-to-end: a real `aoe serve --daemon`, a real cockpit worker driving
+//! a real ACP `session/request_permission`, the native TUI attached over
+//! tmux, and the keystrokes routed through the production input loop.
+//!
+//! Determinism comes from the shared Node fake-ACP agent
+//! (`web/tests/helpers/fakeAcpAgent.mjs`): its `permission_request` turn
+//! entry emits a real ACP permission request and GATES the turn awaiting
+//! the client's decision, so the approval stays pending until the TUI
+//! resolves it.
+//!
+//! Compiled only with `--features serve` (cockpit + `aoe add --cockpit`
+//! don't exist otherwise). Run via:
+//!
+//! ```sh
+//! cargo test --test e2e --features serve -- cockpit_focus_isolation
+//! ```
+#![cfg(feature = "serve")]
+
+use std::time::{Duration, Instant};
+
+use serial_test::serial;
+
+use crate::harness::{pick_free_port, require_node, require_tmux, wait_for_port, TuiTestHarness};
+
+/// One-turn fake-ACP script: emit a single permission request (which the
+/// fake gates on) so the worker surfaces exactly one pending approval and
+/// holds it until the TUI resolves it.
+const APPROVAL_SCRIPT: &str = r#"{
+  "turns": [
+    {
+      "updates": [
+        {
+          "sessionUpdate": "permission_request",
+          "toolCall": {
+            "toolCallId": "focus-isolation-tool",
+            "title": "Edit a file",
+            "kind": "edit"
+          }
+        }
+      ],
+      "stopReason": "end_turn"
+    }
+  ]
+}"#;
+
+/// Parse the `  ID:      <id>` line that `aoe add` prints on success.
+fn parse_session_id(add_stdout: &str) -> String {
+    add_stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("ID:"))
+        .map(|rest| rest.trim().to_string())
+        .unwrap_or_else(|| panic!("could not find session ID in `aoe add` output:\n{add_stdout}"))
+}
+
+/// Retry `aoe cockpit prompt` until it is accepted. The prompt POST 404s
+/// while the worker is still spawning / handshaking, so a successful call
+/// is the readiness oracle for "worker live + ACP handshake done". The
+/// prompt enqueues a turn and returns immediately (it does not block on the
+/// gated approval), so this loop terminates on the first accepted prompt.
+fn prompt_until_accepted(h: &TuiTestHarness, session_id: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let out = h.run_cli(&["cockpit", "prompt", session_id, "please edit a file"]);
+        if out.status.success() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            let ps = h.run_cli(&["cockpit", "ps", "--json"]);
+            panic!(
+                "cockpit worker never accepted a prompt within {:?}.\n\
+                 last prompt stdout: {}\n last prompt stderr: {}\n cockpit ps: {}",
+                timeout,
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr),
+                String::from_utf8_lossy(&ps.stdout),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// Stand up a live daemon, attach the native TUI cockpit view to a session
+/// with a real pending approval, and prove focus isolation:
+///   1. With the composer focused, typing `a`/`A`/`d` does NOT resolve the
+///      approval (the letters land in the composer textarea instead).
+///   2. Moving focus to the approval card and pressing `a` DOES resolve it.
+#[test]
+#[serial]
+fn tui_cockpit_focus_isolation_with_live_daemon() {
+    require_tmux!();
+    require_node!();
+
+    // HOME under /tmp: cockpit workers bind a unix socket under the app
+    // dir, and a deep tempdir overflows the macOS sun_path limit.
+    let mut h = TuiTestHarness::new_in_tmp("cockpit_focus_isolation");
+
+    // Cockpit master flag on at rest so the daemon's reconciler will spawn
+    // the worker for the cockpit-mode session.
+    h.enable_cockpit_master();
+
+    // Shared Node fake-ACP agent, scripted to request one approval.
+    let script_path = h.home_path().join("approval-script.json");
+    std::fs::write(&script_path, APPROVAL_SCRIPT).expect("write fake-acp script");
+    h.install_acp_shim(&script_path);
+
+    // Tear down the worker + daemon on Drop so a panicking assertion can't
+    // leak a daemon onto the test port between serial tests.
+    h.stop_daemon_on_drop();
+
+    // A cockpit session needs a git repo as its workspace; create one.
+    let project = h.project_path();
+    for args in [
+        vec!["init", "-q"],
+        vec!["commit", "--allow-empty", "-q", "-m", "init"],
+    ] {
+        let out = std::process::Command::new("git")
+            .args(&args)
+            .current_dir(&project)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("run git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    // Start the daemon.
+    let port = pick_free_port();
+    let port_s = port.to_string();
+    let start = h.run_cli(&["serve", "--daemon", "--port", &port_s, "--no-auth"]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {}",
+        port
+    );
+
+    // Create the cockpit session (daemon picks it up off disk; the
+    // reconciler auto-spawns the worker since the master flag is on).
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "focus-isolation",
+        "-c",
+        "claude",
+        "--cockpit",
+    ]);
+    assert!(
+        add.status.success(),
+        "aoe add --cockpit failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&add.stdout),
+        String::from_utf8_lossy(&add.stderr),
+    );
+    let session_id = parse_session_id(&String::from_utf8_lossy(&add.stdout));
+
+    // Drive a real pending approval. This also gates worker readiness:
+    // the prompt 404s until the worker is live and handshaked.
+    prompt_until_accepted(&h, &session_id, Duration::from_secs(30));
+
+    // Attach the native TUI cockpit view over tmux. Same HOME, so it
+    // discovers the local daemon via serve.url / serve.pid.
+    h.spawn(&["cockpit", "attach", &session_id]);
+
+    // The approval must surface through the full stack (replay + WS).
+    h.wait_for(" pending approval");
+    h.assert_screen_contains("press a / A / d to resolve");
+
+    // --- Negative path: composer swallows approval letters ---
+    // Default focus on attach is Transcript; `i` focuses the composer.
+    h.send_keys("i");
+    h.type_text("aAd");
+    // If the letters render in the composer textarea, the input dispatcher
+    // routed them to Intent::Compose, which mathematically proves none of
+    // them resolved the approval (a resolve would have consumed the key as
+    // ResolveApproval, so it would never reach the textarea). This is the
+    // race-free oracle for "composer swallowed the approval letters".
+    h.wait_for("aAd");
+    h.assert_screen_not_contains("→ allowed");
+    h.assert_screen_contains(" pending approval");
+
+    // --- Positive path: resolve only under approval focus ---
+    h.send_keys("Escape"); // composer -> transcript
+    h.send_keys("Tab"); // transcript -> approval card (pending)
+    h.send_keys("a"); // resolve: allow
+    h.wait_for("→ allowed");
+}

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -11,6 +11,7 @@
 //! convert it to a GIF via `agg`. Recordings are saved to
 //! `target/e2e-recordings/`. Both `asciinema` and `agg` must be on `$PATH`.
 
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::{Duration, Instant};
@@ -55,6 +56,59 @@ macro_rules! require_tmux {
     };
 }
 pub(crate) use require_tmux;
+
+pub fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Skip the calling test if Node.js is not installed. Cockpit e2e tests
+/// drive the shared `web/tests/helpers/fakeAcpAgent.mjs` fake agent, which
+/// is a Node script; without Node the worker can't speak ACP.
+macro_rules! require_node {
+    () => {
+        if !$crate::harness::node_available() {
+            eprintln!("Skipping test: node not available");
+            return;
+        }
+    };
+}
+pub(crate) use require_node;
+
+// ---------------------------------------------------------------------------
+// Daemon port helpers (shared by serve.rs and cockpit e2e)
+// ---------------------------------------------------------------------------
+
+/// Bind a TCP listener to an ephemeral port, drop it, and return the port.
+/// Tiny TOCTOU window before the daemon binds, but acceptable for a serial
+/// test.
+pub fn pick_free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    l.local_addr().expect("local_addr").port()
+}
+
+/// Poll until the daemon accepts a TCP connection on `port`. The parent
+/// `aoe serve --daemon` returns as soon as it has spawned the child, so a
+/// successful exit doesn't prove the child bound the port; this is the
+/// real signal that the daemon is up.
+pub fn wait_for_port(port: u16, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if TcpStream::connect_timeout(
+            &format!("127.0.0.1:{}", port).parse().unwrap(),
+            Duration::from_millis(200),
+        )
+        .is_ok()
+        {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
 
 // ---------------------------------------------------------------------------
 // Recording helpers
@@ -130,6 +184,18 @@ pub struct TuiTestHarness {
     spawned: bool,
     recording: bool,
     cast_path: Option<PathBuf>,
+    /// Extra env vars exported on every spawned process (tmux session +
+    /// `run_cli` subprocesses). Used by cockpit tests to thread
+    /// FAKE_ACP_* and the runner-socket timeout into the daemon (and
+    /// thus the daemon-spawned worker, which inherits this env).
+    extra_env: Vec<(String, String)>,
+    /// Dirs prepended to PATH ahead of the `claude` stub. Cockpit tests
+    /// install the ACP shim here so it shadows the exit-0 stub.
+    extra_path_dirs: Vec<PathBuf>,
+    /// When set, `Drop` stops the cockpit workers and the serve daemon
+    /// before killing the tmux session, so a panicking assertion can't
+    /// leak a daemon between serial tests.
+    stop_daemon_on_drop: bool,
 }
 
 #[allow(dead_code)]
@@ -138,6 +204,22 @@ impl TuiTestHarness {
     /// so tool detection succeeds.
     pub fn new(test_name: &str) -> Self {
         let home_dir = TempDir::new().expect("failed to create temp home");
+        Self::with_home(test_name, home_dir)
+    }
+
+    /// Like [`new`](Self::new) but roots the isolated `$HOME` under `/tmp`.
+    /// Cockpit workers bind a unix socket at
+    /// `$HOME/.agent-of-empires-dev/cockpit-workers/<id>.sock`; a deep
+    /// tempdir (macOS `/var/folders/...` is ~95 chars) blows past the
+    /// 104-byte `sun_path` limit on Darwin, so the runner's
+    /// `UnixListener::bind` fails. `/tmp` keeps the path short.
+    #[cfg(unix)]
+    pub fn new_in_tmp(test_name: &str) -> Self {
+        let home_dir = TempDir::new_in("/tmp").expect("failed to create temp home under /tmp");
+        Self::with_home(test_name, home_dir)
+    }
+
+    fn with_home(test_name: &str, home_dir: TempDir) -> Self {
         let stub_dir = TempDir::new().expect("failed to create stub dir");
 
         // Unique session name to avoid collisions.
@@ -197,13 +279,88 @@ last_seen_version = "{}"
             spawned: false,
             recording,
             cast_path: None,
+            extra_env: Vec::new(),
+            extra_path_dirs: Vec::new(),
+            stop_daemon_on_drop: false,
         }
     }
 
-    /// Build the PATH with the stub directory prepended so fake `claude` is found.
+    /// Build the PATH with cockpit shim dirs (if any) and the stub
+    /// directory prepended so the fake agent / fake `claude` is found.
+    /// `extra_path_dirs` come first so an installed ACP shim shadows the
+    /// exit-0 `claude` stub.
     fn env_path(&self) -> String {
         let system_path = std::env::var("PATH").unwrap_or_default();
-        format!("{}:{}", self.stub_path.display(), system_path)
+        let mut parts: Vec<String> = self
+            .extra_path_dirs
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        parts.push(self.stub_path.display().to_string());
+        parts.push(system_path);
+        parts.join(":")
+    }
+
+    /// Export an extra env var on every spawned process (tmux + `run_cli`).
+    pub fn set_env(&mut self, key: &str, value: &str) {
+        self.extra_env.push((key.to_string(), value.to_string()));
+    }
+
+    /// Append `[cockpit] enabled = true` to the pre-seeded config so the
+    /// daemon flips its cockpit master atomic on at construction
+    /// (`src/server/mod.rs`).
+    pub fn enable_cockpit_master(&self) {
+        let cfg = app_dir_in(self.home_dir.path()).join("config.toml");
+        let mut content = std::fs::read_to_string(&cfg).unwrap_or_default();
+        content.push_str("\n[cockpit]\nenabled = true\n");
+        std::fs::write(&cfg, content).expect("append cockpit config");
+    }
+
+    /// Install the shared Node fake-ACP agent as the `claude`,
+    /// `claude-agent-acp`, and `aoe-agent` commands on PATH. The cockpit
+    /// supervisor resolves the `claude` tool key to the `claude-agent-acp`
+    /// command via `AgentRegistry`, so all three names must point at the
+    /// fake. `FAKE_ACP_SCRIPT` / `FAKE_ACP_DEBUG_LOG` are baked into the
+    /// shim (the daemon -> runner -> node spawn chain does not reliably
+    /// propagate process env). Also sets the runner-socket timeout high
+    /// so a contended CI box doesn't trip the spawn deadline.
+    pub fn install_acp_shim(&mut self, fake_acp_script: &Path) {
+        let bin = self.home_dir.path().join("acp-bin");
+        std::fs::create_dir_all(&bin).expect("create acp-bin dir");
+        let fake_agent =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("web/tests/helpers/fakeAcpAgent.mjs");
+        assert!(
+            fake_agent.exists(),
+            "fake ACP agent not found at {}",
+            fake_agent.display()
+        );
+        let debug_log = app_dir_in(self.home_dir.path()).join("fake-acp.log");
+        let script = format!(
+            "#!/bin/sh\nexport FAKE_ACP_SCRIPT=\"{}\"\nexport FAKE_ACP_DEBUG_LOG=\"{}\"\nexec node \"{}\" \"$@\"\n",
+            fake_acp_script.display(),
+            debug_log.display(),
+            fake_agent.display(),
+        );
+        for name in ["claude", "claude-agent-acp", "aoe-agent"] {
+            let path = bin.join(name);
+            std::fs::write(&path, &script).expect("write acp shim");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                    .expect("chmod acp shim");
+            }
+        }
+        self.extra_path_dirs.push(bin);
+        // Belt-and-suspenders: the shim bakes these in, but keep them on
+        // the daemon env too for any path that bypasses the shim.
+        self.set_env("FAKE_ACP_DEBUG_LOG", &debug_log.display().to_string());
+        self.set_env("AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS", "60000");
+    }
+
+    /// Make `Drop` tear down cockpit workers and the serve daemon.
+    pub fn stop_daemon_on_drop(&mut self) {
+        self.stop_daemon_on_drop = true;
     }
 
     /// Build the shell command string to run inside the tmux session.
@@ -255,6 +412,7 @@ last_seen_version = "{}"
             .env("XDG_CONFIG_HOME", self.home_dir.path().join(".config"))
             .env("PATH", self.env_path())
             .env("TERM", "xterm-256color")
+            .envs(self.extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
             .output()
             .expect("failed to run tmux new-session");
 
@@ -450,6 +608,7 @@ last_seen_version = "{}"
             .env("PATH", self.env_path())
             .env_remove("AGENT_OF_EMPIRES_DEBUG")
             .env_remove("AOE_LOG_LEVEL")
+            .envs(self.extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
             .output()
             .expect("failed to run aoe CLI")
     }
@@ -509,6 +668,14 @@ last_seen_version = "{}"
 
 impl Drop for TuiTestHarness {
     fn drop(&mut self) {
+        // Stop cockpit workers and the daemon before tearing down tmux so
+        // a panicking assertion can't leak a daemon (which holds the test
+        // port / pid file) into the next serial test. Worker first, then
+        // daemon, so the fake-ACP child exits cleanly.
+        if self.stop_daemon_on_drop {
+            let _ = self.run_cli(&["cockpit", "stop", "--all"]);
+            let _ = self.run_cli(&["serve", "--stop"]);
+        }
         if self.spawned {
             self.kill_session();
         }

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -18,6 +18,7 @@
 mod harness;
 
 mod cli;
+mod cockpit_focus_isolation_e2e;
 mod command_palette;
 mod errors;
 mod intro;

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -10,46 +10,17 @@
 //! ```
 #![cfg(feature = "serve")]
 
-use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use serial_test::serial;
 
-use crate::harness::{require_tmux, TuiTestHarness};
+use crate::harness::{pick_free_port, require_tmux, wait_for_port, TuiTestHarness};
 
 /// Resolve the daemon's PID file inside the harness's isolated home.
 /// Mirrors `crate::session::get_app_dir`'s platform split.
 fn daemon_pid_path(h: &TuiTestHarness) -> PathBuf {
     crate::harness::app_dir_in(h.home_path()).join("serve.pid")
-}
-
-/// Bind a TCP listener to an ephemeral port, drop it, and return the port.
-/// Tiny TOCTOU window before the daemon binds, but acceptable for a serial
-/// test.
-fn pick_free_port() -> u16 {
-    let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
-    l.local_addr().expect("local_addr").port()
-}
-
-/// Poll until the daemon accepts a TCP connection on `port`. The parent
-/// `aoe serve --daemon` returns as soon as it has spawned the child, so a
-/// successful exit doesn't prove the child bound the port; this is the
-/// real signal that the daemon is up.
-fn wait_for_port(port: u16, timeout: Duration) -> bool {
-    let start = Instant::now();
-    while start.elapsed() < timeout {
-        if TcpStream::connect_timeout(
-            &format!("127.0.0.1:{}", port).parse().unwrap(),
-            Duration::from_millis(200),
-        )
-        .is_ok()
-        {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    false
 }
 
 /// True iff the kernel still has a process with this PID.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The cockpit TUI focus-isolation guarantee (the composer swallows approval letters; `a` / `A` / `d` only resolve a pending approval under approval focus) was guarded only by unit tests on the pure dispatch function at `src/tui/cockpit_view/input.rs`. There was no end-to-end coverage proving the isolation holds across the full stack.

This adds `tests/e2e/cockpit_focus_isolation_e2e.rs`, which stands up a real `aoe serve --daemon` against an isolated `/tmp`-rooted `$HOME`, creates a cockpit-mode session, and drives a deterministic pending approval through the shared Node fake-ACP agent (`web/tests/helpers/fakeAcpAgent.mjs`), whose `permission_request` turn entry emits a real ACP `session/request_permission` and gates the turn awaiting the decision. It then attaches the native TUI cockpit view over tmux and proves both directions:

- With the composer focused, typing `aAd` leaves the approval pending. The proof is race-free: `wait_for("aAd")` confirms the letters reached the textarea, which means the input dispatcher routed them to `Intent::Compose` rather than resolving the approval.
- Tabbing to the approval card and pressing `a` resolves it (`→ allowed`).

The harness gains the cockpit support it needed (see commit 1): a `/tmp`-rooted `$HOME` constructor so the worker unix socket stays under the macOS `sun_path` limit, per-process extra env, an ACP shim installer, a cockpit-master config toggle, `require_node!`, and a stop-on-drop hook that tears down the worker and daemon so a panicking assertion can't leak a daemon between serial tests. `pick_free_port` / `wait_for_port` were hoisted out of `serve.rs` into the harness so both suites share one copy.

I verified the test is a real guard, not a tautology: temporarily breaking the composer dispatch so `a` resolves makes the test go red for the right reason (`wait_for("aAd")` times out because the approval resolved and showed `→ allowed`).

Closes #1703

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] `cargo test --test e2e --features serve -- cockpit_focus_isolation` passes (needs `tmux` + `node` on `PATH`).
- [ ] Watching the run (or `-- --nocapture`), the approval stays pending while `aAd` is typed into the composer, then resolves to `→ allowed` after Tab + `a`.
- [ ] With `node` off `PATH`, the test auto-skips with `Skipping test: node not available` instead of failing.
- [ ] Temporarily routing composer `a` to `ResolveApproval` (in `src/tui/cockpit_view/input.rs`) makes the test fail at `wait_for("aAd")`, confirming the e2e guards the isolation.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (pressure-tested with a multi-model debate), and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (reuse the Node fake agent, CLI-trigger the prompt, race-free `wait_for("aAd")` oracle), and confirmed the red-then-green behavior.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a comprehensive end-to-end test that verifies the TUI cockpit focus isolation guarantee works correctly against a live daemon. The test ensures that keyboard input is properly routed only to the focused UI component—preventing approval actions from being triggered when the composer is focused, and only allowing them when the approval card is focused.

### What Changed

**Added:**
- New end-to-end test file (`tests/e2e/cockpit_focus_isolation_e2e.rs`) that exercises the full focus isolation behavior by spinning up a real daemon, injecting a pending approval, and verifying keyboard input routing
- Enhanced test harness (`tests/e2e/harness.rs`) with new utilities and configuration options to support cockpit testing
- Documentation in `AGENTS.md` explaining the new test's setup and dependencies

**Refactored:**
- Moved shared networking utilities (`pick_free_port`, `wait_for_port`) from the serve test into the harness for reuse
- Added module declaration in `tests/e2e/main.rs`

### Key Improvements & Benefits

- **Full-stack coverage**: Tests the entire system (daemon, worker, cockpit TUI, fake ACP agent) working together in a real scenario
- **Focus isolation guarantee**: Proves the core focus-routing behavior that prevents approval actions from leaking into the wrong UI component
- **Reusable infrastructure**: New harness utilities (isolated `/tmp` homes, port management, Node detection, environment variable propagation) benefit future e2e tests
- **Proper cleanup**: Daemon and worker processes are gracefully stopped after each test, preventing resource leaks
- **Graceful degradation**: Test automatically skips if Node.js is not available, rather than failing
- **Addresses regression risk**: Guards against future dispatch logic breaks across the full stack

### Technical Details

The test harness now provides:
- **Node.js detection** via `node_available()` and `require_node!` macro
- **Port utilities** for ephemeral port allocation and TCP readiness polling
- **Isolated execution** with `/tmp`-rooted `$HOME` directories (unix-only)
- **Environment variable control** via `set_env()` to propagate variables to both tmux and CLI subprocesses
- **ACP shim installation** that wraps the Node fake-ACP agent
- **Cockpit configuration** via `enable_cockpit_master()`
- **Deterministic cleanup** via `stop_daemon_on_drop()` to ensure worker/daemon shutdown

The new test verifies two scenarios:
1. **Negative test**: Composer focus does not resolve approvals (input reaches textarea, approval stays pending)
2. **Positive test**: Approval card focus resolves approvals with the `a` key (shows `→ allowed` state)

Closes issue `#1703`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->