### PR TITLE
feat(cockpit): respawn build-stale cockpit workers after aoe update

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,86 @@
 fn main() {
     check_stale_build_cache();
+    emit_build_version();
 
     #[cfg(feature = "serve")]
     build_frontend();
+}
+
+/// Emit `AOE_BUILD_VERSION`, the build identity stamped on each cockpit
+/// worker record so the daemon can tell whether a surviving worker is
+/// running the current binary or an older one (see issue #1754).
+///
+/// `CARGO_PKG_VERSION` alone is insufficient: it stays constant across
+/// many local rebuilds, so a dev who rebuilds and restarts the daemon
+/// would silently re-adopt a worker on stale code. We append a git
+/// commit identity so dev rebuilds across commits are distinguishable.
+///
+/// Source order (first hit wins):
+///   1. `AOE_BUILD_VERSION` env override (release packaging, reproducible
+///      builds, downstream packagers).
+///   2. `GITHUB_SHA` (CI builds where `.git` may be a shallow checkout).
+///   3. Local `git rev-parse` + a coarse dirty flag.
+///   4. `CARGO_PKG_VERSION` alone (source tarball without `.git`).
+///
+/// The dirty flag is intentionally coarse (a boolean suffix, not a
+/// content hash): two different uncommitted edits at the same commit read
+/// as equal. This is a respawn gate, not a cryptographic binary hash, and
+/// a content hash would force a recompile on every source save.
+fn emit_build_version() {
+    use std::process::Command;
+
+    // Re-run when the committed revision changes or an override toggles.
+    // `.git/HEAD` moves on checkout/commit; `.git/index` moves on stage.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
+    println!("cargo:rerun-if-env-changed=AOE_BUILD_VERSION");
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+
+    let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
+
+    let build_version = if let Ok(explicit) = std::env::var("AOE_BUILD_VERSION") {
+        explicit
+    } else if let Ok(sha) = std::env::var("GITHUB_SHA") {
+        let short: String = sha.chars().take(12).collect();
+        format!("{pkg_version}+g{short}")
+    } else if let Some(short) = git_short_sha(&mut Command::new("git")) {
+        let dirty = git_is_dirty(&mut Command::new("git"));
+        format!(
+            "{pkg_version}+g{short}{}",
+            if dirty { "-dirty" } else { "" }
+        )
+    } else {
+        pkg_version
+    };
+
+    println!("cargo:rustc-env=AOE_BUILD_VERSION={build_version}");
+}
+
+/// Short (12-char) HEAD commit hash, or `None` when git is unavailable or
+/// this is not a git checkout (e.g. a source tarball).
+fn git_short_sha(cmd: &mut std::process::Command) -> Option<String> {
+    let out = cmd
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha)
+    }
+}
+
+/// Coarse working-tree dirty check: any tracked or untracked change makes
+/// `git status --porcelain` print at least one line.
+fn git_is_dirty(cmd: &mut std::process::Command) -> bool {
+    match cmd.args(["status", "--porcelain"]).output() {
+        Ok(out) => out.status.success() && !out.stdout.is_empty(),
+        Err(_) => false,
+    }
 }
 
 /// Detect stale build caches by tracking Cargo.lock content hash.

--- a/docs/cockpit/persistence.md
+++ b/docs/cockpit/persistence.md
@@ -32,7 +32,9 @@ files. `aoe cockpit ps` lists running workers.
 Practical implications:
 
 - `aoe update` followed by `aoe serve --stop` + `aoe serve` keeps
