### PR TITLE
feat(cockpit): queued-prompt UI above the TUI composer

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -52,8 +52,9 @@ status banner at the bottom of the screen shows the current focus.
 
 | Focus       | Key             | Action                                                |
 | ----------- | --------------- | ----------------------------------------------------- |
-| Composer    | `Enter`         | Send the buffered text as a prompt                    |
+| Composer    | `Enter`         | Send the buffered text, or queue it if a turn is active |
 | Composer    | `Shift+Enter`   | Insert a newline (multi-line prompts)                 |
+| Composer    | `Enter` (empty) | Retry draining the queue when idle (e.g. after a failed send) |
 | Composer    | `Esc`           | Return focus to the transcript                        |
 | Transcript  | `j` / `↓`       | Scroll down one line                                  |
 | Transcript  | `k` / `↑`       | Scroll up one line                                    |
@@ -69,6 +70,7 @@ status banner at the bottom of the screen shows the current focus.
 | Approval    | `Esc`           | Return focus to the transcript                        |
 | Any         | `Ctrl+C`        | Cancel the in-flight prompt                           |
 | Any         | `Ctrl+O`        | Open the session in the web dashboard                 |
+| Any         | `Ctrl+X`        | Clear every queued (not-yet-sent) prompt              |
 
 **Focus isolation.** Approval keys (`a`/`Shift+A`/`d`) only resolve
 when the approval card itself has focus. Typing "always allow" into
@@ -196,6 +198,20 @@ Queued entries persist in the per-origin localStorage snapshot at
 reopening the tab on the same origin) keeps them across the reconnect
 window. Server-side durability is not currently implemented; clearing
 site data wipes the queue.
+
+**TUI cockpit.** The TUI cockpit view has the same client-side queue.
+Pressing `Enter` while a turn is active (or while the WebSocket is
+down) parks the prompt in a **Queued (N)** strip above the composer
+instead of sending it; the queue drains on the next `Stopped` per the
+daemon's `cockpit.queue_drain_mode`, which the view reads from
+`/api/about` so a remote attach honors the remote daemon's setting.
+`Ctrl+X` clears the queue, and pressing `Enter` on an empty composer
+when idle retries the drain (useful if a send failed and left prompts
+parked). Two small differences from the web composer: there is no
+in-place edit of queued rows (clear and retype), and combined mode
+slices batches only at the `/clear` and `/new` boundaries rather than
+the full per-agent clear-alias list. The TUI queue is in-memory only,
+so it does not survive leaving the cockpit view.
 
 ## Stopping a turn
 

