### PR TITLE
feat(cockpit): paginate replay endpoint for large sessions

### DIFF
--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -668,13 +668,16 @@ fn truncate(s: &str, n: usize) -> String {
 // daemon is the only path to the disk-backed event store; there's no
 // useful read against "no daemon".
 
-use crate::cockpit::client::{require_daemon, HttpClient, HttpError, WsMessage};
+use crate::cockpit::client::{require_daemon, HttpClient, HttpError, WsMessage, REPLAY_PAGE_SIZE};
 use crate::cockpit::protocol::ApprovalDecisionWire;
 
 async fn history(session: &str, since: u64, json: bool) -> Result<()> {
     let endpoint = require_daemon().await?;
     let client = HttpClient::new(endpoint)?;
-    let resp = client.replay(session, since).await.map_err(map_http)?;
+    let resp = client
+        .replay_paged(session, since, REPLAY_PAGE_SIZE)
+        .await
+        .map_err(map_http)?;
     if resp.lost {
         eprintln!(
             "warning: retention window evicted events before seq {}; transcript is partial.",

--- a/src/cockpit/client/http.rs
+++ b/src/cockpit/client/http.rs
@@ -28,6 +28,10 @@ struct AboutResponse {
     cockpit_queue_drain_mode: String,
 }
 
+/// Page size requested by [`HttpClient::replay_paged`]. Stays at or
+/// under the server's `MAX_REPLAY_PAGE` so it is never clamped down.
+pub const REPLAY_PAGE_SIZE: u64 = 1000;
+
 /// Cockpit daemon HTTP client. Cheap to clone; the underlying
 /// `reqwest::Client` is reference-counted.
 #[derive(Debug, Clone)]
@@ -68,7 +72,12 @@ impl HttpClient {
         &self.endpoint
     }
 
-    /// `GET /api/sessions/{id}/cockpit/replay?since=N`.
+    /// `GET /api/sessions/{id}/cockpit/replay?since=N`. Unbounded fetch
+    /// (no `limit`): the server still applies its default page bound, so
+    /// this returns at most one page. Used by the status probe, which
+    /// only reads the metadata (`highest_seq`/`lowest_seq`) and passes
+    /// `since=u64::MAX` so no frames come back. History consumers should
+    /// use [`replay_paged`](Self::replay_paged) instead.
     pub async fn replay(&self, session_id: &str, since: u64) -> Result<ReplayResponse, HttpError> {
         let url = format!(
             "{}/api/sessions/{}/cockpit/replay?since={}",
@@ -77,6 +86,74 @@ impl HttpClient {
         let res = self.auth(self.http.get(&url)).send().await?;
         let res = check_status(res, session_id).await?;
         Ok(res.json::<ReplayResponse>().await?)
+    }
+
+    /// `GET /api/sessions/{id}/cockpit/replay?since=N&limit=L`. One page.
+    pub async fn replay_page(
+        &self,
+        session_id: &str,
+        since: u64,
+        limit: u64,
+    ) -> Result<ReplayResponse, HttpError> {
+        let url = format!(
+            "{}/api/sessions/{}/cockpit/replay?since={}&limit={}",
+            self.endpoint.base_url, session_id, since, limit
+        );
+        let res = self.auth(self.http.get(&url)).send().await?;
+        let res = check_status(res, session_id).await?;
+        Ok(res.json::<ReplayResponse>().await?)
+    }
+
+    /// Page through replay history from `since`, accumulating every
+    /// frame into one `ReplayResponse`. Each request is bounded to
+    /// `page_size` so the daemon never buffers the whole history at once.
+    ///
+    /// The loop is capped at the first page's `highest_seq`: events
+    /// appended after replay began arrive over the live WS channel and
+    /// are deduped by the reducer, so chasing them here would never
+    /// converge on a busy session. Stops early and propagates `lost` if
+    /// any page reports a retention gap, leaving the caller to reset.
+    pub async fn replay_paged(
+        &self,
+        session_id: &str,
+        since: u64,
+        page_size: u64,
+    ) -> Result<ReplayResponse, HttpError> {
+        let mut frames = Vec::new();
+        let mut cursor = since;
+        let mut target: Option<u64> = None;
+        let mut lost = false;
+        // Assigned every iteration before the post-loop read; the loop
+        // always runs at least once.
+        let mut highest_seq;
+        let mut lowest_seq;
+        loop {
+            let page = self.replay_page(session_id, cursor, page_size).await?;
+            highest_seq = page.highest_seq;
+            lowest_seq = page.lowest_seq;
+            let cap = *target.get_or_insert(page.highest_seq);
+            frames.extend(page.frames);
+            if page.lost {
+                lost = true;
+                break;
+            }
+            match page.next_cursor {
+                // Keep paging only while the cursor advances and stays
+                // within the snapshot window captured on the first page.
+                Some(next) if page.has_more && next > cursor && next < cap => {
+                    cursor = next;
+                }
+                _ => break,
+            }
+        }
+        Ok(ReplayResponse {
+            frames,
+            lost,
+            highest_seq,
+            lowest_seq,
+            next_cursor: None,
+            has_more: false,
+        })
     }
 
     /// `GET /api/sessions/{id}/cockpit/context-primer?before_seq=N`.

--- a/src/cockpit/client/mod.rs
+++ b/src/cockpit/client/mod.rs
@@ -29,5 +29,5 @@ pub mod ws;
 
 pub use daemon_manager::{require_daemon, ManagerError};
 pub use discovery::{discover, DaemonEndpoint, DiscoveryError, Source};
-pub use http::{HttpClient, HttpError};
+pub use http::{HttpClient, HttpError, REPLAY_PAGE_SIZE};
 pub use ws::{connect as ws_connect, WsError, WsHandle, WsMessage};

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -82,6 +82,24 @@ fn non_substantive_not_like_clauses() -> String {
         .join("\n               ")
 }
 
+/// One page of replayed events plus the cursor metadata a paginating
+/// client needs to fetch the next page.
+pub struct ReplayPage {
+    /// Deserialised events for this page, oldest first. Rows that fail
+    /// to deserialise are skipped here but still advance `last_scanned_seq`
+    /// so a corrupt row can never stall a paging loop.
+    pub events: Vec<(u64, Event)>,
+    /// Highest `seq` this page consumed, whether or not it deserialised.
+    /// The client passes this back as `since` for the next page, so the
+    /// cursor advances past skipped/corrupt rows. `None` for an empty page.
+    pub last_scanned_seq: Option<u64>,
+    /// True when at least one row exists beyond this page's window.
+    /// Derived from a `LIMIT n + 1` probe row, so it is consistent with
+    /// the page rows under the same lock and never depends on a
+    /// separately queried `highest_seq`.
+    pub has_more: bool,
+}
+
 /// SQLite-backed cockpit event log. One row per (session_id, seq).
 pub struct EventStore {
     conn: Mutex<Connection>,
@@ -323,43 +341,99 @@ impl EventStore {
 
     /// Return all events for `session_id` with `seq > since`, oldest
     /// first. An empty vec means the session has no newer events.
+    ///
+    /// Unbounded; used by the WS on-connect drain and tests. The REST
+    /// replay endpoint pages via [`replay_page`](Self::replay_page).
     pub fn replay_from(&self, session_id: &str, since: u64) -> Vec<(u64, Event)> {
+        self.replay_page(session_id, since, None).events
+    }
+
+    /// Return events for `session_id` with `seq > since`, oldest first,
+    /// at most `limit` of them. `None` means unbounded (no `LIMIT`).
+    ///
+    /// Pagination is keyset over `seq`: callers pass the previous page's
+    /// `last_scanned_seq` back as `since`. When `limit` is `Some(n)` the
+    /// query probes `n + 1` rows so `has_more` reflects whether another
+    /// page exists, computed under the same lock as the page rows (so it
+    /// never races a concurrently growing `highest_seq`). `last_scanned_seq`
+    /// advances over every consumed row including ones that fail to
+    /// deserialise, so a corrupt row can't trap a paging loop.
+    pub fn replay_page(&self, session_id: &str, since: u64, limit: Option<usize>) -> ReplayPage {
         let conn = match self.conn.lock() {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let mut stmt = match conn.prepare(
-            "SELECT seq, event_json FROM cockpit_events
-             WHERE session_id = ?1 AND seq > ?2
-             ORDER BY seq ASC",
-        ) {
+        // Probe one extra row beyond `limit` to detect `has_more` without
+        // a second query against `highest_seq`.
+        let probe = limit.map(|n| n.saturating_add(1));
+        let sql = match probe {
+            Some(_) => {
+                "SELECT seq, event_json FROM cockpit_events
+                 WHERE session_id = ?1 AND seq > ?2
+                 ORDER BY seq ASC LIMIT ?3"
+            }
+            None => {
+                "SELECT seq, event_json FROM cockpit_events
+                 WHERE session_id = ?1 AND seq > ?2
+                 ORDER BY seq ASC"
+            }
+        };
+        let mut stmt = match conn.prepare(sql) {
             Ok(s) => s,
             Err(e) => {
                 warn!(target: "cockpit.event_store", "prepare replay for {session_id}: {e}");
-                return Vec::new();
+                return ReplayPage {
+                    events: Vec::new(),
+                    last_scanned_seq: None,
+                    has_more: false,
+                };
             }
         };
-        let rows = match stmt.query_map(params![session_id, since as i64], |row| {
+        let map_row = |row: &rusqlite::Row| {
             let seq: i64 = row.get(0)?;
             let json: String = row.get(1)?;
             Ok((seq as u64, json))
-        }) {
+        };
+        let rows = match probe {
+            Some(p) => stmt.query_map(params![session_id, since as i64, p as i64], map_row),
+            None => stmt.query_map(params![session_id, since as i64], map_row),
+        };
+        let rows = match rows {
             Ok(r) => r,
             Err(e) => {
                 warn!(target: "cockpit.event_store", "query replay for {session_id}: {e}");
-                return Vec::new();
+                return ReplayPage {
+                    events: Vec::new(),
+                    last_scanned_seq: None,
+                    has_more: false,
+                };
             }
         };
         let mut out = Vec::new();
+        let mut last_scanned_seq = None;
+        let mut scanned = 0usize;
+        let mut has_more = false;
         for row in rows {
             match row {
-                Ok((seq, json)) => match serde_json::from_str::<Event>(&json) {
-                    Ok(event) => out.push((seq, event)),
-                    Err(e) => warn!(
-                        target: "cockpit.event_store",
-                        "deserialise event {session_id}@{seq}: {e}"
-                    ),
-                },
+                Ok((seq, json)) => {
+                    // The probe row proves another page exists; don't
+                    // consume it or advance the cursor onto it.
+                    if let Some(n) = limit {
+                        if scanned == n {
+                            has_more = true;
+                            break;
+                        }
+                    }
+                    scanned += 1;
+                    last_scanned_seq = Some(seq);
+                    match serde_json::from_str::<Event>(&json) {
+                        Ok(event) => out.push((seq, event)),
+                        Err(e) => warn!(
+                            target: "cockpit.event_store",
+                            "deserialise event {session_id}@{seq}: {e}"
+                        ),
+                    }
+                }
                 Err(e) => warn!(target: "cockpit.event_store", "row error: {e}"),
             }
         }
@@ -367,10 +441,16 @@ impl EventStore {
             target: "cockpit.event_store",
             session = %session_id,
             since,
+            limit = ?limit,
             returned = out.len(),
+            has_more,
             "replayed events"
         );
-        out
+        ReplayPage {
+            events: out,
+            last_scanned_seq,
+            has_more,
+        }
     }
 
     /// Return the latest `Event::PlanUpdated` stored for `session_id`,
@@ -1377,6 +1457,90 @@ mod tests {
         let map = store.last_event_at_for_sessions(&["s-a".to_string(), "s-b".to_string()]);
         assert_eq!(map.get("s-a"), Some(&900));
         assert_eq!(map.get("s-b"), Some(&7000));
+    }
+
+    #[test]
+    fn replay_page_reassembles_into_unbounded_result() {
+        // Paging with a small limit and following `last_scanned_seq`
+        // must rebuild exactly what a single unbounded replay returns.
+        let (_tmp, store) = open_store(1000);
+        for i in 1..=10 {
+            store.record("s-1", i, &Event::ThinkingStarted).unwrap();
+        }
+        let unbounded: Vec<u64> = store
+            .replay_from("s-1", 0)
+            .iter()
+            .map(|(s, _)| *s)
+            .collect();
+
+        let mut paged = Vec::new();
+        let mut cursor = 0u64;
+        loop {
+            let page = store.replay_page("s-1", cursor, Some(3));
+            assert!(page.events.len() <= 3, "page exceeded limit");
+            paged.extend(page.events.iter().map(|(s, _)| *s));
+            match page.last_scanned_seq {
+                Some(next) if page.has_more => cursor = next,
+                _ => break,
+            }
+        }
+        assert_eq!(paged, unbounded);
+    }
+
+    #[test]
+    fn replay_page_has_more_at_exact_boundary() {
+        let (_tmp, store) = open_store(1000);
+        for i in 1..=4 {
+            store.record("s-1", i, &Event::ThinkingStarted).unwrap();
+        }
+        // Limit equal to the row count: full page, nothing left over.
+        let full = store.replay_page("s-1", 0, Some(4));
+        assert_eq!(full.events.len(), 4);
+        assert!(!full.has_more);
+        assert_eq!(full.last_scanned_seq, Some(4));
+
+        // One short: a probe row remains, so `has_more` is set and the
+        // cursor stops at the last consumed seq, not the probe row.
+        let partial = store.replay_page("s-1", 0, Some(3));
+        assert_eq!(partial.events.len(), 3);
+        assert!(partial.has_more);
+        assert_eq!(partial.last_scanned_seq, Some(3));
+    }
+
+    #[test]
+    fn replay_page_cursor_advances_past_corrupt_row() {
+        // A row that fails to deserialise is skipped from `events` but
+        // still advances `last_scanned_seq`, so a paging loop can never
+        // get stuck re-requesting the same corrupt seq.
+        let (_tmp, store) = open_store(1000);
+        store.record("s-1", 1, &Event::ThinkingStarted).unwrap();
+        {
+            let conn = store.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO cockpit_events (session_id, seq, event_json, created_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params!["s-1", 2_i64, "{not valid event json", 0_i64],
+            )
+            .unwrap();
+        }
+        store.record("s-1", 3, &Event::ThinkingEnded).unwrap();
+
+        // Page size 2 lands the corrupt row mid-page: it is dropped from
+        // events but the cursor moves to seq 2, so the next page yields 3.
+        let page1 = store.replay_page("s-1", 0, Some(2));
+        assert_eq!(
+            page1.events.iter().map(|(s, _)| *s).collect::<Vec<_>>(),
+            vec![1]
+        );
+        assert_eq!(page1.last_scanned_seq, Some(2));
+        assert!(page1.has_more);
+
+        let page2 = store.replay_page("s-1", page1.last_scanned_seq.unwrap(), Some(2));
+        assert_eq!(
+            page2.events.iter().map(|(s, _)| *s).collect::<Vec<_>>(),
+            vec![3]
+        );
+        assert!(!page2.has_more);
     }
 
     #[test]

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -98,6 +98,47 @@ pub struct ReplayPage {
     /// the page rows under the same lock and never depends on a
     /// separately queried `highest_seq`.
     pub has_more: bool,
+    /// Highest seq stored for the session, or 0 if none. Read under the
+    /// same lock as the page rows so the replay response is a single
+    /// consistent snapshot (a concurrent `record()` can't make `has_more`
+    /// and `highest_seq` disagree). See #1705 review.
+    pub highest_seq: u64,
+    /// Lowest seq still stored, or `None` when empty. Same-snapshot
+    /// guarantee as `highest_seq`; lets the caller compute `lost`.
+    pub lowest_seq: Option<u64>,
+}
+
+/// Highest seq stored for `session_id`, or 0 if none. Free fn so both
+/// the public [`EventStore::highest_seq`] and the single-snapshot
+/// [`EventStore::replay_page`] can share it under one held lock.
+fn query_highest_seq(conn: &Connection, session_id: &str) -> u64 {
+    match conn
+        .query_row(
+            "SELECT MAX(seq) FROM cockpit_events WHERE session_id = ?1",
+            params![session_id],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()
+    {
+        Ok(Some(Some(max))) => max as u64,
+        _ => 0,
+    }
+}
+
+/// Lowest seq still stored for `session_id`, or `None` when empty.
+/// Companion to [`query_highest_seq`].
+fn query_lowest_seq(conn: &Connection, session_id: &str) -> Option<u64> {
+    match conn
+        .query_row(
+            "SELECT MIN(seq) FROM cockpit_events WHERE session_id = ?1",
+            params![session_id],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()
+    {
+        Ok(Some(Some(m))) => Some(m as u64),
+        _ => None,
+    }
 }
 
 /// SQLite-backed cockpit event log. One row per (session_id, seq).
@@ -363,6 +404,17 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
+        // Snapshot the bounds under the same lock as the page rows so the
+        // whole response is consistent: a concurrent `record()` cannot
+        // land between these reads and the page query and make
+        // `has_more`/`highest_seq` disagree (which would let the client's
+        // paging cap stop early). See #1705 review.
+        let highest_seq = query_highest_seq(&conn, session_id);
+        let lowest_seq = query_lowest_seq(&conn, session_id);
+        // `seq` is a signed SQLite column; clamp before the cast so the
+        // status probe's `since = u64::MAX` doesn't wrap to -1 and match
+        // every row (`seq > -1`) instead of returning an empty page.
+        let since_i64 = i64::try_from(since).unwrap_or(i64::MAX);
         // Probe one extra row beyond `limit` to detect `has_more` without
         // a second query against `highest_seq`.
         let probe = limit.map(|n| n.saturating_add(1));
@@ -386,6 +438,8 @@ impl EventStore {
                     events: Vec::new(),
                     last_scanned_seq: None,
                     has_more: false,
+                    highest_seq,
+                    lowest_seq,
                 };
             }
         };
@@ -395,8 +449,8 @@ impl EventStore {
             Ok((seq as u64, json))
         };
         let rows = match probe {
-            Some(p) => stmt.query_map(params![session_id, since as i64, p as i64], map_row),
-            None => stmt.query_map(params![session_id, since as i64], map_row),
+            Some(p) => stmt.query_map(params![session_id, since_i64, p as i64], map_row),
+            None => stmt.query_map(params![session_id, since_i64], map_row),
         };
         let rows = match rows {
             Ok(r) => r,
@@ -406,6 +460,8 @@ impl EventStore {
                     events: Vec::new(),
                     last_scanned_seq: None,
                     has_more: false,
+                    highest_seq,
+                    lowest_seq,
                 };
             }
         };
@@ -450,6 +506,8 @@ impl EventStore {
             events: out,
             last_scanned_seq,
             has_more,
+            highest_seq,
+            lowest_seq,
         }
     }
 
@@ -707,17 +765,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let max = match conn
-            .query_row(
-                "SELECT MAX(seq) FROM cockpit_events WHERE session_id = ?1",
-                params![session_id],
-                |row| row.get::<_, Option<i64>>(0),
-            )
-            .optional()
-        {
-            Ok(Some(Some(max))) => max as u64,
-            _ => 0,
-        };
+        let max = query_highest_seq(&conn, session_id);
         trace!(
             target: "cockpit.event_store",
             session = %session_id,
@@ -737,17 +785,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let min = match conn
-            .query_row(
-                "SELECT MIN(seq) FROM cockpit_events WHERE session_id = ?1",
-                params![session_id],
-                |row| row.get::<_, Option<i64>>(0),
-            )
-            .optional()
-        {
-            Ok(Some(Some(m))) => Some(m as u64),
-            _ => None,
-        };
+        let min = query_lowest_seq(&conn, session_id);
         trace!(
             target: "cockpit.event_store",
             session = %session_id,
@@ -1541,6 +1579,23 @@ mod tests {
             vec![3]
         );
         assert!(!page2.has_more);
+    }
+
+    #[test]
+    fn replay_page_since_u64_max_returns_empty() {
+        // The status probe passes `since = u64::MAX` to read metadata
+        // only. Without clamping, `u64::MAX as i64` is -1 and `seq > -1`
+        // would return the whole transcript. It must return no rows but
+        // still report the bounds.
+        let (_tmp, store) = open_store(1000);
+        for i in 1..=3 {
+            store.record("s-1", i, &Event::ThinkingStarted).unwrap();
+        }
+        let page = store.replay_page("s-1", u64::MAX, Some(1000));
+        assert!(page.events.is_empty());
+        assert!(!page.has_more);
+        assert_eq!(page.highest_seq, 3);
+        assert_eq!(page.lowest_seq, Some(1));
     }
 
     #[test]

--- a/src/cockpit/protocol.rs
+++ b/src/cockpit/protocol.rs
@@ -348,4 +348,25 @@ mod tests {
         let parsed: SwitchAgentRequest = serde_json::from_value(body).unwrap();
         assert_eq!(parsed.reason.as_deref(), Some("manual"));
     }
+
+    #[test]
+    fn replay_query_defaults_limit_when_absent() {
+        // A pre-pagination client sends `{"since":N}` with no `limit`;
+        // the `#[serde(default)]` must keep it parsing (None = server
+        // default page).
+        let query: ReplayQuery = serde_json::from_str(r#"{"since":42}"#).unwrap();
+        assert_eq!(query.since, 42);
+        assert_eq!(query.limit, None);
+    }
+
+    #[test]
+    fn replay_response_defaults_paging_fields_when_absent() {
+        // A pre-pagination response body has no `next_cursor`/`has_more`;
+        // newer clients must still deserialize it with sane defaults.
+        let response: ReplayResponse =
+            serde_json::from_str(r#"{"frames":[],"lost":false,"highest_seq":0,"lowest_seq":null}"#)
+                .unwrap();
+        assert_eq!(response.next_cursor, None);
+        assert!(!response.has_more);
+    }
 }

--- a/src/cockpit/protocol.rs
+++ b/src/cockpit/protocol.rs
@@ -162,6 +162,12 @@ pub struct ReplayQuery {
     /// strictly newer than this. Defaults to 0 (full replay).
     #[serde(default)]
     pub since: u64,
+    /// Max frames to return in this page. Omitted falls back to the
+    /// server's default page size; the server also clamps to a hard
+    /// max. Clients paginate by passing the previous response's
+    /// `next_cursor` back as `since` while `has_more` is true.
+    #[serde(default)]
+    pub limit: Option<u64>,
 }
 
 /// `GET /api/sessions/{id}/cockpit/replay` response.
@@ -183,6 +189,17 @@ pub struct ReplayResponse {
     /// retention window in status output and detect mid-flight prunes.
     #[serde(default)]
     pub lowest_seq: Option<u64>,
+    /// Cursor to pass back as `since` for the next page: the highest
+    /// seq this page consumed (including rows that failed to
+    /// deserialise, so a corrupt row can't stall a paging loop).
+    /// `None` for an empty page. Only meaningful with `has_more`.
+    #[serde(default)]
+    pub next_cursor: Option<u64>,
+    /// True when more events exist beyond this page within the store.
+    /// Clients keep paging (advancing `since` to `next_cursor`) while
+    /// this is set. Always false for an unbounded (`limit`-less) reply.
+    #[serde(default)]
+    pub has_more: bool,
 }
 
 /// `GET /api/sessions/{id}/cockpit/context-primer?before_seq=N` query.

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1011,6 +1011,13 @@ pub async fn cockpit_files(
     }
 }
 
+/// Default replay page size when the client omits `limit`. Bounds the
+/// daemon's per-request buffer and response size for a long session.
+const DEFAULT_REPLAY_PAGE: usize = 1000;
+/// Hard cap on a client-requested replay page, so an oversized `limit`
+/// can't reintroduce the unbounded-buffer footprint this paging removes.
+const MAX_REPLAY_PAGE: usize = 2000;
+
 const WORKER_LOG_DEFAULT_TAIL: usize = 200;
 const WORKER_LOG_MAX_TAIL: usize = 2000;
 /// Cap the read size so a runaway log file can't pin the daemon. A 4 MiB
@@ -1664,8 +1671,23 @@ pub async fn cockpit_replay(
     // events than the ring holds.
     let highest_seq = state.cockpit_event_store.highest_seq(&id);
     let lowest_seq = state.cockpit_event_store.lowest_seq(&id);
-    let entries = state.cockpit_event_store.replay_from(&id, q.since);
-    let frames: Vec<crate::server::CockpitBroadcastFrame> = entries
+    // Bound the page so neither the daemon nor the response scales with
+    // total history. Omitted `limit` falls back to the default rather
+    // than unbounded, so a naive or older client can't make the daemon
+    // buffer an entire long session. All in-repo consumers paginate via
+    // `has_more`/`next_cursor`.
+    let limit = q
+        .limit
+        .map(|l| l as usize)
+        .unwrap_or(DEFAULT_REPLAY_PAGE)
+        .clamp(1, MAX_REPLAY_PAGE);
+    let page = state
+        .cockpit_event_store
+        .replay_page(&id, q.since, Some(limit));
+    let next_cursor = page.last_scanned_seq;
+    let has_more = page.has_more;
+    let frames: Vec<crate::server::CockpitBroadcastFrame> = page
+        .events
         .into_iter()
         .map(|(seq, event)| crate::server::CockpitBroadcastFrame {
             session_id: id.clone(),
@@ -1676,7 +1698,9 @@ pub async fn cockpit_replay(
     // `lost = true` when the client's `since` cursor predates the oldest
     // seq still on disk. The retention cap can evict older events, so a
     // client that returns after a long absence may legitimately need a
-    // full reload. With no events on disk yet, nothing is lost.
+    // full reload. With no events on disk yet, nothing is lost. Computed
+    // per request so a mid-loop prune is caught on whatever page first
+    // sees the gap, not only the first.
     let lost = match lowest_seq {
         Some(lo) => q.since < lo.saturating_sub(1),
         None => false,
@@ -1686,6 +1710,8 @@ pub async fn cockpit_replay(
         lost,
         highest_seq,
         lowest_seq,
+        next_cursor,
+        has_more,
     })
     .into_response()
 }

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1669,8 +1669,6 @@ pub async fn cockpit_replay(
     // endpoint backstops that when the in-memory ring is cold (server
     // just restarted) or the client lagged far enough to need older
     // events than the ring holds.
-    let highest_seq = state.cockpit_event_store.highest_seq(&id);
-    let lowest_seq = state.cockpit_event_store.lowest_seq(&id);
     // Bound the page so neither the daemon nor the response scales with
     // total history. Omitted `limit` falls back to the default rather
     // than unbounded, so a naive or older client can't make the daemon
@@ -1681,9 +1679,14 @@ pub async fn cockpit_replay(
         .map(|l| l as usize)
         .unwrap_or(DEFAULT_REPLAY_PAGE)
         .clamp(1, MAX_REPLAY_PAGE);
+    // One store call returns the page and its `highest_seq`/`lowest_seq`
+    // under a single lock, so the response is a consistent snapshot and a
+    // concurrent `record()` can't desync the cap from the page rows.
     let page = state
         .cockpit_event_store
         .replay_page(&id, q.since, Some(limit));
+    let highest_seq = page.highest_seq;
+    let lowest_seq = page.lowest_seq;
     let next_cursor = page.last_scanned_seq;
     let has_more = page.has_more;
     let frames: Vec<crate::server::CockpitBroadcastFrame> = page

--- a/src/tui/cockpit_view/mod.rs
+++ b/src/tui/cockpit_view/mod.rs
@@ -28,6 +28,7 @@ use self::input::{Focus, Intent};
 use self::state::{CockpitViewState, ToastBanner, ToastKind};
 use crate::cockpit::client::{
     require_daemon, ws_connect, DaemonEndpoint, HttpClient, ManagerError, WsError, WsMessage,
+    REPLAY_PAGE_SIZE,
 };
 use crate::cockpit::protocol::ApprovalDecisionWire;
 use crate::tui::styles::Theme;
@@ -155,7 +156,7 @@ pub async fn run_for_endpoint(
     // Hydrate the transcript via /replay before opening the WebSocket
     // so the user sees the historical conversation immediately instead
     // of a blank pane until live frames start arriving.
-    let initial = http.replay(session_id, 0).await;
+    let initial = http.replay_paged(session_id, 0, REPLAY_PAGE_SIZE).await;
     let ws_result = ws_connect(&endpoint, session_id, 0).await;
 
     let (ws, ws_err) = match ws_result {
@@ -265,7 +266,11 @@ pub async fn run_for_endpoint(
                         // Daemon evicted events we hadn't seen yet. Drop
                         // local reducer state and rehydrate from /replay.
                         state.transcript.reset();
-                        match state.http.replay(&state.session_id, 0).await {
+                        match state
+                            .http
+                            .replay_paged(&state.session_id, 0, REPLAY_PAGE_SIZE)
+                            .await
+                        {
                             Ok(replay) => {
                                 if replay.lost {
                                     state.transcript.set_lagged();

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -309,6 +309,12 @@ function cacheSet(sessionId: string, value: CockpitState): void {
  *  dedupe makes the overlap idempotent. See #1100. */
 const REPLAY_OVERLAP = 50;
 
+/** Page size `fetchReplay` requests per call. The server paginates the
+ *  replay endpoint and bounds its own page; this stays at or under that
+ *  bound so a long session loads over several requests instead of one
+ *  giant response. The loop follows `next_cursor` while `has_more`. */
+const REPLAY_PAGE_SIZE = 1000;
+
 export function clearCockpitCache(sessionId?: string): void {
   if (sessionId === undefined) {
     stateCache.clear();
@@ -669,36 +675,61 @@ export function useCockpit(
         // window, etc.) get a second chance. The reducer's
         // `frame.seq <= state.lastSeq` dedupe drops the overlap, so
         // this is idempotent. See #1100.
-        const since = Math.max(0, lastSeqRef.current - REPLAY_OVERLAP);
-        const res = await fetch(
-          `/api/sessions/${encodeURIComponent(sid)}/cockpit/replay?since=${since}`,
-          { credentials: "same-origin" },
-        );
-        if (!res.ok) return;
-        const data = (await res.json()) as {
-          frames: CockpitFrame[];
-          lost: boolean;
-          highest_seq: number;
-        };
-        // Detect a server-side seq reset: the supervisor's per-session
-        // counter has been forgotten (cockpit_disable → cockpit_enable,
-        // or session delete+recreate with the same id), so the new
-        // conversation is starting fresh from seq=1. Without this reset
-        // the client-side dedupe would drop the new events because
-        // `frame.seq <= state.lastSeq` is true.
-        if (data.highest_seq < since) {
-          dispatch({ kind: "reset" });
-        }
-        if (data.lost) {
-          // The buffer doesn't go back far enough; surface this via
-          // the existing `lagged` flag (the UI shows a "history
-          // truncated" notice) and let the user reload if they want
-          // the full transcript back.
-          dispatch({ kind: "lagged", skipped: data.highest_seq });
-          return;
-        }
-        if (data.frames.length > 0) {
-          dispatch({ kind: "frames", frames: data.frames });
+        const firstSince = Math.max(0, lastSeqRef.current - REPLAY_OVERLAP);
+        let cursor = firstSince;
+        // Snapshot the highest seq seen on the first page and stop there:
+        // events appended after replay began arrive over the live WS and
+        // are deduped, so chasing them here would never converge on a
+        // busy session. Captured from page one's `highest_seq`.
+        let target: number | null = null;
+        for (;;) {
+          const res = await fetch(
+            `/api/sessions/${encodeURIComponent(sid)}/cockpit/replay?since=${cursor}&limit=${REPLAY_PAGE_SIZE}`,
+            { credentials: "same-origin" },
+          );
+          if (!res.ok) return;
+          const data = (await res.json()) as {
+            frames: CockpitFrame[];
+            lost: boolean;
+            highest_seq: number;
+            next_cursor?: number | null;
+            has_more?: boolean;
+          };
+          if (target === null) {
+            target = data.highest_seq;
+            // Detect a server-side seq reset: the supervisor's per-session
+            // counter has been forgotten (cockpit_disable → cockpit_enable,
+            // or session delete+recreate with the same id), so the new
+            // conversation is starting fresh from seq=1. Without this reset
+            // the client-side dedupe would drop the new events because
+            // `frame.seq <= state.lastSeq` is true. Only meaningful on the
+            // first page, where `cursor` is the client's resume point.
+            if (data.highest_seq < firstSince) {
+              dispatch({ kind: "reset" });
+            }
+          }
+          // Honor `lost` on every page: a retention prune between pages
+          // can open a real gap after page one, so surface it via the
+          // existing `lagged` flag and let the user reload for the full
+          // transcript. Stop the loop; a partial transcript is wrong.
+          if (data.lost) {
+            dispatch({ kind: "lagged", skipped: data.highest_seq });
+            return;
+          }
+          if (data.frames.length > 0) {
+            dispatch({ kind: "frames", frames: data.frames });
+          }
+          const next = data.next_cursor;
+          if (
+            data.has_more &&
+            next != null &&
+            next > cursor &&
+            next < target
+          ) {
+            cursor = next;
+            continue;
+          }
+          break;
         }
         dispatch({ kind: "lagged_resolved" });
       } catch {

--- a/web/tests/live/cockpit-replay-catchup.spec.ts
+++ b/web/tests/live/cockpit-replay-catchup.spec.ts
@@ -93,6 +93,48 @@ test("cockpit/replay surfaces seeded events and signals lost frames", async ({},
     expect(tail.frames.length).toBe(0);
     expect(tail.highest_seq).toBe(highest);
     expect(tail.lost).toBe(false);
+
+    // Pagination: with a small `limit`, the endpoint returns bounded
+    // pages plus `next_cursor`/`has_more`, and following the cursor to
+    // exhaustion reassembles the same transcript a single unbounded
+    // (default-page) replay returns. `target` caps the loop at the
+    // snapshot head so a stray startup event appended mid-loop can't
+    // make the two reads disagree.
+    const full = body!;
+    const target = full.highest_seq!;
+    const fullSeqs = full.frames
+      .map((f) => f.seq)
+      .filter((s) => s <= target);
+
+    const PAGE = 2;
+    const pagedSeqs: number[] = [];
+    let cursor = 0;
+    let pages = 0;
+    for (;;) {
+      const page = (await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=${cursor}&limit=${PAGE}`,
+      ).then((r) => r.json())) as {
+        frames: { seq: number }[];
+        lost: boolean;
+        highest_seq: number;
+        next_cursor: number | null;
+        has_more: boolean;
+      };
+      pages++;
+      expect(page.frames.length).toBeLessThanOrEqual(PAGE);
+      for (const f of page.frames) {
+        if (f.seq <= target) pagedSeqs.push(f.seq);
+      }
+      const next = page.next_cursor;
+      if (page.has_more && next != null && next > cursor && next < target) {
+        cursor = next;
+        continue;
+      }
+      break;
+    }
+
+    expect(pages).toBeGreaterThan(1);
+    expect(pagedSeqs).toEqual(fullSeqs);
   } finally {
     await serve.stop();
   }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The cockpit replay endpoint `GET /api/sessions/{id}/cockpit/replay?since=N` loaded the entire event history (`seq > since`) into a `Vec` and shipped it as one JSON array, so both daemon memory and response size scaled with total events in a session. This adds keyset pagination over `seq` so neither side buffers the whole history at once.

`EventStore::replay_page(since, limit)` probes `LIMIT n + 1` rows, so `has_more` is computed under the same lock as the page rows (it never races a concurrently growing `highest_seq`), and it reports `last_scanned_seq` as the next cursor. The cursor advances over rows that fail to deserialise, so a corrupt row can never trap a paging loop. `replay_from` now delegates to it with no limit and keeps backing the WS on-connect drain unchanged.

`ReplayQuery` gains `limit`; `ReplayResponse` gains `next_cursor` and `has_more` (all `#[serde(default)]`). Omitted `limit` now falls back to a bounded default page (1000, hard max 2000) rather than unbounded, so a naive client cannot make the daemon buffer a whole long session. This is an intentional behavior change to the replay endpoint; cockpit client and daemon ship in the same binary, and all three in-repo consumers (web, TUI, `cockpit history`) were updated to page via `has_more`/`next_cursor`. The metadata-only status probe keeps the unbounded `replay`.

Both client loops are capped at the first page's `highest_seq`: events appended after replay began arrive over the live WS channel and are deduped by the reducer, so chasing them in the replay loop would never converge on a busy session. `lost` is honored on every page (a retention prune between pages can open a real gap after page one), not only the first.

Design chosen (cursor pagination over NDJSON streaming) because both reducers already read incrementally and dedupe by seq, whereas NDJSON would force a chunked-body rewrite in three consumers and hold the SQLite mutex across an async boundary.

Closes #1705

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] On a cockpit session with a long transcript, attach via the web dashboard and confirm the full transcript loads with no missing events (the Network tab shows several bounded `/cockpit/replay?...&limit=1000` requests instead of one large response).
- [ ] `aoe cockpit history <session>` on a long session prints the complete event list (now fetched in pages under the hood).
- [ ] Open the cockpit view in the TUI on a long session; confirm the historical transcript renders fully on attach and again after a Lagged reset.
- [ ] `curl '.../api/sessions/<id>/cockpit/replay?since=0&limit=10'` returns at most 10 frames plus `next_cursor` and `has_more: true`; passing `next_cursor` back as `since` and repeating reassembles the whole history, and the final page reports `has_more: false`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the TUI/CLI behavior is unchanged (replay just pages internally now); the paging path they share is covered by Rust store + client unit tests and a live Playwright pagination assertion against the same endpoint.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a multi-model `/debate` pass that hardened the cursor/`has_more` correctness and the default-bound decision. I reviewed each commit, made the design calls, and ran the validation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR changes the cockpit replay flow from returning an entire session's event history as one large JSON array to cursor-based, paginated replay. Replays are delivered in bounded pages so clients and the daemon avoid unbounded memory and response growth for long sessions.

## What changed (non-technical)

- Server now returns replay results in pages instead of one full array.
- Responses include pagination metadata so clients can request the next page.
- Web, TUI, and CLI clients updated to fetch replay pages incrementally.
- Server enforces a bounded default page size and a hard maximum to prevent unbounded buffering.
- Unbounded replay is preserved for metadata/status probes only.

## Benefits

- Prevents unbounded memory and network usage when replaying long sessions.
- Faster first-page responsiveness for clients.
- More robust replay: pagination logic skips corrupt rows to avoid paging loops.
- Live events continue arriving via WebSocket and are deduplicated by existing reducers.

## Technical details (brief)

- New API fields: ReplayQuery.limit: Option<u64>; ReplayResponse.next_cursor: Option<u64> and has_more: bool (serde-defaulted for back-compat).
- EventStore::replay_page(session_id, since, limit) added; returns ReplayPage { events, last_scanned_seq, has_more, highest_seq, lowest_seq }.
- replay_page uses keyset pagination (seq > since), probes limit+1 rows to compute has_more, and advances last_scanned_seq past corrupt rows so pagination resumes correctly.
- replay_from delegates to replay_page with no limit to preserve legacy unbounded behavior for probes.
- Server clamps requested limits to a default (1000) and hard max (2000).
- Clients: added replay_page and replay_paged helpers and a REPLAY_PAGE_SIZE constant; clients iterate pages using next_cursor/has_more and stop at the first page’s highest_seq so concurrent appends are handled via live WS.
- Tests: serde back-compat tests for missing pagination fields, and replay tests ensuring paginated sequence reconstruction matches unpaginated output, correct boundary handling, and corrupt-row skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->