### PR TITLE
feat(tui): tmux-style leader + collapsible sidebar in live mode

### DIFF
--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -1,0 +1,100 @@
+# Live mode
+
+Live mode is a "feels-attached" alternative to a full tmux attach. When
+you enter it, the AoE home view stays on screen (session list, preview,
+status bar) and every keystroke is relayed straight to the selected
+session's pane. You get the ambient awareness of the dashboard and the
+immediacy of typing directly to the agent, without tmux taking over the
+whole terminal.
+
+Contrast with a full attach: `tmux attach` replaces the entire screen
+with the agent until you detach with `Ctrl+b d`. In live mode the
+dashboard never leaves, so you can watch other sessions' states while
+you work.
+
+## Entering and leaving
+
+* **Enter:** press `Tab` on a runnable session, or set live mode as your
+  default so that `Enter` (and clicking a row) drops you straight into
+  it. See **Default Attach Mode** and **New Session Attach Mode** in
+  Settings.
+* **Leave (fast exit):** press `Ctrl+Q`. This is a single press and is
+  always available, independent of the leader below.
+
+The status bar shows a `● LIVE → <session>` banner while you are
+relayed, including a reminder of the exit chord and the leader menu.
+
+## The leader menu
+
+Almost every key you press in live mode goes to the agent, so AoE
+reserves a single **leader** chord (tmux-style prefix) to reach its own
+commands. The default is `Ctrl+B`, matching tmux and herdr.
+
+Press the leader, then a command key:
+
+| Keys | Action |
+| --- | --- |
+| `Ctrl+B` then `k` | Open the command palette |
+| `Ctrl+B` then `b` | Hide / show the sidebar (preview takes the full width) |
+| `Ctrl+B` then `q` | Exit live mode |
+| `Ctrl+B` then `Ctrl+B` | Send a literal `Ctrl+B` to the agent |
+| `Esc` (or any other key) after the leader | Cancel the menu, send nothing |
+
+When the leader is armed, the status bar turns into a which-key menu
+listing these commands, so you do not have to memorize them.
+
+Only the leader itself is taken away from the agent, and pressing it
+twice still delivers it downstream (the same idea as tmux's
+`send-prefix`). Every other chord, including `Ctrl+K`, passes through to
+the agent untouched, so the agent's own keybindings keep working.
+
+Opening the command palette layers it over live mode. Cancel it with
+`Esc` to drop straight back into the relay; choosing any palette command
+leaves live mode first, so the preview never shows one session while
+your keystrokes go to another.
+
+## Collapsing the sidebar
+
+`Ctrl+B` then `b` hides the session list and hands the full terminal
+width to the agent pane, then restores it on the next toggle. This is a
+live-mode focus tool: the sidebar always reappears when you exit live
+mode, so you can never get stranded in the normal home view with the
+list hidden.
+
+## Scrolling history
+
+`Shift+PageUp` and `Shift+PageDown` scroll the preview back through the
+agent's history without leaving live mode or forwarding the keys. Bare
+`PageUp` / `PageDown` still pass through to the agent, so agents that
+page their own UI keep working.
+
+## Configuration
+
+Both chords are editable under Settings, in the Interaction section, and
+in `config.toml`:
+
+```toml
+[session]
+# Leader (prefix) chord for live-mode commands. Tmux-style spec.
+# Leave empty to disable the leader entirely (then Ctrl+B passes
+# straight through to the agent).
+live_send_leader = "C-b"
+
+# One or more comma-separated chords that exit live mode. Single press,
+# independent of the leader.
+live_send_exit_chord = "C-q"
+```
+
+Chord specs are tmux-style: `C-b`, `C-a`, `M-x` (Alt), `F12`, and so on.
+A typo in the leader falls back to the default; an empty value disables
+it.
+
+### Why `Ctrl+B`?
+
+A prefix steals exactly one chord from the agent, so the obvious
+single-key candidates like `Ctrl+K` (readline's kill-to-end-of-line)
+stay free for the shell and the agent. `Ctrl+B` is the chord tmux and
+herdr users already know as a leader. If you run AoE inside your own
+tmux session that also uses `Ctrl+B`, the outer tmux will claim it
+first; rebind `live_send_leader` to something free (for example `C-a` or
+`F1`), and remember that `Ctrl+Q` always exits regardless.

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -624,6 +624,20 @@ pub struct SessionConfig {
     #[serde(default = "default_live_send_exit_chord")]
     pub live_send_exit_chord: String,
 
+    /// Leader (prefix) chord for live-send mode commands, tmux-style
+    /// (`C-b`, `C-a`, `M-Space`, `F1`, …). In live mode the leader arms
+    /// a one-shot menu: leader then `k` opens the command palette, `b`
+    /// toggles the sidebar, `q` exits. Pressing the leader twice sends a
+    /// literal leader keystroke to the agent (matches tmux `send-prefix`).
+    /// Default `C-b` lines up with tmux and herdr; the only chord it
+    /// steals from the agent is the leader itself, and double-tap still
+    /// delivers it. Set empty to disable the leader entirely (every key,
+    /// including `C-b`, then passes straight through). The dedicated exit
+    /// chord (`live_send_exit_chord`, default `C-q`) is independent of the
+    /// leader and stays a single-press fast exit.
+    #[serde(default = "default_live_send_leader")]
+    pub live_send_leader: String,
+
     /// What the TUI does immediately after a new session finishes
     /// creating. `Tmux` (default) drops into the tmux attach view, the
     /// historical behavior. `LiveSend` enters live-send mode against
@@ -737,6 +751,7 @@ impl Default for SessionConfig {
             row_tag: RowTagMode::default(),
             session_id_poller_max_threads: default_session_id_poller_max_threads(),
             live_send_exit_chord: default_live_send_exit_chord(),
+            live_send_leader: default_live_send_leader(),
             new_session_attach_mode: NewSessionAttachMode::default(),
             default_attach_mode: NewSessionAttachMode::default(),
             click_action: ClickAction::default(),
@@ -757,6 +772,13 @@ fn default_live_send_exit_chord() -> String {
     // Ctrl+q: mobile-friendly, passes Termius, well-known quit chord.
     // Kept in sync with live_send::DEFAULT_EXIT_CHORD.
     "C-q".to_string()
+}
+
+fn default_live_send_leader() -> String {
+    // Ctrl+b: the tmux (and herdr) leader. Familiar to multiplexer users
+    // and steals only one chord from the agent. Kept in sync with
+    // live_send::DEFAULT_LEADER.
+    "C-b".to_string()
 }
 
 /// Upper bound on snooze duration: 30 days (43,200 minutes). Originally

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -268,6 +268,9 @@ pub struct SessionConfigOverride {
     pub live_send_exit_chord: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_send_leader: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub new_session_attach_mode: Option<super::config::NewSessionAttachMode>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -516,6 +519,9 @@ pub fn apply_session_overrides(
     }
     if let Some(ref live_send_exit_chord) = source.live_send_exit_chord {
         target.live_send_exit_chord = live_send_exit_chord.clone();
+    }
+    if let Some(ref live_send_leader) = source.live_send_leader {
+        target.live_send_leader = live_send_leader.clone();
     }
     if let Some(new_session_attach_mode) = source.new_session_attach_mode {
         target.new_session_attach_mode = new_session_attach_mode;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2320,6 +2320,17 @@ impl HomeView {
         action: PaletteAction,
         update_info: Option<&crate::update::UpdateInfo>,
     ) -> Option<Action> {
+        // The palette can now be opened over live mode (via the leader),
+        // but every palette command steps out of the per-session relay:
+        // jumping navigates away, Invoke/Activate/ToolSession change what's
+        // focused, and the preview follows `selected_session` while
+        // keystrokes target `live_send`. Committing any of them while still
+        // live would desync the preview from the keystroke target, so leave
+        // live mode first. Cancelling the palette (Esc) never reaches here,
+        // so it still drops the user straight back into live mode.
+        if let Some(state) = self.live_send.clone() {
+            self.exit_live_send_and_restore_sizing(&state);
+        }
         match action {
             PaletteAction::Invoke(id) => {
                 // The palette's mental model is "run the named action," so clear
@@ -3565,15 +3576,24 @@ impl HomeView {
                     return;
                 }
             }
+            // Command letters match only when unmodified: the leader-again
+            // passthrough above already claimed the modified form (`C-b`),
+            // and folding `Ctrl+K` / `Alt+b` into a command would surprise
+            // users reaching for a modified chord. Shift is allowed since
+            // it just yields the uppercase code.
+            let plain = !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT);
             match key.code {
-                KeyCode::Char('k') | KeyCode::Char('K') => self.open_command_palette(),
-                KeyCode::Char('b') | KeyCode::Char('B') => self.toggle_sidebar_collapsed(),
-                KeyCode::Char('q') | KeyCode::Char('Q') => {
+                KeyCode::Char('k') | KeyCode::Char('K') if plain => self.open_command_palette(),
+                KeyCode::Char('b') | KeyCode::Char('B') if plain => self.toggle_sidebar_collapsed(),
+                KeyCode::Char('q') | KeyCode::Char('Q') if plain => {
                     self.exit_live_send_and_restore_sizing(&state)
                 }
-                // Esc (or any unbound key) cancels the menu without
-                // forwarding: the leader already swallowed this keystroke,
-                // and tmux's prefix behaves the same way for unknown keys.
+                // Esc (or any unbound / modified key) cancels the menu
+                // without forwarding: the leader already swallowed this
+                // keystroke, and tmux's prefix behaves the same way for
+                // unknown keys.
                 _ => {}
             }
             return;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3546,6 +3546,39 @@ impl HomeView {
             return;
         };
 
+        // Leader menu: a prior keystroke matched the configured leader
+        // (tmux-style prefix, default Ctrl+B), so this key picks a
+        // live-send command instead of being forwarded. Always disarm
+        // first so a stray second key can't leave the menu stuck open.
+        if self.live_send_pending_leader {
+            self.live_send_pending_leader = false;
+            // Leader pressed twice: deliver a literal leader keystroke to
+            // the agent (matches tmux `send-prefix`), so binding the
+            // leader never fully steals the chord from downstream programs.
+            if let Some(leader) = state.leader {
+                if live_send::chord_matches(leader, key) {
+                    if let live_send::LiveDispatch::Send(tmux_key) = live_send::translate(key) {
+                        if let Some(worker) = &self.live_send_worker {
+                            worker.send(tmux_key);
+                        }
+                    }
+                    return;
+                }
+            }
+            match key.code {
+                KeyCode::Char('k') | KeyCode::Char('K') => self.open_command_palette(),
+                KeyCode::Char('b') | KeyCode::Char('B') => self.toggle_sidebar_collapsed(),
+                KeyCode::Char('q') | KeyCode::Char('Q') => {
+                    self.exit_live_send_and_restore_sizing(&state)
+                }
+                // Esc (or any unbound key) cancels the menu without
+                // forwarding: the leader already swallowed this keystroke,
+                // and tmux's prefix behaves the same way for unknown keys.
+                _ => {}
+            }
+            return;
+        }
+
         // `handle_key` already cleared any finalized preview
         // selection at the top, so the highlight doesn't linger
         // across the keystroke that switched the user out of
@@ -3587,6 +3620,16 @@ impl HomeView {
             self.exit_live_send_and_restore_sizing(&state);
             return;
         }
+        // Leader (prefix) press: arm the live-send command menu and
+        // swallow the keystroke. The next key is handled by the
+        // pending-leader branch at the top. Checked after the exit chord
+        // so a misconfigured leader == exit chord still exits.
+        if let Some(leader) = state.leader {
+            if live_send::chord_matches(leader, key) {
+                self.live_send_pending_leader = true;
+                return;
+            }
+        }
         if let Some(reason) = self.live_send_drift_reason(&state) {
             self.exit_live_send_and_restore_sizing(&state);
             self.info_dialog = Some(InfoDialog::new("Live send ended", reason));
@@ -3616,6 +3659,11 @@ impl HomeView {
         self.live_send = None;
         self.live_send_worker = None;
         self.live_send_last_resize = None;
+        // The leader menu and sidebar collapse are live-mode-only: drop
+        // any half-entered leader chord and re-reveal the session list so
+        // the normal home view is never left in a collapsed or armed state.
+        self.live_send_pending_leader = false;
+        self.sidebar_collapsed = false;
         // Live mode just owned the pane's size; the non-live preview must
         // re-assert its geometry on the next render now that the header is
         // visible again (and so the agent reflows back to the previewed size).

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -61,6 +61,14 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 /// settings (or hand-editing the line out) restores the new default.
 pub(super) const DEFAULT_EXIT_CHORD: &str = "C-q";
 
+/// Default live-send leader (prefix) chord. `Ctrl+b` matches the tmux
+/// and herdr leader, so multiplexer users already have the muscle
+/// memory, and it's the one chord we steal from the agent (double-tap
+/// `C-b C-b` still delivers a literal `C-b` downstream). Kept in sync
+/// with `default_live_send_leader()` in `session::config`. An empty
+/// configured value disables the leader entirely.
+pub(super) const DEFAULT_LEADER: &str = "C-b";
+
 /// Parse a tmux-style chord spec into a `(KeyCode, KeyModifiers)`
 /// pair. Accepts `C-` / `Ctrl-`, `M-` / `Alt-`, `S-` / `Shift-`
 /// prefixes (any order, separated by `-` or `+`) followed by a key
@@ -275,6 +283,14 @@ pub(in crate::tui) struct LiveSendState {
     /// setting at entry time. Captured per-entry so config edits
     /// don't change behavior mid-session.
     pub exit_chords: Vec<(KeyCode, KeyModifiers)>,
+    /// Leader (prefix) chord parsed from the user's configured leader
+    /// setting at entry time. `None` when the user cleared the setting
+    /// (leader disabled, every key passes through). When `Some`, the
+    /// first press arms the live-send command menu; the next key picks
+    /// a command (or a second leader press passes a literal leader to
+    /// the agent). Snapshotted per-entry for the same reason as
+    /// `exit_chords`.
+    pub leader: Option<(KeyCode, KeyModifiers)>,
 }
 
 /// Which paired tmux pane a live-send dispatch targets. The agent
@@ -803,6 +819,32 @@ mod tests {
         // hand exit configure one explicitly.
         assert!(!chords.contains(&(KeyCode::Char(']'), KeyModifiers::CONTROL)));
         assert!(!chords.contains(&(KeyCode::Char('\\'), KeyModifiers::CONTROL)));
+    }
+
+    #[test]
+    fn default_leader_is_ctrl_b() {
+        // Ctrl+B matches the tmux/herdr leader. Kept in sync with
+        // session::config::default_live_send_leader().
+        assert_eq!(
+            parse_chord(DEFAULT_LEADER),
+            Some((KeyCode::Char('b'), KeyModifiers::CONTROL))
+        );
+    }
+
+    #[test]
+    fn leader_matches_only_its_exact_chord() {
+        let leader = parse_chord(DEFAULT_LEADER).unwrap();
+        // The armed leader: Ctrl+B fires it again (passthrough path).
+        assert!(chord_matches(
+            leader,
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL)
+        ));
+        // Bare `b` is a menu command, not a second leader press, so it
+        // must NOT match the leader chord.
+        assert!(!chord_matches(
+            leader,
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE)
+        ));
     }
 
     #[test]

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -433,6 +433,17 @@ pub struct HomeView {
     /// the current live-send session. Used to dedup the resize messages
     /// fired from the preview refresh path; cleared on live-send exit.
     pub(super) live_send_last_resize: Option<(u16, u16)>,
+    /// True between a live-send leader press and the next key. While armed,
+    /// the next key is interpreted as a live-send command (palette, sidebar
+    /// toggle, exit) rather than forwarded to the agent, and the status bar
+    /// shows the which-key menu. Always false outside live mode; cleared on
+    /// live-send exit. See `handle_live_send_key`.
+    pub(super) live_send_pending_leader: bool,
+    /// When true, the session list (sidebar) is hidden so the preview pane
+    /// gets the full terminal width. Toggled from live mode via the leader
+    /// (`leader b`) for a distraction-free agent view; reset on live-send
+    /// exit so the list always reappears in the normal home view.
+    pub(super) sidebar_collapsed: bool,
     /// `(session_id, cols, rows)` of the last NON-live preview resize we sent
     /// to the selected agent's pane, so the 250ms preview poll doesn't
     /// SIGWINCH-storm it every tick. Invalidated (set to None) on attach and on
@@ -812,6 +823,8 @@ impl HomeView {
             live_send: None,
             live_send_worker: None,
             live_send_last_resize: None,
+            live_send_pending_leader: false,
+            sidebar_collapsed: false,
             preview_pane_synced: None,
             pending_paste: None,
             pending_attach_after_warning: None,
@@ -2304,6 +2317,16 @@ impl HomeView {
         self.save_list_width();
     }
 
+    /// Hide or reveal the session list so the preview pane can use the
+    /// full terminal width. Only meaningful while live mode is active
+    /// (the render path ignores the flag otherwise and `exit_live_send_*`
+    /// resets it), so this is deliberately ephemeral rather than persisted
+    /// to config. The next render reflows the preview, and the live-send
+    /// resize loop pushes the new geometry to the agent's pane.
+    pub fn toggle_sidebar_collapsed(&mut self) {
+        self.sidebar_collapsed = !self.sidebar_collapsed;
+    }
+
     fn save_list_width(&self) {
         if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
             config.app_state.home_list_width = Some(self.list_width);
@@ -2884,16 +2907,35 @@ impl HomeView {
         // during live mode aren't possible (settings_view participates
         // in has_dialog and lives in its own takeover), so a snapshot
         // at entry time is sufficient.
-        let exit_chord_spec = resolve_config_or_warn(&self.config_profile())
-            .session
-            .live_send_exit_chord;
+        let resolved_config = resolve_config_or_warn(&self.config_profile());
+        let exit_chord_spec = resolved_config.session.live_send_exit_chord;
         let exit_chords = live_send::parse_chord_list(&exit_chord_spec);
+        // The leader is a single chord, not a list. An empty configured
+        // value disables it (so every key, including the default `C-b`,
+        // passes straight through). A non-empty but unparseable value is
+        // treated as a typo and falls back to the default leader rather
+        // than silently dropping the feature, mirroring how the exit
+        // chord recovers from a bad spec.
+        let leader_spec = resolved_config.session.live_send_leader;
+        let leader = if leader_spec.trim().is_empty() {
+            None
+        } else {
+            live_send::parse_chord(&leader_spec).or_else(|| {
+                tracing::warn!(
+                    "live-send: unparseable leader chord '{}'; falling back to default '{}'",
+                    leader_spec,
+                    live_send::DEFAULT_LEADER
+                );
+                live_send::parse_chord(live_send::DEFAULT_LEADER)
+            })
+        };
         self.live_send = Some(live_send::LiveSendState {
             session_id: inst.id.clone(),
             title: inst.title.clone(),
             tmux_name: tmux_name.clone(),
             target,
             exit_chords,
+            leader,
         });
         // Spawn the background worker that dispatches translated
         // keystrokes as one-shot `tmux send-keys` subprocesses (the

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2943,6 +2943,10 @@ impl HomeView {
         // but turned out to be unreliable on real-world tmux setups
         // and was removed in favor of this simpler model).
         self.live_send_worker = Some(live_send::LiveSendWorker::spawn(tmux_name));
+        // Start every live-mode entry (including a switch from another
+        // session) with a disarmed leader menu, so a half-entered chord
+        // can't carry over from a prior target.
+        self.live_send_pending_leader = false;
         // Clear the resize dedup so `finalize_live_send_resize` always
         // issues its sync resize, even if the cached geometry from a
         // prior session happens to match the current preview_pane_area.

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -497,6 +497,13 @@ impl HomeView {
         // on live-send exit, so the list always returns in the home view.
         if self.live_send.is_some() && self.sidebar_collapsed {
             self.divider_col = None;
+            // render_list is skipped, so its hit-test rects would otherwise
+            // keep last frame's values and a click in the now-preview area
+            // could resolve to an invisible list row (and switch the live
+            // target). Zero them so mouse hit-testing can't target the
+            // hidden sidebar.
+            self.list_area = Rect::default();
+            self.list_inner_area = Rect::default();
             self.render_preview(frame, main_chunks[0], theme);
         } else if available_width < responsive::STACKED_BREAKPOINT {
             let main_height = main_chunks[0].height;

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -491,7 +491,14 @@ impl HomeView {
         // stacking gives the preview the full width.
         let available_width = main_chunks[0].width;
         self.main_area_width = available_width;
-        if available_width < responsive::STACKED_BREAKPOINT {
+        // Collapsed sidebar (live mode only): hand the whole main area to
+        // the preview so the agent pane fills the terminal. The live-send
+        // resize loop then reflows the agent to the wider geometry. Reset
+        // on live-send exit, so the list always returns in the home view.
+        if self.live_send.is_some() && self.sidebar_collapsed {
+            self.divider_col = None;
+            self.render_preview(frame, main_chunks[0], theme);
+        } else if available_width < responsive::STACKED_BREAKPOINT {
             let main_height = main_chunks[0].height;
             let list_height = responsive::stacked_list_height(main_height);
             let chunks = Layout::default()
@@ -2099,6 +2106,37 @@ impl HomeView {
             // dialog's title.
             let raw_title = live_send::format_target_label(base_title, state.target);
             let chip = " \u{25CF} LIVE \u{2192} ";
+            let chip_style = Style::default()
+                .fg(theme.background)
+                .bg(theme.running)
+                .bold();
+
+            // Which-key menu: the leader is armed, so surface the live-send
+            // commands the next key can pick instead of the normal exit
+            // hint. This is the discoverability moment the issue asked for;
+            // pressing the leader shows exactly what it does.
+            if self.live_send_pending_leader {
+                if let Some(leader) = state.leader {
+                    let lead = live_send::display_chord(leader);
+                    let sidebar_cmd = if self.sidebar_collapsed {
+                        "b show sidebar"
+                    } else {
+                        "b hide sidebar"
+                    };
+                    let menu =
+                        format!("  {lead}:  k palette \u{00b7} {sidebar_cmd} \u{00b7} q exit ");
+                    let menu_budget = (area.width as usize)
+                        .saturating_sub(unicode_width::UnicodeWidthStr::width(chip));
+                    let menu = truncate_to_width(&menu, menu_budget);
+                    let spans = vec![
+                        Span::styled(chip, chip_style),
+                        Span::styled(menu, Style::default().fg(theme.accent).bold()),
+                    ];
+                    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+                    return;
+                }
+            }
+
             // The chord display is built from the user's configured
             // exit-chord list so the hint always shows what actually
             // exits live mode for this user. Empty list (impossible
@@ -2112,6 +2150,14 @@ impl HomeView {
                 live_send::display_chord_list(&state.exit_chords)
             };
             let suffix = " to exit ";
+            // Compact reminder that the leader opens the command menu, so
+            // the user can discover the palette / sidebar toggle without
+            // having entered the menu yet. Empty when the leader is
+            // disabled (the user cleared the setting).
+            let leader_hint = state
+                .leader
+                .map(|l| format!(" \u{00b7} {} menu", live_send::display_chord(l)))
+                .unwrap_or_default();
             // `preview_visible_rows` is the output-body height the renderer
             // last painted into (pane height minus the inner banner row only
             // when that banner is shown). Reuse it so the live `[offset/max]`
@@ -2136,17 +2182,12 @@ impl HomeView {
                 + 2 // double space before the chord
                 + unicode_width::UnicodeWidthStr::width(chord.as_str())
                 + unicode_width::UnicodeWidthStr::width(suffix)
+                + unicode_width::UnicodeWidthStr::width(leader_hint.as_str())
                 + unicode_width::UnicodeWidthStr::width(scroll.as_str());
             let title_budget = (area.width as usize).saturating_sub(fixed_width);
             let title = truncate_to_width(&raw_title, title_budget);
             let mut spans: Vec<Span<'static>> = vec![
-                Span::styled(
-                    chip,
-                    Style::default()
-                        .fg(theme.background)
-                        .bg(theme.running)
-                        .bold(),
-                ),
+                Span::styled(chip, chip_style),
                 Span::raw(" "),
                 Span::styled(title, Style::default().fg(theme.text).bold()),
             ];
@@ -2162,6 +2203,12 @@ impl HomeView {
                 Style::default().fg(theme.accent).bold(),
             ));
             spans.push(Span::styled(suffix, Style::default().fg(theme.dimmed)));
+            if !leader_hint.is_empty() {
+                spans.push(Span::styled(
+                    leader_hint,
+                    Style::default().fg(theme.dimmed).italic(),
+                ));
+            }
             frame.render_widget(Paragraph::new(Line::from(spans)), area);
             return;
         }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6224,6 +6224,52 @@ mod scroll_pane_isolation {
         assert!(!env.view.live_send_pending_leader);
     }
 
+    /// A modified key after the leader (e.g. Ctrl+K) cancels the menu
+    /// rather than firing a command: only the leader-again passthrough
+    /// claims a modified form, so the user can't accidentally trigger the
+    /// palette by holding Ctrl out of muscle memory.
+    #[test]
+    #[serial]
+    fn live_leader_then_modified_key_cancels() {
+        let mut env = live_env_with_leader();
+        env.view.handle_key(ctrl('b'), None);
+        env.view.handle_key(ctrl('k'), None);
+        assert!(!env.view.live_send_pending_leader, "menu disarms");
+        assert!(
+            env.view.command_palette.is_none(),
+            "leader + Ctrl+K must NOT open the palette"
+        );
+        assert!(env.view.live_send.is_some(), "still live");
+    }
+
+    /// Committing a palette command while live (here a jump) exits live
+    /// mode first, so the preview can never show one session while
+    /// keystrokes target another. Cancelling the palette is covered
+    /// separately and must stay live.
+    #[test]
+    #[serial]
+    fn palette_command_while_live_exits_live() {
+        let mut env = live_env_with_leader();
+        // Open the palette from within live mode via the leader.
+        env.view.handle_key(ctrl('b'), None);
+        env.view.handle_key(key(KeyCode::Char('k')), None);
+        assert!(env.view.command_palette.is_some());
+        assert!(env.view.live_send.is_some(), "palette opens over live mode");
+
+        // Filter to a jump entry and commit it.
+        for ch in "jump".chars() {
+            env.view.handle_key(key(KeyCode::Char(ch)), None);
+        }
+        env.view.handle_key(key(KeyCode::Enter), None);
+
+        assert!(
+            env.view.live_send.is_none(),
+            "committing a palette command must drop out of live mode"
+        );
+        assert!(env.view.command_palette.is_none());
+        assert!(!env.view.sidebar_collapsed, "live-only state is reset");
+    }
+
     /// Collapsing the sidebar in live mode hands the preview the full
     /// width: the preview sub-rect grows past the normal side-by-side
     /// width, and rendering the which-key banner doesn't panic.

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6114,7 +6114,7 @@ mod scroll_pane_isolation {
         env.view.update_selected();
         let id = match env.view.flat_items.get(1) {
             Some(Item::Session { id, .. }) => id.clone(),
-            _ => "fake".to_string(),
+            _ => panic!("fixture should have a session at flat_items[1]"),
         };
         env.view.live_send = Some(LiveSendState {
             session_id: id,
@@ -6299,6 +6299,17 @@ mod scroll_pane_isolation {
         assert!(
             full_width > split_width,
             "collapsed sidebar should widen the preview ({full_width} vs {split_width})"
+        );
+        // The list isn't drawn while collapsed, so its hit-test rects must
+        // be cleared or a click in the preview area could resolve to a
+        // hidden list row.
+        assert!(
+            env.view.list_inner_area.width == 0 && env.view.list_inner_area.height == 0,
+            "collapsed sidebar must clear the list hit-test rect"
+        );
+        assert!(
+            env.view.handle_click(2, 2).is_none(),
+            "a click in collapsed live mode must not resolve to a list row"
         );
 
         // The which-key banner renders without panicking while armed.

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -191,6 +191,7 @@ fn preview_info_follows_flag_and_never_auto_shows_in_live() {
         tmux_name: "aoe_test_live".to_string(),
         target: LiveSendTarget::Agent,
         exit_chords: Vec::new(),
+        leader: None,
     };
 
     // Hidden via the toggle: gone outside live...
@@ -6062,6 +6063,7 @@ mod scroll_pane_isolation {
             exit_chords: crate::tui::home::live_send::parse_chord_list(
                 crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
             ),
+            leader: None,
         });
 
         let up_handled = env.view.handle_scroll_up(50, 10);
@@ -6093,11 +6095,169 @@ mod scroll_pane_isolation {
             exit_chords: crate::tui::home::live_send::parse_chord_list(
                 crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
             ),
+            leader: None,
         });
 
         let handled = env.view.handle_scroll_down(5, 10);
         assert!(!handled, "list scroll must be a no-op in live mode");
         assert_eq!(env.view.cursor, 1, "selection must not change in live mode");
+    }
+
+    /// Build a live-send env with the default Ctrl+B leader armed and the
+    /// cursor on a real session, so leader-menu keys route through
+    /// `handle_live_send_key`.
+    fn live_env_with_leader() -> TestEnv {
+        use crate::tui::home::live_send::LiveSendState;
+        let mut env = create_test_env_with_sessions(3);
+        setup_panes(&mut env);
+        env.view.cursor = 1;
+        env.view.update_selected();
+        let id = match env.view.flat_items.get(1) {
+            Some(Item::Session { id, .. }) => id.clone(),
+            _ => "fake".to_string(),
+        };
+        env.view.live_send = Some(LiveSendState {
+            session_id: id,
+            title: "session".to_string(),
+            tmux_name: "fake".to_string(),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
+            exit_chords: crate::tui::home::live_send::parse_chord_list(
+                crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
+            ),
+            leader: crate::tui::home::live_send::parse_chord(
+                crate::tui::home::live_send::DEFAULT_LEADER,
+            ),
+        });
+        env
+    }
+
+    fn ctrl(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    /// Pressing the leader arms the menu (swallowed, not forwarded);
+    /// the follow-up `b` toggles the sidebar and disarms.
+    #[test]
+    #[serial]
+    fn live_leader_b_toggles_sidebar() {
+        let mut env = live_env_with_leader();
+        assert!(!env.view.sidebar_collapsed);
+
+        env.view.handle_key(ctrl('b'), None);
+        assert!(
+            env.view.live_send_pending_leader,
+            "leader press should arm the menu"
+        );
+        assert!(
+            !env.view.sidebar_collapsed,
+            "leader alone must not toggle anything yet"
+        );
+
+        env.view.handle_key(key(KeyCode::Char('b')), None);
+        assert!(!env.view.live_send_pending_leader, "menu should disarm");
+        assert!(env.view.sidebar_collapsed, "leader+b hides the sidebar");
+
+        // And again to reveal it.
+        env.view.handle_key(ctrl('b'), None);
+        env.view.handle_key(key(KeyCode::Char('b')), None);
+        assert!(!env.view.sidebar_collapsed, "leader+b again shows it");
+    }
+
+    /// Leader + k opens the command palette over live mode.
+    #[test]
+    #[serial]
+    fn live_leader_k_opens_palette() {
+        let mut env = live_env_with_leader();
+        env.view.handle_key(ctrl('b'), None);
+        env.view.handle_key(key(KeyCode::Char('k')), None);
+        assert!(!env.view.live_send_pending_leader);
+        assert!(
+            env.view.command_palette.is_some(),
+            "leader+k should open the command palette"
+        );
+        // Live mode is still active underneath the palette overlay.
+        assert!(env.view.live_send.is_some());
+    }
+
+    /// Leader + q exits live mode and resets the live-only UI state.
+    #[test]
+    #[serial]
+    fn live_leader_q_exits() {
+        let mut env = live_env_with_leader();
+        env.view.sidebar_collapsed = true;
+        env.view.handle_key(ctrl('b'), None);
+        env.view.handle_key(key(KeyCode::Char('q')), None);
+        assert!(env.view.live_send.is_none(), "leader+q exits live mode");
+        assert!(
+            !env.view.sidebar_collapsed,
+            "exiting must re-reveal the sidebar"
+        );
+        assert!(!env.view.live_send_pending_leader);
+    }
+
+    /// An unbound key after the leader cancels the menu without exiting,
+    /// toggling, or opening anything (it does not fall through to the
+    /// agent either: the leader already swallowed it).
+    #[test]
+    #[serial]
+    fn live_leader_unknown_key_cancels_menu() {
+        let mut env = live_env_with_leader();
+        env.view.handle_key(ctrl('b'), None);
+        env.view.handle_key(key(KeyCode::Char('z')), None);
+        assert!(!env.view.live_send_pending_leader, "menu disarms");
+        assert!(env.view.live_send.is_some(), "still live");
+        assert!(!env.view.sidebar_collapsed);
+        assert!(env.view.command_palette.is_none());
+    }
+
+    /// The fast exit chord (Ctrl+Q) stays a single press, independent of
+    /// the leader: it must not require arming the menu first.
+    #[test]
+    #[serial]
+    fn live_ctrl_q_still_one_press_exit() {
+        let mut env = live_env_with_leader();
+        env.view.handle_key(ctrl('q'), None);
+        assert!(
+            env.view.live_send.is_none(),
+            "Ctrl+Q exits in a single press"
+        );
+        assert!(!env.view.live_send_pending_leader);
+    }
+
+    /// Collapsing the sidebar in live mode hands the preview the full
+    /// width: the preview sub-rect grows past the normal side-by-side
+    /// width, and rendering the which-key banner doesn't panic.
+    #[test]
+    #[serial]
+    fn collapsed_sidebar_gives_preview_full_width() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut env = live_env_with_leader();
+        let theme = crate::tui::styles::load_theme("empire");
+
+        let render = |env: &mut TestEnv| {
+            let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+            terminal
+                .draw(|f| {
+                    let area = f.area();
+                    env.view.render(f, area, &theme, None, None);
+                })
+                .unwrap();
+            env.view.preview_pane_area.width
+        };
+
+        let split_width = render(&mut env);
+        env.view.sidebar_collapsed = true;
+        let full_width = render(&mut env);
+        assert!(
+            full_width > split_width,
+            "collapsed sidebar should widen the preview ({full_width} vs {split_width})"
+        );
+
+        // The which-key banner renders without panicking while armed.
+        env.view.live_send_pending_leader = true;
+        let _ = render(&mut env);
     }
 }
 
@@ -6525,6 +6685,7 @@ mod click_to_select {
             tmux_name: format!("aoe_test_{}", id_a),
             target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: Vec::new(),
+            leader: None,
         });
 
         // Click session B's row.
@@ -6560,6 +6721,7 @@ mod click_to_select {
             tmux_name: format!("aoe_test_{}", id_a),
             target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: Vec::new(),
+            leader: None,
         });
 
         let action = env.view.handle_click(5, 3);
@@ -6939,6 +7101,7 @@ mod preview_drag_select {
             tmux_name: "aoe_test_drag_select".to_string(),
             target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: Vec::new(),
+            leader: None,
         });
     }
 
@@ -7302,6 +7465,7 @@ mod preview_drag_select {
             tmux_name: "aoe_test_full_pipeline".to_string(),
             target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: Vec::new(),
+            leader: None,
         });
 
         // Find a row in the preview area that actually has text in
@@ -7427,6 +7591,7 @@ mod live_send_mode {
             exit_chords: crate::tui::home::live_send::parse_chord_list(
                 crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
             ),
+            leader: None,
         });
         id
     }
@@ -7443,6 +7608,7 @@ mod live_send_mode {
             exit_chords: crate::tui::home::live_send::parse_chord_list(
                 crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
             ),
+            leader: None,
         });
     }
 
@@ -9143,6 +9309,7 @@ mod right_click_context_menu {
             tmux_name: "aoe_test_empty_click_exit_live".to_string(),
             target: live_send::LiveSendTarget::Agent,
             exit_chords: live_send::parse_chord_list(live_send::DEFAULT_EXIT_CHORD),
+            leader: None,
         });
         assert!(env.view.live_send.is_some());
         assert!(env.view.handle_empty_list_click(5, 5));

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -110,6 +110,7 @@ pub enum FieldKey {
     HostEnvironment,
     SessionIdPollerMaxThreads,
     LiveSendExitChord,
+    LiveSendLeader,
     NewSessionAttachMode,
     DefaultAttachMode,
     ClickAction,
@@ -1991,6 +1992,12 @@ fn build_interaction_fields(
         session.and_then(|s| s.live_send_exit_chord.clone()),
     );
 
+    let (live_send_leader, live_send_leader_override) = resolve_value(
+        scope,
+        global.session.live_send_leader.clone(),
+        session.and_then(|s| s.live_send_leader.clone()),
+    );
+
     let (new_session_attach_mode, new_session_attach_mode_override) = resolve_value(
         scope,
         global.session.new_session_attach_mode,
@@ -2110,6 +2117,23 @@ fn build_interaction_fields(
             inherited_display: inherited_if(
                 live_send_exit_chord_override,
                 FieldValue::Text(global.session.live_send_exit_chord.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::LiveSendLeader,
+            label: "Live-Send Leader",
+            description: "Tmux-style leader (prefix) chord for live-send commands. \
+                 Default `C-b` matches tmux. In live mode the leader arms a \
+                 menu: leader then `k` opens the command palette, `b` toggles \
+                 the sidebar, `q` exits. Press the leader twice to send it \
+                 through to the agent. Leave empty to disable the leader. The \
+                 exit chord above stays a separate single-press exit.",
+            value: FieldValue::Text(live_send_leader),
+            category: SettingsCategory::Interaction,
+            has_override: live_send_leader_override,
+            inherited_display: inherited_if(
+                live_send_leader_override,
+                FieldValue::Text(global.session.live_send_leader.clone()),
             ),
         },
         SettingField {
@@ -2612,6 +2636,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         }
         (FieldKey::LiveSendExitChord, FieldValue::Text(v)) => {
             config.session.live_send_exit_chord = v.clone();
+        }
+        (FieldKey::LiveSendLeader, FieldValue::Text(v)) => {
+            config.session.live_send_leader = v.clone();
         }
         (FieldKey::NewSessionAttachMode, FieldValue::Select { selected, .. }) => {
             config.session.new_session_attach_mode = index_to_new_session_attach_mode(*selected);
@@ -3117,6 +3144,11 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
         (FieldKey::LiveSendExitChord, FieldValue::Text(v)) => {
             set_profile_override(v.clone(), &mut config.session, |s, val| {
                 s.live_send_exit_chord = val
+            });
+        }
+        (FieldKey::LiveSendLeader, FieldValue::Text(v)) => {
+            set_profile_override(v.clone(), &mut config.session, |s, val| {
+                s.live_send_leader = val
             });
         }
         (FieldKey::NewSessionAttachMode, FieldValue::Select { selected, .. }) => {
@@ -3831,6 +3863,7 @@ mod tests {
             FieldKey::NewSessionAttachMode,
             FieldKey::ClickAction,
             FieldKey::LiveSendExitChord,
+            FieldKey::LiveSendLeader,
             FieldKey::MouseCapture,
         ] {
             assert!(

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -777,6 +777,11 @@ impl SettingsView {
                     s.live_send_exit_chord = None;
                 }
             }
+            FieldKey::LiveSendLeader => {
+                if let Some(ref mut s) = config.session {
+                    s.live_send_leader = None;
+                }
+            }
             FieldKey::NewSessionAttachMode => {
                 if let Some(ref mut s) = config.session {
                     s.new_session_attach_mode = None;

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -96,6 +96,13 @@ const PAGES = [
     description:
       "Launch a session in a fresh scratch directory under ~/.agent-of-empires/scratch/ with no project path. The directory is removed when the session is deleted.",
   },
+  {
+    source: "docs/guides/live-mode.md",
+    dest: "guides/live-mode.md",
+    title: "Live Mode",
+    description:
+      "A feels-attached alternative to a full tmux attach: the dashboard stays visible while keystrokes relay to the agent. Covers the Ctrl+B leader menu, the collapsible sidebar, scrolling, and the exit chord.",
+  },
 
   // --- Docs pages (docs/ → pages/docs/) ---
   {
@@ -271,6 +278,7 @@ const URL_MAP = {
   "docs/guides/session-resume.md": "/guides/session-resume/",
   "docs/guides/multi-repo-workspaces.md": "/guides/multi-repo-workspaces/",
   "docs/guides/scratch-sessions.md": "/guides/scratch-sessions/",
+  "docs/guides/live-mode.md": "/guides/live-mode/",
   "docs/guides/tool-sessions.md": "/guides/tool-sessions/",
   "docs/guides/podman.md": "/guides/podman/",
   "docs/guides/apple-containers.md": "/guides/apple-containers/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -24,6 +24,7 @@ export const docsNav: NavSection[] = [
       { title: "Docker Sandbox", href: "/guides/sandbox/" },
       { title: "Podman", href: "/guides/podman/" },
       { title: "Apple Containers", href: "/guides/apple-containers/" },
+      { title: "Live Mode", href: "/guides/live-mode/" },
       { title: "Web Dashboard", href: "/guides/web-dashboard/" },
       { title: "Cockpit (Native Agent Rendering)", href: "/docs/cockpit/" },
       { title: "Cockpit Multi-Agent Support", href: "/docs/cockpit/multi-agent/" },


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Closes the live-mode half of #1527.

Live mode forwards almost every keystroke straight to the agent's tmux pane, so until now the only aoe control you could reach while attached was the exit chord. Users kept reaching for `Ctrl+K` (command palette) and got bash's kill-to-end-of-line instead, and there was no way to reclaim screen space.

This adds a configurable tmux-style leader (prefix) chord, default `Ctrl+B` to line up with tmux and herdr, plus a collapsible sidebar:

- `Ctrl+B` then `k`: open the command palette
- `Ctrl+B` then `b`: hide / show the sidebar (preview takes the full terminal width)
- `Ctrl+B` then `q`: exit live mode
- `Ctrl+B` twice: send a literal `Ctrl+B` to the agent (tmux `send-prefix` parity)
- `Ctrl+Q`: unchanged single-press fast exit, independent of the leader

Why `Ctrl+B` rather than a direct `Ctrl+K`: in live mode every chord we intercept is one the agent can no longer receive. A prefix steals exactly one chord (and double-tap still delivers it), so `Ctrl+K` stays free for readline kill-line, which was the original complaint. The normal TUI and web command palettes keep their `Ctrl/Cmd+K` binding since those contexts own the keyboard. The leader is configurable via the new `live_send_leader` setting (empty disables it; a typo falls back to the default).

Discoverability was a specific ask in the thread: the live banner now shows `Ctrl+B menu`, and pressing the leader turns the banner into a which-key menu listing the commands.

The collapsible sidebar is live-mode-only and ephemeral. Collapsing reflows the preview to full width (the existing live-resize loop pushes the new geometry to the agent's pane); exiting live mode always re-reveals the list, so you can never get stranded with a hidden sidebar in the normal view.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(No `docs/` page exists for live mode yet; the thread flagged that as a separate gap. The new setting carries an inline description in the settings TUI. Recording: noting this is a terminal keybinding flow; happy to attach an asciinema via the `needs-recording` label if preferred.)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (TUI / serve config only; no web control added)

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: covered by lib-level tests instead. Added 8 unit tests for leader arm/dispatch (palette, sidebar toggle, exit, double-tap passthrough, unknown-key cancel), the single-press `Ctrl+Q` exit, default-leader parsing, and a `TestBackend` render smoke test proving the collapsed sidebar widens the preview and the which-key banner renders. A full-binary live-send e2e needs a real agent in tmux, and the prior live-send-cycle e2e was removed for cross-platform flakiness (see note in `tests/e2e/new_session.rs`), so I kept coverage at the input/render layer.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude researched the tmux/herdr leader conventions and the readline/nested-tmux collision tradeoffs, then implemented and tested the change. Decisions (leader choice, keeping `Ctrl+Q` as a separate fast exit, scoping collapse to live mode) were made in discussion with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a configurable tmux-style leader (default Ctrl+B) and an ephemeral, collapsible sidebar in live mode, plus related settings, UI updates, tests, docs, and a small test/hardening fix.

High-level (non-technical)
- Leader prefix: press the leader to arm a short which-key menu. After the leader:
  - leader then leader: send a literal leader to the agent
  - leader + k: open the command palette
  - leader + b: hide/show the sidebar (preview expands to full width)
  - leader + q: exit live mode
- Ctrl+Q remains an unchanged single-press fast exit.
- Collapsible sidebar: hides the session list only in live mode and expands the preview; exiting live mode always restores the sidebar.
- Configuration: new setting to rebind or disable the leader.
- UX: status bar shows a compact leader hint and an inline which-key-style menu when the leader is armed.
- Tests/docs: unit tests added/expanded; a Live Mode guide added; a flaky tmux-dependent e2e was removed. A small fix clears list hit-test rects when the sidebar is collapsed to avoid clicks resolving to hidden rows.

What was added / moved / removed (concise)
- Added session config field live_send_leader (default "C-b") with per-profile override support and settings UI integration.
- HomeView: added live_send_pending_leader and sidebar_collapsed state; added toggle_sidebar_collapsed().
- LiveSendState: snapshots an optional parsed leader chord at entry time.
- Input handling: arms/dispatches leader commands, treats double-tap as passthrough, cancels on unknown/modified follow-ups, and ensures palette commands pre-exit live-send.
- Rendering: when sidebar_collapsed during live-send, preview reflows to full width, divider removed, list hit-test rects cleared; status bar includes leader hint and which-key menu.
- Tests: ~8 new unit tests for leader behavior + expanded live-send rendering tests; removed one flaky tmux-dependent full-binary e2e.
- Docs/website: new docs/guides/live-mode.md and sync updates.

Technical notes / implementation details
- DEFAULT_LEADER = "C-b"; empty config disables the leader; unparsable specs fall back to default with a warning.
- Leader parsing is snapshotted on live-send entry so mid-session config changes don’t affect the active session.
- Exiting live-send clears pending leader state and forces sidebar reappearance to avoid persistent half-armed/collapsed UI.
- Leader follow-ups must be unmodified single keys; modified keys cancel the menu.
- Added test hardening: clear hit-test rects when sidebar collapsed and make fixture setup fail-fast to surface regressions.

Benefits
- Adds discoverable, low-interference live-mode controls that preserve single-key agent shortcuts.
- Enables distraction-free, full-width preview during live interactions.
- Configurable and predictable behavior via snapshotting and explicit state resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->