### PR TITLE
feat(tui): hover highlighting on confirm-style dialog buttons

### DIFF
--- a/src/tui/components/buttons.rs
+++ b/src/tui/components/buttons.rs
@@ -1,11 +1,12 @@
 //! Centered "[Yes]    [No]" button row used by destructive-confirm dialogs.
 //!
-//! Used by `confirm` and `delete_options`. If a third caller needs a
-//! different button label set, generalize then.
+//! Used by `confirm`, `delete_options`, and `update_confirm`. If a fourth
+//! caller needs a different button label set, generalize then.
 
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
+use crate::tui::components::hover::paint_hover_bg;
 use crate::tui::styles::Theme;
 
 /// Width of the rendered "[Yes]    [No]" row: 5 (Yes) + 4 spaces + 4
@@ -14,16 +15,21 @@ use crate::tui::styles::Theme;
 const YES_NO_ROW_WIDTH: u16 = 13;
 
 /// Render a centered `[Yes]    [No]` row. Yes uses `theme.error`, No uses
-/// `theme.running`; the unfocused button uses `theme.dimmed`. Returns
-/// `(yes_rect, no_rect)` covering the visible glyphs, so callers that
-/// want mouse-clickable buttons can hit-test the same cells the user
-/// sees. Both rects collapse to zero-width if the row doesn't fit in
-/// `area` (a degenerate render the caller can ignore).
+/// `theme.running`; the unfocused button uses `theme.dimmed`. When
+/// `hovered` is one of the returned button rects, it gets a
+/// `theme.selection` background, the same highlight rows get elsewhere in
+/// the TUI; callers pass the rect a `HoverState` resolved from the last
+/// frame's `(yes_rect, no_rect)`. Returns `(yes_rect, no_rect)` covering
+/// the visible glyphs, so callers that want mouse-clickable buttons can
+/// hit-test the same cells the user sees. Both rects collapse to
+/// zero-width if the row doesn't fit in `area` (a degenerate render the
+/// caller can ignore).
 pub fn render_yes_no(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
     yes_focused: bool,
+    hovered: Option<Rect>,
 ) -> (Rect, Rect) {
     let yes_style = if yes_focused {
         Style::default().fg(theme.error).bold()
@@ -51,8 +57,56 @@ pub fn render_yes_no(
     let left_pad = (area.width - YES_NO_ROW_WIDTH) / 2;
     let yes_x = area.x + left_pad;
     let no_x = yes_x + 9; // "[Yes]" + 4 spaces
-    (
-        Rect::new(yes_x, area.y, 5, 1),
-        Rect::new(no_x, area.y, 4, 1),
-    )
+    let yes_rect = Rect::new(yes_x, area.y, 5, 1);
+    let no_rect = Rect::new(no_x, area.y, 4, 1);
+
+    if let Some(rect) = hovered.filter(|r| *r == yes_rect || *r == no_rect) {
+        paint_hover_bg(frame, rect, theme.selection);
+    }
+
+    (yes_rect, no_rect)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::styles::load_theme;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    /// Render the row twice: first to learn the button rects, then with
+    /// the `[No]` rect marked hovered. Assert the cells under "[No]" pick
+    /// up the selection background while "[Yes]" keeps the default.
+    #[test]
+    fn hovered_button_gets_selection_background() {
+        let theme = load_theme("empire");
+        let backend = TestBackend::new(40, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let mut rects = (Rect::default(), Rect::default());
+        terminal
+            .draw(|f| {
+                rects = render_yes_no(f, f.area(), &theme, false, None);
+            })
+            .unwrap();
+        let (yes_rect, no_rect) = rects;
+
+        terminal
+            .draw(|f| {
+                render_yes_no(f, f.area(), &theme, false, Some(no_rect));
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+
+        assert_eq!(
+            buf[(no_rect.x, no_rect.y)].bg,
+            theme.selection,
+            "hovered [No] should carry the selection background"
+        );
+        assert_ne!(
+            buf[(yes_rect.x, yes_rect.y)].bg,
+            theme.selection,
+            "unhovered [Yes] should keep its default background"
+        );
+    }
 }

--- a/src/tui/components/hover.rs
+++ b/src/tui/components/hover.rs
@@ -41,6 +41,15 @@ impl HoverState {
         self.hovered
     }
 
+    /// Like [`current`](Self::current), but only when the hovered rect is
+    /// still one of `rects`. Paint sites pass the rects they computed this
+    /// frame so a stale rect from a previous layout (e.g. a terminal
+    /// resize with no intervening mouse move) is dropped instead of
+    /// tinting the wrong cells.
+    pub fn current_in(&self, rects: &[Rect]) -> Option<Rect> {
+        self.hovered.filter(|r| rects.contains(r))
+    }
+
     /// Recompute the hovered rect from a pointer position against the
     /// clickable rects captured on the previous frame. Returns `true`
     /// when the hovered rect changed, so callers redraw only on a real

--- a/src/tui/components/hover.rs
+++ b/src/tui/components/hover.rs
@@ -1,0 +1,95 @@
+//! Shared mouse-hover highlight helpers for dialogs.
+//!
+//! Dialogs capture a `Rect` per clickable element during `render` (to
+//! hit-test clicks); `HoverState` reuses those same rects to track which
+//! one the pointer is over, and `paint_hover_bg` highlights it. The
+//! highlight is visual only: hover never moves keyboard focus, because
+//! mouse drift between reading a prompt and pressing Enter would
+//! otherwise flip which action fires.
+
+use ratatui::layout::Position;
+use ratatui::prelude::*;
+
+/// Paint `bg` behind every cell of `area`, leaving glyphs and their
+/// foreground colors intact. The same treatment rows get under the
+/// cursor in the settings and home views.
+pub fn paint_hover_bg(frame: &mut Frame, area: Rect, bg: Color) {
+    let buf = frame.buffer_mut();
+    for y in area.y..area.bottom() {
+        for x in area.x..area.right() {
+            if let Some(cell) = buf.cell_mut((x, y)) {
+                cell.set_bg(bg);
+            }
+        }
+    }
+}
+
+/// Tracks which of a dialog's clickable rects the pointer is over so the
+/// renderer can highlight it. Feed it the same rects the click
+/// hit-test uses; it stays empty until the dialog has rendered once
+/// (every rect is zero-sized before then, and a zero-area rect contains
+/// no point).
+#[derive(Default)]
+pub struct HoverState {
+    hovered: Option<Rect>,
+}
+
+impl HoverState {
+    /// The rect under the cursor, if any. Pass to a renderer (or
+    /// `paint_hover_bg`) to highlight it.
+    pub fn current(&self) -> Option<Rect> {
+        self.hovered
+    }
+
+    /// Recompute the hovered rect from a pointer position against the
+    /// clickable rects captured on the previous frame. Returns `true`
+    /// when the hovered rect changed, so callers redraw only on a real
+    /// move between targets, not on every pixel twitch.
+    pub fn update(&mut self, col: u16, row: u16, rects: &[Rect]) -> bool {
+        let pos = Position::from((col, row));
+        let new = rects.iter().copied().find(|r| r.contains(pos));
+        if self.hovered == new {
+            return false;
+        }
+        self.hovered = new;
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracks_rect_under_cursor_and_reports_changes() {
+        let mut hover = HoverState::default();
+        let a = Rect::new(10, 8, 5, 1);
+        let b = Rect::new(19, 8, 4, 1);
+        assert_eq!(hover.current(), None);
+
+        // Moving onto `a` is a change.
+        assert!(hover.update(12, 8, &[a, b]));
+        assert_eq!(hover.current(), Some(a));
+
+        // Staying within `a` is not.
+        assert!(!hover.update(11, 8, &[a, b]));
+
+        // Crossing to `b` is a change.
+        assert!(hover.update(20, 8, &[a, b]));
+        assert_eq!(hover.current(), Some(b));
+
+        // The gap between the rects clears the highlight.
+        assert!(hover.update(16, 8, &[a, b]));
+        assert_eq!(hover.current(), None);
+    }
+
+    #[test]
+    fn zero_sized_rects_never_match() {
+        // Before the first render every captured rect is the default
+        // zero-sized rect; nothing should register as hovered, not even
+        // the origin.
+        let mut hover = HoverState::default();
+        assert!(!hover.update(0, 0, &[Rect::default(), Rect::default()]));
+        assert_eq!(hover.current(), None);
+    }
+}

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod checkbox;
 mod cycler;
 mod dir_picker;
 mod help;
+pub(crate) mod hover;
 mod list_picker;
 pub(crate) mod preview;
 pub(crate) mod scroll;

--- a/src/tui/dialogs/changelog.rs
+++ b/src/tui/dialogs/changelog.rs
@@ -235,7 +235,7 @@ impl ChangelogDialog {
             button_area,
         );
 
-        if let Some(rect) = self.hover.current() {
+        if let Some(rect) = self.hover.current_in(&[self.got_it_button_area]) {
             paint_hover_bg(frame, rect, theme.selection);
         }
     }

--- a/src/tui/dialogs/changelog.rs
+++ b/src/tui/dialogs/changelog.rs
@@ -19,6 +19,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::*;
 
 use super::DialogResult;
+use crate::tui::components::hover::{paint_hover_bg, HoverState};
 use crate::tui::styles::Theme;
 use crate::update::{get_cached_releases, ReleaseInfo};
 
@@ -26,6 +27,12 @@ pub struct ChangelogDialog {
     scroll_offset: usize,
     display_lines: Vec<DisplayLine>,
     dialog_area: Rect,
+    /// Rect of the `[Got it]` button, captured during `render`. A click
+    /// anywhere dismisses, but the button is the call to action, so it
+    /// picks up the hover highlight to read as clickable.
+    got_it_button_area: Rect,
+    /// Whether the cursor is over `[Got it]`, for the hover highlight.
+    hover: HoverState,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,6 +98,8 @@ impl ChangelogDialog {
             scroll_offset: 0,
             display_lines,
             dialog_area: Rect::default(),
+            got_it_button_area: Rect::default(),
+            hover: HoverState::default(),
         }
     }
 
@@ -107,6 +116,14 @@ impl ChangelogDialog {
         } else {
             None
         }
+    }
+
+    /// Highlight the `[Got it]` button when the cursor is over it. A
+    /// click anywhere still dismisses via `handle_click`; this only
+    /// signals the call to action. Returns `true` when the highlight
+    /// changed.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        self.hover.update(col, row, &[self.got_it_button_area])
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
@@ -196,14 +213,31 @@ impl ChangelogDialog {
             "  j/k scroll".to_string()
         };
 
+        const GOT_IT_WIDTH: u16 = 8; // "[Got it]"
+        let button_area = chunks[1];
+        // The button line is "[Got it]" + scroll_hint, centered as one
+        // unit; mirror that centering to capture just the "[Got it]"
+        // cells for the hover highlight.
+        let line_width = GOT_IT_WIDTH + scroll_hint.chars().count() as u16;
+        self.got_it_button_area = if button_area.width >= line_width {
+            let got_it_x = button_area.x + (button_area.width - line_width) / 2;
+            Rect::new(got_it_x, button_area.y, GOT_IT_WIDTH, 1)
+        } else {
+            Rect::default()
+        };
+
         let button = Line::from(vec![
             Span::styled("[Got it]", Style::default().fg(theme.accent).bold()),
             Span::styled(scroll_hint, Style::default().fg(theme.dimmed)),
         ]);
         frame.render_widget(
             Paragraph::new(button).alignment(Alignment::Center),
-            chunks[1],
+            button_area,
         );
+
+        if let Some(rect) = self.hover.current() {
+            paint_hover_bg(frame, rect, theme.selection);
+        }
     }
 }
 
@@ -516,7 +550,23 @@ mod tests {
             scroll_offset: 0,
             display_lines: lines,
             dialog_area: Rect::default(),
+            got_it_button_area: Rect::default(),
+            hover: HoverState::default(),
         }
+    }
+
+    #[test]
+    fn hover_highlights_got_it_button() {
+        let mut dialog = dialog_with(vec![DisplayLine::NoReleases]);
+        dialog.got_it_button_area = Rect::new(10, 20, 8, 1);
+
+        // Over [Got it]: highlight it.
+        assert!(dialog.handle_hover(12, 20));
+        assert_eq!(dialog.hover.current(), Some(dialog.got_it_button_area));
+
+        // Off the button clears the highlight.
+        assert!(dialog.handle_hover(0, 0));
+        assert_eq!(dialog.hover.current(), None);
     }
 
     #[test]

--- a/src/tui/dialogs/confirm.rs
+++ b/src/tui/dialogs/confirm.rs
@@ -7,6 +7,7 @@ use ratatui::widgets::*;
 use super::DialogResult;
 use crate::tui::components::buttons::render_yes_no;
 use crate::tui::components::checkbox::{checkbox_line, CheckboxStyle};
+use crate::tui::components::hover::HoverState;
 use crate::tui::styles::Theme;
 
 /// The dialog's emphasis color. Destructive confirmations (delete, stop,
@@ -31,6 +32,9 @@ pub struct ConfirmDialog {
     dont_ask_again: Option<bool>,
     yes_button_area: Rect,
     no_button_area: Rect,
+    /// Which Yes/No button the mouse is over, for the hover highlight.
+    /// Visual only; never changes `selected`.
+    hover: HoverState,
 }
 
 impl ConfirmDialog {
@@ -44,6 +48,7 @@ impl ConfirmDialog {
             dont_ask_again: None,
             yes_button_area: Rect::default(),
             no_button_area: Rect::default(),
+            hover: HoverState::default(),
         }
     }
 
@@ -82,12 +87,15 @@ impl ConfirmDialog {
         None
     }
 
-    /// Hover does not change the Yes/No selection. Otherwise the mouse
-    /// drifting over the opposite button between the user reading the
-    /// prompt and pressing Enter would silently flip which action
-    /// fires. Click commits explicitly via `handle_click`.
-    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
-        false
+    /// Highlight the Yes/No button under the cursor. Hover does not
+    /// change `selected`: otherwise the mouse drifting over the opposite
+    /// button between the user reading the prompt and pressing Enter
+    /// would silently flip which action fires. Click commits explicitly
+    /// via `handle_click`. Returns `true` when the highlighted button
+    /// changed so the caller can redraw.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        self.hover
+            .update(col, row, &[self.yes_button_area, self.no_button_area])
     }
 
     pub fn action(&self) -> &str {
@@ -176,7 +184,8 @@ impl ConfirmDialog {
                 CheckboxStyle::confirm(theme),
             );
             frame.render_widget(Paragraph::new(line), chunks[2]);
-            let (yes, no) = render_yes_no(frame, chunks[4], theme, self.selected);
+            let (yes, no) =
+                render_yes_no(frame, chunks[4], theme, self.selected, self.hover.current());
             self.yes_button_area = yes;
             self.no_button_area = no;
         } else {
@@ -187,7 +196,8 @@ impl ConfirmDialog {
                 .split(inner);
 
             self.render_message(frame, chunks[0], theme);
-            let (yes, no) = render_yes_no(frame, chunks[1], theme, self.selected);
+            let (yes, no) =
+                render_yes_no(frame, chunks[1], theme, self.selected, self.hover.current());
             self.yes_button_area = yes;
             self.no_button_area = no;
         }

--- a/src/tui/dialogs/delete_options.rs
+++ b/src/tui/dialogs/delete_options.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::*;
 use super::DialogResult;
 use crate::tui::components::buttons::render_yes_no;
 use crate::tui::components::checkbox::{checkbox_line, CheckboxStyle};
-use crate::tui::components::hover::HoverState;
+use crate::tui::components::hover::{paint_hover_bg, HoverState};
 use crate::tui::styles::Theme;
 
 /// Options for what to clean up when deleting a session
@@ -141,15 +141,22 @@ impl UnifiedDeleteDialog {
         None
     }
 
-    /// Highlight the Yes/No button under the cursor. Hover never moves
-    /// keyboard `focus` (mouse drift between reading the dialog and
-    /// pressing Enter would otherwise silently flip which action fires);
-    /// it only drives the visual highlight. Click still moves focus and
-    /// (for checkboxes) toggles state. Returns `true` when the
-    /// highlighted button changed so the caller can redraw.
+    /// Highlight the Yes/No button or checkbox row under the cursor.
+    /// Hover never moves keyboard `focus` (mouse drift between reading the
+    /// dialog and pressing Enter would otherwise silently flip which
+    /// action fires); it only drives the visual highlight. Click still
+    /// moves focus and (for checkboxes) toggles state. Returns `true` when
+    /// the highlighted target changed so the caller can redraw.
     pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
-        self.hover
-            .update(col, row, &[self.yes_button_area, self.no_button_area])
+        let mut rects = vec![self.yes_button_area, self.no_button_area];
+        rects.extend(self.focusable_rects.iter().map(|(_, r)| *r));
+        self.hover.update(col, row, &rects)
+    }
+
+    /// Rects of the checkbox rows captured this frame, for the hover
+    /// highlight. Yes/No are excluded; they're painted by `render_yes_no`.
+    fn checkbox_rects(&self) -> Vec<Rect> {
+        self.focusable_rects.iter().map(|(_, r)| *r).collect()
     }
 
     fn hit_focusable(&self, col: u16, row: u16) -> Option<FocusElement> {
@@ -465,6 +472,13 @@ impl UnifiedDeleteDialog {
         chunk_idx += 1; // skip spacer
 
         self.render_hints(frame, chunks[chunk_idx], theme, checkbox_count > 0);
+
+        // Yes/No are highlighted by `render_yes_no`; a hovered checkbox
+        // row is painted here, guarded to this frame's rows so a stale
+        // rect (layout shrank between mouse moves) is dropped.
+        if let Some(rect) = self.hover.current_in(&self.checkbox_rects()) {
+            paint_hover_bg(frame, rect, theme.selection);
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -865,12 +879,18 @@ mod tests {
     }
 
     #[test]
-    fn hover_on_checkbox_row_does_not_steal_focus() {
+    fn hover_on_checkbox_row_highlights_without_stealing_focus() {
         let mut dialog = full_dialog();
         stage_rects_for_full(&mut dialog);
         dialog.focus = FocusElement::YesButton;
-        assert!(!dialog.handle_hover(10, 5));
-        assert_eq!(dialog.focus, FocusElement::YesButton);
+        // (10, 5) lands on the branch checkbox row staged by the helper.
+        assert!(dialog.handle_hover(10, 5));
+        assert_eq!(dialog.hover.current(), Some(Rect::new(5, 5, 30, 1)));
+        assert_eq!(
+            dialog.focus,
+            FocusElement::YesButton,
+            "hover must not move keyboard focus"
+        );
     }
 
     #[test]

--- a/src/tui/dialogs/delete_options.rs
+++ b/src/tui/dialogs/delete_options.rs
@@ -7,6 +7,7 @@ use ratatui::widgets::*;
 use super::DialogResult;
 use crate::tui::components::buttons::render_yes_no;
 use crate::tui::components::checkbox::{checkbox_line, CheckboxStyle};
+use crate::tui::components::hover::HoverState;
 use crate::tui::styles::Theme;
 
 /// Options for what to clean up when deleting a session
@@ -66,6 +67,9 @@ pub struct UnifiedDeleteDialog {
     /// have dedicated fields above because the renderer returns them
     /// from `render_yes_no` already; everything else lives here.
     focusable_rects: Vec<(FocusElement, Rect)>,
+    /// Which Yes/No button the mouse is over, for the hover highlight.
+    /// Visual only; never moves keyboard `focus`.
+    hover: HoverState,
 }
 
 impl UnifiedDeleteDialog {
@@ -110,6 +114,7 @@ impl UnifiedDeleteDialog {
             yes_button_area: Rect::default(),
             no_button_area: Rect::default(),
             focusable_rects: Vec::new(),
+            hover: HoverState::default(),
         }
     }
 
@@ -136,11 +141,15 @@ impl UnifiedDeleteDialog {
         None
     }
 
-    /// Hover does not change focus on the checkboxes or Yes/No buttons.
-    /// See `ConfirmDialog::handle_hover` for the rationale. Click still
-    /// moves focus and (for checkboxes) toggles state.
-    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
-        false
+    /// Highlight the Yes/No button under the cursor. Hover never moves
+    /// keyboard `focus` (mouse drift between reading the dialog and
+    /// pressing Enter would otherwise silently flip which action fires);
+    /// it only drives the visual highlight. Click still moves focus and
+    /// (for checkboxes) toggles state. Returns `true` when the
+    /// highlighted button changed so the caller can redraw.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        self.hover
+            .update(col, row, &[self.yes_button_area, self.no_button_area])
     }
 
     fn hit_focusable(&self, col: u16, row: u16) -> Option<FocusElement> {
@@ -503,7 +512,13 @@ impl UnifiedDeleteDialog {
     }
 
     fn render_buttons(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let (yes, no) = render_yes_no(frame, area, theme, self.focus == FocusElement::YesButton);
+        let (yes, no) = render_yes_no(
+            frame,
+            area,
+            theme,
+            self.focus == FocusElement::YesButton,
+            self.hover.current(),
+        );
         self.yes_button_area = yes;
         self.no_button_area = no;
     }
@@ -819,18 +834,34 @@ mod tests {
     }
 
     #[test]
-    fn hover_never_changes_focus() {
-        // Hover must leave focus alone; otherwise mouse drift between
-        // reading the dialog and pressing Enter / Space silently shifts
-        // which element the next keystroke targets.
+    fn hover_highlights_button_without_changing_focus() {
+        // Hover drives the visual highlight only; it must leave focus
+        // alone, otherwise mouse drift between reading the dialog and
+        // pressing Enter / Space silently shifts which element the next
+        // keystroke targets.
         let mut dialog = simple_dialog();
         stage_rects_for_simple(&mut dialog);
         dialog.focus = FocusElement::NoButton;
-        // Over Yes, over No, over checkbox row, off-rects; all no-ops.
-        for (col, row) in [(12, 8), (20, 8), (10, 5), (50, 50)] {
-            assert!(!dialog.handle_hover(col, row), "hover at ({col},{row})");
-            assert_eq!(dialog.focus, FocusElement::NoButton);
-        }
+        let yes = dialog.yes_button_area;
+        let no = dialog.no_button_area;
+
+        // Over Yes: highlight Yes, focus stays put.
+        assert!(dialog.handle_hover(12, 8));
+        assert_eq!(dialog.hover.current(), Some(yes));
+        assert_eq!(dialog.focus, FocusElement::NoButton);
+
+        // Over No: highlight follows, focus still unchanged.
+        assert!(dialog.handle_hover(20, 8));
+        assert_eq!(dialog.hover.current(), Some(no));
+        assert_eq!(dialog.focus, FocusElement::NoButton);
+
+        // Same cell again: nothing changed, so no redraw is requested.
+        assert!(!dialog.handle_hover(20, 8));
+
+        // Off the buttons: highlight clears, focus unchanged.
+        assert!(dialog.handle_hover(50, 50));
+        assert_eq!(dialog.hover.current(), None);
+        assert_eq!(dialog.focus, FocusElement::NoButton);
     }
 
     #[test]

--- a/src/tui/dialogs/group_delete_options.rs
+++ b/src/tui/dialogs/group_delete_options.rs
@@ -412,10 +412,9 @@ impl GroupDeleteOptionsDialog {
         // Paint the hover highlight last so it sits behind a row that
         // still exists this frame (the row set shrinks when "Move" is
         // selected, so a stale rect from a previous layout is dropped).
-        if let Some(rect) = self.hover.current() {
-            if self.focusable_rects.iter().any(|(_, r)| *r == rect) {
-                paint_hover_bg(frame, rect, theme.selection);
-            }
+        let rows: Vec<Rect> = self.focusable_rects.iter().map(|(_, r)| *r).collect();
+        if let Some(rect) = self.hover.current_in(&rows) {
+            paint_hover_bg(frame, rect, theme.selection);
         }
     }
 }

--- a/src/tui/dialogs/group_delete_options.rs
+++ b/src/tui/dialogs/group_delete_options.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::*;
 
 use super::DialogResult;
 use crate::tui::components::checkbox::{checkbox_line, CheckboxStyle};
+use crate::tui::components::hover::{paint_hover_bg, HoverState};
 use crate::tui::styles::Theme;
 
 #[derive(Clone, Debug, Default)]
@@ -25,9 +26,11 @@ pub struct GroupDeleteOptionsDialog {
     options: GroupDeleteOptions,
     focused_field: usize,
     /// Captured rect per focusable field, populated by `render`.
-    /// Drives both click (set focus + toggle) and hover (set focus
-    /// only).
+    /// Drives both click (set focus + toggle) and the hover highlight.
     focusable_rects: Vec<(usize, Rect)>,
+    /// Which field row the mouse is over, for the hover highlight.
+    /// Visual only; never moves keyboard `focused_field`.
+    hover: HoverState,
 }
 
 impl GroupDeleteOptionsDialog {
@@ -45,6 +48,7 @@ impl GroupDeleteOptionsDialog {
             options: GroupDeleteOptions::default(),
             focused_field: 0,
             focusable_rects: Vec::new(),
+            hover: HoverState::default(),
         }
     }
 
@@ -60,11 +64,13 @@ impl GroupDeleteOptionsDialog {
         Some(DialogResult::Continue)
     }
 
-    /// Hover does not change focus on the radios / checkboxes. See
-    /// `ConfirmDialog::handle_hover` for the rationale. Click still
-    /// moves focus and toggles state.
-    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
-        false
+    /// Highlight the field row under the cursor without moving keyboard
+    /// `focused_field`. See `ConfirmDialog::handle_hover` for the
+    /// rationale; click still moves focus and toggles state. Returns
+    /// `true` when the highlighted row changed.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let rects: Vec<Rect> = self.focusable_rects.iter().map(|(_, r)| *r).collect();
+        self.hover.update(col, row, &rects)
     }
 
     /// Mirror the Space-key branch's per-field toggle / radio logic so a
@@ -402,6 +408,15 @@ impl GroupDeleteOptionsDialog {
             Span::raw(" cancel"),
         ]);
         frame.render_widget(Paragraph::new(hints), chunks[next_chunk]);
+
+        // Paint the hover highlight last so it sits behind a row that
+        // still exists this frame (the row set shrinks when "Move" is
+        // selected, so a stale rect from a previous layout is dropped).
+        if let Some(rect) = self.hover.current() {
+            if self.focusable_rects.iter().any(|(_, r)| *r == rect) {
+                paint_hover_bg(frame, rect, theme.selection);
+            }
+        }
     }
 }
 
@@ -753,6 +768,23 @@ mod tests {
         assert!(!dialog.options.force_delete_worktrees);
         assert!(!dialog.options.delete_branches);
         assert!(!dialog.options.delete_containers);
+    }
+
+    #[test]
+    fn hover_highlights_row_without_moving_focus() {
+        // Stage focusable rects manually; the real ones come from render().
+        let mut dialog = dialog();
+        dialog.focusable_rects = vec![(0, Rect::new(2, 4, 40, 1)), (1, Rect::new(2, 5, 40, 1))];
+        dialog.focused_field = 0;
+
+        // Over the delete row: highlight it, focus unchanged.
+        assert!(dialog.handle_hover(5, 5));
+        assert_eq!(dialog.hover.current(), Some(Rect::new(2, 5, 40, 1)));
+        assert_eq!(dialog.focused_field, 0, "hover must not move focus");
+
+        // Off all rows clears the highlight.
+        assert!(dialog.handle_hover(99, 99));
+        assert_eq!(dialog.hover.current(), None);
     }
 
     #[test]

--- a/src/tui/dialogs/hook_trust.rs
+++ b/src/tui/dialogs/hook_trust.rs
@@ -263,7 +263,11 @@ impl HookTrustDialog {
             button_area,
         );
 
-        if let Some(rect) = self.hover.current() {
+        if let Some(rect) = self.hover.current_in(&[
+            self.trust_button_area,
+            self.skip_button_area,
+            self.cancel_button_area,
+        ]) {
             paint_hover_bg(frame, rect, theme.selection);
         }
     }

--- a/src/tui/dialogs/hook_trust.rs
+++ b/src/tui/dialogs/hook_trust.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::*;
 
 use super::DialogResult;
 use crate::session::{repo_config, HooksConfig};
+use crate::tui::components::hover::{paint_hover_bg, HoverState};
 use crate::tui::styles::Theme;
 
 pub struct HookTrustDialog {
@@ -21,6 +22,9 @@ pub struct HookTrustDialog {
     trust_button_area: Rect,
     skip_button_area: Rect,
     cancel_button_area: Rect,
+    /// Which button the mouse is over, for the hover highlight. Visual
+    /// only; never changes `selected`.
+    hover: HoverState,
 }
 
 /// Result from the hook trust dialog.
@@ -52,6 +56,7 @@ impl HookTrustDialog {
             trust_button_area: Rect::default(),
             skip_button_area: Rect::default(),
             cancel_button_area: Rect::default(),
+            hover: HoverState::default(),
         }
     }
 
@@ -73,10 +78,19 @@ impl HookTrustDialog {
         None
     }
 
-    /// Hover does not change the Trust/Skip selection. See
-    /// `ConfirmDialog::handle_hover` for the rationale.
-    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
-        false
+    /// Highlight the button under the cursor without changing the
+    /// Trust/Skip selection. See `ConfirmDialog::handle_hover` for the
+    /// rationale. Returns `true` when the highlighted button changed.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        self.hover.update(
+            col,
+            row,
+            &[
+                self.trust_button_area,
+                self.skip_button_area,
+                self.cancel_button_area,
+            ],
+        )
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<HookTrustAction> {
@@ -248,6 +262,10 @@ impl HookTrustDialog {
             Paragraph::new(buttons).alignment(Alignment::Center),
             button_area,
         );
+
+        if let Some(rect) = self.hover.current() {
+            paint_hover_bg(frame, rect, theme.selection);
+        }
     }
 }
 
