### PR TITLE
fix(tui): chunk large live-send pastes so they don't overflow ARG_MAX

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -82,9 +82,11 @@ const BRACKETED_PASTE_END: &[u8] = &[0x1b, b'[', b'2', b'0', b'1', b'~'];
 /// Without the wrapping, agents that submit on Enter (Claude Code,
 /// Codex, OpenCode, ...) post one user message per pasted line, which
 /// is the bug behind #1546. The whole payload (markers, printable
-/// runs, interior CRs, and tabs) goes through as a single `HexBytes`,
-/// so the worker fires one `tmux send-keys -H` subprocess per paste
-/// instead of one per chunk. `\r\n` pairs coalesce to a single CR so
+/// runs, interior CRs, and tabs) goes through as a single `HexBytes`
+/// action, which the worker dispatches as one or more size-bounded
+/// `tmux send-keys -H` forks (a per-byte argv overflows `ARG_MAX` on a
+/// large paste, so it can't always be one fork). `\r\n` pairs coalesce
+/// to a single CR so
 /// Windows-line-ending pastes don't double up; other control bytes
 /// (BEL, ESC, ...) are dropped rather than risk that an embedded
 /// escape closes the bracketed-paste sequence on the agent's side.

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -475,11 +475,11 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
             // `-H` sends each subsequent arg as the hex byte value of an
             // ASCII character. We use this for control bytes (CR, TAB,
             // ESC) and the bracketed-paste markers, none of which can
