### PR TITLE
fix(cockpit): surface OpenCode's real modes in the mode picker (#1764)

### DIFF
--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -77,7 +77,7 @@ different MCP naming scheme, file an issue or PR adjusting the profile's
   claude-family agents only, claude's built-in Default / Plan / Accept
   edits / Yolo taxonomy. A non-claude agent that advertises no modes
   shows no picker rather than a vocabulary it would reject. OpenCode has
-  no "default" mode: it operates on agents such as `build` and `plan`,
+  no "default" mode: it operates in modes such as `build` and `plan`,
   so the picker surfaces those real names and switches through the
   config-option channel.
 

--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -71,6 +71,15 @@ different MCP naming scheme, file an issue or PR adjusting the profile's
   adapter advertises the matching channels (`available_modes`,
   `available_commands_update`, `usage_update`). When the adapter doesn't
   emit them, the UI simply stays empty rather than showing stale state.
+- **Mode picker sources, in order**: a `category:"mode"` config option
+  (OpenCode, and claude-agent-acp v0.37.0+), then the ACP
+  SessionModeState `available_modes` channel (older claude), then, for
+  claude-family agents only, claude's built-in Default / Plan / Accept
+  edits / Yolo taxonomy. A non-claude agent that advertises no modes
+  shows no picker rather than a vocabulary it would reject. OpenCode has
+  no "default" mode: it operates on agents such as `build` and `plan`,
+  so the picker surfaces those real names and switches through the
+  config-option channel.
 
 ## How the Profile Works
 

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -46,6 +46,7 @@ import { getDraft, setDraft } from "../../lib/cockpitDrafts";
 import { TOUR_ANCHORS, tourAnchor } from "../../lib/tourSteps";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { useAgentProfile } from "../../lib/agentProfileContext";
+import { resolveModeChannel } from "../../lib/modeChannel";
 import { useFocusTerminalTarget } from "../../hooks/useFocusTerminalTarget";
 import { useDictationBurstGuard } from "./useDictationBurstGuard";
 