@@ -336,6 +354,32 @@ mod tests {
         assert!(dialog.selected);
         dialog.handle_key(key(KeyCode::Tab));
         assert!(!dialog.selected);
+    }
+
+    #[test]
+    fn hover_highlights_button_without_changing_selection() {
+        // Stage button rects manually; the real ones come from render().
+        let mut dialog = test_dialog();
+        dialog.trust_button_area = Rect::new(2, 5, 17, 1);
+        dialog.skip_button_area = Rect::new(23, 5, 10, 1);
+        dialog.cancel_button_area = Rect::new(37, 5, 14, 1);
+        assert!(!dialog.selected);
+
+        // Over Trust: highlight it, selection unchanged.
+        assert!(dialog.handle_hover(3, 5));
+        assert_eq!(dialog.hover.current(), Some(dialog.trust_button_area));
+        assert!(
+            !dialog.selected,
+            "hover must not flip the Trust/Skip selection"
+        );
+
+        // Cancel is clickable, so it highlights too.
+        assert!(dialog.handle_hover(38, 5));
+        assert_eq!(dialog.hover.current(), Some(dialog.cancel_button_area));
+
+        // Off all buttons clears the highlight.
+        assert!(dialog.handle_hover(0, 0));
+        assert_eq!(dialog.hover.current(), None);
     }
 
     #[test]

