### PR TITLE
feat(web): nested repo+group sidebar grouping mode

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -75,14 +75,15 @@ A sort toggle next to the filter button in the sidebar header switches to **Rece
 
 The toggle's state is per-browser (localStorage), not synced across devices and not tied to your profile. Toggling back to manual restores the stored manual order and re-enables drag. The Multi-repo group defaults to the bottom; in manual mode you can drag it anywhere and it holds that spot, while in Recent activity mode group drag is disabled and it stays at the bottom.
 
-## Sidebar grouping: by repo or by group
+## Sidebar grouping: by repo, by group, or both
 
-A grouping toggle (the layers icon) next to the sort toggle switches the axis the sidebar organises sessions by:
+A grouping toggle (the layers icon) next to the sort toggle cycles the axis the sidebar organises sessions by. Each click advances through the three modes, **By repo** to **By group** to **By repo and group** and back:
 
 - **By repo** (default) groups workspaces by their git repository, the original behavior.
 - **By group** groups sessions by the user-defined group you assigned in the TUI rename dialog or with `aoe group move`, mirroring the TUI's group headers. Sessions with no group fall into an **Ungrouped** bucket pinned to the bottom. A session whose worktree hosts agents in different groups shows up under each of those groups.
+- **By repo and group** keeps the repository headers and nests the user groups inside each one, so a single repo block shows its `feature`, `fix`, and **Ungrouped** subgroups with the matching sessions under each. This is the mode to use when you want repo-level focus and group-level structure at the same time. A session split across groups appears once per subgroup, sliced to that group's sessions.
 
-The choice is per-browser (localStorage). Collapse state is tracked separately for each axis, so collapsing a group in **By group** does not collapse a repo in **By repo**. The group axis is read-only in v1: group rename, color, and drag-reorder live on the repo axis only, and groups themselves are not yet reorderable.
+The choice is per-browser (localStorage). Collapse state is tracked separately for each axis, so collapsing a group in **By group** does not collapse a repo in **By repo**. In **By repo and group**, the repository headers share their collapse state with **By repo**, while each nested subgroup collapses independently and is keyed per repository, so collapsing `feature` in one repo leaves `feature` in another repo expanded. The group and nested axes are read-only: group rename, color, and drag-reorder live on the repo axis only, and groups themselves are not reorderable.
 
 ## Triage: pin, archive, snooze
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { safeGetItem, safeSetItem } from "./lib/safeStorage";
 import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useSessionGroups } from "./hooks/useSessionGroups";
+import { useNestedSidebarGroups } from "./hooks/useNestedSidebarGroups";
 import { useSidebarSortMode } from "./hooks/useSidebarSortMode";
 import { useSidebarAxis } from "./hooks/useSidebarAxis";
 import { repoGroupToSidebarGroup } from "./lib/sidebarGroups";
@@ -245,6 +246,12 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   } = useRepoGroups(workspaces, workspaceOrdering, sidebarSortMode);
   const { groups: sessionGroups, toggleGroupCollapsed } =
     useSessionGroups(workspaces);
+  // The nested `repo+group` axis reuses the already-built repo groups for
+  // its top level (so repo collapse, appearance, and ordering are shared
+  // with the repo axis) and splits each repo by `group_path` underneath.
+  // See #1720.
+  const { groups: nestedGroups, toggleSubgroupCollapsed } =
+    useNestedSidebarGroups(repoGroups);
 
   // The sidebar render path consumes one honest model (SidebarGroup): the
   // repo axis maps in via an adapter, the user-group axis is already in
