### PR TITLE
fix(hooks): replace shell session_id extractor with Rust subcommand

### DIFF
--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -9,6 +9,7 @@ use clap_complete::Shell;
 use super::add::AddArgs;
 #[cfg(feature = "serve")]
 use super::cockpit::CockpitCommands;
+use super::extract_session_id::ExtractSessionIdArgs;
 use super::group::GroupCommands;
 use super::init::InitArgs;
 use super::list::ListArgs;
@@ -164,6 +165,12 @@ pub enum Commands {
     #[cfg(feature = "serve")]
     #[command(name = "__cockpit-runner", hide = true)]
     CockpitRunner(Box<crate::cockpit::runner::CockpitRunnerArgs>),
+
+    /// Internal: extract Claude's `session_id` from a hook stdin payload
+    /// and write it to the sidecar file. Spawned by the host-side
+    /// `SessionStart`/`UserPromptSubmit` hook. Hidden from help.
+    #[command(name = "__extract-session-id", hide = true)]
+    ExtractSessionId(ExtractSessionIdArgs),
 
     /// Uninstall Agent of Empires
     Uninstall(UninstallArgs),

--- a/src/cli/extract_session_id.rs
+++ b/src/cli/extract_session_id.rs
@@ -23,7 +23,11 @@ pub async fn run(_args: ExtractSessionIdArgs) -> Result<()> {
     let Ok(instance_id) = std::env::var("AOE_INSTANCE_ID") else {
         return Ok(());
     };
-    if instance_id.is_empty() {
+    if !is_safe_instance_id(&instance_id) {
+        tracing::debug!(
+            target: "hooks.session_id",
+            "rejecting unsafe AOE_INSTANCE_ID"
+        );
         return Ok(());
     }
     if let Err(e) = run_inner(
@@ -34,6 +38,18 @@ pub async fn run(_args: ExtractSessionIdArgs) -> Result<()> {
         tracing::debug!(target: "hooks.session_id", "extract failed: {e}");
     }
     Ok(())
+}
+
+/// Reject any `AOE_INSTANCE_ID` that is not safe to use as a single
+/// path component. Production IDs are 16 lowercase hex chars (per
+/// `session::instance::generate_id`); the wider `[A-Za-z0-9_-]` allowlist
+/// accommodates dev / test identifiers. Modeled on `validate_session_id`
+/// in `cockpit::worker_registry`, which guards an identical threat model.
+fn is_safe_instance_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 64
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
 }
 
 fn run_inner<R: Read>(stdin: R, base: &str, instance_id: &str) -> Result<()> {
@@ -186,5 +202,33 @@ mod tests {
         let result = run_inner(InfiniteReader, tmp.path().to_str().unwrap(), "infinite");
         assert!(result.is_err(), "should reject after the 1 MiB cap");
         assert!(read_sidecar(tmp.path(), "infinite").is_none());
+    }
+
+    #[test]
+    fn rejects_path_unsafe_instance_id() {
+        assert!(!is_safe_instance_id(""), "empty");
+        assert!(!is_safe_instance_id(".."), "parent ref");
+        assert!(!is_safe_instance_id("."), "current ref");
+        assert!(!is_safe_instance_id("/etc"), "absolute path");
+        assert!(!is_safe_instance_id("foo/bar"), "subdir traversal");
+        assert!(!is_safe_instance_id("foo\\bar"), "backslash");
+        assert!(!is_safe_instance_id("foo\0bar"), "NUL byte");
+        assert!(!is_safe_instance_id("foo bar"), "whitespace");
+        assert!(!is_safe_instance_id(&"x".repeat(65)), "over length cap");
+    }
+
+    #[test]
+    fn accepts_production_and_test_instance_ids() {
+        assert!(is_safe_instance_id("a3f7c2d1e4b89012"), "production hex");
+        assert!(
+            is_safe_instance_id("0123456789abcdef"),
+            "production hex lower"
+        );
+        assert!(is_safe_instance_id("compact"), "test label");
+        assert!(
+            is_safe_instance_id("nested_first"),
+            "test label with underscore"
+        );
+        assert!(is_safe_instance_id("a-b-c"), "test label with hyphen");
     }
 }

--- a/src/cli/extract_session_id.rs
+++ b/src/cli/extract_session_id.rs
@@ -1,0 +1,190 @@
+//! Hidden `aoe __extract-session-id` subcommand.
+//!
+//! Reads a Claude hook payload from stdin, extracts the top-level
+//! `session_id` UUID via `serde_json`, and writes it atomically to
+//! `HOOK_STATUS_BASE/$AOE_INSTANCE_ID/session_id`.
+//!
+//! Always exits 0: the hook runs synchronously on every Claude prompt
+//! and a non-zero exit blocks the agent. Errors surface through
+//! `tracing::debug!` instead. Stdin is capped at 1 MiB to bound memory.
+
+use std::io::Read;
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use clap::Args;
+
+const STDIN_BYTE_CAP: u64 = 1 << 20;
+
+#[derive(Args)]
+pub struct ExtractSessionIdArgs {}
+
+pub async fn run(_args: ExtractSessionIdArgs) -> Result<()> {
+    let Ok(instance_id) = std::env::var("AOE_INSTANCE_ID") else {
+        return Ok(());
+    };
+    if instance_id.is_empty() {
+        return Ok(());
+    }
+    if let Err(e) = run_inner(
+        std::io::stdin().lock(),
+        crate::hooks::HOOK_STATUS_BASE,
+        &instance_id,
+    ) {
+        tracing::debug!(target: "hooks.session_id", "extract failed: {e}");
+    }
+    Ok(())
+}
+
+fn run_inner<R: Read>(stdin: R, base: &str, instance_id: &str) -> Result<()> {
+    let mut buf = String::new();
+    stdin.take(STDIN_BYTE_CAP).read_to_string(&mut buf)?;
+    let value: serde_json::Value = serde_json::from_str(&buf)?;
+    let sid = value
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("payload has no top-level string `session_id`"))?;
+    uuid::Uuid::parse_str(sid)?;
+    let dir = Path::new(base).join(instance_id);
+    // Best-effort: the hook must never block the agent. If the dir cannot
+    // be created, `atomic_write` below fails, the error propagates to
+    // `run`, and `run` swallows it via `tracing::debug!`.
+    let _ = std::fs::create_dir_all(&dir);
+    crate::session::atomic_write(&dir.join("session_id"), sid.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn extract(payload: &str, instance_id: &str, base: &Path) -> Result<()> {
+        run_inner(payload.as_bytes(), base.to_str().unwrap(), instance_id)
+    }
+
+    fn read_sidecar(base: &Path, instance_id: &str) -> Option<String> {
+        std::fs::read_to_string(base.join(instance_id).join("session_id")).ok()
+    }
+
+    #[test]
+    fn top_level_wins_over_nested() {
+        let tmp = TempDir::new().unwrap();
+        let nested = "11111111-2222-3333-4444-555555555555";
+        let top = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payload = format!(r#"{{"context":{{"session_id":"{nested}"}},"session_id":"{top}"}}"#);
+        extract(&payload, "nested_first", tmp.path()).unwrap();
+        assert_eq!(
+            read_sidecar(tmp.path(), "nested_first").as_deref(),
+            Some(top)
+        );
+    }
+
+    #[test]
+    fn extracts_compact_payload() {
+        let tmp = TempDir::new().unwrap();
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payload = format!(r#"{{"session_id":"{uuid}","cwd":"/x"}}"#);
+        extract(&payload, "compact", tmp.path()).unwrap();
+        assert_eq!(read_sidecar(tmp.path(), "compact").as_deref(), Some(uuid));
+    }
+
+    #[test]
+    fn extracts_multi_line_payload() {
+        let tmp = TempDir::new().unwrap();
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payload = format!("{{\n  \"session_id\":\"{uuid}\",\n  \"cwd\":\"/x\"\n}}");
+        extract(&payload, "multi_line", tmp.path()).unwrap();
+        assert_eq!(
+            read_sidecar(tmp.path(), "multi_line").as_deref(),
+            Some(uuid)
+        );
+    }
+
+    #[test]
+    fn accepts_uppercase_uuid() {
+        let tmp = TempDir::new().unwrap();
+        let uuid = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+        let payload = format!(r#"{{"session_id":"{uuid}"}}"#);
+        extract(&payload, "uppercase", tmp.path()).unwrap();
+        assert_eq!(read_sidecar(tmp.path(), "uppercase").as_deref(), Some(uuid));
+    }
+
+    #[test]
+    fn ignores_user_prompt_injection() {
+        let tmp = TempDir::new().unwrap();
+        let real = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let fake = "11111111-2222-3333-4444-555555555555";
+        let payload = format!(r#"{{"session_id":"{real}","prompt":"\"session_id\":\"{fake}\""}}"#);
+        extract(&payload, "prompt_injection", tmp.path()).unwrap();
+        assert_eq!(
+            read_sidecar(tmp.path(), "prompt_injection").as_deref(),
+            Some(real)
+        );
+    }
+
+    #[test]
+    fn errors_when_no_session_id() {
+        let tmp = TempDir::new().unwrap();
+        let payload = r#"{"cwd":"/x","other":"value"}"#;
+        let err = extract(payload, "no_sid", tmp.path()).unwrap_err();
+        assert!(err.to_string().contains("session_id"), "got: {err}");
+        assert!(read_sidecar(tmp.path(), "no_sid").is_none());
+    }
+
+    #[test]
+    fn errors_on_malformed_json() {
+        let tmp = TempDir::new().unwrap();
+        let err = extract("not json {{{", "malformed", tmp.path()).unwrap_err();
+        assert!(
+            read_sidecar(tmp.path(), "malformed").is_none(),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn errors_on_empty_stdin() {
+        let tmp = TempDir::new().unwrap();
+        let err = extract("", "empty", tmp.path()).unwrap_err();
+        assert!(read_sidecar(tmp.path(), "empty").is_none(), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_non_uuid_string() {
+        let tmp = TempDir::new().unwrap();
+        let payload = r#"{"session_id":"not-a-uuid"}"#;
+        let err = extract(payload, "bad_uuid", tmp.path()).unwrap_err();
+        assert!(read_sidecar(tmp.path(), "bad_uuid").is_none(), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_non_string_session_id() {
+        let tmp = TempDir::new().unwrap();
+        let payload = r#"{"session_id":12345}"#;
+        let err = extract(payload, "non_string", tmp.path()).unwrap_err();
+        assert!(err.to_string().contains("session_id"), "got: {err}");
+        assert!(read_sidecar(tmp.path(), "non_string").is_none());
+    }
+
+    #[test]
+    fn oversized_garbage_yields_no_sidecar() {
+        let tmp = TempDir::new().unwrap();
+        let oversized = "x".repeat(STDIN_BYTE_CAP as usize * 2);
+        let _ = extract(&oversized, "oversized", tmp.path());
+        assert!(read_sidecar(tmp.path(), "oversized").is_none());
+    }
+
+    #[test]
+    fn does_not_hang_on_infinite_stdin() {
+        struct InfiniteReader;
+        impl Read for InfiniteReader {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                buf.fill(b'x');
+                Ok(buf.len())
+            }
+        }
+        let tmp = TempDir::new().unwrap();
+        let result = run_inner(InfiniteReader, tmp.path().to_str().unwrap(), "infinite");
+        assert!(result.is_err(), "should reject after the 1 MiB cap");
+        assert!(read_sidecar(tmp.path(), "infinite").is_none());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod agents;
 #[cfg(feature = "serve")]
 pub mod cockpit;
 pub mod definition;
+pub mod extract_session_id;
 pub mod group;
 pub mod init;
 pub mod list;

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -27,6 +27,20 @@ pub(crate) const HOOK_STATUS_BASE: &str = "/tmp/aoe-hooks";
 /// Any hook command containing this string is considered ours.
 const AOE_HOOK_MARKER: &str = "aoe-hooks";
 
+/// Where an agent's settings file lives. Determines which shell command
+/// `hook_command_session_id` emits.
+///
+/// `Host`: emits a call to the `aoe __extract-session-id` Rust subcommand.
+/// `Sandbox`: emits a POSIX shell pipeline because `aoe` is not installed
+/// inside the sandbox image. The pipeline keeps a known schema-ordering
+/// quirk: a textually-earlier nested `session_id` wins over the top-level
+/// one, accepted because Claude does not emit such payloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookInstallTarget {
+    Host,
+    Sandbox,
+}
+
 /// Resolve the host Codex config path.
 ///
 /// Codex treats `CODEX_HOME` as the directory containing `config.toml`, falling
@@ -95,26 +109,33 @@ fn hook_command_with_base(status: &str, base: &str) -> String {
 /// Build the shell command for a hook that extracts `session_id` from the
 /// agent's stdin JSON payload and writes it to a sidecar file.
 ///
-/// **Schema requirement**: the payload's top-level `session_id` must
-/// appear textually before any nested object that uses the same key. If
-/// the inner copy is emitted first, `head -1` captures the wrong UUID.
+/// Both variants must exit 0 even on failure: a non-zero hook blocks the
+/// agent's tool calls. The trailing `# AOE_HOOK_MARKER` on the host
+/// variant is load-bearing: `is_aoe_hook_command` recognises AoE hooks by
+/// substring; the sandbox variant gets the marker via its baked-in
+/// `HOOK_STATUS_BASE` path.
 ///
-/// The pipeline:
-///   1. `tr -d '\n'` collapses pretty-printed multi-line JSON onto a
-///      single line so the line-oriented `grep` can match `"session_id"
-///      :"<UUID>"` even when key/value are split across lines.
-///   2. `grep -oE` matches `[{,] "session_id":"<UUID>"`. The leading
-///      `[{,]` anchors the field to a JSON-structural boundary so a user
-///      prompt containing the literal substring `"session_id":"<uuid>"`
-///      cannot be captured (a JSON serializer escapes inner quotes as
-///      `\"`, breaking the structural prefix). `[0-9a-fA-F]` accepts
-///      either case for parity with `Uuid::parse_str`.
-///   3. `head -1` keeps the first match.
-///   4. The second `grep -oE` strips the framing, leaving the bare UUID.
-///   5. `printf > $D/.session_id.$$.tmp && mv ... $D/session_id`:
-///      PID-suffixed tempfile + atomic POSIX `rename(2)` makes concurrent
-///      hook invocations race-free.
-fn hook_command_session_id(base: &str) -> String {
+/// Host-variant silent-failure modes (acceptable, equivalent to a regex
+/// miss in the sandbox variant): `aoe` not on PATH at hook-exec time, or
+/// a stale `aoe` on PATH that predates `__extract-session-id`. Both yield
+/// no sidecar without surfacing an error; session resume falls back to
+/// the filesystem scan.
+fn hook_command_session_id(target: HookInstallTarget) -> String {
+    match target {
+        HookInstallTarget::Host => hook_command_session_id_host(),
+        HookInstallTarget::Sandbox => hook_command_session_id_sandbox(HOOK_STATUS_BASE),
+    }
+}
+
+fn hook_command_session_id_host() -> String {
+    format!(
+        "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; \
+         command -v aoe >/dev/null 2>&1 || exit 0; \
+         aoe __extract-session-id 2>/dev/null; exit 0 # {AOE_HOOK_MARKER}'"
+    )
+}
+
+fn hook_command_session_id_sandbox(base: &str) -> String {
     format!(
         "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; \
          D={base}/$AOE_INSTANCE_ID; mkdir -p \"$D\" 2>/dev/null; \
@@ -139,12 +160,12 @@ fn is_aoe_hook_command(cmd: &str) -> bool {
 ///
 /// An event with both produces two `hooks` array entries under the same
 /// matcher block. An event with neither is skipped.
-fn build_aoe_hooks(events: &[crate::agents::HookEvent]) -> Value {
+fn build_aoe_hooks(events: &[crate::agents::HookEvent], target: HookInstallTarget) -> Value {
     let mut hooks_obj = serde_json::Map::new();
     for event in events {
         let mut commands: Vec<String> = Vec::new();
         if event.session_id_capture {
-            commands.push(hook_command_session_id(HOOK_STATUS_BASE));
+            commands.push(hook_command_session_id(target));
         }
         if let Some(status) = event.status {
             commands.push(hook_command(status));
@@ -197,7 +218,11 @@ fn remove_aoe_entries(matchers: &mut Vec<Value>) {
 /// any user-defined hooks. Existing AoE hooks are replaced (idempotent).
 ///
 /// If the file doesn't exist, it will be created with just the hooks.
-pub fn install_hooks(settings_path: &Path, events: &[crate::agents::HookEvent]) -> Result<()> {
+pub fn install_hooks(
+    settings_path: &Path,
+    events: &[crate::agents::HookEvent],
+    target: HookInstallTarget,
+) -> Result<()> {
     let mut settings: Value = if settings_path.exists() {
         let content = std::fs::read_to_string(settings_path)?;
         serde_json::from_str(&content).unwrap_or_else(|e| {
@@ -208,7 +233,7 @@ pub fn install_hooks(settings_path: &Path, events: &[crate::agents::HookEvent]) 
         serde_json::json!({})
     };
 
-    let aoe_hooks = build_aoe_hooks(events);
+    let aoe_hooks = build_aoe_hooks(events, target);
 
     if !settings.get("hooks").is_some_and(|h| h.is_object()) {
         settings
@@ -1345,7 +1370,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let settings_path = tmp.path().join(".claude").join("settings.json");
 
-        install_hooks(&settings_path, claude_events()).unwrap();
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
 
         let content: Value =
             serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
@@ -1379,7 +1404,7 @@ mod tests {
         )
         .unwrap();
 
-        install_hooks(&settings_path, claude_events()).unwrap();
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
 
         let content: Value =
             serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
@@ -1403,8 +1428,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let settings_path = tmp.path().join("settings.json");
 
-        install_hooks(&settings_path, claude_events()).unwrap();
-        install_hooks(&settings_path, claude_events()).unwrap();
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
 
         let content: Value =
             serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
@@ -1430,7 +1455,7 @@ mod tests {
         )
         .unwrap();
 
-        install_hooks(&settings_path, claude_events()).unwrap();
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
 
         let content: Value =
             serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
@@ -1921,7 +1946,7 @@ command = "echo user-hook"
 
     #[test]
     fn test_notification_hook_has_matcher() {
-        let hooks = build_aoe_hooks(claude_events());
+        let hooks = build_aoe_hooks(claude_events(), HookInstallTarget::Sandbox);
         let notification = hooks["Notification"].as_array().unwrap();
         assert_eq!(notification.len(), 1);
         let matcher = notification[0]["matcher"].as_str().unwrap();
@@ -1932,7 +1957,7 @@ command = "echo user-hook"
 
     #[test]
     fn test_stop_hook_writes_idle() {
-        let hooks = build_aoe_hooks(claude_events());
+        let hooks = build_aoe_hooks(claude_events(), HookInstallTarget::Sandbox);
         let stop = hooks["Stop"].as_array().unwrap();
         let cmd = stop[0]["hooks"][0]["command"].as_str().unwrap();
         assert!(
@@ -1944,7 +1969,7 @@ command = "echo user-hook"
 
     #[test]
     fn test_elicitation_result_hook_writes_running() {
-        let hooks = build_aoe_hooks(claude_events());
+        let hooks = build_aoe_hooks(claude_events(), HookInstallTarget::Sandbox);
         let er = hooks["ElicitationResult"].as_array().unwrap();
         assert_eq!(er.len(), 1);
         let cmd = er[0]["hooks"][0]["command"].as_str().unwrap();
@@ -1957,7 +1982,7 @@ command = "echo user-hook"
 
     #[test]
     fn test_hooks_are_synchronous() {
-        let hooks = build_aoe_hooks(claude_events());
+        let hooks = build_aoe_hooks(claude_events(), HookInstallTarget::Sandbox);
         for (_, matchers) in hooks.as_object().unwrap() {
             for matcher in matchers.as_array().unwrap() {
                 for hook in matcher["hooks"].as_array().unwrap() {
@@ -1976,7 +2001,7 @@ command = "echo user-hook"
         let tmp = TempDir::new().unwrap();
         let settings_path = tmp.path().join("settings.json");
 
-        install_hooks(&settings_path, claude_events()).unwrap();
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
 
         let content: Value =
             serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
@@ -2016,7 +2041,7 @@ command = "echo user-hook"
         )
         .unwrap();
 
-        install_hooks(&settings_path, claude_events()).unwrap();
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
         let modified = uninstall_hooks(&settings_path).unwrap();
         assert!(modified);
 
@@ -2099,7 +2124,7 @@ command = "echo user-hook"
         )
         .unwrap();
 
-        install_hooks(&settings_path, claude_events()).unwrap();
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
 
         let content: Value =
             serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
@@ -2566,7 +2591,7 @@ hooks_auto_accept: false
     }
 
     fn run_session_id_hook(payload: &str, instance_id: &str, base: &Path) -> std::process::Output {
-        let cmd = hook_command_session_id(base.to_str().unwrap());
+        let cmd = hook_command_session_id_sandbox(base.to_str().unwrap());
         let mut child = std::process::Command::new("sh")
             .args(["-c", &cmd])
             .env("AOE_INSTANCE_ID", instance_id)
@@ -2613,27 +2638,24 @@ hooks_auto_accept: false
     }
 
     #[test]
-    fn test_hook_command_session_id_locks_top_level_first_contract() {
-        // The grep regex `[{,]"session_id":"<UUID>"` cannot distinguish a
-        // nested object literal from the top-level field: a nested copy
-        // emitted textually before the top-level one is captured by
-        // `head -1`. This test pins the resulting behavior so any drift in
-        // the upstream payload schema (or in the extractor) shows up as a
-        // test failure rather than as silent wrong-UUID capture.
+    fn test_hook_command_session_id_sandbox_pins_nested_first_quirk() {
         let tmp = TempDir::new().unwrap();
         let nested = "11111111-2222-3333-4444-555555555555";
         let top_level = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
         let payload =
             format!(r#"{{"context":{{"session_id":"{nested}"}},"session_id":"{top_level}"}}"#);
-        let output = run_session_id_hook(&payload, "nested_first", tmp.path());
+        let output = run_session_id_hook(&payload, "sandbox_nested_first", tmp.path());
         assert!(output.status.success());
-        let written = std::fs::read_to_string(tmp.path().join("nested_first").join("session_id"))
-            .expect("sidecar file");
+        let written =
+            std::fs::read_to_string(tmp.path().join("sandbox_nested_first").join("session_id"))
+                .expect("sidecar file");
         assert_eq!(
             written, nested,
-            "current extractor returns the nested UUID; replace with a JSON-aware \
-             parser if Claude ever emits a payload where a nested `session_id` \
-             precedes the top-level field"
+            "the sandbox shell pipeline's `[{{,]` regex anchor cannot \
+             distinguish a nested object literal from the top-level field; \
+             a textually-earlier nested `session_id` wins. The host variant \
+             fixes this via `serde_json`. Documented limitation; pinned so \
+             a regex tweak does not silently change ordering semantics."
         );
     }
 
@@ -2672,19 +2694,47 @@ hooks_auto_accept: false
     }
 
     #[test]
-    fn test_hook_command_session_id_uses_pid_suffixed_tempfile() {
-        let cmd = hook_command_session_id("/tmp/aoe-hooks");
+    fn test_hook_command_session_id_host_invokes_aoe_subcommand() {
+        let cmd = hook_command_session_id(HookInstallTarget::Host);
         assert!(
-            cmd.contains(".session_id.$$.tmp"),
-            "expected PID-suffixed tempfile in command, got: {cmd}"
+            cmd.contains("aoe __extract-session-id"),
+            "host hook should invoke the Rust subcommand, got: {cmd}"
         );
-        assert!(cmd.contains("mv"));
+        assert!(
+            cmd.contains("command -v aoe"),
+            "host hook should guard on `aoe` being on PATH, got: {cmd}"
+        );
+        assert!(
+            cmd.contains(AOE_HOOK_MARKER),
+            "host hook must carry the AoE marker so uninstall can find it, got: {cmd}"
+        );
+        assert!(
+            !cmd.contains("grep -oE"),
+            "host hook must not use the legacy GNU/BSD grep pipeline, got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn test_hook_command_session_id_sandbox_keeps_shell_pipeline() {
+        let cmd = hook_command_session_id(HookInstallTarget::Sandbox);
+        assert!(
+            cmd.contains("grep -oE"),
+            "sandbox hook must keep the POSIX pipeline since `aoe` is not in the image, got: {cmd}"
+        );
+        assert!(
+            !cmd.contains("aoe __extract-session-id"),
+            "sandbox hook must not invoke the Rust subcommand, got: {cmd}"
+        );
+        assert!(
+            cmd.contains(AOE_HOOK_MARKER),
+            "sandbox hook must carry the AoE marker, got: {cmd}"
+        );
     }
 
     #[test]
     fn test_build_aoe_hooks_emits_session_id_capture_for_session_start() {
         let events = claude_events();
-        let hooks = build_aoe_hooks(events);
+        let hooks = build_aoe_hooks(events, HookInstallTarget::Sandbox);
         let session_start = hooks
             .get("SessionStart")
             .expect("SessionStart matcher block")
@@ -2701,7 +2751,7 @@ hooks_auto_accept: false
     #[test]
     fn test_build_aoe_hooks_emits_both_for_user_prompt_submit() {
         let events = claude_events();
-        let hooks = build_aoe_hooks(events);
+        let hooks = build_aoe_hooks(events, HookInstallTarget::Sandbox);
         let user_prompt = hooks
             .get("UserPromptSubmit")
             .expect("UserPromptSubmit matcher block")
@@ -2724,7 +2774,7 @@ hooks_auto_accept: false
     #[test]
     fn test_build_aoe_hooks_status_only_events_unchanged() {
         let events = claude_events();
-        let hooks = build_aoe_hooks(events);
+        let hooks = build_aoe_hooks(events, HookInstallTarget::Sandbox);
         for event_name in &["PreToolUse", "Stop", "Notification", "ElicitationResult"] {
             let block = hooks
                 .get(*event_name)

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,6 +199,7 @@ async fn main() -> Result<()> {
             return Ok(());
         }
         Some(Commands::Init(args)) => return cli::init::run(args).await,
+        Some(Commands::ExtractSessionId(args)) => return cli::extract_session_id::run(args).await,
         Some(Commands::Tmux { command }) => {
             use cli::tmux::TmuxCommands;
             return match command {

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -1219,7 +1219,11 @@ pub(crate) fn build_container_config(
                         let result = if agent.name == "codex" {
                             crate::hooks::install_codex_hooks(&settings_file, hook_cfg.events)
                         } else {
-                            crate::hooks::install_hooks(&settings_file, hook_cfg.events)
+                            crate::hooks::install_hooks(
+                                &settings_file,
+                                hook_cfg.events,
+                                crate::hooks::HookInstallTarget::Sandbox,
+                            )
                         };
                         if let Err(e) = result {
                             tracing::warn!(target: "session.profile", "Failed to install hooks in sandbox config: {}", e);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1637,7 +1637,11 @@ impl Instance {
                 // Install hooks in the user's home directory settings
                 if let Some(home) = dirs::home_dir() {
                     let settings_path = home.join(hook_cfg.settings_rel_path);
-                    if let Err(e) = crate::hooks::install_hooks(&settings_path, hook_cfg.events) {
+                    if let Err(e) = crate::hooks::install_hooks(
+                        &settings_path,
+                        hook_cfg.events,
+                        crate::hooks::HookInstallTarget::Host,
+                    ) {
                         tracing::warn!(target: "session.store", "Failed to install agent hooks: {}", e);
                     }
                 }


### PR DESCRIPTION
## Description

The `SessionStart` / `UserPromptSubmit` host hook captures Claude's `session_id` via a `tr | grep -oE | head -1` shell pipeline. The `[{,]` anchor cannot distinguish a top-level opening brace from a nested-object one: a payload like `{"context":{"session_id":"NESTED"},"session_id":"TOP"}` captures `NESTED`. The pipeline also relies on GNU/BSD `grep -oE` extensions.

This PR replaces the host pipeline with a hidden `aoe __extract-session-id` subcommand that reads stdin JSON via `serde_json` and writes the top-level `session_id` atomically. A new `HookInstallTarget { Host, Sandbox }` enum routes `install_hooks` between the Rust path (host) and the legacy shell pipeline (sandbox). The sandbox path is preserved because `aoe` is not installed in the sandbox image.

The hook command is `sh -c '... aoe __extract-session-id 2>/dev/null; exit 0 # aoe-hooks'`. The trailing comment carries the `aoe-hooks` marker that `is_aoe_hook_command` uses for uninstall detection.

Closes #1737

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (2546/2546 lib tests; 12 new unit tests on `run_inner`, plus 3 structural tests pinning the Host vs Sandbox shell strings and the documented sandbox quirk)
- [x] Documentation was updated where necessary (`docs/cli/reference.md` regenerated; the new `__extract-session-id` is correctly excluded by `hide = true`)
- [x] For UI changes: included screenshot or recording (N/A, no UI changes)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: `__extract-session-id` is a hidden internal subcommand spawned only by Claude hooks, not a user-facing CLI surface. Its full behavior is exercised by unit tests on `run_inner` (top-level wins over nested, multi-line, uppercase UUID, missing field, prompt injection, malformed JSON, empty stdin, oversized stdin, infinite reader, non-string `session_id`, non-UUID string). The Host vs Sandbox install-time string contracts are pinned by structural assertions in `src/hooks/mod.rs`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Opus 4.7 (Sisyphus agent via OhMyOpenCode)

**Any Additional AI Details you'd like to share:**
Design and implementation went through three rounds of cross-validated agent review (multiple specialized sub-agents per round) before any code was written, plus two rounds of post-implementation review and a final harmony / project-rules audit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR replaces the fragile, regex-based shell pipeline used to extract session IDs for host-installed hooks with a hidden Rust subcommand while preserving the legacy shell pipeline for sandbox installs.

What changed (high-level)
- Added a hidden CLI subcommand aoe __extract-session-id that reads JSON from stdin, extracts the top-level session_id, validates it as a UUID, and atomically writes it to the agent hook status file.
- Introduced HookInstallTarget { Host, Sandbox } and updated hook-install flows so Host installs invoke the Rust subcommand and Sandbox installs retain the legacy shell pipeline.
- Hook install commands now include a trailing comment marker ("# aoe-hooks") used for uninstall detection.
- Wired the new subcommand into CLI dispatch and updated callers to pass explicit install targets (Host vs Sandbox).
- Tests and docs updated: many new unit tests for the extractor (valid/invalid JSON, size cap, UUID and instance-id validation), structural tests asserting Host vs Sandbox command forms, and regenerated CLI reference; the subcommand is hidden from public docs.
- Closes issue `#1737`. AI-assisted drafting was used in the PR process.

Notable technical details
- The extractor:
  - Caps stdin at 1 MiB and parses JSON with serde_json.
  - Extracts only the top-level "session_id" (avoids capturing nested session_id values).
  - Validates the session_id as a UUID and atomically writes it to HOOK_STATUS_BASE/$AOE_INSTANCE_ID/session_id.
  - Silently no-ops if AOE_INSTANCE_ID is missing/invalid; runtime errors in the helper are logged at debug and do not cause a non-zero exit.
- Host hook command example:
  sh -c 'command -v aoe >/dev/null && aoe __extract-session-id 2>/dev/null; exit 0 # aoe-hooks'
- Sandbox hooks continue using the legacy tr | grep -oE | head -1 pipeline because aoe is not present in the sandbox image.
- API changes: added HookInstallTarget enum and extended install_hooks signature; added cli::extract_session_id module and hidden CLI variant.
- Tests: 12 new unit tests focused on run_inner plus 3 structural tests for Host vs Sandbox command strings; existing test suite remains green.

Benefits
- Eliminates schema-ordering bug that could capture nested session_id values.
- Removes dependence on non-POSIX grep extensions, improving portability.
- Provides atomic, schema-aware, and well-tested extraction logic.
- Preserves sandbox behavior to avoid breaking existing sandbox images.

Potential follow-ups
- Ship aoe into sandbox images to unify extraction behavior across environments.
- Audit other hook shell pipelines for similar fragility and consider migrating parsing to Rust helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->