--- a/src/tui/dialogs/hooks_install.rs
+++ b/src/tui/dialogs/hooks_install.rs
@@ -270,7 +270,10 @@ impl HooksInstallDialog {
             button_area,
         );
 
-        if let Some(rect) = self.hover.current() {
+        if let Some(rect) = self
+            .hover
+            .current_in(&[self.accept_button_area, self.cancel_button_area])
+        {
             paint_hover_bg(frame, rect, theme.selection);
         }
     }

--- a/src/tui/dialogs/hooks_install.rs
+++ b/src/tui/dialogs/hooks_install.rs
@@ -5,6 +5,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::*;
 
 use super::DialogResult;
+use crate::tui::components::hover::{paint_hover_bg, HoverState};
 use crate::tui::styles::Theme;
 
 pub struct HooksInstallDialog {
@@ -15,6 +16,9 @@ pub struct HooksInstallDialog {
     scroll_offset: u16,
     accept_button_area: Rect,
     cancel_button_area: Rect,
+    /// Which button the mouse is over, for the hover highlight. Visual
+    /// only; never changes `selected`.
+    hover: HoverState,
 }
 
 impl HooksInstallDialog {
@@ -59,6 +63,7 @@ impl HooksInstallDialog {
             scroll_offset: 0,
             accept_button_area: Rect::default(),
             cancel_button_area: Rect::default(),
+            hover: HoverState::default(),
         }
     }
 
@@ -73,10 +78,15 @@ impl HooksInstallDialog {
         None
     }
 
-    /// Hover does not change the Accept / Cancel selection. See
-    /// `ConfirmDialog::handle_hover` for the rationale.
-    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
-        false
+    /// Highlight the button under the cursor without changing the
+    /// Accept / Cancel selection. See `ConfirmDialog::handle_hover` for
+    /// the rationale. Returns `true` when the highlighted button changed.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        self.hover.update(
+            col,
+            row,
+            &[self.accept_button_area, self.cancel_button_area],
+        )
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<bool> {
@@ -259,6 +269,10 @@ impl HooksInstallDialog {
             Paragraph::new(buttons).alignment(Alignment::Center),
             button_area,
         );
+
+        if let Some(rect) = self.hover.current() {
+            paint_hover_bg(frame, rect, theme.selection);
+        }
     }
 }
 
