### PR TITLE
fix(cockpit): open transcript markdown links in a new tab

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -101,7 +101,9 @@ in a dim block, and `-`/`1.` lists with bullet or number markers. The
 raw `#`, `**`, backtick, and fence characters are not shown. Styling
 uses text attributes only (bold, italic, dim) so it tracks your theme
 colors. Code-block syntax highlighting is deferred; press `o` to open
-the web dashboard for full-fidelity rendering.
+the web dashboard for full-fidelity rendering. In the web dashboard,
+links inside transcript messages open in a new browser tab so following
+a docs, CI, or repo link keeps your cockpit session open.
 
 **Tool cards.** Tool calls in the transcript render per kind rather than
 as a single generic line. An edit or write shows the file path and a

--- a/web/src/components/cockpit/Markdown.test.tsx
+++ b/web/src/components/cockpit/Markdown.test.tsx
@@ -112,6 +112,7 @@ describe("Markdown wrapper config", () => {
         "CodeHeader",
         "table",
         "blockquote",
+        "a",
       ]),
     );
   });
@@ -167,6 +168,43 @@ describe("Blockquote override", () => {
     expect(container.querySelector("blockquote")?.className).toContain(
       "cockpit-callout-warn",
     );
+  });
+});
+
+// #1714: transcript links must open in a new tab with a safe rel so
+// clicking a docs/CI/repo link does not replace the live cockpit page.
+describe("anchor override", () => {
+  function getAnchor(): React.ComponentType<
+    React.ComponentPropsWithoutRef<"a">
+  > {
+    render(<Markdown text="x" />);
+    return primitiveCalls.at(-1)!.components.a as React.ComponentType<
+      React.ComponentPropsWithoutRef<"a">
+    >;
+  }
+
+  it("forces transcript links to open in a new tab with a safe rel", () => {
+    const Anchor = getAnchor();
+    const { container } = render(
+      <Anchor href="https://example.com">docs</Anchor>,
+    );
+    const a = container.querySelector("a");
+    expect(a).not.toBeNull();
+    expect(a?.getAttribute("target")).toBe("_blank");
+    expect(a?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("preserves the original href and children", () => {
+    const Anchor = getAnchor();
+    const { container } = render(
+      <Anchor href="https://example.com/path" title="t">
+        link text
+      </Anchor>,
+    );
+    const a = container.querySelector("a");
+    expect(a?.getAttribute("href")).toBe("https://example.com/path");
+    expect(a?.getAttribute("title")).toBe("t");
+    expect(a?.textContent).toBe("link text");
   });
 });
 

--- a/web/src/components/cockpit/Markdown.tsx
+++ b/web/src/components/cockpit/Markdown.tsx
@@ -77,9 +77,24 @@ export function Markdown({ text, smooth = false, breaks = false }: Props) {
         CodeHeader,
         table: TableWithScroll,
         blockquote: Blockquote,
+        a: TranscriptLink,
       }}
     />
   );
+}
+
+/**
+ * Transcript link. Cockpit is a long-running debugging surface, so a
+ * link that navigates the current tab pulls the user out of the live
+ * session. Force every transcript anchor to open a new tab with the
+ * dashboard-standard safe rel (matches AboutModal, Dashboard, etc., and
+ * guards against tabnabbing). Existing anchor props (href, title,
+ * className, children) are forwarded untouched. See #1714.
+ */
+function TranscriptLink({
+  ...rest
+}: React.ComponentPropsWithoutRef<"a">) {
+  return <a {...rest} target="_blank" rel="noopener noreferrer" />;
 }
 
 /**


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Links rendered inside cockpit transcript messages opened in the same browser tab. Clicking a docs, CI, or repo link replaced the live cockpit page and interrupted the debugging session, on both user and assistant bubbles.

Root cause: cockpit transcript text renders through the `Markdown` wrapper, whose `components` map overrode code, tables, and blockquotes but not anchors (`web/src/components/cockpit/Markdown.tsx`). With no `a` override, anchors fell back to the browser default same-tab navigation.

This adds a `TranscriptLink` anchor override that forces `target="_blank"` plus the dashboard-standard safe `rel="noopener noreferrer"` (matching `AboutModal`, `Dashboard`, etc., and guarding against tabnabbing), while forwarding the original `href`, `title`, `className`, and `children` untouched. It applies to every transcript anchor. A Vitest regression asserts the contract and the docs note the behavior.

Closes #1714

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a cockpit session in the web dashboard and have the agent (or a user prompt) produce a markdown link, e.g. `[docs](https://example.com)`.
- [ ] Click the link in the transcript; it opens in a new browser tab and the cockpit session stays open in the original tab.
- [ ] Click several transcript links in a row; each opens in its own new tab so the transcript position is never lost.
- [ ] Inspect a rendered transcript anchor; it carries `target="_blank"` and `rel="noopener noreferrer"`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the anchor contract (`target="_blank"`, safe `rel`, preserved `href`/children) is fully proven by a Vitest regression in `web/src/components/cockpit/Markdown.test.tsx`, which the existing `cockpit.markdown` matrix entry already maps. A real "new OS tab opened" Playwright assertion is flaky and low value over the attribute check.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (apply to all links, dashboard-standard `rel`, no `referrerPolicy`, Vitest over Playwright), reviewed each commit, and confirmed the regression goes red on the pre-fix tree and green after.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes an issue where links in Cockpit transcript messages would open in the same tab, disrupting live debugging sessions. The fix ensures that all links in transcript markdown consistently open in a new browser tab.

### What Changed

**Added:**
- A new `TranscriptLink` component that wraps anchors in the Cockpit markdown renderer, forcing links to open in new tabs
- Test suite validating that transcript links render with the correct target and security attributes
- Documentation noting the new link behavior in the Cockpit interface guide

**Updated:**
- Cockpit markdown rendering configuration to use the new anchor override

### Benefits

- **Improved user experience**: Users can follow documentation, CI logs, and repository links without losing their live debugging session
- **Consistent behavior**: Matches the existing behavior on the dashboard for link handling
- **Security**: Implements standard security attributes (`rel="noopener noreferrer"`) for new-tab links
- **Regression coverage**: Includes automated tests to prevent accidental reversion of this behavior

### Technical Details

The implementation adds a `TranscriptLink` wrapper component that:
- Forces `target="_blank"` on all transcript anchors
- Adds `rel="noopener noreferrer"` for security
- Preserves all original anchor properties (href, title, className, children)
- Applies consistently to all anchors rendered in cockpit transcript messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->