### PR TITLE
fix(cockpit): keep mobile composer footer actions reachable on narrow viewports

### DIFF
--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -854,9 +854,14 @@ export function Composer({
               </div>
             )}
 
-            {/* Footer strip — affordances on the left, send/stop on the right */}
-            <div className="flex items-center justify-between gap-2 border-t border-surface-800/60 px-2 pb-2 pt-1.5">
-              <div className="flex items-center gap-0.5">
+            {/* Footer strip: affordances on the left, send/stop on the
+                right. The left cluster wraps onto extra rows when crowded
+                (mode/model/effort/attachment) so the right action cluster
+                stays pinned and fully reachable on narrow viewports. No
+                overflow-x scroll here: it would force overflow-y to clip
+                the upward-opening model dropdown. See #1717. */}
+            <div className="flex items-end gap-2 border-t border-surface-800/60 px-2 pb-2 pt-1.5">
+              <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-0.5 gap-y-1">
                 <ToolbarButton
                   icon={<AtSign className="h-3.5 w-3.5" />}
                   label="Add file context (@)"
@@ -908,7 +913,7 @@ export function Composer({
                 />
               </div>
 
-              <div className="flex items-center gap-2">
+              <div className="flex shrink-0 items-center gap-2">
                 <UsageHint usage={sessionUsage} />
                 {turnActive ? (
                   <>

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -860,7 +860,10 @@ export function Composer({
                 stays pinned and fully reachable on narrow viewports. No
                 overflow-x scroll here: it would force overflow-y to clip
                 the upward-opening model dropdown. See #1717. */}
-            <div className="flex items-end gap-2 border-t border-surface-800/60 px-2 pb-2 pt-1.5">
+            <div
+              data-testid="composer-footer"
+              className="flex items-end gap-2 border-t border-surface-800/60 px-2 pb-2 pt-1.5"
+            >
               <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-0.5 gap-y-1">
                 <ToolbarButton
                   icon={<AtSign className="h-3.5 w-3.5" />}
@@ -913,7 +916,10 @@ export function Composer({
                 />
               </div>
 
-              <div className="flex shrink-0 items-center gap-2">
+              <div
+                data-testid="composer-actions"
+                className="flex shrink-0 items-center gap-2"
+              >
                 <UsageHint usage={sessionUsage} />
                 {turnActive ? (
                   <>

--- a/web/src/components/cockpit/SessionConfigControls.tsx
+++ b/web/src/components/cockpit/SessionConfigControls.tsx
@@ -64,7 +64,7 @@ export function SessionConfigControls({
   return (
     <div
       data-testid="session-config-controls"
-      className="inline-flex items-center gap-1.5"
+      className="flex flex-wrap items-center gap-1.5"
     >
       {model && (
         <ModelDropdown

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2210,6 +2210,18 @@
       ]
     },
     {
+      "id": "cockpit.story.composer-mobile-footer-actions",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/composer-mobile-footer-actions.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/Composer.tsx",
+        "web/src/components/cockpit/SessionConfigControls.tsx"
+      ]
+    },
+    {
       "id": "cockpit.story.composer-stop-mid-turn",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/cockpit-stories/composer-mobile-footer-actions.spec.ts
+++ b/web/tests/live/cockpit-stories/composer-mobile-footer-actions.spec.ts
@@ -1,0 +1,94 @@
+// User story (#1717): on a narrow mobile viewport the composer footer
+// keeps the right-side action button reachable even when the left
+// control cluster (mode + model + effort + attachment) is wide.
+//
+// Pre-fix the footer was a single non-wrapping flex row with
+// `justify-between` and no shrink budget, so the populated left cluster
+// pushed the Send / Stop cluster past the clipped viewport edge and the
+// action button became untappable. The fix lets the left cluster wrap
+// onto extra rows and pins the right cluster with `shrink-0`.
+//
+// The fake ACP agent advertises model + reasoning-effort config options
+// by default, so simply enabling cockpit on a narrow viewport recreates
+// the worst-case left-cluster width. The fix is pure responsive CSS
+// (no pointer-capability branch), so a narrow viewport alone reproduces
+// it; no coarse-pointer emulation is needed.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import {
+  waitForCockpitView,
+  enableCockpitAndWait,
+  attachServeDiagnostics,
+} from "../../helpers/cockpit";
+
+base("mobile composer footer keeps the Send action reachable when config controls are present", async ({ page }, testInfo) => {
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+
+  try {
+    // Narrow viewport: the populated left cluster is wider than the row.
+    await page.setViewportSize({ width: 360, height: 740 });
+
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-footer-actions" }),
+    });
+
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-footer-actions");
+    if (!seeded) throw new Error("seeded session 'story-footer-actions' missing");
+    const sessionId = seeded.id;
+
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    // The model chip rendering confirms the left cluster carries the
+    // config controls that create the width pressure this story guards.
+    await expect(page.getByTestId("config-option-model")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Core regression: the footer must not overflow horizontally, so the
+    // right action cluster is never pushed past the clipped viewport edge.
+    const footer = page.getByTestId("composer-footer");
+    await expect(footer).toBeVisible();
+    await expect
+      .poll(async () =>
+        footer.evaluate(
+          (el) =>
+            (el as HTMLElement).scrollWidth - (el as HTMLElement).clientWidth,
+        ),
+      )
+      .toBeLessThanOrEqual(0);
+
+    // The Send button sits entirely within the viewport (pre-fix its
+    // right edge exceeded the 360px viewport width).
+    const send = page.getByRole("button", { name: "Send message" });
+    await expect(send).toBeVisible();
+    const box = await send.boundingBox();
+    expect(box).not.toBeNull();
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width);
+
+    // And it is actually tappable without a forced click.
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("reachable on mobile");
+    await send.click();
+  } finally {
+    if (serve) {
+      await attachServeDiagnostics(testInfo, serve);
+      await serve.stop();
+    }
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On narrow mobile cockpit viewports the composer footer was a single non-wrapping flex row with `justify-between` and no shrink budget. As the left control cluster grew (the @ / slash / attachment buttons plus the mode picker and the model + reasoning-effort config controls added in #1548), it pushed the right-side action cluster past the viewport edge. Because the mobile pane and app root clip overflow, the `Stop` / `Send` / queue-send buttons ended up off-screen and untappable: users could type but could not submit or stop a turn.

The fix makes the footer layout resilient instead of width-unbounded:

- The left cluster now wraps onto extra rows (`min-w-0 flex-1 flex-wrap`) when crowded.
- The right action cluster is pinned with `shrink-0` so `Stop` / `Send` always keep their width and stay in view.
- `SessionConfigControls` itself wraps (`flex flex-wrap`) so a single wide config item does not re-introduce the overflow one level down.

No horizontal scroll is used on the left cluster: `overflow-x: auto` forces `overflow-y` to compute to `auto`, which would clip the upward-opening (`absolute bottom-full`) model dropdown. The change is pure responsive CSS with no pointer-capability branch, so it also fixes narrow desktop windows. `UsageHint` is already hidden below the `sm` breakpoint, so it does not compete for space on mobile.

Closes #1717

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a cockpit session on a narrow mobile viewport (or a browser window ~360px wide) with the model and effort controls present in the footer.
- [ ] Confirm the `Send` button is fully visible at the right edge and tappable, with no horizontal scroll, while the left controls wrap to a second row when crowded.
- [ ] Start a turn and confirm `Stop` and the queue-send button stay visible and tappable.
- [ ] Open the model dropdown and confirm its menu still opens upward un-clipped.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

New live story `web/tests/live/cockpit-stories/composer-mobile-footer-actions.spec.ts` (surface `cockpit.story.composer-mobile-footer-actions`) seeds the model + effort config controls, sets a 360px viewport, and asserts the footer does not overflow horizontally and the `Send` button stays inside the viewport and is tappable. The live suite runs in CI; locally it needs a from-scratch `--features serve` binary, so this PR was statically validated with `tsc`, ESLint, the production web bundle build, and the full Vitest suite (1364 passing). The turn-active `Stop` path is not driven by a live spec because the live prompt-to-active-turn path is currently `base.skip`-blocked (#1237); `Stop` and queue-send share the same `shrink-0` right cluster the idle test pins.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a two-model design debate on the layout approach. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Summary

This PR fixes a mobile usability issue where the composer footer's action buttons (Stop/Send) were being pushed off-screen and became untappable on narrow viewports.

**What changed:**
- The composer footer layout was restructured to be responsive on mobile devices
- The left side controls (mode, buttons, and config options) now wrap instead of forcing everything into a single line
- The right side action buttons (Stop/Send) are now pinned to stay visible regardless of left-side content
- The model and reasoning-effort config controls were updated to support wrapping as well

**What was added:**
- A new automated test that verifies the footer works correctly on 360px wide mobile viewports
- Test assertions ensure no horizontal scrolling occurs and that the Send button remains tappable

**Benefits:**
- Improved mobile user experience by ensuring critical action buttons (Stop/Send) remain accessible on narrow screens
- No breaking changes to functionality or API
- Regression prevention through automated test coverage for mobile-sized viewports

---

## Technical Details

**File Changes:**
1. **Composer.tsx** - Restructured the footer flex layout: the left control cluster now has `min-w-0 flex-1 flex-wrap` to allow wrapping, and the right action cluster is wrapped with `shrink-0` to prevent shrinking. Added `data-testid` attributes for testability.

2. **SessionConfigControls.tsx** - Changed the container from `inline-flex` to `flex flex-wrap` to allow the model dropdown and effort control to wrap on narrow layouts.

3. **coverage-matrix.json** - Added a new coverage entry mapping the new Playwright test to the affected components.

4. **composer-mobile-footer-actions.spec.ts** (new) - Playwright test that sets a 360×740px viewport, verifies no horizontal overflow by checking `scrollWidth <= clientWidth`, and confirms the Send button is visible and tappable.

The fix uses CSS-only responsive design without introducing horizontal scrolling, which preserves the functionality of upward-opening dropdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->