@@ -355,6 +369,27 @@ mod tests {
         assert!(!dialog.selected);
         dialog.handle_key(key(KeyCode::Tab));
         assert!(dialog.selected);
+    }
+
+    #[test]
+    fn hover_highlights_button_without_changing_selection() {
+        let mut dialog = HooksInstallDialog::new("claude");
+        dialog.accept_button_area = Rect::new(2, 5, 12, 1);
+        dialog.cancel_button_area = Rect::new(20, 5, 14, 1);
+        assert!(dialog.selected);
+
+        // Over Accept: highlight it, selection unchanged.
+        assert!(dialog.handle_hover(3, 5));
+        assert_eq!(dialog.hover.current(), Some(dialog.accept_button_area));
+        assert!(dialog.selected, "hover must not flip the selection");
+
+        // Over Cancel.
+        assert!(dialog.handle_hover(21, 5));
+        assert_eq!(dialog.hover.current(), Some(dialog.cancel_button_area));
+
+        // Off the buttons clears.
+        assert!(dialog.handle_hover(0, 0));
+        assert_eq!(dialog.hover.current(), None);
     }
 
     #[test]

--- a/src/tui/dialogs/info.rs
+++ b/src/tui/dialogs/info.rs
@@ -121,7 +121,7 @@ impl InfoDialog {
             button_area,
         );
 
