### PR TITLE
refactor(session): unify cascade Tier-1 sid clear and intent downgrade into a single flock

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2070,10 +2070,11 @@ impl Instance {
     /// the flock), not the caller's memory: a user repin landing
     /// between the probe and the clear keeps its fresh pin.
     ///
-    /// Also heals the legacy `(None, Use(stale_sid))` shape that a
-    /// pre-flock daemon could persist mid-cascade: when disk's sid is
-    /// already `None` but intent still pins the dead sid, downgrade
-    /// intent to `Default` and return `Applied`.
+    /// Also heals the legacy `(None, Use(stale_sid))` shape that the
+    /// previous two-flock implementation could persist after a daemon
+    /// crash mid-cascade: when disk's sid is already `None` but intent
+    /// still pins the dead sid, downgrade intent to `Default` and
+    /// return `Applied`.
     ///
     /// On sid CAS skip: skip both writes. On Applied or Skipped:
     /// reload both fields from disk so memory matches whatever the
@@ -2715,12 +2716,17 @@ impl Instance {
 
         self.agent_session_id = None;
         let _ = std::fs::remove_file(crate::hooks::hook_status_dir(&self.id).join("session_id"));
-        // Populate the poller exclusion before the disk write so a
-        // bail on Failed below still keeps the bad sid out of the
-        // next retroactive capture cycle.
+        // Populate the poller exclusion before calling
+        // `clear_session_for_resume_fallback` so its `Failed` bail
+        // still keeps the bad sid out of the next retroactive capture
+        // cycle. Must stay before that call for the bail to win.
         self.retroactive_capture_excludes.insert(stale_sid.clone());
         match self.clear_session_for_resume_fallback(&profile, &stale_sid) {
             SidWrite::Applied | SidWrite::Skipped => {}
+            // `Failed` is unit-tested via
+            // `clear_for_resume_fallback_returns_failed_on_missing_row`;
+            // bail rather than launch Tier-2 against a disk we know
+            // could not be cleaned, which would re-pin the dead sid.
             SidWrite::Failed => {
                 anyhow::bail!(
                     "resume-fallback could not clear stale sid {} for {}",
@@ -6560,6 +6566,9 @@ mod tests {
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
 
+            // Seed required: clear_session_for_resume_fallback bails on
+            // missing-row Failed before reaching Tier-2, so the row must
+            // exist on disk for the cascade to reach the probe assertions.
             let xs = vec![inst.clone()];
             _storage
                 .update(|i, g| {
@@ -6648,6 +6657,9 @@ mod tests {
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
 
+            // Seed required: clear_session_for_resume_fallback bails on
+            // missing-row Failed before reaching Tier-2, so the row must
+            // exist on disk for the cascade to reach the probe assertions.
             let xs = vec![inst.clone()];
             _storage
                 .update(|i, g| {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2070,6 +2070,11 @@ impl Instance {
     /// the flock), not the caller's memory: a user repin landing
     /// between the probe and the clear keeps its fresh pin.
     ///
+    /// Also heals the legacy `(None, Use(stale_sid))` shape that a
+    /// pre-flock daemon could persist mid-cascade: when disk's sid is
+    /// already `None` but intent still pins the dead sid, downgrade
+    /// intent to `Default` and return `Applied`.
+    ///
     /// On sid CAS skip: skip both writes. On Applied or Skipped:
     /// reload both fields from disk so memory matches whatever the
     /// closure committed (or the peer's state on Skipped).
@@ -2092,6 +2097,21 @@ impl Instance {
             let Some(inst) = instances.iter_mut().find(|i| i.id == instance_id) else {
                 return Ok(SidWrite::Failed);
             };
+
+            // Heal legacy `(None, Use(stale_sid))` stuck state from a
+            // pre-flock daemon crash between the two writes. Rare
+            // post-migration; tracing is for forensic visibility.
+            if inst.agent_session_id.is_none()
+                && matches!(&inst.resume_intent, ResumeIntent::Use(p) if p == &stale_for_closure)
+            {
+                tracing::info!(target: "session.store",
+                    instance_id = %instance_id,
+                    stale_sid = %stale_for_closure,
+                    "healing legacy (None, Use(stale)) stuck state in resume-fallback clear"
+                );
+                inst.resume_intent = ResumeIntent::Default;
+                return Ok(SidWrite::Applied);
+            }
 
             if inst.agent_session_id.as_deref() != Some(stale_for_closure.as_str()) {
                 tracing::warn!(target: "session.store",
@@ -2695,8 +2715,20 @@ impl Instance {
 
         self.agent_session_id = None;
         let _ = std::fs::remove_file(crate::hooks::hook_status_dir(&self.id).join("session_id"));
-        let _ = self.clear_session_for_resume_fallback(&profile, &stale_sid);
+        // Populate the poller exclusion before the disk write so a
+        // bail on Failed below still keeps the bad sid out of the
+        // next retroactive capture cycle.
         self.retroactive_capture_excludes.insert(stale_sid.clone());
+        match self.clear_session_for_resume_fallback(&profile, &stale_sid) {
+            SidWrite::Applied | SidWrite::Skipped => {}
+            SidWrite::Failed => {
+                anyhow::bail!(
+                    "resume-fallback could not clear stale sid {} for {}",
+                    stale_sid,
+                    self.id,
+                );
+            }
+        }
 
         self.start_with_size_opts(size, true).with_context(|| {
             format!(
@@ -6265,13 +6297,13 @@ mod tests {
 
         #[test]
         #[serial]
-        fn clear_for_resume_fallback_skipped_when_disk_already_none() {
+        fn clear_for_resume_fallback_heals_legacy_stuck_state() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
             #[cfg(target_os = "linux")]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
-            let profile = "fallback-clear-already-none";
+            let profile = "fallback-clear-heal-legacy";
             let mut inst = Instance::new("title", "/tmp/x");
             inst.source_profile = profile.to_string();
             inst.agent_session_id = Some("stale".to_string());
@@ -6287,16 +6319,58 @@ mod tests {
                 .unwrap();
 
             let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
+            assert_eq!(outcome, super::SidWrite::Applied);
+
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded[0].agent_session_id, None);
+            assert_eq!(
+                loaded[0].resume_intent,
+                ResumeIntent::Default,
+                "legacy (None, Use(stale)) state must heal to Default",
+            );
+            assert_eq!(inst.agent_session_id, None);
+            assert_eq!(inst.resume_intent, ResumeIntent::Default);
+        }
+
+        #[test]
+        #[serial]
+        fn clear_for_resume_fallback_skips_on_user_repin_with_none_sid() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "fallback-clear-repin-none-sid";
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = profile.to_string();
+            inst.agent_session_id = Some("stale".to_string());
+            inst.resume_intent = ResumeIntent::Use("stale".to_string());
+            seed_disk(profile, &inst);
+
+            let storage = crate::session::storage::Storage::new(profile).unwrap();
+            storage
+                .update(|i, _g| {
+                    i[0].agent_session_id = None;
+                    i[0].resume_intent = ResumeIntent::Use("other".to_string());
+                    Ok(())
+                })
+                .unwrap();
+
+            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
             assert_eq!(outcome, super::SidWrite::Skipped);
 
             let loaded = storage.load().unwrap();
             assert_eq!(loaded[0].agent_session_id, None);
             assert_eq!(
                 loaded[0].resume_intent,
-                ResumeIntent::Use("stale".to_string()),
-                "intent stays untouched when sid CAS skips",
+                ResumeIntent::Use("other".to_string()),
+                "pin to a different sid must not be healed",
             );
-            assert_eq!(inst.agent_session_id, None);
+            assert_eq!(
+                inst.resume_intent,
+                ResumeIntent::Use("other".to_string()),
+                "memory must reload the user's repin",
+            );
         }
 
         #[test]
@@ -6486,6 +6560,15 @@ mod tests {
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
 
+            let xs = vec![inst.clone()];
+            _storage
+                .update(|i, g| {
+                    *i = xs.to_vec();
+                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
             let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
             let _ = std::process::Command::new("tmux")
                 .args(["kill-session", "-t", &tmux_name])
@@ -6564,6 +6647,15 @@ mod tests {
             );
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
+
+            let xs = vec![inst.clone()];
+            _storage
+                .update(|i, g| {
+                    *i = xs.to_vec();
+                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
 
             let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
             let _ = std::process::Command::new("tmux")

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -660,108 +660,6 @@ pub(crate) fn persist_session_to_storage(
     }
 }
 
-/// Clear the persisted `agent_session_id` for an instance.
-///
-/// Inverse of `persist_session_to_storage`. Used by the resume-fallback
-/// cascade after Tier 1 detects a crashed pane: the bad sid was already
-/// flushed to `sessions.json` by the Tier-1 `finalize_launch`, so an
-/// in-memory clear is not enough. If the daemon dies between Tier 1 and
-/// Tier 2's `finalize_launch`, the next launch would otherwise re-load the
-/// bad sid from disk and pass `--resume <bad>` again, looping.
-///
-/// Concurrent callers within and across processes (TUI tick, server
-/// `spawn_blocking` workers, CLI `restart --all` JoinSet workers, peer
-/// `aoe` invocations) are serialised via `Storage::update`'s two-layer
-/// lock (in-process mutex + cross-process flock; see `storage.rs` module
-/// rustdoc).
-fn clear_session_id_on_disk(
-    profile: &str,
-    instance_id: &str,
-    expected_prior: Option<&str>,
-) -> SidWrite {
-    let storage = match super::storage::Storage::new(profile) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(target: "session.store", "Failed to create storage to clear session ID: {}", e);
-            return SidWrite::Failed;
-        }
-    };
-
-    let outcome = storage.update(|instances, _groups| {
-        if let Some(inst) = instances.iter_mut().find(|i| i.id == instance_id) {
-            if inst.agent_session_id.as_deref() != expected_prior {
-                tracing::warn!(target: "session.store",
-                    instance_id = %instance_id,
-                    expected = ?expected_prior,
-                    disk = ?inst.agent_session_id,
-                    "sid CAS mismatch; skipping clear"
-                );
-                return Ok(SidWrite::Skipped);
-            }
-            inst.agent_session_id = None;
-            Ok(SidWrite::Applied)
-        } else {
-            Ok(SidWrite::Failed)
-        }
-    });
-
-    match outcome {
-        Ok(SidWrite::Applied) => {
-            tracing::debug!(target: "session.store", "Session ID cleared on disk for {}", instance_id);
-            SidWrite::Applied
-        }
-        Ok(other) => other,
-        Err(e) => {
-            tracing::warn!(target: "session.store", "Failed to clear session ID for {}: {}", instance_id, e);
-            SidWrite::Failed
-        }
-    }
-}
-
-/// CAS-write `resume_intent = Default` to disk, used to auto-promote a
-/// one-shot intent (`Cleared`, or a `Use(X)` whose pin has been invalidated
-/// by the cascade) after the launch it gated. CAS-skipped if the user
-/// re-set their intent during the launch sequence.
-fn reset_resume_intent_to_default(
-    profile: &str,
-    instance_id: &str,
-    expected_prior: ResumeIntent,
-) -> SidWrite {
-    let storage = match super::storage::Storage::new(profile) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(target: "session.store", "Failed to create storage to reset resume_intent: {}", e);
-            return SidWrite::Failed;
-        }
-    };
-
-    let outcome = storage.update(|instances, _groups| {
-        if let Some(inst) = instances.iter_mut().find(|i| i.id == instance_id) {
-            if inst.resume_intent != expected_prior {
-                tracing::warn!(target: "session.store",
-                    instance_id = %instance_id,
-                    expected = ?expected_prior,
-                    disk = ?inst.resume_intent,
-                    "resume_intent CAS mismatch; skipping reset"
-                );
-                return Ok(SidWrite::Skipped);
-            }
-            inst.resume_intent = ResumeIntent::Default;
-            Ok(SidWrite::Applied)
-        } else {
-            Ok(SidWrite::Failed)
-        }
-    });
-
-    match outcome {
-        Ok(w) => w,
-        Err(e) => {
-            tracing::warn!(target: "session.store", "Failed to reset resume_intent for {}: {}", instance_id, e);
-            SidWrite::Failed
-        }
-    }
-}
-
 /// Publish a captured session ID to the tmux environment only.
 ///
 /// Background threads (poller on_change) call this so that
@@ -2161,6 +2059,107 @@ impl Instance {
             }
         }
     }
+
+    /// Atomic single-flock CAS+clear of `agent_session_id` and (when disk
+    /// still pins the just-invalidated sid) downgrade of `resume_intent`
+    /// from `Use(stale_sid)` to `Default`.
+    ///
+    /// Inverse direction of `persist_session_id`: the resume-fallback
+    /// cascade has just declared `stale_sid` dead, so we erase it from
+    /// disk and, if the user's pin still names that dead sid, drop the
+    /// pin so Tier-2 doesn't loop on it. Both writes happen inside one
+    /// `Storage::update` closure, so peers (and the next launch after a
+    /// daemon SIGKILL) never observe the intermediate
+    /// `(agent_session_id=None, resume_intent=Use(stale_sid))` state
+    /// that the previous two-flock implementation could leave on disk.
+    ///
+    /// CAS contract:
+    /// - `stale_sid`: the sid the caller observed dead. Both writes are
+    ///   skipped (`Skipped` outcome) if disk has diverged (peer wrote a
+    ///   fresh sid, or peer already cleared the row).
+    /// - Intent downgrade is conditional on `inst.resume_intent` (read
+    ///   from disk under the flock) matching `Use(stale_sid)`. Reading
+    ///   disk rather than memory means a user repin landing between the
+    ///   probe and this call wins: sid is cleared, the fresh pin is
+    ///   preserved.
+    ///
+    /// Post-condition (memory): on `Applied` and `Skipped`, both
+    /// `agent_session_id` and `resume_intent` are reloaded from disk so
+    /// memory matches whatever the closure committed (or the peer's
+    /// state on Skipped). On `Failed` (row missing or storage error),
+    /// memory is unchanged and a warn is logged.
+    ///
+    /// Sister atomic write: `persist_session_id` (capture path).
+    /// Tracking issue: #1742.
+    fn clear_session_for_resume_fallback(&mut self, profile: &str, stale_sid: &str) -> SidWrite {
+        let storage = match super::storage::Storage::new(profile) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(target: "session.store",
+                    "Failed to create storage for resume-fallback clear for {}: {}",
+                    self.id,
+                    e
+                );
+                return SidWrite::Failed;
+            }
+        };
+
+        let instance_id = self.id.clone();
+        let stale_for_closure = stale_sid.to_string();
+        let outcome = storage.update(|instances, _groups| {
+            let Some(inst) = instances.iter_mut().find(|i| i.id == instance_id) else {
+                return Ok(SidWrite::Failed);
+            };
+
+            if inst.agent_session_id.as_deref() != Some(stale_for_closure.as_str()) {
+                tracing::warn!(target: "session.store",
+                    instance_id = %instance_id,
+                    expected_sid = %stale_for_closure,
+                    disk_sid = ?inst.agent_session_id,
+                    "sid CAS mismatch in resume-fallback clear; skipping both writes"
+                );
+                return Ok(SidWrite::Skipped);
+            }
+
+            inst.agent_session_id = None;
+
+            // Downgrade only when the pin still names the dead sid. The
+            // "user repinned to fresh-sid mid-cascade" and "intent was
+            // already Default/Cleared" paths are legitimate, no warn.
+            if matches!(&inst.resume_intent, ResumeIntent::Use(p) if p == &stale_for_closure) {
+                inst.resume_intent = ResumeIntent::Default;
+            }
+
+            Ok(SidWrite::Applied)
+        });
+
+        match outcome {
+            Ok(write @ (SidWrite::Applied | SidWrite::Skipped)) => {
+                if let Ok(insts) = storage.load() {
+                    if let Some(disk) = insts.into_iter().find(|i| i.id == self.id) {
+                        self.agent_session_id = disk.agent_session_id;
+                        self.resume_intent = disk.resume_intent;
+                    }
+                }
+                write
+            }
+            Ok(SidWrite::Failed) => {
+                tracing::warn!(target: "session.store",
+                    "Resume-fallback clear found no instance row for {}",
+                    self.id
+                );
+                SidWrite::Failed
+            }
+            Err(e) => {
+                tracing::warn!(target: "session.store",
+                    "Failed to clear sid for resume fallback for {}: {}",
+                    self.id,
+                    e
+                );
+                SidWrite::Failed
+            }
+        }
+    }
 }
 
 impl Instance {
@@ -2714,27 +2713,8 @@ impl Instance {
 
         self.agent_session_id = None;
         let _ = std::fs::remove_file(crate::hooks::hook_status_dir(&self.id).join("session_id"));
-        let _ = clear_session_id_on_disk(&profile, &self.id, Some(&stale_sid));
+        let _ = self.clear_session_for_resume_fallback(&profile, &stale_sid);
         self.retroactive_capture_excludes.insert(stale_sid.clone());
-
-        // Tier-2 will retry through `acquire_session_id`. If the user had
-        // pinned the just-invalidated sid via `Use(stale_sid)`, retrying
-        // would loop on the dead pin. Downgrade to `Default` so Tier-2
-        // generates a fresh start.
-        //
-        // Two-flock window with the `clear_session_id_on_disk` call above:
-        // a daemon crash here leaves disk at `(None, Use(stale_sid))`,
-        // which the next launch self-heals via the cascade re-firing.
-        // Tracked for atomic single-flock unification in #1742.
-        if matches!(&self.resume_intent, ResumeIntent::Use(pinned) if pinned == &stale_sid) {
-            let prior = self.resume_intent.clone();
-            if matches!(
-                reset_resume_intent_to_default(&profile, &self.id, prior),
-                SidWrite::Applied
-            ) {
-                self.resume_intent = ResumeIntent::Default;
-            }
-        }
 
         self.start_with_size_opts(size, true).with_context(|| {
             format!(
@@ -5323,10 +5303,7 @@ mod tests {
     }
 
     mod resume_fallback {
-        use super::super::{
-            clear_session_id_on_disk, should_attempt_resume, Instance, ResumeIntent, StartOutcome,
-            Status,
-        };
+        use super::super::{should_attempt_resume, Instance, ResumeIntent, StartOutcome, Status};
         use serial_test::serial;
         use tempfile::tempdir;
 
@@ -5370,64 +5347,6 @@ mod tests {
         #[test]
         fn unknown_tool_does_not_attempt_resume() {
             assert!(!should_attempt_resume(Some("uuid-abc-123"), "nonexistent"));
-        }
-
-        #[test]
-        #[serial]
-        fn clear_session_id_on_disk_is_idempotent_when_already_none() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let storage =
-                crate::session::storage::Storage::new("test-profile-already-none").unwrap();
-            let inst = Instance::new("title", "/tmp/x");
-            let id = inst.id.clone();
-            assert!(inst.agent_session_id.is_none());
-            let xs = vec![inst];
-            storage
-                .update(|i, g| {
-                    *i = xs.to_vec();
-                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
-                    Ok(())
-                })
-                .unwrap();
-
-            let _ = clear_session_id_on_disk("test-profile-already-none", &id, None);
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded.len(), 1);
-            assert_eq!(loaded[0].agent_session_id, None);
-            assert_eq!(loaded[0].id, id);
-        }
-
-        #[test]
-        #[serial]
-        fn clear_session_id_on_disk_clears_persisted_value() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let storage = crate::session::storage::Storage::new("clear-test").unwrap();
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.agent_session_id = Some("stale-uuid-1234".to_string());
-            let id = inst.id.clone();
-            let xs = vec![inst];
-            storage
-                .update(|i, g| {
-                    *i = xs.to_vec();
-                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
-                    Ok(())
-                })
-                .unwrap();
-
-            let _ = clear_session_id_on_disk("clear-test", &id, Some("stale-uuid-1234"));
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded.len(), 1);
-            assert_eq!(loaded[0].agent_session_id, None);
         }
 
         #[test]
@@ -5490,34 +5409,6 @@ mod tests {
 
         #[test]
         #[serial]
-        fn clear_session_id_on_disk_skips_on_cas_mismatch() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let storage = crate::session::storage::Storage::new("cas-clear-mismatch").unwrap();
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.agent_session_id = Some("peer-wrote".to_string());
-            let id = inst.id.clone();
-            let xs = vec![inst];
-            storage
-                .update(|i, g| {
-                    *i = xs.to_vec();
-                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
-                    Ok(())
-                })
-                .unwrap();
-
-            let outcome = clear_session_id_on_disk("cas-clear-mismatch", &id, Some("stale"));
-            assert_eq!(outcome, super::SidWrite::Skipped);
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].agent_session_id.as_deref(), Some("peer-wrote"));
-        }
-
-        #[test]
-        #[serial]
         fn reconcile_from_disk_picks_up_peer_persist() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
@@ -5567,7 +5458,6 @@ mod tests {
             let mut inst = Instance::new("title", "/tmp/x");
             inst.source_profile = "reconcile-clear".to_string();
             inst.agent_session_id = Some("old-sid".to_string());
-            let id = inst.id.clone();
             let on_disk = inst.clone();
             storage
                 .update(|i, g| {
@@ -5581,7 +5471,12 @@ mod tests {
                 })
                 .unwrap();
 
-            let _ = clear_session_id_on_disk("reconcile-clear", &id, Some("old-sid"));
+            storage
+                .update(|i, _g| {
+                    i[0].agent_session_id = None;
+                    Ok(())
+                })
+                .unwrap();
 
             inst.reconcile_from_disk();
             assert_eq!(inst.agent_session_id, None);
@@ -5699,80 +5594,6 @@ mod tests {
 
             let back: Instance = serde_json::from_value(stripped).unwrap();
             assert_eq!(back.resume_intent, ResumeIntent::Default);
-        }
-
-        #[test]
-        #[serial]
-        fn reset_resume_intent_to_default_auto_promotes_cleared() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let storage = crate::session::storage::Storage::new("intent-promote").unwrap();
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = "intent-promote".to_string();
-            inst.resume_intent = ResumeIntent::Cleared;
-            let id = inst.id.clone();
-            let on_disk = inst.clone();
-            storage
-                .update(|i, g| {
-                    *i = vec![on_disk.clone()];
-                    *g = crate::session::GroupTree::new_with_groups(
-                        std::slice::from_ref(&on_disk),
-                        &[],
-                    )
-                    .get_all_groups();
-                    Ok(())
-                })
-                .unwrap();
-
-            let outcome =
-                super::reset_resume_intent_to_default("intent-promote", &id, ResumeIntent::Cleared);
-            assert_eq!(outcome, super::SidWrite::Applied);
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].resume_intent, ResumeIntent::Default);
-        }
-
-        #[test]
-        #[serial]
-        fn reset_resume_intent_to_default_skips_on_cas_mismatch() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let storage = crate::session::storage::Storage::new("intent-mismatch").unwrap();
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = "intent-mismatch".to_string();
-            inst.resume_intent = ResumeIntent::Use("peer-pinned".to_string());
-            let id = inst.id.clone();
-            let on_disk = inst.clone();
-            storage
-                .update(|i, g| {
-                    *i = vec![on_disk.clone()];
-                    *g = crate::session::GroupTree::new_with_groups(
-                        std::slice::from_ref(&on_disk),
-                        &[],
-                    )
-                    .get_all_groups();
-                    Ok(())
-                })
-                .unwrap();
-
-            let outcome = super::reset_resume_intent_to_default(
-                "intent-mismatch",
-                &id,
-                ResumeIntent::Cleared,
-            );
-            assert_eq!(outcome, super::SidWrite::Skipped);
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(
-                loaded[0].resume_intent,
-                ResumeIntent::Use("peer-pinned".to_string())
-            );
         }
 
         #[test]
@@ -6091,43 +5912,6 @@ mod tests {
 
         #[test]
         #[serial]
-        fn cascade_tier1_downgrades_use_pin_to_default_when_dead() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let storage = crate::session::storage::Storage::new("cascade-use-downgrade").unwrap();
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = "cascade-use-downgrade".to_string();
-            inst.resume_intent = ResumeIntent::Use("dead-sid".to_string());
-            let id = inst.id.clone();
-            let on_disk = inst.clone();
-            storage
-                .update(|i, g| {
-                    *i = vec![on_disk.clone()];
-                    *g = crate::session::GroupTree::new_with_groups(
-                        std::slice::from_ref(&on_disk),
-                        &[],
-                    )
-                    .get_all_groups();
-                    Ok(())
-                })
-                .unwrap();
-
-            let outcome = super::reset_resume_intent_to_default(
-                "cascade-use-downgrade",
-                &id,
-                ResumeIntent::Use("dead-sid".to_string()),
-            );
-            assert_eq!(outcome, super::SidWrite::Applied);
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].resume_intent, ResumeIntent::Default);
-        }
-
-        #[test]
-        #[serial]
         fn persist_session_id_reloads_memory_on_skipped() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
@@ -6343,6 +6127,251 @@ mod tests {
                 ResumeIntent::Use("peer-pinned".to_string()),
                 "intent must reload from disk on sid CAS skip",
             );
+        }
+
+        fn seed_disk(profile: &str, inst: &Instance) {
+            let storage = crate::session::storage::Storage::new(profile).unwrap();
+            let on_disk = inst.clone();
+            storage
+                .update(|i, g| {
+                    *i = vec![on_disk.clone()];
+                    *g = crate::session::GroupTree::new_with_groups(
+                        std::slice::from_ref(&on_disk),
+                        &[],
+                    )
+                    .get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+        }
+
+        #[test]
+        #[serial]
+        fn clear_for_resume_fallback_atomically_clears_and_downgrades() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "fallback-clear-happy";
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = profile.to_string();
+            inst.agent_session_id = Some("stale".to_string());
+            inst.resume_intent = ResumeIntent::Use("stale".to_string());
+            seed_disk(profile, &inst);
+
+            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
+            assert_eq!(outcome, super::SidWrite::Applied);
+
+            let storage = crate::session::storage::Storage::new(profile).unwrap();
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded[0].agent_session_id, None);
+            assert_eq!(loaded[0].resume_intent, ResumeIntent::Default);
+            assert_eq!(inst.agent_session_id, None);
+            assert_eq!(inst.resume_intent, ResumeIntent::Default);
+        }
+
+        #[test]
+        #[serial]
+        fn clear_for_resume_fallback_intent_already_default() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "fallback-clear-default";
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = profile.to_string();
+            inst.agent_session_id = Some("stale".to_string());
+            inst.resume_intent = ResumeIntent::Default;
+            seed_disk(profile, &inst);
+
+            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
+            assert_eq!(outcome, super::SidWrite::Applied);
+
+            let storage = crate::session::storage::Storage::new(profile).unwrap();
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded[0].agent_session_id, None);
+            assert_eq!(loaded[0].resume_intent, ResumeIntent::Default);
+            assert_eq!(inst.resume_intent, ResumeIntent::Default);
+        }
+
+        #[test]
+        #[serial]
+        fn clear_for_resume_fallback_preserves_user_repin() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "fallback-clear-repin";
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = profile.to_string();
+            inst.agent_session_id = Some("stale".to_string());
+            // Memory says the daemon's pre-cascade view (Use(stale)).
+            inst.resume_intent = ResumeIntent::Use("stale".to_string());
+            seed_disk(profile, &inst);
+
+            // Peer (CLI / cockpit) repins to fresh between probe and clear.
+            let storage = crate::session::storage::Storage::new(profile).unwrap();
+            storage
+                .update(|i, _g| {
+                    i[0].resume_intent = ResumeIntent::Use("fresh".to_string());
+                    Ok(())
+                })
+                .unwrap();
+
+            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
+            assert_eq!(outcome, super::SidWrite::Applied);
+
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded[0].agent_session_id, None);
+            assert_eq!(
+                loaded[0].resume_intent,
+                ResumeIntent::Use("fresh".to_string()),
+                "user's repin must survive the cascade clear",
+            );
+            assert_eq!(
+                inst.resume_intent,
+                ResumeIntent::Use("fresh".to_string()),
+                "memory must reload to honor the repin so Tier-2 picks it up",
+            );
+        }
+
+        #[test]
+        #[serial]
+        fn clear_for_resume_fallback_skips_on_sid_cas_mismatch() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "fallback-clear-sid-mismatch";
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = profile.to_string();
+            inst.agent_session_id = Some("stale".to_string());
+            inst.resume_intent = ResumeIntent::Use("stale".to_string());
+            seed_disk(profile, &inst);
+
+            // Peer fully replaced sid + intent.
+            let storage = crate::session::storage::Storage::new(profile).unwrap();
+            storage
+                .update(|i, _g| {
+                    i[0].agent_session_id = Some("peer-fresh".to_string());
+                    i[0].resume_intent = ResumeIntent::Use("peer-fresh".to_string());
+                    Ok(())
+                })
+                .unwrap();
+
+            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
+            assert_eq!(outcome, super::SidWrite::Skipped);
+
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded[0].agent_session_id.as_deref(), Some("peer-fresh"));
+            assert_eq!(
+                loaded[0].resume_intent,
+                ResumeIntent::Use("peer-fresh".to_string()),
+            );
+            assert_eq!(
+                inst.agent_session_id.as_deref(),
+                Some("peer-fresh"),
+                "memory must reload sid to converge on peer",
+            );
+            assert_eq!(
+                inst.resume_intent,
+                ResumeIntent::Use("peer-fresh".to_string()),
+                "memory must reload intent to converge on peer",
+            );
+        }
+
+        #[test]
+        #[serial]
+        fn clear_for_resume_fallback_skipped_when_disk_already_none() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "fallback-clear-already-none";
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = profile.to_string();
+            inst.agent_session_id = Some("stale".to_string());
+            inst.resume_intent = ResumeIntent::Use("stale".to_string());
+            seed_disk(profile, &inst);
+
+            // Peer already cleared sid (e.g. concurrent cascade run).
+            let storage = crate::session::storage::Storage::new(profile).unwrap();
+            storage
+                .update(|i, _g| {
+                    i[0].agent_session_id = None;
+                    Ok(())
+                })
+                .unwrap();
+
+            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
+            assert_eq!(outcome, super::SidWrite::Skipped);
+
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded[0].agent_session_id, None);
+            assert_eq!(
+                loaded[0].resume_intent,
+                ResumeIntent::Use("stale".to_string()),
+                "intent stays untouched when sid CAS skips",
+            );
+            assert_eq!(inst.agent_session_id, None);
+        }
+
+        #[test]
+        #[serial]
+        fn clear_for_resume_fallback_intent_cleared_not_downgraded() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "fallback-clear-intent-cleared";
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = profile.to_string();
+            inst.agent_session_id = Some("stale".to_string());
+            inst.resume_intent = ResumeIntent::Cleared;
+            seed_disk(profile, &inst);
+
+            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
+            assert_eq!(outcome, super::SidWrite::Applied);
+
+            let storage = crate::session::storage::Storage::new(profile).unwrap();
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded[0].agent_session_id, None);
+            assert_eq!(
+                loaded[0].resume_intent,
+                ResumeIntent::Cleared,
+                "Cleared is not Use(stale_sid); downgrade must not fire",
+            );
+            assert_eq!(inst.resume_intent, ResumeIntent::Cleared);
+        }
+
+        #[test]
+        #[serial]
+        fn clear_for_resume_fallback_returns_failed_on_missing_row() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "fallback-clear-missing";
+            let other = Instance::new("other", "/tmp/x");
+            seed_disk(profile, &other);
+
+            let mut inst = Instance::new("missing", "/tmp/x");
+            inst.source_profile = profile.to_string();
+            inst.agent_session_id = Some("stale".to_string());
+            inst.resume_intent = ResumeIntent::Use("stale".to_string());
+
+            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
+            assert_eq!(outcome, super::SidWrite::Failed);
+
+            assert_eq!(inst.agent_session_id.as_deref(), Some("stale"));
+            assert_eq!(inst.resume_intent, ResumeIntent::Use("stale".to_string()));
         }
 
         #[cfg(feature = "serve")]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2060,37 +2060,19 @@ impl Instance {
         }
     }
 
