### PR TITLE
feat(web): dedicated Profiles page with read-only lifecycle hooks

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -98,6 +98,14 @@ The "Snoozed & archived" section sits at the very bottom of the sidebar and aggr
 
 In read-only mode (`aoe serve --read-only`) the three menu entries are hidden, matching the existing read-only gate on Delete.
 
+## Profiles
+
+The Profiles entry in the sidebar footer opens a dedicated page (`/profiles`) for managing configuration profiles. It lists every profile in a left rail with a **default** badge, and the detail panel lets you create, rename, delete, set the default, and edit a profile's description. The **Edit configuration** buttons deep-link into the matching Settings tab scoped to that profile (`/settings/<tab>?profile=<name>`), where the per-section editing (including the passphrase-gated sandbox and worktree fields) lives.
+
+Lifecycle hooks are shown **read-only** on this page. Each event (On Create, On Launch, On Destroy) is labeled with its source: a profile override, an override that disables the inherited commands (an explicit empty list), the inherited global commands, or none. Hooks run arbitrary shell commands when sessions are created, launched, and destroyed, so a hooks section set through the dashboard API would be remote code execution. For that reason hook editing is blocked server-side and the dashboard never writes hooks; edit them in your config file or the TUI settings. This mirrors the agent-command and environment fields (`agent_command_override`, `agent_extra_args`, `extra_env`, `custom_agents`, `agent_detect_as`), which are also not editable from the web.
+
+In read-only mode (`aoe serve --read-only`) the create / rename / delete / set-default / description controls are hidden; the profile list and the read-only hooks view stay visible.
+
 ## On mobile
 
 Below the `md` breakpoint the dashboard shows a single full-viewport pane rather than the desktop side-by-side split. The right-panel button in the top bar opens a picker that swaps the main pane between three views: the **Agent terminal**, the **Diff** (changed files and review), and the **Paired terminal** (host or container shell). A back chip in the top-left of the diff and paired views returns you to the agent terminal.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useMatch, useNavigate } from "react-router-dom";
+import { useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import { IDLE_DECAY_WINDOW_MS, isSessionActive } from "./lib/session";
 import { useSessions } from "./hooks/useSessions";
 import { clearCockpitCache } from "./hooks/useCockpit";
@@ -195,6 +195,7 @@ function isInsideEditable(target: EventTarget | null): boolean {
 
 function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLogout: () => void }) {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const idleDecayWindowMs = useIdleDecayWindowMs();
   const { settings: webSettings } = useWebSettings();
   const sessionMatch = useMatch("/session/:sessionId");
@@ -814,9 +815,20 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         <SettingsView
           tab={settingsTab}
           onClose={handleCloseSettings}
-          onSelectTab={(t) => navigate(`/settings/${t}`)}
+          onSelectTab={(t) => {
+            const p = searchParams.get("profile");
+            navigate(
+              `/settings/${t}${p ? `?profile=${encodeURIComponent(p)}` : ""}`,
+            );
+          }}
           serverAbout={serverAbout}
           onServerAboutRefresh={refreshServerAbout}
+          profile={searchParams.get("profile")}
+          onSelectProfile={(p) => {
+            const next = new URLSearchParams(searchParams);
+            next.set("profile", p);
+            setSearchParams(next, { replace: true });
+          }}
         />
       );
     }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1083,6 +1083,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     !activeSessionId &&
     !showSettings &&
     !showProjects &&
+    !showProfiles &&
     !showSessionWizard &&
     !showHelp &&
     !showAbout &&

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,6 +67,7 @@ import { MobileMainPane } from "./components/MobileMainPane";
 import { DiffFileViewer } from "./components/diff/DiffFileViewer";
 import { SettingsView } from "./components/SettingsView";
 import { ProjectsView } from "./components/ProjectsView";
+import { ProfilesPage } from "./components/profiles/ProfilesPage";
 import { HelpOverlay } from "./components/HelpOverlay";
 import { useTour } from "./hooks/useTour";
 import type { TourScope } from "./lib/tourSteps";
@@ -200,9 +201,11 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const settingsRootMatch = useMatch("/settings");
   const settingsTabMatch = useMatch("/settings/:tab");
   const projectsMatch = useMatch("/projects");
+  const profilesMatch = useMatch("/profiles");
   const activeSessionId = sessionMatch?.params.sessionId ?? null;
   const showSettings = settingsRootMatch !== null || settingsTabMatch !== null;
   const showProjects = projectsMatch !== null;
+  const showProfiles = profilesMatch !== null;
   const settingsTab = settingsTabMatch?.params.tab ?? null;
 
   const {
@@ -610,6 +613,19 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     }
   }, [navigate, activeSessionId]);
 