@@ -1087,6 +1094,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         {!showSettings && !showProjects && (
           <WorkspaceSidebar
             groups={sidebarGroups}
+            nestedGroups={nestedGroups}
+            onToggleSubgroup={toggleSubgroupCollapsed}
             onReorderWorkspaces={handleReorderWorkspaces}
             onReorderGroups={reorderRepoGroups}
             activeId={activeWorkspace?.id ?? null}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -45,7 +45,9 @@ import type {
 } from "../lib/types";
 import type { SidebarAxis } from "../lib/sidebarAxis";
 import {
+  nestedSidebarGroupHasLiveWorkspace,
   sidebarGroupHasLiveWorkspace,
+  type NestedSidebarGroup,
   type SidebarGroup,
 } from "../lib/sidebarGroups";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
@@ -140,6 +142,10 @@ const typedClosestCenter: CollisionDetection = (args) => {
 
 interface Props {
   groups: SidebarGroup[];
+  // The nested `repo+group` axis model (#1720). Only consumed when
+  // `axis === "repo+group"`; the flat `groups` list drives the other axes.
+  nestedGroups: NestedSidebarGroup[];
+  onToggleSubgroup: (repoId: string, groupPath: string) => void;
   onReorderWorkspaces: (newOrder: string[]) => void;
   onReorderGroups: (orderedGroupIds: string[]) => void;
   activeId: string | null;
@@ -1752,8 +1758,37 @@ function workspaceMatchesFilter(ws: Workspace, q: string): boolean {
   );
 }
 
+// The grouping toggle cycles through the three axes on each click. Order is
+// chosen so the first click off the default still lands on the flat group
+// axis (preserving the pre-#1720 repo -> group step), then adds nesting.
+const NEXT_AXIS: Record<SidebarAxis, SidebarAxis> = {
+  repo: "group",
+  group: "repo+group",
+  "repo+group": "repo",
+};
+
+const AXIS_HEADING: Record<SidebarAxis, string> = {
+  repo: "Projects",
+  group: "Groups",
+  "repo+group": "Projects",
+};
+
+const AXIS_TOOLTIP: Record<SidebarAxis, string> = {
+  repo: "Grouping: by repository",
+  group: "Grouping: by user group",
+  "repo+group": "Grouping: by repository, then user group",
+};
+
+const AXIS_ARIA: Record<SidebarAxis, string> = {
+  repo: "Group sessions by repository",
+  group: "Group sessions by user group",
+  "repo+group": "Group sessions by repository, then user group",
+};
+
 export function WorkspaceSidebar({
   groups,
+  nestedGroups,
+  onToggleSubgroup,
   onReorderWorkspaces,
   onReorderGroups,
   activeId,
@@ -1874,6 +1909,8 @@ export function WorkspaceSidebar({
 
   const q = filterQuery.trim().toLowerCase();
 
+  const isNested = axis === "repo+group";
+
   const filteredGroups = q
     ? groups
         .map((g) => ({
@@ -1886,7 +1923,31 @@ export function WorkspaceSidebar({
         .filter((g) => g.workspaces.length > 0)
     : groups;
 
-  const hasResults = filteredGroups.length > 0;
+  // Filter the nested model the same way the flat list is filtered: a row
+  // survives if it matches, or if its subgroup or repo header name matches;
+  // empty subgroups and then empty repos drop out. See #1720.
+  const filteredNested: NestedSidebarGroup[] = q
+    ? nestedGroups
+        .map((ng) => ({
+          repo: ng.repo,
+          subgroups: ng.subgroups
+            .map((sg) => ({
+              ...sg,
+              workspaces: sg.workspaces.filter(
+                (v) =>
+                  workspaceMatchesFilter(v.workspace, q) ||
+                  sg.displayName.toLowerCase().includes(q) ||
+                  ng.repo.displayName.toLowerCase().includes(q),
+              ),
+            }))
+            .filter((sg) => sg.workspaces.length > 0),
+        }))
+        .filter((ng) => ng.subgroups.length > 0)
+    : nestedGroups;
+
+  const hasResults = isNested
+    ? filteredNested.length > 0
+    : filteredGroups.length > 0;
 
   const toggleFilter = () => {
     setFilterOpen((o) => {
@@ -1949,27 +2010,21 @@ export function WorkspaceSidebar({
       >
         <div className="px-3 pt-3 pb-1 flex items-center">
           <span className="text-sm text-text-muted flex-1">
-            {axis === "group" ? "Groups" : "Projects"}
+            {AXIS_HEADING[axis]}
           </span>
-          <Tooltip
-            text={
-              axis === "group"
-                ? "Grouping: by user group"
-                : "Grouping: by repository"
-            }
-          >
+          <Tooltip text={AXIS_TOOLTIP[axis]}>
             <button
-              onClick={() => onAxisChange(axis === "repo" ? "group" : "repo")}
-              aria-pressed={axis === "group"}
+              onClick={() => onAxisChange(NEXT_AXIS[axis])}
+              aria-pressed={axis !== "repo"}
               aria-label={
-                axis === "group"
-                  ? "Group sessions by user group, currently pressed"
-                  : "Group sessions by repository"
+                axis === "repo"
+                  ? AXIS_ARIA[axis]
+                  : `${AXIS_ARIA[axis]}, currently pressed`
               }
               data-testid="sidebar-axis-toggle"
               data-axis={axis}
               className={`w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors ${
-                axis === "group"
+                axis !== "repo"
                   ? "text-brand-500"
                   : "text-text-dim hover:text-text-secondary"
               }`}
@@ -2084,6 +2139,7 @@ export function WorkspaceSidebar({
         )}
 
         <div className="flex-1 overflow-y-auto overflow-x-hidden">
+          {!isNested && (
           <DragSuppressContext.Provider value={dragSuppressRef}>
           <DndContext
             sensors={sensors}
@@ -2208,6 +2264,96 @@ export function WorkspaceSidebar({
             })()}
           </DndContext>
           </DragSuppressContext.Provider>
+          )}
+          {isNested &&
+            filteredNested
+              .filter(nestedSidebarGroupHasLiveWorkspace)
+              .map((ng) => {
+                const repo = ng.repo;
+                const repoExpanded = q ? true : !repo.collapsed;
+                const repoHasActiveChild = ng.subgroups.some((sg) =>
+                  sg.workspaces.some(
+                    (v) => v.workspace.id === displayedActiveId,
+                  ),
+                );
+                return (
+                  <div
+                    key={repo.id}
+                    data-testid="sidebar-nested-repo"
+                    data-repo-id={repo.id}
+                  >
+                    <SidebarGroupHeader
+                      group={{ ...repo, collapsed: !repoExpanded }}
+                      hasActiveChild={!repoExpanded && repoHasActiveChild}
+                      onClick={() => !q && onToggleGroup(repo.id)}
+                      onUpdateAppearance={onUpdateRepoAppearance}
+                      onNewSession={() =>
+                        repo.capabilities.create === "repo" && repo.repoPath
+                          ? onCreateSession(repo.repoPath)
+                          : onNew()
+                      }
+                      offline={offline}
+                    />
+                    {repoExpanded &&
+                      ng.subgroups
+                        .filter(sidebarGroupHasLiveWorkspace)
+                        .map((sg) => {
+                          const groupPath = sg.groupPath ?? "";
+                          const subExpanded = q ? true : !sg.collapsed;
+                          const subHasActiveChild = sg.workspaces.some(
+                            (v) => v.workspace.id === displayedActiveId,
+                          );
+                          // Sunk rows are pulled into the single global
+                          // footer below, exactly like the flat axes, so
+                          // each subgroup renders only its live tier.
+                          const liveWorkspaces = sg.workspaces.filter(
+                            (v) => !workspaceIsSunk(v.workspace),
+                          );
+                          return (
+                            <div
+                              key={`${repo.id}::${groupPath}`}
+                              className="pl-3"
+                              data-testid="sidebar-nested-subgroup"
+                              data-repo-id={repo.id}
+                            >
+                              <SidebarGroupHeader
+                                group={{ ...sg, collapsed: !subExpanded }}
+                                hasActiveChild={
+                                  !subExpanded && subHasActiveChild
+                                }
+                                onClick={() =>
+                                  !q && onToggleSubgroup(repo.id, groupPath)
+                                }
+                                onUpdateAppearance={onUpdateRepoAppearance}
+                                onNewSession={onNew}
+                                offline={offline}
+                              />
+                              {subExpanded &&
+                                liveWorkspaces.map((v) => (
+                                  <SessionRow
+                                    key={`${repo.id}::${groupPath}::${v.key}`}
+                                    workspace={v.workspace}
+                                    isActive={
+                                      v.workspace.id === displayedActiveId
+                                    }
+                                    onClick={() => {
+                                      setOptimisticActive({
+                                        id: v.workspace.id,
+                                        fromActiveId: activeId,
+                                      });
+                                      onSelect(v.workspace.id);
+                                    }}
+                                    onDelete={onDeleteSession}
+                                    readOnly={readOnly}
+                                    indented
+                                  />
+                                ))}
+                            </div>
+                          );
+                        })}
+                  </div>
+                );
+              })}
           {(() => {
             // Single global "Snoozed & archived" section at the very
             // bottom of the sidebar. Aggregates sunk workspaces from
@@ -2216,10 +2362,18 @@ export function WorkspaceSidebar({
             // Rows are listed flat in the order they appear inside
             // their respective groups; each row's SessionRow already
             // surfaces the title/branch/repo chips that anchor it to
-            // its project. See #1581.
-            const sunkWorkspaces = filteredGroups.flatMap((g) =>
-              g.workspaces.filter((v) => workspaceIsSunk(v.workspace)),
-            );
+            // its project. The nested axis flattens across its
+            // repo -> subgroup tree to feed the same bucket. See #1581,
+            // #1720.
+            const sunkWorkspaces = isNested
+              ? filteredNested.flatMap((ng) =>
+                  ng.subgroups.flatMap((sg) =>
+                    sg.workspaces.filter((v) => workspaceIsSunk(v.workspace)),
+                  ),
+                )
+              : filteredGroups.flatMap((g) =>
+                  g.workspaces.filter((v) => workspaceIsSunk(v.workspace)),
+                );
             if (sunkWorkspaces.length === 0) return null;
             return (
               <div data-testid="sidebar-sunk-section">

--- a/web/src/hooks/useNestedSidebarGroups.ts
+++ b/web/src/hooks/useNestedSidebarGroups.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { RepoGroup } from "../lib/types";
+import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
+import {
+  buildNestedSidebarGroups,
+  type NestedSidebarGroup,
+} from "../lib/sidebarGroups";
+import { useIdleDecayWindowMs } from "../lib/idleDecay";
+
+// Distinct from both the repo prefix (`aoe-repo-collapsed-`) and the flat
+// group prefix (`aoe-group-collapsed-`): a subgroup only exists inside one
+// repo, so its collapse state is keyed on the repo plus the group path and
+// never shared with the flat group axis. See #1720.
+const COLLAPSED_KEY_PREFIX = "aoe-nested-group-collapsed-";
+
+// Encode both halves so a `::` inside a repo path or group path cannot make
+// two different (repo, group) pairs collapse the same key. Keying on the
+// raw `groupPath` ("" for Ungrouped) also sidesteps the `UNGROUPED_GROUP_ID`
+// sentinel, so a literal user group named like the sentinel stays distinct.
+function subgroupKey(repoId: string, groupPath: string): string {
+  return `${encodeURIComponent(repoId)}::${encodeURIComponent(groupPath)}`;
+}
+
+function loadCollapsed(key: string): boolean {
+  return safeGetItem(`${COLLAPSED_KEY_PREFIX}${key}`) === "1";
+}
+
+export function useNestedSidebarGroups(repoGroups: RepoGroup[]): {
+  groups: NestedSidebarGroup[];
+  toggleSubgroupCollapsed: (repoId: string, groupPath: string) => void;
+} {
+  const idleDecayWindowMs = useIdleDecayWindowMs();
+  const [collapsedMap, setCollapsedMap] = useState<Record<string, boolean>>({});
+
+  const groups = useMemo(
+    () =>
+      buildNestedSidebarGroups(repoGroups, {
+        idleDecayWindowMs,
+        isSubgroupCollapsed: (repoId, groupPath) => {
+          const key = subgroupKey(repoId, groupPath);
+          return collapsedMap[key] ?? loadCollapsed(key);
+        },
+      }),
+    [repoGroups, idleDecayWindowMs, collapsedMap],
+  );
+
+  // The updater stays pure and persistence runs in an effect, for the same
+  // StrictMode double-invoke reason documented in `useSessionGroups`.
+  const toggleSubgroupCollapsed = useCallback(
+    (repoId: string, groupPath: string) => {
+      const key = subgroupKey(repoId, groupPath);
+      setCollapsedMap((prev) => {
+        const current = prev[key] ?? loadCollapsed(key);
+        return { ...prev, [key]: !current };
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    for (const [key, collapsed] of Object.entries(collapsedMap)) {
+      if (collapsed) {
+        safeSetItem(`${COLLAPSED_KEY_PREFIX}${key}`, "1");
+      } else {
+        safeRemoveItem(`${COLLAPSED_KEY_PREFIX}${key}`);
+      }
+    }
+  }, [collapsedMap]);
+
+  return { groups, toggleSubgroupCollapsed };
+}

--- a/web/src/hooks/useSidebarAxis.test.ts
+++ b/web/src/hooks/useSidebarAxis.test.ts
@@ -27,6 +27,12 @@ describe("useSidebarAxis", () => {
     expect(result.current[0]).toBe("group");
   });
 
+  it("hydrates from a stored 'repo+group' value (#1720)", () => {
+    window.localStorage.setItem(SIDEBAR_AXIS_KEY, "repo+group");
+    const { result } = renderHook(() => useSidebarAxis());
+    expect(result.current[0]).toBe("repo+group");
+  });
+
   it("falls back to 'repo' for an unrecognised stored value", () => {
     window.localStorage.setItem(SIDEBAR_AXIS_KEY, "garbage");
     const { result } = renderHook(() => useSidebarAxis());
@@ -42,6 +48,17 @@ describe("useSidebarAxis", () => {
 
     expect(result.current[0]).toBe("group");
     expect(window.localStorage.getItem(SIDEBAR_AXIS_KEY)).toBe("group");
+  });
+
+  it("setter persists the 'repo+group' axis (#1720)", () => {
+    const { result } = renderHook(() => useSidebarAxis());
+
+    act(() => {
+      result.current[1]("repo+group");
+    });
+
+    expect(result.current[0]).toBe("repo+group");
+    expect(window.localStorage.getItem(SIDEBAR_AXIS_KEY)).toBe("repo+group");
   });
 
   it("setter is stable across renders (useCallback)", () => {

--- a/web/src/lib/__tests__/sidebarGroups.test.ts
+++ b/web/src/lib/__tests__/sidebarGroups.test.ts
@@ -11,7 +11,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildNestedSidebarGroups,
   buildSessionGroups,
+  nestedSidebarGroupHasLiveWorkspace,
   repoGroupToSidebarGroup,
   sidebarGroupHasLiveWorkspace,
   UNGROUPED_GROUP_ID,
@@ -218,6 +220,157 @@ describe("repoGroupToSidebarGroup", () => {
     );
     expect(sg.capabilities.create).toBe("generic");
     expect(sg.capabilities.appearance).toBe(true);
+  });
+});
+
+describe("buildNestedSidebarGroups", () => {
+  function repoGroup(over: Partial<RepoGroup> = {}): RepoGroup {
+    return {
+      id: "/repo-a",
+      repoPath: "/repo-a",
+      displayName: "repo-a",
+      defaultDisplayName: "repo-a",
+      alias: null,
+      color: null,
+      remoteOwner: null,
+      workspaces: [],
+      status: "idle",
+      collapsed: false,
+      ...over,
+    };
+  }
+
+  const buildNested = (
+    repoGroups: RepoGroup[],
+    isSubgroupCollapsed: (repoId: string, groupPath: string) => boolean = () =>
+      false,
+  ) =>
+    buildNestedSidebarGroups(repoGroups, {
+      idleDecayWindowMs: IDLE_DECAY_WINDOW_MS,
+      isSubgroupCollapsed,
+    });
+
+  it("keeps the repo header and nests its user groups underneath", () => {
+    const nested = buildNested([
+      repoGroup({
+        workspaces: [
+          workspace("w1", [session({ id: "a", group_path: "feature" })]),
+          workspace("w2", [session({ id: "b", group_path: "fix" })]),
+        ],
+      }),
+    ]);
+    expect(nested).toHaveLength(1);
+    expect(nested[0]!.repo.kind).toBe("repo");
+    expect(nested[0]!.repo.repoPath).toBe("/repo-a");
+    expect(nested[0]!.subgroups.map((sg) => sg.id)).toEqual(["feature", "fix"]);
+    expect(nested[0]!.subgroups.every((sg) => sg.kind === "sessionGroup")).toBe(
+      true,
+    );
+  });
+
+  it("drops manual reorder on the repo header (nested axis has no order)", () => {
+    const nested = buildNested([
+      repoGroup({
+        workspaces: [workspace("w1", [session({ id: "a", group_path: "x" })])],
+      }),
+    ]);
+    expect(nested[0]!.repo.capabilities.reorder).toBe(false);
+    // Other repo affordances stay intact.
+    expect(nested[0]!.repo.capabilities.appearance).toBe(true);
+    expect(nested[0]!.repo.capabilities.create).toBe("repo");
+  });
+
+  it("puts ungrouped sessions in an Ungrouped subgroup within the repo", () => {
+    const nested = buildNested([
+      repoGroup({
+        workspaces: [
+          workspace("w1", [session({ id: "a", group_path: "feature" })]),
+          workspace("w2", [session({ id: "b", group_path: "" })]),
+        ],
+      }),
+    ]);
+    const ids = nested[0]!.subgroups.map((sg) => sg.id);
+    expect(ids).toEqual(["feature", UNGROUPED_GROUP_ID]);
+    const ungrouped = nested[0]!.subgroups.find(
+      (sg) => sg.id === UNGROUPED_GROUP_ID,
+    )!;
+    expect(ungrouped.groupPath).toBe("");
+  });
+
+  it("slices a split workspace per subgroup with the real id preserved", () => {
+    const nested = buildNested([
+      repoGroup({
+        workspaces: [
+          workspace("w1", [
+            session({ id: "a", group_path: "feature" }),
+            session({ id: "b", group_path: "fix" }),
+          ]),
+        ],
+      }),
+    ]);
+    const [feature, fix] = nested[0]!.subgroups;
+    expect(feature!.workspaces[0]!.workspace.id).toBe("w1");
+    expect(fix!.workspaces[0]!.workspace.id).toBe("w1");
+    expect(feature!.workspaces[0]!.key).not.toBe(fix!.workspaces[0]!.key);
+    expect(
+      feature!.workspaces[0]!.workspace.sessions.map((s) => s.id),
+    ).toEqual(["a"]);
+    expect(fix!.workspaces[0]!.workspace.sessions.map((s) => s.id)).toEqual([
+      "b",
+    ]);
+  });
+
+  it("keys subgroup collapse on (repoId, groupPath), not group id alone", () => {
+    const nested = buildNested(
+      [
+        repoGroup({
+          id: "/repo-a",
+          repoPath: "/repo-a",
+          workspaces: [
+            workspace("w1", [session({ id: "a", group_path: "feature" })]),
+          ],
+        }),
+        repoGroup({
+          id: "/repo-b",
+          repoPath: "/repo-b",
+          workspaces: [
+            workspace("w2", [session({ id: "b", group_path: "feature" })], {
+              projectPath: "/repo-b",
+            }),
+          ],
+        }),
+      ],
+      (repoId, groupPath) => repoId === "/repo-a" && groupPath === "feature",
+    );
+    // Same group path in two repos collapses independently.
+    expect(nested[0]!.subgroups[0]!.collapsed).toBe(true);
+    expect(nested[1]!.subgroups[0]!.collapsed).toBe(false);
+  });
+
+  it("reports liveness from any live subgroup row", () => {
+    const allSunk = buildNested([
+      repoGroup({
+        workspaces: [
+          workspace("w1", [
+            session({
+              id: "a",
+              group_path: "feature",
+              archived_at: "2025-01-02T00:00:00Z",
+            }),
+          ]),
+        ],
+      }),
+    ]);
+    expect(nestedSidebarGroupHasLiveWorkspace(allSunk[0]!)).toBe(false);
+
+    const live = buildNested([
+      repoGroup({
+        workspaces: [
+          workspace("w1", [session({ id: "a", group_path: "feature" })]),
+        ],
+      }),
+    ]);
+    expect(nestedSidebarGroupHasLiveWorkspace(live[0]!)).toBe(true);
   });
 });
 

--- a/web/src/lib/sidebarAxis.ts
+++ b/web/src/lib/sidebarAxis.ts
@@ -1,15 +1,17 @@
 import { safeGetItem, safeSetItem } from "./safeStorage";
 
 /** Which organisation axis the sidebar groups sessions by: the auto-derived
- *  repository axis (default, the original behavior) or the user-defined
- *  group axis backed by each session's `group_path`. Per-browser, like the
- *  sort mode. See #1234. */
-export type SidebarAxis = "repo" | "group";
+ *  repository axis (default, the original behavior), the user-defined group
+ *  axis backed by each session's `group_path`, or the nested `repo+group`
+ *  axis that keeps repository headers and nests user groups inside each one.
+ *  Per-browser, like the sort mode. See #1234, #1720. */
+export type SidebarAxis = "repo" | "group" | "repo+group";
 
 export const SIDEBAR_AXIS_KEY = "aoe-sidebar-axis";
 
 export function loadSidebarAxis(): SidebarAxis {
-  return safeGetItem(SIDEBAR_AXIS_KEY) === "group" ? "group" : "repo";
+  const value = safeGetItem(SIDEBAR_AXIS_KEY);
+  return value === "group" || value === "repo+group" ? value : "repo";
 }
 
 export function saveSidebarAxis(axis: SidebarAxis): void {

--- a/web/src/lib/sidebarGroups.ts
+++ b/web/src/lib/sidebarGroups.ts
@@ -119,7 +119,11 @@ export function buildSessionGroups(
   workspaces: Workspace[],
   opts: {
     idleDecayWindowMs: number;
-    isCollapsed: (groupId: string) => boolean;
+    // `groupPath` is the normalized path ("" for Ungrouped), passed
+    // alongside the synthetic id so nested callers can key collapse state
+    // on the path and dodge the `UNGROUPED_GROUP_ID` sentinel. Flat callers
+    // ignore it. See #1720.
+    isCollapsed: (groupId: string, groupPath: string) => boolean;
   },
 ): SidebarGroup[] {
   const byGroup = new Map<string, SidebarWorkspaceView[]>();
@@ -171,7 +175,7 @@ export function buildSessionGroups(
       remoteOwner: null,
       workspaces: views,
       status: hasActive ? "active" : "idle",
-      collapsed: opts.isCollapsed(id),
+      collapsed: opts.isCollapsed(id, gp),
       capabilities: { appearance: false, reorder: false, create: "generic" },
       groupPath: gp,
     });
@@ -191,4 +195,55 @@ export function buildSessionGroups(
 // footer, so an all-sunk group's header is not rendered empty.
 export function sidebarGroupHasLiveWorkspace(group: SidebarGroup): boolean {
   return group.workspaces.some((v) => !workspaceIsSunk(v.workspace));
+}
+
+// The nested `repo+group` axis (#1720). A repository header keeps its full
+// repo-axis identity (`repo`), and inside it the same `group_path` buckets
+// the user-group axis already computes show up as `subgroups`. This is a
+// composition of the two existing builders, not a third bucketing pass:
+// `repo` comes from `repoGroupToSidebarGroup`, `subgroups` from
+// `buildSessionGroups` over that repo's own workspaces.
+export interface NestedSidebarGroup {
+  repo: SidebarGroup;
+  subgroups: SidebarGroup[];
+}
+
+// Build the nested axis from the already-built repo-axis groups. Top-level
+// ordering, appearance, synthetic Multi-repo / Scratch buckets, and per-repo
+// collapse are inherited verbatim from the repo axis; only manual drag
+// reorder is dropped (the nested axis has no manual order, like the group
+// axis). Each repo's subgroups are the user-group split of just that repo's
+// workspaces, so a workspace whose sessions span groups is sliced per
+// subgroup exactly as the flat group axis does.
+export function buildNestedSidebarGroups(
+  repoGroups: RepoGroup[],
+  opts: {
+    idleDecayWindowMs: number;
+    isSubgroupCollapsed: (repoId: string, groupPath: string) => boolean;
+  },
+): NestedSidebarGroup[] {
+  return repoGroups.map((repoGroup) => {
+    const repo = repoGroupToSidebarGroup(repoGroup);
+    const subgroups = buildSessionGroups(repoGroup.workspaces, {
+      idleDecayWindowMs: opts.idleDecayWindowMs,
+      isCollapsed: (_groupId, groupPath) =>
+        opts.isSubgroupCollapsed(repo.id, groupPath),
+    });
+    return {
+      repo: {
+        ...repo,
+        capabilities: { ...repo.capabilities, reorder: false },
+      },
+      subgroups,
+    };
+  });
+}
+
+// Nested-axis equivalent of `sidebarGroupHasLiveWorkspace`: true while any
+// subgroup still has a live row, so an all-sunk repository block is not
+// rendered as an empty header.
+export function nestedSidebarGroupHasLiveWorkspace(
+  group: NestedSidebarGroup,
+): boolean {
+  return group.subgroups.some(sidebarGroupHasLiveWorkspace);
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -815,6 +815,30 @@
       ]
     },
     {
+      "id": "sidebar.nested-axis-pure",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/lib/__tests__/sidebarGroups.test.ts"
+      ],
+      "components": [
+        "web/src/lib/sidebarGroups.ts"
+      ]
+    },
+    {
+      "id": "sidebar.nested-axis-live",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/sidebar-nested-axis.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/hooks/useNestedSidebarGroups.ts",
+        "web/src/lib/sidebarGroups.ts"
+      ]
+    },
+    {
       "id": "session.lifecycle",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/sidebar-groups-axis.spec.ts
+++ b/web/tests/live/sidebar-groups-axis.spec.ts
@@ -142,8 +142,12 @@ base.describe("sidebar user-group axis (#1234)", () => {
         featureHeader.locator("button[aria-expanded]"),
       ).toHaveAttribute("aria-expanded", "false");
 
-      // Switching back to the repo axis shows an independent collapse map:
-      // the repo group is not collapsed just because a user group was.
+      // Cycling back to the repo axis shows an independent collapse map:
+      // the repo group is not collapsed just because a user group was. The
+      // toggle now cycles repo -> group -> repo+group -> repo (#1720), so
+      // returning to repo from group takes two clicks.
+      await axisToggle.click();
+      await expect(axisToggle).toHaveAttribute("data-axis", "repo+group");
       await axisToggle.click();
       await expect(axisToggle).toHaveAttribute("data-axis", "repo");
       await expect(

--- a/web/tests/live/sidebar-nested-axis.spec.ts
+++ b/web/tests/live/sidebar-nested-axis.spec.ts
@@ -69,8 +69,12 @@ async function cycleAxisTo(
   target: string,
 ) {
   for (let i = 0; i < 3; i++) {
-    if ((await toggle.getAttribute("data-axis")) === target) return;
+    const current = await toggle.getAttribute("data-axis");
+    if (current === target) return;
     await toggle.click();
+    // Wait for the axis to actually advance before reading again, so a
+    // not-yet-flushed re-render cannot trigger an extra overshooting click.
+    await expect(toggle).not.toHaveAttribute("data-axis", current ?? "");
   }
   await expect(toggle).toHaveAttribute("data-axis", target);
 }

--- a/web/tests/live/sidebar-nested-axis.spec.ts
+++ b/web/tests/live/sidebar-nested-axis.spec.ts
@@ -1,0 +1,188 @@
+// Live coverage for the nested repo+group sidebar axis (#1720).
+//   - Sessions seeded in ONE repo dir across two user groups plus one
+//     ungrouped session render, on the "By repo and group" axis, as a
+//     single repository block with nested subgroup headers (feature, fix,
+//     Ungrouped), each holding its own sessions.
+//   - Subgroup collapse is independent of repo collapse and persists, and
+//     collapsing the repo header hides every nested subgroup.
+//
+// The bucketing/split correctness is unit-tested in
+// `src/lib/__tests__/sidebarGroups.test.ts`; this spec exercises the real
+// server -> nested render + the localStorage-backed axis/collapse toggles.
+//
+// Seeding runs BEFORE serve spawns so `state.instances` picks up the
+// records on boot, mirroring `sidebar-groups-axis.spec.ts`.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  resolveAoeBinary,
+} from "../helpers/aoeServe";
+
+function seedNestedSessions(
+  sessions: { title: string; group?: string }[],
+) {
+  return ({ home, env }: { home: string; shimBin: string; env: NodeJS.ProcessEnv }) => {
+    const binary = resolveAoeBinary();
+    const projectDir = join(home, "project");
+    mkdirSync(projectDir, { recursive: true });
+    spawnSync("git", ["init", "-q"], { cwd: projectDir });
+    spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+      cwd: projectDir,
+      env: {
+        ...env,
+        GIT_AUTHOR_NAME: "t",
+        GIT_AUTHOR_EMAIL: "t@t",
+        GIT_COMMITTER_NAME: "t",
+        GIT_COMMITTER_EMAIL: "t@t",
+      },
+    });
+    for (const { title, group } of sessions) {
+      const args = ["add", projectDir, "-t", title, "-c", "claude"];
+      if (group) args.push("-g", group);
+      const res = spawnSync(binary, args, { env });
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed for ${title}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    }
+  };
+}
+
+const SEED = seedNestedSessions([
+  { title: "feat-one", group: "feature" },
+  { title: "feat-two", group: "feature" },
+  { title: "fix-one", group: "fix" },
+  { title: "loose-one" },
+]);
+
+// Click the layers toggle until it reaches the requested axis. The toggle
+// cycles repo -> group -> repo+group -> repo, so a bounded loop lands on
+// any target without hard-coding the click count.
+async function cycleAxisTo(
+  toggle: import("@playwright/test").Locator,
+  target: string,
+) {
+  for (let i = 0; i < 3; i++) {
+    if ((await toggle.getAttribute("data-axis")) === target) return;
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute("data-axis", target);
+}
+
+base.describe("sidebar nested repo+group axis (#1720)", () => {
+  base("nests user groups inside the repo block", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: SEED,
+    });
+
+    try {
+      expect(await listSessions(serve.baseUrl)).toHaveLength(4);
+      await page.goto(`${serve.baseUrl}/`);
+
+      const axisToggle = page.locator("[data-testid='sidebar-axis-toggle']");
+      await expect(axisToggle).toHaveAttribute("data-axis", "repo", {
+        timeout: 10_000,
+      });
+      await cycleAxisTo(axisToggle, "repo+group");
+
+      // One repository block holds all four sessions, split into three
+      // nested subgroups: feature, fix, and Ungrouped.
+      const repoBlocks = page.locator("[data-testid='sidebar-nested-repo']");
+      await expect(repoBlocks).toHaveCount(1);
+      const repo = repoBlocks.first();
+
+      await expect(
+        repo.locator("[data-testid='sidebar-nested-subgroup']"),
+      ).toHaveCount(3);
+      await expect(
+        repo.locator(
+          "[data-testid='sidebar-nested-subgroup'] [data-group-id='feature']",
+        ),
+      ).toBeVisible();
+      await expect(
+        repo.locator(
+          "[data-testid='sidebar-nested-subgroup'] [data-group-id='fix']",
+        ),
+      ).toBeVisible();
+      await expect(
+        repo.locator(
+          "[data-testid='sidebar-nested-subgroup'] [data-group-id='__ungrouped__']",
+        ),
+      ).toBeVisible();
+
+      // Every session stays visible, now nested under its subgroup.
+      await expect(
+        page.locator("[data-testid='sidebar-session-row']"),
+      ).toHaveCount(4);
+    } finally {
+      await serve.stop();
+    }
+  });
+
+  base("subgroup collapse is independent of repo collapse and persists", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: SEED,
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+
+      const axisToggle = page.locator("[data-testid='sidebar-axis-toggle']");
+      await expect(axisToggle).toHaveAttribute("data-axis", "repo", {
+        timeout: 10_000,
+      });
+      await cycleAxisTo(axisToggle, "repo+group");
+
+      const featureSub = page.locator(
+        "[data-testid='sidebar-nested-subgroup'] [data-group-id='feature']",
+      );
+      const featureExpand = featureSub.locator("button[aria-expanded]");
+      await expect(featureExpand).toHaveAttribute("aria-expanded", "true");
+
+      // Collapse just the feature subgroup: its rows hide, the fix
+      // subgroup's rows stay, and the repo header stays expanded.
+      await featureExpand.click();
+      await expect(featureExpand).toHaveAttribute("aria-expanded", "false");
+      await expect(page.getByText("feat-one")).toBeHidden();
+      await expect(page.getByText("fix-one")).toBeVisible();
+
+      // The subgroup collapse survives a reload (per-repo localStorage key).
+      await page.reload();
+      await expect(axisToggle).toHaveAttribute("data-axis", "repo+group", {
+        timeout: 10_000,
+      });
+      await expect(
+        page
+          .locator(
+            "[data-testid='sidebar-nested-subgroup'] [data-group-id='feature']",
+          )
+          .locator("button[aria-expanded]"),
+      ).toHaveAttribute("aria-expanded", "false");
+
+      // Collapsing the repo header hides every nested subgroup.
+      const repoHeader = page
+        .locator("[data-testid='sidebar-nested-repo']")
+        .first()
+        .locator("[data-testid='sidebar-group-header']")
+        .first();
+      await repoHeader.locator("button[aria-expanded]").click();
+      await expect(
+        page.locator("[data-testid='sidebar-nested-subgroup']"),
+      ).toHaveCount(0);
+    } finally {
+      await serve.stop();
+    }
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web sidebar could group sessions by repository **or** by user group, never both. Picking **By repo** lost the `group_path` structure; picking **By group** lost the repo-first layout. That made it hard to triage work inside one repo where sessions are intentionally split across groups like `feature` and `fix`.

This adds a third grouping mode, **By repo and group**, that keeps the repository headers and nests the user groups inside each one. A single repo block now shows its `feature`, `fix`, and `Ungrouped` subgroups with the matching sessions under each. The grouping toggle (the layers icon) cycles `repo` to `group` to `repo+group` and back.

The new mode is a composition, not a rewrite: the top tier reuses the existing repo-axis output (so repo ordering, appearance, synthetic Multi-repo / Scratch buckets, and repo collapse are inherited), and each repo's subgroups are the existing user-group split run over just that repo's workspaces. A workspace whose sessions span groups is sliced once per subgroup, the real workspace id preserved for actions. Repo collapse is shared with **By repo**; each nested subgroup collapses independently and is keyed per repository, so collapsing `feature` in one repo leaves it expanded in another. Sunk rows still flow into the single global "Snoozed & archived" footer. The axis lives in localStorage like the existing modes, so there is no server config or migration.

Closes #1720

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard with sessions in one repo across `feature` and `fix` groups plus one ungrouped session.
- [ ] Click the layers (grouping) toggle twice to reach **By repo and group**; confirm the tooltip reads "Grouping: by repository, then user group".
- [ ] Confirm the repo header shows nested `feature`, `fix`, and `Ungrouped` subgroups, each holding its own sessions, and no session is missing or duplicated under the wrong subgroup.
- [ ] Collapse one subgroup; confirm only its rows hide, sibling subgroups stay, and the repo header stays expanded.
- [ ] Collapse the repo header; confirm every nested subgroup hides.
- [ ] Reload; confirm the axis choice and the subgroup collapse both restore.
- [ ] With two repos that both have a `feature` group, collapse `feature` in one; confirm the other repo's `feature` stays expanded.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added Vitest coverage for `buildNestedSidebarGroups` (repo header retained, nested user groups, `Ungrouped` subgroup, split-workspace slicing, per-(repo, group) collapse keying) and the `repo+group` axis hydrate/persist cases. Added a live Playwright spec (`web/tests/live/sidebar-nested-axis.spec.ts`) for the nested render and repo-versus-subgroup collapse, and updated the existing axis spec for the three-state toggle cycle. New matrix entries: `sidebar.nested-axis-pure`, `sidebar.nested-axis-live`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult between models to settle the design forks (third axis value, nested render branch, composed model, collapse keying, global sunk footer). I reviewed each commit, made the design calls, and ran the test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR introduces a new sidebar grouping mode for the web dashboard that combines repositories and user groups in a nested layout. Previously, users could only organize their sessions by repository OR by group. Now they can view sessions organized **by repository with groups nested inside each one**.

### Key Changes

**New Sidebar Organization Mode:**
- Added a third grouping option: "By repo and group" (complementing "By repo" and "By group")
- The grouping toggle now cycles through three modes: `repo` → `group` → `repo+group` → `repo`
- Sessions are grouped under subgroup headers (like "feature", "fix", "Ungrouped") within each repository

**Supporting Changes:**
- Updated the dashboard guide documentation to explain the new grouping mode
- Created a new hook `useNestedSidebarGroups` to manage the nested group structure and collapse state
- Extended `WorkspaceSidebar` component to render the new nested layout
- Added a new builder function `buildNestedSidebarGroups` that creates the nested structure
- Updated the sidebar axis type to recognize the new `"repo+group"` option
- Enhanced session group builder to track collapse state per (repo, group) pair

**Collapse & Persistence:**
- Each nested subgroup's collapse state is stored independently in localStorage using a `(repoId, groupPath)` key
- Repository-level collapse state is shared across the "By repo" and "By repo+group" modes
- Workspaces that span multiple groups are intelligently split so sessions appear under their correct subgroup while preserving workspace identity

**Testing:**
- Added Vitest unit tests covering the nested builder logic, collapse state keying, and workspace splitting
- Added a new Playwright live test verifying the nested render behavior, subgroup collapse persistence, and interaction with repo collapse

### Benefits

1. **Better Organization**: Users can now see both repository and group context simultaneously, reducing cognitive load when navigating across multiple repos with multiple groups
2. **Flexible Collapse**: Independent collapse control per subgroup allows fine-grained visibility management while keeping repo-level collapse behavior consistent
3. **Preserved State**: Collapse preferences persist across page reloads and are keyed appropriately so there's no confusion between grouping modes
4. **No Breaking Changes**: The new mode is additive; existing "By repo" and "By group" modes remain unchanged

### Technical Details

The implementation composes existing repo-axis logic with per-repo user-group splitting:
- `NestedSidebarGroup` interface wraps a repo-level `SidebarGroup` with an array of subgroup `SidebarGroup`s
- Collapse state is tracked via `useNestedSidebarGroups` hook using a `Map<string, boolean>` keyed by `"${repoId}:${groupPath}"`
- Storage uses a separate localStorage namespace to avoid conflicts with existing axis persistence
- The nested render path disables drag-reordering for the repo level but preserves all visual styling and synthetic bucket behavior
- Sunk rows (snoozed & archived) remain in the global footer, aggregated from all nested structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->