### PR TITLE
feat(cockpit): per-kind tool cards in the TUI cockpit transcript

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -102,6 +102,16 @@ uses text attributes only (bold, italic, dim) so it tracks your theme
 colors. Code-block syntax highlighting is deferred; press `o` to open
 the web dashboard for full-fidelity rendering.
 
+**Tool cards.** Tool calls in the transcript render per kind rather than
+as a single generic line. An edit or write shows the file path and a
+compact added/removed line diff (colored with your theme's diff colors);
+an execute shows the command and a bounded preview of its output; a read
+shows the path and a content preview; a delete shows the target path.
+The diff is capped at 20 changed lines and previews at 12 lines, with a
+"+N more" footer when there is more; press `o` to open the web dashboard
+for the full diff and output. Any other tool kind falls back to the
+generic one-liner (name, arguments, output snapshot).
+
 ### Web composer Enter behavior
 
 On desktop, Enter sends the prompt and Shift+Enter inserts a

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -80,6 +80,12 @@ pub enum ActivityRow {
 #[derive(Debug, Clone)]
 pub struct ToolCallRow {
     pub name: String,
+    /// ACP `ToolKind` lowercased (`read` / `edit` / `delete` / `execute`
+    /// / …), forwarded from `ToolCall::kind`. Drives the per-kind
+    /// renderer in `render_tool_lines`; empty string falls back to the
+    /// generic one-liner. `ToolCallUpdated` does not carry kind, so the
+    /// value set at `ToolCallStarted` is authoritative for the row.
+    pub kind: String,
     pub args: String,
     pub completed: Option<ToolCompletion>,
 }
@@ -229,6 +235,7 @@ impl CockpitTranscript {
                 self.flush_pending_chunk();
                 let row = ToolCallRow {
                     name: tool_call.name.clone(),
+                    kind: tool_call.kind.clone(),
                     args: tool_call.args_preview.clone(),
                     completed: None,
                 };
@@ -561,6 +568,22 @@ mod tests {
                 let c = row.completed.as_ref().expect("completed");
                 assert!(c.ok);
                 assert_eq!(c.content, "ok");
+            }
+            _ => panic!("expected ToolCall"),
+        }
+    }
+
+    #[test]
+    fn tool_call_started_carries_kind_to_row() {
+        let mut t = CockpitTranscript::new("s-1");
+        let mut tc = tool("t-1", "Edit");
+        tc.kind = "edit".into();
+        tc.args_preview = r#"{"file_path":"a.rs","old_string":"x","new_string":"y"}"#.into();
+        t.apply(&frame(1, Event::ToolCallStarted { tool_call: tc }));
+        match &t.rows[0] {
+            ActivityRow::ToolCall(row) => {
+                assert_eq!(row.kind, "edit");
+                assert!(row.args.contains("old_string"));
             }
             _ => panic!("expected ToolCall"),
         }

--- a/src/tui/cockpit_view/render.rs
+++ b/src/tui/cockpit_view/render.rs
@@ -1,15 +1,18 @@
 //! Four-pane render of a cockpit session: transcript / status banner /
-//! queued-prompts strip / composer. Tool-card breakdowns are intentionally minimal in the MVP
-//! (one-liner per tool call); rich diff / image / file previews are
-//! deferred to the followup issues called out in the implementation
-//! plan. Press `o` from the transcript pane to open the web cockpit
-//! for full-fidelity inspection.
+//! queued-prompts strip / composer. Tool calls render through a
+//! per-kind dispatcher (`render_tool_lines`): edit/write show a compact
+//! line diff, execute shows the command and an output preview, read
+//! shows the path and a content preview, delete shows the path, and any
+//! other kind falls back to the generic one-liner. Image previews and
+//! syntax highlighting stay deferred to the web cockpit; press `o` from
+//! the transcript pane to open it for full-fidelity inspection.
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
 use ratatui::Frame;
+use similar::{ChangeTag, TextDiff};
 
 use super::input::Focus;
 use super::reducer::{ActivityRow, CockpitTranscript, NoteKind, ToolCallRow};
@@ -221,7 +224,12 @@ fn render_transcript(frame: &mut Frame, area: Rect, theme: &Theme, state: &Cockp
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let lines = transcript_lines(&state.transcript, state.selected_approval, state.focus);
+    let lines = transcript_lines(
+        &state.transcript,
+        state.selected_approval,
+        state.focus,
+        theme,
+    );
     // Clamp scroll against the *wrapped* visual row count, not
     // `lines.len()`. Streaming `AgentMessage` rows grew text inside
     // a single logical line: Paragraph's wrap inflated the
@@ -520,6 +528,7 @@ fn transcript_lines<'a>(
     transcript: &'a CockpitTranscript,
     selected_approval: Option<usize>,
     focus: Focus,
+    theme: &Theme,
 ) -> Vec<Line<'a>> {
     let mut out: Vec<Line<'a>> = Vec::new();
     let mut approval_render_idx: usize = 0;
@@ -537,7 +546,7 @@ fn transcript_lines<'a>(
                 out.push(Line::default());
             }
             ActivityRow::ToolCall(tool) => {
-                out.extend(render_tool_lines(tool));
+                out.extend(render_tool_lines(tool, theme));
                 out.push(Line::default());
             }
             ActivityRow::Approval(row) => {
@@ -625,7 +634,26 @@ fn truncate_chars(s: &str, max_chars: usize) -> Option<String> {
     }
 }
 
-fn render_tool_lines(tool: &ToolCallRow) -> Vec<Line<'static>> {
+/// Arg-name variants the agents use for a tool's primary path, command,
+/// and edit before/after text. Mirrors the web cockpit's `pickStr` key
+/// lists in `web/src/components/cockpit/ToolCards.tsx` so the TUI and the
+/// dashboard surface the same field across agent versions.
+const PATH_KEYS: &[&str] = &["path", "file_path", "filePath", "filename"];
+const OLD_KEYS: &[&str] = &["old_string", "oldString", "old_str"];
+const NEW_KEYS: &[&str] = &["new_string", "newString", "new_str", "content"];
+const CMD_KEYS: &[&str] = &["command", "cmd", "args"];
+
+/// +/- lines beyond this budget collapse into a "+N more" footer so a
+/// large Edit can't flood the transcript on a narrow terminal.
+const TOOL_DIFF_MAX_LINES: usize = 20;
+/// Read/execute output previews are capped to this many lines.
+const TOOL_PREVIEW_MAX_LINES: usize = 12;
+
+/// Render one tool call. Dispatches on `tool.kind` (the lowercased ACP
+/// `ToolKind`) to a per-kind body; any kind we don't special-case, or
+/// one whose args don't parse into the expected shape, falls back to the
+/// generic one-liner so unknown tools still render.
+fn render_tool_lines(tool: &ToolCallRow, theme: &Theme) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     let header = format!(
         "tool {} · {}",
@@ -640,6 +668,176 @@ fn render_tool_lines(tool: &ToolCallRow) -> Vec<Line<'static>> {
         header,
         Style::default().add_modifier(Modifier::BOLD),
     )));