-            // ride a `-l` payload safely.
-            cmd.args(["send-keys", "-t", &target, "-H"]);
-            for b in bytes {
-                cmd.arg(format!("{:02x}", b));
-            }
+            // ride a `-l` payload safely. One arg per byte means a large
+            // multi-line paste would overflow the OS `execve` argv limit
+            // (macOS ARG_MAX is 256 KiB) and fail with E2BIG, silently
+            // dropping the whole paste, so split it across bounded forks.
+            return dispatch_hex_bytes(&target, bytes);
         }
         TmuxAction::Resize { cols, rows } => {
             cmd.args([
@@ -500,6 +500,50 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
         anyhow::bail!("live-send tmux subprocess exited non-zero for {:?}", action);
     }
     Ok(())
+}
+
+/// Upper bound on the number of bytes encoded into a single
+/// `tmux send-keys -H` fork. Each byte becomes one ~2-char hex argument
+/// plus its argv pointer (~11 bytes of kernel arg space), and macOS caps
+/// `execve` argv+envp at `ARG_MAX` = 256 KiB, so a per-byte encoding of
+/// a large paste overflows around 20 KB and fails wholesale with E2BIG.
+/// 4 KiB per fork keeps every argv under ~45 KiB, comfortably below the
+/// limit on every platform while keeping the fork count low.
+const MAX_HEX_BYTES_PER_SEND: usize = 4096;
+
+/// Dispatch a raw byte payload as one or more `tmux send-keys -H` forks,
+/// each bounded by [`MAX_HEX_BYTES_PER_SEND`]. tmux injects the bytes
+/// into the pane in order, so splitting a bracketed paste across forks is
+/// transparent to the agent: it still reassembles one contiguous paste
+/// from the `\e[200~` ... `\e[201~` byte stream.
+fn dispatch_hex_bytes(target: &str, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::process::{Command, Stdio};
+    for batch in hex_send_batches(bytes) {
+        let mut cmd = Command::new("tmux");
+        cmd.stderr(Stdio::null());
+        cmd.args(["send-keys", "-t", target, "-H"]);
+        cmd.args(&batch);
+        let status = cmd
+            .status()
+            .map_err(|e| anyhow::anyhow!("spawn live-send tmux subprocess: {}", e))?;
+        if !status.success() {
+            anyhow::bail!(
+                "live-send tmux subprocess exited non-zero for {} bytes",
+                bytes.len()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Split a byte payload into the hex-argument batches passed to
+/// successive `tmux send-keys -H` forks. Pure so the chunking bound and
+/// byte-order preservation are unit-testable without a tmux session.
+fn hex_send_batches(bytes: &[u8]) -> Vec<Vec<String>> {
+    bytes
+        .chunks(MAX_HEX_BYTES_PER_SEND)
+        .map(|chunk| chunk.iter().map(|b| format!("{:02x}", b)).collect())
+        .collect()
 }
 
 /// What the translator says to do with one incoming key event.
@@ -1108,5 +1152,47 @@ mod tests {
         // verifies the passthrough.
         assert_literal(translate(k(KeyCode::Char('q'))), "q");
         assert_literal(translate(k(KeyCode::Char('Q'))), "Q");
+    }
+
+    #[test]
+    fn large_hex_paste_splits_into_bounded_send_keys_batches() {
+        // Regression for the silently-dropped large paste: a ~100 KB
+        // bracketed paste, encoded one hex arg per byte, overflows the
+        // `execve` argv limit (macOS ARG_MAX = 256 KiB) and the whole
+        // `tmux send-keys` fails with E2BIG. The fix splits the payload
+        // into bounded batches; verify it splits, each batch stays under
+        // the cap, and the bytes reconstruct in order.
+        let payload: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
+        let batches = hex_send_batches(&payload);
+        assert!(
+            batches.len() > 1,
+            "a large paste must split across multiple forks, got {}",
+            batches.len()
+        );
+        for batch in &batches {
+            assert!(
+                batch.len() <= MAX_HEX_BYTES_PER_SEND,
+                "a single fork's argv must stay under the ARG_MAX bound",
+            );
+        }
+        let roundtrip: Vec<u8> = batches
+            .iter()
+            .flatten()
+            .map(|h| u8::from_str_radix(h, 16).unwrap())
+            .collect();
+        assert_eq!(
+            roundtrip, payload,
+            "chunking must preserve every byte and its order",
+        );
+    }
+
+    #[test]
+    fn small_hex_paste_stays_one_batch() {
+        // A short bracketed paste fits in a single fork: no behavior
+        // change for the common case.
+        let payload = b"\x1b[200~hi\x1b[201~".to_vec();
+        let batches = hex_send_batches(&payload);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].first().map(String::as_str), Some("1b"));
     }
 }


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Pasting more than a few hundred lines into TUI **live mode** silently does nothing: the paste never reaches the agent, and there's no error in the UI.

Root cause: a multi-line paste is coalesced into one `HexBytes` action and dispatched as `tmux send-keys -t <pane> -H aa bb cc ...` with **one argv argument per byte** (`dispatch_via_fork` in `src/tui/home/live_send.rs`, fed by `split_bracketed_paste` in `src/tui/home/input.rs`). A large paste produces tens of thousands of arguments, which overflows the OS `execve` argument-list limit. The spawn fails with `E2BIG`, `dispatch_via_fork` bails, and `dispatch_batch` drops the paste with only a `warn` log. On macOS, where `ARG_MAX` is 256 KB, this trips at roughly 20 KB of pasted text (a few hundred lines); a 2000-line paste fails on every platform.

The "[Pasted N lines]" chip people see for small pastes is the **agent's own** bracketed-paste indicator (Claude Code / Codex), not an AoE widget, which is why it appears for small pastes and vanishes for large ones: the bytes simply never arrive.

Fix: split the byte payload across bounded `send-keys -H` forks (`MAX_HEX_BYTES_PER_SEND = 4096`) so no single argv can overflow the limit. tmux injects the bytes in order, so a bracketed paste split across forks reassembles transparently on the agent side.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (inline doc comments corrected)
- [ ] For UI changes: included screenshot or recording (no visual change)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (TUI live mode only)

**TUI / CLI (e2e test)**
- [x] Added or updated a test: two unit tests in `src/tui/home/live_send.rs` cover the chunking (`large_hex_paste_splits_into_bounded_send_keys_batches`, `small_hex_paste_stays_one_batch`). The chunking is a pure function (`hex_send_batches`) so the regression is deterministic without spawning tmux.

### How I tested

- `cargo fmt --check`, `cargo clippy --lib` (clean), `cargo test --lib` (2480 passed).
- Reproduced the bug: a single `send-keys -H` over ~300K args returns `errno 7` ("Argument list too long").
- End-to-end against tmux 3.6: a 400 KB payload that fails `E2BIG` as a single fork is delivered **intact** (400000/400000 bytes, zero corruption) across 98 chunked forks to a raw-mode reader (how a real agent reads its PTY). A `cat`-based reader only kept 4096 bytes because canonical-mode tty buffering caps a newline-less line; agents run their PTY in raw mode, so that cap does not apply.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude investigated the root cause, wrote the fix and tests, and ran the verification under my direction.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a bug where large multi-line pastes into the TUI live mode were being silently lost without any user-visible error. The root cause was that extremely large text pastes were being sent to the operating system as a single command with too many arguments, causing the OS to reject the operation.

## What Changed
**Two files were modified:**

1. **`src/tui/home/input.rs`** — Updated documentation to clarify how multi-line pastes are processed and handled.

2. **`src/tui/home/live_send.rs`** — Refactored the paste handling logic to split large pastes into smaller chunks before sending them. Added two new unit tests to verify the chunking behavior works correctly.

## What Was Added
- Chunking logic that splits large byte payloads into bounded batches (max 4096 bytes per batch)
- Multiple helper functions to manage sending bytes in smaller, sequential operations
- Two unit tests verifying that large pastes are correctly split into multiple batches and small pastes remain as a single batch
- Inline documentation explaining the chunking behavior

## Benefits
- **Fixes silent data loss**: Large pastes (hundreds of lines or more) are now successfully delivered instead of being dropped
- **Cross-platform compatibility**: Works correctly on all platforms, including macOS where the argument limit is particularly restrictive
- **Transparent to users**: The fix is automatic—users can paste any size content without special handling
- **Data integrity**: Because tmux injects bytes in order, pastes split across multiple operations reassemble correctly on the receiving end

## Technical Details
The fix works by:
- Replacing the single oversized `tmux send-keys -H` invocation with multiple smaller invocations
- Each chunk is limited to `MAX_HEX_BYTES_PER_SEND = 4096` bytes to stay well under OS `ARG_MAX` limits (≈256 KB on macOS, higher on Linux)
- Preserving byte order across multiple fork operations ensures that bracketed pastes reassemble correctly on the agent side
- The chunking implementation is deterministic and thoroughly tested without requiring tmux spawning in unit tests

## Validation
- Local reproduction confirmed the original failure
- End-to-end testing verified 400 KB payloads successfully delivered across 98 chunked operations
- All existing tests pass (2480 passed)
- Code formatted and linted (`cargo fmt --check`, `cargo clippy --lib`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->