-        if let Some(rect) = self.hover.current() {
+        if let Some(rect) = self.hover.current_in(&[self.ok_button_area]) {
             paint_hover_bg(frame, rect, theme.selection);
         }
     }

--- a/src/tui/dialogs/info.rs
+++ b/src/tui/dialogs/info.rs
@@ -5,6 +5,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::*;
 
 use super::DialogResult;
+use crate::tui::components::hover::{paint_hover_bg, HoverState};
 use crate::tui::styles::Theme;
 
 pub struct InfoDialog {
@@ -13,6 +14,12 @@ pub struct InfoDialog {
     width: u16,
     height: u16,
     dialog_area: Rect,
+    /// Rect of the `[OK]` button, captured during `render`. A click
+    /// anywhere dismisses, but the button is the call to action, so it
+    /// picks up the hover highlight to read as clickable.
+    ok_button_area: Rect,
+    /// Whether the cursor is over `[OK]`, for the hover highlight.
+    hover: HoverState,
 }
 
 impl InfoDialog {
@@ -23,6 +30,8 @@ impl InfoDialog {
             width: 50,
             height: 9,
             dialog_area: Rect::default(),
+            ok_button_area: Rect::default(),
+            hover: HoverState::default(),
         }
     }
 
@@ -39,6 +48,13 @@ impl InfoDialog {
         } else {
             None
         }
+    }
+
+    /// Highlight the `[OK]` button when the cursor is over it. A click
+    /// anywhere still dismisses via `handle_click`; this only signals the
+    /// call to action. Returns `true` when the highlight changed.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        self.hover.update(col, row, &[self.ok_button_area])
     }
 
     /// Customize the dialog's footprint. Useful for long, multi-paragraph