--- a/src/cockpit/client/http.rs
+++ b/src/cockpit/client/http.rs
@@ -19,6 +19,14 @@ use crate::cockpit::protocol::{
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Subset of the daemon's `GET /api/about` payload the cockpit client
+/// reads. The full `ServerAbout` carries many more fields; serde drops
+/// the rest.
+#[derive(serde::Deserialize)]
+struct AboutResponse {
+    cockpit_queue_drain_mode: String,
+}
+
 /// Cockpit daemon HTTP client. Cheap to clone; the underlying
 /// `reqwest::Client` is reference-counted.
 #[derive(Debug, Clone)]
@@ -98,6 +106,23 @@ impl HttpClient {
         let res = self.auth(self.http.post(&url)).json(&body).send().await?;
         check_status(res, session_id).await?;
         Ok(())
+    }
+
+    /// `GET /api/about`. Returns the daemon's resolved
+    /// `cockpit.queue_drain_mode`, which the TUI cockpit needs because it
+    /// may attach to a remote daemon whose config differs from the local
+    /// machine's. Unknown / unparseable values fall back to the default.
+    pub async fn queue_drain_mode(
+        &self,
+    ) -> Result<crate::session::config::QueueDrainMode, HttpError> {
+        let url = format!("{}/api/about", self.endpoint.base_url);
+        let res = self.auth(self.http.get(&url)).send().await?;
+        let res = check_status(res, "<about>").await?;
+        let about = res.json::<AboutResponse>().await?;
+        Ok(
+            crate::session::config::QueueDrainMode::parse(&about.cockpit_queue_drain_mode)
+                .unwrap_or_default(),
+        )
     }
 
     /// `POST /api/sessions/{id}/cockpit/cancel`.

--- a/src/cockpit/client/http.rs
+++ b/src/cockpit/client/http.rs
@@ -24,6 +24,7 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 /// the rest.
 #[derive(serde::Deserialize)]
 struct AboutResponse {
+    #[serde(default)]
     cockpit_queue_drain_mode: String,
 }
 

--- a/src/tui/cockpit_view/input.rs
+++ b/src/tui/cockpit_view/input.rs
@@ -33,6 +33,8 @@ pub enum Intent {
     ResolveApproval(ApprovalDecisionWire),
     /// Cancel the in-flight prompt (Ctrl-C style).
     CancelInFlight,
+    /// Drop every queued (not-yet-sent) prompt.
+    ClearQueue,
     /// Open the daemon URL for this session in the user's browser.
     OpenInBrowser,
     /// Move focus to the named region.
@@ -59,6 +61,13 @@ pub fn dispatch(focus: Focus, key: &KeyEvent, has_pending_approval: bool) -> Int
     // browser tab.
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('o') {
         return Intent::OpenInBrowser;
+    }
+    // Universal: Ctrl-x drops every queued prompt. Intercepted here,
+    // before the composer sees it, so it works from any focus and a
+    // queued backlog can always be abandoned without leaving the
+    // composer. A no-op when the queue is empty.
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('x') {
+        return Intent::ClearQueue;
     }
 
     match focus {
@@ -219,6 +228,23 @@ mod tests {
             );
             assert_eq!(intent, Intent::CancelInFlight);
         }
+    }
+
+    #[test]
+    fn ctrl_x_clears_queue_from_any_focus() {
+        for focus in [Focus::Composer, Focus::Transcript, Focus::Approval] {
+            let intent = dispatch(
+                focus,
+                &key_mod(KeyCode::Char('x'), KeyModifiers::CONTROL),
+                false,
+            );
+            assert_eq!(intent, Intent::ClearQueue);
+        }
+        // Plain 'x' in the composer is still a typed character.
+        assert!(matches!(
+            dispatch(Focus::Composer, &key(KeyCode::Char('x')), false),
+            Intent::Compose(_)
+        ));
     }
 
     #[test]

--- a/src/tui/cockpit_view/mod.rs
+++ b/src/tui/cockpit_view/mod.rs
@@ -168,6 +168,22 @@ pub async fn run_for_endpoint(
 
     let mut toast_deadline: Option<Instant> = None;
 
+    // Resolve the queue drain mode from the daemon (not local config:
+    // this view can attach to a remote daemon). A failure here is
+    // non-fatal; the queue still works, it just uses the default mode.
+    match state.http.queue_drain_mode().await {
+        Ok(mode) => state.drain_mode = mode,
+        Err(e) => {
+            tracing::warn!(target: "cockpit.tui", "queue drain mode fetch failed: {e}");
+            set_toast(
+                &mut state,
+                &mut toast_deadline,
+                format!("queue drain mode unknown ({e}); using default"),
+                ToastKind::Error,
+            );
+        }
+    }
+
     // Capture both startup-path errors before showing a toast so we
     // can fold them into a single message when both fail (they
     // usually share a root cause, e.g. 401 from the auth middleware).
@@ -228,8 +244,21 @@ pub async fn run_for_endpoint(
             ws_msg = recv_ws(&mut state) => {
                 match ws_msg {
                     Some(Ok(WsMessage::Frame(frame))) => {
+                        let was_active = state.transcript.turn_active;
                         state.transcript.apply(&frame);
                         state.reconcile_selection();
+                        let now_active = state.transcript.turn_active;
+                        if !was_active && now_active {
+                            // Turn started (our own prompt echoed back, or
+                            // another client's). The optimistic lock has
+                            // served its purpose; release it.
+                            state.in_flight = false;
+                        } else if was_active && !now_active {
+                            // Turn ended: release the lock and drain the
+                            // next queued batch, if any.
+                            state.in_flight = false;
+                            maybe_drain(&mut state, &mut toast_deadline).await;
+                        }
                         redraw(terminal, theme, &state)?;
                     }
                     Some(Ok(WsMessage::Lagged)) => {
@@ -245,6 +274,11 @@ pub async fn run_for_endpoint(
                                     state.transcript.apply(frame);
                                 }
                                 state.reconcile_selection();
+                                // Re-derived turn state from the rebuilt
+                                // transcript; the lock no longer reflects
+                                // anything observable. Drain if idle.
+                                state.in_flight = false;
+                                maybe_drain(&mut state, &mut toast_deadline).await;
                             }
                             Err(e) => {
                                 set_toast(&mut state, &mut toast_deadline, format!("replay failed: {e}"), ToastKind::Error);
@@ -262,11 +296,21 @@ pub async fn run_for_endpoint(
                         tracing::warn!(target: "cockpit.tui.ws", "ws disconnect: {e}");
                         set_toast(&mut state, &mut toast_deadline, format!("ws disconnected: {e}; reconnecting…"), ToastKind::Error);
                         state.ws = None;
+                        // Can't observe turn boundaries while the socket
+                        // is down; drop the lock so a stuck send doesn't
+                        // wedge the composer, and queue any new prompts
+                        // (is_busy() is true while ws is None).
+                        state.in_flight = false;
                         let since = state.transcript.last_seq;
                         match reconnect_with_backoff(&state.endpoint, &state.session_id, since).await {
                             Ok(handle) => {
                                 state.ws = Some(handle);
                                 set_toast(&mut state, &mut toast_deadline, "ws reconnected".into(), ToastKind::Info);
+                                // Resumed frames will re-derive turn state
+                                // and drain on the next edge, but if the
+                                // turn already ended before reconnect there
+                                // is no edge to wait for: drain now.
+                                maybe_drain(&mut state, &mut toast_deadline).await;
                             }
                             Err(e) => {
                                 set_toast(&mut state, &mut toast_deadline, format!("ws reconnect failed: {e}"), ToastKind::Error);
@@ -335,32 +379,54 @@ async fn handle_terminal_event(
         Intent::SubmitPrompt => {
             let text = state.take_composer_text();
             if text.is_empty() {
+                // Empty Enter is a manual flush: if the agent is idle and
+                // prompts are stuck in the queue (e.g. a drain POST failed
+                // earlier), retry the drain. Otherwise just nudge the user.
+                if !state.is_busy() && !state.queue.is_empty() {
+                    maybe_drain(state, toast_deadline).await;
+                } else {
+                    set_toast(
+                        state,
+                        toast_deadline,
+                        "composer is empty".into(),
+                        ToastKind::Info,
+                    );
+                }
+                return Ok(false);
+            }
+            if state.is_busy() {
+                // A turn is running (or the socket is down): park the
+                // prompt so it drains when the agent next goes idle.
+                state.queue.push(text);
                 set_toast(
                     state,
                     toast_deadline,
-                    "composer is empty".into(),
+                    format!("queued ({} waiting)", state.queue.len()),
                     ToastKind::Info,
                 );
                 return Ok(false);
             }
-            match state.http.prompt(&state.session_id, &text).await {
-                Ok(()) => {
-                    set_toast(
-                        state,
-                        toast_deadline,
-                        format!("prompt sent ({} bytes)", text.len()),
-                        ToastKind::Info,
-                    );
-                }
-                Err(e) => {
-                    set_toast(
-                        state,
-                        toast_deadline,
-                        format!("send failed: {e}"),
-                        ToastKind::Error,
-                    );
-                }
+            if send_prompt_now(state, toast_deadline, &text).await {
+                set_toast(
+                    state,
+                    toast_deadline,
+                    format!("prompt sent ({} bytes)", text.len()),
+                    ToastKind::Info,
+                );
             }
+            Ok(false)
+        }
+        Intent::ClearQueue => {
+            if state.queue.is_empty() {
+                return Ok(false);
+            }
+            state.queue.clear();
+            set_toast(
+                state,
+                toast_deadline,
+                "queue cleared".into(),
+                ToastKind::Info,
+            );
             Ok(false)
         }
         Intent::Scroll(delta) => {
@@ -501,6 +567,55 @@ fn set_toast(
 ) {
     state.toast = Some(ToastBanner { text, kind });
     *deadline = Some(Instant::now() + TOAST_TTL);
+}
+
+/// POST one prompt to the daemon, taking the optimistic in-flight lock
+/// for the round-trip. The lock stays set on success (the WS turn-start
+/// echo clears it) so a rapid second Enter queues instead of double-
+/// firing; it is released on failure since no turn began. Returns whether
+/// the POST succeeded.
+async fn send_prompt_now(
+    state: &mut CockpitViewState,
+    toast_deadline: &mut Option<Instant>,
+    text: &str,
+) -> bool {
+    state.in_flight = true;
+    match state.http.prompt(&state.session_id, text).await {
+        Ok(()) => true,
+        Err(e) => {
+            state.in_flight = false;
+            set_toast(
+                state,
+                toast_deadline,
+                format!("send failed: {e}"),
+                ToastKind::Error,
+            );
+            false
+        }
+    }
+}
+
+/// Drain the next queued batch if the agent is idle. The batch is removed
+/// from the queue only after its POST succeeds, so a failed send leaves
+/// the prompts in place to retry (via the next turn-end edge or an empty-
+/// composer flush) instead of silently dropping them.
+async fn maybe_drain(state: &mut CockpitViewState, toast_deadline: &mut Option<Instant>) {
+    if state.is_busy() || state.queue.is_empty() {
+        return;
+    }
+    let Some((text, count)) = state.queue.next_batch(state.drain_mode) else {
+        return;
+    };
+    if send_prompt_now(state, toast_deadline, &text).await {
+        state.queue.drop_front(count);
+        let remaining = state.queue.len();
+        let msg = if remaining == 0 {
+            "queue drained".to_string()
+        } else {
+            format!("draining queue ({remaining} waiting)")
+        };
+        set_toast(state, toast_deadline, msg, ToastKind::Info);
+    }
 }
 
 fn redraw(

--- a/src/tui/cockpit_view/mod.rs
+++ b/src/tui/cockpit_view/mod.rs
@@ -9,6 +9,7 @@
 //! https://github.com/agent-of-empires/agent-of-empires/issues/1018#issuecomment-4444040929.
 
 pub mod input;
+pub mod queue;
 pub mod reducer;
 pub mod render;
 pub mod state;

--- a/src/tui/cockpit_view/queue.rs
+++ b/src/tui/cockpit_view/queue.rs
@@ -1,0 +1,193 @@
+//! Client-side prompt queue for the TUI cockpit composer.
+//!
+//! Mirrors the web composer's queue (`web/src/hooks/useCockpit.ts`): the
+//! user can keep typing while a turn is in flight, the prompts park here,
+//! and they drain when the agent goes idle. Like the web, this is pure
+//! local state, never persisted and never round-tripped through the
+//! daemon. The view layer owns the busy-detection and the actual POST;
+//! this module is the pure data structure plus the drain-batching policy,
+//! so it can be unit-tested without a terminal or a daemon.
+
+use crate::session::config::QueueDrainMode;
+
+/// FIFO of queued prompt strings awaiting a drain.
+#[derive(Debug, Default)]
+pub struct PromptQueue {
+    items: Vec<String>,
+}
+
+impl PromptQueue {
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &String> {
+        self.items.iter()
+    }
+
+    /// Append a prompt to the back of the queue.
+    pub fn push(&mut self, text: String) {
+        self.items.push(text);
+    }
+
+    /// Drop the whole queue (the user hit the clear-queue hotkey).
+    pub fn clear(&mut self) {
+        self.items.clear();
+    }
+
+    /// Remove the first `n` entries. Called only after the drain POST for
+    /// those entries succeeds, so a failed send leaves the queue intact.
+    pub fn drop_front(&mut self, n: usize) {
+        let n = n.min(self.items.len());
+        self.items.drain(..n);
+    }
+
+    /// Peek the next batch to drain for `mode`, returning the prompt text
+    /// to POST and the number of queued entries it consumes. Does NOT
+    /// mutate the queue: the caller removes the consumed entries via
+    /// [`drop_front`] only once the POST succeeds, so a network failure
+    /// never silently drops prompts. `None` when the queue is empty.
+    ///
+    /// - `Serial`: the head fires alone, one response per entry.
+    /// - `Combined`: the leading run of non-boundary entries is joined
+    ///   with a blank line into one follow-up. A leading clear-command
+    ///   entry (`/clear` / `/new`) fires alone so it is never glued to
+    ///   adjacent prose, which would corrupt slash-command parsing
+    ///   (matches the web's clear-alias sub-batching, #1356).
+    pub fn next_batch(&self, mode: QueueDrainMode) -> Option<(String, usize)> {
+        let head = self.items.first()?;
+        match mode {
+            QueueDrainMode::Serial => Some((head.clone(), 1)),
+            QueueDrainMode::Combined => {
+                if is_clear_boundary(head) {
+                    return Some((head.clone(), 1));
+                }
+                let run: Vec<&String> = self
+                    .items
+                    .iter()
+                    .take_while(|entry| !is_clear_boundary(entry))
+                    .collect();
+                let count = run.len();
+                let text = run
+                    .into_iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join("\n\n");
+                Some((text, count))
+            }
+        }
+    }
+}
+
+/// Whether a queued entry is a context-clearing command that must drain
+/// alone rather than be joined into a combined batch. The TUI cockpit can
+/// attach to any agent, so this is the union of the per-agent clear
+/// aliases (`/clear` for claude, `/new` for codex / opencode); the daemon
+/// `/about` surface does not carry the active agent's alias list, so the
+/// union is the safe v1 boundary. Leading whitespace is tolerated and a
+/// trailing argument (`/clear --hard`) still counts.
+fn is_clear_boundary(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    for alias in ["/clear", "/new"] {
+        if trimmed == alias {
+            return true;
+        }
+        if let Some(rest) = trimmed.strip_prefix(alias) {
+            if rest.starts_with(char::is_whitespace) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn queue(items: &[&str]) -> PromptQueue {
+        let mut q = PromptQueue::default();
+        for it in items {
+            q.push((*it).to_string());
+        }
+        q
+    }
+
+    #[test]
+    fn empty_queue_has_no_batch() {
+        let q = PromptQueue::default();
+        assert!(q.is_empty());
+        assert_eq!(q.next_batch(QueueDrainMode::Serial), None);
+        assert_eq!(q.next_batch(QueueDrainMode::Combined), None);
+    }
+
+    #[test]
+    fn serial_takes_only_the_head() {
+        let q = queue(&["first", "second", "third"]);
+        let (text, count) = q.next_batch(QueueDrainMode::Serial).expect("batch");
+        assert_eq!(text, "first");
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn combined_joins_the_whole_queue_with_blank_lines() {
+        let q = queue(&["alpha", "beta", "gamma"]);
+        let (text, count) = q.next_batch(QueueDrainMode::Combined).expect("batch");
+        assert_eq!(text, "alpha\n\nbeta\n\ngamma");
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn combined_fires_a_leading_clear_alias_alone() {
+        let q = queue(&["/clear", "do the thing", "and this"]);
+        let (text, count) = q.next_batch(QueueDrainMode::Combined).expect("batch");
+        assert_eq!(text, "/clear");
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn combined_batches_up_to_a_clear_boundary() {
+        let q = queue(&["one", "two", "/new", "three"]);
+        let (text, count) = q.next_batch(QueueDrainMode::Combined).expect("batch");
+        assert_eq!(text, "one\n\ntwo");
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn clear_boundary_tolerates_whitespace_and_arguments() {
+        assert!(is_clear_boundary("/clear"));
+        assert!(is_clear_boundary("  /clear  "));
+        assert!(is_clear_boundary("/clear --hard"));
+        assert!(is_clear_boundary("/new fresh"));
+        assert!(!is_clear_boundary("/cleart"));
+        assert!(!is_clear_boundary("clear"));
+        assert!(!is_clear_boundary("tell me about /clear"));
+        assert!(!is_clear_boundary(""));
+    }
+
+    #[test]
+    fn drop_front_removes_consumed_entries_only() {
+        let mut q = queue(&["a", "b", "c"]);
+        q.drop_front(2);
+        let remaining: Vec<&String> = q.iter().collect();
+        assert_eq!(remaining, vec!["c"]);
+    }
+
+    #[test]
+    fn drop_front_saturates_at_len() {
+        let mut q = queue(&["only"]);
+        q.drop_front(5);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn clear_empties_the_queue() {
+        let mut q = queue(&["x", "y"]);
+        q.clear();
+        assert!(q.is_empty());
+    }
+}

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -40,6 +40,13 @@ pub struct CockpitTranscript {
     /// "context lost, re-prime?" banner until the user dismisses it
     /// or sends the next prompt.
     pub context_primer_pending: bool,
+    /// Whether the agent is mid-turn, derived purely from daemon events:
+    /// true on `UserPromptSent` / `ThinkingStarted`, false on `Stopped`
+    /// / `AgentStartupError` / `PromptRejected`. Server truth (mirrors
+    /// the web reducer's `turnActive`), so it lives here and is rebuilt
+    /// by `/replay` after a `reset()`. The composer reads it to decide
+    /// whether Enter sends now or parks the prompt in the local queue.
+    pub turn_active: bool,
     /// Set when the WS layer reports `{"kind":"lagged"}`; the view
     /// layer should clear and rehydrate via HTTP /replay.
     pub lagged: bool,
@@ -121,6 +128,7 @@ impl CockpitTranscript {
             current_mode: None,
             available_commands: Vec::new(),
             context_primer_pending: false,
+            turn_active: false,
             lagged: false,
             last_seq: 0,
             pending_message_idx: None,
@@ -192,6 +200,7 @@ impl CockpitTranscript {
                 self.rows.push(ActivityRow::UserPrompt(row));
                 // Sending a prompt dismisses any context-primer hint.
                 self.context_primer_pending = false;
+                self.turn_active = true;
             }
             Event::UserDiffCommentsPrompt {
                 assembled_markdown, ..
@@ -207,6 +216,7 @@ impl CockpitTranscript {
             Event::ThinkingStarted => {
                 self.flush_pending_chunk();
                 self.status_text = Some("thinking…".to_string());
+                self.turn_active = true;
             }
             Event::ThinkingEnded => {
                 self.flush_pending_chunk();
@@ -329,6 +339,7 @@ impl CockpitTranscript {
                     kind: NoteKind::Info,
                     text: format!("agent stopped: {reason}"),
                 });
+                self.turn_active = false;
             }
             Event::AgentStartupError { message } => {
                 self.flush_pending_chunk();
@@ -337,6 +348,7 @@ impl CockpitTranscript {
                     kind: NoteKind::Error,
                     text: format!("agent startup failed: {message}"),
                 });
+                self.turn_active = false;
             }
             Event::IncompatibleAgent { .. } => {
                 // Structured detail for the web cockpit's StartupErrorScreen.
@@ -399,13 +411,19 @@ impl CockpitTranscript {
                 // Legacy hard-coded mode enum. Fold to the same field.
                 self.current_mode = Some(format!("{mode:?}"));
             }
+            Event::PromptRejected { .. } => {
+                // The daemon refused the prompt (e.g. read-only mode); no
+                // turn started, so clear the busy flag the optimistic
+                // submit path may have set. The richer rejected-prompt
+                // renderer is followup work (see the no-op group below).
+                self.turn_active = false;
+            }
             Event::DiffEmitted { .. }
             | Event::RateLimit { .. }
             | Event::UsageUpdated { .. }
             | Event::RawAgentUpdate { .. }
             | Event::WakeupScheduled { .. }
             | Event::CancelRequested { .. }
-            | Event::PromptRejected { .. }
             | Event::PromptCapabilities { .. }
             | Event::AgentSwitched { .. }
             | Event::ModeSwitchFailed { .. }
@@ -666,6 +684,61 @@ mod tests {
             } => {}
             _ => panic!("expected warning note"),
         }
+    }
+
+    #[test]
+    fn turn_active_tracks_prompt_and_stop_edges() {
+        let mut t = CockpitTranscript::new("s-1");
+        assert!(!t.turn_active, "fresh transcript is idle");
+        t.apply(&frame(1, Event::UserPromptSent { text: "go".into() }));
+        assert!(t.turn_active, "UserPromptSent opens the turn");
+        t.apply(&frame(2, Event::ThinkingStarted));
+        assert!(t.turn_active, "thinking keeps the turn open");
+        t.apply(&frame(
+            3,
+            Event::Stopped {
+                reason: "completed".into(),
+            },
+        ));
+        assert!(!t.turn_active, "Stopped closes the turn");
+    }
+
+    #[test]
+    fn turn_active_clears_on_startup_error_and_rejection() {
+        let mut t = CockpitTranscript::new("s-1");
+        t.apply(&frame(1, Event::UserPromptSent { text: "go".into() }));
+        t.apply(&frame(
+            2,
+            Event::AgentStartupError {
+                message: "boom".into(),
+            },
+        ));
+        assert!(!t.turn_active, "startup error ends any in-flight turn");
+
+        t.apply(&frame(
+            3,
+            Event::UserPromptSent {
+                text: "again".into(),
+            },
+        ));
+        assert!(t.turn_active);
+        t.apply(&frame(
+            4,
+            Event::PromptRejected {
+                text: "again".into(),
+                reason: "read-only".into(),
+            },
+        ));
+        assert!(!t.turn_active, "a rejected prompt never started a turn");
+    }
+
+    #[test]
+    fn reset_returns_to_idle() {
+        let mut t = CockpitTranscript::new("s-1");
+        t.apply(&frame(1, Event::UserPromptSent { text: "go".into() }));
+        assert!(t.turn_active);
+        t.reset();
+        assert!(!t.turn_active, "reset drops derived turn state for replay");
     }
 
     #[test]

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -690,7 +690,13 @@ mod tests {
     fn turn_active_tracks_prompt_and_stop_edges() {
         let mut t = CockpitTranscript::new("s-1");
         assert!(!t.turn_active, "fresh transcript is idle");
-        t.apply(&frame(1, Event::UserPromptSent { text: "go".into() }));
+        t.apply(&frame(
+            1,
+            Event::UserPromptSent {
+                text: "go".into(),
+                attachments: vec![],
+            },
+        ));
         assert!(t.turn_active, "UserPromptSent opens the turn");
         t.apply(&frame(2, Event::ThinkingStarted));
         assert!(t.turn_active, "thinking keeps the turn open");
@@ -706,7 +712,13 @@ mod tests {
     #[test]
     fn turn_active_clears_on_startup_error_and_rejection() {
         let mut t = CockpitTranscript::new("s-1");
-        t.apply(&frame(1, Event::UserPromptSent { text: "go".into() }));
+        t.apply(&frame(
+            1,
+            Event::UserPromptSent {
+                text: "go".into(),
+                attachments: vec![],
+            },
+        ));
         t.apply(&frame(
             2,
             Event::AgentStartupError {
@@ -719,6 +731,7 @@ mod tests {
             3,
             Event::UserPromptSent {
                 text: "again".into(),
+                attachments: vec![],
             },
         ));
         assert!(t.turn_active);
@@ -735,7 +748,13 @@ mod tests {
     #[test]
     fn reset_returns_to_idle() {
         let mut t = CockpitTranscript::new("s-1");
-        t.apply(&frame(1, Event::UserPromptSent { text: "go".into() }));
+        t.apply(&frame(
+            1,
+            Event::UserPromptSent {
+                text: "go".into(),
+                attachments: vec![],
+            },
+        ));
         assert!(t.turn_active);
         t.reset();
         assert!(!t.turn_active, "reset drops derived turn state for replay");

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -212,6 +212,7 @@ impl CockpitTranscript {
                 self.rows
                     .push(ActivityRow::UserPrompt(assembled_markdown.clone()));
                 self.context_primer_pending = false;
+                self.turn_active = true;
             }
             Event::ThinkingStarted => {
                 self.flush_pending_chunk();

--- a/src/tui/cockpit_view/render.rs
+++ b/src/tui/cockpit_view/render.rs
@@ -18,18 +18,72 @@ use crate::cockpit::approvals::ApprovalDecision;
 use crate::tui::styles::Theme;
 
 pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, state: &CockpitViewState) {
+    let queue_height = queued_strip_height(state);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(5),    // transcript
-            Constraint::Length(1), // status line
+            Constraint::Min(5),               // transcript
+            Constraint::Length(1),            // status line
+            Constraint::Length(queue_height), // queued prompts strip (0 when empty)
             Constraint::Length(composer_height(state)),
         ])
         .split(area);
 
     render_transcript(frame, chunks[0], theme, state);
     render_status(frame, chunks[1], theme, state);
-    render_composer(frame, chunks[2], theme, state);
+    if queue_height > 0 {
+        render_queue(frame, chunks[2], theme, state);
+    }
+    render_composer(frame, chunks[3], theme, state);
+}
+
+/// Up to this many queued prompts are previewed in the strip; the rest
+/// collapse into a "(+N more)" line so a large backlog can't squeeze the
+/// transcript off-screen.
+const QUEUE_PREVIEW_ROWS: usize = 3;
+
+/// Height of the queued-prompts strip: zero when the queue is empty,
+/// otherwise the previewed rows plus the block's top and bottom borders.
+fn queued_strip_height(state: &CockpitViewState) -> u16 {
+    if state.queue.is_empty() {
+        return 0;
+    }
+    let shown = state.queue.len().min(QUEUE_PREVIEW_ROWS);
+    let overflow = usize::from(state.queue.len() > QUEUE_PREVIEW_ROWS);
+    (shown + overflow) as u16 + 2
+}
+
+fn render_queue(frame: &mut Frame, area: Rect, theme: &Theme, state: &CockpitViewState) {
+    let title = format!(
+        " Queued ({}) · drains on idle · Ctrl-x clears ",
+        state.queue.len()
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(theme.border));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, prompt) in state.queue.iter().take(QUEUE_PREVIEW_ROWS).enumerate() {
+        let preview = match truncate_chars(prompt, 80) {
+            Some(head) => format!("{}. {head}…", i + 1),
+            None => format!("{}. {prompt}", i + 1),
+        };
+        lines.push(Line::from(Span::styled(
+            preview,
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+    }
+    if state.queue.len() > QUEUE_PREVIEW_ROWS {
+        let extra = state.queue.len() - QUEUE_PREVIEW_ROWS;
+        lines.push(Line::from(Span::styled(
+            format!("(+{extra} more)"),
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+    }
+    frame.render_widget(Paragraph::new(lines), inner);
 }
 
 /// Top + bottom border rows wrapping the composer textarea.
@@ -533,6 +587,42 @@ fn help_hint(focus: Focus) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cockpit::client::discovery::Source;
+    use crate::cockpit::client::{DaemonEndpoint, HttpClient};
+
+    fn test_state() -> CockpitViewState {
+        let endpoint = DaemonEndpoint {
+            base_url: "http://127.0.0.1:8080".into(),
+            token: None,
+            source: Source::Env,
+        };
+        let http = HttpClient::new(endpoint.clone()).unwrap();
+        CockpitViewState::new("s-1".into(), endpoint, http, None)
+    }
+
+    #[test]
+    fn queued_strip_height_is_zero_when_empty() {
+        let state = test_state();
+        assert_eq!(queued_strip_height(&state), 0);
+    }
+
+    #[test]
+    fn queued_strip_height_grows_with_entries_then_caps() {
+        let mut state = test_state();
+        state.queue.push("one".into());
+        assert_eq!(queued_strip_height(&state), 1 + 2);
+        state.queue.push("two".into());
+        state.queue.push("three".into());
+        assert_eq!(queued_strip_height(&state), 3 + 2);
+        // Beyond the preview cap, an extra "+N more" row is added but the
+        // height stays bounded.
+        state.queue.push("four".into());
+        state.queue.push("five".into());
+        assert_eq!(
+            queued_strip_height(&state),
+            QUEUE_PREVIEW_ROWS as u16 + 1 + 2
+        );
+    }
 
     #[test]
     fn visual_line_count_counts_wrapped_rows() {

--- a/src/tui/cockpit_view/render.rs
+++ b/src/tui/cockpit_view/render.rs
@@ -1,5 +1,5 @@
-//! Three-pane render of a cockpit session: transcript / status banner /
-//! composer. Tool-card breakdowns are intentionally minimal in the MVP
+//! Four-pane render of a cockpit session: transcript / status banner /
+//! queued-prompts strip / composer. Tool-card breakdowns are intentionally minimal in the MVP
 //! (one-liner per tool call); rich diff / image / file previews are
 //! deferred to the followup issues called out in the implementation
 //! plan. Press `o` from the transcript pane to open the web cockpit
@@ -8,7 +8,7 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Padding, Paragraph, Wrap};
 use ratatui::Frame;
 
 use super::input::Focus;
@@ -60,6 +60,8 @@ fn render_queue(frame: &mut Frame, area: Rect, theme: &Theme, state: &CockpitVie
     );
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
         .title(title)
         .border_style(Style::default().fg(theme.border));
     let inner = block.inner(area);
@@ -67,9 +69,13 @@ fn render_queue(frame: &mut Frame, area: Rect, theme: &Theme, state: &CockpitVie
 
     let mut lines: Vec<Line> = Vec::new();
     for (i, prompt) in state.queue.iter().take(QUEUE_PREVIEW_ROWS).enumerate() {
-        let preview = match truncate_chars(prompt, 80) {
+        // Queued prompts can hold newlines (Shift+Enter in the composer);
+        // ratatui's Line strips them, so collapse whitespace first to keep
+        // the preview on one tidy line and truncate predictably.
+        let one_line = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
+        let preview = match truncate_chars(&one_line, 80) {
             Some(head) => format!("{}. {head}…", i + 1),
-            None => format!("{}. {prompt}", i + 1),
+            None => format!("{}. {one_line}", i + 1),
         };
         lines.push(Line::from(Span::styled(
             preview,

--- a/src/tui/cockpit_view/state.rs
+++ b/src/tui/cockpit_view/state.rs
@@ -7,8 +7,10 @@
 use ratatui_textarea::TextArea;
 
 use super::input::Focus;
+use super::queue::PromptQueue;
 use super::reducer::CockpitTranscript;
 use crate::cockpit::client::{DaemonEndpoint, HttpClient, WsHandle};
+use crate::session::config::QueueDrainMode;
 
 pub struct CockpitViewState {
     pub session_id: String,
@@ -26,6 +28,20 @@ pub struct CockpitViewState {
     /// Toast banner that appears briefly above the composer, e.g.
     /// "prompt sent" or an HTTP error.
     pub toast: Option<ToastBanner>,
+    /// Prompts the user queued while a turn was in flight, awaiting the
+    /// next idle drain. Pure local state, like the web composer's queue.
+    pub queue: PromptQueue,
+    /// How the queue drains on turn-end, resolved from the daemon's
+    /// `/api/about` at startup (the TUI can attach to a remote daemon, so
+    /// local config is not authoritative). Falls back to the config
+    /// default if that fetch fails.
+    pub drain_mode: QueueDrainMode,
+    /// Optimistic in-flight lock: set the instant a prompt POST is sent
+    /// and cleared when the daemon echoes the turn start / end (or the
+    /// POST fails). Without it, a second Enter pressed in the window
+    /// between the POST returning and the `UserPromptSent` echo would see
+    /// a stale-idle reducer and fire a duplicate concurrent prompt.
+    pub in_flight: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -61,7 +77,19 @@ impl CockpitViewState {
             selected_approval: None,
             ws,
             toast: None,
+            queue: PromptQueue::default(),
+            drain_mode: QueueDrainMode::default(),
+            in_flight: false,
         }
+    }
+
+    /// Whether a fresh Enter should park in the queue rather than send
+    /// now. Busy when the agent is mid-turn, a POST is in flight, or the
+    /// WebSocket is down (no handle): in every case an immediate send
+    /// would either collide with the running turn or fire into a daemon
+    /// whose turn boundaries we can no longer observe.
+    pub fn is_busy(&self) -> bool {
+        self.transcript.turn_active || self.in_flight || self.ws.is_none()
     }
 
     /// Drain the composer's current text and clear it so the user can
@@ -94,5 +122,61 @@ impl CockpitViewState {
             None => self.selected_approval = Some(0),
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cockpit::client::discovery::Source;
+
+    fn test_state(ws: Option<WsHandle>) -> CockpitViewState {
+        let endpoint = DaemonEndpoint {
+            base_url: "http://127.0.0.1:8080".into(),
+            token: None,
+            source: Source::Env,
+        };
+        let http = HttpClient::new(endpoint.clone()).unwrap();
+        CockpitViewState::new("s-1".into(), endpoint, http, ws)
+    }
+
+    #[test]
+    fn fresh_state_has_idle_turn_flags() {
+        let state = test_state(None);
+        assert!(!state.transcript.turn_active);
+        assert!(!state.in_flight);
+    }
+
+    #[test]
+    fn busy_while_turn_active() {
+        let mut state = test_state(None);
+        state.transcript.turn_active = true;
+        assert!(state.is_busy());
+    }
+
+    #[test]
+    fn busy_while_post_in_flight() {
+        let mut state = test_state(None);
+        state.in_flight = true;
+        assert!(state.is_busy());
+    }
+
+    #[test]
+    fn busy_while_socket_down() {
+        // A dropped WebSocket (ws = None) must force queuing, since turn
+        // boundaries can't be observed to drive an immediate send.
+        let state = test_state(None);
+        assert!(state.is_busy());
+    }
+
+    #[test]
+    fn enqueue_grows_the_local_queue() {
+        let mut state = test_state(None);
+        assert!(state.queue.is_empty());
+        state.queue.push("hello".into());
+        state.queue.push("world".into());
+        assert_eq!(state.queue.len(), 2);
+        let items: Vec<&String> = state.queue.iter().collect();
+        assert_eq!(items, vec!["hello", "world"]);
     }
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The TUI cockpit had no queued-prompt UI: pressing Enter mid-turn either did nothing useful or fired a prompt into a running turn. The web composer has had a client-side prompt queue for a while (queue while busy, drain on idle per `cockpit.queue_drain_mode`); this brings the same behavior to the TUI cockpit.

What changed:

- Pressing Enter while the agent is busy (turn active, a POST in flight, or the WebSocket down) now parks the prompt in a local queue rendered as a **Queued (N)** strip above the composer instead of sending it. When the agent goes idle (the `Stopped` edge), the queue drains per the daemon's `cockpit.queue_drain_mode`: `combined` joins the queued entries into one follow-up, `serial` fires the head and the next idle fires the rest. The mode is read from `GET /api/about` rather than local config, because the TUI cockpit can attach to a remote daemon.
- An optimistic in-flight lock closes the POST-then-echo race so hammering Enter never double-fires a concurrent prompt. A drained batch stays in the queue until its POST succeeds, so a failed send is recoverable (next turn-end edge, a reconnect, or an empty-composer flush) rather than silently dropped.
- `Ctrl+X` clears the whole queue. Combined mode slices batches at `/clear` and `/new` boundaries so a clear command never glues to adjacent prose and corrupts slash-command parsing (matching the web's #1356 behavior).

Turn-active state is derived purely from daemon events on the reducer (so it rebuilds correctly after a `/replay`), while the queue and the in-flight lock live on the view state.

Closes #1700

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a cockpit session in the TUI (`aoe cockpit attach <id>`), send a prompt, and while the agent is still working type another and press Enter: it appears in the **Queued (N)** strip above the composer instead of being sent.
- [ ] Queue two or more prompts during a turn; when the agent stops, confirm they drain per the configured `cockpit.queue_drain_mode` (combined: one joined follow-up; serial: one at a time across successive turns).
- [ ] With prompts queued, press `Ctrl+X` and confirm the strip clears.
- [ ] Queue a `/clear` followed by a normal prompt in combined mode and confirm `/clear` fires on its own turn, not glued to the following text.
- [ ] Hammer Enter rapidly right after a send and confirm only one prompt reaches the agent (no duplicate concurrent turn).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the cockpit-view logic is covered by unit tests (`queue.rs` drain batching, reducer `turn_active` edges, `is_busy()` gating, strip-height rendering). A full e2e for the queue would need the harness to drive a mid-turn cockpit view, which requires a daemon plus a fake ACP agent streaming and staying mid-turn; the current `tests/e2e/` harness only drives the home TUI with a fake `claude`. Deferred to a follow-up that adds that fake-agent terminal plumbing.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (pressure-tested with a multi-model design debate), and implementation were drafted by Claude under my direction. I made the design calls (scope, queue semantics, drain-failure handling) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a client-side queued-prompt UI and plumbing to the TUI cockpit so users can park prompts while the agent is busy and have them sent automatically when the agent becomes idle.

What changed (high-level)
- UI/UX: introduces a "Queued (N)" strip above the composer that previews queued prompts; Enter is turn-aware (sends when idle, queues when busy); Shift+Enter still inserts newlines; Ctrl+X clears the queue; Enter on an empty composer can manually drain the queue when idle.
- Behavior: queue drain behavior follows the daemon-configured cockpit.queue_drain_mode (fetched from GET /api/about): "combined" batches queued entries into a follow-up, "serial" sends them one at a time when idle. Queued batches remain until their POST succeeds so failures are recoverable.
- Reliability: adds an optimistic in-flight lock to avoid duplicate concurrent POSTs when Enter is hammered; view state resets the lock on relevant daemon events (turn end, reconnect, lagged).
- State & rendering: queue, drain mode, and in_flight lock live in CockpitViewState; reducer tracks turn_active on the transcript; render now uses a 4-pane layout and draws the queued-strip with collapsed-whitespace previews and truncation.
- Tests & docs: unit tests cover queue logic and turn_active transitions; docs updated with TUI queue semantics and keybind changes.

Technical summary (concise)
- New module: PromptQueue (FIFO) with methods push, clear, iter, len, next_batch(mode) and drop_front; next_batch implements combined vs serial batching and respects /clear and /new boundaries.
- View state: CockpitViewState gains queue: PromptQueue, drain_mode: QueueDrainMode (fetched from HttpClient::queue_drain_mode()), and in_flight: bool; adds is_busy().
- Reducer: CockpitTranscript adds pub turn_active: bool and unit tests for state transitions.
- Input: Intent::ClearQueue added; Ctrl+X routed to clear queue; Enter logic updated to queue/send/drain based on is_busy().
- Networking: HttpClient::queue_drain_mode() reads cockpit_queue_drain_mode from GET /api/about.
- Rendering: queued-strip preview with whitespace collapsing, truncation, overflow (+N more) handling and height calculation.
- Error recovery: drained batches are removed only after successful POST; failed sends leave queue intact for retry on next idle/reconnect/flush.

Benefits
- Prevents user input loss while the agent is busy and improves UX parity with the web cockpit.
- Configurable drain behavior to match remote daemon settings.
- Safer concurrency: avoids accidental duplicate requests and allows recoverable retries on failures.
- Clear visual feedback and straightforward controls (queued preview, Ctrl+X).

Potential areas for follow-up
- Add e2e tests for full enqueue/drain flows and network failure recovery (some e2e tests deferred).
- Consider in-place editing of queued entries in the TUI (currently not supported).
- Review UX of combined batching with slash-commands for edge-case command composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->