### PR TITLE
fix(cockpit): clamp inlined tool label in working spinner

### DIFF
--- a/web/src/lib/cockpitRattle.test.ts
+++ b/web/src/lib/cockpitRattle.test.ts
@@ -12,6 +12,7 @@ import {
   SPINNER_FRAMES,
   SPINNER_INTERVAL_MS,
   THINKING_VERBS,
+  TOOL_LABEL_MAX,
   VERB_INTERVAL_MS,
   WORKING_VERBS,
 } from "./cockpitRattle";
@@ -68,6 +69,31 @@ describe("chooseVerb", () => {
     const out = chooseVerb("tool", 3, "Bash");
     expect(out.endsWith("…")).toBe(true);
     expect(out.endsWith(" Bash…")).toBe(true);
+  });
+
+  it("clamps a long tool title so it does not flood the spinner (#1728)", () => {
+    // inFlightTool.name carries the ACP title, which for Bash is the full
+    // command line. A heredoc-into-consult-llm dispatch can run hundreds
+    // of chars; the inline spinner must not inline it verbatim.
+    const longCommand =
+      "cat <<'__CONSULT_LLM_END__' | consult-llm --task plan -m gemini -m openai -f /Users/foo/terminal_handler.rs";
+    const out = chooseVerb("tool", 3, longCommand);
+    expect(out.endsWith("…")).toBe(true);
+    // The inlined name is bounded; the full command never reaches the row.
+    expect(out).not.toContain(longCommand);
+    expect(out).not.toContain("consult-llm");
+    // Whole label = "<verb> <clamped>…"; clamped slice is <= TOOL_LABEL_MAX.
+    const verb = out.split(" ")[0];
+    const inlined = out.slice(verb.length + 1, -1);
+    expect(inlined.length).toBeLessThanOrEqual(TOOL_LABEL_MAX);
+    expect(longCommand.startsWith(inlined.trimEnd())).toBe(true);
+  });
+
+  it("leaves short tool titles unchanged (#1728)", () => {
+    expect(chooseVerb("tool", 3, "Bash").endsWith(" Bash…")).toBe(true);
+    expect(chooseVerb("tool", 3, "Read foo.ts").endsWith(" Read foo.ts…")).toBe(
+      true,
+    );
   });
 
   it("falls back to WORKING_VERBS when state=tool but toolName is null", () => {

--- a/web/src/lib/cockpitRattle.ts
+++ b/web/src/lib/cockpitRattle.ts
@@ -29,6 +29,16 @@ export const SPINNER_INTERVAL_MS = 80;
 export const VERB_INTERVAL_MS = 18_000;
 
 /**
+ * Max characters of the tool name inlined into the spinner verb. The
+ * spinner is a single italic inline line, but `inFlightTool.name` carries
+ * the ACP tool title, which for Bash is the full command line (a heredoc
+ * or piped consult-llm dispatch can run hundreds of chars). Clamping here
+ * keeps `Dispatching Bash…` and short titles intact while stopping a long
+ * command from flooding the row. See #1728.
+ */
+export const TOOL_LABEL_MAX = 24;
+
+/**
  * General "agent is working" pool. Used when there's no thinking/tool
  * sub-state to be more specific. Themed around empire building and
  * statecraft — conscripting, mining, forging, scouting, etc.
@@ -141,7 +151,11 @@ export function chooseVerb(
       "Wielding",
     ];
     const v = verbs[pickIndex(verbs.length, seed)];
-    return `${v} ${toolName}…`;
+    const label =
+      toolName.length > TOOL_LABEL_MAX
+        ? toolName.slice(0, TOOL_LABEL_MAX).trimEnd()
+        : toolName;
+    return `${v} ${label}…`;
   }
   if (state === "thinking") {
     return `${THINKING_VERBS[pickIndex(THINKING_VERBS.length, seed)]}…`;


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the cockpit web view, when the agent ran a long Bash command (a heredoc, a piped `consult-llm` debate dispatch, anything with a verbose command line), the working spinner inlined the entire raw command into its verb label, flooding the single italic spinner row and burying the spinner glyph. `/debate` and `/collab` style flows that pipe a long heredoc into a CLI tripped it every time.

Root cause: the spinner derives its verb from `inFlightTool.name`, which carries the ACP tool title. For Bash the title is the full command line (correct for the tool card, which wraps and clamps with its own layout), and `chooseVerb` inlined it verbatim with no bound.

This clamps the inlined tool name to 24 characters in `chooseVerb` before composing the verb label. Short titles like `Bash` and `Read foo.ts` pass through unchanged; long command lines are bounded so the spinner glyph and layout stay intact. The kind to label readability rework stays with #1213, per the issue's out-of-scope note. Web cockpit only; no Rust, server, or on-disk change.

Closes #1728

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the cockpit web view and start a session.
- [ ] Have the agent run a long Bash command (a heredoc piped into `consult-llm`, or trigger a `/debate` / `/collab` flow).
- [ ] While it runs, confirm the working spinner shows a bounded verb label (e.g. `Dispatching cat <<'__CONSULT_LL…`) instead of the full command line, and the spinner glyph stays visible.
- [ ] Run a short-titled tool (read a file). Confirm the label still shows the full short name unchanged (e.g. `Dispatching Read foo.ts…`).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the bug lives in a pure label helper (`chooseVerb`), so the reproducing regression is a Vitest in `web/src/lib/cockpitRattle.test.ts` (matches the layer the issue specified). The file is already mapped in `web/tests/coverage-matrix.json` via the `cockpit.rattle` entry; no DOM or flow behavior changed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design call (clamp-only, approach A), and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR fixes a UI bug in the cockpit working spinner where excessively long tool titles (such as full Bash command lines) would overflow the spinner label and hide the spinner icon. 

**Key changes:**
- Added a new constant `TOOL_LABEL_MAX = 24` to define a maximum character limit for tool names displayed in the spinner
- Updated the `chooseVerb()` function to truncate long tool names to 24 characters before displaying them in the spinner verb label
- Added unit tests to verify that long tool titles are properly clamped and short titles remain unchanged

## Benefits

- **Improved UI Layout**: The spinner label now stays bounded and won't overflow, ensuring the spinner glyph remains visible and the layout stays intact
- **Better User Experience**: Users see a truncated label (e.g., "Dispatching Bash…") instead of a runaway long command line
- **Consistent Behavior**: Short tool titles continue to display normally, while excessively long ones are gracefully truncated with an ellipsis
- **Maintainability**: Test coverage ensures the clamping behavior works correctly for both short and long titles

## Technical Details

The implementation uses a simple and direct approach: the constant `TOOL_LABEL_MAX` is set to 24 characters, and when `chooseVerb()` processes a `toolName` for the `"tool"` state, it clamps the name to this maximum length and right-trims it before interpolating it into the verb label string (e.g., "Dispatching {clamped_label}…"). This is a web-only change with no backend or filesystem impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->