@@ -900,6 +901,9 @@ export function Composer({
                   availableModes={availableModes}
                   currentModeId={currentModeId}
                   legacyMode={legacyMode}
+                  configOptions={configOptions}
+                  pendingConfigOption={pendingConfigOption}
+                  setConfigOption={setConfigOption}
                 />
                 <SessionConfigControls
                   configOptions={configOptions}
@@ -1136,23 +1140,30 @@ function ToolbarButton({
 
 /* ── Mode picker ─────────────────────────────────────────────────── */
 
-const LEGACY_MODES: ReadonlyArray<{
-  id: string;
-  legacyId: CockpitState["mode"];
-  name: string;
-  description: string;
-}> = [
-  { id: "default", legacyId: "Default", name: "Default", description: "Approve each tool individually" },
-  { id: "plan", legacyId: "Plan", name: "Plan", description: "Plan first, no edits applied" },
-  { id: "accept_edits", legacyId: "AcceptEdits", name: "Accept edits", description: "Auto-approve safe file edits" },
-  { id: "bypass_permissions", legacyId: "BypassPermissions", name: "Yolo", description: "Skip all approvals (destructive)" },
-];
-
 interface ModePickerProps {
   sessionId: string;
   availableModes: CockpitState["availableModes"];
   currentModeId: string | null;
   legacyMode: CockpitState["mode"];
+  configOptions: CockpitState["configOptions"];
+  pendingConfigOption: CockpitState["pendingConfigOption"];
+  setConfigOption: (configId: string, value: string) => void | Promise<void>;
+}
+
+/** POST the legacy `session/set_mode` path. Used by the SessionModeState
+ *  and claude-fallback channels; the config-option channel switches via
+ *  `setConfigOption` instead. */
+async function postLegacyMode(sessionId: string, id: string): Promise<void> {
+  try {
+    await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/cockpit/mode`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode_id: id }),
+    });
+  } catch {
+    // The agent broadcasts CurrentModeChanged on success; if the request
+    // fails the UI stays on the current mode.
+  }
 }
 
 function ModePicker({
@@ -1160,37 +1171,28 @@ function ModePicker({
   availableModes,
   currentModeId,
   legacyMode,
+  configOptions,
+  pendingConfigOption,
+  setConfigOption,
 }: ModePickerProps) {
+  const profile = useAgentProfile();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
 
-  // Use real agent-advertised modes when available, otherwise fall
-  // back to the four-mode taxonomy. Even with agent modes, we still
-  // tint by id pattern (default/plan/accept/bypass) because Claude's
-  // adapter happens to use those tokens.
-  const usingAgentModes = availableModes.length > 0;
-  const modes = usingAgentModes
-    ? availableModes.map((m) => ({
-        id: m.id,
-        name: m.name,
-        description: m.description ?? "",
-      }))
-    : LEGACY_MODES.map((m) => ({
-        id: m.id,
-        name: m.name,
-        description: m.description,
-      }));
+  // Resolve which channel drives the picker (config option vs ACP
+  // SessionModeState vs claude fallback) and pair each with its own
+  // write path so the two never drift. See lib/modeChannel.ts.
+  const channel = resolveModeChannel({
+    configOptions,
+    availableModes,
+    currentModeId,
+    legacyMode,
+    pendingConfigOption,
+    allowLegacyFallback: profile.capabilities.legacyModeFallback,
+  });
 
-  // Pick "current": agent-reported id wins; else map legacyMode → id.
-  const fallbackId =
-    LEGACY_MODES.find((m) => m.legacyId === legacyMode)?.id ?? "default";
-  const activeId = currentModeId ?? fallbackId;
-  const current = modes.find((m) => m.id === activeId) ?? modes[0]!;
-
-  // Tint the chip by id pattern so destructive modes are visually loud.
-  const tone = toneForId(activeId);
-
-  // Close on outside click / Esc.
+  // Close on outside click / Esc. Declared before the early return so
+  // hook order stays stable across renders where `channel` is null.
   useEffect(() => {
     if (!open) return;
     const onClick = (e: MouseEvent) => {
@@ -1207,21 +1209,23 @@ function ModePicker({
     };
   }, [open]);
 
-  const select = async (id: string) => {
+  // Nothing advertised on an agent without a claude-style taxonomy:
+  // render no picker rather than a phantom vocabulary it would reject.
+  if (!channel) return null;
+
+  const current =
+    channel.modes.find((m) => m.id === channel.activeId) ?? channel.modes[0]!;
+
+  // Tint the chip by id pattern so destructive modes are visually loud.
+  const tone = toneForId(channel.activeId);
+
+  const select = (id: string) => {
     setOpen(false);
-    if (id === activeId) return;
-    try {
-      await fetch(
-        `/api/sessions/${encodeURIComponent(sessionId)}/cockpit/mode`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ mode_id: id }),
-        },
-      );
-    } catch {
-      // The agent broadcasts CurrentModeChanged on success; if the
-      // request fails the UI stays on the current mode.
+    if (id === channel.activeId || id === channel.pendingId) return;
+    if (channel.kind === "config" && channel.configId) {
+      void setConfigOption(channel.configId, id);
+    } else {
+      void postLegacyMode(sessionId, id);
     }
   };
 
@@ -1246,39 +1250,47 @@ function ModePicker({
           role="menu"
         >
           <div className="border-b border-surface-800 px-3 py-1.5 text-[10px] uppercase tracking-wider text-text-dim">
-            {usingAgentModes ? "Agent modes" : "Modes"}
+            {channel.label}
           </div>
-          {modes.map((opt) => (
-            <button
-              key={opt.id}
-              type="button"
-              role="menuitem"
-              onClick={() => void select(opt.id)}
-              className={[
-                "flex w-full items-start gap-2 px-3 py-2 text-left text-xs hover:bg-surface-800",
-                opt.id === activeId ? "bg-surface-800/60" : "",
-              ].join(" ")}
-            >
-              <span
+          {channel.modes.map((opt) => {
+            const isPending = opt.id === channel.pendingId;
+            return (
+              <button
+                key={opt.id}
+                type="button"
+                role="menuitem"
+                disabled={isPending}
+                onClick={() => select(opt.id)}
                 className={[
-                  "mt-0.5 inline-block h-3 w-3 shrink-0 rounded-full border",
-                  opt.id === activeId
-                    ? "border-brand-500 bg-brand-500"
-                    : "border-surface-700",
+                  "flex w-full items-start gap-2 px-3 py-2 text-left text-xs hover:bg-surface-800",
+                  opt.id === channel.activeId ? "bg-surface-800/60" : "",
+                  isPending ? "cursor-not-allowed opacity-50" : "",
                 ].join(" ")}
-              />
-              <span className="min-w-0 flex-1">
-                <span className="block font-medium text-text-primary">
-                  {opt.name}
-                </span>
-                {opt.description && (
-                  <span className="block text-[11px] text-text-dim">
-                    {opt.description}
+              >
+                <span
+                  className={[
+                    "mt-0.5 inline-block h-3 w-3 shrink-0 rounded-full border",
+                    opt.id === channel.activeId
+                      ? "border-brand-500 bg-brand-500"
+                      : "border-surface-700",
+                  ].join(" ")}
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block font-medium text-text-primary">
+                    {opt.name}
                   </span>
+                  {opt.description && (
+                    <span className="block text-[11px] text-text-dim">
+                      {opt.description}
+                    </span>
+                  )}
+                </span>
+                {isPending && (
+                  <span className="text-[10px] uppercase text-text-dim">…</span>
                 )}
-              </span>
-            </button>
-          ))}
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -1222,7 +1222,7 @@ function ModePicker({
   const select = (id: string) => {
     setOpen(false);
     if (id === channel.activeId || id === channel.pendingId) return;
-    if (channel.kind === "config" && channel.configId) {
+    if (channel.kind === "config") {
       void setConfigOption(channel.configId, id);
     } else {
       void postLegacyMode(sessionId, id);

--- a/web/src/components/cockpit/SessionConfigControls.tsx
+++ b/web/src/components/cockpit/SessionConfigControls.tsx
@@ -2,10 +2,11 @@
 //
 // Renders the model dropdown + reasoning-effort selector by filtering
 // the unified `configOptions` snapshot the daemon publishes from
-// ACP `SessionUpdate::ConfigOptionUpdate`. Mode is handled by the
-// existing ModePicker because the legacy mode pipeline still drives
-// `availableModes`/`currentModeId`; a follow-up migrates it onto this
-// same path.
+// ACP `SessionUpdate::ConfigOptionUpdate`. The mode picker lives in the
+// composer (`ModePicker`); it reads a `category:"mode"` config option
+// from this same `configOptions` snapshot when the agent advertises one
+// (OpenCode, claude-agent-acp v0.37.0+), and only falls back to the ACP
+// SessionModeState channel otherwise. See lib/modeChannel.ts (#1764).
 //
 // Behavior:
 // - Pessimistic UI. Current value stays put until the adapter pushes a

--- a/web/src/lib/agentProfiles.ts
+++ b/web/src/lib/agentProfiles.ts
@@ -41,6 +41,12 @@ export interface AgentProfile {
      *  Currently informational; subagent indentation only renders when
      *  `parentMetaNamespaces` is also non-empty. */
     subagents: boolean;
+    /** Whether the mode picker may fall back to Claude's hardcoded
+     *  Default/Plan/AcceptEdits/Yolo taxonomy when the agent advertises
+     *  no modes through either the config-option channel or ACP
+     *  SessionModeState. Claude-family only; other agents render no mode
+     *  picker rather than a phantom vocabulary they reject (#1764). */
+    legacyModeFallback: boolean;
   };
   /** `_meta.<namespace>.parentToolUseId` lookup order for subagent
    *  child linkage. Empty when the agent's parent-child linkage isn't
@@ -79,7 +85,7 @@ export interface AgentProfile {
 
 const CLAUDE: AgentProfile = {
   key: "claude",
-  capabilities: { todos: true, skills: true, wakeup: true, subagents: true },
+  capabilities: { todos: true, skills: true, wakeup: true, subagents: true, legacyModeFallback: true },
   parentMetaNamespaces: ["claudeCode"],
   mcpPrefixes: ["mcp__"],
   clearAliases: ["/clear"],
@@ -98,7 +104,7 @@ const CLAUDE_CODE: AgentProfile = {
 
 const CODEX: AgentProfile = {
   key: "codex",
-  capabilities: { todos: false, skills: false, wakeup: false, subagents: false },
+  capabilities: { todos: false, skills: false, wakeup: false, subagents: false, legacyModeFallback: false },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
   clearAliases: ["/new"],
@@ -116,7 +122,7 @@ const CODEX: AgentProfile = {
 
 const OPENCODE: AgentProfile = {
   key: "opencode",
-  capabilities: { todos: false, skills: false, wakeup: false, subagents: true },
+  capabilities: { todos: false, skills: false, wakeup: false, subagents: true, legacyModeFallback: false },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
   clearAliases: ["/new"],
@@ -137,7 +143,7 @@ const OPENCODE: AgentProfile = {
 
 const GEMINI: AgentProfile = {
   key: "gemini",
-  capabilities: { todos: false, skills: false, wakeup: false, subagents: false },
+  capabilities: { todos: false, skills: false, wakeup: false, subagents: false, legacyModeFallback: false },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
   clearAliases: [],
@@ -157,7 +163,7 @@ const GEMINI: AgentProfile = {
 
 const VIBE: AgentProfile = {
   key: "vibe",
-  capabilities: { todos: false, skills: false, wakeup: false, subagents: false },
+  capabilities: { todos: false, skills: false, wakeup: false, subagents: false, legacyModeFallback: false },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
   clearAliases: [],
@@ -167,7 +173,7 @@ const VIBE: AgentProfile = {
 
 const PI: AgentProfile = {
   key: "pi",
-  capabilities: { todos: false, skills: false, wakeup: false, subagents: false },
+  capabilities: { todos: false, skills: false, wakeup: false, subagents: false, legacyModeFallback: false },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
   clearAliases: [],
@@ -185,7 +191,7 @@ const AOE_AGENT: AgentProfile = {
  *  through the generic card path rather than crashing. */
 export const DEFAULT_AGENT_PROFILE: AgentProfile = {
   key: "default",
-  capabilities: { todos: false, skills: false, wakeup: false, subagents: false },
+  capabilities: { todos: false, skills: false, wakeup: false, subagents: false, legacyModeFallback: false },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
   clearAliases: [],

--- a/web/src/lib/modeChannel.test.ts
+++ b/web/src/lib/modeChannel.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigOptionDescriptor } from "./cockpitTypes";
+import { resolveModeChannel, type ResolveModeChannelArgs } from "./modeChannel";
+
+const BASE: ResolveModeChannelArgs = {
+  configOptions: [],
+  availableModes: [],
+  currentModeId: null,
+  legacyMode: "Default",
+  pendingConfigOption: null,
+  allowLegacyFallback: false,
+};
+
+const OPENCODE_MODE_OPTION: ConfigOptionDescriptor = {
+  id: "mode",
+  name: "Session Mode",
+  category: "mode",
+  current_value: "build",
+  options: [
+    { value: "build", name: "Build" },
+    { value: "plan", name: "Plan" },
+  ],
+};
+
+describe("resolveModeChannel", () => {
+  it("prefers the config-option channel and switches via set_config_option", () => {
+    const channel = resolveModeChannel({
+      ...BASE,
+      configOptions: [OPENCODE_MODE_OPTION],
+    });
+    expect(channel).not.toBeNull();
+    expect(channel!.kind).toBe("config");
+    expect(channel!.configId).toBe("mode");
+    expect(channel!.activeId).toBe("build");
+    expect(channel!.modes.map((m) => m.id)).toEqual(["build", "plan"]);
+    expect(channel!.label).toBe("Session Mode");
+  });
+
+  it("never offers a phantom 'default' mode for config-backed agents (#1764)", () => {
+    const channel = resolveModeChannel({
+      ...BASE,
+      configOptions: [OPENCODE_MODE_OPTION],
+      // Even with the claude fallback allowed, a real config option wins
+      // so OpenCode's user is never shown a mode it would reject.
+      allowLegacyFallback: true,
+    });
+    expect(channel!.modes.some((m) => m.id === "default")).toBe(false);
+  });
+
+  it("reflects an in-flight config switch as the pending id", () => {
+    const channel = resolveModeChannel({
+      ...BASE,
+      configOptions: [OPENCODE_MODE_OPTION],
+      pendingConfigOption: { configId: "mode", value: "plan" },
+    });
+    expect(channel!.pendingId).toBe("plan");
+    // Active stays put (pessimistic UI) until the adapter confirms.
+    expect(channel!.activeId).toBe("build");
+  });
+
+  it("ignores a pending config option for a different control", () => {
+    const channel = resolveModeChannel({
+      ...BASE,
+      configOptions: [OPENCODE_MODE_OPTION],
+      pendingConfigOption: { configId: "model", value: "claude-opus-4-8" },
+    });
+    expect(channel!.pendingId).toBeNull();
+  });
+
+  it("falls back to the SessionModeState channel and switches via set_mode", () => {
+    const channel = resolveModeChannel({
+      ...BASE,
+      availableModes: [
+        { id: "default", name: "Default", description: null },
+        { id: "plan", name: "Plan", description: null },
+      ],
+      currentModeId: "plan",
+    });
+    expect(channel!.kind).toBe("legacy");
+    expect(channel!.configId).toBeNull();
+    expect(channel!.activeId).toBe("plan");
+    expect(channel!.pendingId).toBeNull();
+  });
+
+  it("uses the claude hardcoded taxonomy only when the profile opts in", () => {
+    const channel = resolveModeChannel({ ...BASE, allowLegacyFallback: true });
+    expect(channel!.kind).toBe("legacy");
+    expect(channel!.modes.map((m) => m.id)).toEqual([
+      "default",
+      "plan",
+      "accept_edits",
+      "bypass_permissions",
+    ]);
+    expect(channel!.activeId).toBe("default");
+  });
+
+  it("maps the legacy SessionMode enum to the fallback active id", () => {
+    const channel = resolveModeChannel({
+      ...BASE,
+      legacyMode: "Plan",
+      allowLegacyFallback: true,
+    });
+    expect(channel!.activeId).toBe("plan");
+  });
+
+  it("renders nothing for a non-claude agent that advertised no modes", () => {
+    expect(resolveModeChannel(BASE)).toBeNull();
+  });
+
+  it("ignores an empty mode config option", () => {
+    const empty: ConfigOptionDescriptor = {
+      ...OPENCODE_MODE_OPTION,
+      options: [],
+    };
+    expect(resolveModeChannel({ ...BASE, configOptions: [empty] })).toBeNull();
+  });
+});

--- a/web/src/lib/modeChannel.ts
+++ b/web/src/lib/modeChannel.ts
@@ -51,16 +51,28 @@ export interface ModeOption {
 /** The resolved channel the picker should read and write. `kind`
  *  selects the write path: "config" -> session/set_config_option on
  *  `configId`; "legacy" -> session/set_mode. `pendingId` is the value
- *  currently in flight (config channel only; pessimistic UI). */
-export interface ModeChannel {
-  kind: "config" | "legacy";
-  configId: string | null;
-  modes: ModeOption[];
-  activeId: string;
-  pendingId: string | null;
-  /** Menu header label. */
-  label: string;
-}
+ *  currently in flight (config channel only; pessimistic UI). A
+ *  discriminated union so the "config" variant guarantees a non-null
+ *  `configId`. */
+export type ModeChannel =
+  | {
+      kind: "config";
+      configId: string;
+      modes: ModeOption[];
+      activeId: string;
+      pendingId: string | null;
+      /** Menu header label. */
+      label: string;
+    }
+  | {
+      kind: "legacy";
+      configId: null;
+      modes: ModeOption[];
+      activeId: string;
+      pendingId: null;
+      /** Menu header label. */
+      label: string;
+    };
 
 export interface ResolveModeChannelArgs {
   configOptions: CockpitState["configOptions"];

--- a/web/src/lib/modeChannel.ts
+++ b/web/src/lib/modeChannel.ts
@@ -1,0 +1,149 @@
+// Mode-picker channel resolution (#1764).
+//
+// The cockpit composer's mode picker can be driven by three different
+// sources depending on what the active agent advertises over ACP. This
+// module owns the precedence and the read/write pairing so the picker
+// never reads one channel while writing another (the bug that trapped
+// OpenCode users: OpenCode advertises modes via the config-option
+// channel and rejects session/set_mode, so reading config + writing
+// set_mode left them with a phantom "default" mode they could not
+// leave).
+//
+// Precedence, most authoritative first:
+//   1. config: an ACP config option of category "mode" (OpenCode, and
+//      claude-agent-acp v0.37.0+). Active value is `current_value`;
+//      switches go through session/set_config_option.
+//   2. legacy: ACP SessionModeState (`availableModes` / `currentModeId`,
+//      older claude). Switches go through session/set_mode.
+//   3. fallback: claude's hardcoded Default/Plan/AcceptEdits/Yolo
+//      taxonomy, only when the agent's profile opts in
+//      (`capabilities.legacyModeFallback`). Switches go through
+//      session/set_mode.
+// When none apply (a non-claude agent that advertised nothing), the
+// picker renders nothing rather than a vocabulary the agent rejects.
+
+import type {
+  CockpitState,
+  ConfigOptionDescriptor,
+  SessionMode,
+} from "./cockpitTypes";
+
+/** Claude's historical four-mode taxonomy. Used only as the
+ *  `capabilities.legacyModeFallback` fallback; not an ACP default. */
+export const LEGACY_MODES: ReadonlyArray<{
+  id: string;
+  legacyId: SessionMode;
+  name: string;
+  description: string;
+}> = [
+  { id: "default", legacyId: "Default", name: "Default", description: "Approve each tool individually" },
+  { id: "plan", legacyId: "Plan", name: "Plan", description: "Plan first, no edits applied" },
+  { id: "accept_edits", legacyId: "AcceptEdits", name: "Accept edits", description: "Auto-approve safe file edits" },
+  { id: "bypass_permissions", legacyId: "BypassPermissions", name: "Yolo", description: "Skip all approvals (destructive)" },
+];
+
+export interface ModeOption {
+  id: string;
+  name: string;
+  description: string;
+}
+
+/** The resolved channel the picker should read and write. `kind`
+ *  selects the write path: "config" -> session/set_config_option on
+ *  `configId`; "legacy" -> session/set_mode. `pendingId` is the value
+ *  currently in flight (config channel only; pessimistic UI). */
+export interface ModeChannel {
+  kind: "config" | "legacy";
+  configId: string | null;
+  modes: ModeOption[];
+  activeId: string;
+  pendingId: string | null;
+  /** Menu header label. */
+  label: string;
+}
+
+export interface ResolveModeChannelArgs {
+  configOptions: CockpitState["configOptions"];
+  availableModes: CockpitState["availableModes"];
+  currentModeId: string | null;
+  legacyMode: SessionMode;
+  pendingConfigOption: CockpitState["pendingConfigOption"];
+  /** From the active agent's profile (`capabilities.legacyModeFallback`). */
+  allowLegacyFallback: boolean;
+}
+
+function findModeConfig(
+  options: ConfigOptionDescriptor[],
+): ConfigOptionDescriptor | undefined {
+  return options.find(
+    (o) => o.category === "mode" && o.options.length > 0,
+  );
+}
+
+/** Resolve the mode-picker channel, or null when the picker should not
+ *  render. Pure; unit-tested in `modeChannel.test.ts`. */
+export function resolveModeChannel(
+  args: ResolveModeChannelArgs,
+): ModeChannel | null {
+  const {
+    configOptions,
+    availableModes,
+    currentModeId,
+    legacyMode,
+    pendingConfigOption,
+    allowLegacyFallback,
+  } = args;
+
+  const modeConfig = findModeConfig(configOptions);
+  if (modeConfig) {
+    return {
+      kind: "config",
+      configId: modeConfig.id,
+      modes: modeConfig.options.map((o) => ({
+        id: o.value,
+        name: o.name,
+        description: o.description ?? "",
+      })),
+      activeId: modeConfig.current_value,
+      pendingId:
+        pendingConfigOption?.configId === modeConfig.id
+          ? pendingConfigOption.value
+          : null,
+      label: modeConfig.name || "Agent modes",
+    };
+  }
+
+  if (availableModes.length > 0) {
+    return {
+      kind: "legacy",
+      configId: null,
+      modes: availableModes.map((m) => ({
+        id: m.id,
+        name: m.name,
+        description: m.description ?? "",
+      })),
+      activeId: currentModeId ?? availableModes[0]!.id,
+      pendingId: null,
+      label: "Agent modes",
+    };
+  }
+
+  if (allowLegacyFallback) {
+    const fallbackId =
+      LEGACY_MODES.find((m) => m.legacyId === legacyMode)?.id ?? "default";
+    return {
+      kind: "legacy",
+      configId: null,
+      modes: LEGACY_MODES.map((m) => ({
+        id: m.id,
+        name: m.name,
+        description: m.description,
+      })),
+      activeId: currentModeId ?? fallbackId,
+      pendingId: null,
+      label: "Modes",
+    };
+  }
+
+  return null;
+}

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -339,7 +339,7 @@ function writeFakeClaudeShim(binDir: string): void {
   // so without these the picker only offers claude and persistence
   // specs that pick a non-default tool would hang on a missing button.
   const script = "#!/bin/bash\nexec tail -f /dev/null\n";
-  for (const name of ["claude", "codex", "gemini"]) {
+  for (const name of ["claude", "codex", "gemini", "opencode"]) {
     const path = join(binDir, name);
     writeFileSync(path, script);
     chmodSync(path, 0o755);
@@ -378,7 +378,7 @@ function writeFakeAcpShim(
     scriptLines.push(`export ${key}=${JSON.stringify(value)}`);
   }
   const script = `#!/bin/bash\n${scriptLines.join("\n")}\nexec node ${JSON.stringify(fakeAgentJs)} "$@"\n`;
-  for (const name of ["claude", "claude-agent-acp", "aoe-agent"]) {
+  for (const name of ["claude", "claude-agent-acp", "aoe-agent", "opencode"]) {
     const path = join(binDir, name);
     writeFileSync(path, script);
     chmodSync(path, 0o755);

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -523,7 +523,7 @@ async function handleRequest(msg) {
         sendError(id, -32000, process.env.FAKE_ACP_REJECT_CONFIG_OPTION);
         return;
       }
-      if (configId === "mode") {
+      if (process.env.FAKE_ACP_MODE_VIA_CONFIG_OPTION && configId === "mode") {
         // OpenCode-shaped mode switch via the config-option channel.
         if (!OPENCODE_MODE_CHOICES.some((m) => m.value === value)) {
           sendError(id, -32000, `mode not found: ${value}`);

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -229,6 +229,28 @@ const DEFAULT_PERMISSION_OPTIONS = [
 // "cancelled" instead of running the rest of the scripted updates.
 const cancelFlags = new Map();
 
+// OpenCode-shaped mode advertisement (#1764). When
+// FAKE_ACP_MODE_VIA_CONFIG_OPTION is set, the fake advertises its modes
+// ONLY as a `category:"mode"` config option (no ACP SessionModeState
+// `modes` field) and rejects any mode value outside this list, exactly
+// like `opencode acp`. Lets a test prove the cockpit picker reads the
+// config-option channel and never offers a phantom "default" mode.
+const OPENCODE_MODE_CHOICES = [
+  { value: "build", name: "Build" },
+  { value: "plan", name: "Plan" },
+];
+const opencodeModeBySession = new Map();
+function makeOpencodeModeOption(currentValue) {
+  return {
+    id: "mode",
+    name: "Session Mode",
+    category: "mode",
+    type: "select",
+    currentValue,
+    options: OPENCODE_MODE_CHOICES,
+  };
+}
+
 async function emitSessionUpdates(sessionId, updates) {
   for (const u of updates) {
     if (cancelFlags.get(sessionId)) return;
@@ -447,6 +469,14 @@ async function handleRequest(msg) {
           },
         ];
       }
+      if (process.env.FAKE_ACP_MODE_VIA_CONFIG_OPTION) {
+        const current = opencodeModeBySession.get(sessionId) ?? "build";
+        opencodeModeBySession.set(sessionId, current);
+        result.configOptions = [
+          ...(result.configOptions ?? []),
+          makeOpencodeModeOption(current),
+        ];
+      }
       sendResult(id, result);
       return;
     }
@@ -458,6 +488,15 @@ async function handleRequest(msg) {
       // rename doesn't silently regress this fake.
       const sessionId = params?.sessionId;
       const modeId = params?.modeId;
+      if (
+        process.env.FAKE_ACP_MODE_VIA_CONFIG_OPTION &&
+        !OPENCODE_MODE_CHOICES.some((m) => m.value === modeId)
+      ) {
+        // OpenCode rejects set_mode for any id outside its real mode
+        // list (this is the "mode not found" the trapped user hit).
+        sendError(id, -32000, `mode not found: ${modeId}`);
+        return;
+      }
       sendResult(id, {});
       if (sessionId && modeId) {
         // Emit the ACP-correct variant so the supervisor translates to
@@ -482,6 +521,17 @@ async function handleRequest(msg) {
       const value = params?.value;
       if (process.env.FAKE_ACP_REJECT_CONFIG_OPTION) {
         sendError(id, -32000, process.env.FAKE_ACP_REJECT_CONFIG_OPTION);
+        return;
+      }
+      if (configId === "mode") {
+        // OpenCode-shaped mode switch via the config-option channel.
+        if (!OPENCODE_MODE_CHOICES.some((m) => m.value === value)) {
+          sendError(id, -32000, `mode not found: ${value}`);
+          return;
+        }
+        const sessionId = params?.sessionId;
+        if (sessionId) opencodeModeBySession.set(sessionId, value);
+        sendResult(id, { configOptions: [makeOpencodeModeOption(value)] });
         return;
       }
       const configOptions =

--- a/web/tests/live/cockpit-stories/cockpit-mode-picker.spec.ts
+++ b/web/tests/live/cockpit-stories/cockpit-mode-picker.spec.ts
@@ -69,3 +69,75 @@ base("ModePicker switches the cockpit mode", async ({ page }, testInfo) => {
     await serve.stop();
   }
 });
+
+// Regression for #1764: OpenCode advertises its modes ONLY via a
+// `category:"mode"` config option (no ACP SessionModeState) and rejects
+// any mode value outside its real list. Before the fix the picker fell
+// back to claude's hardcoded taxonomy, showing a phantom "Default" that
+// OpenCode rejected ("mode not found"), trapping the user. The picker
+// must now read the config-option channel, show the real modes, and let
+// the user switch back and forth freely.
+base(
+  "ModePicker uses OpenCode's config-option modes and never traps the user",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      extraEnv: { FAKE_ACP_MODE_VIA_CONFIG_OPTION: "1" },
+      seedFn: seedSessionViaAoeAdd({
+        title: "story-mode-opencode",
+        tool: "opencode",
+      }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find((s) => s.title === "story-mode-opencode");
+      if (!seeded) throw new Error("seeded session 'story-mode-opencode' missing");
+      const sessionId = seeded.id;
+      await enableCockpitAndWait(serve.baseUrl, sessionId);
+      const spawnRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/spawn`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agent: "opencode" }),
+        },
+      );
+      if (![200, 202, 409].includes(spawnRes.status)) {
+        throw new Error(`cockpit spawn failed: ${spawnRes.status}`);
+      }
+
+      await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+      await waitForCockpitView(page);
+
+      // The chip shows OpenCode's real default mode ("Build"), never the
+      // phantom claude "Default".
+      const trigger = page
+        .locator("button")
+        .filter({ has: page.locator(":scope > span", { hasText: /^(Build|Plan)$/ }) })
+        .first();
+      await expect(trigger).toBeVisible({ timeout: 10_000 });
+      await expect(trigger).toContainText(/Build/i);
+      await expect(page.getByText("Default", { exact: true })).toHaveCount(0);
+
+      // Switch to Plan via the config-option channel; the fake returns the
+      // updated configOptions and the chip flips.
+      await trigger.click();
+      const menu = page.locator('[role="menu"]');
+      await expect(menu.getByText(/^Default$/)).toHaveCount(0);
+      await menu.getByText(/^Plan$/i).first().click();
+      await expect(trigger).toContainText(/Plan/i, { timeout: 10_000 });
+
+      // Switch back to Build: this is the path that used to fail ("mode
+      // not found"). It must succeed now, proving the user is not trapped.
+      await trigger.click();
+      await page.locator('[role="menu"]').getByText(/^Build$/i).first().click();
+      await expect(trigger).toContainText(/Build/i, { timeout: 10_000 });
+    } finally {
+      await serve.stop();
+    }
+  },
+);

--- a/web/tests/live/cockpit-stories/cockpit-mode-picker.spec.ts
+++ b/web/tests/live/cockpit-stories/cockpit-mode-picker.spec.ts
@@ -120,11 +120,14 @@ base(
         .filter({ has: page.locator(":scope > span", { hasText: /^(Build|Plan)$/ }) })
         .first();
       await expect(trigger).toBeVisible({ timeout: 10_000 });
+      // The chip shows OpenCode's real default mode, never the phantom
+      // claude "Default". (A page-wide "Default" check would false-match
+      // the reasoning-effort selector, which has its own "Default" label.)
       await expect(trigger).toContainText(/Build/i);
-      await expect(page.getByText("Default", { exact: true })).toHaveCount(0);
 
       // Switch to Plan via the config-option channel; the fake returns the
-      // updated configOptions and the chip flips.
+      // updated configOptions and the chip flips. The open mode menu must
+      // not offer the phantom "Default".
       await trigger.click();
       const menu = page.locator('[role="menu"]');
       await expect(menu.getByText(/^Default$/)).toHaveCount(0);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The cockpit mode picker exposed a phantom "Default" mode for OpenCode sessions. Switching from "Default" to "Plan" worked, but switching back failed with "mode not found", leaving the user trapped in plan mode.

Root cause: OpenCode advertises its modes only through the ACP config-option channel (a `category:"mode"` option carrying its real agents, e.g. `build` / `plan`), never through the `NewSessionResponse.modes` SessionModeState field, and it rejects any mode id outside that real list. The picker read only the SessionModeState channel, found it empty, and fell back to claude's hardcoded `Default / Plan / AcceptEdits / Yolo` taxonomy. "plan" happened to match a real opencode mode so it worked, but "default" does not exist in OpenCode, so the switch-back was rejected.

The fix resolves the picker's modes through one precedence (`web/src/lib/modeChannel.ts`): a `category:"mode"` config option first (OpenCode, and claude-agent-acp v0.37.0+), then the legacy SessionModeState channel (older claude), then claude's built-in taxonomy gated to claude-family agents via a new `legacyModeFallback` profile capability. Each channel owns both its read source and its write path so the two never drift: config-backed modes read `current_value` and switch via `session/set_config_option` (reusing the existing pessimistic pending UI and the config-option failure notice); legacy modes keep `session/set_mode`. A non-claude agent that advertises no modes shows no picker rather than a vocabulary it would reject.

Result: OpenCode sessions now show their real mode names and the user can switch freely in both directions. Claude is unaffected. No backend, migration, or settings change; this lives entirely in the web dashboard.

Closes #1764

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create an OpenCode cockpit session: `aoe add . --cmd opencode --cockpit`, then `aoe serve`, and open Cockpit on that session.
- [ ] Open the mode picker in the composer. Confirm it shows OpenCode's real modes (for example `build`, `plan`) and does not show "Default".
- [ ] Switch to `plan`, then reopen the picker and switch to another real mode (for example back to `build`). Confirm the switch succeeds and the chip updates, with no "mode not found" banner.
- [ ] Trigger a rejected switch (an invalid mode) and confirm a non-blocking notice appears while the chip stays on the current valid mode.
- [ ] On a Claude cockpit session, confirm the mode picker still works exactly as before.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added a Vitest unit suite for the mode-channel resolver (`web/src/lib/modeChannel.test.ts`), a live Playwright story that drives an OpenCode-shaped agent and proves the picker never offers "Default" and lets the user switch both ways (`web/tests/live/cockpit-stories/cockpit-mode-picker.spec.ts`), and taught the fake ACP agent an opencode-shaped mode set. The existing `cockpit.story.mode-picker` matrix entry maps the touched `Composer.tsx`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction (including reading the OpenCode ACP binary to confirm the modes-via-config-option behavior). I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview of Changes

This PR fixes the Cockpit mode picker so agents that publish modes via a config option (OpenCode) show and switch to their real mode names instead of a phantom "Default" mode that could not be restored.

### What Was Added
- A new resolver module (web/src/lib/modeChannel.ts) that chooses the mode source with strict precedence.
- A new agent profile capability flag (legacyModeFallback) to opt into an older built-in Claude taxonomy when appropriate.
- Unit tests for the resolver and a Playwright live test reproducing the OpenCode regression.
- Test harness updates and fake-agent logic to simulate OpenCode-shaped config-option mode behavior.
- Documentation describing the mode-picker source priority.

### What Was Changed
- ModePicker (Composer.tsx) refactored to use the resolver and to route selections through channel-specific write paths (config-option writes vs legacy session/set_mode).
- Agent profiles updated to include legacyModeFallback (enabled for Claude; disabled for others).
- Test helpers extended to register an opencode shim and a FAKE_ACP_MODE_VIA_CONFIG_OPTION pathway.

### What Was Removed
- The ModePicker’s local hardcoded fallback taxonomy was removed in favor of the centralized resolver (legacy taxonomy retained only behind the legacyModeFallback capability).

## Technical Summary (brief)
- resolveModeChannel implements precedence: (1) ACP config-option with category:"mode" (preferred), (2) legacy SessionModeState.available_modes, (3) built-in Claude LEGACY_MODES when capabilities.legacyModeFallback is true; otherwise null.
- Config-backed channels expose configId and use session/set_config_option for writes; legacy channels use session/set_mode.
- Picker shows no UI for agents that advertise no modes.

## Benefits
- OpenCode sessions display real modes (e.g., build, plan) and allow switching both ways — the "mode not found" regression is resolved.
- Claude behavior remains unchanged.
- No backend changes or migrations required; changes confined to the web dashboard.
- Improved test coverage reduces regression risk and makes future agent-mode integrations straightforward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->