@@ -85,17 +101,29 @@ impl InfoDialog {
             .wrap(Wrap { trim: true });
         frame.render_widget(message, chunks[0]);
 
-        // OK button rendered for visual affordance; click is handled
-        // by the whole-dialog hit region in `handle_click`, so the
-        // button's own rect doesn't need to be captured.
+        // OK button. Click is handled by the whole-dialog hit region in
+        // `handle_click`; the rect is captured only so hover can
+        // highlight the button as the call to action.
         let button = Line::from(vec![Span::styled(
             "[OK]",
             Style::default().fg(theme.accent).bold(),
         )]);
+        let button_area = chunks[1];
+        const OK_WIDTH: u16 = 4; // "[OK]"
+        self.ok_button_area = if button_area.width >= OK_WIDTH {
+            let ok_x = button_area.x + (button_area.width - OK_WIDTH) / 2;
+            Rect::new(ok_x, button_area.y, OK_WIDTH, 1)
+        } else {
+            Rect::default()
+        };
         frame.render_widget(
             Paragraph::new(button).alignment(Alignment::Center),
-            chunks[1],
+            button_area,
         );
+
+        if let Some(rect) = self.hover.current() {
+            paint_hover_bg(frame, rect, theme.selection);
+        }
     }
 }
 
@@ -134,5 +162,20 @@ mod tests {
         let mut dialog = InfoDialog::new("Test", "Message");
         let result = dialog.handle_key(key(KeyCode::Char('x')));
         assert!(matches!(result, DialogResult::Continue));
+    }
+
+    #[test]
+    fn hover_highlights_ok_button() {
+        // Stage the button rect manually; the real one comes from render().
+        let mut dialog = InfoDialog::new("Test", "Message");
+        dialog.ok_button_area = Rect::new(10, 8, 4, 1);
+
+        // Over [OK]: highlight it.
+        assert!(dialog.handle_hover(11, 8));
+        assert_eq!(dialog.hover.current(), Some(dialog.ok_button_area));
+
+        // Off the button clears the highlight.
+        assert!(dialog.handle_hover(0, 0));
+        assert_eq!(dialog.hover.current(), None);
     }
 }

--- a/src/tui/dialogs/no_agents.rs
+++ b/src/tui/dialogs/no_agents.rs
@@ -203,7 +203,10 @@ impl NoAgentsDialog {
             button_area,
         );
 
-        if let Some(rect) = self.hover.current() {
+        if let Some(rect) = self
+            .hover
+            .current_in(&[self.recheck_button_area, self.quit_button_area])
+        {
             paint_hover_bg(frame, rect, theme.selection);
         }
     }

--- a/src/tui/dialogs/no_agents.rs
+++ b/src/tui/dialogs/no_agents.rs
@@ -8,6 +8,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::*;
 
 use super::DialogResult;