+
+    let args = parse_args_object(&tool.args);
+    let body = match tool.kind.as_str() {
+        "edit" | "write" => render_edit_body(args.as_ref(), theme),
+        "execute" => render_execute_body(args.as_ref(), tool),
+        "read" => render_read_body(args.as_ref(), tool),
+        "delete" => render_delete_body(args.as_ref()),
+        _ => None,
+    };
+    lines.extend(body.unwrap_or_else(|| render_generic_body(tool)));
+    lines
+}
+
+/// Parse `args_preview` as a JSON object. Mirrors the web cockpit's
+/// `parseJsonObject`: returns `None` for non-object, unparsable, or
+/// truncated payloads so callers fall back to the generic renderer.
+fn parse_args_object(args: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+    match serde_json::from_str::<serde_json::Value>(args) {
+        Ok(serde_json::Value::Object(map)) => Some(map),
+        _ => None,
+    }
+}
+
+/// First string-valued key from `keys`, mirroring the web `pickStr`.
+fn pick_str<'a>(
+    args: Option<&'a serde_json::Map<String, serde_json::Value>>,
+    keys: &[&str],
+) -> Option<&'a str> {
+    let args = args?;
+    keys.iter().find_map(|k| match args.get(*k) {
+        Some(serde_json::Value::String(s)) => Some(s.as_str()),
+        _ => None,
+    })
+}
+
+/// Edit/Write: the file path plus a compact line diff built from the
+/// `old_string`/`new_string` (or `content`) args, the same source the
+/// web Edit card uses. `None` when no after-text arg is present (the
+/// generic renderer then handles it).
+fn render_edit_body(
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+    theme: &Theme,
+) -> Option<Vec<Line<'static>>> {
+    let new = pick_str(args, NEW_KEYS)?;
+    let old = pick_str(args, OLD_KEYS).unwrap_or("");
+    if old.is_empty() && new.is_empty() {
+        return None;
+    }
+    let path = pick_str(args, PATH_KEYS).unwrap_or("(unknown file)");
+    let mut lines = vec![Line::from(format!("  {path}"))];
+    lines.extend(diff_lines(old, new, theme));
+    Some(lines)
+}
+
+/// Compact line diff in the style of `src/tui/diff/render.rs`: only the
+/// changed (`+`/`-`) lines, bounded to `TOOL_DIFF_MAX_LINES`.
+fn diff_lines(old: &str, new: &str, theme: &Theme) -> Vec<Line<'static>> {
+    let diff = TextDiff::from_lines(old, new);
+    let mut out = Vec::new();
+    let mut hidden = 0usize;
+    for change in diff.iter_all_changes() {
+        let (sign, style) = match change.tag() {
+            ChangeTag::Delete => ("-", Style::default().fg(theme.diff_delete)),
+            ChangeTag::Insert => ("+", Style::default().fg(theme.diff_add)),
+            // Context lines carry no signal in the compact card; drop them.
+            ChangeTag::Equal => continue,
+        };
+        if out.len() >= TOOL_DIFF_MAX_LINES {
+            hidden += 1;
+            continue;
+        }
+        let text = change.value();
+        let text = text.strip_suffix('\n').unwrap_or(text);
+        out.push(Line::from(Span::styled(format!("  {sign} {text}"), style)));
+    }
+    if hidden > 0 {
+        out.push(Line::from(Span::styled(
+            format!("  … +{hidden} more diff lines; press `o` for full"),
+            Style::default().fg(theme.dimmed),
+        )));
+    }
+    if out.is_empty() {
+        out.push(Line::from(Span::styled(
+            "  (no textual changes)",
+            Style::default().fg(theme.dimmed),
+        )));
+    }
+    out
+}
+
+/// Execute: the command plus a bounded preview of its output.
+fn render_execute_body(
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+    tool: &ToolCallRow,
+) -> Option<Vec<Line<'static>>> {
+    let command = pick_str(args, CMD_KEYS)?;
+    let cmd_lines: Vec<&str> = command.lines().collect();
+    let mut lines = vec![Line::from(format!(
+        "  $ {}",
+        cmd_lines.first().copied().unwrap_or("")
+    ))];
+    if cmd_lines.len() > 1 {
+        lines.push(Line::from(Span::styled(
+            format!("    (+{} more command lines)", cmd_lines.len() - 1),
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+    }
+    lines.extend(output_preview_lines(tool));
+    Some(lines)
+}
+
+/// Read: the file path plus a bounded preview of the read content.
+fn render_read_body(
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+    tool: &ToolCallRow,
+) -> Option<Vec<Line<'static>>> {
+    let path = pick_str(args, PATH_KEYS)?;
+    let mut lines = vec![Line::from(format!("  {path}"))];
+    lines.extend(output_preview_lines(tool));
+    Some(lines)
+}
+
+/// Delete: just the target path.
+fn render_delete_body(
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> Option<Vec<Line<'static>>> {
+    let path = pick_str(args, PATH_KEYS)?;
+    Some(vec![Line::from(format!("  {path}"))])
+}
+
+/// Bounded preview of a tool's completion content, shared by the read
+/// and execute cards. Falls back to a status word before completion or
+/// when the agent shipped no body.
+fn output_preview_lines(tool: &ToolCallRow) -> Vec<Line<'static>> {
+    let Some(completion) = &tool.completed else {
+        return vec![Line::from(Span::styled(
+            "  (running…)",
+            Style::default().add_modifier(Modifier::DIM),
+        ))];
+    };
+    if completion.content.is_empty() {
+        let msg = if completion.ok {
+            "  (no output)"
+        } else {
+            "  (tool failed; press `o` for details)"
+        };
+        return vec![Line::from(msg.to_string())];
+    }
+    let mut out = Vec::new();
+    let total = completion.content.lines().count();
+    for line in completion.content.lines().take(TOOL_PREVIEW_MAX_LINES) {
+        out.push(Line::from(format!("  {line}")));
+    }
+    if total > TOOL_PREVIEW_MAX_LINES {
+        out.push(Line::from(Span::styled(
+            format!(
+                "  … +{} more lines; press `o` for full",
+                total - TOOL_PREVIEW_MAX_LINES
+            ),
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+    }
+    out
+}
+
+/// Generic one-liner fallback for unknown tool kinds: the truncated args
+/// preview plus a truncated output snapshot. This is the pre-#1702
+/// rendering, preserved verbatim so unrecognized tools are unchanged.
+fn render_generic_body(tool: &ToolCallRow) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
     if !tool.args.is_empty() {
         let truncated = match truncate_chars(&tool.args, 200) {
             Some(head) => format!("  $ {head}…"),
@@ -992,5 +1190,126 @@ mod tests {
             dump.contains(&format!("/{last_name}")),
             "selected row /{last_name} scrolled off-screen: {dump:?}"
         );
+    }
+    fn tool_row(kind: &str, args: &str, completion: Option<(bool, &str)>) -> ToolCallRow {
+        use super::super::reducer::ToolCompletion;
+        ToolCallRow {
+            name: "Tool".into(),
+            kind: kind.into(),
+            args: args.into(),
+            completed: completion.map(|(ok, content)| ToolCompletion {
+                ok,
+                content: content.into(),
+            }),
+        }
+    }
+
+    fn joined(lines: &[Line]) -> String {
+        lines.iter().map(line_text).collect::<Vec<_>>().join("\n")
+    }
+
+    #[test]
+    fn edit_kind_renders_added_and_removed_diff_lines() {
+        let row = tool_row(
+            "edit",
+            r#"{"file_path":"src/a.rs","old_string":"let x = 1;","new_string":"let x = 2;"}"#,
+            None,
+        );
+        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        assert!(out.contains("src/a.rs"), "path missing: {out:?}");
+        assert!(
+            out.contains("- let x = 1;"),
+            "removed line missing: {out:?}"
+        );
+        assert!(out.contains("+ let x = 2;"), "added line missing: {out:?}");
+    }
+
+    #[test]
+    fn write_kind_renders_all_inserts_from_content() {
+        let row = tool_row(
+            "write",
+            r#"{"file_path":"new.txt","content":"line one\nline two"}"#,
+            None,
+        );
+        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        assert!(out.contains("new.txt"));
+        assert!(out.contains("+ line one"), "{out:?}");
+        assert!(out.contains("+ line two"), "{out:?}");
+    }
+
+    #[test]
+    fn edit_diff_caps_at_budget_with_more_footer() {
+        // 30 changed lines exceed TOOL_DIFF_MAX_LINES (20).
+        let new_body: String = (0..30).map(|i| format!("line {i}\n")).collect();
+        let args =
+            serde_json::json!({ "file_path": "big.txt", "old_string": "", "new_string": new_body });
+        let row = tool_row("edit", &args.to_string(), None);
+        let lines = render_tool_lines(&row, &Theme::default());
+        let plus = lines
+            .iter()
+            .filter(|l| line_text(l).trim_start().starts_with("+ "))
+            .count();
+        assert_eq!(plus, TOOL_DIFF_MAX_LINES, "diff not capped: {plus}");
+        assert!(
+            joined(&lines).contains("+10 more diff lines"),
+            "missing more-footer: {:?}",
+            joined(&lines)
+        );
+    }
+
+    #[test]
+    fn execute_kind_renders_command_and_output_preview() {
+        let row = tool_row(
+            "execute",
+            r#"{"command":"ls -la"}"#,
+            Some((true, "file_a\nfile_b")),
+        );
+        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        assert!(out.contains("$ ls -la"), "command missing: {out:?}");
+        assert!(out.contains("file_a"), "output preview missing: {out:?}");
+        assert!(out.contains("file_b"), "{out:?}");
+    }
+
+    #[test]
+    fn read_kind_renders_path_and_content_preview() {
+        let row = tool_row(
+            "read",
+            r#"{"path":"src/lib.rs"}"#,
+            Some((true, "pub fn main() {}")),
+        );
+        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        assert!(out.contains("src/lib.rs"), "path missing: {out:?}");
+        assert!(
+            out.contains("pub fn main()"),
+            "content preview missing: {out:?}"
+        );
+    }
+
+    #[test]
+    fn delete_kind_renders_only_path() {
+        let row = tool_row("delete", r#"{"path":"old.txt"}"#, Some((true, "")));
+        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        assert!(out.contains("old.txt"), "path missing: {out:?}");
+        // No diff gutters for a delete.
+        assert!(!out.contains("+ "), "{out:?}");
+        assert!(!out.contains("- "), "{out:?}");
+    }
+
+    #[test]
+    fn unknown_kind_falls_back_to_generic_one_liner() {
+        let row = tool_row("fetch", "https://example.com", Some((true, "200 OK")));
+        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        // Generic body shows the raw args prefixed with `$ ` and the output.
+        assert!(out.contains("$ https://example.com"), "{out:?}");
+        assert!(out.contains("200 OK"), "{out:?}");
+    }
+
+    #[test]
+    fn edit_with_unparsable_args_falls_back_to_generic() {
+        // Truncated JSON (16KB ingest cap can clip mid-object) must not
+        // panic or vanish; it falls through to the generic renderer.
+        let row = tool_row("edit", r#"{"file_path":"a.rs","old_str"#, None);
+        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        assert!(out.contains("$ {\"file_path\""), "{out:?}");
     }
 }

--- a/tests/e2e/cockpit_tool_cards_e2e.rs
+++ b/tests/e2e/cockpit_tool_cards_e2e.rs
@@ -1,0 +1,183 @@
+//! Full-stack e2e: the native TUI cockpit renders a per-kind Edit card
+//! (a compact +/- line diff) instead of a generic one-liner. #1702.
+//!
+//! Per-kind dispatch is unit-tested at `src/tui/cockpit_view/render.rs`;
+//! this proves the same end-to-end: a real `aoe serve --daemon`, a real
+//! cockpit worker bridging a scripted ACP `tool_call` (kind `edit`,
+//! carrying `old_string`/`new_string` in `rawInput`), and the native TUI
+//! attached over tmux rendering the diff through the production path.
+//!
+//! Mirrors the web Edit-card story `edit-card-diff-scroll.spec.ts`: the
+//! fake-ACP `tool_call` shape (toolCallId / kind / status / rawInput) is
+//! identical, so the TUI and the dashboard exercise the same wire data.
+//!
+//! Compiled only with `--features serve`. Run via:
+//!
+//! ```sh
+//! cargo test --test e2e --features serve -- cockpit_tool_cards
+//! ```
+#![cfg(feature = "serve")]
+
+use std::time::{Duration, Instant};
+
+use serial_test::serial;
+
+use crate::harness::{pick_free_port, require_node, require_tmux, wait_for_port, TuiTestHarness};
+
+/// One-turn fake-ACP script: emit a single completed `edit` tool call
+/// whose `rawInput` carries the before/after text the cockpit turns into
+/// a diff. The turn ends immediately (no gating).
+const EDIT_SCRIPT: &str = r#"{
+  "turns": [
+    {
+      "updates": [
+        {
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-edit-1",
+          "title": "edit greeting.txt",
+          "kind": "edit",
+          "status": "completed",
+          "rawInput": {
+            "file_path": "greeting.txt",
+            "old_string": "hello from before",
+            "new_string": "hello from after"
+          }
+        }
+      ],
+      "stopReason": "end_turn"
+    }
+  ]
+}"#;
+
+/// Parse the `  ID:      <id>` line that `aoe add` prints on success.
+fn parse_session_id(add_stdout: &str) -> String {
+    add_stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("ID:"))
+        .map(|rest| rest.trim().to_string())
+        .unwrap_or_else(|| panic!("could not find session ID in `aoe add` output:\n{add_stdout}"))
+}
+
+/// Retry `aoe cockpit prompt` until accepted. The prompt POST 404s while
+/// the worker is still spawning / handshaking, so a successful call is
+/// the readiness oracle for "worker live + ACP handshake done".
+fn prompt_until_accepted(h: &TuiTestHarness, session_id: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let out = h.run_cli(&["cockpit", "prompt", session_id, "please edit a file"]);
+        if out.status.success() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            let ps = h.run_cli(&["cockpit", "ps", "--json"]);
+            panic!(
+                "cockpit worker never accepted a prompt within {:?}.\n\
+                 last prompt stdout: {}\n last prompt stderr: {}\n cockpit ps: {}",
+                timeout,
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr),
+                String::from_utf8_lossy(&ps.stdout),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// Stand up a live daemon, drive one scripted `edit` tool call, attach
+/// the native TUI cockpit, and assert the transcript shows the compact
+/// added/removed line diff rather than the generic one-liner.
+#[test]
+#[serial]
+fn tui_cockpit_renders_edit_diff_with_live_daemon() {
+    require_tmux!();
+    require_node!();
+
+    // HOME under /tmp: cockpit workers bind a unix socket under the app
+    // dir, and a deep tempdir overflows the macOS sun_path limit.
+    let mut h = TuiTestHarness::new_in_tmp("cockpit_tool_cards");
+
+    // Cockpit master flag on at rest so the daemon's reconciler spawns
+    // the worker for the cockpit-mode session.
+    h.enable_cockpit_master();
+
+    // Shared Node fake-ACP agent, scripted to emit one completed edit.
+    let script_path = h.home_path().join("edit-script.json");
+    std::fs::write(&script_path, EDIT_SCRIPT).expect("write fake-acp script");
+    h.install_acp_shim(&script_path);
+
+    // Tear down the worker + daemon on Drop so a panicking assertion can't
+    // leak a daemon onto the test port between serial tests.
+    h.stop_daemon_on_drop();
+
+    // A cockpit session needs a git repo as its workspace; create one.
+    let project = h.project_path();
+    for args in [
+        vec!["init", "-q"],
+        vec!["commit", "--allow-empty", "-q", "-m", "init"],
+    ] {
+        let out = std::process::Command::new("git")
+            .args(&args)
+            .current_dir(&project)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("run git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    // Start the daemon.
+    let port = pick_free_port();
+    let port_s = port.to_string();
+    let start = h.run_cli(&["serve", "--daemon", "--port", &port_s, "--no-auth"]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {}",
+        port
+    );
+
+    // Create the cockpit session (daemon picks it up off disk; the
+    // reconciler auto-spawns the worker since the master flag is on).
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "tool-cards",
+        "-c",
+        "claude",
+        "--cockpit",
+    ]);
+    assert!(
+        add.status.success(),
+        "aoe add --cockpit failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&add.stdout),
+        String::from_utf8_lossy(&add.stderr),
+    );
+    let session_id = parse_session_id(&String::from_utf8_lossy(&add.stdout));
+
+    // Drive the scripted edit turn. This also gates worker readiness: the
+    // prompt 404s until the worker is live and handshaked.
+    prompt_until_accepted(&h, &session_id, Duration::from_secs(30));
+
+    // Attach the native TUI cockpit view over tmux. Same HOME, so it
+    // discovers the local daemon via serve.url / serve.pid.
+    h.spawn(&["cockpit", "attach", &session_id]);
+
+    // The edit card must surface through the full stack (replay + WS):
+    // header + path + a removed line + an added line.
+    h.wait_for("greeting.txt");
+    h.assert_screen_contains("- hello from before");
+    h.assert_screen_contains("+ hello from after");
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -19,6 +19,7 @@ mod harness;
 
 mod cli;
 mod cockpit_focus_isolation_e2e;
+mod cockpit_tool_cards_e2e;
 mod command_palette;
 mod errors;
 mod intro;


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The native TUI cockpit rendered every tool call in the transcript as the same generic one-liner: name, a truncated args blob, and a truncated output snapshot. An Edit looked identical to a Read, and a file edit gave no visible diff, so the only way to see what an agent actually changed was to press `o` and open the web dashboard.

This adds per-kind tool cards to the TUI transcript, mirroring the web cockpit's cards:

- **edit / write**: the file path plus a compact added/removed line diff, built with `similar::TextDiff` and colored with the active theme's diff colors.
- **execute**: the command plus a bounded preview of its output.
- **read**: the file path plus a bounded content preview.
- **delete**: the target path.
- **anything else** (or any kind whose args don't parse): the unchanged generic one-liner, so unknown tools still render exactly as before.

The diff and previews parse the same `args_preview` JSON the web Edit/Read cards consume, using the same field-name variants (`path`/`file_path`, `old_string`/`old_str`, `command`/`cmd`, etc.), so no new wire data is needed and the two surfaces stay in sync. `ToolCall.kind` was already on the wire; the TUI reducer just dropped it. The diff is capped at 20 changed lines and previews at 12 lines, with a "+N more" footer, so a large edit can't flood a narrow transcript.

Closes #1702

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a cockpit session (`aoe add <repo> -c claude --cockpit`) and `aoe cockpit attach <id>`.
- [ ] Ask the agent to edit a file; confirm the transcript shows the file path and a `-`/`+` line diff (theme diff colors), not a one-liner.
- [ ] Ask it to run a shell command; confirm the card shows `$ <command>` and a bounded output preview.
- [ ] Ask it to read a file; confirm the card shows the path and a content preview.
- [ ] Trigger a large edit (20+ changed lines); confirm the diff caps with a "+N more diff lines" footer and `o` still opens the full diff in the web dashboard.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

`tests/e2e/cockpit_tool_cards_e2e.rs` drives a scripted ACP edit tool call through a live `aoe serve --daemon` + cockpit worker, attaches the native TUI, and asserts the `-`/`+` diff lines render. Render-layer unit tests in `src/tui/cockpit_view/render.rs` cover each kind (edit/write diff, execute, read, delete, unknown fallback, diff-budget cap, unparsable-args fallback), plus a reducer test that `ToolCallStarted` carries `kind` onto the row.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (mirror the web cards via `args_preview` rather than wiring the dead `DiffEmitted` event, 20-line diff budget, add an e2e on the now-landed cockpit harness) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Replaces the TUI cockpit’s generic one-line tool-call rendering with structured, per-kind tool cards that mirror the web cockpit. Tool calls in the transcript now present concise, themed diffs and previews so users get meaningful context in-terminal.

## What changed (non-technical)
- Documentation updated to describe "Tool cards" behavior and truncation hints.
- TUI now preserves tool kind for each recorded tool call.
- Rendering switched from a single generic line to per-kind compact cards for edit/write, execute, read, and delete; unknown or unparsable cases fall back to the original one-liner.
- Added tests: unit tests for render-layer behavior and an e2e TUI test driving a live daemon.

## What moved / added / removed
- Added per-kind rendering logic and theming in the TUI render layer (render.rs).
- ToolCallRow extended to retain kind when processing events (reducer.rs).
- New e2e test file and harness wiring to validate live edit-diff rendering (tests/e2e/cockpit_tool_cards_e2e.rs and tests/e2e/main.rs).
- Docs updated (docs/cockpit/interface.md).
- No public API/declaration changes.

## Key behaviors and limits
- Edit/write: shows file path + compact +/- line diff generated from existing args_preview JSON; diffs capped at 20 changed lines.
- Execute: shows command + bounded preview of command output.
- Read: shows path + bounded content preview.
- Delete: shows target path.
- Previews capped at 12 lines with a “+N more” footer to avoid flooding narrow terminals.
- Uses existing wire data (args_preview variants); no protocol changes.
- ToolCall.kind is preserved (previously dropped).

## Tests
- Unit tests cover per-kind rendering, diff generation and truncation, and JSON resilience.
- An e2e test boots a live daemon and asserts the compact edit diff appears in the native TUI.

## Benefits
- Improves visibility of tool activity directly in the TUI (diffs, outputs, file previews).
- Aligns TUI UX with the web cockpit for consistency.
- Keeps terminal output compact and readable via truncation and themed styling.
- Backwards-compatible: unknown kinds gracefully degrade to the prior behavior.

## Technical notes (concise)
- Diffs computed with similar::TextDiff and colored using the active theme.
- Args parsing reuses existing field-name variants from web cockpit; handles unparsable JSON by falling back.
- No exported function/type signatures changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->