### PR TITLE
refactor(web): single source of truth for keyboard shortcuts

### DIFF
--- a/web/src/components/HelpOverlay.tsx
+++ b/web/src/components/HelpOverlay.tsx
@@ -1,3 +1,10 @@
+import {
+  IS_MAC,
+  SHORTCUTS,
+  SHORTCUTS_BY_ID,
+  formatHelpShortcut,
+} from "../lib/shortcuts";
+
 interface Props {
   onClose: () => void;
 }
@@ -16,29 +23,11 @@ const MOBILE_GESTURES = [
   { key: "Hold session", desc: "Long-press a session to rename it" },
 ];
 
-const IS_MAC =
-  typeof navigator !== "undefined" &&
-  /Mac|iPhone|iPad|iPod/.test(navigator.platform);
-
 export function HelpOverlay({ onClose }: Props) {
-  const modKey = IS_MAC ? "⌘" : "Ctrl";
-
-  const optKey = IS_MAC ? "⌥" : "Alt";
-
-  const shiftKey = IS_MAC ? "⇧" : "Shift";
-
-  const shortcuts = [
-    { key: `${modKey}K`, desc: "Open command palette" },
-    { key: `${modKey}B`, desc: "Toggle left sidebar" },
-    { key: `${modKey}${optKey}B`, desc: "Toggle right panel" },
-    { key: `${modKey}\``, desc: "Toggle agent / shell terminal focus" },
-    { key: "n", desc: "New session" },
-    { key: `${modKey}${shiftKey}N`, desc: "New scratch session" },
-    { key: "D", desc: "Toggle diff panel" },
-    { key: "s", desc: "Toggle settings" },
-    { key: "Esc", desc: "Close dialog" },
-    { key: "?", desc: "Toggle this help" },
-  ];
+  const shortcuts = SHORTCUTS.map((s) => ({
+    key: formatHelpShortcut(s.chord, IS_MAC),
+    desc: s.description,
+  }));
 
   return (
     <div
@@ -115,7 +104,8 @@ export function HelpOverlay({ onClose }: Props) {
 
         <div className="px-5 py-3 border-t border-surface-700">
           <p className="text-sm text-text-dim">
-            Single-key shortcuts are disabled when typing in inputs. {modKey}K works
+            Single-key shortcuts are disabled when typing in inputs.{" "}
+            {formatHelpShortcut(SHORTCUTS_BY_ID.palette.chord, IS_MAC)} works
             everywhere.
           </p>
         </div>

--- a/web/src/components/tour/TourRunner.tsx
+++ b/web/src/components/tour/TourRunner.tsx
@@ -15,7 +15,12 @@ import {
   type Step,
   type Styles,
 } from "react-joyride";
-import { type TourStep, tourSelector } from "../../lib/tourSteps";
+import {
+  type TourShortcutHint,
+  type TourStep,
+  tourSelector,
+} from "../../lib/tourSteps";
+import { SHORTCUTS_BY_ID, formatTourShortcut } from "../../lib/shortcuts";
 
 export interface TourRunnerProps {
   run: boolean;
@@ -64,21 +69,25 @@ const STYLES: Partial<Styles> = {
   buttonSkip: { color: "var(--color-text-dim)" },
 };
 
+function hintLine(hint: TourShortcutHint): string {
+  return `${formatTourShortcut(SHORTCUTS_BY_ID[hint.id].chord)} ${hint.verb}`;
+}
+
 function StepBody({
   body,
-  shortcuts,
+  shortcutHints,
 }: {
   body: string;
-  shortcuts?: readonly string[];
+  shortcutHints?: readonly TourShortcutHint[];
 }) {
   return (
     <div>
       <p>{body}</p>
-      {shortcuts && shortcuts.length > 0 && (
+      {shortcutHints && shortcutHints.length > 0 && (
         <ul className="mt-2 space-y-0.5 text-[11px] text-text-muted">
-          {shortcuts.map((s) => (
-            <li key={s} className="font-mono">
-              {s}
+          {shortcutHints.map((hint) => (
+            <li key={`${hint.id}:${hint.verb}`} className="font-mono">
+              {hintLine(hint)}
             </li>
           ))}
         </ul>
@@ -92,7 +101,7 @@ function toJoyrideStep(step: TourStep): Step {
     id: step.id,
     target: tourSelector(step.anchor),
     title: step.title,
-    content: <StepBody body={step.body} shortcuts={step.shortcuts} />,
+    content: <StepBody body={step.body} shortcutHints={step.shortcutHints} />,
     placement: "auto",
   };
 }

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,26 +1,15 @@
 import { useEffect } from "react";
+import { IS_MAC, matchShortcut } from "../lib/shortcuts";
+import type { ShortcutActions } from "../lib/shortcuts";
 
-const IS_MAC =
-  typeof navigator !== "undefined" &&
-  /Mac|iPhone|iPad|iPod/.test(navigator.platform);
-
-interface ShortcutActions {
-  onNew: () => void;
-  /** Fast-path: opens the wizard pre-configured for a scratch session
-   *  and jumped to the Review step so Cmd+Enter immediately creates it. */
-  onNewScratch: () => void;
-  onDiff: () => void;
-  onEscape: () => void;
-  onHelp: () => void;
-  onSettings: () => void;
-  onPalette: () => void;
-  onToggleSidebar: () => void;
-  onToggleRightPanel: () => void;
-  onToggleTerminalFocus: () => void;
-}
+export type { ShortcutActions };
 
 /**
- * Global keyboard shortcuts for the dashboard.
+ * Global keyboard shortcuts for the dashboard. Bindings, help-overlay labels,
+ * and tour hints all read from the single SHORTCUTS registry in lib/shortcuts.
+ * This hook is the DOM seam: it decides whether the keydown target is an input,
+ * delegates matching to the pure matchShortcut, and applies the effects.
+ *
  * Single-key shortcuts fire only when no input/textarea/terminal is focused.
  * Cmd+K (Mac) / Ctrl+K (other) and Escape fire regardless of focus.
  */
@@ -34,85 +23,12 @@ export function useKeyboardShortcuts(getActions: () => ShortcutActions) {
           target.tagName === "TEXTAREA" ||
           target.isContentEditable);
 
-      const actions = getActions();
-      const mod = IS_MAC ? e.metaKey : e.metaKey || e.ctrlKey;
+      const matched = matchShortcut(e, { mac: IS_MAC, isInput });
+      if (!matched) return;
 
-      // Palette: Cmd+K (Mac) / Ctrl+K (other), works everywhere.
-      if (mod && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        e.stopPropagation();
-        actions.onPalette();
-        return;
-      }
-
-      // Toggle terminal focus: Cmd+` (Mac) / Ctrl+` (other), works everywhere.
-      // Use e.code so layouts where backtick lives behind a modifier still match.
-      // No stopPropagation: preventDefault is enough to suppress the browser's
-      // own Cmd+` window cycling, and we don't want to silently shadow other
-      // doc-level listeners that might want this combo.
-      if (mod && !e.shiftKey && !e.altKey && e.code === "Backquote") {
-        e.preventDefault();
-        actions.onToggleTerminalFocus();
-        return;
-      }
-
-      // Use e.code for B shortcuts because Option+B on Mac produces "∫"
-      // instead of "b", causing e.key matching to fail.
-      // Toggle right panel: Cmd+Opt+B (Mac) / Ctrl+Alt+B (other)
-      // Check alt combo first so Cmd+B doesn't swallow Cmd+Opt+B.
-      if (mod && !e.shiftKey && e.altKey && e.code === "KeyB") {
-        e.preventDefault();
-        e.stopPropagation();
-        actions.onToggleRightPanel();
-        return;
-      }
-
-      // Toggle left sidebar: Cmd+B (Mac) / Ctrl+B (other)
-      if (mod && !e.shiftKey && !e.altKey && e.code === "KeyB") {
-        e.preventDefault();
-        e.stopPropagation();
-        actions.onToggleSidebar();
-        return;
-      }
-
-      // New scratch session: Cmd+Shift+N (Mac) / Ctrl+Shift+N (other).
-      // Use e.code so Shift+layout punctuation doesn't break match (Shift+N
-      // is still "N" by e.key but `code === "KeyN"` is layout-stable).
-      // Works regardless of focus so the user can fire it from anywhere
-      // including the terminal pane.
-      if (mod && e.shiftKey && !e.altKey && e.code === "KeyN") {
-        e.preventDefault();
-        e.stopPropagation();
-        actions.onNewScratch();
-        return;
-      }
-
-      if (e.key === "Escape") {
-        actions.onEscape();
-        return;
-      }
-
-      if (isInput) return;
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
-
-      switch (e.key) {
-        case "n":
-          e.preventDefault();
-          actions.onNew();
-          break;
-        case "D":
-          e.preventDefault();
-          actions.onDiff();
-          break;
-        case "?":
-          e.preventDefault();
-          actions.onHelp();
-          break;
-        case "s":
-          e.preventDefault();
-          actions.onSettings();
-          break;
-      }
+      if (matched.preventDefault) e.preventDefault();
+      if (matched.stopPropagation) e.stopPropagation();
+      getActions()[matched.shortcut.action]();
     };
 
     // Capture phase so we observe the keydown before xterm.js's helper

--- a/web/src/lib/__tests__/shortcuts.test.ts
+++ b/web/src/lib/__tests__/shortcuts.test.ts
@@ -1,0 +1,215 @@
+// Drift guard + behavioral lock for the single shortcut registry (issue #1648).
+//
+// This is the test that makes "one source of truth" real: it pins the exact
+// rendered label strings (so the help overlay and tour cannot silently change
+// formatting), pins the match behavior of every binding (so a refactor cannot
+// rebind a key), proves the SHORTCUTS array order is cosmetic (exactly one
+// shortcut matches any given event), and couples the tour to the registry
+// (every tour hint id resolves to a registered shortcut).
+import { describe, expect, it } from "vitest";
+import {
+  SHORTCUTS,
+  SHORTCUTS_BY_ID,
+  type ShortcutDef,
+  type ShortcutKeyEvent,
+  formatHelpShortcut,
+  formatTourShortcut,
+  matchShortcut,
+} from "../shortcuts";
+import { TOUR_STEPS } from "../tourSteps";
+
+function ev(partial: Partial<ShortcutKeyEvent>): ShortcutKeyEvent {
+  return {
+    key: "",
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...partial,
+  };
+}
+
+describe("SHORTCUTS registry", () => {
+  it("has unique ids", () => {
+    const ids = SHORTCUTS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("SHORTCUTS_BY_ID resolves every entry", () => {
+    for (const s of SHORTCUTS) {
+      expect(SHORTCUTS_BY_ID[s.id]).toBe(s);
+    }
+  });
+});
+
+describe("label formatting (locked byte-for-byte against pre-refactor output)", () => {
+  const helpMac: Record<string, string> = {
+    palette: "⌘K",
+    sidebar: "⌘B",
+    rightPanel: "⌘⌥B",
+    terminalFocus: "⌘`",
+    new: "n",
+    newScratch: "⌘⇧N",
+    diff: "D",
+    settings: "s",
+    escape: "Esc",
+    help: "?",
+  };
+  const helpOther: Record<string, string> = {
+    palette: "CtrlK",
+    sidebar: "CtrlB",
+    rightPanel: "CtrlAltB",
+    terminalFocus: "Ctrl`",
+    new: "n",
+    newScratch: "CtrlShiftN",
+    diff: "D",
+    settings: "s",
+    escape: "Esc",
+    help: "?",
+  };
+  const tour: Record<string, string> = {
+    palette: "⌘K / Ctrl+K",
+    sidebar: "⌘B / Ctrl+B",
+    rightPanel: "⌘⌥B / Ctrl+Alt+B",
+    terminalFocus: "⌘` / Ctrl+`",
+    new: "n",
+    newScratch: "⌘⇧N / Ctrl+Shift+N",
+    diff: "D",
+    settings: "s",
+    escape: "Esc",
+    help: "?",
+  };
+
+  for (const s of SHORTCUTS) {
+    it(`${s.id} renders the expected help (mac/other) and tour strings`, () => {
+      expect(formatHelpShortcut(s.chord, true)).toBe(helpMac[s.id]);
+      expect(formatHelpShortcut(s.chord, false)).toBe(helpOther[s.id]);
+      expect(formatTourShortcut(s.chord)).toBe(tour[s.id]);
+    });
+  }
+});
+
+describe("matchShortcut behavior (no binding changed by the refactor)", () => {
+  const cases: Array<{
+    name: string;
+    event: ShortcutKeyEvent;
+    mac: boolean;
+    isInput?: boolean;
+    expected: ShortcutDef["id"] | null;
+  }> = [
+    { name: "mac Meta+K -> palette", event: ev({ key: "k", metaKey: true }), mac: true, expected: "palette" },
+    { name: "mac Ctrl+K -> no match", event: ev({ key: "k", ctrlKey: true }), mac: true, expected: null },
+    { name: "other Ctrl+K -> palette", event: ev({ key: "k", ctrlKey: true }), mac: false, expected: "palette" },
+    { name: "other Meta+K -> palette", event: ev({ key: "k", metaKey: true }), mac: false, expected: "palette" },
+    { name: "palette fires inside an input", event: ev({ key: "k", metaKey: true }), mac: true, isInput: true, expected: "palette" },
+    { name: "Meta+Backquote -> terminalFocus", event: ev({ key: "`", code: "Backquote", metaKey: true }), mac: true, expected: "terminalFocus" },
+    { name: "Meta+Alt+B (KeyB) -> rightPanel", event: ev({ key: "b", code: "KeyB", metaKey: true, altKey: true }), mac: true, expected: "rightPanel" },
+    { name: "Meta+B (KeyB) -> sidebar", event: ev({ key: "b", code: "KeyB", metaKey: true }), mac: true, expected: "sidebar" },
+    { name: "Mac Option+B (key '∫', code KeyB) still -> rightPanel", event: ev({ key: "∫", code: "KeyB", metaKey: true, altKey: true }), mac: true, expected: "rightPanel" },
+    { name: "Meta+Shift+N -> newScratch", event: ev({ key: "N", code: "KeyN", metaKey: true, shiftKey: true }), mac: true, expected: "newScratch" },
+    { name: "newScratch fires inside an input", event: ev({ key: "N", code: "KeyN", metaKey: true, shiftKey: true }), mac: true, isInput: true, expected: "newScratch" },
+    { name: "Escape -> escape (no modifiers)", event: ev({ key: "Escape" }), mac: true, expected: "escape" },
+    { name: "Escape fires inside an input", event: ev({ key: "Escape" }), mac: true, isInput: true, expected: "escape" },
+    { name: "Escape fires even with a modifier", event: ev({ key: "Escape", metaKey: true }), mac: true, expected: "escape" },
+    { name: "n -> new", event: ev({ key: "n" }), mac: true, expected: "new" },
+    { name: "N (no mod) -> no match (case sensitive)", event: ev({ key: "N" }), mac: true, expected: null },
+    { name: "D -> diff", event: ev({ key: "D" }), mac: true, expected: "diff" },
+    { name: "d -> no match (case sensitive)", event: ev({ key: "d" }), mac: true, expected: null },
+    { name: "s -> settings", event: ev({ key: "s" }), mac: true, expected: "settings" },
+    { name: "S -> no match (case sensitive)", event: ev({ key: "S" }), mac: true, expected: null },
+    { name: "? -> help", event: ev({ key: "?" }), mac: true, expected: "help" },
+    { name: "single-key blocked inside an input", event: ev({ key: "n" }), mac: true, isInput: true, expected: null },
+    { name: "single-key blocked when Ctrl held", event: ev({ key: "n", ctrlKey: true }), mac: true, expected: null },
+    { name: "single-key blocked when Alt held", event: ev({ key: "n", altKey: true }), mac: true, expected: null },
+  ];
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const matched = matchShortcut(c.event, { mac: c.mac, isInput: c.isInput ?? false });
+      expect(matched?.shortcut.id ?? null).toBe(c.expected);
+    });
+  }
+
+  it("propagates the per-shortcut preventDefault / stopPropagation flags", () => {
+    const palette = matchShortcut(ev({ key: "k", metaKey: true }), { mac: true, isInput: false });
+    expect(palette).toMatchObject({ preventDefault: true, stopPropagation: true });
+
+    // terminalFocus deliberately does not stopPropagation.
+    const term = matchShortcut(ev({ key: "`", code: "Backquote", metaKey: true }), { mac: true, isInput: false });
+    expect(term).toMatchObject({ preventDefault: true, stopPropagation: false });
+
+    // escape neither prevents nor stops.
+    const esc = matchShortcut(ev({ key: "Escape" }), { mac: true, isInput: false });
+    expect(esc).toMatchObject({ preventDefault: false, stopPropagation: false });
+  });
+});
+
+describe("array order is cosmetic (predicates are mutually exclusive)", () => {
+  // Build the event that should fire each shortcut, then assert exactly one
+  // shortcut in the whole registry matches it. If a future binding overlaps an
+  // existing one, this turns red regardless of array order.
+  function triggeringEvent(s: ShortcutDef): { event: ShortcutKeyEvent; isInput: boolean } {
+    const t = s.trigger;
+    const e = ev({});
+    if (t.scope === "global") {
+      if (t.mod) e.metaKey = true;
+      if (t.shift) e.shiftKey = true;
+      if (t.alt) e.altKey = true;
+      if (t.code) {
+        e.code = t.code;
+        e.key = t.code === "Backquote" ? "`" : t.code.replace(/^Key/, "").toLowerCase();
+      }
+      if (t.key) e.key = t.key;
+    } else {
+      e.key = t.key ?? "";
+    }
+    return { event: e, isInput: false };
+  }
+
+  function allMatchingIds(event: ShortcutKeyEvent, opts: { mac: boolean; isInput: boolean }): string[] {
+    const mod = opts.mac ? event.metaKey : event.metaKey || event.ctrlKey;
+    const hasMetaCtrlAlt = event.metaKey || event.ctrlKey || event.altKey;
+    const ids: string[] = [];
+    for (const s of SHORTCUTS) {
+      const t = s.trigger;
+      if (t.scope === "global") {
+        if (t.mod !== undefined && t.mod !== mod) continue;
+        if (t.shift !== undefined && t.shift !== event.shiftKey) continue;
+        if (t.alt !== undefined && t.alt !== event.altKey) continue;
+        if (t.code !== undefined) {
+          if (event.code !== t.code) continue;
+        } else if (t.key !== undefined) {
+          const ok = t.keyCaseInsensitive
+            ? event.key.toLowerCase() === t.key.toLowerCase()
+            : event.key === t.key;
+          if (!ok) continue;
+        } else {
+          continue;
+        }
+        ids.push(s.id);
+      } else {
+        if (opts.isInput || hasMetaCtrlAlt) continue;
+        if (event.key === t.key) ids.push(s.id);
+      }
+    }
+    return ids;
+  }
+
+  for (const s of SHORTCUTS) {
+    it(`exactly one shortcut matches the event that triggers ${s.id} (mac)`, () => {
+      const { event, isInput } = triggeringEvent(s);
+      expect(allMatchingIds(event, { mac: true, isInput })).toEqual([s.id]);
+    });
+  }
+});
+
+describe("tour drift guard", () => {
+  it("every tour shortcut hint id resolves to a registered shortcut", () => {
+    for (const step of TOUR_STEPS) {
+      for (const hint of step.shortcutHints ?? []) {
+        expect(SHORTCUTS_BY_ID[hint.id], `step "${step.id}" hint "${hint.id}" is not registered`).toBeDefined();
+      }
+    }
+  });
+});

--- a/web/src/lib/shortcuts.ts
+++ b/web/src/lib/shortcuts.ts
@@ -1,0 +1,339 @@
+// Single source of truth for the dashboard's keyboard shortcuts.
+//
+// Three consumers read from SHORTCUTS so they cannot drift apart:
+//   - useKeyboardShortcuts (the keydown handler, via matchShortcut)
+//   - HelpOverlay (the `?` overlay list and footer)
+//   - tourSteps / TourRunner (the first-run tutorial hints, by id)
+//
+// Each entry separates two concerns that are deliberately unrelated:
+//   - `chord`: how the shortcut is *displayed* (e.g. "⌘⌥B"), driven by the
+//     mod/alt/shift booleans plus a base label.
+//   - `trigger`: how the keydown is *matched* (e.g. `e.code === "KeyB"`),
+//     which often differs from the display because of layout quirks (Option+B
+//     on Mac yields "∫", backtick can live behind a modifier).
+//
+// The drift guard in shortcuts.test.ts locks the binding behavior, the exact
+// rendered label strings, and the tour's id references.
+
+export const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+
+export interface ShortcutActions {
+  onNew: () => void;
+  /** Fast-path: opens the wizard pre-configured for a scratch session
+   *  and jumped to the Review step so Cmd+Enter immediately creates it. */
+  onNewScratch: () => void;
+  onDiff: () => void;
+  onEscape: () => void;
+  onHelp: () => void;
+  onSettings: () => void;
+  onPalette: () => void;
+  onToggleSidebar: () => void;
+  onToggleRightPanel: () => void;
+  onToggleTerminalFocus: () => void;
+}
+
+export type ShortcutId =
+  | "palette"
+  | "sidebar"
+  | "rightPanel"
+  | "terminalFocus"
+  | "new"
+  | "newScratch"
+  | "diff"
+  | "settings"
+  | "escape"
+  | "help";
+
+/** The display model: which modifier glyphs to show, plus the base label. */
+export interface ShortcutChord {
+  mod?: boolean;
+  alt?: boolean;
+  shift?: boolean;
+  base: string;
+}
+
+interface ShortcutTrigger {
+  /**
+   * `global` shortcuts fire even when an input/textarea/terminal is focused.
+   * `textless` shortcuts fire only when no input is focused and no
+   * meta/ctrl/alt is held (shift is allowed, e.g. Shift+/ to type "?").
+   */
+  scope: "global" | "textless";
+  /** Logical mod: metaKey on Mac, metaKey OR ctrlKey elsewhere. */
+  mod?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  /** Layout-stable physical key. Preferred for letter combos. */
+  code?: string;
+  /** Logical key. Used when `code` is not appropriate (Escape, "?"). */
+  key?: string;
+  keyCaseInsensitive?: boolean;
+  preventDefault: boolean;
+  stopPropagation: boolean;
+}
+
+export interface ShortcutDef {
+  id: ShortcutId;
+  action: keyof ShortcutActions;
+  description: string;
+  chord: ShortcutChord;
+  trigger: ShortcutTrigger;
+}
+
+// Ordered to match the help overlay's display order. Match predicates are
+// mutually exclusive (see the exclusivity guard in shortcuts.test.ts), so this
+// order does not affect which shortcut a keydown resolves to; it is purely the
+// rendered order of the overlay.
+export const SHORTCUTS: readonly ShortcutDef[] = [
+  {
+    id: "palette",
+    action: "onPalette",
+    description: "Open command palette",
+    chord: { mod: true, base: "K" },
+    // Works everywhere. Uses e.key (case-insensitive) since "k" is layout-stable.
+    trigger: {
+      scope: "global",
+      mod: true,
+      shift: false,
+      alt: false,
+      key: "k",
+      keyCaseInsensitive: true,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+  },
+  {
+    id: "sidebar",
+    action: "onToggleSidebar",
+    description: "Toggle left sidebar",
+    chord: { mod: true, base: "B" },
+    // e.code because Option+B on Mac produces "∫" instead of "b".
+    trigger: {
+      scope: "global",
+      mod: true,
+      shift: false,
+      alt: false,
+      code: "KeyB",
+      preventDefault: true,
+      stopPropagation: true,
+    },
+  },
+  {
+    id: "rightPanel",
+    action: "onToggleRightPanel",
+    description: "Toggle right panel",
+    chord: { mod: true, alt: true, base: "B" },
+    trigger: {
+      scope: "global",
+      mod: true,
+      shift: false,
+      alt: true,
+      code: "KeyB",
+      preventDefault: true,
+      stopPropagation: true,
+    },
+  },
+  {
+    id: "terminalFocus",
+    action: "onToggleTerminalFocus",
+    description: "Toggle agent / shell terminal focus",
+    chord: { mod: true, base: "`" },
+    // No stopPropagation: preventDefault alone suppresses the browser's own
+    // Cmd+` window cycling, and we don't want to shadow other doc-level
+    // listeners. e.code so layouts with backtick behind a modifier still match.
+    trigger: {
+      scope: "global",
+      mod: true,
+      shift: false,
+      alt: false,
+      code: "Backquote",
+      preventDefault: true,
+      stopPropagation: false,
+    },
+  },
+  {
+    id: "new",
+    action: "onNew",
+    description: "New session",
+    chord: { base: "n" },
+    trigger: {
+      scope: "textless",
+      key: "n",
+      preventDefault: true,
+      stopPropagation: false,
+    },
+  },
+  {
+    id: "newScratch",
+    action: "onNewScratch",
+    description: "New scratch session",
+    chord: { mod: true, shift: true, base: "N" },
+    // Works regardless of focus so it fires from the terminal pane too.
+    trigger: {
+      scope: "global",
+      mod: true,
+      shift: true,
+      alt: false,
+      code: "KeyN",
+      preventDefault: true,
+      stopPropagation: true,
+    },
+  },
+  {
+    id: "diff",
+    action: "onDiff",
+    description: "Toggle diff panel",
+    chord: { base: "D" },
+    trigger: {
+      scope: "textless",
+      key: "D",
+      preventDefault: true,
+      stopPropagation: false,
+    },
+  },
+  {
+    id: "settings",
+    action: "onSettings",
+    description: "Toggle settings",
+    chord: { base: "s" },
+    trigger: {
+      scope: "textless",
+      key: "s",
+      preventDefault: true,
+      stopPropagation: false,
+    },
+  },
+  {
+    id: "escape",
+    action: "onEscape",
+    description: "Close dialog",
+    chord: { base: "Esc" },
+    // Fires regardless of focus and regardless of modifiers.
+    trigger: {
+      scope: "global",
+      key: "Escape",
+      preventDefault: false,
+      stopPropagation: false,
+    },
+  },
+  {
+    id: "help",
+    action: "onHelp",
+    description: "Toggle this help",
+    chord: { base: "?" },
+    trigger: {
+      scope: "textless",
+      key: "?",
+      preventDefault: true,
+      stopPropagation: false,
+    },
+  },
+] as const;
+
+export const SHORTCUTS_BY_ID: Record<ShortcutId, ShortcutDef> =
+  Object.fromEntries(SHORTCUTS.map((s) => [s.id, s])) as Record<
+    ShortcutId,
+    ShortcutDef
+  >;
+
+function modifierGlyphs(chord: ShortcutChord, mac: boolean): string[] {
+  const parts: string[] = [];
+  if (chord.mod) parts.push(mac ? "⌘" : "Ctrl");
+  if (chord.alt) parts.push(mac ? "⌥" : "Alt");
+  if (chord.shift) parts.push(mac ? "⇧" : "Shift");
+  return parts;
+}
+
+/**
+ * Render a chord for one platform. Mac always concatenates glyphs with no
+ * separator (e.g. "⌘⌥B"); other platforms join with `separator` (the help
+ * overlay passes "" for "CtrlAltB", the tour passes "+" for "Ctrl+Alt+B").
+ */
+export function formatShortcut(
+  chord: ShortcutChord,
+  { mac, separator = "" }: { mac: boolean; separator?: string },
+): string {
+  const parts = modifierGlyphs(chord, mac);
+  parts.push(chord.base);
+  return mac ? parts.join("") : parts.join(separator);
+}
+
+/** The help overlay form: current platform only, no separator. */
+export function formatHelpShortcut(chord: ShortcutChord, mac: boolean): string {
+  return formatShortcut(chord, { mac, separator: "" });
+}
+
+/**
+ * The tour form: both platforms, joined with " / " (e.g. "⌘K / Ctrl+K").
+ * Modifier-less chords are identical across platforms, so they render once.
+ */
+export function formatTourShortcut(chord: ShortcutChord): string {
+  const macForm = formatShortcut(chord, { mac: true });
+  const otherForm = formatShortcut(chord, { mac: false, separator: "+" });
+  return macForm === otherForm ? macForm : `${macForm} / ${otherForm}`;
+}
+
+/** The subset of a KeyboardEvent the matcher reads; lets tests pass plain objects. */
+export type ShortcutKeyEvent = Pick<
+  KeyboardEvent,
+  "key" | "code" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+>;
+
+export interface MatchedShortcut {
+  shortcut: ShortcutDef;
+  preventDefault: boolean;
+  stopPropagation: boolean;
+}
+
+function globalMatches(
+  e: ShortcutKeyEvent,
+  t: ShortcutTrigger,
+  mod: boolean,
+): boolean {
+  if (t.mod !== undefined && t.mod !== mod) return false;
+  if (t.shift !== undefined && t.shift !== e.shiftKey) return false;
+  if (t.alt !== undefined && t.alt !== e.altKey) return false;
+  if (t.code !== undefined) return e.code === t.code;
+  if (t.key !== undefined) {
+    return t.keyCaseInsensitive
+      ? e.key.toLowerCase() === t.key.toLowerCase()
+      : e.key === t.key;
+  }
+  return false;
+}
+
+function toMatched(shortcut: ShortcutDef): MatchedShortcut {
+  return {
+    shortcut,
+    preventDefault: shortcut.trigger.preventDefault,
+    stopPropagation: shortcut.trigger.stopPropagation,
+  };
+}
+
+/**
+ * Resolve a keydown to a shortcut. Global shortcuts are evaluated first and
+ * fire regardless of focus; single-key shortcuts fire only when not typing and
+ * no meta/ctrl/alt is held. Pure (no DOM access) so it is unit-testable.
+ */
+export function matchShortcut(
+  e: ShortcutKeyEvent,
+  { mac, isInput }: { mac: boolean; isInput: boolean },
+): MatchedShortcut | null {
+  const mod = mac ? e.metaKey : e.metaKey || e.ctrlKey;
+
+  for (const s of SHORTCUTS) {
+    if (s.trigger.scope !== "global") continue;
+    if (globalMatches(e, s.trigger, mod)) return toMatched(s);
+  }
+
+  if (isInput) return null;
+  if (e.metaKey || e.ctrlKey || e.altKey) return null;
+
+  for (const s of SHORTCUTS) {
+    if (s.trigger.scope !== "textless") continue;
+    if (e.key === s.trigger.key) return toMatched(s);
+  }
+  return null;
+}

--- a/web/src/lib/tourSteps.ts
+++ b/web/src/lib/tourSteps.ts
@@ -7,6 +7,8 @@
 // convention: every anchor must be referenced through `TOUR_ANCHORS.<key>`, never
 // as a raw `data-tour="..."` literal, so a renamed or deleted anchor fails fast.
 
+import type { ShortcutId } from "./shortcuts";
+
 /**
  * Every UI region the tour can point at. The string value is the literal that
  * lands in the DOM as `data-tour="<value>"`. Keep these on stable region
@@ -34,6 +36,16 @@ export type TourAnchorId = (typeof TOUR_ANCHORS)[keyof typeof TOUR_ANCHORS];
  */
 export type TourScope = "dashboard" | "session" | "cockpit";
 
+/**
+ * A tour shortcut hint references a registered shortcut by id (so the rendered
+ * key chord cannot drift from the actual binding) plus a step-local verb phrase.
+ * TourRunner renders it as `${formatTourShortcut(chord)} ${verb}`.
+ */
+export interface TourShortcutHint {
+  id: ShortcutId;
+  verb: string;
+}
+
 export interface TourStep {
   /** Stable id, also used as the react-joyride step id. */
   id: string;
@@ -41,8 +53,8 @@ export interface TourStep {
   scopes: readonly TourScope[];
   title: string;
   body: string;
-  /** Human-readable shortcut hints rendered under the body, e.g. "⌘K / Ctrl+K". */
-  shortcuts?: readonly string[];
+  /** Shortcut hints rendered under the body, resolved from the SHORTCUTS registry. */
+  shortcutHints?: readonly TourShortcutHint[];
   /** Drop the step when the dashboard is in read-only mode (mutation UI absent). */
   writableOnly?: boolean;
   /** Drop the step on coarse-pointer / non-desktop layouts (region not shown). */
@@ -70,7 +82,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
     scopes: ["dashboard", "session", "cockpit"],
     title: "Command bar",
     body: "Jump anywhere from the command palette: switch sessions, open settings, toggle panels.",
-    shortcuts: ["⌘K / Ctrl+K opens the palette"],
+    shortcutHints: [{ id: "palette", verb: "opens the palette" }],
   },
   {
     id: "sidebar",
@@ -78,7 +90,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
     scopes: ["dashboard", "session", "cockpit"],
     title: "Workspaces and sessions",
     body: "Your sessions are grouped by workspace here. Pick one to open its terminal or cockpit.",
-    shortcuts: ["⌘B / Ctrl+B toggles the sidebar"],
+    shortcutHints: [{ id: "sidebar", verb: "toggles the sidebar" }],
   },
   {
     id: "new-session",
@@ -86,7 +98,10 @@ export const TOUR_STEPS: readonly TourStep[] = [
     scopes: ["dashboard"],
     title: "Start a session",
     body: "Launch a new agent session: pick a project, choose an agent, and go.",
-    shortcuts: ["n opens the wizard", "⌘⇧N / Ctrl+Shift+N starts a scratch session"],
+    shortcutHints: [
+      { id: "new", verb: "opens the wizard" },
+      { id: "newScratch", verb: "starts a scratch session" },
+    ],
     writableOnly: true,
   },
   {
@@ -95,7 +110,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
     scopes: ["dashboard", "session", "cockpit"],
     title: "Settings and profiles",
     body: "Tune sandboxing, worktrees, sounds, devices, and per-profile overrides here.",
-    shortcuts: ["s opens settings"],
+    shortcutHints: [{ id: "settings", verb: "opens settings" }],
   },
   {
     id: "right-panel",
@@ -103,7 +118,10 @@ export const TOUR_STEPS: readonly TourStep[] = [
     scopes: ["session", "cockpit"],
     title: "Diff and review",
     body: "Review the agent's file changes and send comments back without leaving the session.",
-    shortcuts: ["D toggles the diff", "⌘⌥B / Ctrl+Alt+B toggles the panel"],
+    shortcutHints: [
+      { id: "diff", verb: "toggles the diff" },
+      { id: "rightPanel", verb: "toggles the panel" },
+    ],
     desktopOnly: true,
   },
   {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2697,6 +2697,22 @@
         "web/src/lib/tourSteps.ts",
         "web/src/hooks/useTour.tsx"
       ]
+    },
+    {
+      "id": "shortcuts.single-source",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/lib/__tests__/shortcuts.test.ts",
+        "src/hooks/useKeyboardShortcuts.test.ts"
+      ],
+      "components": [
+        "web/src/components/HelpOverlay.tsx",
+        "web/src/components/tour/TourRunner.tsx",
+        "web/src/lib/shortcuts.ts",
+        "web/src/hooks/useKeyboardShortcuts.ts",
+        "web/src/lib/tourSteps.ts"
+      ]
     }
   ]
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Web dashboard keyboard shortcuts were described in three independent places that drifted silently: `useKeyboardShortcuts.ts` (the actual key bindings), `HelpOverlay.tsx` (a parallel hardcoded label list for the `?` overlay), and `tourSteps.ts` (per-step hardcoded shortcut hint strings). A rebind in one did not update the others, and nothing tested that they agreed.

This extracts a single typed `SHORTCUTS` registry in the new `web/src/lib/shortcuts.ts` that all three consumers read from. Each entry separates a display `chord` (the mod/alt/shift glyphs plus a base label, e.g. `⌘⌥B`) from an event `trigger` (the match rules, e.g. `e.code === "KeyB"`), since the displayed form and the matched form differ on purpose (Option+B on Mac yields `∫`, backtick can live behind a modifier). The keydown algorithm moves into a pure `matchShortcut`, so it is unit-testable without the DOM, and the hook becomes a thin DOM seam. `HelpOverlay` renders its Dashboard list and footer from the registry; the tour references shortcuts by id with a step-local verb phrase.

No key binding changes and no visible string changes: the help-overlay labels (including the non-Mac `CtrlK` no-separator form) and the tour hints (the `⌘K / Ctrl+K` two-platform form) render byte-for-byte identical to before. The only new behavior is the CI drift guard.

`shortcuts.test.ts` locks the rendered label strings, pins every binding's match behavior, proves the registry's array order is cosmetic (exactly one shortcut matches any given event), and asserts every tour hint id resolves to a registered shortcut. The existing `useKeyboardShortcuts.test.ts` and `tourSteps.test.ts` stay green unchanged.

Closes #1648

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the dashboard, press `?`, confirm the Dashboard shortcut list and the footer (`⌘K works everywhere` / `CtrlK works everywhere`) read exactly as before.
- [ ] Press each shortcut and confirm the same action fires: `⌘K`/`Ctrl+K` palette, `⌘B`/`Ctrl+B` sidebar, `⌘⌥B`/`Ctrl+Alt+B` right panel, `` ⌘` `` terminal focus, `n` new, `⌘⇧N`/`Ctrl+Shift+N` scratch, `D` diff, `s` settings, `Esc` close, `?` help.
- [ ] Clear the `aoe-tour-seen` flag, reload, and confirm each tour step's shortcut hint line renders identically (e.g. `⌘K / Ctrl+K opens the palette`, `n opens the wizard`).
- [ ] Confirm single-key shortcuts stay disabled while typing in an input, and `⌘K` / `Esc` still fire from inside inputs and the terminal.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

(Drift guard is a Vitest unit suite, `web/src/lib/__tests__/shortcuts.test.ts`, the right tier for this pure-logic registry; `web/tests/coverage-matrix.json` gains a `shortcuts.single-source` entry. No binding or visible behavior changed, so the existing live Playwright shortcut specs continue to pass unchanged.)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a multi-model design debate on the chord/trigger split and tour-consumption approach. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR consolidates keyboard shortcut management into a single, centralized source of truth. Previously, shortcut definitions were scattered across three different files (keyboard hook, help overlay, and tour steps), which created maintenance challenges and risked inconsistency.

### Added
- **New shortcuts registry** (`web/src/lib/shortcuts.ts`): A centralized file containing all keyboard shortcut definitions with metadata including display labels, descriptions, platform-specific formatting, and matching rules. This replaces the previous fragmented approach.
- **Comprehensive test suite** (`web/src/lib/__tests__/shortcuts.test.ts`): 215 new lines of tests that validate shortcut consistency, ensure no conflicts between bindings, verify platform-specific formatting, and prevent tour references from becoming stale.
- **Coverage tracking** (`web/tests/coverage-matrix.json`): Added CI integration to monitor this refactoring.

### Modified
- **Keyboard hook** (`web/src/hooks/useKeyboardShortcuts.ts`): Simplified to use the centralized registry. The hook now delegates shortcut matching to a pure function instead of maintaining its own logic, making it easier to test and maintain. Reduced from 97 to 13 lines of core logic.
- **Help overlay** (`web/src/components/HelpOverlay.tsx`): Now reads shortcut definitions from the registry rather than maintaining its own list, ensuring consistency with other UI elements.
- **Tour step definitions** (`web/src/lib/tourSteps.ts`): Updated to reference shortcuts by ID with contextual verb phrases, replacing hardcoded shortcut strings.
- **Tour rendering** (`web/src/components/tour/TourRunner.tsx`): Adapted to display structured shortcut hints from the centralized registry.

### What Stayed the Same
- **All keyboard bindings**: No changes to which keys trigger which actions.
- **All visible labels**: Shortcut display strings remain identical.
- **User behavior**: Everything works exactly as before.

## Benefits

1. **Single source of truth**: Shortcut definitions, labels, and matching logic are now in one place, eliminating duplication and drift.
2. **Better maintainability**: Changes to shortcuts only need to be made once, reducing bugs and inconsistencies.
3. **Testability**: The new pure `matchShortcut` function can be unit tested without DOM dependencies.
4. **CI safety**: Automated tests lock down shortcut behavior, formatting, and verify tour references resolve correctly—preventing regressions.
5. **Type safety**: All shortcuts are now typed, reducing runtime errors and improving IDE autocomplete.
6. **Platform awareness**: Centralized handling of Mac vs. non-Mac formatting differences.

## Technical Details

The refactoring introduces:
- `SHORTCUTS`: A typed array defining each shortcut with `id`, display `chord` (platform-aware glyphs), `description`, `action`, and trigger `rules` (matching logic via `code` or `key` matching).
- `SHORTCUTS_BY_ID`: A lookup map for O(1) shortcut resolution.
- `matchShortcut(event, options)`: A pure function that tests a keyboard event against all registered shortcuts and returns the matched shortcut plus metadata about whether `preventDefault` or `stopPropagation` should be called.
- `formatShortcut`, `formatHelpShortcut`, `formatTourShortcut`: Rendering helpers that format shortcut chords for different UI contexts, handling Mac (⌘⌥) vs. Ctrl/Alt/Shift notation transparently.
- Scope handling: Shortcuts are evaluated in order—global shortcuts first, then single-key shortcuts (only when not typing and no meta/control/alt modifiers are held).
- A 215-line Vitest suite ensuring all shortcut strings remain stable, verifying each shortcut matches exactly its intended events, and enforcing that tour references resolve to real shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->