-    /// Atomic single-flock CAS+clear of `agent_session_id` and (when disk
-    /// still pins the just-invalidated sid) downgrade of `resume_intent`
-    /// from `Use(stale_sid)` to `Default`.
+    /// Atomic single-flock CAS+clear of `agent_session_id` and (when
+    /// disk still pins `Use(stale_sid)`) downgrade of `resume_intent`
+    /// to `Default`. A split would let a daemon crash freeze disk at
+    /// `(None, Use(stale_sid))`, forcing one extra cascade cycle on
+    /// the next launch.
     ///
-    /// Inverse direction of `persist_session_id`: the resume-fallback
-    /// cascade has just declared `stale_sid` dead, so we erase it from
-    /// disk and, if the user's pin still names that dead sid, drop the
-    /// pin so Tier-2 doesn't loop on it. Both writes happen inside one
-    /// `Storage::update` closure, so peers (and the next launch after a
-    /// daemon SIGKILL) never observe the intermediate
-    /// `(agent_session_id=None, resume_intent=Use(stale_sid))` state
-    /// that the previous two-flock implementation could leave on disk.
+    /// Intent downgrade is gated on disk's `resume_intent` (read under
+    /// the flock), not the caller's memory: a user repin landing
+    /// between the probe and the clear keeps its fresh pin.
     ///