-  every cockpit agent's in-flight turn alive.
+  every cockpit agent's in-flight turn alive; a worker left on the old
+  build then respawns on the new binary once its turn finishes (see
+  [Build-version upgrade after `aoe update`](#build-version-upgrade-after-aoe-update)).
 - Closing the laptop or restarting the host with `aoe serve` running:
   the daemon dies on suspend, but the runner continues. On wake the
   next `aoe serve` reattaches.
@@ -79,6 +81,36 @@ Practical implications:
   agent starts so the UI clears immediately. The same path covers the
   `main`-branch case where there is no runner at all and every cockpit
   session takes the fresh-spawn branch on restart.
+
+## Build-version upgrade after `aoe update`
+
+Surviving a daemon restart is the right behavior for in-flight turns,
+but it means a daemon restarted on a newly-installed binary would
+otherwise re-adopt workers still executing the previous build, running
+mixed versions silently. To prevent that, each runner records the build
+identity of the binary that spawned it (`build_version` in its registry
+JSON, shown as the `BUILD` column in `aoe cockpit ps`), and the daemon
+compares it against its own on every reattach:
+
+- A worker whose build matches the daemon is reattached as usual; a
+  same-version `aoe serve` restart keeps in-flight turns alive exactly as
+  before.
+- A worker on an older build with **no** in-flight turn is terminated and
+  respawned on the new binary immediately.
+- A worker on an older build that is **mid-turn** is adopted so the turn
+  keeps streaming, then respawned on the new binary at the next idle
+  boundary. The in-flight turn is drained, never hard-killed.
+
+`aoe cockpit ps` tags any such not-yet-respawned worker `(stale)` in its
+`BUILD` column so a mixed-version state is visible rather than silent.
+
+Note that the new binary takes effect only once the daemon itself
+restarts: `aoe update` swaps the binary on disk but does not restart a
+running `aoe serve`, so you must `aoe serve --stop` and start it again
+for the reconciler pass above to run. A worker's build identity pairs the
+package version with a git commit hash, so local rebuilds across commits
+are detected, not just shipped release upgrades. See
+[#1754](https://github.com/agent-of-empires/agent-of-empires/issues/1754).
 
 ## Session deletion
 

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,0 +1,17 @@
+//! Compile-time build identity.
+//!
+//! [`BUILD_VERSION`] is the string `build.rs` stamps via the
+//! `AOE_BUILD_VERSION` rustc-env. It pairs the package version with a git
+//! commit identity (e.g. `1.9.5+g7f31a9c42e01`, or `…-dirty` for an
+//! uncommitted working tree), falling back to the bare `CARGO_PKG_VERSION`
+//! when no VCS identity is available.
+//!
+//! Cockpit worker records embed this value so the daemon can respawn
+//! workers left running on an older binary after `aoe update`. See #1754.
+
+/// Build identity of this binary. Stamped by `build.rs`; falls back to the
+/// package version when `AOE_BUILD_VERSION` was not emitted.
+pub const BUILD_VERSION: &str = match option_env!("AOE_BUILD_VERSION") {
+    Some(v) => v,
+    None => env!("CARGO_PKG_VERSION"),
+};

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -442,6 +442,8 @@ fn ps(json: bool) -> Result<()> {
                     "pid": r.pid,
                     "alive": worker_registry::is_record_live(r),
                     "agent": r.agent_name,
+                    "build_version": r.build_version,
+                    "build_stale": !worker_registry::is_build_current(r),
                     "socket": r.socket_path,
                     "cwd": r.cwd,
                     "started_at": r.started_at,
@@ -458,8 +460,8 @@ fn ps(json: bool) -> Result<()> {
         return Ok(());
     }
     println!(
-        "{:<24} {:<8} {:<14} {:<10} SOCKET",
-        "SESSION", "PID", "AGENT", "STATE"
+        "{:<24} {:<8} {:<14} {:<10} {:<24} SOCKET",
+        "SESSION", "PID", "AGENT", "STATE", "BUILD"
     );
     for r in &records {
         let state = if !worker_registry::is_record_live(r) {
@@ -471,16 +473,36 @@ fn ps(json: bool) -> Result<()> {
         } else {
             "attached"
         };
+        let build = render_build_cell(&r.build_version, !worker_registry::is_build_current(r));
         println!(
-            "{:<24} {:<8} {:<14} {:<10} {}",
+            "{:<24} {:<8} {:<14} {:<10} {:<24} {}",
             truncate(&r.session_id, 24),
             r.pid,
             truncate(&r.agent_name, 14),
             state,
+            truncate(&build, 24),
             r.socket_path.display()
         );
     }
     Ok(())
+}
+
+/// Render the BUILD cell for `aoe cockpit ps`. An empty `build_version`
+/// (a legacy record written before the field existed) shows `<legacy>`;
+/// any worker whose build differs from the running daemon's is tagged
+/// `(stale)` so a not-yet-respawned worker is visible rather than silent.
+/// See #1754.
+fn render_build_cell(build_version: &str, stale: bool) -> String {
+    let base = if build_version.is_empty() {
+        "<legacy>"
+    } else {
+        build_version
+    };
+    if stale {
+        format!("{base} (stale)")
+    } else {
+        base.to_string()
+    }
 }
 
 async fn stop(session: Option<String>, all: bool, timeout_secs: u64) -> Result<()> {
@@ -879,5 +901,21 @@ mod tests {
         assert_eq!(parse_node_major("v20.0.0"), Some(20));
         assert_eq!(parse_node_major("18.17.1"), Some(18));
         assert_eq!(parse_node_major("not a version"), None);
+    }
+
+    /// Story 3: `aoe cockpit ps` surfaces the worker build version, tags
+    /// a build-stale worker, and renders an empty (legacy) version as
+    /// `<legacy>`. See #1754.
+    #[test]
+    fn render_build_cell_cases() {
+        // Current build: bare version, no marker.
+        assert_eq!(render_build_cell("1.9.5+gabc123", false), "1.9.5+gabc123");
+        // Stale build: version plus marker.
+        assert_eq!(
+            render_build_cell("1.9.4+gdeadbe", true),
+            "1.9.4+gdeadbe (stale)"
+        );
+        // Legacy record (field absent on disk): placeholder, always stale.
+        assert_eq!(render_build_cell("", true), "<legacy> (stale)");
     }
 }

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -108,11 +108,26 @@ pub async fn run(args: UpdateArgs) -> Result<()> {
             "✓ Updated to v{}. Restart `aoe` to use the new version.",
             info.latest_version
         );
+        println!("{}", daemon_restart_hint());
         println!("{}", completion_refresh_hint());
     } else if matches!(&method, InstallMethod::Homebrew) {
         println!("✓ brew upgrade complete.");
     }
     Ok(())
+}
+
+/// Reminder printed after a successful in-place update: a running
+/// `aoe serve` daemon keeps executing the old code it already loaded
+/// until it is restarted, and its cockpit workers survive that restart by
+/// design (see #1037). The new binary therefore does not take effect
+/// anywhere until the daemon restarts; once it does, a worker left on the
+/// old build finishes any in-flight turn and then respawns on the new
+/// build automatically (see #1754). Surfacing this avoids the silent
+/// mixed-version trap where a freshly-shipped fix appears not to work.
+fn daemon_restart_hint() -> &'static str {
+    "  If `aoe serve` is running, restart it (`aoe serve --stop`, then start it\n  \
+     again) so the daemon picks up the new binary. Cockpit workers from the old\n  \
+     build finish their current turn, then respawn on the new build."
 }
 
 /// Reminder printed after a successful in-place update. A static completion
@@ -129,7 +144,7 @@ fn completion_refresh_hint() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::completion_refresh_hint;
+    use super::{completion_refresh_hint, daemon_restart_hint};
 
     #[test]
     fn hint_points_at_regen_and_eval_alternative() {
@@ -138,5 +153,14 @@ mod tests {
         assert!(hint.contains("guides/shell-completions"));
         // Mentions the always-fresh alternative so users can avoid manual refresh.
         assert!(hint.to_lowercase().contains("eval"));
+    }
+
+    #[test]
+    fn daemon_hint_mentions_restart_and_respawn() {
+        let hint = daemon_restart_hint();
+        // Points the user at the restart that actually applies the binary.
+        assert!(hint.contains("aoe serve --stop"));
+        // Sets the expectation that workers converge to the new build.
+        assert!(hint.to_lowercase().contains("respawn"));
     }
 }

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -353,6 +353,13 @@ pub struct Supervisor<S: BroadcastSink> {
     /// just after the spawn handshake finishes resumes within a
     /// scheduler tick instead of waiting up to 50 ms.
     worker_notify: Arc<tokio::sync::Notify>,
+    /// Sessions whose adopted worker is running an older binary than the
+    /// daemon (detected at reconcile after `aoe update`) and carried an
+    /// in-flight turn, so the reconciler attached to drain it rather than
+    /// hard-killing the turn. The reconciler's per-tick drain check
+    /// respawns these on the current binary once the turn finishes. See
+    /// #1754.
+    build_respawn_pending: Arc<std::sync::Mutex<HashSet<String>>>,
     /// Cap on concurrently-running workers, snapshotted from
     /// `[cockpit] max_concurrent_workers` at startup. Enforced in
     /// `spawn`; new workers past the cap return `CapacityFull`.
@@ -453,8 +460,31 @@ impl<S: BroadcastSink> Supervisor<S> {
             warmed_up_agents: Arc::new(std::sync::Mutex::new(HashSet::new())),
             agent_warmup_locks: Arc::new(std::sync::Mutex::new(HashMap::new())),
             worker_notify: Arc::new(tokio::sync::Notify::new()),
+            build_respawn_pending: Arc::new(std::sync::Mutex::new(HashSet::new())),
             max_concurrent_workers,
         }
+    }
+
+    /// Flag a session whose build-stale worker was adopted to drain an
+    /// in-flight turn; the reconciler respawns it on the current binary
+    /// at the next idle boundary. Idempotent. See #1754.
+    pub fn mark_build_respawn_pending(&self, session_id: &str) {
+        lock_recover(&self.build_respawn_pending).insert(session_id.to_string());
+    }
+
+    /// Snapshot the sessions awaiting a post-drain respawn. The reconciler
+    /// polls this each tick and respawns those that have gone idle.
+    pub fn build_respawn_pending_ids(&self) -> Vec<String> {
+        lock_recover(&self.build_respawn_pending)
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Drop a session from the pending set once it has been respawned (or
+    /// is gone). Idempotent.
+    pub fn clear_build_respawn_pending(&self, session_id: &str) {
+        lock_recover(&self.build_respawn_pending).remove(session_id);
     }
 
     /// Snapshot the lifecycle state of every cockpit session known to

--- a/src/cockpit/worker_registry.rs
+++ b/src/cockpit/worker_registry.rs
@@ -35,6 +35,16 @@ pub const RUNNER_VERSION: u32 = 1;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerRecord {
     pub runner_version: u32,
+    /// Binary build identity (`build_info::BUILD_VERSION`) of the
+    /// `aoe __cockpit-runner` process that wrote this record, e.g.
+    /// `"1.9.5+g7f31a9c42e01"`. Distinct from `runner_version`, which is
+    /// the on-disk SCHEMA version. The daemon compares this against its
+    /// own `BUILD_VERSION` to detect a worker left running on an older
+    /// binary after `aoe update` and respawn it (see #1754). Defaulted on
+    /// load for legacy records that pre-date this field; the empty string
+    /// compares unequal to any current build, forcing a one-time respawn.
+    #[serde(default)]
+    pub build_version: String,
     pub session_id: String,
     /// PID of the `aoe __cockpit-runner` process. Used by the stale-sweep
     /// to decide whether the registry entry corresponds to a live owner.
@@ -94,6 +104,7 @@ impl WorkerRecord {
     ) -> Self {
         Self {
             runner_version: RUNNER_VERSION,
+            build_version: crate::build_info::BUILD_VERSION.to_string(),
             session_id,
             pid,
             socket_path,
@@ -401,6 +412,19 @@ pub fn is_record_live(rec: &WorkerRecord) -> bool {
     rec.runner_version == RUNNER_VERSION && is_pid_alive(rec.pid) && socket_exists(&rec.socket_path)
 }
 
+/// Whether the worker's recorded binary build matches the running
+/// daemon's. A live-but-stale worker (this returns `false`) is still
+/// "live" by `is_record_live`; the reconciler keeps it for any in-flight
+/// turn and respawns it on the current binary at the next idle boundary,
+/// rather than treating a version mismatch as death. See #1754.
+///
+/// Build identity is NOT folded into `is_record_live` on purpose: doing
+/// so would make a busy stale worker look dead and push the reconciler
+/// toward orphaning its in-flight turn.
+pub fn is_build_current(rec: &WorkerRecord) -> bool {
+    rec.build_version == crate::build_info::BUILD_VERSION
+}
+
 fn socket_exists(path: &Path) -> bool {
     match std::fs::metadata(path) {
         Ok(_) => true,
@@ -517,6 +541,78 @@ mod tests {
             assert_eq!(loaded.runner_version, RUNNER_VERSION);
             assert_eq!(loaded.agent_name, "claude-agent-acp");
             assert_eq!(loaded.agent_key, "claude");
+        });
+    }
+
+    /// A fresh record is stamped with this binary's build identity and
+    /// reports as current; the empty-string legacy default reports stale.
+    /// This is the gate the reconciler uses to respawn workers left on an
+    /// old binary after `aoe update`. See #1754.
+    #[test]
+    #[serial]
+    fn build_version_stamped_and_current() {
+        with_temp_home(|| {
+            let rec = WorkerRecord::new(
+                "sess-bv".into(),
+                1,
+                PathBuf::from("/tmp/sess-bv.sock"),
+                "aoe-agent".into(),
+                "aoe-agent".into(),
+                PathBuf::from("/repo"),
+                None,
+                vec![],
+                vec![],
+                None,
+                None,
+            );
+            assert_eq!(rec.build_version, crate::build_info::BUILD_VERSION);
+            assert!(is_build_current(&rec));
+
+            let mut stale = rec.clone();
+            stale.build_version = String::new();
+            assert!(
+                !is_build_current(&stale),
+                "empty (legacy) build_version must read as stale"
+            );
+
+            stale.build_version = "0.0.0+gdeadbeef".into();
+            assert!(!is_build_current(&stale));
+        });
+    }
+
+    /// Legacy records written before `build_version` existed must load
+    /// with the empty-string default (and thus read as build-stale), not
+    /// fail to deserialize.
+    #[test]
+    #[serial]
+    fn load_legacy_record_without_build_version() {
+        with_temp_home(|| {
+            let dir = workers_dir().unwrap();
+            let legacy = serde_json::json!({
+                "runner_version": RUNNER_VERSION,
+                "session_id": "legacy-bv-1",
+                "pid": 7,
+                "socket_path": "/tmp/legacy-bv.sock",
+                "agent_name": "claude-agent-acp",
+                "agent_key": "claude",
+                "cwd": "/repo",
+                "model": null,
+                "additional_dirs": [],
+                "provider_env_keys": [],
+                "stored_acp_session_id": null,
+                "source_profile": null,
+                "started_at": 0,
+                "last_attached_at": null,
+                "detached_at": null
+            });
+            std::fs::write(
+                dir.join("legacy-bv-1.json"),
+                serde_json::to_string(&legacy).unwrap(),
+            )
+            .unwrap();
+            let loaded = load("legacy-bv-1").unwrap().unwrap();
+            assert_eq!(loaded.build_version, "");
+            assert!(!is_build_current(&loaded));
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Agent of Empires library - Core functionality for the terminal session manager
 
 pub mod agents;
+pub mod build_info;
 pub mod claude_settings;
 pub mod cli;
 #[cfg(feature = "serve")]

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -92,11 +92,19 @@ pub async fn reconcile_cockpit_workers(
         return;
     }
 
+    // Respawn build-stale workers that were adopted to drain an in-flight
+    // turn (see #1754) and have since gone idle. Runs BEFORE
+    // `reap_user_stopped` so the marker + registry-delete this writes is
+    // picked up by the same tick's reaper, which tears down the attached
+    // handle and clears `attempted` so the resume pass below fresh-spawns
+    // on the current binary.
+    respawn_drained_stale_workers(state).await;
+
     // Detect `aoe cockpit stop|kill|restart` (a separate process that
     // deletes the registry entry + SIGTERMs the runner) and surface it
     // as a typed Stopped event. The daemon's protocol-layer connection
     // task blocks on `cmd_rx.recv()` while idle, so socket EOF doesn't
-    // propagate to the drain task on its own — without this poll, the
+    // propagate to the drain task on its own, so without this poll the
     // UI stays stuck on "thinking" and the supervisor keeps a phantom
     // worker. For the `restart` case, the reaper returns the ids it
     // marked as `restart_pending`; clear them from `attempted` so the
@@ -517,6 +525,80 @@ async fn reap_idle_workers(state: &Arc<AppState>) {
     }
 }
 
+/// Respawn build-stale workers that were adopted mid-turn (flagged via
+/// `Supervisor::mark_build_respawn_pending` in `resume_one`) once their
+/// in-flight turn has finished. Idle is detected with the same
+/// `has_in_flight_turn` event-store probe the resume pass uses.
+///
+/// For each drained session this mirrors `aoe cockpit restart`: write the
+/// restart marker so the reaper publishes `restart_pending` (the UI shows
+/// "Restarting…" rather than a stop), then SIGTERM the stale runner group
+/// and delete its registry entry. The caller runs the reaper immediately
+/// after, which tears down the attached handle and clears `attempted`, so
+/// the resume pass fresh-spawns on the current binary. See #1754.
+async fn respawn_drained_stale_workers(state: &Arc<AppState>) {
+    for id in state.cockpit_supervisor.build_respawn_pending_ids() {
+        let store = Arc::clone(&state.cockpit_event_store);
+        let id_probe = id.clone();
+        let in_flight =
+            match tokio::task::spawn_blocking(move || store.has_in_flight_turn(&id_probe)).await {
+                Ok(v) => v,
+                // Probe failed: assume still busy so a transient error
+                // never hard-kills a possibly-live turn. Retried next tick.
+                Err(e) => {
+                    tracing::warn!(
+                        target: "cockpit.supervisor",
+                        session = %id,
+                        error = %e,
+                        "in-flight probe failed for draining stale worker; deferring respawn"
+                    );
+                    true
+                }
+            };
+        if in_flight {
+            continue;
+        }
+        tracing::info!(
+            target: "cockpit.supervisor",
+            session = %id,
+            "build-stale cockpit worker drained; respawning on current binary"
+        );
+        crate::cockpit::worker_registry::mark_restart_pending(&id);
+        crate::cockpit::worker_registry::terminate(&id);
+        state.cockpit_supervisor.clear_build_respawn_pending(&id);
+    }
+}
+
+/// What `resume_one` should do with the worker registry record it found
+/// for a cockpit session that has no live in-memory worker yet. Split out
+/// as a pure function so the build-version respawn policy (#1754) is
+/// unit-testable without standing up a daemon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AdoptDecision {
+    /// No usable record (dead PID / missing socket): sweep and fresh-spawn.
+    FreshSpawn,
+    /// Live worker on the current binary: reattach.
+    Attach,
+    /// Live worker on an older binary with no in-flight turn: terminate
+    /// now and fresh-spawn on the current binary.
+    RespawnStaleIdle,
+    /// Live worker on an older binary mid-turn: adopt to keep the turn
+    /// streaming, then respawn at the next idle boundary.
+    AdoptStaleForDrain,
+}
+
+fn adopt_decision(live: bool, build_current: bool, in_flight_turn: bool) -> AdoptDecision {
+    if !live {
+        AdoptDecision::FreshSpawn
+    } else if build_current {
+        AdoptDecision::Attach
+    } else if in_flight_turn {
+        AdoptDecision::AdoptStaleForDrain
+    } else {
+        AdoptDecision::RespawnStaleIdle
+    }
+}
+
 async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome {
     let ResumeTarget {
         id,
@@ -535,7 +617,46 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
     // of spawning a fresh agent. Bounded by the registry probe — no
     // network IO unless we have a live PID + socket on disk.
     if let Ok(Some(record)) = crate::cockpit::worker_registry::load(&id) {
-        if crate::cockpit::worker_registry::is_record_live(&record) {
+        let decision = adopt_decision(
+            crate::cockpit::worker_registry::is_record_live(&record),
+            crate::cockpit::worker_registry::is_build_current(&record),
+            in_flight_turn,
+        );
+        if decision == AdoptDecision::FreshSpawn {
+            // Dead PID or missing socket: sweep the orphan registry entry
+            // so the fall-through below is a clean fresh spawn.
+            crate::cockpit::worker_registry::delete(&id).ok();
+        } else if decision == AdoptDecision::RespawnStaleIdle {
+            // The runner survived a daemon restart but is executing an
+            // older binary (e.g. after `aoe update`) and has no in-flight
+            // turn. Replace it now: SIGTERM the stale runner group (which
+            // also deletes the registry entry) and fall through to a
+            // fresh spawn on the current binary. See #1754.
+            tracing::info!(
+                target: "cockpit.supervisor",
+                session = %id,
+                old_build = %record.build_version,
+                new_build = crate::build_info::BUILD_VERSION,
+                "respawning idle build-stale cockpit worker on current binary"
+            );
+            crate::cockpit::worker_registry::terminate(&id);
+        } else {
+            // Attach or AdoptStaleForDrain: dial the live runner.
+            if decision == AdoptDecision::AdoptStaleForDrain {
+                // Build-stale but mid-turn: adopt now so the in-flight
+                // turn keeps streaming, and flag the session so the next
+                // idle boundary respawns it on the current binary instead
+                // of hard-killing the turn. Preserves the #1037
+                // survive-restart contract. See #1754.
+                tracing::info!(
+                    target: "cockpit.supervisor",
+                    session = %id,
+                    old_build = %record.build_version,
+                    new_build = crate::build_info::BUILD_VERSION,
+                    "adopting build-stale cockpit worker to drain in-flight turn before respawn"
+                );
+                state.cockpit_supervisor.mark_build_respawn_pending(&id);
+            }
             let supervisor = Arc::clone(&state.cockpit_supervisor);
             let cwd = PathBuf::from(&project_path);
             // Reconstruct sandbox context from the live instance state
@@ -604,10 +725,6 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
                     return ResumeOutcome::RetryAfterAttachTimeout;
                 }
             }
-        } else {
-            // Dead PID or missing socket: sweep the orphan registry
-            // entry so the next attempt is a clean fresh spawn.
-            crate::cockpit::worker_registry::delete(&id).ok();
         }
     }
 
@@ -879,9 +996,52 @@ async fn sweep_orphan_workers(state: &Arc<AppState>, live: &HashSet<&String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::should_auto_stop;
+    use super::{adopt_decision, should_auto_stop, AdoptDecision};
 
     const HOUR_MS: i64 = 3_600_000;
+
+    // --- build-version respawn policy (#1754) ---
+
+    /// Story 1: a live worker whose build differs from the daemon and is
+    /// NOT mid-turn is respawned (terminate + fresh spawn), not adopted.
+    #[test]
+    fn stale_build_idle_worker_respawns() {
+        assert_eq!(
+            adopt_decision(true, false, false),
+            AdoptDecision::RespawnStaleIdle
+        );
+    }
+
+    /// Story 2: a live worker whose build differs from the daemon but is
+    /// mid-turn is adopted to drain, not hard-killed. The reconciler's
+    /// per-tick drain check respawns it once the turn finishes.
+    #[test]
+    fn stale_build_busy_worker_adopts_to_drain() {
+        assert_eq!(
+            adopt_decision(true, false, true),
+            AdoptDecision::AdoptStaleForDrain
+        );
+    }
+
+    /// A live worker on the current build is reattached regardless of
+    /// in-flight state: the survive-restart contract (#1037) is unchanged
+    /// for same-version restarts.
+    #[test]
+    fn current_build_worker_attaches() {
+        assert_eq!(adopt_decision(true, true, false), AdoptDecision::Attach);
+        assert_eq!(adopt_decision(true, true, true), AdoptDecision::Attach);
+    }
+
+    /// A dead record fresh-spawns no matter the build/turn state; build
+    /// currency only matters for a live worker.
+    #[test]
+    fn dead_record_fresh_spawns() {
+        assert_eq!(
+            adopt_decision(false, false, false),
+            AdoptDecision::FreshSpawn
+        );
+        assert_eq!(adopt_decision(false, true, true), AdoptDecision::FreshSpawn);
+    }
 
     #[test]
     fn disabled_threshold_never_stops() {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Cockpit workers are detached `aoe __cockpit-runner` processes that survive an `aoe serve` restart by design (#1037), so in-flight agent turns are not killed. The tradeoff: after `aoe update` swaps the binary in place, a daemon restarted on the new code re-adopted workers still executing the previous build, running mixed versions silently. A fix shipped in an update appeared not to work because the worker was still on old code, with no visible signal.

This makes worker adoption build-aware:

- Each runner records the build identity of the binary that spawned it. `build.rs` emits `AOE_BUILD_VERSION` (package version plus a git commit hash, with a coarse dirty flag and env/CI/tarball fallbacks), exposed as `build_info::BUILD_VERSION` and stamped into the worker registry record. Pairing the version with a commit hash means local rebuilds across commits are detected, not just shipped release upgrades.
- On reattach, the reconciler compares the worker's build against the daemon's. A worker on the current build reattaches as before (same-version restarts keep in-flight turns alive, unchanged). A worker on an older build with no in-flight turn is terminated and respawned on the new binary immediately. A worker on an older build that is mid-turn is adopted so the turn keeps streaming, then respawned at the next idle boundary, reusing the existing `aoe cockpit restart` (marker + reap + respawn) machinery. The in-flight turn is drained, never hard-killed, preserving the #1037 contract.
- `aoe cockpit ps` gains a `BUILD` column (plus `build_version` / `build_stale` in `--json`) and tags any not-yet-respawned worker `(stale)`, so a mixed-version state is visible.
- `aoe update` now warns that a running daemon stays on the old binary until it restarts, and that old-build workers finish their turn then respawn.

Scope note: the new binary still takes effect only when the daemon itself restarts (`aoe serve --stop` + start). Auto-restarting the daemon from `aoe update` (proposal B of the issue) is deferred to a follow-up: doing it safely needs persisted serve launch state (host/mode/port) and interacts with daemon-owned in-flight turns; a naive restart would be worse than the current behavior. This PR establishes the correct lifecycle semantics first.

Closes #1754

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Build + install, run `aoe serve`, open a cockpit session and let a turn complete. Rebuild at a new commit, `aoe serve --stop` then `aoe serve`. Confirm the idle worker is respawned on the new build: `aoe cockpit ps` BUILD column shows the current build with no `(stale)` tag.
- [ ] Start a long-running turn, then rebuild and restart the daemon while the turn is mid-flight. Confirm the turn finishes normally (not hard-killed) and the worker respawns on the new build once it goes idle.
- [ ] Run `aoe cockpit ps`: confirm the `BUILD` column appears; a worker from an older build shows `(stale)`; `aoe cockpit ps --json` includes `build_version` and `build_stale`.
- [ ] Run `aoe update` (on an installed Tarball build): confirm the post-update output includes the daemon-restart hint mentioning `aoe serve --stop` and worker respawn.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (the change is CLI + daemon reconciler, not the web dashboard)

**TUI / CLI (e2e test)**
- [ ] Skipped a full restart-cycle e2e, because: the three mandatory user stories are covered by deterministic tests instead. The adoption decision (idle stale -> respawn, busy stale -> adopt+drain, current -> attach, dead -> fresh spawn) is a pure `adopt_decision()` unit-tested in `src/server/cockpit_reconciler.rs`; the `cockpit ps` rendering is a formatter unit test in `src/cli/cockpit.rs`; the record stamping + legacy default are unit-tested in `src/cockpit/worker_registry.rs`. A live e2e would need two binaries built at different versions, which is disproportionate; the deterministic tests pin the same behavior.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a multi-model design debate consulted on the version-identity, drain-semantics, and scope decisions. I reviewed each commit, made the design calls, and will run the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds build identity tracking to cockpit workers so that when the `aoe` daemon is restarted with a new binary (after running `aoe update`), it can detect and properly handle workers that are still running under the older binary version. Instead of silently mixing old and new code versions, the system now respawns stale workers at safe points.

## What was added

- **Build identity generation** (`build.rs` and `src/build_info.rs`): A new build version identifier is generated at compile time that captures the package version and git commit hash (with fallbacks for CI environments and dirty builds). This uniquely identifies each binary.

- **Worker build tracking** (`src/cockpit/worker_registry.rs`): Worker records now store the build version they were spawned with, allowing the daemon to compare current workers against its own binary version.

- **Smart worker respawn logic** (`src/server/cockpit_reconciler.rs`): The adoption policy now includes build-awareness:
  - Workers on the same build: reattach normally (no disruption)
  - Workers on older builds that are idle: terminate and respawn immediately with the new binary
  - Workers on older builds that are mid-operation: adopt and let them finish their current turn, then respawn at the next safe idle point (preserves the guarantee that operations complete even across restarts)

- **Respawn tracking** (`src/cockpit/supervisor.rs`): Added internal tracking for sessions pending respawn so the system knows which workers to restart after their operations complete.

- **CLI visibility** (`src/cli/cockpit.rs`): The `aoe cockpit ps` command now shows a BUILD column and includes build status markers (showing version, `<legacy>` for old records, and `(stale)` for outdated workers). JSON output includes `build_version` and `build_stale` flags.

- **User guidance** (`src/cli/update.rs` and `docs/cockpit/persistence.md`): Post-update messages now explain that the daemon must be restarted and that workers will respawn appropriately. Documentation clarifies the upgrade behavior.

## What was removed

Nothing was removed; this is purely additive functionality.

## Technical details

- **Build version stamping**: Uses `AOE_BUILD_VERSION` env var (set by build.rs), falls back to `GITHUB_SHA` in CI, then `git describe` for local builds, with a dirty-tree suffix indicator. Final fallback is `CARGO_PKG_VERSION`.

- **Worker record changes**: `WorkerRecord` struct gains a `build_version: String` field with `#[serde(default)]` for backward compatibility with legacy records. New public function `is_build_current()` checks if a record's build matches the daemon's.

- **Adoption decision logic**: New pure function `adopt_decision(live, build_current, in_flight_turn)` encapsulates the policy and is unit-tested independently. The reconciler calls this during the `resume_one` phase to determine whether to reattach, respawn, or adopt-for-drain.

- **Drain-respawn semantics**: Sessions adopted for mid-turn completion are marked in `build_respawn_pending`, then handled in a new pre-resume pass `respawn_drained_stale_workers()` that waits for operation completion before terminating and respawning.

## Benefits

- **Prevents silent mixed-version operation**: After `aoe update`, users no longer risk having old and new code execute in the same session.
- **Preserves operational integrity**: In-flight operations are allowed to complete safely; no hard kills mid-operation.
- **Observable upgrades**: The CLI now shows which workers are running stale code, giving visibility into the upgrade state.
- **Automatic respawn**: Stale workers are automatically refreshed without manual intervention, once it's safe to do so.
- **Backwards compatible**: Legacy worker records without build version info are handled gracefully and marked as stale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->