+use crate::tui::components::hover::{paint_hover_bg, HoverState};
 use crate::tui::styles::Theme;
 
 /// Result of the no-agents dialog interaction.
@@ -23,6 +24,9 @@ pub struct NoAgentsDialog {
     recheck_focused: bool,
     recheck_button_area: Rect,
     quit_button_area: Rect,
+    /// Which button the mouse is over, for the hover highlight. Visual
+    /// only; never changes `recheck_focused`.
+    hover: HoverState,
 }
 
 impl NoAgentsDialog {
@@ -31,6 +35,7 @@ impl NoAgentsDialog {
             recheck_focused: true,
             recheck_button_area: Rect::default(),
             quit_button_area: Rect::default(),
+            hover: HoverState::default(),
         }
     }
 
@@ -45,10 +50,12 @@ impl NoAgentsDialog {
         None
     }
 
-    /// Hover does not change the Re-check / Quit focus. See
-    /// `ConfirmDialog::handle_hover` for the rationale.
-    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
-        false
+    /// Highlight the button under the cursor without changing the
+    /// Re-check / Quit focus. See `ConfirmDialog::handle_hover` for the
+    /// rationale. Returns `true` when the highlighted button changed.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        self.hover
+            .update(col, row, &[self.recheck_button_area, self.quit_button_area])
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<NoAgentsAction> {
@@ -195,6 +202,10 @@ impl NoAgentsDialog {
             .alignment(Alignment::Center),
             button_area,
         );
+
+        if let Some(rect) = self.hover.current() {
+            paint_hover_bg(frame, rect, theme.selection);
+        }
     }
 }
 
@@ -257,6 +268,23 @@ mod tests {
         // Enter now submits Quit
         let result = dialog.handle_key(key(KeyCode::Enter));
         assert!(matches!(result, DialogResult::Submit(NoAgentsAction::Quit)));
+    }
+
+    #[test]
+    fn hover_highlights_button_without_changing_focus() {
+        let mut dialog = NoAgentsDialog::new();
+        dialog.recheck_button_area = Rect::new(2, 5, 10, 1);
+        dialog.quit_button_area = Rect::new(16, 5, 6, 1);
+        assert!(dialog.recheck_focused);
+
+        // Over Quit: highlight it, focus unchanged.
+        assert!(dialog.handle_hover(17, 5));
+        assert_eq!(dialog.hover.current(), Some(dialog.quit_button_area));
+        assert!(dialog.recheck_focused, "hover must not move focus");
+
+        // Off the buttons clears.
+        assert!(dialog.handle_hover(99, 99));
+        assert_eq!(dialog.hover.current(), None);
     }
 
     #[test]

--- a/src/tui/dialogs/restart.rs
+++ b/src/tui/dialogs/restart.rs
@@ -307,7 +307,10 @@ impl RestartDialog {
         self.tool_selector_area = chunks[5];
         self.render_hints(frame, chunks[7], theme);
 
-        if let Some(rect) = self.hover.current() {
+        if let Some(rect) = self
+            .hover
+            .current_in(&[self.profile_selector_area, self.tool_selector_area])
+        {
             paint_hover_bg(frame, rect, theme.selection);
         }
     }

--- a/src/tui/dialogs/restart.rs
+++ b/src/tui/dialogs/restart.rs
@@ -13,6 +13,7 @@ use ratatui::widgets::*;
 
 use super::DialogResult;
 use crate::session::profile_config::resolve_config_or_warn;
+use crate::tui::components::hover::{paint_hover_bg, HoverState};
 use crate::tui::components::{profile_cycler_spans, tool_cycler_spans};
 use crate::tui::styles::Theme;
 
@@ -37,6 +38,9 @@ pub struct RestartDialog {
     focused_field: usize,
     profile_selector_area: Rect,
     tool_selector_area: Rect,
+    /// Which selector row the mouse is over, for the hover highlight.
+    /// Visual only; never moves keyboard `focused_field`.
+    hover: HoverState,
 }
 
 impl RestartDialog {
@@ -67,6 +71,7 @@ impl RestartDialog {
             focused_field: 0,
             profile_selector_area: Rect::default(),
             tool_selector_area: Rect::default(),
+            hover: HoverState::default(),
         }
     }
 
@@ -92,13 +97,18 @@ impl RestartDialog {
         None
     }
 
-    /// Hover does not change the focused field. Click commits via
-    /// `handle_click`; see `ConfirmDialog::handle_hover` for the
-    /// rationale (mouse drift between the user reading the dialog and
-    /// hitting a keystroke must not silently shift which field that
-    /// key targets).
-    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
-        false
+    /// Highlight the selector row under the cursor without moving the
+    /// focused field. Click commits via `handle_click`; see
+    /// `ConfirmDialog::handle_hover` for the rationale (mouse drift
+    /// between the user reading the dialog and hitting a keystroke must
+    /// not silently shift which field that key targets). Returns `true`
+    /// when the highlighted row changed.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        self.hover.update(
+            col,
+            row,
+            &[self.profile_selector_area, self.tool_selector_area],
+        )
     }
 
     /// Re-resolve the default tool for the currently selected profile
@@ -296,6 +306,10 @@ impl RestartDialog {
         self.render_tool_selector(frame, chunks[5], theme);
         self.tool_selector_area = chunks[5];
         self.render_hints(frame, chunks[7], theme);
+
+        if let Some(rect) = self.hover.current() {
+            paint_hover_bg(frame, rect, theme.selection);
+        }
     }
 
     /// Profile picker, rendered via the shared `profile_cycler_spans` so the
@@ -514,6 +528,24 @@ mod tests {
             d.handle_key(key(KeyCode::Char('x'))),
             DialogResult::Continue
         ));
+    }
+
+    #[test]
+    fn hover_highlights_selector_without_moving_focus() {
+        // Stage selector rects manually; the real ones come from render().
+        let mut d = RestartDialog::new("S", "default", "claude", profiles(), tools());
+        d.profile_selector_area = Rect::new(2, 4, 50, 1);
+        d.tool_selector_area = Rect::new(2, 5, 50, 1);
+        assert_eq!(d.focused_field, 0);
+
+        // Over the tool row: highlight it, focus unchanged.
+        assert!(d.handle_hover(5, 5));
+        assert_eq!(d.hover.current(), Some(d.tool_selector_area));
+        assert_eq!(d.focused_field, 0, "hover must not move the focused field");
+
+        // Off both rows clears the highlight.
+        assert!(d.handle_hover(99, 99));
+        assert_eq!(d.hover.current(), None);
     }
 
     #[test]

