### PR TITLE
feat(session): auto-stop idle tmux sessions for inactivity

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -101,6 +101,12 @@ Alternative runtimes that share the same code paths:
 
 Each session reports `Running`, `Waiting`, `Idle`, or `Error` based on tmux pane content and agent-specific heuristics. The TUI, web dashboard, and cockpit all show the same status column.
 
+### Auto-stop idle sessions
+
+Reclaim resources from forgotten sessions: set `session.auto_stop_idle_secs` and a plain tmux session that sits `Idle` past the threshold is stopped automatically, leaving a restartable `Stopped` row. It is off by default, never stops a session with an attached tmux client or one you used recently, and runs from both the TUI and `aoe serve`. Cockpit workers have the separate `cockpit.auto_stop_idle_secs` knob.
+
+[Configuration: session section](guides/configuration.md#session)
+
 ### Session resume
 
 Persist and resume Claude Code conversations across reboots, upgrades, and runtime rotations. AoE captures the resume token so the next launch picks up where the agent left off.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -94,11 +94,13 @@ The schema is flat; every field is optional. Missing fields in a partial custom 
 default_tool = "claude"   # any supported agent name
 yolo_mode_default = false
 agent_status_hooks = true
+auto_stop_idle_secs = 0   # 0 disables; e.g. 7200 = stop after 2h idle
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `default_tool` | (auto-detect) | Default agent for new sessions. Falls back to the first available tool if unset or unavailable. Can be set to a custom agent name. |
+| `auto_stop_idle_secs` | `0` | Seconds a plain tmux session may sit `Idle` before it is auto-stopped: its tmux session and any sandbox container are killed, leaving a restartable `Stopped` row. `0` disables it; no session is ever auto-stopped for inactivity. Idle age is measured from the later of the last transition into `Idle` and the last user interaction, and a session with an attached tmux client is always spared, so a session you are reading is never reaped. Evaluated about once a minute (by the TUI and by `aoe serve`), so the stop can lag the threshold by up to a minute. Cockpit workers use the separate `cockpit.auto_stop_idle_secs`. See #1689 and #1690. |
 | `yolo_mode_default` | `false` | Enable YOLO mode by default for new sessions (skip permission prompts). Works with or without sandbox. In tmux mode this passes `--dangerously-skip-permissions` to the agent CLI; in cockpit mode it maps to ACP `bypassPermissions` (see [Cockpit: Permission modes and YOLO](../cockpit.md#permission-modes-and-yolo) for the adapter caveat). |
 | `agent_status_hooks` | `true` | Install status-detection hooks into the agent's config file. Codex uses the `[hooks]` table in `~/.codex/config.toml`; other JSON-based agents use their settings JSON. When disabled, status detection falls back to tmux pane content parsing. Codex is hook-first, but known hook gaps are reconciled from pane content. |
 | `agent_extra_args` | `{}` | Per-agent extra arguments appended after the binary (e.g., `{ opencode = "--port 8080" }`). |

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1620,6 +1620,8 @@ async fn status_poll_loop(state: Arc<AppState>) {
         std::collections::HashSet::new();
     #[cfg(feature = "serve")]
     let mut last_idle_reap: Option<std::time::Instant> = None;
+    #[cfg(feature = "serve")]
+    let mut last_session_idle_reap: Option<std::time::Instant> = None;
     loop {
         interval.tick().await;
 
@@ -1754,7 +1756,135 @@ async fn status_poll_loop(state: Arc<AppState>) {
                 &mut last_idle_reap,
             )
             .await;
+
+            #[cfg(feature = "serve")]
+            reap_idle_sessions(&state, &mut last_session_idle_reap).await;
         }
+    }
+}
+
+/// How often the serve daemon evaluates plain tmux sessions for idle
+/// auto-stop. Mirrors the cockpit reaper's cadence so a 2s status tick does
+/// not drive a storage + tmux sweep on every iteration.
+#[cfg(feature = "serve")]
+const SESSION_IDLE_REAP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Cap on concurrent `perform_stop` calls during one reap pass. `Instance::stop`
+/// can block ~10s on `docker stop`; without a bound, a fleet of sessions all
+/// crossing the threshold on the same tick would stampede the Docker daemon.
+#[cfg(feature = "serve")]
+const SESSION_IDLE_REAP_MAX_CONCURRENT: usize = 4;
+
+/// Auto-stop plain (non-cockpit) tmux sessions that have been `Idle` past
+/// their per-profile `session.auto_stop_idle_secs` (#1690). Gated to run at
+/// most once per [`SESSION_IDLE_REAP_INTERVAL`]. Each candidate is claimed
+/// under the per-profile storage lock (so a concurrently running TUI cannot
+/// double-stop it) and stopped on a detached task with bounded concurrency,
+/// keeping the status poll loop responsive.
+#[cfg(feature = "serve")]
+async fn reap_idle_sessions(state: &Arc<AppState>, last_reap: &mut Option<std::time::Instant>) {
+    if last_reap.is_some_and(|t| t.elapsed() < SESSION_IDLE_REAP_INTERVAL) {
+        return;
+    }
+    *last_reap = Some(std::time::Instant::now());
+
+    // Live attach state. If the tmux query fails, skip this pass entirely
+    // rather than risk reaping a session the user is attached to.
+    let attached = match tokio::task::spawn_blocking(crate::tmux::attached_session_names).await {
+        Ok(Ok(set)) => set,
+        _ => return,
+    };
+
+    let now = chrono::Utc::now();
+    let instances = { state.instances.read().await.clone() };
+
+    // Resolve each distinct profile's threshold once.
+    let mut thresholds: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+    for inst in &instances {
+        if inst.is_cockpit_mode() {
+            continue;
+        }
+        thresholds
+            .entry(inst.effective_profile())
+            .or_insert_with_key(|p| {
+                crate::session::profile_config::resolve_config_or_warn(p)
+                    .session
+                    .auto_stop_idle_secs
+            });
+    }
+
+    let candidates =
+        crate::session::idle_reap::idle_reap_candidates(&instances, now, &attached, |p| {
+            thresholds.get(p).copied().unwrap_or(0)
+        });
+
+    let sem = Arc::new(tokio::sync::Semaphore::new(
+        SESSION_IDLE_REAP_MAX_CONCURRENT,
+    ));
+    for cand in candidates {
+        let sem = sem.clone();
+        tokio::spawn(async move {
+            let _permit = sem.acquire().await;
+            let claim = {
+                let cand = cand.clone();
+                tokio::task::spawn_blocking(move || {
+                    crate::session::idle_reap::claim_idle_stop(
+                        &cand.profile,
+                        &cand.session_id,
+                        now,
+                        cand.threshold_secs,
+                    )
+                })
+                .await
+            };
+            let instance = match claim {
+                Ok(Ok(Some(instance))) => instance,
+                // Not eligible anymore (peer reaper won, user woke it) or a
+                // storage error already logged downstream: nothing to do.
+                _ => return,
+            };
+            let req = crate::session::stop::StopRequest {
+                session_id: cand.session_id.clone(),
+                instance,
+            };
+            let result =
+                tokio::task::spawn_blocking(move || crate::session::stop::perform_stop(&req)).await;
+            match result {
+                Ok(r) if r.success => {
+                    tracing::info!(
+                        target: "server.idle_reap",
+                        session = %cand.session_id,
+                        profile = %cand.profile,
+                        threshold_secs = cand.threshold_secs,
+                        "auto-stopped idle tmux session",
+                    );
+                }
+                _ => {
+                    // The claim already persisted `Stopped`; a failed kill
+                    // means tmux/container may still be alive, so flip to
+                    // `Error` (matching the manual-stop failure path) instead
+                    // of leaving a sticky-but-wrong `Stopped`.
+                    let id = cand.session_id.clone();
+                    let profile = cand.profile.clone();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        if let Ok(storage) = crate::session::Storage::new(&profile) {
+                            let _ = storage.update(|instances, _groups| {
+                                if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+                                    inst.status = crate::session::Status::Error;
+                                }
+                                Ok(())
+                            });
+                        }
+                    })
+                    .await;
+                    tracing::warn!(
+                        target: "server.idle_reap",
+                        session = %cand.session_id,
+                        "idle auto-stop kill failed; marked Error",
+                    );
+                }
+            }
+        });
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1798,20 +1798,30 @@ async fn reap_idle_sessions(state: &Arc<AppState>, last_reap: &mut Option<std::t
     let now = chrono::Utc::now();
     let instances = { state.instances.read().await.clone() };
 
-    // Resolve each distinct profile's threshold once.
-    let mut thresholds: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
-    for inst in &instances {
-        if inst.is_cockpit_mode() {
-            continue;
-        }
-        thresholds
-            .entry(inst.effective_profile())
-            .or_insert_with_key(|p| {
-                crate::session::profile_config::resolve_config_or_warn(p)
-                    .session
-                    .auto_stop_idle_secs
-            });
-    }
+    // Resolve each distinct profile's threshold once, off the async runtime:
+    // `resolve_config_or_warn` reads config files from disk, so building the
+    // map directly here would block the poll loop.
+    let profiles: Vec<String> = instances
+        .iter()
+        .filter(|inst| !inst.is_cockpit_mode())
+        .map(|inst| inst.effective_profile())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    let thresholds: std::collections::HashMap<String, u32> =
+        tokio::task::spawn_blocking(move || {
+            profiles
+                .into_iter()
+                .map(|p| {
+                    let secs = crate::session::profile_config::resolve_config_or_warn(&p)
+                        .session
+                        .auto_stop_idle_secs;
+                    (p, secs)
+                })
+                .collect()
+        })
+        .await
+        .unwrap_or_default();
 
     let candidates =
         crate::session::idle_reap::idle_reap_candidates(&instances, now, &attached, |p| {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -614,6 +614,19 @@ pub struct SessionConfig {
     #[serde(default = "default_snooze_duration_minutes")]
     pub snooze_duration_minutes: u32,
 
+    /// Seconds of inactivity after which a plain TUI/tmux session that has
+    /// been `Idle` this long is auto-stopped (its tmux session and any
+    /// sandbox container are killed and the row becomes a restartable
+    /// `Stopped` row). `0` disables (default); no session is ever auto-stopped
+    /// for inactivity. Idle age is anchored on the later of the last
+    /// transition into `Idle` and the last user interaction, and a session
+    /// with a currently attached tmux client is never stopped, so a session
+    /// the user is reading is spared. Checked about once a minute, so the stop
+    /// can lag the threshold by up to a minute. Cockpit workers use the
+    /// separate `cockpit.auto_stop_idle_secs` knob; see #1689 and #1690.
+    #[serde(default = "default_auto_stop_idle_secs")]
+    pub auto_stop_idle_secs: u32,
+
     /// Text sent to the agent after a successful `aoe session restart` /
     /// `e`-keybind restart, once the post-restart readiness probe says the
     /// pane is alive. Restart re-execs the agent at a blank prompt; this
@@ -774,6 +787,7 @@ impl Default for SessionConfig {
             agent_cockpit_cmd: HashMap::new(),
             strict_hotkeys: false,
             snooze_duration_minutes: 30,
+            auto_stop_idle_secs: default_auto_stop_idle_secs(),
             restart_wake_message: default_restart_wake_message(),
             row_tag: RowTagMode::default(),
             session_id_poller_max_threads: default_session_id_poller_max_threads(),
@@ -819,6 +833,17 @@ pub fn validate_snooze_duration(minutes: u64) -> Result<(), String> {
         return Err(format!(
             "Snooze duration must be between 1 and {} minutes (got {})",
             SNOOZE_MAX_MINUTES, minutes
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_auto_stop_idle_secs(secs: u64) -> Result<(), String> {
+    if secs > u32::MAX as u64 {
+        return Err(format!(
+            "Auto-stop idle seconds must be at most {} (got {})",
+            u32::MAX,
+            secs
         ));
     }
     Ok(())

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2335,6 +2335,18 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_auto_stop_idle_secs_accepts_u32_range() {
+        assert!(validate_auto_stop_idle_secs(0).is_ok());
+        assert!(validate_auto_stop_idle_secs(3600).is_ok());
+        assert!(validate_auto_stop_idle_secs(u32::MAX as u64).is_ok());
+    }
+
+    #[test]
+    fn test_validate_auto_stop_idle_secs_rejects_above_u32() {
+        assert!(validate_auto_stop_idle_secs(u32::MAX as u64 + 1).is_err());
+    }
+
+    #[test]
     fn test_validate_snooze_duration_accepts_dialog_presets() {
         // The TUI dialog presets must all pass the validator; otherwise
         // the API silently rejects what the UI offered. Presets:

--- a/src/session/idle_reap.rs
+++ b/src/session/idle_reap.rs
@@ -1,0 +1,390 @@
+//! Pure decision logic for auto-stopping idle plain TUI/tmux sessions
+//! (`session.auto_stop_idle_secs`, #1690).
+//!
+//! This module owns the eligibility predicate only: no tmux calls, no storage
+//! writes, no config resolution, no process locks. Callers (the TUI main loop
+//! and the serve `status_poll_loop`) resolve the per-profile threshold, gather
+//! the live tmux attach state, then ask this predicate per session and claim
+//! the stop through `Storage::update` so concurrent reapers cannot double-stop.
+//!
+//! The cockpit substrate has its own reaper (`server::cockpit_reconciler`,
+//! #1689) with dormancy and seamless respawn; this is the tmux-substrate analog
+//! where a stop kills the pane and leaves a restartable `Stopped` row.
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
+
+use super::{Instance, Status, Storage};
+
+/// A plain session the reaper intends to auto-stop, with the inputs the
+/// caller needs to claim it (`profile` to open the right storage, the resolved
+/// `threshold_secs` for the in-lock re-check).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdleReapCandidate {
+    pub session_id: String,
+    pub profile: String,
+    pub threshold_secs: u32,
+}
+
+/// Select the plain (non-cockpit) sessions eligible for idle auto-stop.
+///
+/// Shared by the TUI main loop and the serve `status_poll_loop` so both apply
+/// identical policy. `attached` is the set of tmux session names with a live
+/// client (from [`crate::tmux::attached_session_names`]); a session whose tmux
+/// name is in it is spared. `resolve_threshold` maps a profile name to its
+/// effective `session.auto_stop_idle_secs`; callers cache it per profile.
+pub fn idle_reap_candidates(
+    instances: &[Instance],
+    now: DateTime<Utc>,
+    attached: &HashSet<String>,
+    resolve_threshold: impl Fn(&str) -> u32,
+) -> Vec<IdleReapCandidate> {
+    let mut candidates = Vec::new();
+    for inst in instances {
+        if inst.is_cockpit_mode() {
+            continue;
+        }
+        let profile = inst.effective_profile();
+        let threshold_secs = resolve_threshold(&profile);
+        if threshold_secs == 0 {
+            continue;
+        }
+        let is_attached = inst
+            .tmux_session()
+            .ok()
+            .is_some_and(|s| attached.contains(s.name()));
+        if should_auto_stop_session(
+            now,
+            inst.status,
+            inst.idle_entered_at,
+            inst.last_accessed_at,
+            is_attached,
+            threshold_secs,
+        ) {
+            candidates.push(IdleReapCandidate {
+                session_id: inst.id.clone(),
+                profile,
+                threshold_secs,
+            });
+        }
+    }
+    candidates
+}
+
+/// Decide whether a plain (non-cockpit) session should be auto-stopped for
+/// inactivity.
+///
+/// Eligible only when all hold:
+/// - `threshold_secs > 0` (the feature is opt-in; `0` disables it),
+/// - the session is currently `Idle` (a `Running`/`Waiting` session is never
+///   stopped, which `idle_entered_at` also reflects since it is cleared on any
+///   non-Idle transition),
+/// - no tmux client is attached (a session the user is reading is spared),
+/// - `idle_entered_at` is known (legacy rows that predate the field are
+///   skipped rather than inferred),
+/// - the idle anchor is at least `threshold_secs` in the past.
+///
+/// The anchor is `max(idle_entered_at, last_accessed_at)`: `last_accessed_at`
+/// is bumped on user interaction (and equals `idle_entered_at` at the moment a
+/// session enters `Idle`), so a session the user recently touched is spared
+/// even if the agent went idle earlier. A negative elapsed (clock skew, anchor
+/// in the future) is treated as not-yet-eligible rather than panicking.
+pub fn should_auto_stop_session(
+    now: DateTime<Utc>,
+    status: Status,
+    idle_entered_at: Option<DateTime<Utc>>,
+    last_accessed_at: Option<DateTime<Utc>>,
+    is_attached: bool,
+    threshold_secs: u32,
+) -> bool {
+    if threshold_secs == 0 {
+        return false;
+    }
+    if status != Status::Idle {
+        return false;
+    }
+    if is_attached {
+        return false;
+    }
+    let Some(entered) = idle_entered_at else {
+        return false;
+    };
+    let anchor = match last_accessed_at {
+        Some(accessed) if accessed > entered => accessed,
+        _ => entered,
+    };
+    match (now - anchor).to_std() {
+        Ok(elapsed) => elapsed.as_secs() >= threshold_secs as u64,
+        // Negative duration (anchor in the future / clock skew): not eligible.
+        Err(_) => false,
+    }
+}
+
+/// Atomically claim an idle session for auto-stop, under the per-profile
+/// storage file lock so concurrent reapers (a standalone TUI and an `aoe serve`
+/// daemon against the same on-disk state) cannot double-stop it.
+///
+/// Re-reads the session from disk inside the lock and re-checks eligibility
+/// (still `Idle`, still idle past `threshold_secs`); attach state is not
+/// re-queried here because it is a blocking tmux call and the caller already
+/// filtered attached sessions before claiming. On success the on-disk status
+/// is flipped to `Stopped` (the claim, mirroring the manual-stop path) and the
+/// claimed `Instance` is returned for the caller to actually kill via
+/// `perform_stop`. Returns `Ok(None)` when the session is no longer eligible
+/// (already claimed by the peer reaper, woken by the user, or gone).
+pub fn claim_idle_stop(
+    profile: &str,
+    session_id: &str,
+    now: DateTime<Utc>,
+    threshold_secs: u32,
+) -> anyhow::Result<Option<Instance>> {
+    let storage = Storage::new(profile)?;
+    storage.update(|instances, _groups| {
+        let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) else {
+            return Ok(None);
+        };
+        let eligible = should_auto_stop_session(
+            now,
+            inst.status,
+            inst.idle_entered_at,
+            inst.last_accessed_at,
+            false,
+            threshold_secs,
+        );
+        if !eligible {
+            return Ok(None);
+        }
+        inst.status = Status::Stopped;
+        Ok(Some(inst.clone()))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn now() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    #[test]
+    fn disabled_threshold_never_stops() {
+        let n = now();
+        assert!(!should_auto_stop_session(
+            n,
+            Status::Idle,
+            Some(n - Duration::hours(10)),
+            None,
+            false,
+            0,
+        ));
+    }
+
+    #[test]
+    fn non_idle_is_never_stopped() {
+        let n = now();
+        for status in [Status::Running, Status::Waiting, Status::Error] {
+            assert!(
+                !should_auto_stop_session(
+                    n,
+                    status,
+                    Some(n - Duration::hours(10)),
+                    None,
+                    false,
+                    60,
+                ),
+                "status {status:?} should survive the reap"
+            );
+        }
+    }
+
+    #[test]
+    fn attached_session_is_never_stopped() {
+        let n = now();
+        assert!(!should_auto_stop_session(
+            n,
+            Status::Idle,
+            Some(n - Duration::hours(10)),
+            None,
+            true,
+            60,
+        ));
+    }
+
+    #[test]
+    fn missing_idle_entered_at_never_stops() {
+        let n = now();
+        assert!(!should_auto_stop_session(
+            n,
+            Status::Idle,
+            None,
+            None,
+            false,
+            60,
+        ));
+    }
+
+    #[test]
+    fn idle_past_threshold_stops() {
+        let n = now();
+        assert!(should_auto_stop_session(
+            n,
+            Status::Idle,
+            Some(n - Duration::seconds(120)),
+            None,
+            false,
+            60,
+        ));
+    }
+
+    #[test]
+    fn idle_within_threshold_survives() {
+        let n = now();
+        assert!(!should_auto_stop_session(
+            n,
+            Status::Idle,
+            Some(n - Duration::seconds(30)),
+            None,
+            false,
+            60,
+        ));
+    }
+
+    #[test]
+    fn exactly_at_threshold_stops() {
+        let n = now();
+        assert!(should_auto_stop_session(
+            n,
+            Status::Idle,
+            Some(n - Duration::seconds(60)),
+            None,
+            false,
+            60,
+        ));
+    }
+
+    #[test]
+    fn recent_access_after_idle_entry_spares_session() {
+        let n = now();
+        // Went idle 2h ago, but the user interacted 10s ago: anchor is the
+        // recent access, so the session is spared.
+        assert!(!should_auto_stop_session(
+            n,
+            Status::Idle,
+            Some(n - Duration::hours(2)),
+            Some(n - Duration::seconds(10)),
+            false,
+            60,
+        ));
+    }
+
+    #[test]
+    fn stale_access_does_not_extend_idle() {
+        let n = now();
+        // last_accessed_at older than idle entry: anchor stays at idle entry,
+        // which is past the threshold.
+        assert!(should_auto_stop_session(
+            n,
+            Status::Idle,
+            Some(n - Duration::seconds(120)),
+            Some(n - Duration::hours(5)),
+            false,
+            60,
+        ));
+    }
+
+    #[test]
+    fn future_anchor_clock_skew_does_not_stop() {
+        let n = now();
+        assert!(!should_auto_stop_session(
+            n,
+            Status::Idle,
+            Some(n + Duration::seconds(60)),
+            None,
+            false,
+            60,
+        ));
+    }
+
+    fn idle_instance(title: &str) -> Instance {
+        let mut inst = Instance::new(title, "/tmp/idle-reap-test");
+        inst.status = Status::Idle;
+        inst.idle_entered_at = Some(Utc::now() - Duration::seconds(120));
+        inst
+    }
+
+    #[test]
+    fn candidates_select_idle_past_threshold() {
+        let n = now();
+        let instances = vec![idle_instance("a")];
+        let attached = HashSet::new();
+        let got = idle_reap_candidates(&instances, n, &attached, |_| 60);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].session_id, instances[0].id);
+        assert_eq!(got[0].threshold_secs, 60);
+    }
+
+    #[test]
+    fn candidates_skip_disabled_threshold() {
+        let n = now();
+        let instances = vec![idle_instance("a")];
+        let attached = HashSet::new();
+        assert!(idle_reap_candidates(&instances, n, &attached, |_| 0).is_empty());
+    }
+
+    #[test]
+    fn candidates_skip_running_session() {
+        let n = now();
+        let mut inst = idle_instance("a");
+        inst.status = Status::Running;
+        let attached = HashSet::new();
+        assert!(idle_reap_candidates(&[inst], n, &attached, |_| 60).is_empty());
+    }
+
+    #[test]
+    fn candidates_skip_attached_session() {
+        let n = now();
+        let inst = idle_instance("a");
+        let name = inst.tmux_session().unwrap().name().to_string();
+        let mut attached = HashSet::new();
+        attached.insert(name);
+        assert!(idle_reap_candidates(&[inst], n, &attached, |_| 60).is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn claim_is_single_shot_under_storage_lock() {
+        // The double-reap guard: the first claim wins and flips the on-disk
+        // status to Stopped; a second claim (the peer reaper) sees a non-Idle
+        // session and returns None, so the session is never stopped twice.
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", temp.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+        let inst = idle_instance("claimable");
+        let id = inst.id.clone();
+        let storage = Storage::new("test-profile").unwrap();
+        storage
+            .update(|instances, _groups| {
+                instances.push(inst);
+                Ok(())
+            })
+            .unwrap();
+
+        let now = Utc::now();
+        let first = claim_idle_stop("test-profile", &id, now, 60).unwrap();
+        assert!(first.is_some(), "first claim should win");
+
+        let second = claim_idle_stop("test-profile", &id, now, 60).unwrap();
+        assert!(
+            second.is_none(),
+            "second claim must not re-stop the session"
+        );
+
+        let stored = storage.load().unwrap();
+        assert_eq!(stored[0].status, Status::Stopped);
+    }
+}

--- a/src/session/idle_reap.rs
+++ b/src/session/idle_reap.rs
@@ -144,6 +144,12 @@ pub fn claim_idle_stop(
         let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) else {
             return Ok(None);
         };
+        // Defense in depth: never stop a cockpit row through the plain-session
+        // path, even if a caller reached here without going through
+        // `idle_reap_candidates` (which already excludes cockpit sessions).
+        if inst.is_cockpit_mode() {
+            return Ok(None);
+        }
         let eligible = should_auto_stop_session(
             now,
             inst.status,
@@ -353,12 +359,43 @@ mod tests {
         assert!(idle_reap_candidates(&[inst], n, &attached, |_| 60).is_empty());
     }
 
+    /// Saves and restores `HOME` / `XDG_CONFIG_HOME` so a test that points the
+    /// app dir at a tempdir does not leak that into sibling tests sharing the
+    /// process.
+    struct EnvGuard {
+        home: Option<std::ffi::OsString>,
+        xdg: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn capture() -> Self {
+            Self {
+                home: std::env::var_os("HOME"),
+                xdg: std::env::var_os("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match &self.xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+
     #[test]
     #[serial_test::serial]
     fn claim_is_single_shot_under_storage_lock() {
         // The double-reap guard: the first claim wins and flips the on-disk
         // status to Stopped; a second claim (the peer reaper) sees a non-Idle
         // session and returns None, so the session is never stopped twice.
+        let _env = EnvGuard::capture();
         let temp = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", temp.path());
         #[cfg(target_os = "linux")]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod container_config;
 pub mod deletion;
 pub(crate) mod environment;
 mod groups;
+pub mod idle_reap;
 mod instance;
 pub mod poller;
 pub mod profile_config;

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -264,6 +264,9 @@ pub struct SessionConfigOverride {
     pub snooze_duration_minutes: Option<u32>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_stop_idle_secs: Option<u32>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub restart_wake_message: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -518,6 +521,9 @@ pub fn apply_session_overrides(
     }
     if let Some(snooze_duration_minutes) = source.snooze_duration_minutes {
         target.snooze_duration_minutes = snooze_duration_minutes;
+    }
+    if let Some(auto_stop_idle_secs) = source.auto_stop_idle_secs {
+        target.auto_stop_idle_secs = auto_stop_idle_secs;
     }
     if let Some(ref restart_wake_message) = source.restart_wake_message {
         target.restart_wake_message = restart_wake_message.clone();

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -27,7 +27,7 @@ pub mod test_support {
     };
 }
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::process::Command;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
@@ -183,6 +183,52 @@ pub fn batch_pane_metadata() -> anyhow::Result<HashMap<String, PaneMetadata>> {
         "batch pane metadata fetched",
     );
     result
+}
+
+/// Names of aoe tmux sessions that currently have at least one attached
+/// client, from a single `tmux list-sessions` call.
+///
+/// Used by the idle auto-stop reapers (#1690) to spare a session the user is
+/// reading. Returns `Err` when the underlying tmux call fails to spawn or
+/// exits non-zero: callers MUST treat `Err` as "don't know, skip this reap
+/// pass" rather than "nothing attached", so a transient tmux glitch cannot
+/// kill a pane the user is sitting in.
+pub fn attached_session_names() -> anyhow::Result<HashSet<String>> {
+    let output = Command::new("tmux")
+        .args(["list-sessions", "-F", "#{session_name}|#{session_attached}"])
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let mut attached = HashSet::new();
+            for line in stdout.lines() {
+                if let Some((name, flag)) = line.split_once(FIELD_SEP) {
+                    // `#{session_attached}` is the attached client count; any
+                    // non-zero value means a client is attached.
+                    if name.starts_with(SESSION_PREFIX) && flag.trim() != "0" {
+                        attached.insert(name.to_string());
+                    }
+                }
+            }
+            Ok(attached)
+        }
+        Ok(out) => {
+            tracing::warn!(
+                target: "tmux.cache",
+                status = ?out.status,
+                "list-sessions (attached) returned non-zero",
+            );
+            Err(anyhow::anyhow!(
+                "tmux list-sessions returned non-zero status: {:?}",
+                out.status
+            ))
+        }
+        Err(e) => {
+            tracing::warn!(target: "tmux.cache", error = %e, "list-sessions (attached) spawn failed");
+            Err(anyhow::anyhow!("tmux list-sessions spawn failed: {}", e))
+        }
+    }
 }
 
 /// Parse the output of `tmux list-panes -a` into a map of session name to pane metadata.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -533,6 +533,7 @@ impl App {
         let mut last_spinner_redraw = std::time::Instant::now();
         let mut last_heartbeat = std::time::Instant::now();
         let mut last_presence_refresh = std::time::Instant::now();
+        let mut last_session_idle_reap = std::time::Instant::now();
         // Throttle for how often the periodic block re-reads settings;
         // without this, the inner guards would re-fire on every loop
         // iteration once any time has passed, hitting the config file at
@@ -548,6 +549,11 @@ impl App {
         // "another instance appeared/left" signal responsive without disk I/O
         // on the hot render path.
         const PRESENCE_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
+        // How often the standalone TUI evaluates plain tmux sessions for idle
+        // auto-stop (`session.auto_stop_idle_secs`, #1690). Matches the serve
+        // daemon's cadence; both reapers claim under the storage lock so they
+        // never double-stop a session when run side by side.
+        const SESSION_IDLE_REAP_INTERVAL: Duration = Duration::from_secs(60);
         // A presence file counts as live while its mtime is within this window.
         // Larger than HEARTBEAT_INTERVAL so a couple of missed beats (busy loop,
         // brief stall) don't drop an instance; matches the push consumer.
@@ -1074,6 +1080,14 @@ impl App {
             if self.home.apply_stop_results() {
                 refresh_needed = true;
                 needs_full_refresh = true;
+            }
+
+            if last_session_idle_reap.elapsed() >= SESSION_IDLE_REAP_INTERVAL {
+                last_session_idle_reap = std::time::Instant::now();
+                if self.reap_idle_sessions() {
+                    refresh_needed = true;
+                    needs_full_refresh = true;
+                }
             }
 
             if self.home.apply_session_id_updates() {
@@ -1753,6 +1767,77 @@ impl App {
             self.update_status = Some(UpdateStatus::transient(format!("cockpit closed: {e}")));
         }
         Ok(())
+    }
+
+    /// Auto-stop plain tmux sessions idle past `session.auto_stop_idle_secs`
+    /// (#1690). Runs on a 60s gate from the main loop. Each candidate is
+    /// claimed under the per-profile storage lock (so a co-running `aoe serve`
+    /// cannot double-stop it), marked `Stopped` in memory, then handed to the
+    /// background `StopPoller`; the result is reconciled by `apply_stop_results`
+    /// like a manual stop. Returns true if any session was reaped.
+    fn reap_idle_sessions(&mut self) -> bool {
+        // Live attach state; on a tmux query failure skip this pass rather
+        // than risk reaping a session the user is attached to.
+        let Ok(attached) = crate::tmux::attached_session_names() else {
+            return false;
+        };
+        let now = chrono::Utc::now();
+        let candidates = crate::session::idle_reap::idle_reap_candidates(
+            self.home.instances(),
+            now,
+            &attached,
+            |profile| {
+                crate::session::profile_config::resolve_config_or_warn(profile)
+                    .session
+                    .auto_stop_idle_secs
+            },
+        );
+        let mut reaped = false;
+        for cand in candidates {
+            match crate::session::idle_reap::claim_idle_stop(
+                &cand.profile,
+                &cand.session_id,
+                now,
+                cand.threshold_secs,
+            ) {
+                Ok(Some(instance)) => {
+                    // Mirror Action::StopSession: the claim already persisted
+                    // `Stopped`; reassert it in memory and run the kill off the
+                    // UI thread so a sandbox `docker stop` cannot freeze the TUI.
+                    self.home
+                        .set_instance_status(&cand.session_id, crate::session::Status::Stopped);
+                    self.home
+                        .stop_poller
+                        .request_stop(crate::tui::stop_poller::StopRequest {
+                            session_id: cand.session_id.clone(),
+                            instance,
+                        });
+                    tracing::info!(
+                        target: "tui.idle_reap",
+                        session = %cand.session_id,
+                        profile = %cand.profile,
+                        threshold_secs = cand.threshold_secs,
+                        "auto-stopped idle tmux session",
+                    );
+                    reaped = true;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        target: "tui.idle_reap",
+                        session = %cand.session_id,
+                        error = %e,
+                        "idle auto-stop claim failed",
+                    );
+                }
+            }
+        }
+        if reaped {
+            if let Err(e) = self.home.save() {
+                tracing::error!(target: "tui.idle_reap", "failed to save after idle reap: {e}");
+            }
+        }
+        reaped
     }
 
     fn execute_action(

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -2710,7 +2710,7 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
             config.session.snooze_duration_minutes = *v as u32;
         }
         (FieldKey::SessionAutoStopIdleSecs, FieldValue::Number(v)) => {
-            config.session.auto_stop_idle_secs = *v as u32;
+            config.session.auto_stop_idle_secs = (*v).min(u32::MAX as u64) as u32;
         }
         (FieldKey::RestartWakeMessage, FieldValue::Text(v)) => {
             config.session.restart_wake_message = v.clone();
@@ -3224,9 +3224,11 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
             });
         }
         (FieldKey::SessionAutoStopIdleSecs, FieldValue::Number(v)) => {
-            set_profile_override(*v as u32, &mut config.session, |s, val| {
-                s.auto_stop_idle_secs = val
-            });
+            set_profile_override(
+                (*v).min(u32::MAX as u64) as u32,
+                &mut config.session,
+                |s, val| s.auto_stop_idle_secs = val,
+            );
         }
         (FieldKey::RestartWakeMessage, FieldValue::Text(v)) => {
             set_profile_override(v.clone(), &mut config.session, |s, val| {

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -100,6 +100,7 @@ pub enum FieldKey {
     StrictHotkeys,
     ConfirmBeforeQuit,
     SnoozeDurationMinutes,
+    SessionAutoStopIdleSecs,
     RestartWakeMessage,
     RowTag,
     AgentExtraArgs,
@@ -333,6 +334,10 @@ impl SettingField {
             }
             (FieldKey::SnoozeDurationMinutes, FieldValue::Number(n)) => {
                 validate_snooze_duration(*n)?;
+                Ok(())
+            }
+            (FieldKey::SessionAutoStopIdleSecs, FieldValue::Number(n)) => {
+                crate::session::config::validate_auto_stop_idle_secs(*n)?;
                 Ok(())
             }
             (FieldKey::MemoryLimit, FieldValue::OptionalText(Some(v))) => {
@@ -1650,6 +1655,14 @@ fn build_session_fields(
             .map(|v| v as u64),
     );
 
+    let (auto_stop_idle_secs, auto_stop_idle_secs_override) = resolve_value(
+        scope,
+        global.session.auto_stop_idle_secs as u64,
+        session
+            .and_then(|s| s.auto_stop_idle_secs)
+            .map(|v| v as u64),
+    );
+
     let (restart_wake_message, restart_wake_message_override) = resolve_value(
         scope,
         global.session.restart_wake_message.clone(),
@@ -1704,6 +1717,18 @@ fn build_session_fields(
             inherited_display: inherited_if(
                 snooze_duration_override,
                 FieldValue::Number(global.session.snooze_duration_minutes as u64),
+            ),
+        },
+        SettingField {
+            key: FieldKey::SessionAutoStopIdleSecs,
+            label: "Auto-stop Idle Sessions (seconds)",
+            description: "Stop a plain tmux session after it sits idle this long (0 disables; attached or recently-used sessions are spared)",
+            value: FieldValue::Number(auto_stop_idle_secs),
+            category: SettingsCategory::Session,
+            has_override: auto_stop_idle_secs_override,
+            inherited_display: inherited_if(
+                auto_stop_idle_secs_override,
+                FieldValue::Number(global.session.auto_stop_idle_secs as u64),
             ),
         },
         SettingField {
@@ -2684,6 +2709,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::SnoozeDurationMinutes, FieldValue::Number(v)) => {
             config.session.snooze_duration_minutes = *v as u32;
         }
+        (FieldKey::SessionAutoStopIdleSecs, FieldValue::Number(v)) => {
+            config.session.auto_stop_idle_secs = *v as u32;
+        }
         (FieldKey::RestartWakeMessage, FieldValue::Text(v)) => {
             config.session.restart_wake_message = v.clone();
         }
@@ -3193,6 +3221,11 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
         (FieldKey::SnoozeDurationMinutes, FieldValue::Number(v)) => {
             set_profile_override(*v as u32, &mut config.session, |s, val| {
                 s.snooze_duration_minutes = val
+            });
+        }
+        (FieldKey::SessionAutoStopIdleSecs, FieldValue::Number(v)) => {
+            set_profile_override(*v as u32, &mut config.session, |s, val| {
+                s.auto_stop_idle_secs = val
             });
         }
         (FieldKey::RestartWakeMessage, FieldValue::Text(v)) => {

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -768,6 +768,11 @@ impl SettingsView {
                     s.snooze_duration_minutes = None;
                 }
             }
+            FieldKey::SessionAutoStopIdleSecs => {
+                if let Some(ref mut s) = config.session {
+                    s.auto_stop_idle_secs = None;
+                }
+            }
             FieldKey::RestartWakeMessage => {
                 if let Some(ref mut s) = config.session {
                     s.restart_wake_message = None;

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -278,6 +278,17 @@ export function SettingsView({
               checked={(session.agent_status_hooks as boolean) ?? true}
               onChange={(v) => saveField("session", session, "agent_status_hooks", v)}
             />
+            <NumberField
+              label="Auto-stop idle sessions (s)"
+              description="Seconds a plain tmux session may sit Idle before it is auto-stopped (its tmux session and any sandbox container are killed, leaving a restartable Stopped row). 0 disables (default). A session with an attached tmux client, or used more recently than the threshold, is spared. Checked about once a minute, so the stop can lag by up to a minute. Cockpit workers use the separate cockpit setting. Persists to config.toml as session.auto_stop_idle_secs; cross-device. See #1690."
+              value={
+                typeof session.auto_stop_idle_secs === "number"
+                  ? (session.auto_stop_idle_secs as number)
+                  : 0
+              }
+              min={0}
+              onChange={(v) => saveField("session", session, "auto_stop_idle_secs", v)}
+            />
           </div>
         );
 

--- a/web/src/components/__tests__/SettingsView.session.test.tsx
+++ b/web/src/components/__tests__/SettingsView.session.test.tsx
@@ -1,11 +1,9 @@
 // @vitest-environment jsdom
 //
 // Behavioral coverage for the Session tab's "Auto-stop idle sessions" number
-// field (#1690): committing a value persists `session.auto_stop_idle_secs`
-// through the normal profile-settings path, the same wiring the TUI uses.
-//
-// The end-to-end persist-through-reload path lives in live Playwright at
-// web/tests/live/settings-persistence-session.spec.ts.
+// field (#1690): a persisted value renders into the field, and committing a
+// value persists `session.auto_stop_idle_secs` through the normal
+// profile-settings path, the same wiring the TUI uses.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -54,6 +52,40 @@ function commit(input: HTMLInputElement, value: string) {
 describe("Session tab auto-stop idle field", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks resets call history but not implementations, so restore
+    // the empty-settings default here to isolate tests that override it.
+    vi.mocked(api.fetchSettings).mockResolvedValue({
+      session: {},
+      cockpit: {},
+      sandbox: {},
+      worktree: {},
+    } as never);
+  });
+
+  it("renders the persisted auto_stop_idle_secs value into the field", async () => {
+    vi.mocked(api.fetchSettings).mockResolvedValue({
+      session: { auto_stop_idle_secs: 1800 },
+      cockpit: {},
+      sandbox: {},
+      worktree: {},
+    } as never);
+
+    const { container } = render(
+      <SettingsView
+        onClose={() => {}}
+        tab="session"
+        onSelectTab={() => {}}
+        serverAbout={SERVER_ABOUT as never}
+        onServerAboutRefresh={() => {}}
+      />,
+    );
+    await screen.findByText("Auto-stop idle sessions (s)");
+
+    await waitFor(() =>
+      expect(
+        numberInputByLabel(container, "Auto-stop idle sessions (s)").value,
+      ).toBe("1800"),
+    );
   });
 
   it("persists session.auto_stop_idle_secs through the profile path", async () => {

--- a/web/src/components/__tests__/SettingsView.session.test.tsx
+++ b/web/src/components/__tests__/SettingsView.session.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+//
+// Behavioral coverage for the Session tab's "Auto-stop idle sessions" number
+// field (#1690): committing a value persists `session.auto_stop_idle_secs`
+// through the normal profile-settings path, the same wiring the TUI uses.
+//
+// The end-to-end persist-through-reload path lives in live Playwright at
+// web/tests/live/settings-persistence-session.spec.ts.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SettingsView } from "../SettingsView";
+import * as api from "../../lib/api";
+
+const PROFILES = [{ name: "main", is_default: true }];
+
+vi.mock("../../lib/api", () => ({
+  fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchSettings: vi.fn(() =>
+    Promise.resolve({ session: {}, cockpit: {}, sandbox: {}, worktree: {} }),
+  ),
+  updateProfileSettings: vi.fn(() => Promise.resolve(true)),
+  setCockpitMaster: vi.fn(() => Promise.resolve(true)),
+  setDefaultProfile: vi.fn(() => Promise.resolve(true)),
+  createProfile: vi.fn(() => Promise.resolve(true)),
+  renameProfile: vi.fn(() => Promise.resolve(true)),
+  deleteProfile: vi.fn(() => Promise.resolve(true)),
+}));
+
+const SERVER_ABOUT = {
+  cockpit_master_enabled: true,
+  cockpit_show_tool_durations: true,
+  cockpit_queue_drain_mode: "combined" as const,
+  cockpit_max_concurrent_resumes: 4,
+};
+
+function numberInputByLabel(
+  container: HTMLElement,
+  label: string,
+): HTMLInputElement {
+  const labels = Array.from(container.querySelectorAll("label"));
+  const match = labels.find((l) => l.textContent === label);
+  const input = match?.parentElement?.querySelector('input[type="number"]');
+  expect(input).toBeTruthy();
+  return input as HTMLInputElement;
+}
+
+function commit(input: HTMLInputElement, value: string) {
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value } });
+  fireEvent.blur(input);
+}
+
+describe("Session tab auto-stop idle field", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists session.auto_stop_idle_secs through the profile path", async () => {
+    const { container } = render(
+      <SettingsView
+        onClose={() => {}}
+        tab="session"
+        onSelectTab={() => {}}
+        serverAbout={SERVER_ABOUT as never}
+        onServerAboutRefresh={() => {}}
+      />,
+    );
+    await screen.findByText("Auto-stop idle sessions (s)");
+
+    commit(numberInputByLabel(container, "Auto-stop idle sessions (s)"), "7200");
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+        session: { auto_stop_idle_secs: 7200 },
+      }),
+    );
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -249,6 +249,18 @@
       ]
     },
     {
+      "id": "settings.session-auto-stop-idle",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/SettingsView.session.test.tsx"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/FormFields.tsx"
+      ]
+    },
+    {
       "id": "settings.advanced-fold-persistence",
       "kind": "live-playwright",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Plain TUI/tmux sessions (a `claude` running in a tmux pane, not cockpit mode) were never auto-stopped for inactivity, so a machine used for a few days accumulates dozens of idle agent processes. #1689 shipped auto-stop for cockpit workers only and explicitly carved this out as a follow-up. This adds the same behavior on the tmux substrate.

New `[session] auto_stop_idle_secs` (default `0`, disabled). When set, a plain session that has been `Idle` longer than the threshold is stopped: its tmux session and any sandbox container are killed and the row becomes a restartable `Stopped` row (the same path as a manual stop, so restart works unchanged). Cockpit workers keep their separate `cockpit.auto_stop_idle_secs` knob.

Design notes (the non-obvious bits, after a `/debate` design pass):

- **Idle signal** reuses the existing `Instance::idle_age()` and is anchored on `max(idle_entered_at, last_accessed_at)`, so a session you interacted with recently is spared even if the agent went idle earlier. A session with a currently attached tmux client is never stopped (`tmux::attached_session_names`), so a session you are reading is never reaped. `Running`/`Waiting` are structurally excluded.
- **Both surfaces own the timer** (the standalone TUI and `aoe serve`), because a TUI-only user has no daemon. To make that safe, each candidate is claimed under the per-profile storage file lock (`claim_idle_stop`): the first reaper flips `Idle` to `Stopped` and wins, the second sees a non-`Idle` row and skips, so the same session is never double-stopped. No new lifecycle state.
- **Off the hot path**: evaluated on a 60s gate (matching the cockpit reaper); serve runs the kills on detached tasks with bounded concurrency so a fleet of `docker stop` calls cannot stampede or stall the status poll loop; the TUI runs them through the existing background `StopPoller`.
- Per-profile threshold resolution mirrors the cockpit reaper.

Closes #1690

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In `config.toml` set `[session] auto_stop_idle_secs = 30`, start a `claude` session in the TUI, let it go `Idle`, detach, and wait ~1 minute: the row flips to `Stopped` and the tmux session is gone.
- [ ] Set `auto_stop_idle_secs = 0` (or leave unset): a session left `Idle` indefinitely is never auto-stopped.
- [ ] Start a session, keep it `Running`/`Waiting` past the threshold: it is not stopped.
- [ ] Stay attached to an `Idle` tmux session past the threshold: it is not stopped (attached sessions are spared).
- [ ] In the web dashboard Settings > Session, set "Auto-stop idle sessions (s)", reload: the value persists; confirm `session.auto_stop_idle_secs` in `config.toml`.
- [ ] In the TUI settings screen, set "Auto-stop Idle Sessions (seconds)" on a profile and clear the override: per-profile override behaves like other session fields.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
  <!-- The settings input is a request-payload permutation, which per AGENTS.md belongs in Vitest, not Playwright: added `web/src/components/__tests__/SettingsView.session.test.tsx` (matrix id `settings.session-auto-stop-idle`). -->
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a heavy e2e, because: the reap policy is covered by deterministic unit tests (`should_auto_stop_session` boundaries, candidate selection, attach carve-out) plus a storage-backed single-shot `claim_idle_stop` test. The e2e harness has no clock control, so a real-agent idle e2e would be slow and flaky; this matches the #1689 cockpit precedent, which also verifies via unit tests.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a multi-model `/debate` design pass, and implementation were drafted by Claude under my direction. I made the design calls (separate config knob, both-surfaces reaping made safe by a storage-lock claim, attach and recent-use carve-outs) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds an opt-in auto-stop for idle plain TUI/tmux sessions: when a session’s idle age exceeds a configurable threshold it is stopped (tmux session and sandbox killed) and left as a restartable "Stopped" row. The behavior extends prior cockpit-only cleanup to TUI and daemon (serve) modes while keeping cockpit’s separate knob.

## What changed (high level)

- New config option: session.auto_stop_idle_secs (u32, default 0 = disabled) with per-profile override and validation.
- Idle rule: uses max(idle_entered_at, last_accessed_at) as the anchor; sessions in Running/Waiting, sessions with attached tmux clients, recently accessed sessions, or sessions missing idle_entered_at are excluded.
- Safe reaping: idle candidate selection plus an atomic claim-via-storage flow prevent double-stops when multiple reapers run.
- Reapers: a ~60s gated reaper runs in both the TUI (via StopPoller path) and aoe serve (status poll loop); serve limits concurrent kill operations with a semaphore.
- Stop semantics: stops kill tmux sessions and any sandbox container, flip instance to Stopped (or persist Status::Error on failure), matching the manual/cockpit stop UX.
- UI, docs, tests: TUI and web settings expose the field (number input), docs updated, and unit/web tests added to cover logic, claiming, and persistence.

## Benefits

- Reduces resource clutter by automatically cleaning idle tmux sessions.
- Opt-in and per-profile configurable with safe defaults (0 = off).
- Race-free claiming via storage locks and bounded concurrency for stops.
- Consistent, restartable stopped rows and unified UI/config exposure.

## Technical notes (concise)

- New module: src/session/idle_reap.rs — IdleReapCandidate, idle_reap_candidates, should_auto_stop_session, claim_idle_stop (atomic claim under profile storage).
- Config: SessionConfig.auto_stop_idle_secs added; validate_auto_stop_idle_secs(secs: u64) implemented; SessionConfigOverride supports per-profile override.
- Tmux: added tmux.attached_session_names() helper to detect attached clients.
- Serve: reap_idle_sessions integrated into status_poll_loop, rate-limited (~60s), skips on probe failure, spawns blocking stops with bounded concurrency; failures set Status::Error.
- TUI: App::reap_idle_sessions runs on a 60s timer, claims/stops candidates, triggers UI refresh and persists state when reaps occur.
- Tests: unit tests for eligibility and claiming logic, Vitest for settings rendering/persistence, Playwright/coverage updates for UI behavior.
- Docs: docs/features.md and docs/guides/configuration.md updated to document the new setting and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->