### PR TITLE
feat(web): show rate-limited indicator on sidebar session rows

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -15,6 +15,7 @@ import {
   ArrowLeftRight,
   Clock,
   GripVertical,
+  Hourglass,
   Layers,
   ListOrdered,
   Moon,
@@ -74,6 +75,7 @@ import { requestSwitchAgent } from "../lib/switchAgentTrigger";
 import { useClampedMenuPosition } from "../lib/menuPosition";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { useQueuedCountForSessions } from "../hooks/useCockpitQueueCount";
+import { useRateLimitedForSessions } from "../hooks/useCockpitRateLimit";
 import { reportError } from "../lib/toastBus";
 import {
   resolveEffectiveSnoozedUntil,
@@ -627,6 +629,21 @@ export const SessionRow = memo(function SessionRow({
   // `hasDraft` ORs the same set. Lets a user juggling sessions see at a
   // glance which rows have prompts pending without opening the cockpit.
   const queuedCount = useQueuedCountForSessions(sessionIds);
+  // Rate-limit park visibility parity with the cockpit notice (#1715).
+  // The server maps rate-limited stops to Idle, so the status glyph can't
+  // distinguish a parked session from a normal idle one; surface it here
+  // from the same cockpit-state mirror the queued badge reads.
+  const rateLimited = useRateLimitedForSessions(sessionIds);
+  const rateLimitResetLabel = useMemo(() => {
+    if (!rateLimited?.resetsAt) return null;
+    const reset = new Date(rateLimited.resetsAt);
+    return Number.isNaN(reset.getTime())
+      ? null
+      : reset.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }, [rateLimited]);
+  const rateLimitTitle = rateLimited
+    ? `Rate-limited${rateLimited.count > 1 ? ` (${rateLimited.count} sessions)` : ""}${rateLimitResetLabel ? `; resets at ${rateLimitResetLabel}` : ""}`
+    : "";
 
   const setNotifyPreset = async (preset: NotifyPreset) => {
     setContextMenu(null);
@@ -985,6 +1002,19 @@ export const SessionRow = memo(function SessionRow({
                   className="inline-flex shrink-0 items-center rounded border border-sky-700/40 bg-sky-950/30 px-1 text-[10px] font-mono font-medium tabular-nums text-sky-300"
                 >
                   {queuedCount}
+                </span>
+              )}
+              {rateLimited && (
+                <span
+                  title={rateLimitTitle}
+                  aria-label={rateLimitTitle}
+                  className="inline-flex shrink-0 items-center gap-0.5 rounded border border-orange-700/40 bg-orange-950/30 px-1 text-[10px] font-mono font-medium text-orange-300"
+                >
+                  <Hourglass className="h-3 w-3" />
+                  {rateLimited.count > 1 && (
+                    <span className="tabular-nums">{rateLimited.count}</span>
+                  )}
+                  {rateLimitResetLabel && <span>{rateLimitResetLabel}</span>}
                 </span>
               )}
               {effectiveArchived && (

--- a/web/src/hooks/__tests__/useCockpitRateLimit.test.tsx
+++ b/web/src/hooks/__tests__/useCockpitRateLimit.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useRateLimitedForSessions } from "../useCockpitRateLimit";
+import {
+  STORAGE_KEY_PREFIX,
+  clearQueueCount,
+  setRateLimit,
+} from "../../lib/cockpitStateStorage";
+import type { RateLimitInfo } from "../../lib/cockpitTypes";
+
+function entryKey(id: string): string {
+  return `${STORAGE_KEY_PREFIX}${id}`;
+}
+
+function rl(resetsAt: string): RateLimitInfo {
+  return { status: "rate_limited", resets_at: resetsAt, kind: "requests" };
+}
+
+// Write a persisted cockpit-state entry shaped like useCockpit's
+// persistState output, with the given rateLimit (or null).
+function writeEntry(
+  id: string,
+  rateLimit: RateLimitInfo | null,
+  savedAt = Date.now(),
+): void {
+  localStorage.setItem(
+    entryKey(id),
+    JSON.stringify({
+      savedAt,
+      state: { lastSeq: 0, activity: [], queuedPrompts: [], rateLimit },
+    }),
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  clearQueueCount();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  clearQueueCount();
+});
+
+describe("useRateLimitedForSessions", () => {
+  it("returns null when no session is rate-limited", () => {
+    const { result } = renderHook(() => useRateLimitedForSessions(["a"]));
+    expect(result.current).toBeNull();
+  });
+
+  it("lazily reads rate-limit info from a persisted localStorage entry", () => {
+    writeEntry("a", rl("2026-06-01T12:00:00Z"));
+    const { result } = renderHook(() => useRateLimitedForSessions(["a"]));
+    expect(result.current).toEqual({
+      count: 1,
+      resetsAt: "2026-06-01T12:00:00Z",
+    });
+  });
+
+  // Story 3: only rate-limited sessions count; the soonest reset wins.
+  it("counts rate-limited sessions and reports the soonest reset", () => {
+    writeEntry("a", rl("2026-06-01T13:00:00Z"));
+    writeEntry("b", null);
+    writeEntry("c", rl("2026-06-01T12:30:00Z"));
+    const { result } = renderHook(() =>
+      useRateLimitedForSessions(["a", "b", "c"]),
+    );
+    expect(result.current).toEqual({
+      count: 2,
+      resetsAt: "2026-06-01T12:30:00Z",
+    });
+  });
+
+  // Story 2: the session recovers (agent switch sets rateLimit null); the
+  // indicator clears on the next persistState write.
+  it("updates same-tab as rate-limit sets and clears via persistState", () => {
+    const { result } = renderHook(() => useRateLimitedForSessions(["a"]));
+    expect(result.current).toBeNull();
+
+    act(() => setRateLimit("a", rl("2026-06-01T12:00:00Z")));
+    expect(result.current).toEqual({
+      count: 1,
+      resetsAt: "2026-06-01T12:00:00Z",
+    });
+
+    act(() => setRateLimit("a", null));
+    expect(result.current).toBeNull();
+  });
+
+  // Story 1 cross-tab: another tab persists a rate-limit; this tab's
+  // sidebar updates via the storage event without a local write.
+  it("updates cross-tab via a storage event without a local write", () => {
+    const { result } = renderHook(() => useRateLimitedForSessions(["a"]));
+    expect(result.current).toBeNull();
+
+    const newValue = JSON.stringify({
+      savedAt: Date.now(),
+      state: {
+        lastSeq: 0,
+        activity: [],
+        queuedPrompts: [],
+        rateLimit: rl("2026-06-01T12:00:00Z"),
+      },
+    });
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: entryKey("a"),
+          newValue,
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toEqual({
+      count: 1,
+      resetsAt: "2026-06-01T12:00:00Z",
+    });
+  });
+
+  it("does not react to a storage event for an unsubscribed session", () => {
+    const { result } = renderHook(() => useRateLimitedForSessions(["a"]));
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: entryKey("b"),
+          newValue: JSON.stringify({
+            savedAt: Date.now(),
+            state: {
+              lastSeq: 0,
+              activity: [],
+              queuedPrompts: [],
+              rateLimit: rl("2026-06-01T12:00:00Z"),
+            },
+          }),
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBeNull();
+  });
+
+  it("treats a TTL-expired entry as not rate-limited", () => {
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    writeEntry("a", rl("2026-06-01T12:00:00Z"), eightDaysAgo);
+    const { result } = renderHook(() => useRateLimitedForSessions(["a"]));
+    expect(result.current).toBeNull();
+  });
+
+  it("treats a corrupt entry as not rate-limited", () => {
+    localStorage.setItem(entryKey("a"), "{not json");
+    const { result } = renderHook(() => useRateLimitedForSessions(["a"]));
+    expect(result.current).toBeNull();
+  });
+
+  it("removes its storage listener on unmount", () => {
+    const { unmount, result } = renderHook(() =>
+      useRateLimitedForSessions(["a"]),
+    );
+    unmount();
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: entryKey("a"),
+          newValue: JSON.stringify({
+            savedAt: Date.now(),
+            state: {
+              lastSeq: 0,
+              activity: [],
+              queuedPrompts: [],
+              rateLimit: rl("2026-06-01T12:00:00Z"),
+            },
+          }),
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBeNull();
+  });
+});

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -31,6 +31,7 @@ import {
   STATE_TTL_MS,
   clearQueueCount,
   setQueueCount,
+  setRateLimit,
   type PersistedEntry,
 } from "../lib/cockpitStateStorage";
 import { getToken } from "../lib/token";
@@ -151,6 +152,7 @@ function persistState(sessionId: string, state: CockpitState): void {
   const body = JSON.stringify({ savedAt: Date.now(), state } satisfies PersistedEntry);
   if (safeSetItem(key, body)) {
     setQueueCount(sessionId, state.queuedPrompts.length);
+    setRateLimit(sessionId, state.rateLimit);
     return;
   }
   // Storage write failed (likely QuotaExceeded). Evict a single oldest
@@ -160,6 +162,7 @@ function persistState(sessionId: string, state: CockpitState): void {
   if (!evictOldestPersistedCockpitState(key)) return;
   if (safeSetItem(key, body)) {
     setQueueCount(sessionId, state.queuedPrompts.length);
+    setRateLimit(sessionId, state.rateLimit);
   }
 }
 

--- a/web/src/hooks/useCockpitRateLimit.ts
+++ b/web/src/hooks/useCockpitRateLimit.ts
@@ -1,0 +1,67 @@
+// Sidebar "rate-limited" indicator data source. Mirrors
+// useQueuedCountForSessions (useCockpitQueueCount.ts): it reads the
+// per-session rate-limit info cached in cockpit-state storage and
+// re-renders the caller only when one of the given session ids changes.
+//
+// A workspace row aggregates its sessions, so this reports how MANY of
+// them are rate-limited plus the soonest reset time across them, letting
+// the row show a count and a "resets at" hint without mounting any
+// cockpit hook.
+
+import { useMemo, useSyncExternalStore } from "react";
+
+import {
+  getRateLimit,
+  subscribeCockpitState,
+} from "../lib/cockpitStateStorage";
+
+export interface SidebarRateLimit {
+  /** How many of the given sessions are currently rate-limited. */
+  count: number;
+  /** Soonest `resets_at` across the rate-limited sessions, or null. */
+  resetsAt: string | null;
+}
+
+// Encode the aggregate into a primitive so useSyncExternalStore's
+// getSnapshot returns a stable value across renders (Object.is on a
+// freshly built object would tear under React 18). The hook decodes it
+// back into SidebarRateLimit via useMemo.
+function snapshotFor(ids: readonly string[]): string {
+  let count = 0;
+  let soonest: string | null = null;
+  for (const id of ids) {
+    if (!id) continue;
+    const info = getRateLimit(id);
+    if (!info) continue;
+    count += 1;
+    if (soonest === null || info.resets_at < soonest) {
+      soonest = info.resets_at;
+    }
+  }
+  return `${count}|${soonest ?? ""}`;
+}
+
+// Returns the rate-limit aggregate for the given session ids, or null
+// when none are rate-limited. Re-renders the caller only when one of
+// THESE ids' rate-limit state changes.
+export function useRateLimitedForSessions(
+  sessionIds: readonly string[],
+): SidebarRateLimit | null {
+  const ids = sessionIds.join("|");
+  const subscribe = useMemo(() => {
+    const filter = new Set(ids ? ids.split("|").filter(Boolean) : []);
+    return (cb: () => void) => subscribeCockpitState(cb, filter);
+  }, [ids]);
+  const snapshot = useSyncExternalStore(
+    subscribe,
+    () => snapshotFor(ids ? ids.split("|") : []),
+    () => "0|",
+  );
+  return useMemo(() => {
+    const sep = snapshot.indexOf("|");
+    const count = Number(snapshot.slice(0, sep));
+    if (!count) return null;
+    const resetsAt = snapshot.slice(sep + 1);
+    return { count, resetsAt: resetsAt || null };
+  }, [snapshot]);
+}

--- a/web/src/lib/cockpitStateStorage.ts
+++ b/web/src/lib/cockpitStateStorage.ts
@@ -15,7 +15,7 @@
 // publishes it on every write, and cross-tab `storage` events parse the
 // new value exactly once.
 
-import type { CockpitState } from "./cockpitTypes";
+import type { CockpitState, RateLimitInfo } from "./cockpitTypes";
 
 export const STORAGE_KEY_PREFIX = "aoe:cockpit-state:v1:";
 export const STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -40,6 +40,15 @@ function sessionIdFromKey(key: string): string | null {
 // from localStorage on first read so inactive sessions (no mounted
 // cockpit hook writing) still resolve a count.
 const queueCounts = new Map<string, number>();
+
+// Last-known rate-limit info per session id, kept in sync alongside
+// queueCounts by setRateLimit (same-tab writes) and the cross-tab
+// storage listener. Mirrors the queued-prompt cache so the sidebar can
+// render a rate-limited indicator for a session whose cockpit view is
+// not mounted. A stored `null` means "known, not rate-limited"; a
+// missing (`undefined`) entry means "not yet read this page load", which
+// getRateLimit lazily fills from localStorage.
+const rateLimits = new Map<string, RateLimitInfo | null>();
 
 type Listener = () => void;
 
@@ -76,6 +85,32 @@ function parseQueuedCount(raw: string | null): number | null {
   }
 }
 
+// Parse the rate-limit info out of a raw persisted entry, honoring the
+// TTL. Returns null when the entry is missing, expired, corrupt, or has
+// no (or malformed) rate-limit, so callers treat the session as not
+// rate-limited rather than caching a bogus value.
+function parseRateLimit(raw: string | null): RateLimitInfo | null {
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as PersistedEntry | null;
+    if (
+      !parsed ||
+      typeof parsed.savedAt !== "number" ||
+      Number.isNaN(parsed.savedAt) ||
+      Date.now() - parsed.savedAt > STATE_TTL_MS
+    ) {
+      return null;
+    }
+    const rl = (parsed.state as Partial<CockpitState> | undefined)?.rateLimit;
+    if (rl && typeof rl.resets_at === "string" && typeof rl.kind === "string") {
+      return rl;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 // Publish a session's current queued-prompt count. Called by useCockpit's
 // persistState on every successful write; the length is already in hand
 // there, so no JSON parsing happens on the write hot path.
@@ -84,15 +119,29 @@ export function setQueueCount(sessionId: string, count: number): void {
   notify(sessionId);
 }
 
-// Drop a session's cached count (session delete / cache clear). With no
-// argument, clears the whole cache.
+// Publish a session's current rate-limit info (null when not rate
+// limited). Called by useCockpit's persistState on every successful
+// write; the value is already in hand there, so no JSON parsing happens
+// on the write hot path.
+export function setRateLimit(
+  sessionId: string,
+  info: RateLimitInfo | null,
+): void {
+  rateLimits.set(sessionId, info);
+  notify(sessionId);
+}
+
+// Drop a session's cached count and rate-limit (session delete / cache
+// clear). With no argument, clears the whole cache.
 export function clearQueueCount(sessionId?: string): void {
   if (sessionId === undefined) {
     queueCounts.clear();
+    rateLimits.clear();
     notify(null);
     return;
   }
   queueCounts.delete(sessionId);
+  rateLimits.delete(sessionId);
   notify(sessionId);
 }
 
@@ -116,6 +165,24 @@ export function getQueuedCount(sessionId: string): number {
   return count;
 }
 
+// Side-effect-free read of a session's last-known rate-limit info (null
+// when not rate limited). Same contract as getQueuedCount: cache first,
+// parse localStorage once on a miss and memoise.
+export function getRateLimit(sessionId: string): RateLimitInfo | null {
+  const cached = rateLimits.get(sessionId);
+  if (cached !== undefined) return cached;
+  if (typeof window === "undefined") return null;
+  let info: RateLimitInfo | null;
+  try {
+    info = parseRateLimit(window.localStorage.getItem(storageKey(sessionId)));
+  } catch {
+    // localStorage blocked/threw: don't memoise a transient failure.
+    return null;
+  }
+  rateLimits.set(sessionId, info);
+  return info;
+}
+
 // Subscribe to cockpit-state changes. `filter` scopes the listener to a
 // set of session ids; null receives every change. Fires for same-tab
 // writes (via the notify in setQueueCount) and cross-tab writes (storage
@@ -130,14 +197,16 @@ export function subscribeCockpitState(
     // whole count cache and fire unconditionally.
     if (e.key === null) {
       queueCounts.clear();
+      rateLimits.clear();
       cb();
       return;
     }
     const sid = sessionIdFromKey(e.key);
     if (sid === null) return;
-    // Refresh the cache from the cross-tab value (parsed once) so the
-    // next snapshot read is consistent, then notify if in scope.
+    // Refresh both caches from the cross-tab value (parsed once each) so
+    // the next snapshot read is consistent, then notify if in scope.
     queueCounts.set(sid, parseQueuedCount(e.newValue) ?? 0);
+    rateLimits.set(sid, parseRateLimit(e.newValue));
     if (filter === null || filter.has(sid)) cb();
   };
   window.addEventListener("storage", onStorage);

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1722,6 +1722,28 @@
       ]
     },
     {
+      "id": "story.sidebar-rate-limit",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/sidebar-rate-limit.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.rate-limit-hook",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/hooks/__tests__/useCockpitRateLimit.test.tsx"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "story.sidebar-select-focuses-input",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -522,6 +522,19 @@ async function handleRequest(msg) {
       }
       const wasCancelled = sessionId ? cancelFlags.get(sessionId) : false;
       if (sessionId) cancelFlags.set(sessionId, false);
+      // Rate-limit park: a turn with `rateLimit` returns session/prompt as
+      // a JSON-RPC error carrying the fingerprint aoe's
+      // classify_rate_limit_error reads (errorKind "rate_limit" plus a
+      // resets_at), instead of a normal stopReason. The cockpit worker
+      // then emits a typed RateLimit event and parks the session. See
+      // #1281 / #1715. A cancel mid-turn still wins over the park.
+      if (!wasCancelled && turn.rateLimit) {
+        sendError(id, -32000, turn.rateLimit.message ?? "rate limit reached", {
+          errorKind: "rate_limit",
+          resets_at: turn.rateLimit.resets_at,
+        });
+        return;
+      }
       sendResult(id, {
         stopReason: wasCancelled ? "cancelled" : (turn.stopReason ?? "end_turn"),
       });

--- a/web/tests/live/cockpit-stories/sidebar-rate-limit.spec.ts
+++ b/web/tests/live/cockpit-stories/sidebar-rate-limit.spec.ts
@@ -1,0 +1,110 @@
+// User story: a cockpit session hits a provider rate limit and gets
+// parked. The server maps the rate-limited stop to Idle, so the sidebar
+// status glyph alone can't tell it apart from a normal idle session.
+// After navigating back to the dashboard, the session row must carry a
+// rate-limited indicator (Hourglass + reset time) sourced from the same
+// persisted cockpit-state mirror the queued-prompt badge reads. See
+// #1715.
+//
+// The fake ACP agent returns session/prompt as a `rate_limit` JSON-RPC
+// error (errorKind "rate_limit" + resets_at), which drives the cockpit
+// worker to emit a real RateLimit event end-to-end; no client-side state
+// is hand-seeded.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import {
+  enableCockpitAndWait,
+  waitForCockpitView,
+  attachServeDiagnostics,
+} from "../../helpers/cockpit";
+
+// Reset time an hour out so the cockpit notice and sidebar chip both
+// have a concrete "resets at" to render.
+const RESETS_AT = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Working on it." },
+        },
+      ],
+      // The prompt returns a rate_limit error instead of a stopReason,
+      // parking the session.
+      rateLimit: { resets_at: RESETS_AT, message: "usage limit reached" },
+    },
+  ],
+};
+
+base("sidebar row shows a rate-limited indicator after a park", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-sidebar-rl-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "sidebar-rl-a" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const sessionA = sessions.find((s) => s.title === "sidebar-rl-a");
+    if (!sessionA) throw new Error("seeded session 'sidebar-rl-a' missing");
+
+    await enableCockpitAndWait(serve.baseUrl, sessionA.id, 30_000, serve.home);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionA.id)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", {
+      name: /Send a message|Queue a follow-up/i,
+    });
+    await composer.fill("kick off A");
+    await composer.press("Enter");
+
+    // The cockpit surfaces the rate-limit park as a system notice; wait
+    // for it so we know the RateLimit event landed and was persisted
+    // before navigating away.
+    await expect(page.getByText(/Rate-limited/i)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Navigate to the dashboard so the sidebar is the primary surface
+    // and the cockpit view unmounts.
+    await page.goto(serve.baseUrl);
+
+    // The row for session A carries the rate-limited indicator, read from
+    // the persisted client-only rate-limit state.
+    await expect(page.getByTitle(/Rate-limited/i)).toBeVisible({
+      timeout: 15_000,
+    });
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

When a cockpit session hits a provider rate limit it gets parked, and the cockpit view shows a dedicated notice. The dashboard sidebar row, however, looked just like a normal idle row: the server intentionally maps a rate-limited stop to `Idle` (`src/server/mod.rs:2418`), so the status glyph alone cannot tell a parked session apart from one sitting idle. A user juggling sessions had no quick way to spot which row was blocked.

This adds a rate-limited indicator to the sidebar row, next to the existing draft and queued-prompt indicators, closing a visibility-parity gap. The implementation reuses the same client-side cockpit-state mirror those indicators already read, so it needs no backend or `SessionResponse` change:

- `web/src/lib/cockpitStateStorage.ts` gains a per-session rate-limit cache alongside the queued-count cache. `persistState` publishes `state.rateLimit` on every write, the cross-tab `storage` listener refreshes it, and the delete/clear path drops it.
- `web/src/hooks/useCockpitRateLimit.ts` (new) exposes `useRateLimitedForSessions`, aggregating across a workspace row's session ids via `useSyncExternalStore`, mirroring `useQueuedCountForSessions`. It reports how many sessions are parked plus the soonest reset time.
- `WorkspaceSidebar.tsx` renders an Hourglass chip with the reset time inline and a count when more than one session is parked.

Lifecycle semantics are unchanged: the server still treats rate-limited sessions as idle and the cockpit notice still carries the recovery flow. This PR is sidebar visibility only.

Closes #1715

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a cockpit session, drive it into a provider rate limit (or simulate one), and confirm the cockpit shows the rate-limit notice.
- [ ] Navigate back to the dashboard; the parked session's sidebar row shows an Hourglass indicator with a "resets at" time, even though its status glyph is still Idle.
- [ ] Recover the session (switch agent), and confirm the sidebar indicator clears for that row.
- [ ] With multiple sessions where only one is rate-limited, confirm only that row shows the indicator; with more than one parked in a workspace row, confirm the chip shows a count.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added `web/tests/live/cockpit-stories/sidebar-rate-limit.spec.ts` (parks a session via a real `rate_limit` `session/prompt` error and asserts the sidebar indicator appears end-to-end) and `web/src/hooks/__tests__/useCockpitRateLimit.test.tsx` (hook unit tests: lazy read, same-tab update and clear, cross-tab storage event, scoping, TTL/corrupt handling, multi-session count and soonest-reset). Both entries added to `coverage-matrix.json`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (icon plus inline reset time, count on aggregate rows) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a rate-limited indicator to the dashboard sidebar so users can see at a glance which sessions have been parked by provider rate limits, alongside existing draft and queued-prompt indicators.

### What Changed

**Added:**
- A new `useCockpitRateLimit` hook that tracks and aggregates rate-limit state across multiple sessions
- A visual indicator (Hourglass icon badge) in the `SessionRow` component showing when a session is rate-limited
- Per-session rate-limit state storage in `cockpitStateStorage` with cross-tab synchronization support
- Comprehensive test coverage: unit tests for the rate-limit hook, integration tests for storage persistence, and a Playwright live test validating the end-to-end flow

**Modified:**
- `WorkspaceSidebar.tsx` now renders an orange-styled rate-limit badge with the reset time and session count when rate-limited
- `useCockpit.ts` now persists rate-limit information alongside queued-prompt counts
- `cockpitStateStorage.ts` extended to cache and expose per-session rate-limit state with TTL-aware parsing and cross-tab event handling
- `coverage-matrix.json` updated with new test scenarios

### Key Design Decisions

- Reuses the existing local cockpit-state storage pattern without requiring backend or `SessionResponse` changes
- Maintains server lifecycle semantics: rate-limited sessions remain mapped to Idle and the cockpit recovery flow is unchanged
- Implements cross-tab synchronization so rate-limit state updates are visible across all open tabs without explicit coordination

### Benefits

- **Improved visibility**: Users can now see which sessions are waiting for rate-limit windows to reset
- **Better time management**: Shows the reset time directly in the sidebar for quick reference
- **No backend burden**: Leverages existing client-side storage pattern without adding server complexity
- **Seamless experience**: Works across multiple browser tabs with automatic synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->