-    /// CAS contract:
-    /// - `stale_sid`: the sid the caller observed dead. Both writes are
-    ///   skipped (`Skipped` outcome) if disk has diverged (peer wrote a
-    ///   fresh sid, or peer already cleared the row).
-    /// - Intent downgrade is conditional on `inst.resume_intent` (read
-    ///   from disk under the flock) matching `Use(stale_sid)`. Reading
-    ///   disk rather than memory means a user repin landing between the
-    ///   probe and this call wins: sid is cleared, the fresh pin is
-    ///   preserved.
-    ///
-    /// Post-condition (memory): on `Applied` and `Skipped`, both
-    /// `agent_session_id` and `resume_intent` are reloaded from disk so
-    /// memory matches whatever the closure committed (or the peer's
-    /// state on Skipped). On `Failed` (row missing or storage error),
-    /// memory is unchanged and a warn is logged.
-    ///
-    /// Sister atomic write: `persist_session_id` (capture path).
-    /// Tracking issue: #1742.
+    /// On sid CAS skip: skip both writes. On Applied or Skipped:
+    /// reload both fields from disk so memory matches whatever the
+    /// closure committed (or the peer's state on Skipped).
     fn clear_session_for_resume_fallback(&mut self, profile: &str, stale_sid: &str) -> SidWrite {
         let storage = match super::storage::Storage::new(profile) {
             Ok(s) => s,
@@ -6208,11 +6190,9 @@ mod tests {
             let mut inst = Instance::new("title", "/tmp/x");
             inst.source_profile = profile.to_string();
             inst.agent_session_id = Some("stale".to_string());
-            // Memory says the daemon's pre-cascade view (Use(stale)).
             inst.resume_intent = ResumeIntent::Use("stale".to_string());
             seed_disk(profile, &inst);
 
-            // Peer (CLI / cockpit) repins to fresh between probe and clear.
             let storage = crate::session::storage::Storage::new(profile).unwrap();
             storage
                 .update(|i, _g| {
@@ -6253,7 +6233,6 @@ mod tests {
             inst.resume_intent = ResumeIntent::Use("stale".to_string());
             seed_disk(profile, &inst);
 
-            // Peer fully replaced sid + intent.
             let storage = crate::session::storage::Storage::new(profile).unwrap();
             storage
                 .update(|i, _g| {
@@ -6299,7 +6278,6 @@ mod tests {
             inst.resume_intent = ResumeIntent::Use("stale".to_string());
             seed_disk(profile, &inst);
 
-            // Peer already cleared sid (e.g. concurrent cascade run).
             let storage = crate::session::storage::Storage::new(profile).unwrap();
             storage
                 .update(|i, _g| {


### PR DESCRIPTION
## Description

Closes #1742.

The resume-fallback cascade's Tier-1 cleanup in `start_with_resume_fallback` acquired two `Storage::update` flocks back to back: `clear_session_id_on_disk` then `reset_resume_intent_to_default`. A daemon SIGKILL between the two left disk at `(agent_session_id=None, resume_intent=Use(stale_sid))`, which the next launch self-healed via cascade re-firing (one extra cycle).

This refactor mirrors the F1 atomic single-flock pattern from PR #1731's `persist_session_id` (capture path) for the inverse direction (cleanup path). One `Storage::update` closure now CAS-checks sid against `stale_sid`, clears sid, and conditionally downgrades `resume_intent` from `Use(stale_sid)` to `Default`. The intermediate `(None, Use(stale_sid))` state is no longer observable.

Two correctness improvements come along:

1. The intent CAS now reads `inst.resume_intent` from disk under the flock rather than the caller's stale memory. A user repin landing between the probe and the clear correctly survives: sid is wiped, the fresh pin is preserved.
2. The post-flock memory reload converges both `agent_session_id` and `resume_intent` with disk on both `Applied` and `Skipped`, removing an implicit pre-flock-clear dependency on the caller.

After the initial review, two additional fixes addressed CodeRabbit findings plus a defensive bug surfaced by an internal adversarial pass:

3. **Heal legacy stuck state.** A pre-PR daemon crash between the two flocks could leave disk at `(None, Use(stale))`. The original two-flock code self-healed this by accident. The unified flock initially coupled both writes behind the sid CAS, dropping that self-heal. Added an explicit heal branch before the sid CAS check: when disk is exactly `(None, Use(stale_sid))`, downgrade intent to `Default` and return `Applied`. `tracing::info!` surfaces the legacy state for forensic visibility during rolling-upgrade migrations.
4. **Bail on `Failed`.** The previous `let _ =` silently continued on storage failures, which let Tier-2 re-pin the dead sid via `acquire_session_id_inner` (a pre-existing latent bug, not a PR-introduced regression). Now bails with a direct error. `retroactive_capture_excludes.insert` was reordered above the clear call so the in-memory poller exclusion survives the bail.

`clear_session_id_on_disk` and `reset_resume_intent_to_default` had no production callers after this change; removed per AGENTS.md no-dead-code. Their unit tests collapse into eight new tests on the unified function.

### Cross-PR coordination

PR #1740 (file-watch TUI consumer) is still open and adds a `FileWatchService` argument to the helpers this PR removes. If #1740 lands first, rebase here by adding `&FileWatchService` to `clear_session_for_resume_fallback`'s signature; mechanical one-line change.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The behavioral change is internal to the resume-fallback cascade's disk-write atomicity. Coverage is via eight new unit tests under `session::instance::tests::resume_fallback`:

- `clear_for_resume_fallback_atomically_clears_and_downgrades` — happy path (sid + intent atomically cleared/downgraded)
- `clear_for_resume_fallback_intent_already_default` — no spurious intent write when intent is already Default
- `clear_for_resume_fallback_preserves_user_repin` — disk-side intent CAS preserves a mid-cascade user repin
- `clear_for_resume_fallback_skips_on_sid_cas_mismatch` — peer overwrote both fields; both writes skipped, memory reloads
- `clear_for_resume_fallback_heals_legacy_stuck_state` — `(None, Use(stale))` legacy state heals to `(None, Default)`
- `clear_for_resume_fallback_skips_on_user_repin_with_none_sid` — `(None, Use(other))` does NOT heal; user pin to a different sid is preserved
- `clear_for_resume_fallback_intent_cleared_not_downgraded` — `Cleared` is not `Use(stale)`; downgrade does not fire
- `clear_for_resume_fallback_returns_failed_on_missing_row` — proves the `Failed` trigger that the call-site bail relies on

The SIGKILL-between-flocks scenario is closed by construction (single `Storage::update` closure = single flock per the storage rustdoc); the rustdoc on the new method states the atomicity contract explicitly. Two existing tmux integration tests (`fallback_returns_restarted_when_tier2_pane_lives`, `cascade_fires_when_pane_dies_inside_post_shell_grace_window`) had to seed the instance row in storage because the new bail-on-`Failed` rejects missing-row calls (where the previous `let _ =` silently dropped the same `Failed`).

### How tested

```
cargo fmt --check         # clean
cargo clippy --lib --tests -- -D warnings   # clean
cargo test --lib          # 2568 passed, 0 failed
```

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via OhMyOpenCode.

**Any Additional AI Details you'd like to share:**

Design produced via three parallel oracle sub-agents (API/architecture, implementation+test plan, adversarial review) followed by cross-validation and synthesis. Implementation followed the synthesized design; outputs gated by two independent code-review passes. CodeRabbit's two review comments were also cross-validated by three parallel oracle agents before applying — the adversarial pass surfaced the `retroactive_capture_excludes` ordering bug that CodeRabbit missed. A final 4-agent quality audit (correctness/atomicity, AGENTS.md compliance, test coverage, hostile final pass) drove the polish commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Overview

This PR replaces a two-step disk update in the session resume-fallback flow with a single atomic operation to eliminate a crash window that could leave on-disk state inconsistent.

What changed (non-technical)

- Consolidated two sequential disk writes (clear stored session id, then downgrade resume intent) into one atomic operation.
- Added Instance::clear_session_for_resume_fallback which performs a combined CAS+conditional-downgrade under a single Storage::update flock.
- start_with_resume_fallback now uses the new atomic helper and adds the stale SID to retroactive_capture_excludes before the disk update.
- Removed two now-unused helpers: clear_session_id_on_disk and reset_resume_intent_to_default.
- Reworked tests: deleted tests for the removed helpers and added seven focused unit tests under session::instance::tests::resume_fallback to cover success, skips, legacy stuck-state healing, user repin preservation, and missing-row failures.
- Minor integration test seeding adjusted to match real instance-row expectations.

Technical details

- The new Storage::update closure:
  - CAS-clears agent_session_id only if it equals the provided stale SID.
  - Reads resume_intent from disk under the flock and downgrades ResumeIntent::Use(stale_sid) → Default only if the disk intent still targets that stale SID, preserving concurrent user repins.
  - Detects and heals legacy stuck disk state where agent_session_id is None but resume_intent points to the stale SID by downgrading intent and returning Applied.
  - On Applied and Skipped, reloads agent_session_id and resume_intent from disk into memory; on Failed, logs and returns Failed (e.g., when the instance row is missing).
- The cascade inserts the stale SID into retroactive_capture_excludes before the atomic disk update so subsequent Tier-2 scans won't re-import the bad SID.
- CI: cargo fmt/clippy/test pass. If PR `#1740` lands first, rebase to add a &FileWatchService parameter.

Benefits

- Removes the SIGKILL/inter-flock window that could leave disk in an inconsistent (None, Use(stale_sid)) state, avoiding the need for extra self-healing.
- Ensures atomic consistency between clearing the session id and downgrading resume intent.
- Preserves user-initiated repins that race with the clear by reading intent under the flock.
- Reduces code surface and centralizes logic with targeted unit tests to prevent regressions.

Potential follow-ups

- Rebase to incorporate FileWatchService changes if PR `#1740` or `#1746` land first.
- Optionally add an end-to-end integration test that simulates a SIGKILL between the old two-step writes for extra regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->