+  const handleOpenProfiles = useCallback(() => {
+    navigate("/profiles");
+    if (window.innerWidth < 768) setSidebarOpen(false);
+  }, [navigate]);
+
+  const handleCloseProfiles = useCallback(() => {
+    if (activeSessionId) {
+      navigate(`/session/${encodeURIComponent(activeSessionId)}`);
+    } else {
+      navigate("/");
+    }
+  }, [navigate, activeSessionId]);
+
   const handleCloseSettings = useCallback(() => {
     if (activeSessionId) {
       navigate(`/session/${encodeURIComponent(activeSessionId)}`);
@@ -809,6 +825,15 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       return (
         <ProjectsView
           onClose={handleCloseProjects}
+          readOnly={serverAbout?.read_only}
+        />
+      );
+    }
+
+    if (showProfiles) {
+      return (
+        <ProfilesPage
+          onClose={handleCloseProfiles}
           readOnly={serverAbout?.read_only}
         />
       );
@@ -1099,6 +1124,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             onCreateSession={handleCreateSession}
             onSettings={handleOpenSettings}
             onProjects={handleOpenProjects}
+            onProfiles={handleOpenProfiles}
             onDeleteSession={handleDeleteSession}
             readOnly={serverAbout?.read_only}
             sortMode={sidebarSortMode}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { ConnectedDevices } from "./ConnectedDevices";
 import { NotificationSettings } from "./NotificationSettings";
@@ -86,6 +86,12 @@ interface Props {
   onSelectTab: (tab: TabId) => void;
   serverAbout: ServerAbout | null;
   onServerAboutRefresh: () => Promise<void> | void;
+  /** Profile to preselect, sourced from the `?profile=` query so the
+   *  Profiles page can deep-link into a specific profile's section. */
+  profile?: string | null;
+  /** Notifies the host when the profile changes via the header dropdown,
+   *  so it can keep `?profile=` in sync for shareable/refreshable URLs. */
+  onSelectProfile?: (profile: string) => void;
 }
 
 const ALL_TAB_IDS = new Set<TabId>([
@@ -129,6 +135,8 @@ export function SettingsView({
   onSelectTab,
   serverAbout,
   onServerAboutRefresh,
+  profile,
+  onSelectProfile,
 }: Props) {
   const offline = useServerDown();
   const [settings, setSettings] = useState<Record<string, unknown> | null>(
@@ -146,7 +154,9 @@ export function SettingsView({
   // setSettings could race ahead of an optimistic user edit and
   // clobber it. See #1383 (profile-settings-isolation / settings-
   // tmux-* flakes).
-  const [selectedProfile, setSelectedProfile] = useState("");
+  // Seed from the `?profile=` query (deep-link from the Profiles page) when
+  // present, else empty (see the note above on why not "default").
+  const [selectedProfile, setSelectedProfile] = useState(profile ?? "");
   // Bumped only on a user-initiated profile switch (the header picker), never
   // on the mount-time fetchProfiles resolution that flips selectedProfile from
   // its "" seed to the default. The content fieldset keys its remount on this
@@ -155,10 +165,15 @@ export function SettingsView({
   // profile switches still remount (reset folds, clear half-typed drafts, break
   // sibling-tab reconciliation), which is what user story #4 wants.
   const [profileEpoch, setProfileEpoch] = useState(0);
-  const handleSelectProfile = useCallback((profile: string) => {
-    setSelectedProfile(profile);
-    setProfileEpoch((e) => e + 1);
-  }, []);
+  const handleSelectProfile = useCallback(
+    (next: string) => {
+      setSelectedProfile(next);
+      setProfileEpoch((e) => e + 1);
+      // Keep ?profile= in sync so the URL stays shareable/refreshable.
+      onSelectProfile?.(next);
+    },
+    [onSelectProfile],
+  );
   const sidebar = buildSidebar();
   const tabs = sidebar.filter(
     (s): s is { kind: "tab"; id: TabId; label: string } => s.kind === "tab",
@@ -173,6 +188,12 @@ export function SettingsView({
     });
   }, []);
 
+  // Follow `?profile=` when it changes after mount (e.g. a second deep-link
+  // from the Profiles page while Settings stays mounted).
+  useEffect(() => {
+    if (profile) setSelectedProfile(profile);
+  }, [profile]);
+
   const defaultProfile = profiles.find((p) => p.is_default)?.name ?? "default";
 
   const handleSetDefault = async (name: string) => {
@@ -180,9 +201,15 @@ export function SettingsView({
     if (ok) fetchProfiles().then(setProfiles);
   };
 
+  // Guard against a slow fetch for a previously-selected profile landing
+  // after a fast switch and clobbering the current profile's settings. The
+  // Profiles page deep-links raise the odds of rapid profile changes.
+  const loadSeq = useRef(0);
   const loadSettings = useCallback(() => {
     if (!selectedProfile) return;
+    const seq = ++loadSeq.current;
     fetchSettings(selectedProfile).then((s) => {
+      if (seq !== loadSeq.current) return;
       if (s) setSettings(s);
     });
   }, [selectedProfile]);

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -208,10 +208,15 @@ export function SettingsView({
   const loadSettings = useCallback(() => {
     if (!selectedProfile) return;
     const seq = ++loadSeq.current;
-    fetchSettings(selectedProfile).then((s) => {
-      if (seq !== loadSeq.current) return;
-      if (s) setSettings(s);
-    });
+    fetchSettings(selectedProfile)
+      .then((s) => {
+        if (seq !== loadSeq.current) return;
+        if (s) setSettings(s);
+      })
+      .catch(() => {
+        if (seq !== loadSeq.current) return;
+        setSettings(null);
+      });
   }, [selectedProfile]);
 
   useEffect(() => {

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -152,6 +152,7 @@ interface Props {
   onCreateSession: (repoPath: string) => void;
   onSettings: () => void;
   onProjects: () => void;
+  onProfiles: () => void;
   onDeleteSession?: (workspaceId: string) => void;
   readOnly?: boolean;
   sortMode: SidebarSortMode;
@@ -1766,6 +1767,7 @@ export function WorkspaceSidebar({
   onCreateSession,
   onSettings,
   onProjects,
+  onProfiles,
   onDeleteSession,
   readOnly,
   sortMode,
@@ -2300,6 +2302,28 @@ export function WorkspaceSidebar({
               strokeLinejoin="round"
             >
               <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+            </svg>
+          </button>
+          <button
+            onClick={onProfiles}
+            className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
+            title="Profiles"
+            aria-label="Profiles"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
             </svg>
           </button>
           <button

--- a/web/src/components/profiles/HooksReadOnlyPanel.tsx
+++ b/web/src/components/profiles/HooksReadOnlyPanel.tsx
@@ -1,0 +1,83 @@
+import type { EffectiveHookGroup, HookSource } from "../../lib/profileHooks";
+
+interface Props {
+  groups: EffectiveHookGroup[];
+}
+
+const SOURCE_BADGE: Record<HookSource, { label: string; className: string }> = {
+  override: {
+    label: "Profile override",
+    className: "bg-brand-600/15 text-brand-400",
+  },
+  "override-empty": {
+    label: "Overridden: none",
+    className: "bg-surface-700 text-text-dim",
+  },
+  inherited: {
+    label: "Inherited from global",
+    className: "bg-surface-700 text-text-secondary",
+  },
+  none: {
+    label: "None",
+    className: "bg-surface-700 text-text-dim",
+  },
+};
+
+/** Read-only view of a profile's effective lifecycle hooks.
+ *
+ *  Lifecycle hooks run arbitrary shell commands on session create/launch/
+ *  destroy, so a hooks section set through the API would be remote code
+ *  execution. The server blocks hook writes (ALLOWED_PROFILE_SETTINGS_
+ *  SECTIONS in src/server/api/mod.rs) and this panel deliberately renders
+ *  display-only: it takes no onChange/save props and exposes no inputs, so
+ *  there is no path from here to a profile PATCH. */
+export function HooksReadOnlyPanel({ groups }: Props) {
+  return (
+    <section className="rounded-lg border border-surface-700 bg-surface-900 p-4">
+      <h3 className="text-sm font-semibold text-text-primary">
+        Lifecycle hooks
+      </h3>
+      <p className="mt-1 text-xs text-text-dim">
+        Lifecycle hooks run shell commands when sessions are created,
+        launched, and destroyed. To prevent remote code execution, the
+        dashboard shows them read-only; edit hooks in your config file or the
+        TUI settings.
+      </p>
+      <ul className="mt-3 flex flex-col gap-3">
+        {groups.map((group) => {
+          const badge = SOURCE_BADGE[group.source];
+          return (
+            <li key={group.key}>
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-text-secondary">
+                  {group.label}
+                </span>
+                <span
+                  className={`rounded-md px-1.5 py-0.5 text-[11px] font-medium ${badge.className}`}
+                >
+                  {badge.label}
+                </span>
+              </div>
+              {group.commands.length > 0 ? (
+                <ul className="mt-1 flex flex-col gap-1">
+                  {group.commands.map((cmd, i) => (
+                    <li
+                      key={i}
+                      className="rounded-md bg-surface-850 px-2 py-1 font-mono text-xs text-text-primary break-all"
+                    >
+                      {cmd}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-1 text-xs text-text-dim italic">
+                  No commands.
+                </p>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/web/src/components/profiles/ProfilesPage.tsx
+++ b/web/src/components/profiles/ProfilesPage.tsx
@@ -79,16 +79,21 @@ export function ProfilesPage({ onClose, readOnly }: Props) {
       return;
     }
     const seq = ++loadSeq.current;
-    Promise.all([getProfileSettings(selected), fetchSettings()]).then(
-      ([profile, global]) => {
+    Promise.all([getProfileSettings(selected), fetchSettings()])
+      .then(([profile, global]) => {
         if (seq !== loadSeq.current) return;
         setProfileSettings(profile);
         setGlobalHooks(global?.hooks as HooksOverride | undefined);
         setDescription(
           typeof profile?.description === "string" ? profile.description : "",
         );
-      },
-    );
+      })
+      .catch(() => {
+        if (seq !== loadSeq.current) return;
+        setProfileSettings(null);
+        setGlobalHooks(undefined);
+        setError("Failed to load profile settings");
+      });
   }, [selected]);
 
   const closeInput = () => {

--- a/web/src/components/profiles/ProfilesPage.tsx
+++ b/web/src/components/profiles/ProfilesPage.tsx
@@ -1,0 +1,376 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  createProfile,
+  deleteProfile,
+  fetchProfiles,
+  fetchSettings,
+  getProfileSettings,
+  renameProfile,
+  setDefaultProfile,
+  updateProfileSettings,
+} from "../../lib/api";
+import type {
+  HooksOverride,
+  ProfileInfo,
+  ProfileSettingsResponse,
+} from "../../lib/types";
+import { buildEffectiveHooks } from "../../lib/profileHooks";
+import { HooksReadOnlyPanel } from "./HooksReadOnlyPanel";
+
+interface Props {
+  onClose: () => void;
+  readOnly?: boolean;
+}
+
+// Sections deep-linked into the existing Settings page (scoped to the
+// selected profile via ?profile=). Per-section editing, including the
+// passphrase-gated sandbox/worktree saves, stays in SettingsView; this page
+// owns profile-management metadata only.
+const EDIT_SECTIONS: ReadonlyArray<{ tab: string; label: string }> = [
+  { tab: "session", label: "Session" },
+  { tab: "theme", label: "Theme" },
+  { tab: "sandbox", label: "Sandbox" },
+  { tab: "worktree", label: "Worktree" },
+];
+
+function validateName(name: string): string | null {
+  if (!name) return "Name is required";
+  if (!/^[a-zA-Z0-9_-]+$/.test(name))
+    return "Only letters, digits, hyphens, and underscores";
+  return null;
+}
+
+export function ProfilesPage({ onClose, readOnly }: Props) {
+  const navigate = useNavigate();
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [selected, setSelected] = useState<string>("");
+  const [profileSettings, setProfileSettings] =
+    useState<ProfileSettingsResponse | null>(null);
+  const [globalHooks, setGlobalHooks] = useState<HooksOverride | undefined>(
+    undefined,
+  );
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+
+  const reload = useCallback(async () => {
+    const list = await fetchProfiles();
+    setProfiles(list);
+    setSelected((current) => {
+      if (list.some((p) => p.name === current)) return current;
+      return list.find((p) => p.is_default)?.name ?? list[0]?.name ?? "";
+    });
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  // Load the selected profile's settings (hook overrides + description) and
+  // the global hooks together. A request id guards against a slow response
+  // for a previously-selected profile winning after a fast switch.
+  const loadSeq = useRef(0);
+  useEffect(() => {
+    if (!selected) {
+      setProfileSettings(null);
+      return;
+    }
+    const seq = ++loadSeq.current;
+    Promise.all([getProfileSettings(selected), fetchSettings()]).then(
+      ([profile, global]) => {
+        if (seq !== loadSeq.current) return;
+        setProfileSettings(profile);
+        setGlobalHooks(global?.hooks as HooksOverride | undefined);
+        setDescription(
+          typeof profile?.description === "string" ? profile.description : "",
+        );
+      },
+    );
+  }, [selected]);
+
+  const closeInput = () => {
+    setCreating(false);
+    setRenaming(false);
+    setInputValue("");
+    setError(null);
+  };
+
+  const handleCreate = async () => {
+    const trimmed = inputValue.trim();
+    const err = validateName(trimmed);
+    if (err) {
+      setError(err);
+      return;
+    }
+    const ok = await createProfile(trimmed);
+    if (!ok) {
+      setError("Failed to create profile");
+      return;
+    }
+    closeInput();
+    setSelected(trimmed);
+    await reload();
+  };
+
+  const handleRename = async () => {
+    const trimmed = inputValue.trim();
+    if (trimmed === selected) {
+      closeInput();
+      return;
+    }
+    const err = validateName(trimmed);
+    if (err) {
+      setError(err);
+      return;
+    }
+    const ok = await renameProfile(selected, trimmed);
+    if (!ok) {
+      setError("Failed to rename profile");
+      return;
+    }
+    closeInput();
+    setSelected(trimmed);
+    await reload();
+  };
+
+  const handleDelete = async (name: string) => {
+    if (!confirm(`Delete profile "${name}"?`)) return;
+    const ok = await deleteProfile(name);
+    if (!ok) {
+      setError("Failed to delete profile");
+      return;
+    }
+    if (selected === name) setSelected("");
+    await reload();
+  };
+
+  const handleSetDefault = async (name: string) => {
+    const ok = await setDefaultProfile(name);
+    if (ok) await reload();
+  };
+
+  const handleSaveDescription = async () => {
+    setError(null);
+    const trimmed = description.trim();
+    const ok = await updateProfileSettings(selected, {
+      description: trimmed ? trimmed : null,
+    });
+    if (!ok) {
+      setError("Failed to save description");
+      return;
+    }
+    await reload();
+  };
+
+  const selectedInfo = profiles.find((p) => p.name === selected);
+  const isDefault = selectedInfo?.is_default ?? false;
+  const hookGroups = buildEffectiveHooks(profileSettings?.hooks, globalHooks);
+
+  return (
+    <div className="flex flex-col h-full bg-surface-900">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-surface-700/30">
+        <div>
+          <h1 className="text-lg font-semibold text-text-primary">Profiles</h1>
+          <p className="text-xs text-text-dim">
+            Manage configuration profiles and inspect their lifecycle hooks.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {!readOnly && !creating && !renaming && (
+            <button
+              type="button"
+              onClick={() => {
+                setCreating(true);
+                setInputValue("");
+                setError(null);
+              }}
+              className="px-3 py-1.5 text-sm bg-brand-600 hover:bg-brand-700 text-surface-900 rounded-md cursor-pointer font-medium"
+            >
+              + New profile
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mx-4 mt-3 px-3 py-2 bg-red-900/20 border border-red-700/30 rounded-md">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+
+      {(creating || renaming) && (
+        <div className="px-4 pt-3">
+          <div className="flex gap-2 bg-surface-850 border border-surface-700 rounded-lg p-3">
+            <input
+              type="text"
+              value={inputValue}
+              autoFocus
+              onChange={(e) => {
+                setInputValue(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  if (creating) handleCreate();
+                  else handleRename();
+                }
+                if (e.key === "Escape") closeInput();
+              }}
+              placeholder={creating ? "Profile name" : "New name"}
+              className="flex-1 bg-surface-900 border border-surface-700 rounded-md px-2 py-1.5 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={creating ? handleCreate : handleRename}
+              className="px-3 py-1.5 rounded-md bg-brand-600 hover:bg-brand-500 text-xs font-medium text-surface-950 cursor-pointer"
+            >
+              {creating ? "Create" : "Rename"}
+            </button>
+            <button
+              type="button"
+              onClick={closeInput}
+              className="px-3 py-1.5 rounded-md border border-surface-700 text-xs text-text-secondary hover:bg-surface-800 cursor-pointer"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-1 min-h-0 gap-4 p-4">
+        <nav className="w-56 shrink-0 flex flex-col gap-1 overflow-y-auto">
+          {profiles.map((p) => (
+            <button
+              key={p.name}
+              type="button"
+              onClick={() => setSelected(p.name)}
+              className={`flex items-center justify-between rounded-md px-3 py-2 text-sm text-left cursor-pointer ${
+                p.name === selected
+                  ? "bg-surface-700 text-text-primary"
+                  : "text-text-secondary hover:bg-surface-800"
+              }`}
+            >
+              <span className="truncate">{p.name}</span>
+              {p.is_default && (
+                <span className="ml-2 shrink-0 rounded-md bg-brand-600/15 px-1.5 py-0.5 text-[11px] font-medium text-brand-400">
+                  default
+                </span>
+              )}
+            </button>
+          ))}
+        </nav>
+
+        <div className="flex-1 min-w-0 overflow-y-auto">
+          {selectedInfo ? (
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center gap-2">
+                <h2 className="text-base font-semibold text-text-primary">
+                  {selectedInfo.name}
+                </h2>
+                {!readOnly && (
+                  <>
+                    {!isDefault && (
+                      <button
+                        type="button"
+                        onClick={() => handleSetDefault(selectedInfo.name)}
+                        className="text-xs text-text-dim hover:text-text-primary cursor-pointer"
+                      >
+                        Set as default
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setRenaming(true);
+                        setCreating(false);
+                        setInputValue(selectedInfo.name);
+                        setError(null);
+                      }}
+                      className="text-xs text-text-dim hover:text-text-primary cursor-pointer"
+                    >
+                      Rename
+                    </button>
+                    {!isDefault && (
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(selectedInfo.name)}
+                        className="text-xs text-text-dim hover:text-red-400 cursor-pointer"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </>
+                )}
+              </div>
+
+              <div>
+                <label className="block text-xs text-text-dim mb-1">
+                  Description
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={description}
+                    disabled={readOnly}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="What this profile is for"
+                    className="flex-1 bg-surface-900 border border-surface-700 rounded-md px-2 py-1.5 text-sm text-text-primary focus:border-brand-600 focus:outline-none disabled:opacity-60"
+                  />
+                  {!readOnly && (
+                    <button
+                      type="button"
+                      onClick={handleSaveDescription}
+                      className="px-3 py-1.5 rounded-md border border-surface-700 text-xs text-text-secondary hover:bg-surface-800 cursor-pointer"
+                    >
+                      Save
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-semibold text-text-primary mb-2">
+                  Edit configuration
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {EDIT_SECTIONS.map((s) => (
+                    <button
+                      key={s.tab}
+                      type="button"
+                      onClick={() =>
+                        navigate(
+                          `/settings/${s.tab}?profile=${encodeURIComponent(selectedInfo.name)}`,
+                        )
+                      }
+                      className="px-3 py-1.5 rounded-md border border-surface-700 text-xs text-text-secondary hover:bg-surface-800 cursor-pointer"
+                    >
+                      {s.label} &rarr;
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <HooksReadOnlyPanel groups={hookGroups} />
+            </div>
+          ) : (
+            <p className="text-sm text-text-dim">
+              {profiles.length === 0
+                ? "No profiles yet."
+                : "Select a profile to view its details."}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/profiles/__tests__/HooksReadOnlyPanel.test.tsx
+++ b/web/src/components/profiles/__tests__/HooksReadOnlyPanel.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+//
+// The hooks panel is a security boundary surface: it must render lifecycle
+// hooks read-only (no inputs/controls) and explain why they cannot be
+// edited from the dashboard. These tests pin the three-state rendering and
+// the read-only invariant.
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { HooksReadOnlyPanel } from "../HooksReadOnlyPanel";
+import { buildEffectiveHooks } from "../../../lib/profileHooks";
+
+function mount(
+  profile: Parameters<typeof buildEffectiveHooks>[0],
+  global: Parameters<typeof buildEffectiveHooks>[1],
+) {
+  return render(
+    <HooksReadOnlyPanel groups={buildEffectiveHooks(profile, global)} />,
+  );
+}
+
+describe("HooksReadOnlyPanel", () => {
+  it("renders the explain-why note about remote code execution", () => {
+    const { getByText } = mount({}, {});
+    expect(getByText(/remote code execution/i)).toBeTruthy();
+  });
+
+  it("exposes no editable controls (read-only invariant)", () => {
+    const { container } = mount(
+      { on_create: ["echo hi"] },
+      { on_launch: ["echo global"] },
+    );
+    expect(container.querySelectorAll("input").length).toBe(0);
+    expect(container.querySelectorAll("textarea").length).toBe(0);
+    expect(container.querySelectorAll("button").length).toBe(0);
+    expect(container.querySelectorAll("select").length).toBe(0);
+  });
+
+  it("shows a profile override command with the override badge", () => {
+    const { getByText } = mount({ on_create: ["echo hi"] }, {});
+    expect(getByText("echo hi")).toBeTruthy();
+    expect(getByText("Profile override")).toBeTruthy();
+  });
+
+  it("labels an inherited global command", () => {
+    const { getByText } = mount({}, { on_launch: ["echo global"] });
+    expect(getByText("echo global")).toBeTruthy();
+    expect(getByText("Inherited from global")).toBeTruthy();
+  });
+
+  it("labels an explicit empty override as overridden-to-none", () => {
+    const { getByText } = mount(
+      { on_destroy: [] },
+      { on_destroy: ["docker compose down"] },
+    );
+    expect(getByText("Overridden: none")).toBeTruthy();
+  });
+});

--- a/web/src/components/profiles/__tests__/ProfilesPage.test.tsx
+++ b/web/src/components/profiles/__tests__/ProfilesPage.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+//
+// Contract test for the Profiles page write path: even though the profile
+// settings GET returns a `hooks` section (unfiltered on reads), no PATCH
+// the page issues may ever carry it. Also covers the basic list + detail
+// render and the description payload shape.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ProfilesPage } from "../ProfilesPage";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const fetchSpy = vi.fn<typeof fetch>();
+
+function route(url: string, init?: RequestInit): Response {
+  const method = init?.method ?? "GET";
+  if (url === "/api/profiles" && method === "GET") {
+    return jsonResponse([
+      { name: "main", is_default: true },
+      { name: "work", is_default: false, description: "" },
+    ]);
+  }
+  if (url === "/api/profiles/work/settings" && method === "GET") {
+    // The GET deliberately includes hooks; the page must never echo them
+    // back on a write.
+    return jsonResponse({
+      description: "",
+      hooks: { on_create: ["echo seeded"] },
+    });
+  }
+  if (url === "/api/settings" || url.startsWith("/api/settings?")) {
+    return jsonResponse({ hooks: { on_launch: ["echo global"] } });
+  }
+  if (url === "/api/profiles/work/settings" && method === "PATCH") {
+    return jsonResponse({ ok: true });
+  }
+  return new Response("", { status: 404 });
+}
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  fetchSpy.mockImplementation((input, init) =>
+    Promise.resolve(route(String(input), init)),
+  );
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mount() {
+  return render(
+    <MemoryRouter>
+      <ProfilesPage onClose={() => {}} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ProfilesPage", () => {
+  it("lists profiles with a default badge", async () => {
+    const { getByRole, getByText } = mount();
+    await waitFor(() => getByRole("button", { name: "work" }));
+    expect(getByText("default")).toBeTruthy();
+  });
+
+  it("shows the read-only hooks panel for the selected profile", async () => {
+    const { getByRole, getByText } = mount();
+    await waitFor(() => getByRole("button", { name: "work" }));
+    fireEvent.click(getByRole("button", { name: "work" }));
+    await waitFor(() => getByText("Lifecycle hooks"));
+    // Profile override is rendered, inherited global is too.
+    await waitFor(() => getByText("echo seeded"));
+    expect(getByText("echo global")).toBeTruthy();
+  });
+
+  it("saves a description with a body containing only `description`, never hooks", async () => {
+    const { getByRole, getByPlaceholderText } = mount();
+    await waitFor(() => getByRole("button", { name: "work" }));
+    fireEvent.click(getByRole("button", { name: "work" }));
+    await waitFor(() => getByPlaceholderText("What this profile is for"));
+
+    fireEvent.change(getByPlaceholderText("What this profile is for"), {
+      target: { value: "client repos" },
+    });
+    fireEvent.click(getByRole("button", { name: "Save" }));
+
+    let patchBody: Record<string, unknown> | null = null;
+    await waitFor(() => {
+      const patch = fetchSpy.mock.calls.find(
+        ([url, init]) =>
+          String(url) === "/api/profiles/work/settings" &&
+          init?.method === "PATCH",
+      );
+      expect(patch).toBeTruthy();
+      patchBody = JSON.parse(patch![1]!.body as string);
+    });
+    expect(patchBody).toEqual({ description: "client repos" });
+    expect(patchBody).not.toHaveProperty("hooks");
+  });
+
+  it("never sends a PATCH that includes hooks across any interaction", () => {
+    mount();
+    const sawHooks = fetchSpy.mock.calls.some(([url, init]) => {
+      if (init?.method !== "PATCH") return false;
+      if (!String(url).includes("/settings")) return false;
+      return (init.body as string)?.includes("hooks");
+    });
+    expect(sawHooks).toBe(false);
+  });
+});

--- a/web/src/components/profiles/__tests__/ProfilesPage.test.tsx
+++ b/web/src/components/profiles/__tests__/ProfilesPage.test.tsx
@@ -1,13 +1,14 @@
 // @vitest-environment jsdom
 //
-// Contract test for the Profiles page write path: even though the profile
-// settings GET returns a `hooks` section (unfiltered on reads), no PATCH
-// the page issues may ever carry it. Also covers the basic list + detail
-// render and the description payload shape.
+// Contract + interaction tests for the Profiles page. The security-critical
+// invariant: even though the profile settings GET returns a `hooks` section
+// (unfiltered on reads), no PATCH the page issues may ever carry it. Also
+// exercises the CRUD / set-default / deep-link / read-only paths so the
+// page's handlers are covered without a live backend.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { ProfilesPage } from "../ProfilesPage";
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -27,7 +28,19 @@ function route(url: string, init?: RequestInit): Response {
       { name: "work", is_default: false, description: "" },
     ]);
   }
-  if (url === "/api/profiles/work/settings" && method === "GET") {
+  if (url === "/api/profiles" && method === "POST") {
+    return jsonResponse({ ok: true });
+  }
+  if (/^\/api\/profiles\/[^/]+\/rename$/.test(url) && method === "PATCH") {
+    return jsonResponse({ ok: true });
+  }
+  if (/^\/api\/profiles\/[^/]+$/.test(url) && method === "DELETE") {
+    return jsonResponse({ ok: true });
+  }
+  if (url === "/api/default-profile" && method === "PATCH") {
+    return jsonResponse({ ok: true });
+  }
+  if (/^\/api\/profiles\/[^/]+\/settings$/.test(url) && method === "GET") {
     // The GET deliberately includes hooks; the page must never echo them
     // back on a write.
     return jsonResponse({
@@ -35,13 +48,19 @@ function route(url: string, init?: RequestInit): Response {
       hooks: { on_create: ["echo seeded"] },
     });
   }
+  if (/^\/api\/profiles\/[^/]+\/settings$/.test(url) && method === "PATCH") {
+    return jsonResponse({ ok: true });
+  }
   if (url === "/api/settings" || url.startsWith("/api/settings?")) {
     return jsonResponse({ hooks: { on_launch: ["echo global"] } });
   }
-  if (url === "/api/profiles/work/settings" && method === "PATCH") {
-    return jsonResponse({ ok: true });
-  }
   return new Response("", { status: 404 });
+}
+
+function findCall(predicate: (url: string, init?: RequestInit) => boolean) {
+  return fetchSpy.mock.calls.find(([url, init]) =>
+    predicate(String(url), init as RequestInit | undefined),
+  );
 }
 
 beforeEach(() => {
@@ -54,50 +73,60 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
-function mount() {
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="loc">{loc.pathname + loc.search}</div>;
+}
+
+function mount(props: { readOnly?: boolean } = {}) {
   return render(
-    <MemoryRouter>
-      <ProfilesPage onClose={() => {}} />
+    <MemoryRouter initialEntries={["/profiles"]}>
+      <ProfilesPage onClose={() => {}} readOnly={props.readOnly} />
+      <LocationProbe />
     </MemoryRouter>,
   );
 }
 
+// Click the profile-rail row for `name`; exact avoids matching the
+// "Worktree ->" edit button (substring of "work").
+async function selectWork(api: ReturnType<typeof mount>) {
+  await waitFor(() => api.getByRole("button", { name: "work", exact: true }));
+  fireEvent.click(api.getByRole("button", { name: "work", exact: true }));
+}
+
 describe("ProfilesPage", () => {
   it("lists profiles with a default badge", async () => {
-    const { getByRole, getByText } = mount();
-    await waitFor(() => getByRole("button", { name: "work" }));
-    expect(getByText("default")).toBeTruthy();
+    const api = mount();
+    await waitFor(() => api.getByRole("button", { name: "work", exact: true }));
+    expect(api.getByText("default")).toBeTruthy();
   });
 
   it("shows the read-only hooks panel for the selected profile", async () => {
-    const { getByRole, getByText } = mount();
-    await waitFor(() => getByRole("button", { name: "work" }));
-    fireEvent.click(getByRole("button", { name: "work" }));
-    await waitFor(() => getByText("Lifecycle hooks"));
-    // Profile override is rendered, inherited global is too.
-    await waitFor(() => getByText("echo seeded"));
-    expect(getByText("echo global")).toBeTruthy();
+    const api = mount();
+    await selectWork(api);
+    await waitFor(() => api.getByText("Lifecycle hooks"));
+    await waitFor(() => api.getByText("echo seeded"));
+    expect(api.getByText("echo global")).toBeTruthy();
   });
 
   it("saves a description with a body containing only `description`, never hooks", async () => {
-    const { getByRole, getByPlaceholderText } = mount();
-    await waitFor(() => getByRole("button", { name: "work" }));
-    fireEvent.click(getByRole("button", { name: "work" }));
-    await waitFor(() => getByPlaceholderText("What this profile is for"));
+    const api = mount();
+    await selectWork(api);
+    await waitFor(() => api.getByPlaceholderText("What this profile is for"));
 
-    fireEvent.change(getByPlaceholderText("What this profile is for"), {
+    fireEvent.change(api.getByPlaceholderText("What this profile is for"), {
       target: { value: "client repos" },
     });
-    fireEvent.click(getByRole("button", { name: "Save" }));
+    fireEvent.click(api.getByRole("button", { name: "Save" }));
 
     let patchBody: Record<string, unknown> | null = null;
     await waitFor(() => {
-      const patch = fetchSpy.mock.calls.find(
-        ([url, init]) =>
-          String(url) === "/api/profiles/work/settings" &&
-          init?.method === "PATCH",
+      const patch = findCall(
+        (url, init) =>
+          url === "/api/profiles/work/settings" && init?.method === "PATCH",
       );
       expect(patch).toBeTruthy();
       patchBody = JSON.parse(patch![1]!.body as string);
@@ -106,12 +135,100 @@ describe("ProfilesPage", () => {
     expect(patchBody).not.toHaveProperty("hooks");
   });
 
+  it("creates a profile via + New profile (POST /api/profiles)", async () => {
+    const api = mount();
+    await waitFor(() => api.getByRole("button", { name: "work", exact: true }));
+    fireEvent.click(api.getByRole("button", { name: "+ New profile" }));
+    fireEvent.change(api.getByPlaceholderText("Profile name"), {
+      target: { value: "qa" },
+    });
+    fireEvent.click(api.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      const post = findCall(
+        (url, init) => url === "/api/profiles" && init?.method === "POST",
+      );
+      expect(post).toBeTruthy();
+      expect(JSON.parse(post![1]!.body as string)).toEqual({ name: "qa" });
+    });
+  });
+
+  it("renames the selected profile (PATCH .../rename)", async () => {
+    const api = mount();
+    await selectWork(api);
+    fireEvent.click(api.getByRole("button", { name: "Rename" }));
+    const renameInput = api.getByPlaceholderText("New name");
+    fireEvent.change(renameInput, { target: { value: "clients" } });
+    fireEvent.keyDown(renameInput, { key: "Enter" });
+
+    await waitFor(() => {
+      const patch = findCall(
+        (url, init) =>
+          url === "/api/profiles/work/rename" && init?.method === "PATCH",
+      );
+      expect(patch).toBeTruthy();
+      expect(JSON.parse(patch![1]!.body as string)).toEqual({
+        new_name: "clients",
+      });
+    });
+  });
+
+  it("deletes the selected profile after confirm (DELETE)", async () => {
+    vi.stubGlobal("confirm", () => true);
+    const api = mount();
+    await selectWork(api);
+    fireEvent.click(api.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      const del = findCall(
+        (url, init) =>
+          url === "/api/profiles/work" && init?.method === "DELETE",
+      );
+      expect(del).toBeTruthy();
+    });
+  });
+
+  it("sets the selected profile as default (PATCH /api/default-profile)", async () => {
+    const api = mount();
+    await selectWork(api);
+    fireEvent.click(api.getByRole("button", { name: "Set as default" }));
+
+    await waitFor(() => {
+      const patch = findCall(
+        (url, init) =>
+          url === "/api/default-profile" && init?.method === "PATCH",
+      );
+      expect(patch).toBeTruthy();
+      expect(JSON.parse(patch![1]!.body as string)).toEqual({ name: "work" });
+    });
+  });
+
+  it("deep-links into Settings scoped to the profile", async () => {
+    const api = mount();
+    await selectWork(api);
+    fireEvent.click(api.getByRole("button", { name: /^Worktree/ }));
+    await waitFor(() =>
+      expect(api.getByTestId("loc").textContent).toBe(
+        "/settings/worktree?profile=work",
+      ),
+    );
+  });
+
+  it("hides mutation controls in read-only mode", async () => {
+    const api = mount({ readOnly: true });
+    await selectWork(api);
+    expect(api.queryByRole("button", { name: "+ New profile" })).toBeNull();
+    expect(api.queryByRole("button", { name: "Set as default" })).toBeNull();
+    expect(api.queryByRole("button", { name: "Rename" })).toBeNull();
+    expect(api.queryByRole("button", { name: "Save" })).toBeNull();
+  });
+
   it("never sends a PATCH that includes hooks across any interaction", () => {
     mount();
     const sawHooks = fetchSpy.mock.calls.some(([url, init]) => {
-      if (init?.method !== "PATCH") return false;
+      if ((init as RequestInit | undefined)?.method !== "PATCH") return false;
       if (!String(url).includes("/settings")) return false;
-      return (init.body as string)?.includes("hooks");
+      return ((init as RequestInit).body as string)?.includes("hooks");
     });
     expect(sawHooks).toBe(false);
   });

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -205,6 +205,7 @@ describe("updateProfileSettings write guard", () => {
       "worktree",
       "web",
       "logging",
+      "cockpit",
       "description",
     ]);
   });

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -22,6 +22,8 @@ import {
   setSessionArchive,
   setSessionPin,
   setSessionSnooze,
+  updateProfileSettings,
+  PROFILE_WRITABLE_SECTIONS,
   type ServerAbout,
 } from "./api";
 
@@ -184,6 +186,63 @@ describe("setSessionSnooze", () => {
   it("returns null on 400 (server rejected an out-of-range duration)", async () => {
     fetchSpy.mockResolvedValueOnce(new Response("", { status: 400 }));
     expect(await setSessionSnooze("sess-1", 0)).toBeNull();
+  });
+});
+
+describe("updateProfileSettings write guard", () => {
+  // PROFILE_WRITABLE_SECTIONS mirrors the server's
+  // ALLOWED_PROFILE_SETTINGS_SECTIONS (src/server/api/mod.rs). This literal
+  // pin fails CI if the client list drifts; keep it in sync with the Rust
+  // constant and its pinned regression test by hand.
+  it("pins the allowlist to the server's writable sections", () => {
+    expect([...PROFILE_WRITABLE_SECTIONS]).toEqual([
+      "theme",
+      "session",
+      "tmux",
+      "updates",
+      "sound",
+      "sandbox",
+      "worktree",
+      "web",
+      "logging",
+      "description",
+    ]);
+  });
+
+  it("refuses to send a body containing the blocked `hooks` section", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ok = await updateProfileSettings("work", {
+      hooks: { on_create: ["rm -rf /"] },
+    });
+    expect(ok).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("refuses any unknown/blocked key even alongside an allowed one", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ok = await updateProfileSettings("work", {
+      theme: { name: "empire" },
+      custom_agents: { evil: "ssh host claude" },
+    });
+    expect(ok).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("PATCHes an allowed section through to the server", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 200 }));
+    const ok = await updateProfileSettings("work", {
+      description: "my profile",
+    });
+    expect(ok).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/profiles/work/settings");
+    expect(init?.method).toBe("PATCH");
+    expect(JSON.parse(init!.body as string)).toEqual({
+      description: "my profile",
+    });
   });
 });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   RichFileDiffResponse,
   AgentInfo,
   ProfileInfo,
+  ProfileSettingsResponse,
   BrowseResponse,
   GroupInfo,
   ProjectInfo,
@@ -210,16 +211,52 @@ export async function setDefaultProfile(name: string): Promise<boolean> {
 
 export function getProfileSettings(
   name: string,
-): Promise<Record<string, unknown> | null> {
-  return fetchJson<Record<string, unknown>>(
+): Promise<ProfileSettingsResponse | null> {
+  return fetchJson<ProfileSettingsResponse>(
     `/api/profiles/${encodeURIComponent(name)}/settings`,
   );
 }
+
+/** Profile-settings sections the dashboard is allowed to PATCH. Mirror of
+ *  the server's `ALLOWED_PROFILE_SETTINGS_SECTIONS` (src/server/api/mod.rs).
+ *  Sections NOT listed here, notably `hooks` plus the agent-command and
+ *  env fields, are remote-code-execution surfaces blocked server-side with
+ *  a pinned regression test (mod.rs tests module). We reject them client
+ *  side too as defense in depth. Keep this in sync with the Rust constant
+ *  by hand: there is no automated cross-language pin. */
+export const PROFILE_WRITABLE_SECTIONS = [
+  "theme",
+  "session",
+  "tmux",
+  "updates",
+  "sound",
+  "sandbox",
+  "worktree",
+  "web",
+  "logging",
+  "description",
+] as const;
+
+const PROFILE_WRITABLE_SECTION_SET: ReadonlySet<string> = new Set(
+  PROFILE_WRITABLE_SECTIONS,
+);
 
 export async function updateProfileSettings(
   name: string,
   updates: Record<string, unknown>,
 ): Promise<boolean> {
+  for (const key of Object.keys(updates)) {
+    if (!PROFILE_WRITABLE_SECTION_SET.has(key)) {
+      // Refuse loudly rather than silently dropping the key. A blocked
+      // section in a profile PATCH (e.g. `hooks`) is a caller bug; the
+      // server would 400 it anyway. Failing here keeps a buggy caller
+      // from reporting a partial save as success.
+      console.error(
+        `updateProfileSettings: refusing to send blocked profile section "${key}"`,
+      );
+      return false;
+    }
+  }
   try {
     const res = await fetch(
       `/api/profiles/${encodeURIComponent(name)}/settings`,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -234,6 +234,7 @@ export const PROFILE_WRITABLE_SECTIONS = [
   "worktree",
   "web",
   "logging",
+  "cockpit",
   "description",
 ] as const;
 

--- a/web/src/lib/profileHooks.test.ts
+++ b/web/src/lib/profileHooks.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildEffectiveHooks } from "./profileHooks";
+
+describe("buildEffectiveHooks", () => {
+  it("returns the three lifecycle events in TUI order with parity labels", () => {
+    const groups = buildEffectiveHooks(undefined, undefined);
+    expect(groups.map((g) => g.key)).toEqual([
+      "on_create",
+      "on_launch",
+      "on_destroy",
+    ]);
+    expect(groups.map((g) => g.label)).toEqual([
+      "On Create",
+      "On Launch",
+      "On Destroy",
+    ]);
+  });
+
+  it("marks a non-empty profile override as `override`", () => {
+    const groups = buildEffectiveHooks(
+      { on_create: ["echo hi"] },
+      { on_create: ["echo global"] },
+    );
+    const onCreate = groups.find((g) => g.key === "on_create")!;
+    expect(onCreate.source).toBe("override");
+    expect(onCreate.commands).toEqual(["echo hi"]);
+  });
+
+  it("marks an explicit empty array as `override-empty` (disables global)", () => {
+    const groups = buildEffectiveHooks(
+      { on_launch: [] },
+      { on_launch: ["notify-send launch"] },
+    );
+    const onLaunch = groups.find((g) => g.key === "on_launch")!;
+    expect(onLaunch.source).toBe("override-empty");
+    expect(onLaunch.commands).toEqual([]);
+  });
+
+  it("inherits global commands when the profile has no override", () => {
+    const groups = buildEffectiveHooks(
+      {},
+      { on_create: ["docker compose up"] },
+    );
+    const onCreate = groups.find((g) => g.key === "on_create")!;
+    expect(onCreate.source).toBe("inherited");
+    expect(onCreate.commands).toEqual(["docker compose up"]);
+  });
+
+  it("reports `none` when neither profile nor global define the event", () => {
+    const groups = buildEffectiveHooks({}, {});
+    expect(groups.every((g) => g.source === "none")).toBe(true);
+    expect(groups.every((g) => g.commands.length === 0)).toBe(true);
+  });
+
+  it("treats a malformed (non-array) field as absent, not a crash", () => {
+    const groups = buildEffectiveHooks(
+      { on_create: "echo hi" as unknown as string[] },
+      { on_create: ["echo global"] },
+    );
+    const onCreate = groups.find((g) => g.key === "on_create")!;
+    expect(onCreate.source).toBe("inherited");
+    expect(onCreate.commands).toEqual(["echo global"]);
+  });
+});

--- a/web/src/lib/profileHooks.ts
+++ b/web/src/lib/profileHooks.ts
@@ -1,0 +1,69 @@
+import type { HooksOverride } from "./types";
+
+export type HookEventKey = "on_create" | "on_launch" | "on_destroy";
+
+/** How the effective hooks for one lifecycle event are resolved for a
+ *  profile:
+ *  - `override`: the profile sets a non-empty command list (runs these).
+ *  - `override-empty`: the profile sets an explicit empty list, disabling
+ *    the inherited global hooks for this event.
+ *  - `inherited`: the profile has no override, so the global hooks run.
+ *  - `none`: neither the profile nor the global config defines hooks. */
+export type HookSource = "override" | "override-empty" | "inherited" | "none";
+
+export interface EffectiveHookGroup {
+  key: HookEventKey;
+  /** TUI-parity label (see src/tui/settings/fields.rs build_hooks_fields). */
+  label: string;
+  source: HookSource;
+  /** Commands that will run for this event under the profile. */
+  commands: string[];
+}
+
+/** Lifecycle events in TUI display order with their parity labels. */
+const HOOK_EVENTS: ReadonlyArray<readonly [HookEventKey, string]> = [
+  ["on_create", "On Create"],
+  ["on_launch", "On Launch"],
+  ["on_destroy", "On Destroy"],
+];
+
+/** Return the array for one event if the source explicitly set it (the
+ *  tri-state `Some`), else `undefined` (the tri-state `None` = inherit).
+ *  Non-array values are treated as absent so a malformed payload degrades
+ *  to "inherited" rather than throwing. */
+function hookArray(
+  src: HooksOverride | undefined,
+  key: HookEventKey,
+): string[] | undefined {
+  const value = src?.[key];
+  return Array.isArray(value) ? value : undefined;
+}
+
+/** Merge a profile's hook overrides with the global hooks into the
+ *  effective per-event view rendered by HooksReadOnlyPanel. The profile
+ *  override shape is tri-state (mirrors Rust `Option<Vec<String>>`):
+ *  absent inherits global, an explicit `[]` disables it, a non-empty array
+ *  replaces it. */
+export function buildEffectiveHooks(
+  profile: HooksOverride | undefined,
+  global: HooksOverride | undefined,
+): EffectiveHookGroup[] {
+  return HOOK_EVENTS.map(([key, label]) => {
+    const override = hookArray(profile, key);
+    if (override !== undefined) {
+      return {
+        key,
+        label,
+        source: override.length === 0 ? "override-empty" : "override",
+        commands: override,
+      };
+    }
+    const inherited = hookArray(global, key) ?? [];
+    return {
+      key,
+      label,
+      source: inherited.length === 0 ? "none" : "inherited",
+      commands: inherited,
+    };
+  });
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -307,6 +307,27 @@ export interface ProfileInfo {
   description?: string;
 }
 
+/** Per-profile lifecycle-hook overrides, as returned by
+ *  GET /api/profiles/:name/settings. Mirrors the Rust
+ *  HooksConfigOverride (src/session/profile_config.rs): a field that is
+ *  absent/undefined means "inherit the global hooks"; an explicit array
+ *  (including the empty array) means "override". Hooks are read-only on
+ *  the dashboard; see HooksReadOnlyPanel and PROFILE_WRITABLE_SECTIONS. */
+export interface HooksOverride {
+  on_create?: string[];
+  on_launch?: string[];
+  on_destroy?: string[];
+}
+
+/** Shape of GET /api/profiles/:name/settings: the serialized
+ *  ProfileConfig. Only the fields the dashboard reads are typed; the rest
+ *  stays indexable. `hooks` is present on reads but never writable. */
+export interface ProfileSettingsResponse {
+  description?: string | null;
+  hooks?: HooksOverride;
+  [key: string]: unknown;
+}
+
 /** Directory entry returned by /api/filesystem/browse */
 export interface DirEntry {
   name: string;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -348,6 +348,41 @@
       ]
     },
     {
+      "id": "profiles.page",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/profiles-page.spec.ts"
+      ],
+      "components": [
+        "web/src/components/profiles/ProfilesPage.tsx"
+      ]
+    },
+    {
+      "id": "profiles.hooks-readonly",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/components/profiles/__tests__/HooksReadOnlyPanel.test.tsx",
+        "src/lib/profileHooks.test.ts"
+      ],
+      "components": [
+        "web/src/components/profiles/HooksReadOnlyPanel.tsx"
+      ]
+    },
+    {
+      "id": "profiles.write-guard",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/lib/api.test.ts",
+        "src/components/profiles/__tests__/ProfilesPage.test.tsx"
+      ],
+      "components": [
+        "web/src/components/profiles/ProfilesPage.tsx"
+      ]
+    },
+    {
       "id": "profiles.override",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/profiles-page.spec.ts
+++ b/web/tests/live/profiles-page.spec.ts
@@ -52,7 +52,7 @@ test("set as default round-trips through PATCH /api/default-profile", async ({
   await seedProfile(serve, "work");
 
   await page.goto(`${serve.baseUrl}/profiles`);
-  await page.getByRole("button", { name: "work" }).click();
+  await page.getByRole("button", { name: "work", exact: true }).click();
   await page.getByRole("button", { name: "Set as default" }).click();
 
   await expect(async () => {
@@ -65,7 +65,7 @@ test("description edit persists across reload", async ({ serve, page }) => {
   await seedProfile(serve, "work");
 
   await page.goto(`${serve.baseUrl}/profiles`);
-  await page.getByRole("button", { name: "work" }).click();
+  await page.getByRole("button", { name: "work", exact: true }).click();
 
   const desc = page.getByPlaceholder("What this profile is for");
   await desc.fill("client repos");
@@ -79,7 +79,7 @@ test("description edit persists across reload", async ({ serve, page }) => {
   }).toPass({ timeout: 5_000 });
 
   await page.reload();
-  await page.getByRole("button", { name: "work" }).click();
+  await page.getByRole("button", { name: "work", exact: true }).click();
   await expect(page.getByPlaceholder("What this profile is for")).toHaveValue(
     "client repos",
   );
@@ -92,7 +92,7 @@ test("Edit configuration deep-links into Settings scoped to the profile", async 
   await seedProfile(serve, "work");
 
   await page.goto(`${serve.baseUrl}/profiles`);
-  await page.getByRole("button", { name: "work" }).click();
+  await page.getByRole("button", { name: "work", exact: true }).click();
   await page.getByRole("button", { name: /^Session/ }).click();
 
   await expect(page).toHaveURL(/\/settings\/session\?profile=work/);

--- a/web/tests/live/profiles-page.spec.ts
+++ b/web/tests/live/profiles-page.spec.ts
@@ -1,0 +1,120 @@
+// Dedicated Profiles page (/profiles) against a real `aoe serve`. Covers
+// the CRUD + set-default + description round-trips, the deep-link into
+// Settings (?profile=), and the read-only hooks panel invariant.
+//
+// Each test runs against its own fresh serve so profile state is
+// deterministic. Pairs with profile-lifecycle.spec.ts, which covers the
+// ProfileSelector dropdown inside Settings.
+
+import { test, expect, type ServeHandle } from "../helpers/liveTest";
+
+async function fetchProfiles(
+  serve: ServeHandle,
+): Promise<Array<{ name: string; is_default: boolean; description?: string }>> {
+  const res = await fetch(`${serve.baseUrl}/api/profiles`);
+  expect(res.ok).toBeTruthy();
+  return res.json();
+}
+
+async function seedProfile(serve: ServeHandle, name: string): Promise<void> {
+  const res = await fetch(`${serve.baseUrl}/api/profiles`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  expect(res.ok).toBeTruthy();
+}
+
+test("create profile via + New round-trips through POST /api/profiles", async ({
+  serve,
+  page,
+}) => {
+  await page.goto(`${serve.baseUrl}/profiles`);
+  await expect(
+    page.getByRole("heading", { name: "Profiles" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "+ New profile" }).click();
+  const nameInput = page.getByPlaceholder("Profile name");
+  await nameInput.fill("work");
+  await nameInput.press("Enter");
+
+  await expect(async () => {
+    const profiles = await fetchProfiles(serve);
+    expect(profiles.map((p) => p.name).sort()).toEqual(["main", "work"]);
+  }).toPass({ timeout: 5_000 });
+});
+
+test("set as default round-trips through PATCH /api/default-profile", async ({
+  serve,
+  page,
+}) => {
+  await seedProfile(serve, "work");
+
+  await page.goto(`${serve.baseUrl}/profiles`);
+  await page.getByRole("button", { name: "work" }).click();
+  await page.getByRole("button", { name: "Set as default" }).click();
+
+  await expect(async () => {
+    const profiles = await fetchProfiles(serve);
+    expect(profiles.find((p) => p.name === "work")?.is_default).toBe(true);
+  }).toPass({ timeout: 5_000 });
+});
+
+test("description edit persists across reload", async ({ serve, page }) => {
+  await seedProfile(serve, "work");
+
+  await page.goto(`${serve.baseUrl}/profiles`);
+  await page.getByRole("button", { name: "work" }).click();
+
+  const desc = page.getByPlaceholder("What this profile is for");
+  await desc.fill("client repos");
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(async () => {
+    const profiles = await fetchProfiles(serve);
+    expect(profiles.find((p) => p.name === "work")?.description).toBe(
+      "client repos",
+    );
+  }).toPass({ timeout: 5_000 });
+
+  await page.reload();
+  await page.getByRole("button", { name: "work" }).click();
+  await expect(page.getByPlaceholder("What this profile is for")).toHaveValue(
+    "client repos",
+  );
+});
+
+test("Edit configuration deep-links into Settings scoped to the profile", async ({
+  serve,
+  page,
+}) => {
+  await seedProfile(serve, "work");
+
+  await page.goto(`${serve.baseUrl}/profiles`);
+  await page.getByRole("button", { name: "work" }).click();
+  await page.getByRole("button", { name: /^Session/ }).click();
+
+  await expect(page).toHaveURL(/\/settings\/session\?profile=work/);
+  const profileSelect = page
+    .locator("label", { hasText: /^Profile$/ })
+    .locator("..")
+    .locator("select");
+  await expect(profileSelect).toHaveValue("work");
+});
+
+test("lifecycle hooks render read-only with the explain-why note", async ({
+  serve,
+  page,
+}) => {
+  await page.goto(`${serve.baseUrl}/profiles`);
+  await page.getByRole("button", { name: "main" }).click();
+
+  const panel = page
+    .locator("section", { hasText: "Lifecycle hooks" })
+    .first();
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText(/remote code execution/i)).toBeVisible();
+  // Read-only invariant: the hooks panel exposes no form controls.
+  await expect(panel.locator("input, textarea, button, select")).toHaveCount(0);
+});

--- a/web/tests/live/profiles-page.spec.ts
+++ b/web/tests/live/profiles-page.spec.ts
@@ -65,13 +65,22 @@ test("description edit persists across reload", async ({ serve, page }) => {
   await seedProfile(serve, "work");
 
   await page.goto(`${serve.baseUrl}/profiles`);
-  await page.getByRole("button", { name: "work", exact: true }).click();
+  // Selecting a profile fires an async load (getProfileSettings +
+  // fetchSettings) whose .then resets the description field to the loaded
+  // value. Wait for both responses before typing, otherwise a late resolve
+  // clobbers the typed value back to empty and Save PATCHes null.
+  await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/profiles/work/settings") &&
+        r.request().method() === "GET",
+    ),
+    page.waitForResponse((r) => /\/api\/settings(\?|$)/.test(r.url())),
+    page.getByRole("button", { name: "work", exact: true }).click(),
+  ]);
 
   const desc = page.getByPlaceholder("What this profile is for");
   await desc.fill("client repos");
-  // The field is a controlled input (value={description}); wait until the
-  // DOM value reflects committed React state before saving, otherwise the
-  // Save handler can read a stale empty description and PATCH null.
   await expect(desc).toHaveValue("client repos");
   await page.getByRole("button", { name: "Save" }).click();
 

--- a/web/tests/live/profiles-page.spec.ts
+++ b/web/tests/live/profiles-page.spec.ts
@@ -69,6 +69,10 @@ test("description edit persists across reload", async ({ serve, page }) => {
 
   const desc = page.getByPlaceholder("What this profile is for");
   await desc.fill("client repos");
+  // The field is a controlled input (value={description}); wait until the
+  // DOM value reflects committed React state before saving, otherwise the
+  // Save handler can read a stale empty description and PATCH null.
+  await expect(desc).toHaveValue("client repos");
   await page.getByRole("button", { name: "Save" }).click();
 
   await expect(async () => {

--- a/web/tests/live/profiles-page.spec.ts
+++ b/web/tests/live/profiles-page.spec.ts
@@ -103,6 +103,19 @@ test("Edit configuration deep-links into Settings scoped to the profile", async 
   await expect(profileSelect).toHaveValue("work");
 });
 
+test("opens from the sidebar footer and closes back to the dashboard", async ({
+  serve,
+  page,
+}) => {
+  await page.goto(serve.baseUrl);
+  await page.getByRole("button", { name: "Profiles", exact: true }).click();
+  await expect(page).toHaveURL(/\/profiles$/);
+  await expect(page.getByRole("heading", { name: "Profiles" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(page).not.toHaveURL(/\/profiles/);
+});
+
 test("lifecycle hooks render read-only with the explain-why note", async ({
   serve,
   page,


### PR DESCRIPTION
## Description

Adds a dedicated **Profiles** page to the web dashboard (`/profiles`), reachable from a new sidebar-footer button. It pulls profile management out of the cramped Settings header dropdown into a master-detail page:

- **Left rail:** every profile with a `default` badge.
- **Detail panel:** create / rename / delete / set-default, inline description editing, and **Edit configuration** buttons that deep-link into `/settings/<tab>?profile=<name>` for per-section editing (the passphrase-gated sandbox/worktree saves stay in Settings, untouched).
- **Read-only lifecycle hooks:** On Create / On Launch / On Destroy, each labeled by source (profile override / overridden-to-none / inherited-global / none), with an explain-why note.

### Why hooks (and agent/env) are read-only

Setting a `hooks` section through the API runs arbitrary shell on session start, i.e. remote code execution. The server already blocks it (`ALLOWED_PROFILE_SETTINGS_SECTIONS`, pinned by a regression test), so this PR **respects that boundary**: hooks are displayed, never editable from the web, and the same applies to `agent_command_override` / `agent_extra_args` / `extra_env` / `custom_agents` / `agent_detect_as`. As defense in depth, the API client now mirrors the server allowlist (`PROFILE_WRITABLE_SECTIONS`) and refuses (loudly, no request) any PATCH carrying a blocked/unknown section.

Settings also learns to deep-link: `SettingsView` reads `?profile=` and keeps it in sync when the header dropdown changes, plus a request-id guard so a stale settings fetch can't clobber the current profile after a fast switch.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording <!-- add `needs-recording` label if a recording is wanted -->

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## How I tested

Web-only change (no Rust touched), so the cockpit/cargo gates are N/A; ran the web suites locally:

- `tsc -b` clean, `eslint` clean on changed files.
- `vitest run`: 1383 passed (new: `api.test.ts` write-guard, `profileHooks.test.ts`, `HooksReadOnlyPanel.test.tsx`, `ProfilesPage.test.tsx`).
- `node tests/validate-coverage-matrix.mjs` passes.
- Live Playwright spec `tests/live/profiles-page.spec.ts` added (CRUD / set-default / description persistence / deep-link / read-only hooks invariant).

### User-runnable checks
- [ ] `aoe serve`, open the dashboard, click the Profiles icon in the sidebar footer → lands on `/profiles`.
- [ ] Create, rename, delete, and set-default a profile; reload and confirm each persists.
- [ ] Edit a profile description, reload, confirm it persists.
- [ ] Click an **Edit configuration** button → lands on `/settings/<tab>?profile=<name>` with that profile selected in the header.
- [ ] The hooks panel shows On Create / On Launch / On Destroy read-only with the explain-why note and no input controls.
- [ ] `aoe serve --read-only` hides the create/rename/delete/set-default/description controls but keeps the list and read-only hooks visible.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (1M context) via Claude Code, with a 3-model design debate (Gemini 3.1 Pro, GPT-5.5, Claude Opus 4.7) to settle the architecture.

- [x] I am an AI Agent filling out this form (check box if true)

Closes #950


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a dedicated Profiles page and client-side safeguards so users can manage configuration profiles in the web dashboard while keeping unsafe sections read-only.

High-level changes
- New Profiles UI: Adds a master–detail Profiles page at /profiles, reachable from a new sidebar-footer button. Left rail lists profiles (with a default badge); right panel shows profile details, description editing, actions (create, rename, delete, set-default), deep-links to settings tabs, and a read-only lifecycle hooks section.
- Profile management flows: Create, rename, delete (with confirmation), set-as-default, and persist description changes; name validation enforces safe characters.
- Read-only unsafe sections: Lifecycle hooks (on_create, on_launch, on_destroy) and other sensitive fields (agent command/args/env, custom_agents, agent_detect_as) are shown but not editable; hooks are labeled by source (override / override-empty / inherited / none) with an explanatory note about remote code execution risk.
- URL & navigation sync: SettingsView preserves and syncs ?profile= across tabs and dropdowns; App routing and sidebar handlers support opening/closing /profiles. Tutorial auto-launch is suppressed on /profiles.
- Client-side write guard: API client exposes PROFILE_WRITABLE_SECTIONS and refuses PATCH requests containing blocked or unknown sections (logs and returns false) to prevent accidental unsafe updates.
- Read-only mode: `aoe serve --read-only` hides mutation controls while preserving listing and read-only hooks.
- Tests & docs: Vitest unit/integration tests and a Playwright e2e spec cover CRUD, set-default, description persistence, deep-linking, read-only hooks, and the client write-guard. Documentation updated and coverage matrix extended.

Benefits
- Makes profile management accessible without editing TOML.
- Reduces risk of remote code execution and misconfiguration by preventing web edits to unsafe sections and adding client-side validation.
- Improves navigation and discoverability via deep-links and a dedicated page.
- Makes hook provenance clear (why a command runs or is disabled).

Potential follow-ups
- Ensure server-side enforcement mirrors the client allowlist and returns clear errors (critical).
- Add an audited, sandboxed "test run" for hooks with explicit trust controls.
- Revisit which profile fields can be safely exposed for editing and add logging/auditing for profile mutations.
- Accessibility and UX polish for mobile/sidebar interactions and tutorial behavior.

Technical details (concise)
- New/changed components: ProfilesPage, HooksReadOnlyPanel; WorkspaceSidebar adds onProfiles; App.tsx routing supports /profiles; SettingsView gains profile prop/onSelectProfile and a request-id (loadSeq) guard.
- Hook handling: Added buildEffectiveHooks + types (HookEventKey, HookSource, EffectiveHookGroup) to merge profile/global hooks and report sources (override, override-empty, inherited, none).
- Types: Added HooksOverride and ProfileSettingsResponse.
- API client: getProfileSettings returns typed ProfileSettingsResponse; updateProfileSettings enforces PROFILE_WRITABLE_SECTIONS and blocks invalid PATCH bodies.
- Concurrency guards: loadSeq pattern used in SettingsView and ProfilesPage to avoid stale async results clobbering state.
- Tests: Vitest for hooks merging, HooksReadOnlyPanel, ProfilesPage, and api write-guard; Playwright spec for /profiles; coverage-matrix updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->