--- a/src/tui/dialogs/update_confirm.rs
+++ b/src/tui/dialogs/update_confirm.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::*;
 
 use super::DialogResult;
 use crate::tui::components::buttons::render_yes_no;
+use crate::tui::components::hover::HoverState;
 use crate::tui::styles::Theme;
 use crate::update::install::InstallMethod;
 
@@ -17,6 +18,9 @@ pub struct UpdateConfirmDialog {
     selected: bool, // true = Yes, false = No
     yes_button_area: Rect,
     no_button_area: Rect,
+    /// Which Yes/No button the mouse is over, for the hover highlight.
+    /// Visual only; never changes `selected`.
+    hover: HoverState,
 }
 
 impl UpdateConfirmDialog {
@@ -40,6 +44,7 @@ impl UpdateConfirmDialog {
             selected: false,
             yes_button_area: Rect::default(),
             no_button_area: Rect::default(),
+            hover: HoverState::default(),
         }
     }
 
@@ -54,10 +59,12 @@ impl UpdateConfirmDialog {
         None
     }
 
-    /// Hover does not change the Yes/No selection. See `ConfirmDialog`
-    /// for the rationale.
-    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
-        false
+    /// Highlight the Yes/No button under the cursor without changing
+    /// `selected`. See `ConfirmDialog::handle_hover` for the rationale.
+    /// Returns `true` when the highlighted button changed.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        self.hover
+            .update(col, row, &[self.yes_button_area, self.no_button_area])
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
@@ -113,7 +120,7 @@ impl UpdateConfirmDialog {
             Paragraph::new(self.prompt_block.as_str()).style(Style::default().fg(theme.text));
         frame.render_widget(body, chunks[0]);
 
-        let (yes, no) = render_yes_no(frame, chunks[1], theme, self.selected);
+        let (yes, no) = render_yes_no(frame, chunks[1], theme, self.selected, self.hover.current());
         self.yes_button_area = yes;
         self.no_button_area = no;
     }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3323,6 +3323,12 @@ impl HomeView {
         if let Some(dialog) = &mut self.intro_dialog {
             overlay_changed |= dialog.handle_hover(col, row);
         }
+        if let Some(dialog) = &mut self.info_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.changelog_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
 
         let new_pos = if self.list_inner_area.contains(Position::from((col, row))) {
             Some((col, row))


### PR DESCRIPTION
## Description

Mouse hover now highlights the button or row under the cursor in the confirm-style dialogs, matching the row hover already used in the settings and home views. Previously these dialogs hit-tested clicks but left `handle_hover` a no-op, so there was no visual cue for what a click would land on.

This started as a request to highlight `[Yes]` / `[No]` in the delete-session dialog, then extended to the whole cluster of dialogs that shared the same gap.

### Shared primitive

The highlight is factored into a new `src/tui/components/hover.rs`:

- `paint_hover_bg(frame, area, bg)`: paints a background behind a rect, preserving glyphs (the same treatment settings / home rows get under the cursor).
- `HoverState`: tracks which captured rect the pointer is over and returns `true` only when that target changes, so redraws fire on real moves between targets rather than every pixel twitch. It stays empty until the first render (zero-sized rects match no point).

`render_yes_no` now takes the hovered rect and paints it.

### Dialogs wired up

| Dialog | Highlighted elements |
| --- | --- |
| `confirm`, `delete_options`, `update_confirm` | `[Yes]` / `[No]` |
| `hook_trust` | Trust / Skip / Cancel |
| `hooks_install` | Accept / Cancel |
| `no_agents` | Re-check / Quit |
| `group_delete_options` | each radio / checkbox row |
| `restart` | profile / tool selector rows |
| `info`, `changelog` | the dismiss button (`[OK]` / `[Got it]`) |

`info` and `changelog` dismiss on a click anywhere, so they have no distinct click target; their call-to-action button picks up the highlight to read as clickable, and both were added to the home view's hover dispatch (they had no `handle_hover` before).

### Invariant preserved

Hover stays visual only and never moves keyboard focus or selection. Mouse drift between reading a prompt and pressing Enter must not silently flip which action fires, so what Enter does is unchanged; clicks still commit explicitly via `handle_click`. Each dialog has a test asserting the highlight follows the cursor while focus / selection stays put.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs cover dialog mouse affordances)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the hover logic and the background paint are covered by unit tests at each dialog plus the shared `HoverState` / `render_yes_no`; the tmux e2e harness drives keystrokes, not mouse-move events, so a hover-highlight assertion isn't expressible there.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implemented via Claude Code through back-and-forth with @njbrake. The reasoning and scoping decisions (which dialogs to include, keeping hover visual-only) are his; the code and prose are Claude's.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds consistent mouse-hover visual highlighting to TUI dialogs so buttons and selectable rows under the cursor are visually indicated. A small reusable hover system centralizes painting and tracking, and dialogs were updated to use it while preserving all keyboard and click behavior.

## What changed (high-level)

- New shared hover primitive: src/tui/components/hover.rs
  - paint_hover_bg(frame, area, bg): paints a background for a Rect without altering glyphs/foregrounds
  - HoverState: tracks the currently hovered captured rect and exposes update/current/current_in helpers
- Button rendering updated:
  - render_yes_no now accepts an optional hovered Rect and paints hover background for the matching button
- Dialogs wired to hover highlighting:
  - Confirm-style and yes/no dialogs: confirm, delete_options, update_confirm
  - Multi-button/triple dialogs: hook_trust, hooks_install, no_agents
  - Row-selection dialogs: group_delete_options, restart
  - Info dialogs: info, changelog (home view hover routing updated to include changelog/info)
- Tests and small docs updated; implementation noted as assisted by AI (Claude Code).
- Behavior invariant retained: hover is visual-only (doesn't change keyboard focus/selection); Enter and click semantics unchanged.

## Key benefits

- Improved UX: immediate visual indication of which button/row will be clicked
- Consistency: hover behavior unified across dialog types
- Efficiency: HoverState avoids redrawing on every pixel move by reporting changes only when hovered target changes
- Maintainability: centralized hover painting/tracking reduces ad-hoc checks and stale-highlight bugs (added current_in to drop stale rects after layout changes)

## Technical notes (concise)

- API additions: pub fn paint_hover_bg(...), pub struct HoverState with methods current(), current_in(&[Rect]) and update(col, row, rects).
- render_yes_no signature changed to accept hovered: Option<Rect>.
- Dialogs capture button/row Rects during render, store them on the struct, and implement handle_hover(col,row) to update HoverState and return whether the hovered target changed so callers can trigger redraws.
- Tests added/updated to assert hover follows the cursor while keyboard focus/selection remain unchanged; guards added to avoid painting stale rects after resizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->