### PR TITLE
perf(tui): move live-send preview capture off the render thread

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -539,6 +539,15 @@ impl App {
         // the 20Hz loop rate.
         let mut last_update_eval = std::time::Instant::now();
         const STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
+        // While in live-send, the off-thread capture worker forks
+        // `tmux capture-pane` continuously on a background thread. The
+        // status poller (also background) sweeps every session's pane plus
+        // container health on its own thread, and that concurrent tmux /
+        // docker load contends on the tmux server, inflating the capture
+        // fork's tail latency. The user is watching one session's preview,
+        // not the sidebar, so back the sweep off to 2s for the duration;
+        // the first tick after exit re-checks against the 500ms interval.
+        const STATUS_REFRESH_INTERVAL_LIVE: Duration = Duration::from_secs(2);
         const DISK_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
         // Fastest spinner (breathe) changes every 180ms; 120ms ensures smooth animation
         const SPINNER_REDRAW_INTERVAL: Duration = Duration::from_millis(120);
@@ -1056,7 +1065,12 @@ impl App {
                 needs_full_refresh = true;
             }
 
-            if last_status_refresh.elapsed() >= STATUS_REFRESH_INTERVAL {
+            let status_interval = if self.home.live_send.is_some() {
+                STATUS_REFRESH_INTERVAL_LIVE
+            } else {
+                STATUS_REFRESH_INTERVAL
+            };
+            if last_status_refresh.elapsed() >= status_interval {
                 self.home.request_status_refresh();
                 last_status_refresh = std::time::Instant::now();
             }
@@ -1249,6 +1263,10 @@ impl App {
             self.update_status = None;
         }
         let status_text = self.update_status.as_ref().map(|s| s.text.as_str());
+        // Reset before the render so a frame that skips the preview path
+        // (dialog open, non-home view) reads as zero capture/parse rather
+        // than leaking the previous frame's durations.
+        self.home.preview_timings = Default::default();
         self.home.render(
             frame,
             frame.area(),
@@ -1256,19 +1274,30 @@ impl App {
             self.update_info.as_ref(),
             status_text,
         );
-        // Sampled / slow-frame only: full-frame trace would dominate the
-        // log at `default_level = trace`. Only emit when a frame breaks the
-        // 16ms budget (60fps), which is the diagnostic case worth tracing.
+        // Sampled trace for frame-budget diagnostics. A full-frame trace on
+        // every paint would dominate the log at `default_level = trace`, so
+        // we only emit for (a) frames that break the 16ms / 60fps budget and
+        // (b) live-send frames, where the per-frame `tmux capture-pane` fork
+        // is the latency we're profiling and individual frames usually stay
+        // under 16ms. `capture_us` / `parse_us` break the frame down into the
+        // capture fork vs. the `ansi-to-tui` parse; the remainder (frame_ms
+        // minus those two) is the widget build + ratatui diff.
         let elapsed = start.elapsed();
-        if elapsed.as_millis() > 16
+        let in_live = self.home.live_send.is_some();
+        if (elapsed.as_millis() > 16 || in_live)
             && tracing::enabled!(target: "tui.render", tracing::Level::TRACE)
         {
+            let timings = self.home.preview_timings;
             tracing::trace!(
                 target: "tui.render",
                 frame_ms = elapsed.as_millis() as u64,
+                frame_us = elapsed.as_micros() as u64,
+                capture_us = timings.capture.as_micros() as u64,
+                parse_us = timings.parse.as_micros() as u64,
+                live = in_live,
                 width = frame.area().width,
                 height = frame.area().height,
-                "slow frame",
+                "render frame sample",
             );
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -539,15 +539,6 @@ impl App {
         // the 20Hz loop rate.
         let mut last_update_eval = std::time::Instant::now();
         const STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
-        // While in live-send, the off-thread capture worker forks
-        // `tmux capture-pane` continuously on a background thread. The
-        // status poller (also background) sweeps every session's pane plus
-        // container health on its own thread, and that concurrent tmux /
-        // docker load contends on the tmux server, inflating the capture
-        // fork's tail latency. The user is watching one session's preview,
-        // not the sidebar, so back the sweep off to 2s for the duration;
-        // the first tick after exit re-checks against the 500ms interval.
-        const STATUS_REFRESH_INTERVAL_LIVE: Duration = Duration::from_secs(2);
         const DISK_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
         // Fastest spinner (breathe) changes every 180ms; 120ms ensures smooth animation
         const SPINNER_REDRAW_INTERVAL: Duration = Duration::from_millis(120);
@@ -1065,12 +1056,7 @@ impl App {
                 needs_full_refresh = true;
             }
 
-            let status_interval = if self.home.live_send.is_some() {
-                STATUS_REFRESH_INTERVAL_LIVE
-            } else {
-                STATUS_REFRESH_INTERVAL
-            };
-            if last_status_refresh.elapsed() >= status_interval {
+            if last_status_refresh.elapsed() >= STATUS_REFRESH_INTERVAL {
                 self.home.request_status_refresh();
                 last_status_refresh = std::time::Instant::now();
             }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3615,6 +3615,7 @@ impl HomeView {
         session.reset_size_to_latest_client();
         self.live_send = None;
         self.live_send_worker = None;
+        self.live_capture_worker = None;
         self.live_send_last_resize = None;
         // Live mode just owned the pane's size; the non-live preview must
         // re-assert its geometry on the next render now that the header is

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -437,20 +437,24 @@ impl LiveSendWorker {
 
 /// How often the off-thread capture worker forks `tmux capture-pane`.
 /// It free-runs at roughly this cadence (a fork is ~3-13ms on macOS, so
-/// the real cycle is interval + fork time), keeping the preview cache
-/// fresh on a background thread so the render loop never forks
-/// capture-pane itself. A touch tighter than the 33ms render ticker so a
-/// frame almost always finds content that postdates the last keystroke.
-const LIVE_CAPTURE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
+/// the real cycle is interval + fork time), keeping the preview fresh on
+/// a background thread so the render loop never forks capture-pane
+/// itself. Sits just under the 33ms render ticker so a frame almost
+/// always finds content that postdates the last keystroke, while keeping
+/// the steady-state fork rate close to the old render-driven ~30/s (a
+/// tighter value buys little perceived freshness for a lot more idle
+/// forks, since the render only paints every ~33ms anyway).
+const LIVE_CAPTURE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
 /// Off-thread preview capture for agent live-send. Spawned alongside
 /// [`LiveSendWorker`] when live-send targets the agent pane, it forks
-/// `tmux capture-pane` on its own thread and ships fresh pane content
-/// back to the render loop over a channel. The render loop applies the
-/// latest content without forking, which is what moves the per-frame
-/// capture cost (~8.5ms measured on macOS, ~90% of a live-send frame)
-/// off the hot path. Dropping the worker flips `stop` so the thread
-/// exits after its current cycle; like `LiveSendWorker` we don't join.
+/// `tmux capture-pane` on its own thread and publishes fresh pane content
+/// into a single-slot mailbox the render loop drains. The render loop
+/// applies the latest content without forking, which is what moves the
+/// per-frame capture cost (~8.5ms measured on macOS, ~90% of a live-send
+/// frame) off the hot path. Dropping the worker flips `stop` so the
+/// thread exits after its current cycle; like `LiveSendWorker` we don't
+/// join.
 ///
 /// Scoped to the agent target on purpose: only the agent preview
 /// force-refreshes every frame in live-send (the terminal/container/tool
@@ -461,8 +465,11 @@ pub(in crate::tui) struct LiveCaptureWorker {
     /// `0` means "not set yet"; the worker skips capturing until the first
     /// render publishes a real value. `capture_lines_for` never yields 0.
     capture_lines: std::sync::Arc<std::sync::atomic::AtomicUsize>,
-    /// Fresh pane content, newest-last. The render loop drains to the tail.
-    rx: std::sync::mpsc::Receiver<String>,
+    /// Single-slot mailbox holding the newest capture not yet consumed by
+    /// the render loop. A new capture overwrites an unconsumed one (the
+    /// render only ever wants the latest), so this can't grow unbounded if
+    /// the render thread stalls.
+    latest: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
@@ -475,15 +482,16 @@ impl Drop for LiveCaptureWorker {
 impl LiveCaptureWorker {
     pub(in crate::tui) fn spawn(tmux_name: String) -> Self {
         use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-        use std::sync::Arc;
+        use std::sync::{Arc, Mutex};
         let capture_lines = Arc::new(AtomicUsize::new(0));
+        let latest: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
         let stop = Arc::new(AtomicBool::new(false));
-        let (tx, rx) = std::sync::mpsc::channel::<String>();
         let lines_cell = capture_lines.clone();
+        let slot = latest.clone();
         let stop_flag = stop.clone();
         std::thread::spawn(move || {
             let session = crate::tmux::Session::from_name(&tmux_name);
-            let mut last_sent: Option<String> = None;
+            let mut last_captured: Option<String> = None;
             while !stop_flag.load(Ordering::Relaxed) {
                 let lines = lines_cell.load(Ordering::Relaxed);
                 if lines > 0 {
@@ -491,12 +499,13 @@ impl LiveCaptureWorker {
                         // Skip empties (preserve the last-good preview, the
                         // #1501 kill switch) and unchanged frames (no point
                         // waking a re-parse). Only changed, non-empty
-                        // captures cross the channel.
-                        if !content.is_empty() && last_sent.as_deref() != Some(content.as_str()) {
-                            if tx.send(content.clone()).is_err() {
-                                break; // render loop dropped the worker
+                        // captures reach the render loop.
+                        if !content.is_empty() && last_captured.as_deref() != Some(content.as_str())
+                        {
+                            if let Ok(mut guard) = slot.lock() {
+                                *guard = Some(content.clone());
                             }
-                            last_sent = Some(content);
+                            last_captured = Some(content);
                         }
                     }
                 }
@@ -505,7 +514,7 @@ impl LiveCaptureWorker {
         });
         Self {
             capture_lines,
-            rx,
+            latest,
             stop,
         }
     }
@@ -518,9 +527,11 @@ impl LiveCaptureWorker {
             .store(lines, std::sync::atomic::Ordering::Relaxed);
     }
 
-    /// Non-blocking pull of the next fresh capture, if any.
-    pub(in crate::tui) fn try_recv(&self) -> Option<String> {
-        self.rx.try_recv().ok()
+    /// Take the newest capture the worker has produced since the last
+    /// call, if any. Returns `None` when nothing new has arrived (the
+    /// render loop then keeps the current preview).
+    pub(in crate::tui) fn take_latest(&self) -> Option<String> {
+        self.latest.lock().ok().and_then(|mut guard| guard.take())
     }
 }
 
@@ -1290,9 +1301,9 @@ mod tests {
         // With no line count published the worker must not capture at all,
         // so nothing crosses the channel. (`capture_lines == 0` guard.)
         let worker = LiveCaptureWorker::spawn("aoe_test_capture_no_geometry".into());
-        std::thread::sleep(std::time::Duration::from_millis(40));
+        std::thread::sleep(std::time::Duration::from_millis(60));
         assert!(
-            worker.try_recv().is_none(),
+            worker.take_latest().is_none(),
             "worker should stay idle until set_capture_lines is called",
         );
     }
@@ -1305,9 +1316,9 @@ mod tests {
         // without a real tmux session: a missing pane always reads empty.
         let worker = LiveCaptureWorker::spawn("aoe_test_capture_missing_session".into());
         worker.set_capture_lines(40);
-        std::thread::sleep(std::time::Duration::from_millis(60));
+        std::thread::sleep(std::time::Duration::from_millis(80));
         assert!(
-            worker.try_recv().is_none(),
+            worker.take_latest().is_none(),
             "empty captures must never be forwarded",
         );
     }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -435,6 +435,95 @@ impl LiveSendWorker {
     }
 }
 
+/// How often the off-thread capture worker forks `tmux capture-pane`.
+/// It free-runs at roughly this cadence (a fork is ~3-13ms on macOS, so
+/// the real cycle is interval + fork time), keeping the preview cache
+/// fresh on a background thread so the render loop never forks
+/// capture-pane itself. A touch tighter than the 33ms render ticker so a
+/// frame almost always finds content that postdates the last keystroke.
+const LIVE_CAPTURE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
+
+/// Off-thread preview capture for agent live-send. Spawned alongside
+/// [`LiveSendWorker`] when live-send targets the agent pane, it forks
+/// `tmux capture-pane` on its own thread and ships fresh pane content
+/// back to the render loop over a channel. The render loop applies the
+/// latest content without forking, which is what moves the per-frame
+/// capture cost (~8.5ms measured on macOS, ~90% of a live-send frame)
+/// off the hot path. Dropping the worker flips `stop` so the thread
+/// exits after its current cycle; like `LiveSendWorker` we don't join.
+///
+/// Scoped to the agent target on purpose: only the agent preview
+/// force-refreshes every frame in live-send (the terminal/container/tool
+/// previews stay 250ms-throttled), so it's the only path paying the
+/// per-frame fork. Non-agent targets keep the synchronous capture.
+pub(in crate::tui) struct LiveCaptureWorker {
+    /// Lines the render loop wants captured (height + scrollback + buffer).
+    /// `0` means "not set yet"; the worker skips capturing until the first
+    /// render publishes a real value. `capture_lines_for` never yields 0.
+    capture_lines: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    /// Fresh pane content, newest-last. The render loop drains to the tail.
+    rx: std::sync::mpsc::Receiver<String>,
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl Drop for LiveCaptureWorker {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+impl LiveCaptureWorker {
+    pub(in crate::tui) fn spawn(tmux_name: String) -> Self {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use std::sync::Arc;
+        let capture_lines = Arc::new(AtomicUsize::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = std::sync::mpsc::channel::<String>();
+        let lines_cell = capture_lines.clone();
+        let stop_flag = stop.clone();
+        std::thread::spawn(move || {
+            let session = crate::tmux::Session::from_name(&tmux_name);
+            let mut last_sent: Option<String> = None;
+            while !stop_flag.load(Ordering::Relaxed) {
+                let lines = lines_cell.load(Ordering::Relaxed);
+                if lines > 0 {
+                    if let Ok(content) = session.capture_pane(lines) {
+                        // Skip empties (preserve the last-good preview, the
+                        // #1501 kill switch) and unchanged frames (no point
+                        // waking a re-parse). Only changed, non-empty
+                        // captures cross the channel.
+                        if !content.is_empty() && last_sent.as_deref() != Some(content.as_str()) {
+                            if tx.send(content.clone()).is_err() {
+                                break; // render loop dropped the worker
+                            }
+                            last_sent = Some(content);
+                        }
+                    }
+                }
+                std::thread::sleep(LIVE_CAPTURE_INTERVAL);
+            }
+        });
+        Self {
+            capture_lines,
+            rx,
+            stop,
+        }
+    }
+
+    /// Publish the line count the worker should capture. Cheap (one atomic
+    /// store); called each render so resizes and history scroll reach the
+    /// worker promptly.
+    pub(in crate::tui) fn set_capture_lines(&self, lines: usize) {
+        self.capture_lines
+            .store(lines, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Non-blocking pull of the next fresh capture, if any.
+    pub(in crate::tui) fn try_recv(&self) -> Option<String> {
+        self.rx.try_recv().ok()
+    }
+}
+
 /// Walk one drained batch and execute it as one-shot `tmux` subprocesses.
 /// `coalesce` merges literal-key runs into a single `send-keys -l` call;
 /// named keys and resizes dispatch individually. Tests verify the
@@ -1194,5 +1283,32 @@ mod tests {
         let batches = hex_send_batches(&payload);
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].first().map(String::as_str), Some("1b"));
+    }
+
+    #[test]
+    fn live_capture_worker_idle_until_geometry_set() {
+        // With no line count published the worker must not capture at all,
+        // so nothing crosses the channel. (`capture_lines == 0` guard.)
+        let worker = LiveCaptureWorker::spawn("aoe_test_capture_no_geometry".into());
+        std::thread::sleep(std::time::Duration::from_millis(40));
+        assert!(
+            worker.try_recv().is_none(),
+            "worker should stay idle until set_capture_lines is called",
+        );
+    }
+
+    #[test]
+    fn live_capture_worker_skips_empty_captures() {
+        // A worker pointed at a session that doesn't exist captures empty
+        // strings. Forwarding those would blank the preview, defeating the
+        // #1501 kill switch, so the worker must drop them. Deterministic
+        // without a real tmux session: a missing pane always reads empty.
+        let worker = LiveCaptureWorker::spawn("aoe_test_capture_missing_session".into());
+        worker.set_capture_lines(40);
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert!(
+            worker.try_recv().is_none(),
+            "empty captures must never be forwarded",
+        );
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -272,6 +272,28 @@ impl PreviewCache {
             ));
         }
     }
+
+    /// Store a fresh capture, invalidating the parsed cache and stamping
+    /// the session/dimensions/time the content belongs to. Returns the
+    /// captured line count so the caller can clamp scroll. Shared by the
+    /// synchronous fork path (`refresh_preview_cache_core`) and the
+    /// off-thread worker path so the two can't drift.
+    pub(super) fn store_capture(
+        &mut self,
+        content: String,
+        session_id: String,
+        dimensions: (u16, u16),
+    ) -> usize {
+        self.captured_lines = content.lines().count();
+        self.content = content;
+        // Invalidate the cached parse; the next `ensure_parsed` re-runs
+        // `ansi-to-tui`.
+        self.parsed_text = None;
+        self.session_id = Some(session_id);
+        self.dimensions = dimensions;
+        self.last_refresh = Instant::now();
+        self.captured_lines
+    }
 }
 
 /// Per-frame durations for the preview pipeline's two fork/CPU phases.
@@ -2905,6 +2927,13 @@ impl HomeView {
             // Stop the old session's capture worker too; a fresh one
             // (if the new target is the agent) is spawned below.
             self.live_capture_worker = None;
+            // Drop the previous session's cached preview so the first
+            // frames after the switch don't paint session A's content
+            // under session B's header while B's capture worker spins up.
+            // (The synchronous path got this for free via its cross-session
+            // kill-switch branch; the worker path applies content lazily,
+            // so clear it explicitly here.)
+            self.preview_cache = PreviewCache::default();
             if let Some(name) = &prev_tmux_name {
                 crate::tmux::Session::from_name(name).reset_size_to_latest_client();
             }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -274,6 +274,16 @@ impl PreviewCache {
     }
 }
 
+/// Per-frame durations for the preview pipeline's two fork/CPU phases.
+/// Lives on `HomeView`, reset each frame by `App::render`, and read back
+/// by the render sampler so a slow or live-send frame logs the breakdown
+/// instead of a single opaque `frame_ms`.
+#[derive(Default, Clone, Copy)]
+pub(super) struct PreviewTimings {
+    pub(super) capture: std::time::Duration,
+    pub(super) parse: std::time::Duration,
+}
+
 pub(super) const INDENTS: [&str; 10] = [
     "",
     " ",
@@ -429,6 +439,12 @@ pub struct HomeView {
     /// latency. Dropping (set to None when live mode exits) closes the
     /// channel and the worker thread exits cleanly on its own.
     pub(super) live_send_worker: Option<live_send::LiveSendWorker>,
+    /// Background capture worker for agent live-send. Forks `tmux
+    /// capture-pane` on its own thread so the render loop applies fresh
+    /// preview content without forking (the per-frame capture was ~90% of
+    /// a live-send frame). `Some` only while live-send targets the agent
+    /// pane; `None` otherwise, where the synchronous capture path runs.
+    pub(super) live_capture_worker: Option<live_send::LiveCaptureWorker>,
     /// Last (cols, rows) we asked the worker to resize the pane to in
     /// the current live-send session. Used to dedup the resize messages
     /// fired from the preview refresh path; cleared on live-send exit.
@@ -494,6 +510,15 @@ pub struct HomeView {
     pub(super) terminal_preview_cache: PreviewCache,
     pub(super) container_terminal_preview_cache: PreviewCache,
     pub(super) tool_preview_cache: PreviewCache,
+
+    /// Per-frame timing of the preview pipeline's two latency-sensitive
+    /// phases, reset by `App::render` before each `render` and populated
+    /// at the agent-preview call site. `capture` is the `tmux
+    /// capture-pane` fork (sub-100us when the gate short-circuits, ~1-10ms
+    /// when it actually forks); `parse` is the `ansi-to-tui` pass (~0 on a
+    /// parsed-cache hit). The app loop's render sampler reads these to
+    /// break a live-send frame down into fork vs. parse vs. widget build.
+    pub(super) preview_timings: PreviewTimings,
 
     /// Mouse wheel offset for the preview pane, in lines back from the bottom.
     /// Reset to 0 whenever the selected session changes.
@@ -811,6 +836,7 @@ impl HomeView {
             pending_live_send_target: live_send::LiveSendTarget::Agent,
             live_send: None,
             live_send_worker: None,
+            live_capture_worker: None,
             live_send_last_resize: None,
             preview_pane_synced: None,
             pending_paste: None,
@@ -833,6 +859,7 @@ impl HomeView {
             creating_hook_progress: HashMap::new(),
             creating_stub_id: None,
             preview_cache: PreviewCache::default(),
+            preview_timings: PreviewTimings::default(),
             terminal_preview_cache: PreviewCache::default(),
             container_terminal_preview_cache: PreviewCache::default(),
             tool_preview_cache: PreviewCache::default(),
@@ -2875,6 +2902,9 @@ impl HomeView {
             // Drop worker first so its queued resizes (if any) drain
             // against the old session before we reset its sizing.
             self.live_send_worker = None;
+            // Stop the old session's capture worker too; a fresh one
+            // (if the new target is the agent) is spawned below.
+            self.live_capture_worker = None;
             if let Some(name) = &prev_tmux_name {
                 crate::tmux::Session::from_name(name).reset_size_to_latest_client();
             }
@@ -2900,7 +2930,19 @@ impl HomeView {
         // pre-#1485 path; control-mode was tried as an optimization
         // but turned out to be unreliable on real-world tmux setups
         // and was removed in favor of this simpler model).
-        self.live_send_worker = Some(live_send::LiveSendWorker::spawn(tmux_name));
+        self.live_send_worker = Some(live_send::LiveSendWorker::spawn(tmux_name.clone()));
+        // Spawn the off-thread preview capture only for the agent target:
+        // it's the one preview that force-refreshes every frame in
+        // live-send, so it's the only path paying the per-frame
+        // capture-pane fork. `tmux_name` is the agent session here.
+        self.live_capture_worker = match target {
+            live_send::LiveSendTarget::Agent => {
+                Some(live_send::LiveCaptureWorker::spawn(tmux_name))
+            }
+            live_send::LiveSendTarget::Terminal | live_send::LiveSendTarget::ContainerTerminal => {
+                None
+            }
+        };
         // Clear the resize dedup so `finalize_live_send_resize` always
         // issues its sync resize, even if the cached geometry from a
         // prior session happens to match the current preview_pane_area.

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1333,19 +1333,17 @@ impl HomeView {
     }
 
     pub(super) fn refresh_preview_cache_if_needed(&mut self, width: u16, height: u16) {
-        // Outside live-send, captures fork a fresh `tmux capture-pane`
-        // so we throttle to 250ms (4 Hz). Inside live-send, captures
-        // ride the long-lived `tmux -C` control-mode socket and cost
-        // a single round-trip (~1-2ms), so there's no upside to
-        // throttling: every render refreshes the preview, the agent's
-        // output appears as soon as the main loop wakes (key event,
-        // tokio ticker, or the %output wake-up the reader thread
-        // pushes when tmux notifies us of new pane bytes). The result
-        // is roughly attach-quality latency in the common case; the
-        // residual gap is the cost of capture-pane + ratatui re-render
-        // vs. tmux writing bytes straight into your terminal. The core's
-        // `force` flag carries this: we pass `in_live` so live-send bypasses
-        // the 250ms idle throttle.
+        // Outside live-send, captures fork a fresh `tmux capture-pane` so we
+        // throttle to 250ms (4 Hz). Inside agent live-send the fork moves off
+        // the render thread entirely: `LiveCaptureWorker` keeps the cache
+        // fresh on its own thread and the block below just applies the newest
+        // content (the core's `force` flag and the synchronous fork remain
+        // for non-agent live-send targets and the throttled non-live path).
+        // This replaced the old per-frame on-thread fork, which the
+        // `tui.render` trace measured at ~8.5ms on macOS (~90% of a frame).
+        // Control-mode capture was removed with the rest of the `tmux -C`
+        // path (#1485 revert); there is no socket round-trip and no
+        // `%output` wake. Profile the result via `capture_us` on the trace.
         let in_live = self.live_send.is_some();
         // While in live-send mode, keep the agent's tmux pane sized to the
         // preview's visible output area so it renders directly into view.
@@ -1385,15 +1383,55 @@ impl HomeView {
             }
         }
 
-        // Captures always go through the fork-based path
-        // (`Session::capture_pane_with_size` via the instance helper). The
-        // long-lived `tmux -C` connection is reserved for `send-keys` from the
-        // worker thread; on some tmux builds (macOS 3.x observed) the control-
-        // mode connection EOFs mid-session, and routing captures through it as
-        // well meant a dropped connection froze the preview until the user
-        // exited live mode. Forking per capture costs ~5-10 ms on a local mac
-        // and is invisible against the 250 ms idle throttle / `%output`-wake
-        // cadence; we trade that overhead for "preview never gets stuck".
+        // Agent live-send reads from the off-thread capture worker instead
+        // of forking `capture-pane` on the render thread. The worker keeps
+        // fresh pane content flowing on its own thread (see
+        // `LiveCaptureWorker`); here we just publish the current geometry and
+        // apply the newest content it has produced. This is what moves the
+        // ~8.5ms (macOS) per-frame capture cost off the hot path: the
+        // measured `capture_us` drops from thousands to tens. The worker
+        // already skips empty captures, so the #1501 kill switch (don't flash
+        // blank when a capture comes back empty) is preserved by simply not
+        // overwriting the cache when there's no new content.
+        if in_live {
+            if let Some(id) = self.selected_session.clone() {
+                let capture_lines = capture_lines_for(height, self.preview_scroll_offset);
+                let latest = self.live_capture_worker.as_ref().map(|worker| {
+                    worker.set_capture_lines(capture_lines);
+                    let mut latest = None;
+                    while let Some(content) = worker.try_recv() {
+                        latest = Some(content);
+                    }
+                    latest
+                });
+                // `Some(None)` = worker present, nothing new this frame (keep
+                // the cache). `None` = no worker (non-agent target); fall
+                // through to the synchronous path below.
+                if let Some(latest) = latest {
+                    if let Some(content) = latest {
+                        let cache = &mut self.preview_cache;
+                        cache.captured_lines = content.lines().count();
+                        cache.content = content;
+                        cache.parsed_text = None;
+                        cache.session_id = Some(id);
+                        cache.dimensions = (width, height);
+                        cache.last_refresh = Instant::now();
+                        let captured_lines = cache.captured_lines;
+                        self.preview_scroll_offset = clamp_scroll_to_capture(
+                            self.preview_scroll_offset,
+                            captured_lines,
+                            self.preview_visible_rows,
+                        );
+                    }
+                    return;
+                }
+            }
+        }
+
+        // Captures otherwise go through the fork-based path
+        // (`Session::capture_pane_with_size` via the instance helper); the
+        // synchronous path runs outside live-send (250ms-throttled) and for
+        // non-agent live-send targets, which don't force-refresh per frame.
         //
         // Live vs. non-live failure semantics differ. In live mode an empty
         // capture (which is what `Session::capture_pane_with_size` returns when
@@ -1716,8 +1754,12 @@ impl HomeView {
                     // means subsequent shared borrows on
                     // `parsed_text` and on `self.get_instance` can
                     // coexist in the actual render call.
+                    let cap_start = Instant::now();
                     self.refresh_preview_cache_if_needed(pane_area.width, pane_area.height);
+                    self.preview_timings.capture = cap_start.elapsed();
+                    let parse_start = Instant::now();
                     self.preview_cache.ensure_parsed();
+                    self.preview_timings.parse = parse_start.elapsed();
 
                     if let Some(id) = &self.selected_session {
                         if let Some(inst) = self.get_instance(id) {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1314,16 +1314,7 @@ impl HomeView {
             return;
         };
 
-        let cache = select(self);
-        cache.captured_lines = content.lines().count();
-        cache.content = content;
-        // Invalidate the cached parse; the next render that needs
-        // `ensure_parsed` will re-run `ansi-to-tui`.
-        cache.parsed_text = None;
-        cache.session_id = Some(id);
-        cache.dimensions = (width, height);
-        cache.last_refresh = Instant::now();
-        let captured_lines = cache.captured_lines;
+        let captured_lines = select(self).store_capture(content, id, (width, height));
 
         self.preview_scroll_offset = clamp_scroll_to_capture(
             self.preview_scroll_offset,
@@ -1345,6 +1336,14 @@ impl HomeView {
         // path (#1485 revert); there is no socket round-trip and no
         // `%output` wake. Profile the result via `capture_us` on the trace.
         let in_live = self.live_send.is_some();
+        // The agent preview can render (ViewMode::Agent) while live-send is
+        // pointed at a non-agent pane. Only agent live-send should bypass the
+        // throttle / use the capture worker; otherwise this preview is a
+        // background view and must stay 250ms-throttled like any other.
+        let agent_live = self
+            .live_send
+            .as_ref()
+            .is_some_and(|s| s.target == live_send::LiveSendTarget::Agent);
         // While in live-send mode, keep the agent's tmux pane sized to the
         // preview's visible output area so it renders directly into view.
         self.resize_live_pane_if_target(live_send::LiveSendTarget::Agent, width, height);
@@ -1393,30 +1392,21 @@ impl HomeView {
         // already skips empty captures, so the #1501 kill switch (don't flash
         // blank when a capture comes back empty) is preserved by simply not
         // overwriting the cache when there's no new content.
-        if in_live {
+        if agent_live {
             if let Some(id) = self.selected_session.clone() {
                 let capture_lines = capture_lines_for(height, self.preview_scroll_offset);
                 let latest = self.live_capture_worker.as_ref().map(|worker| {
                     worker.set_capture_lines(capture_lines);
-                    let mut latest = None;
-                    while let Some(content) = worker.try_recv() {
-                        latest = Some(content);
-                    }
-                    latest
+                    worker.take_latest()
                 });
                 // `Some(None)` = worker present, nothing new this frame (keep
-                // the cache). `None` = no worker (non-agent target); fall
-                // through to the synchronous path below.
+                // the cache). `None` = no worker; fall through to the
+                // synchronous path below.
                 if let Some(latest) = latest {
                     if let Some(content) = latest {
-                        let cache = &mut self.preview_cache;
-                        cache.captured_lines = content.lines().count();
-                        cache.content = content;
-                        cache.parsed_text = None;
-                        cache.session_id = Some(id);
-                        cache.dimensions = (width, height);
-                        cache.last_refresh = Instant::now();
-                        let captured_lines = cache.captured_lines;
+                        let captured_lines =
+                            self.preview_cache
+                                .store_capture(content, id, (width, height));
                         self.preview_scroll_offset = clamp_scroll_to_capture(
                             self.preview_scroll_offset,
                             captured_lines,
@@ -1446,10 +1436,13 @@ impl HomeView {
         self.refresh_preview_cache_core(
             width,
             height,
-            in_live,
+            agent_live,
             |s| &mut s.preview_cache,
             |s, id, capture_lines| {
-                let in_live = s.live_send.is_some();
+                let in_live = s
+                    .live_send
+                    .as_ref()
+                    .is_some_and(|st| st.target == live_send::LiveSendTarget::Agent);
                 // Only treat an empty fork capture as "preserve the existing
                 // cache" when the cache is FOR THIS SAME SESSION. If the user
                 // just switched live-send from session A to session B and B's


### PR DESCRIPTION
## Description

In agent live-send the preview pane re-captured the agent's tmux pane on every frame by forking `tmux capture-pane` **synchronously on the render thread**. Per-phase tracing added here (behind the existing slow-frame sampler) measured that fork at **~8.5ms on macOS, ~90% of every live-send frame**; the parse and widget build were negligible by comparison.

This PR moves that capture off the render thread.

### Changes

1. **Per-frame `tui.render` instrumentation.** `PreviewTimings` on `HomeView` records the capture and parse durations; the render sampler now emits `capture_us` / `parse_us` / `frame_us` for slow (>16ms) **or** live-send frames so the breakdown is visible on a real machine (enable with `AOE_LOG_LEVEL=trace`).

2. **`LiveCaptureWorker` (the main fix).** A background thread forks `tmux capture-pane` for the agent pane and publishes fresh content into a single-slot mailbox the render loop drains; the render loop applies the newest content without forking. Scoped to the **agent** target, the only preview that force-refreshes every frame (terminal/container/tool previews stay 250ms-throttled). The worker skips empty captures (preserving the #1501 kill switch) and unchanged frames (so the ANSI parse only runs on real content changes). Free-runs at 25ms, roughly the old render-driven fork rate.

3. **Stale-comment cleanup.** Removed comments claiming live-send captures rode a `tmux -C` control-mode socket and `%output` wakes; both were removed in the #1485 revert.

### Results (measured on macOS via the new instrumentation)

| Metric (agent live-send) | Before | After |
| --- | --- | --- |
| `capture_us` | ~8,500 | 0-60 (>100x) |
| total `frame_us` | ~8,500 | ~100-1,600 (~8x) |

The render thread is now essentially free during live-send; the residual frame time is pure ratatui widget-build + diff. Confirmed live in the trace: `capture_us` is `0` on most frames and jumps back to ~17,000 the instant live-send exits (the synchronous non-live path is unchanged).

### Review round (self-review + CodeRabbit)

The first commit also tried throttling the status poller during live-send; that was **reverted** in review. `Session::exists()` is cache-first but forks `tmux has-session` on a miss, the session cache TTL is 2s, and the only periodic refresher in the TUI loop is that poller. Backing it off to 2s parked the cache at its expiry boundary, so the capture worker (which calls `exists()` ~40x/s) started paying an extra fork per capture, increasing tmux load instead of reducing it. Keeping the poller at 500ms keeps the cache warm. Also addressed: single-slot mailbox so a stalled render can't queue captures unbounded; preview-cache reset on live-send session switch; the agent force/worker gate narrowed to `LiveSendTarget::Agent` (the agent preview can render while live-send targets a non-agent pane); and a shared `PreviewCache::store_capture` so the sync and worker paths can't drift.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test: unit tests for `LiveCaptureWorker` (idle-until-geometry-set, skips-empty-captures, deterministic without a live tmux session). The existing `refresh_preserves_cache_when_live_capture_fails` test covers the synchronous fallback. Full e2e of the off-thread timing path needs a real agent producing output and was instead validated by the on-device trace numbers above.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Profiling, the off-thread capture design, and the implementation were done via Claude Code under @njbrake's direction. The before/after numbers come from running the built binary on @njbrake's Mac.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This pull request significantly improves the performance of the live-send preview feature by moving a slow operation off the main rendering thread. Previously, each frame of the live-send preview would synchronously capture the agent's tmux pane, which took approximately 8.5 milliseconds (90% of the frame budget) and caused noticeable lag.

## What Was Added

- **LiveCaptureWorker**: A new background thread that captures pane content independently and makes it available to the render loop without blocking
- **PreviewTimings**: A new timing structure that tracks how long capture and parsing operations take for each frame
- **Enhanced preview cache management**: A new `store_capture()` method that centralizes how captured content is stored and indexed
- **Timing instrumentation**: Frame-level timing measurements that log slow frames (>16ms) or live-send frames with capture/parse breakdown details

## How It Works

Instead of forking `tmux capture-pane` during rendering, a background worker now:
- Runs on a ~25ms interval to capture pane content
- Skips empty captures and unchanged frames
- Places results in a single-slot mailbox that prevents unbounded queuing
- Lets the render loop grab the latest content without any fork overhead

The worker is only active when rendering the agent's live-send preview; other previews continue using the existing 250ms throttle approach.

## Performance Benefits

Measured on macOS:
- **Capture operation**: ~8,500 microseconds → 0–60 microseconds (>100× faster)
- **Total frame time**: ~8,500 microseconds → ~100–1,600 microseconds (~8× faster)

This means live-send rendering now completes in roughly 100–1,600µs instead of ~8,500µs, dramatically improving responsiveness during agent execution monitoring.

## Technical Details

The implementation includes:
- `LiveCaptureWorker::spawn()` creates the background thread with a stop flag and single-slot mailbox
- `set_capture_lines()` tells the worker the desired capture height; `take_latest()` drains the mailbox
- `refresh_preview_cache_if_needed()` in the render path detects agent live-send mode and uses the worker instead of synchronous capture
- `PreviewCache::store_capture()` centralizes updates to captured text, session ID, dimensions, and invalidates the parsed-text cache to force re-parse on the next render
- Worker spawning is gated by live-send target type: only `Agent` gets a background worker
- Preview cache is reset when switching between live-send sessions to avoid rendering stale content
- Status poller remains at 500ms (not throttled to 2s) to keep the `Session::exists()` cache warm and avoid extra `tmux has-session` forks

## Testing

Unit tests were added to verify the `LiveCaptureWorker` correctly:
- Remains idle when geometry/capture lines are unset
- Does not forward empty capture results for missing sessions
- All existing tests continue to pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->