### PR TITLE
feat(web): sidebar multi-select for bulk pin, archive, and snooze

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -101,6 +101,18 @@ The "Snoozed & archived" section sits at the very bottom of the sidebar and aggr
 
 In read-only mode (`aoe serve --read-only`) the three menu entries are hidden, matching the existing read-only gate on Delete.
 
+### Multi-select and bulk triage
+
+To triage many sessions at once, select more than one row and act on the whole selection:
+
+- **Cmd/Ctrl+click** a row toggles it in or out of the selection without navigating to it.
+- **Shift+click** selects every row between the last clicked row and this one, in the order they appear. The range spans only visible rows: collapsed groups and a collapsed "Snoozed & archived" footer contribute nothing, and an active filter trims the range to matches.
+- A plain click (no modifier) clears the selection and opens that session, the same as before.
+
+While a selection is active, a bulk action bar appears above the list showing the count and the actions that apply. Actions split by the rows they can affect, so a mixed selection shows, for example, **Pin 3** alongside **Unpin 2** rather than one ambiguous toggle: **Pin**, **Archive**, and **Snooze** target the live rows; **Unpin**, **Unarchive**, and **Unsnooze** target the already-triaged rows. **Snooze** offers the same duration presets as the single-row menu.
+
+Bulk actions are best-effort, not all-or-nothing: each session is updated independently, and the bar reports a summary (how many succeeded, failed, or were skipped) when the action finishes, then clears the selection. The selection survives collapsing a group or changing the filter and is dropped only when a session no longer exists; it is not saved across reloads. Like the single-row menu, the bulk bar is hidden in read-only mode.
+
 ## On mobile
 
 Below the `md` breakpoint the dashboard shows a single full-viewport pane rather than the desktop side-by-side split. The right-panel button in the top bar opens a picker that swaps the main pane between three views: the **Agent terminal**, the **Diff** (changed files and review), and the **Paired terminal** (host or container shell). A back chip in the top-left of the diff and paired views returns you to the agent terminal.

--- a/web/src/components/BulkActionBar.tsx
+++ b/web/src/components/BulkActionBar.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { Archive, Moon, Pin, X } from "lucide-react";
+
+import type { BulkTriageBuckets } from "../lib/sidebarBulk";
+import type { Workspace } from "../lib/types";
+
+interface BulkActionBarProps {
+  selectedCount: number;
+  buckets: BulkTriageBuckets;
+  snoozePresets: readonly { label: string; minutes: number }[];
+  onBulkPin: (workspaces: Workspace[], pinned: boolean) => void;
+  onBulkArchive: (workspaces: Workspace[], archived: boolean) => void;
+  onBulkSnooze: (workspaces: Workspace[], minutes: number | null) => void;
+  onClear: () => void;
+}
+
+const BTN =
+  "inline-flex items-center gap-1 rounded border border-surface-700/50 bg-surface-800/60 px-2 py-1 text-[11px] font-mono text-text-secondary hover:bg-surface-700/60 hover:text-text-primary cursor-pointer transition-colors disabled:opacity-40 disabled:cursor-default";
+
+/** Bulk triage bar shown while one or more sidebar rows are multi-selected.
+ *  Actions split by eligibility so a mixed selection shows count-labelled
+ *  buttons ("Pin 3" / "Unpin 2") instead of one ambiguous toggle; an action
+ *  applies only to its compatible subset. See #1724. */
+export function BulkActionBar({
+  selectedCount,
+  buckets,
+  snoozePresets,
+  onBulkPin,
+  onBulkArchive,
+  onBulkSnooze,
+  onClear,
+}: BulkActionBarProps) {
+  const [snoozeOpen, setSnoozeOpen] = useState(false);
+  if (selectedCount === 0) return null;
+  return (
+    <div
+      data-testid="sidebar-bulk-bar"
+      className="flex flex-wrap items-center gap-1.5 border-b border-surface-700/40 bg-surface-850 px-3 py-2"
+    >
+      <span className="mr-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">
+        {selectedCount} selected
+      </span>
+      {buckets.pinnable.length > 0 && (
+        <button
+          type="button"
+          data-testid="sidebar-bulk-pin"
+          className={BTN}
+          onClick={() => onBulkPin(buckets.pinnable, true)}
+        >
+          <Pin className="h-3 w-3 -rotate-45" />
+          Pin {buckets.pinnable.length}
+        </button>
+      )}
+      {buckets.unpinnable.length > 0 && (
+        <button
+          type="button"
+          data-testid="sidebar-bulk-unpin"
+          className={BTN}
+          onClick={() => onBulkPin(buckets.unpinnable, false)}
+        >
+          <Pin className="h-3 w-3 -rotate-45" />
+          Unpin {buckets.unpinnable.length}
+        </button>
+      )}
+      {buckets.archivable.length > 0 && (
+        <button
+          type="button"
+          data-testid="sidebar-bulk-archive"
+          className={BTN}
+          onClick={() => onBulkArchive(buckets.archivable, true)}
+        >
+          <Archive className="h-3 w-3" />
+          Archive {buckets.archivable.length}
+        </button>
+      )}
+      {buckets.unarchivable.length > 0 && (
+        <button
+          type="button"
+          data-testid="sidebar-bulk-unarchive"
+          className={BTN}
+          onClick={() => onBulkArchive(buckets.unarchivable, false)}
+        >
+          <Archive className="h-3 w-3" />
+          Unarchive {buckets.unarchivable.length}
+        </button>
+      )}
+      {buckets.snoozable.length > 0 && (
+        <div className="relative">
+          <button
+            type="button"
+            data-testid="sidebar-bulk-snooze"
+            className={BTN}
+            aria-haspopup="menu"
+            aria-expanded={snoozeOpen}
+            onClick={() => setSnoozeOpen((o) => !o)}
+          >
+            <Moon className="h-3 w-3" />
+            Snooze {buckets.snoozable.length}
+          </button>
+          {snoozeOpen && (
+            <div
+              data-testid="sidebar-bulk-snooze-menu"
+              role="menu"
+              className="absolute left-0 z-50 mt-1 min-w-28 rounded border border-surface-700/60 bg-surface-900 py-1 shadow-lg"
+            >
+              {snoozePresets.map((preset) => (
+                <button
+                  type="button"
+                  key={preset.minutes}
+                  role="menuitem"
+                  className="block w-full px-3 py-1.5 text-left text-[12px] font-mono text-text-secondary hover:bg-surface-700/50 hover:text-text-primary cursor-pointer"
+                  onClick={() => {
+                    setSnoozeOpen(false);
+                    onBulkSnooze(buckets.snoozable, preset.minutes);
+                  }}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+      {buckets.unsnoozable.length > 0 && (
+        <button
+          type="button"
+          data-testid="sidebar-bulk-unsnooze"
+          className={BTN}
+          onClick={() => onBulkSnooze(buckets.unsnoozable, null)}
+        >
+          <Moon className="h-3 w-3" />
+          Unsnooze {buckets.unsnoozable.length}
+        </button>
+      )}
+      <button
+        type="button"
+        data-testid="sidebar-bulk-clear"
+        className={`${BTN} ml-auto`}
+        onClick={onClear}
+        aria-label="Clear selection"
+      >
+        <X className="h-3 w-3" />
+        Clear
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/BulkActionBar.tsx
+++ b/web/src/components/BulkActionBar.tsx
@@ -15,7 +15,7 @@ interface BulkActionBarProps {
 }
 
 const BTN =
-  "inline-flex items-center gap-1 rounded border border-surface-700/50 bg-surface-800/60 px-2 py-1 text-[11px] font-mono text-text-secondary hover:bg-surface-700/60 hover:text-text-primary cursor-pointer transition-colors disabled:opacity-40 disabled:cursor-default";
+  "inline-flex h-8 items-center gap-1 rounded-md border border-surface-700/50 bg-surface-800/60 px-2 text-[11px] font-mono text-text-secondary hover:bg-surface-700/60 hover:text-text-primary cursor-pointer transition-colors disabled:opacity-40 disabled:cursor-default";
 
 /** Bulk triage bar shown while one or more sidebar rows are multi-selected.
  *  Actions split by eligibility so a mixed selection shows count-labelled
@@ -35,7 +35,7 @@ export function BulkActionBar({
   return (
     <div
       data-testid="sidebar-bulk-bar"
-      className="flex flex-wrap items-center gap-1.5 border-b border-surface-700/40 bg-surface-850 px-3 py-2"
+      className="flex flex-wrap items-center gap-2 border-b border-surface-700/40 bg-surface-850 px-3 py-2"
     >
       <span className="mr-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">
         {selectedCount} selected

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -98,6 +98,12 @@ import {
   classifyClick,
   selectionReducer,
 } from "../lib/sidebarSelection";
+import {
+  bucketSelectionForBulk,
+  summarizeBulkResults,
+} from "../lib/sidebarBulk";
+import { reportError, reportInfo } from "../lib/toastBus";
+import { BulkActionBar } from "./BulkActionBar";
 // Re-exported for back-compat with `SnoozeModal.test.tsx`, which imports it
 // from this module; the definition now lives in `sidebarOptimistic.ts`.
 export { makeOptimisticSnoozedUntil } from "../lib/sidebarOptimistic";
@@ -2203,6 +2209,61 @@ export function WorkspaceSidebar({
     dispatchSelection({ type: "prune", validIds: existingWorkspaceIds });
   }, [existingWorkspaceIds]);
 
+  const clearSelection = useCallback(
+    () => dispatchSelection({ type: "clear" }),
+    [],
+  );
+
+  // Selected workspaces (existing ones only) and their per-action eligibility
+  // buckets, for the bulk bar. Deduped against existence so a stale id never
+  // resolves to a phantom workspace.
+  const selectedWorkspaces = useMemo(
+    () => allWorkspaces.filter((w) => selection.selectedIds.has(w.id)),
+    [allWorkspaces, selection.selectedIds],
+  );
+  const bulkBuckets = useMemo(
+    () => bucketSelectionForBulk(selectedWorkspaces, triage.optimisticFor),
+    [selectedWorkspaces, triage],
+  );
+
+  // Run a bulk triage action over its eligible subset, then summarize and
+  // clear the selection. One summary toast instead of per-row toasts.
+  const runBulkAction = useCallback(
+    async (
+      verb: string,
+      run: () => Promise<readonly { ok: boolean; skipped?: boolean }[]>,
+    ) => {
+      const results = await run();
+      const summary = summarizeBulkResults(verb, results);
+      if (results.some((r) => !r.ok && !r.skipped)) reportError(summary);
+      else reportInfo(summary);
+      clearSelection();
+    },
+    [clearSelection],
+  );
+
+  const onBulkPin = useCallback(
+    (wss: Workspace[], pinned: boolean) =>
+      void runBulkAction(pinned ? "Pinned" : "Unpinned", () =>
+        triage.bulkPin(wss, pinned),
+      ),
+    [runBulkAction, triage],
+  );
+  const onBulkArchive = useCallback(
+    (wss: Workspace[], archived: boolean) =>
+      void runBulkAction(archived ? "Archived" : "Unarchived", () =>
+        triage.bulkArchive(wss, archived),
+      ),
+    [runBulkAction, triage],
+  );
+  const onBulkSnooze = useCallback(
+    (wss: Workspace[], minutes: number | null) =>
+      void runBulkAction(minutes == null ? "Unsnoozed" : "Snoozed", () =>
+        triage.bulkSnooze(wss, minutes),
+      ),
+    [runBulkAction, triage],
+  );
+
   // Interpret a row click: plain click clears the selection and navigates
   // (today's behavior), modifier clicks build the selection instead. The row
   // has already guarded button / deleting / drag, and called preventDefault.
@@ -2426,6 +2487,18 @@ export function WorkspaceSidebar({
               className="w-full bg-surface-800 border border-surface-700 rounded-md px-2.5 py-1.5 text-[13px] text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
             />
           </div>
+        )}
+
+        {!readOnly && (
+          <BulkActionBar
+            selectedCount={selection.selectedIds.size}
+            buckets={bulkBuckets}
+            snoozePresets={SNOOZE_PRESETS}
+            onBulkPin={onBulkPin}
+            onBulkArchive={onBulkArchive}
+            onBulkSnooze={onBulkSnooze}
+            onClear={clearSelection}
+          />
         )}
 
         <div className="flex-1 overflow-y-auto overflow-x-hidden">

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2109,14 +2109,22 @@ export function WorkspaceSidebar({
     [groups, onReorderWorkspaces, onReorderGroups],
   );
 
-  // All workspaces flattened across groups, used to reconcile the optimistic
-  // triage overlay against server truth on each refresh. A workspace can
-  // appear under multiple groups (group axis); reconcileOptimistic keys by
-  // workspace id so duplicates are harmless.
-  const allWorkspaces = useMemo(
-    () => groups.flatMap((g) => g.workspaces.map((v) => v.workspace)),
-    [groups],
-  );
+  // All workspaces flattened across groups, deduped by id. A workspace can
+  // appear under more than one group (group axis), so without the dedupe the
+  // same id would surface twice in `selectedWorkspaces` and bulk actions
+  // would fan out to the same session more than once. First occurrence wins.
+  const allWorkspaces = useMemo(() => {
+    const seen = new Set<string>();
+    const out: Workspace[] = [];
+    for (const g of groups) {
+      for (const v of g.workspaces) {
+        if (seen.has(v.workspace.id)) continue;
+        seen.add(v.workspace.id);
+        out.push(v.workspace);
+      }
+    }
+    return out;
+  }, [groups]);
 
   // Optimistic triage overlay + single-id PATCH wiring, lifted out of
   // SessionRow so single-row and (in #1724) bulk actions share one source of
@@ -2178,18 +2186,27 @@ export function WorkspaceSidebar({
   // must mirror the render below; both walk filteredGroups the same way.
   const flatRenderedOrder = useMemo(() => {
     const ids: string[] = [];
+    const seen = new Set<string>();
+    // A workspace that renders under more than one group still resolves to a
+    // single selectable id, so the range order keeps only its first
+    // occurrence; pushing it twice would make Shift+range math ambiguous.
+    const push = (id: string) => {
+      if (seen.has(id)) return;
+      seen.add(id);
+      ids.push(id);
+    };
     for (const g of filteredGroups) {
       if (!sidebarGroupHasLiveWorkspace(g)) continue;
       const expanded = q ? true : !g.collapsed;
       if (!expanded) continue;
       for (const v of g.workspaces) {
-        if (!workspaceIsSunk(v.workspace)) ids.push(v.workspace.id);
+        if (!workspaceIsSunk(v.workspace)) push(v.workspace.id);
       }
     }
     if (sunkExpanded) {
       for (const g of filteredGroups) {
         for (const v of g.workspaces) {
-          if (workspaceIsSunk(v.workspace)) ids.push(v.workspace.id);
+          if (workspaceIsSunk(v.workspace)) push(v.workspace.id);
         }
       }
     }

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -66,10 +66,7 @@ import { useIdleDecayWindowMs } from "../lib/idleDecay";
 import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import {
   renameSession,
-  setSessionArchive,
   setSessionNotifications,
-  setSessionPin,
-  setSessionSnooze,
   setWorktreeName,
   updateSessionGroup,
 } from "../lib/api";
@@ -82,14 +79,22 @@ import { useQueuedCountForSessions } from "../hooks/useCockpitQueueCount";
 import { useRateLimitedForSessions } from "../hooks/useCockpitRateLimit";
 import { reportError } from "../lib/toastBus";
 import {
-  resolveEffectiveSnoozedUntil,
-  snoozeTimestampCloseEnough,
   triageMenuShape,
   triageStateOf,
   workspaceIsPinned,
   workspaceIsSunk,
   type SidebarSortMode,
 } from "../lib/sidebarSort";
+import {
+  effectiveArchivedOf,
+  effectivePinnedOf,
+  effectiveSnoozedUntilOf,
+  type OptimisticTriage,
+} from "../lib/sidebarOptimistic";
+import { useSidebarTriage } from "../hooks/useSidebarTriage";
+// Re-exported for back-compat with `SnoozeModal.test.tsx`, which imports it
+// from this module; the definition now lives in `sidebarOptimistic.ts`.
+export { makeOptimisticSnoozedUntil } from "../lib/sidebarOptimistic";
 import { StatusGlyph } from "./StatusGlyph";
 import { OwnerAvatar } from "./OwnerAvatar";
 import { SessionGroupModal } from "./SessionGroupModal";
@@ -327,17 +332,6 @@ function formatDurationSecondsShort(seconds: number): string {
   return remM === 0 ? `${h}h` : `${h}h ${remM}m`;
 }
 
-/** Wall-clock target for an optimistic snooze: `Date.now() + minutes
- *  * 60_000` as an RFC3339 ISO string. Sits outside the component so
- *  the `Date.now()` call doesn't trip
- *  `react-hooks/purity`; the event handler that calls it is itself a
- *  closure, not a render. The exact value is throwaway (the server's
- *  response on the next poll is the source of truth), so a few ms
- *  of jitter is harmless. See #1581. */
-export function makeOptimisticSnoozedUntil(minutes: number): string {
-  return new Date(Date.now() + minutes * 60_000).toISOString();
-}
-
 /** Compact "time remaining" label for the snooze chip computed once at
  *  render time (no per-second timer, by design: snooze rows poll the
  *  sessions API at the existing cadence and the static label is more
@@ -432,6 +426,10 @@ function SortableSessionRow({
   onDelete?: (workspaceId: string) => void;
   readOnly?: boolean;
   dragDisabled?: boolean;
+  optimistic: OptimisticTriage;
+  onPinToggle: (ws: Workspace, pinned: boolean) => void;
+  onArchiveToggle: (ws: Workspace, archived: boolean) => void;
+  onSnooze: (ws: Workspace, minutes: number | null) => void;
 }) {
   const dragSuppressRef = useDragSuppressRef();
   // `disabled` no-ops the sensor listeners. `readOnly` covers viewers
@@ -557,6 +555,10 @@ export const SessionRow = memo(function SessionRow({
   onDelete,
   readOnly,
   indented,
+  optimistic,
+  onPinToggle,
+  onArchiveToggle,
+  onSnooze,
 }: {
   workspace: Workspace;
   isActive: boolean;
@@ -564,6 +566,14 @@ export const SessionRow = memo(function SessionRow({
   onDelete?: (workspaceId: string) => void;
   readOnly?: boolean;
   indented?: boolean;
+  // Optimistic triage overlay for this row plus the parent-owned mutation
+  // callbacks. Triage state used to live in the row as three `useState`s;
+  // it now lives in the sidebar so bulk actions can drive many rows from
+  // one place. See #1724.
+  optimistic: OptimisticTriage;
+  onPinToggle: (ws: Workspace, pinned: boolean) => void;
+  onArchiveToggle: (ws: Workspace, archived: boolean) => void;
+  onSnooze: (ws: Workspace, minutes: number | null) => void;
 }) {
   const idleDecayWindowMs = useIdleDecayWindowMs();
   const { status: sessionStatus, createdAt, idleEnteredAt } = bestSession(
@@ -660,25 +670,12 @@ export const SessionRow = memo(function SessionRow({
     await setSessionNotifications(sessionId, preset);
   };
 
-  // Triage actions (pin / archive / snooze). Optimistic state lets the
-  // glyph, chip, and tier flip immediately on click; on PATCH failure we
-  // revert and surface a toast. The optimistic snap clears itself once
-  // the next sessions-poll reflects the same value, so a successful
-  // round-trip is invisible to the user (just feels fast).
-  const [optimisticPinned, setOptimisticPinned] = useState<boolean | null>(
-    null,
-  );
-  const [optimisticArchived, setOptimisticArchived] = useState<boolean | null>(
-    null,
-  );
-  // Optimistic `snoozed_until` override. `undefined` = no override
-  // (use the prop), a string = pretend the server already returned
-  // this RFC3339 timestamp, `null` = pretend the server already
-  // unsnoozed. Clears once the prop matches the override on the next
-  // poll, matching the pin / archive pattern above.
-  const [optimisticSnoozedUntil, setOptimisticSnoozedUntil] = useState<
-    string | null | undefined
-  >(undefined);
+  // Triage actions (pin / archive / snooze). The optimistic overlay and the
+  // network calls live in the sidebar parent now (keyed by workspace id) so
+  // a bulk action can drive many rows at once; the row just closes its own
+  // menu/modal and delegates the mutation. See #1724. The optimistic snap
+  // still clears itself once the next sessions-poll reflects the same value,
+  // so a successful round-trip is invisible to the user (just feels fast).
   // Snooze duration picker. Lives in its own portal-rendered modal,
   // independent of the context menu's lifecycle so the parent-menu
   // dismissal listener cannot close the picker out from under us.
@@ -686,83 +683,21 @@ export const SessionRow = memo(function SessionRow({
   // Edit-workdir-name picker, also in its own portal-rendered modal so the
   // context-menu dismissal listener does not close it. See #1723.
   const [workdirModalOpen, setWorkdirModalOpen] = useState(false);
-  useEffect(() => {
-    if (optimisticPinned !== null && optimisticPinned === isPinned) {
-      setOptimisticPinned(null);
-    }
-  }, [isPinned, optimisticPinned]);
-  useEffect(() => {
-    if (optimisticArchived !== null && optimisticArchived === isArchived) {
-      setOptimisticArchived(null);
-    }
-  }, [isArchived, optimisticArchived]);
-  useEffect(() => {
-    if (optimisticSnoozedUntil === undefined) return;
-    // Clear the override only when the server value actually matches
-    // it. A naive "both non-null" check used to fire prematurely
-    // when the user re-snoozed an already-snoozed row: the prop
-    // was still the OLD timestamp but non-null, the override was
-    // the NEW timestamp, the effect treated them as a match, and
-    // the chip snapped back to the stale time until the next
-    // poll. See #1581 CodeRabbit review.
-    if (optimisticSnoozedUntil === null && snoozedUntil == null) {
-      setOptimisticSnoozedUntil(undefined);
-      return;
-    }
-    if (
-      optimisticSnoozedUntil != null &&
-      snoozedUntil != null &&
-      snoozeTimestampCloseEnough(optimisticSnoozedUntil, snoozedUntil)
-    ) {
-      setOptimisticSnoozedUntil(undefined);
-    }
-  }, [snoozedUntil, optimisticSnoozedUntil]);
 
-  const togglePin = async () => {
+  const togglePin = () => {
     setContextMenu(null);
-    if (!sessionId) return;
-    const next = !isPinned;
-    setOptimisticPinned(next);
-    const result = await setSessionPin(sessionId, next);
-    if (!result) {
-      setOptimisticPinned(null);
-      reportError(next ? "Failed to pin session" : "Failed to unpin session");
-    }
+    onPinToggle(workspace, !effectivePinnedOf(optimistic, isPinned));
   };
 
-  const toggleArchive = async () => {
+  const toggleArchive = () => {
     setContextMenu(null);
-    if (!sessionId) return;
-    const next = !isArchived;
-    setOptimisticArchived(next);
-    const result = await setSessionArchive(sessionId, next);
-    if (!result) {
-      setOptimisticArchived(null);
-      reportError(
-        next ? "Failed to archive session" : "Failed to unarchive session",
-      );
-    }
+    onArchiveToggle(workspace, !effectiveArchivedOf(optimistic, isArchived));
   };
 
-  const applySnooze = async (minutes: number | null) => {
+  const applySnooze = (minutes: number | null) => {
     setContextMenu(null);
     setSnoozeModalOpen(false);
-    if (!sessionId) return;
-    // Optimistic flip: render the snooze chip + sink the row before
-    // the PATCH round-trip lands, matching the pin / archive
-    // affordance. For positive minutes we synthesise a target
-    // timestamp; the server is the source of truth and the value is
-    // discarded on the next poll, so a few ms of drift is harmless.
-    const optimisticUntil =
-      minutes == null ? null : makeOptimisticSnoozedUntil(minutes);
-    setOptimisticSnoozedUntil(optimisticUntil);
-    const result = await setSessionSnooze(sessionId, minutes);
-    if (!result) {
-      setOptimisticSnoozedUntil(undefined);
-      reportError(
-        minutes == null ? "Failed to unsnooze session" : "Failed to snooze session",
-      );
-    }
+    onSnooze(workspace, minutes);
   };
 
   // Close the context menu first, then open the modal in the next
@@ -787,13 +722,10 @@ export const SessionRow = memo(function SessionRow({
   };
 
   // Effective state for rendering: optimistic overrides win until the
-  // prop catches up (cleared in the effects above).
-  const effectivePinned = optimisticPinned ?? isPinned;
-  const effectiveArchived = optimisticArchived ?? isArchived;
-  const effectiveSnoozedUntil = resolveEffectiveSnoozedUntil(
-    optimisticSnoozedUntil,
-    snoozedUntil,
-  );
+  // sidebar's overlay reconciler drops them once the prop catches up.
+  const effectivePinned = effectivePinnedOf(optimistic, isPinned);
+  const effectiveArchived = effectiveArchivedOf(optimistic, isArchived);
+  const effectiveSnoozedUntil = effectiveSnoozedUntilOf(optimistic, snoozedUntil);
   const effectiveSnoozed = effectiveSnoozedUntil != null;
 
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
@@ -2145,6 +2077,20 @@ export function WorkspaceSidebar({
     [groups, onReorderWorkspaces, onReorderGroups],
   );
 
+  // All workspaces flattened across groups, used to reconcile the optimistic
+  // triage overlay against server truth on each refresh. A workspace can
+  // appear under multiple groups (group axis); reconcileOptimistic keys by
+  // workspace id so duplicates are harmless.
+  const allWorkspaces = useMemo(
+    () => groups.flatMap((g) => g.workspaces.map((v) => v.workspace)),
+    [groups],
+  );
+
+  // Optimistic triage overlay + single-id PATCH wiring, lifted out of
+  // SessionRow so single-row and (in #1724) bulk actions share one source of
+  // truth. Triage always targets the workspace's primary session.
+  const triage = useSidebarTriage(allWorkspaces);
+
   const q = filterQuery.trim().toLowerCase();
 
   const isNested = axis === "repo+group";
@@ -2454,6 +2400,12 @@ export function WorkspaceSidebar({
                                 }}
                                 onDelete={onDeleteSession}
                                 readOnly={readOnly}
+                                optimistic={triage.optimisticFor(
+                                  v.workspace.id,
+                                )}
+                                onPinToggle={triage.pinToggle}
+                                onArchiveToggle={triage.archiveToggle}
+                                onSnooze={triage.snooze}
                                 // Drag is disabled when the tier
                                 // comparator already controls placement:
                                 // lastActivity mode has no manual
@@ -2658,6 +2610,10 @@ export function WorkspaceSidebar({
                       }}
                       onDelete={onDeleteSession}
                       readOnly={readOnly}
+                      optimistic={triage.optimisticFor(v.workspace.id)}
+                      onPinToggle={triage.pinToggle}
+                      onArchiveToggle={triage.archiveToggle}
+                      onSnooze={triage.snooze}
                       indented
                     />
                   ))}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2231,6 +2231,13 @@ export function WorkspaceSidebar({
     [],
   );
 
+  // Read-only viewers can't act on a selection (the bulk bar is hidden), so
+  // never let one accumulate: drop any existing selection when read-only
+  // turns on. Row clicks are forced down the navigate path below.
+  useEffect(() => {
+    if (readOnly) dispatchSelection({ type: "clear" });
+  }, [readOnly]);
+
   // Selected workspaces (existing ones only) and their per-action eligibility
   // buckets, for the bulk bar. Deduped against existence so a stale id never
   // resolves to a phantom workspace.
@@ -2286,6 +2293,14 @@ export function WorkspaceSidebar({
   // has already guarded button / deleting / drag, and called preventDefault.
   const handleRowActivate = useCallback(
     (workspaceId: string, e: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean }) => {
+      // Read-only: ignore modifier gestures entirely and always navigate, so
+      // no hidden selection state can build up.
+      if (readOnly) {
+        dispatchSelection({ type: "clear" });
+        setOptimisticActive({ id: workspaceId, fromActiveId: activeId });
+        onSelect(workspaceId);
+        return;
+      }
       const intent = classifyClick(e);
       switch (intent) {
         case "navigate":
@@ -2314,7 +2329,7 @@ export function WorkspaceSidebar({
           break;
       }
     },
-    [activeId, onSelect, flatRenderedOrder],
+    [activeId, onSelect, flatRenderedOrder, readOnly],
   );
 
   const toggleFilter = () => {
@@ -2587,9 +2602,10 @@ export function WorkspaceSidebar({
                                 isActive={
                                   v.workspace.id === displayedActiveId
                                 }
-                                isSelected={selection.selectedIds.has(
-                                  v.workspace.id,
-                                )}
+                                isSelected={
+                                  !readOnly &&
+                                  selection.selectedIds.has(v.workspace.id)
+                                }
                                 onActivate={(e) =>
                                   handleRowActivate(v.workspace.id, e)
                                 }
@@ -2796,7 +2812,9 @@ export function WorkspaceSidebar({
                       key={v.key}
                       workspace={v.workspace}
                       isActive={v.workspace.id === displayedActiveId}
-                      isSelected={selection.selectedIds.has(v.workspace.id)}
+                      isSelected={
+                        !readOnly && selection.selectedIds.has(v.workspace.id)
+                      }
                       onActivate={(e) => handleRowActivate(v.workspace.id, e)}
                       onDelete={onDeleteSession}
                       readOnly={readOnly}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
   type MutableRefObject,
@@ -92,6 +93,11 @@ import {
   type OptimisticTriage,
 } from "../lib/sidebarOptimistic";
 import { useSidebarTriage } from "../hooks/useSidebarTriage";
+import {
+  EMPTY_SELECTION,
+  classifyClick,
+  selectionReducer,
+} from "../lib/sidebarSelection";
 // Re-exported for back-compat with `SnoozeModal.test.tsx`, which imports it
 // from this module; the definition now lives in `sidebarOptimistic.ts`.
 export { makeOptimisticSnoozedUntil } from "../lib/sidebarOptimistic";
@@ -422,7 +428,12 @@ function SortableSessionRow({
   rowKey?: string;
   workspace: Workspace;
   isActive: boolean;
-  onClick: () => void;
+  isSelected: boolean;
+  onActivate: (e: {
+    metaKey: boolean;
+    ctrlKey: boolean;
+    shiftKey: boolean;
+  }) => void;
   onDelete?: (workspaceId: string) => void;
   readOnly?: boolean;
   dragDisabled?: boolean;
@@ -551,7 +562,8 @@ function SortableRepoGroup({
 export const SessionRow = memo(function SessionRow({
   workspace,
   isActive,
-  onClick,
+  isSelected,
+  onActivate,
   onDelete,
   readOnly,
   indented,
@@ -562,7 +574,16 @@ export const SessionRow = memo(function SessionRow({
 }: {
   workspace: Workspace;
   isActive: boolean;
-  onClick: () => void;
+  // Whether this row is part of the sidebar multi-select. See #1724.
+  isSelected: boolean;
+  // Row click. The parent interprets the modifier keys (plain navigates,
+  // Cmd/Ctrl toggles, Shift ranges), so the row forwards the event up rather
+  // than navigating directly. See #1724.
+  onActivate: (e: {
+    metaKey: boolean;
+    ctrlKey: boolean;
+    shiftKey: boolean;
+  }) => void;
   onDelete?: (workspaceId: string) => void;
   readOnly?: boolean;
   indented?: boolean;
@@ -889,13 +910,9 @@ export const SessionRow = memo(function SessionRow({
         data-testid="sidebar-session-row"
         draggable={false}
         onClick={(e) => {
-          if (
-            e.button !== 0 ||
-            e.metaKey ||
-            e.ctrlKey ||
-            e.shiftKey ||
-            e.altKey
-          ) {
+          // Let the browser handle non-primary clicks (middle-click still
+          // opens the session href in a new tab) and Alt+click.
+          if (e.button !== 0 || e.altKey) {
             return;
           }
           if (isDeleting) {
@@ -906,22 +923,31 @@ export const SessionRow = memo(function SessionRow({
             e.preventDefault();
             return;
           }
+          // Primary click (plain or with Shift / Cmd / Ctrl): the parent
+          // decides navigate vs. select. Always preventDefault so a modifier
+          // click builds the selection instead of following the href.
           e.preventDefault();
-          onClick();
+          onActivate(e);
         }}
         onContextMenu={handleContextMenu}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onTouchMove={clearLongPress}
         onTouchCancel={clearLongPress}
+        data-selected={isSelected || undefined}
         className={`block w-full text-left py-2 cursor-pointer select-none [-webkit-touch-callout:none] transition-colors duration-75 ${
           indented ? "pl-6 pr-3" : "px-3"
         } ${
           isActive
             ? "bg-surface-850 border-l-2 border-brand-600"
             : "border-l-2 border-transparent hover:bg-surface-700/40"
+        } ${
+          isSelected
+            ? "ring-1 ring-inset ring-brand-500/60 bg-brand-500/10"
+            : ""
         } ${isDeleting ? "opacity-50 pointer-events-none" : ""}`}
       >
+        {isSelected && <span className="sr-only">Selected</span>}
         <div className="flex items-center gap-2">
           <span
             className={`text-sm shrink-0 leading-none font-mono ${textClass}`}
@@ -2133,6 +2159,86 @@ export function WorkspaceSidebar({
     ? filteredNested.length > 0
     : filteredGroups.length > 0;
 
+  // Sidebar multi-select. Selection is ephemeral sidebar UI state (not routed
+  // or persisted); the anchor pivots Shift+click ranges. See #1724.
+  const [selection, dispatchSelection] = useReducer(
+    selectionReducer,
+    EMPTY_SELECTION,
+  );
+
+  // Workspace ids in the exact order they render, so a Shift+click range
+  // spans only what the user can see: collapsed groups and (when collapsed)
+  // the sunk section contribute no rows, and a filter trims to matches. This
+  // must mirror the render below; both walk filteredGroups the same way.
+  const flatRenderedOrder = useMemo(() => {
+    const ids: string[] = [];
+    for (const g of filteredGroups) {
+      if (!sidebarGroupHasLiveWorkspace(g)) continue;
+      const expanded = q ? true : !g.collapsed;
+      if (!expanded) continue;
+      for (const v of g.workspaces) {
+        if (!workspaceIsSunk(v.workspace)) ids.push(v.workspace.id);
+      }
+    }
+    if (sunkExpanded) {
+      for (const g of filteredGroups) {
+        for (const v of g.workspaces) {
+          if (workspaceIsSunk(v.workspace)) ids.push(v.workspace.id);
+        }
+      }
+    }
+    return ids;
+  }, [filteredGroups, q, sunkExpanded]);
+
+  // Drop selected ids for workspaces that no longer exist (a session was
+  // deleted or moved). Existence-based, not visibility-based: collapsing a
+  // group or filtering keeps the selection, matching file-manager behavior;
+  // only a vanished workspace is pruned. Range math above is already scoped
+  // to the visible order.
+  const existingWorkspaceIds = useMemo(
+    () => new Set(allWorkspaces.map((w) => w.id)),
+    [allWorkspaces],
+  );
+  useEffect(() => {
+    dispatchSelection({ type: "prune", validIds: existingWorkspaceIds });
+  }, [existingWorkspaceIds]);
+
+  // Interpret a row click: plain click clears the selection and navigates
+  // (today's behavior), modifier clicks build the selection instead. The row
+  // has already guarded button / deleting / drag, and called preventDefault.
+  const handleRowActivate = useCallback(
+    (workspaceId: string, e: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean }) => {
+      const intent = classifyClick(e);
+      switch (intent) {
+        case "navigate":
+          dispatchSelection({ type: "clear" });
+          setOptimisticActive({ id: workspaceId, fromActiveId: activeId });
+          onSelect(workspaceId);
+          break;
+        case "toggle":
+          dispatchSelection({ type: "toggle", id: workspaceId });
+          break;
+        case "range":
+          dispatchSelection({
+            type: "range",
+            targetId: workspaceId,
+            orderedIds: flatRenderedOrder,
+            additive: false,
+          });
+          break;
+        case "additive-range":
+          dispatchSelection({
+            type: "range",
+            targetId: workspaceId,
+            orderedIds: flatRenderedOrder,
+            additive: true,
+          });
+          break;
+      }
+    },
+    [activeId, onSelect, flatRenderedOrder],
+  );
+
   const toggleFilter = () => {
     setFilterOpen((o) => {
       if (o) setFilterQuery("");
@@ -2391,13 +2497,12 @@ export function WorkspaceSidebar({
                                 isActive={
                                   v.workspace.id === displayedActiveId
                                 }
-                                onClick={() => {
-                                  setOptimisticActive({
-                                    id: v.workspace.id,
-                                    fromActiveId: activeId,
-                                  });
-                                  onSelect(v.workspace.id);
-                                }}
+                                isSelected={selection.selectedIds.has(
+                                  v.workspace.id,
+                                )}
+                                onActivate={(e) =>
+                                  handleRowActivate(v.workspace.id, e)
+                                }
                                 onDelete={onDeleteSession}
                                 readOnly={readOnly}
                                 optimistic={triage.optimisticFor(
@@ -2601,13 +2706,8 @@ export function WorkspaceSidebar({
                       key={v.key}
                       workspace={v.workspace}
                       isActive={v.workspace.id === displayedActiveId}
-                      onClick={() => {
-                        setOptimisticActive({
-                          id: v.workspace.id,
-                          fromActiveId: activeId,
-                        });
-                        onSelect(v.workspace.id);
-                      }}
+                      isSelected={selection.selectedIds.has(v.workspace.id)}
+                      onActivate={(e) => handleRowActivate(v.workspace.id, e)}
                       onDelete={onDeleteSession}
                       readOnly={readOnly}
                       optimistic={triage.optimisticFor(v.workspace.id)}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -78,7 +78,6 @@ import { useClampedMenuPosition } from "../lib/menuPosition";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { useQueuedCountForSessions } from "../hooks/useCockpitQueueCount";
 import { useRateLimitedForSessions } from "../hooks/useCockpitRateLimit";
-import { reportError } from "../lib/toastBus";
 import {
   triageMenuShape,
   triageStateOf,
@@ -2737,15 +2736,21 @@ export function WorkspaceSidebar({
                                     isActive={
                                       v.workspace.id === displayedActiveId
                                     }
-                                    onClick={() => {
-                                      setOptimisticActive({
-                                        id: v.workspace.id,
-                                        fromActiveId: activeId,
-                                      });
-                                      onSelect(v.workspace.id);
-                                    }}
+                                    isSelected={
+                                      !readOnly &&
+                                      selection.selectedIds.has(v.workspace.id)
+                                    }
+                                    onActivate={(e) =>
+                                      handleRowActivate(v.workspace.id, e)
+                                    }
                                     onDelete={onDeleteSession}
                                     readOnly={readOnly}
+                                    optimistic={triage.optimisticFor(
+                                      v.workspace.id,
+                                    )}
+                                    onPinToggle={triage.pinToggle}
+                                    onArchiveToggle={triage.archiveToggle}
+                                    onSnooze={triage.snooze}
                                     indented
                                   />
                                 ))}

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -9,12 +9,13 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { useRef, type ReactNode } from "react";
+import { useMemo, useRef, type ReactNode } from "react";
 
 import {
   DragSuppressContext,
   SessionRow,
 } from "../WorkspaceSidebar";
+import { useSidebarTriage } from "../../hooks/useSidebarTriage";
 import type { SessionResponse, Workspace } from "../../lib/types";
 import { OPEN_SESSION_EVENT } from "../../lib/sessionRoute";
 import {
@@ -79,6 +80,29 @@ function Wrap({ children }: { children: ReactNode }) {
   );
 }
 
+// Mounts a SessionRow wired to the real `useSidebarTriage` controller, the
+// same way `WorkspaceSidebar` wires it in production. Triage state and the
+// pin/archive/snooze PATCH calls live in the hook now (lifted out of the row
+// so bulk actions can share them, see #1724), so the row + hook are
+// exercised together here rather than the row owning the mutation. Returns
+// `null` while the workspace has no row to render.
+function Row({ ws, readOnly }: { ws: Workspace; readOnly?: boolean }) {
+  const workspaces = useMemo(() => [ws], [ws]);
+  const triage = useSidebarTriage(workspaces);
+  return (
+    <SessionRow
+      workspace={ws}
+      isActive={false}
+      onClick={() => {}}
+      readOnly={readOnly}
+      optimistic={triage.optimisticFor(ws.id)}
+      onPinToggle={triage.pinToggle}
+      onArchiveToggle={triage.archiveToggle}
+      onSnooze={triage.snooze}
+    />
+  );
+}
+
 const fetchSpy = vi.fn<typeof fetch>();
 
 beforeEach(() => {
@@ -107,7 +131,7 @@ describe("SessionRow chips", () => {
     ]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     expect(screen.queryByLabelText("Pinned")).not.toBeNull();
@@ -121,7 +145,7 @@ describe("SessionRow chips", () => {
     ]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     expect(screen.queryByLabelText("Archived")).not.toBeNull();
@@ -134,7 +158,7 @@ describe("SessionRow chips", () => {
     const ws = workspace("w-snoozed", [session({ snoozed_until: future })]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     const chip = screen.queryByLabelText("Snoozed");
@@ -154,7 +178,7 @@ describe("SessionRow chips", () => {
     ]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     expect(screen.queryByLabelText("Archived")).not.toBeNull();
@@ -173,7 +197,7 @@ describe("SessionRow context menu", () => {
     ]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     const row = screen.getByTestId("sidebar-session-row");
@@ -190,7 +214,7 @@ describe("SessionRow context menu", () => {
     ]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -205,7 +229,7 @@ describe("SessionRow context menu", () => {
     const ws = workspace("w-snoozed", [session({ snoozed_until: future })]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -219,7 +243,7 @@ describe("SessionRow context menu", () => {
     const ws = workspace("w-live", [session({})]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -235,7 +259,7 @@ describe("SessionRow context menu", () => {
     ]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -248,7 +272,7 @@ describe("SessionRow context menu", () => {
     const ws = workspace("w-tmux", [session({ cockpit_mode: false })]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -263,12 +287,7 @@ describe("SessionRow context menu", () => {
     const ws = workspace("w-live", [session({ cockpit_mode: true })]);
     render(
       <Wrap>
-        <SessionRow
-          workspace={ws}
-          isActive={false}
-          onClick={() => {}}
-          readOnly
-        />
+        <Row ws={ws} readOnly />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -288,7 +307,7 @@ describe("SessionRow triage actions", () => {
     const ws = workspace("w-live", [session({ id: "sess-pin-it" })]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -305,7 +324,7 @@ describe("SessionRow triage actions", () => {
     const ws = workspace("w-live", [session({ id: "sess-arch-it" })]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -328,7 +347,7 @@ describe("SessionRow triage actions", () => {
     const ws = workspace("w-live", [session({ id: "sess-opt-archive" })]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -345,7 +364,7 @@ describe("SessionRow triage actions", () => {
     const ws = workspace("w-live", [session({ id: "sess-snooze-it" })]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -360,7 +379,7 @@ describe("SessionRow triage actions", () => {
     ]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -377,7 +396,7 @@ describe("SessionRow triage actions", () => {
     ]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -399,7 +418,7 @@ describe("SessionRow triage actions", () => {
     const ws = workspace("w-live", [session({ id: "sess-pin-fail" })]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -419,7 +438,7 @@ describe("SessionRow triage actions", () => {
     const ws = workspace("w-live", [session({ id: "sess-arch-fail" })]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -437,7 +456,7 @@ describe("SessionRow triage actions", () => {
     ]);
     render(
       <Wrap>
-        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+        <Row ws={ws} />
       </Wrap>,
     );
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
@@ -463,7 +482,7 @@ describe("SessionRow triage actions", () => {
     try {
       render(
         <Wrap>
-          <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+          <Row ws={ws} />
         </Wrap>,
       );
       fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -93,7 +93,8 @@ function Row({ ws, readOnly }: { ws: Workspace; readOnly?: boolean }) {
     <SessionRow
       workspace={ws}
       isActive={false}
-      onClick={() => {}}
+      isSelected={false}
+      onActivate={() => {}}
       readOnly={readOnly}
       optimistic={triage.optimisticFor(ws.id)}
       onPinToggle={triage.pinToggle}

--- a/web/src/components/__tests__/WorkdirNameEdit.test.tsx
+++ b/web/src/components/__tests__/WorkdirNameEdit.test.tsx
@@ -10,6 +10,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useRef, type ReactNode } from "react";
 
 import { DragSuppressContext, SessionRow } from "../WorkspaceSidebar";
+import { EMPTY_OPTIMISTIC } from "../../lib/sidebarOptimistic";
 import type { SessionResponse, Workspace } from "../../lib/types";
 
 function session(over: Partial<SessionResponse> = {}): SessionResponse {
@@ -91,7 +92,16 @@ afterEach(() => {
 function openMenu(ws: Workspace) {
   render(
     <Wrap>
-      <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      <SessionRow
+        workspace={ws}
+        isActive={false}
+        isSelected={false}
+        onActivate={() => {}}
+        optimistic={EMPTY_OPTIMISTIC}
+        onPinToggle={() => {}}
+        onArchiveToggle={() => {}}
+        onSnooze={() => {}}
+      />
     </Wrap>,
   );
   fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));

--- a/web/src/hooks/useSidebarTriage.ts
+++ b/web/src/hooks/useSidebarTriage.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  setSessionArchive,
+  setSessionPin,
+  setSessionSnooze,
+} from "../lib/api";
+import { reportError } from "../lib/toastBus";
+import {
+  EMPTY_OPTIMISTIC,
+  makeOptimisticSnoozedUntil,
+  reconcileOptimistic,
+  withOverride,
+  type OptimisticTriage,
+} from "../lib/sidebarOptimistic";
+import type { Workspace } from "../lib/types";
+
+/** Outcome of one triage mutation, used to build the bulk summary toast. */
+export interface TriageResult {
+  workspaceId: string;
+  ok: boolean;
+  /** Set when the workspace had no session to act on. */
+  skipped?: boolean;
+}
+
+/** Sidebar triage controller: owns the optimistic overlay (keyed by workspace
+ *  id) and the single-id PATCH calls for pin / archive / snooze, for both
+ *  single-row and bulk actions. Lifted out of `SessionRow` so a bulk action
+ *  can drive many rows from one place rather than reaching into N independent
+ *  row components. Triage always targets the workspace's primary session
+ *  (`sessions[0]`), matching the prior row-level behavior. See #1724. */
+export function useSidebarTriage(workspaces: readonly Workspace[]) {
+  const [overlay, setOverlay] = useState<Map<string, OptimisticTriage>>(
+    () => new Map(),
+  );
+
+  // Drop overrides the server has caught up to. reconcileOptimistic returns
+  // the same map reference when nothing changed, so this never loops.
+  useEffect(() => {
+    setOverlay((prev) => reconcileOptimistic(prev, workspaces));
+  }, [workspaces]);
+
+  const setOverride = useCallback(
+    (workspaceId: string, patch: Partial<OptimisticTriage>) => {
+      setOverlay((prev) => {
+        const next = new Map(prev);
+        next.set(workspaceId, withOverride(prev.get(workspaceId), patch));
+        return next;
+      });
+    },
+    [],
+  );
+
+  const optimisticFor = useCallback(
+    (workspaceId: string): OptimisticTriage =>
+      overlay.get(workspaceId) ?? EMPTY_OPTIMISTIC,
+    [overlay],
+  );
+
+  const pin = useCallback(
+    async (ws: Workspace, pinned: boolean): Promise<TriageResult> => {
+      const sessionId = ws.sessions[0]?.id;
+      if (!sessionId) return { workspaceId: ws.id, ok: false, skipped: true };
+      setOverride(ws.id, { pinned });
+      const result = await setSessionPin(sessionId, pinned);
+      if (!result) {
+        setOverride(ws.id, { pinned: null });
+        return { workspaceId: ws.id, ok: false };
+      }
+      return { workspaceId: ws.id, ok: true };
+    },
+    [setOverride],
+  );
+
+  const archive = useCallback(
+    async (ws: Workspace, archived: boolean): Promise<TriageResult> => {
+      const sessionId = ws.sessions[0]?.id;
+      if (!sessionId) return { workspaceId: ws.id, ok: false, skipped: true };
+      setOverride(ws.id, { archived });
+      const result = await setSessionArchive(sessionId, archived);
+      if (!result) {
+        setOverride(ws.id, { archived: null });
+        return { workspaceId: ws.id, ok: false };
+      }
+      return { workspaceId: ws.id, ok: true };
+    },
+    [setOverride],
+  );
+
+  const snooze = useCallback(
+    async (ws: Workspace, minutes: number | null): Promise<TriageResult> => {
+      const sessionId = ws.sessions[0]?.id;
+      if (!sessionId) return { workspaceId: ws.id, ok: false, skipped: true };
+      const optimisticUntil =
+        minutes == null ? null : makeOptimisticSnoozedUntil(minutes);
+      setOverride(ws.id, { snoozedUntil: optimisticUntil });
+      const result = await setSessionSnooze(sessionId, minutes);
+      if (!result) {
+        setOverride(ws.id, { snoozedUntil: undefined });
+        return { workspaceId: ws.id, ok: false };
+      }
+      return { workspaceId: ws.id, ok: true };
+    },
+    [setOverride],
+  );
+
+  // Single-row handlers surface a toast on failure (the bulk path reports a
+  // single summary toast instead, so these don't).
+  const pinToggle = useCallback(
+    (ws: Workspace, pinned: boolean) => {
+      void pin(ws, pinned).then((r) => {
+        if (!r.ok && !r.skipped) {
+          reportError(
+            pinned ? "Failed to pin session" : "Failed to unpin session",
+          );
+        }
+      });
+    },
+    [pin],
+  );
+
+  const archiveToggle = useCallback(
+    (ws: Workspace, archived: boolean) => {
+      void archive(ws, archived).then((r) => {
+        if (!r.ok && !r.skipped) {
+          reportError(
+            archived
+              ? "Failed to archive session"
+              : "Failed to unarchive session",
+          );
+        }
+      });
+    },
+    [archive],
+  );
+
+  const snoozeOne = useCallback(
+    (ws: Workspace, minutes: number | null) => {
+      void snooze(ws, minutes).then((r) => {
+        if (!r.ok && !r.skipped) {
+          reportError(
+            minutes == null
+              ? "Failed to unsnooze session"
+              : "Failed to snooze session",
+          );
+        }
+      });
+    },
+    [snooze],
+  );
+
+  return {
+    optimisticFor,
+    pinToggle,
+    archiveToggle,
+    snooze: snoozeOne,
+    // Raw promise-returning primitives, reused by the bulk runner in #1724.
+    pin,
+    archive,
+    snoozeRaw: snooze,
+  };
+}

--- a/web/src/hooks/useSidebarTriage.ts
+++ b/web/src/hooks/useSidebarTriage.ts
@@ -149,14 +149,51 @@ export function useSidebarTriage(workspaces: readonly Workspace[]) {
     [snooze],
   );
 
+  // Bulk fan-out. Serial on purpose: each single-id PATCH re-persists the
+  // whole profile's session list, so firing them concurrently could race on
+  // that write. For the handful of rows a user bulk-triages against a local
+  // server this is sub-second, and it keeps the per-session semantics
+  // (lock, persist-first, archive side effects) exactly as the single path.
+  // Best-effort, not atomic: a failure rolls back only its own row. See
+  // #1724. Swapping this loop for a real bulk endpoint later is a localized
+  // change.
+  const runBulk = useCallback(
+    async (
+      workspaces: readonly Workspace[],
+      action: (ws: Workspace) => Promise<TriageResult>,
+    ): Promise<TriageResult[]> => {
+      const results: TriageResult[] = [];
+      for (const ws of workspaces) {
+        results.push(await action(ws));
+      }
+      return results;
+    },
+    [],
+  );
+
+  const bulkPin = useCallback(
+    (wss: readonly Workspace[], pinned: boolean) =>
+      runBulk(wss, (ws) => pin(ws, pinned)),
+    [runBulk, pin],
+  );
+  const bulkArchive = useCallback(
+    (wss: readonly Workspace[], archived: boolean) =>
+      runBulk(wss, (ws) => archive(ws, archived)),
+    [runBulk, archive],
+  );
+  const bulkSnooze = useCallback(
+    (wss: readonly Workspace[], minutes: number | null) =>
+      runBulk(wss, (ws) => snooze(ws, minutes)),
+    [runBulk, snooze],
+  );
+
   return {
     optimisticFor,
     pinToggle,
     archiveToggle,
     snooze: snoozeOne,
-    // Raw promise-returning primitives, reused by the bulk runner in #1724.
-    pin,
-    archive,
-    snoozeRaw: snooze,
+    bulkPin,
+    bulkArchive,
+    bulkSnooze,
   };
 }

--- a/web/src/lib/__tests__/sidebarBulk.test.ts
+++ b/web/src/lib/__tests__/sidebarBulk.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { bucketSelectionForBulk, summarizeBulkResults } from "../sidebarBulk";
+import { EMPTY_OPTIMISTIC, withOverride } from "../sidebarOptimistic";
+import type { SessionResponse, Workspace } from "../types";
+
+function ws(id: string, over: Partial<SessionResponse>): Workspace {
+  return {
+    id,
+    branch: null,
+    projectPath: "/p",
+    displayName: id,
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    sessions: [over] as SessionResponse[],
+  };
+}
+
+const noOverride = () => EMPTY_OPTIMISTIC;
+
+describe("bucketSelectionForBulk", () => {
+  it("splits a mixed selection into per-action eligible subsets", () => {
+    const workspaces = [
+      ws("live", {}),
+      ws("pinned", { pinned_at: "t" }),
+      ws("archived", { archived_at: "t" }),
+      ws("snoozed", { snoozed_until: "2099-01-01T00:00:00Z" }),
+    ];
+    const b = bucketSelectionForBulk(workspaces, noOverride);
+    expect(b.pinnable.map((w) => w.id)).toEqual(["live"]);
+    expect(b.archivable.map((w) => w.id)).toEqual(["live"]);
+    expect(b.snoozable.map((w) => w.id)).toEqual(["live"]);
+    expect(b.unpinnable.map((w) => w.id)).toEqual(["pinned"]);
+    expect(b.unarchivable.map((w) => w.id)).toEqual(["archived"]);
+    expect(b.unsnoozable.map((w) => w.id)).toEqual(["snoozed"]);
+  });
+
+  it("respects an optimistic override over the server value", () => {
+    // Server says live, but a pending optimistic pin makes it eligible only
+    // for Unpin, not Pin.
+    const workspaces = [ws("w", {})];
+    const overlay = new Map([["w", withOverride(EMPTY_OPTIMISTIC, { pinned: true })]]);
+    const b = bucketSelectionForBulk(
+      workspaces,
+      (id) => overlay.get(id) ?? EMPTY_OPTIMISTIC,
+    );
+    expect(b.pinnable).toHaveLength(0);
+    expect(b.unpinnable.map((w) => w.id)).toEqual(["w"]);
+  });
+});
+
+describe("summarizeBulkResults", () => {
+  it("reports successes, failures, and skips", () => {
+    expect(
+      summarizeBulkResults("Archived", [
+        { ok: true },
+        { ok: true },
+        { ok: false },
+        { ok: false, skipped: true },
+      ]),
+    ).toBe("Archived 2 sessions. 1 failed. 1 skipped.");
+  });
+
+  it("uses the singular noun and omits zero counts", () => {
+    expect(summarizeBulkResults("Pinned", [{ ok: true }])).toBe(
+      "Pinned 1 session.",
+    );
+  });
+});

--- a/web/src/lib/__tests__/sidebarOptimistic.test.ts
+++ b/web/src/lib/__tests__/sidebarOptimistic.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EMPTY_OPTIMISTIC,
+  effectiveArchivedOf,
+  effectivePinnedOf,
+  effectiveSnoozedUntilOf,
+  reconcileOptimistic,
+  serverTriageOf,
+  withOverride,
+  type OptimisticTriage,
+} from "../sidebarOptimistic";
+import type { SessionResponse, Workspace } from "../types";
+
+function ws(id: string, sessions: Partial<SessionResponse>[]): Workspace {
+  return {
+    id,
+    branch: null,
+    projectPath: "/p",
+    displayName: id,
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    // serverTriageOf only reads the triage timestamps, so a partial cast is
+    // enough here and avoids restating the full SessionResponse shape.
+    sessions: sessions as SessionResponse[],
+  };
+}
+
+function override(over: Partial<OptimisticTriage>): OptimisticTriage {
+  return withOverride(EMPTY_OPTIMISTIC, over);
+}
+
+describe("effective resolvers", () => {
+  it("pin/archive override wins, null falls through to the server value", () => {
+    expect(effectivePinnedOf(override({ pinned: true }), false)).toBe(true);
+    expect(effectivePinnedOf(override({ pinned: false }), true)).toBe(false);
+    expect(effectivePinnedOf(EMPTY_OPTIMISTIC, true)).toBe(true);
+    expect(effectiveArchivedOf(override({ archived: true }), false)).toBe(true);
+    expect(effectiveArchivedOf(EMPTY_OPTIMISTIC, true)).toBe(true);
+  });
+
+  it("snooze override: undefined falls through, null and string win", () => {
+    expect(effectiveSnoozedUntilOf(EMPTY_OPTIMISTIC, "2099-01-01T00:00:00Z")).toBe(
+      "2099-01-01T00:00:00Z",
+    );
+    expect(effectiveSnoozedUntilOf(override({ snoozedUntil: null }), "x")).toBeNull();
+    expect(
+      effectiveSnoozedUntilOf(override({ snoozedUntil: "2099-01-01T00:00:00Z" }), null),
+    ).toBe("2099-01-01T00:00:00Z");
+  });
+});
+
+describe("serverTriageOf", () => {
+  it("aggregates pin/archive with `.some` and snooze with the first match", () => {
+    const w = ws("w", [
+      { pinned_at: null, archived_at: null, snoozed_until: null },
+      { pinned_at: "2026-01-01T00:00:00Z", archived_at: null, snoozed_until: "2099-01-01T00:00:00Z" },
+    ]);
+    expect(serverTriageOf(w)).toEqual({
+      isPinned: true,
+      isArchived: false,
+      snoozedUntil: "2099-01-01T00:00:00Z",
+    });
+  });
+});
+
+describe("withOverride", () => {
+  it("merges a patch, preserving unmentioned fields", () => {
+    const base = override({ pinned: true });
+    expect(withOverride(base, { archived: true })).toEqual({
+      pinned: true,
+      archived: true,
+      snoozedUntil: undefined,
+    });
+  });
+
+  it("applies an explicit null (clear) and an explicit undefined snooze", () => {
+    const base = override({ pinned: true, snoozedUntil: "2099-01-01T00:00:00Z" });
+    expect(withOverride(base, { pinned: null }).pinned).toBeNull();
+    expect(withOverride(base, { snoozedUntil: undefined }).snoozedUntil).toBeUndefined();
+  });
+});
+
+describe("reconcileOptimistic", () => {
+  it("returns the same reference when the map is empty", () => {
+    const map = new Map<string, OptimisticTriage>();
+    expect(reconcileOptimistic(map, [])).toBe(map);
+  });
+
+  it("drops a pin override the server has caught up to", () => {
+    const map = new Map([["w", override({ pinned: true })]]);
+    const next = reconcileOptimistic(map, [ws("w", [{ pinned_at: "t" }])]);
+    expect(next.has("w")).toBe(false);
+  });
+
+  it("keeps a pin override the server has not caught up to", () => {
+    const map = new Map([["w", override({ pinned: true })]]);
+    const next = reconcileOptimistic(map, [ws("w", [{ pinned_at: null }])]);
+    expect(next.get("w")?.pinned).toBe(true);
+    // No change means the same reference is returned.
+    expect(next).toBe(map);
+  });
+
+  it("drops an unsnooze override once the server reports no snooze", () => {
+    const map = new Map([["w", override({ snoozedUntil: null })]]);
+    const next = reconcileOptimistic(map, [ws("w", [{ snoozed_until: null }])]);
+    expect(next.has("w")).toBe(false);
+  });
+
+  it("drops a snooze override once the server deadline matches (within tolerance)", () => {
+    const target = "2099-01-01T00:00:00.000Z";
+    const near = "2099-01-01T00:00:30.000Z"; // 30s skew, within the 2min window
+    const map = new Map([["w", override({ snoozedUntil: target })]]);
+    const next = reconcileOptimistic(map, [ws("w", [{ snoozed_until: near }])]);
+    expect(next.has("w")).toBe(false);
+  });
+
+  it("keeps an override for a workspace that vanished from the tree", () => {
+    const map = new Map([["w", override({ archived: true })]]);
+    const next = reconcileOptimistic(map, [ws("other", [{}])]);
+    expect(next.get("w")?.archived).toBe(true);
+  });
+
+  it("clears only the caught-up field, keeping the rest of the entry", () => {
+    const map = new Map([["w", override({ pinned: true, archived: false })]]);
+    // Server caught up to the archived=false override (no archive), but not
+    // the pin. The pin override survives; the archived override is dropped.
+    const next = reconcileOptimistic(map, [ws("w", [{ pinned_at: null, archived_at: null }])]);
+    expect(next.get("w")).toEqual({
+      pinned: true,
+      archived: null,
+      snoozedUntil: undefined,
+    });
+  });
+});

--- a/web/src/lib/__tests__/sidebarSelection.test.ts
+++ b/web/src/lib/__tests__/sidebarSelection.test.ts
@@ -31,6 +31,11 @@ describe("classifyClick", () => {
     expect(classifyClick({ metaKey: true, ctrlKey: false, shiftKey: true })).toBe(
       "additive-range",
     );
+    // Ctrl+Shift on Windows/Linux is the same additive-range gesture as
+    // Cmd+Shift on macOS.
+    expect(classifyClick({ metaKey: false, ctrlKey: true, shiftKey: true })).toBe(
+      "additive-range",
+    );
   });
 });
 
@@ -78,6 +83,28 @@ describe("selectionReducer", () => {
       additive: false,
     });
     expect([...reranged.selectedIds].sort()).toEqual(["a", "b"]);
+  });
+
+  it("range re-anchors to the target when the old anchor is no longer rendered", () => {
+    // Anchor "x" scrolled out of the rendered order (collapsed group, filter).
+    // The range falls back to the clicked row AND re-anchors there, so the
+    // next Shift+click forms a real range instead of collapsing again.
+    const stale = state(["x"], "x");
+    const ranged = selectionReducer(stale, {
+      type: "range",
+      targetId: "c",
+      orderedIds: ORDER,
+      additive: false,
+    });
+    expect([...ranged.selectedIds]).toEqual(["c"]);
+    expect(ranged.anchorId).toBe("c");
+    const next = selectionReducer(ranged, {
+      type: "range",
+      targetId: "e",
+      orderedIds: ORDER,
+      additive: false,
+    });
+    expect([...next.selectedIds].sort()).toEqual(["c", "d", "e"]);
   });
 
   it("range with no anchor selects only the clicked row and sets the anchor", () => {

--- a/web/src/lib/__tests__/sidebarSelection.test.ts
+++ b/web/src/lib/__tests__/sidebarSelection.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EMPTY_SELECTION,
+  classifyClick,
+  rangeBetween,
+  selectionReducer,
+  type SidebarSelectionState,
+} from "../sidebarSelection";
+
+const ORDER = ["a", "b", "c", "d", "e"];
+
+function state(ids: string[], anchorId: string | null): SidebarSelectionState {
+  return { selectedIds: new Set(ids), anchorId };
+}
+
+describe("classifyClick", () => {
+  it("maps modifier combinations to intents", () => {
+    expect(classifyClick({ metaKey: false, ctrlKey: false, shiftKey: false })).toBe(
+      "navigate",
+    );
+    expect(classifyClick({ metaKey: true, ctrlKey: false, shiftKey: false })).toBe(
+      "toggle",
+    );
+    expect(classifyClick({ metaKey: false, ctrlKey: true, shiftKey: false })).toBe(
+      "toggle",
+    );
+    expect(classifyClick({ metaKey: false, ctrlKey: false, shiftKey: true })).toBe(
+      "range",
+    );
+    expect(classifyClick({ metaKey: true, ctrlKey: false, shiftKey: true })).toBe(
+      "additive-range",
+    );
+  });
+});
+
+describe("rangeBetween", () => {
+  it("returns an inclusive range regardless of direction", () => {
+    expect(rangeBetween(ORDER, "b", "d")).toEqual(["b", "c", "d"]);
+    expect(rangeBetween(ORDER, "d", "b")).toEqual(["b", "c", "d"]);
+  });
+
+  it("returns the single id when anchor equals target", () => {
+    expect(rangeBetween(ORDER, "c", "c")).toEqual(["c"]);
+  });
+
+  it("collapses to the target when an endpoint is missing", () => {
+    expect(rangeBetween(ORDER, "missing", "c")).toEqual(["c"]);
+    expect(rangeBetween(ORDER, "c", "missing")).toEqual(["missing"]);
+  });
+});
+
+describe("selectionReducer", () => {
+  it("toggle adds, then removes, and tracks the anchor", () => {
+    const s1 = selectionReducer(EMPTY_SELECTION, { type: "toggle", id: "b" });
+    expect([...s1.selectedIds]).toEqual(["b"]);
+    expect(s1.anchorId).toBe("b");
+    const s2 = selectionReducer(s1, { type: "toggle", id: "b" });
+    expect([...s2.selectedIds]).toEqual([]);
+    expect(s2.anchorId).toBe("b");
+  });
+
+  it("range replaces the selection from the anchor to the target", () => {
+    const anchored = selectionReducer(EMPTY_SELECTION, { type: "toggle", id: "b" });
+    const ranged = selectionReducer(anchored, {
+      type: "range",
+      targetId: "d",
+      orderedIds: ORDER,
+      additive: false,
+    });
+    expect([...ranged.selectedIds].sort()).toEqual(["b", "c", "d"]);
+    // Anchor stays put so a second Shift+click re-pivots from "b".
+    expect(ranged.anchorId).toBe("b");
+    const reranged = selectionReducer(ranged, {
+      type: "range",
+      targetId: "a",
+      orderedIds: ORDER,
+      additive: false,
+    });
+    expect([...reranged.selectedIds].sort()).toEqual(["a", "b"]);
+  });
+
+  it("range with no anchor selects only the clicked row and sets the anchor", () => {
+    const ranged = selectionReducer(EMPTY_SELECTION, {
+      type: "range",
+      targetId: "c",
+      orderedIds: ORDER,
+      additive: false,
+    });
+    expect([...ranged.selectedIds]).toEqual(["c"]);
+    expect(ranged.anchorId).toBe("c");
+  });
+
+  it("additive range unions the new range with the existing selection", () => {
+    const start = state(["a"], "a");
+    const moved = selectionReducer(start, { type: "toggle", id: "d" });
+    const added = selectionReducer(moved, {
+      type: "range",
+      targetId: "e",
+      orderedIds: ORDER,
+      additive: true,
+    });
+    expect([...added.selectedIds].sort()).toEqual(["a", "d", "e"]);
+  });
+
+  it("clear empties the selection and anchor", () => {
+    expect(selectionReducer(state(["a", "b"], "b"), { type: "clear" })).toEqual(
+      EMPTY_SELECTION,
+    );
+  });
+
+  it("prune drops ids and the anchor that no longer exist", () => {
+    const pruned = selectionReducer(state(["a", "b", "gone"], "gone"), {
+      type: "prune",
+      validIds: new Set(["a", "b"]),
+    });
+    expect([...pruned.selectedIds].sort()).toEqual(["a", "b"]);
+    expect(pruned.anchorId).toBeNull();
+  });
+
+  it("prune returns the same reference when nothing changed", () => {
+    const s = state(["a", "b"], "a");
+    expect(
+      selectionReducer(s, { type: "prune", validIds: new Set(["a", "b", "c"]) }),
+    ).toBe(s);
+  });
+});

--- a/web/src/lib/sidebarBulk.ts
+++ b/web/src/lib/sidebarBulk.ts
@@ -1,0 +1,84 @@
+import {
+  effectiveArchivedOf,
+  effectivePinnedOf,
+  effectiveSnoozedUntilOf,
+  serverTriageOf,
+  type OptimisticTriage,
+} from "./sidebarOptimistic";
+import { triageStateOf } from "./sidebarSort";
+import type { Workspace } from "./types";
+
+/** Eligible subsets of a multi-selection for each bulk triage action.
+ *  Mixed selections (live + pinned + archived + snoozed) split into
+ *  count-labelled buckets so the bulk bar can offer "Pin 3" / "Unpin 2"
+ *  rather than one ambiguous toggle, mirroring the single-row menu's
+ *  state machine (triageMenuShape). A workspace's eligibility is computed
+ *  from its effective triage state (server value overlaid with any pending
+ *  optimistic override). See #1724. */
+export interface BulkTriageBuckets {
+  /** Live rows can be pinned, archived, or snoozed. */
+  pinnable: Workspace[];
+  archivable: Workspace[];
+  snoozable: Workspace[];
+  /** Already-triaged rows offer only their inverse. */
+  unpinnable: Workspace[];
+  unarchivable: Workspace[];
+  unsnoozable: Workspace[];
+}
+
+export function bucketSelectionForBulk(
+  workspaces: readonly Workspace[],
+  optimisticFor: (workspaceId: string) => OptimisticTriage,
+): BulkTriageBuckets {
+  const buckets: BulkTriageBuckets = {
+    pinnable: [],
+    archivable: [],
+    snoozable: [],
+    unpinnable: [],
+    unarchivable: [],
+    unsnoozable: [],
+  };
+  for (const ws of workspaces) {
+    const o = optimisticFor(ws.id);
+    const server = serverTriageOf(ws);
+    const state = triageStateOf({
+      isPinned: effectivePinnedOf(o, server.isPinned),
+      isArchived: effectiveArchivedOf(o, server.isArchived),
+      isSnoozed: effectiveSnoozedUntilOf(o, server.snoozedUntil) != null,
+    });
+    switch (state) {
+      case "live":
+        buckets.pinnable.push(ws);
+        buckets.archivable.push(ws);
+        buckets.snoozable.push(ws);
+        break;
+      case "pinned":
+        buckets.unpinnable.push(ws);
+        break;
+      case "archived":
+        buckets.unarchivable.push(ws);
+        break;
+      case "snoozed":
+        buckets.unsnoozable.push(ws);
+        break;
+    }
+  }
+  return buckets;
+}
+
+/** One-line summary toast for a completed bulk action, e.g.
+ *  "Archived 12 workspaces. 2 failed." Skipped rows (no session) are folded
+ *  in only when present. */
+export function summarizeBulkResults(
+  verb: string,
+  results: readonly { ok: boolean; skipped?: boolean }[],
+): string {
+  const ok = results.filter((r) => r.ok).length;
+  const skipped = results.filter((r) => r.skipped).length;
+  const failed = results.filter((r) => !r.ok && !r.skipped).length;
+  const noun = ok === 1 ? "session" : "sessions";
+  let msg = `${verb} ${ok} ${noun}.`;
+  if (failed > 0) msg += ` ${failed} failed.`;
+  if (skipped > 0) msg += ` ${skipped} skipped.`;
+  return msg;
+}

--- a/web/src/lib/sidebarOptimistic.ts
+++ b/web/src/lib/sidebarOptimistic.ts
@@ -1,0 +1,162 @@
+import type { Workspace } from "./types";
+import { resolveEffectiveSnoozedUntil, snoozeTimestampCloseEnough } from "./sidebarSort";
+
+/** Wall-clock target for an optimistic snooze: `Date.now() + minutes *
+ *  60_000` as an RFC3339 ISO string. Sits outside any component so the
+ *  `Date.now()` call doesn't trip `react-hooks/purity`; the event handler
+ *  that calls it is itself a closure, not a render. The exact value is
+ *  throwaway (the server's response on the next poll is the source of
+ *  truth), so a few ms of jitter is harmless. See #1581. */
+export function makeOptimisticSnoozedUntil(minutes: number): string {
+  return new Date(Date.now() + minutes * 60_000).toISOString();
+}
+
+/** Optimistic triage override for a single sidebar row, keyed by workspace
+ *  id in the sidebar's overlay map. Each field mirrors the three pieces of
+ *  per-row state that used to live inside `SessionRow` as `useState`:
+ *  `pinned` / `archived` use `boolean | null` where `null` means "no
+ *  override, fall through to the server value"; `snoozedUntil` uses
+ *  `string | null | undefined` where `undefined` means "no override",
+ *  `null` means "pretend the server already unsnoozed", and a string means
+ *  "pretend the server already snoozed until then". Lifting this out of the
+ *  row is what lets a bulk action drive many rows from one place instead of
+ *  reaching into N independent row components. See #1724. */
+export interface OptimisticTriage {
+  pinned: boolean | null;
+  archived: boolean | null;
+  snoozedUntil: string | null | undefined;
+}
+
+/** A row with no optimistic override. Shared frozen singleton so rows that
+ *  are not mid-mutation all read the same object identity (keeps the
+ *  memoized `SessionRow` from re-rendering on unrelated overlay changes). */
+export const EMPTY_OPTIMISTIC: OptimisticTriage = Object.freeze({
+  pinned: null,
+  archived: null,
+  snoozedUntil: undefined,
+});
+
+/** Server-truth triage aggregates for a workspace, matching the exact
+ *  per-row aggregators the sidebar renders with: pin/archive use `.some`
+ *  across the workspace's sessions, snooze takes the first session that
+ *  carries a `snoozed_until`. Kept here so the overlay reconciler and the
+ *  row render agree on the same baseline. */
+export function serverTriageOf(ws: Workspace): {
+  isPinned: boolean;
+  isArchived: boolean;
+  snoozedUntil: string | null;
+} {
+  return {
+    isPinned: ws.sessions.some((s) => s.pinned_at != null),
+    isArchived: ws.sessions.some((s) => s.archived_at != null),
+    snoozedUntil:
+      ws.sessions.find((s) => s.snoozed_until)?.snoozed_until ?? null,
+  };
+}
+
+export function effectivePinnedOf(
+  optimistic: OptimisticTriage,
+  serverPinned: boolean,
+): boolean {
+  return optimistic.pinned ?? serverPinned;
+}
+
+export function effectiveArchivedOf(
+  optimistic: OptimisticTriage,
+  serverArchived: boolean,
+): boolean {
+  return optimistic.archived ?? serverArchived;
+}
+
+export function effectiveSnoozedUntilOf(
+  optimistic: OptimisticTriage,
+  serverSnoozedUntil: string | null | undefined,
+): string | null | undefined {
+  return resolveEffectiveSnoozedUntil(optimistic.snoozedUntil, serverSnoozedUntil);
+}
+
+/** True when an override has been caught up to by the server and can be
+ *  dropped. Mirrors the three per-field reconciliation effects that used to
+ *  live in `SessionRow`: a boolean override clears once it equals the
+ *  server value; a snooze override clears when both sides are unsnoozed or
+ *  both point at the same deadline (within the close-enough tolerance). */
+function fieldCaughtUp<T>(override: T | null, server: T): boolean {
+  return override !== null && override === server;
+}
+
+function snoozeCaughtUp(
+  override: string | null | undefined,
+  server: string | null,
+): boolean {
+  if (override === undefined) return false;
+  if (override === null) return server == null;
+  return server != null && snoozeTimestampCloseEnough(override, server);
+}
+
+/** Given the current overlay map and the latest workspaces, return a new map
+ *  with any override the server has caught up to removed, dropping rows whose
+ *  every field has reconciled. Returns the SAME map reference when nothing
+ *  changed so callers can skip a state update (avoids a render loop when used
+ *  from an effect). Pure: no React, fully unit-testable. */
+export function reconcileOptimistic(
+  map: ReadonlyMap<string, OptimisticTriage>,
+  workspaces: readonly Workspace[],
+): Map<string, OptimisticTriage> {
+  if (map.size === 0) return map as Map<string, OptimisticTriage>;
+  const serverById = new Map<string, ReturnType<typeof serverTriageOf>>();
+  for (const ws of workspaces) {
+    if (!serverById.has(ws.id)) serverById.set(ws.id, serverTriageOf(ws));
+  }
+  let changed = false;
+  const next = new Map<string, OptimisticTriage>();
+  for (const [id, override] of map) {
+    const server = serverById.get(id);
+    // Workspace vanished from the tree: keep the override until it either
+    // reappears (and reconciles) or the consumer prunes it; dropping it
+    // here would make a row flicker back to a stale state mid-refresh.
+    if (!server) {
+      next.set(id, override);
+      continue;
+    }
+    const pinned = fieldCaughtUp(override.pinned, server.isPinned)
+      ? null
+      : override.pinned;
+    const archived = fieldCaughtUp(override.archived, server.isArchived)
+      ? null
+      : override.archived;
+    const snoozedUntil = snoozeCaughtUp(override.snoozedUntil, server.snoozedUntil)
+      ? undefined
+      : override.snoozedUntil;
+    if (
+      pinned !== override.pinned ||
+      archived !== override.archived ||
+      snoozedUntil !== override.snoozedUntil
+    ) {
+      changed = true;
+    }
+    if (pinned === null && archived === null && snoozedUntil === undefined) {
+      changed = true;
+      continue;
+    }
+    next.set(id, { pinned, archived, snoozedUntil });
+  }
+  return changed ? next : (map as Map<string, OptimisticTriage>);
+}
+
+/** Merge a partial override into an existing entry, preserving the fields the
+ *  patch does not mention. Used by both single-row and bulk mutations to set
+ *  the optimistic state before the request lands. */
+export function withOverride(
+  prev: OptimisticTriage | undefined,
+  patch: Partial<OptimisticTriage>,
+): OptimisticTriage {
+  return {
+    pinned: patch.pinned !== undefined ? patch.pinned : (prev?.pinned ?? null),
+    archived:
+      patch.archived !== undefined ? patch.archived : (prev?.archived ?? null),
+    snoozedUntil:
+      "snoozedUntil" in patch
+        ? patch.snoozedUntil
+        : prev?.snoozedUntil ?? undefined,
+  };
+}

--- a/web/src/lib/sidebarSelection.ts
+++ b/web/src/lib/sidebarSelection.ts
@@ -78,9 +78,14 @@ export function selectionReducer(
       return { selectedIds: next, anchorId: action.id };
     }
     case "range": {
-      // Pivot from the existing anchor; if there is none, the clicked row
-      // becomes the anchor and the "range" is just that row.
-      const anchor = state.anchorId ?? action.targetId;
+      // Pivot from the existing anchor; if there is none, or it scrolled out
+      // of the rendered order (collapsed group, filter), re-anchor on the
+      // clicked row so the next Shift+click forms a range from here instead
+      // of repeatedly collapsing to a single row.
+      const anchor =
+        state.anchorId != null && action.orderedIds.includes(state.anchorId)
+          ? state.anchorId
+          : action.targetId;
       const range = rangeBetween(action.orderedIds, anchor, action.targetId);
       const next = action.additive
         ? new Set([...state.selectedIds, ...range])

--- a/web/src/lib/sidebarSelection.ts
+++ b/web/src/lib/sidebarSelection.ts
@@ -1,0 +1,107 @@
+// Pure selection model for the sidebar's multi-select (Shift+click range,
+// Cmd/Ctrl+click additive toggle). Kept free of React so the gesture
+// semantics are unit-testable, mirroring how sidebarSort.ts holds the pure
+// sort/triage helpers. Selection is keyed by workspace id (rows are workspace
+// rows); resolution to a session id happens at action time. See #1724.
+
+export interface SidebarSelectionState {
+  /** Currently selected workspace ids. */
+  selectedIds: ReadonlySet<string>;
+  /** Pivot for Shift+click range selection: the last row the user toggled or
+   *  the start of the most recent range. `null` when there is no selection. */
+  anchorId: string | null;
+}
+
+export const EMPTY_SELECTION: SidebarSelectionState = {
+  selectedIds: new Set<string>(),
+  anchorId: null,
+};
+
+/** What a row click means, derived purely from its modifier keys. The parent
+ *  classifies the event and dispatches the matching reducer action (and, for
+ *  `navigate`, also performs route navigation). Mac uses Cmd, Windows/Linux
+ *  use Ctrl; both map to the additive toggle. */
+export type ClickIntent = "navigate" | "toggle" | "range" | "additive-range";
+
+export function classifyClick(modifiers: {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+}): ClickIntent {
+  const mod = modifiers.metaKey || modifiers.ctrlKey;
+  if (modifiers.shiftKey) return mod ? "additive-range" : "range";
+  if (mod) return "toggle";
+  return "navigate";
+}
+
+/** Inclusive id range between `anchorId` and `targetId` within the rendered
+ *  order. Direction-agnostic (anchor may be above or below the target). If
+ *  either endpoint is missing from `orderedIds` (e.g. it scrolled into a
+ *  collapsed group since the anchor was set) the range collapses to just the
+ *  target, which is the least surprising fallback. */
+export function rangeBetween(
+  orderedIds: readonly string[],
+  anchorId: string,
+  targetId: string,
+): string[] {
+  const a = orderedIds.indexOf(anchorId);
+  const b = orderedIds.indexOf(targetId);
+  if (a === -1 || b === -1) return [targetId];
+  const [start, end] = a <= b ? [a, b] : [b, a];
+  return orderedIds.slice(start, end + 1);
+}
+
+export type SidebarSelectionAction =
+  | { type: "toggle"; id: string }
+  | {
+      type: "range";
+      targetId: string;
+      orderedIds: readonly string[];
+      /** Add the range to the existing selection instead of replacing it
+       *  (Shift+Cmd/Ctrl). */
+      additive: boolean;
+    }
+  | { type: "clear" }
+  | { type: "prune"; validIds: ReadonlySet<string> };
+
+export function selectionReducer(
+  state: SidebarSelectionState,
+  action: SidebarSelectionAction,
+): SidebarSelectionState {
+  switch (action.type) {
+    case "toggle": {
+      const next = new Set(state.selectedIds);
+      if (next.has(action.id)) next.delete(action.id);
+      else next.add(action.id);
+      // Anchor follows the toggled row so a subsequent Shift+click ranges
+      // from here.
+      return { selectedIds: next, anchorId: action.id };
+    }
+    case "range": {
+      // Pivot from the existing anchor; if there is none, the clicked row
+      // becomes the anchor and the "range" is just that row.
+      const anchor = state.anchorId ?? action.targetId;
+      const range = rangeBetween(action.orderedIds, anchor, action.targetId);
+      const next = action.additive
+        ? new Set([...state.selectedIds, ...range])
+        : new Set(range);
+      // Anchor stays put so repeated Shift+clicks re-pivot from the same
+      // origin, matching Finder / file-manager behavior.
+      return { selectedIds: next, anchorId: anchor };
+    }
+    case "clear":
+      return EMPTY_SELECTION;
+    case "prune": {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of state.selectedIds) {
+        if (action.validIds.has(id)) next.add(id);
+        else changed = true;
+      }
+      const anchorValid = state.anchorId != null && action.validIds.has(state.anchorId);
+      if (!anchorValid && state.anchorId != null) changed = true;
+      if (!changed) return state;
+      return { selectedIds: next, anchorId: anchorValid ? state.anchorId : null };
+    }
+  }
+}

--- a/web/src/lib/toastBus.ts
+++ b/web/src/lib/toastBus.ts
@@ -15,3 +15,7 @@ export const toastBus: ToastBus = { handler: null };
 export function reportError(message: string): void {
   toastBus.handler?.error(message);
 }
+
+export function reportInfo(message: string): void {
+  toastBus.handler?.info(message);
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2740,6 +2740,44 @@
       ]
     },
     {
+      "id": "sidebar.multi-select-logic",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/lib/__tests__/sidebarSelection.test.ts",
+        "src/lib/__tests__/sidebarOptimistic.test.ts",
+        "src/lib/__tests__/sidebarBulk.test.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/BulkActionBar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.multi-select-gestures",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/sidebar-multi-select.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/BulkActionBar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.bulk-triage-live",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/sidebar-bulk-triage.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/BulkActionBar.tsx"
+      ]
+    },
+    {
       "id": "triage.cockpit-banners",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/live/sidebar-bulk-triage.spec.ts
+++ b/web/tests/live/sidebar-bulk-triage.spec.ts
@@ -1,0 +1,67 @@
+// Live coverage for sidebar multi-select bulk triage (#1724):
+//   - Cmd/Ctrl+click selects two session rows without navigating.
+//   - The bulk bar's "Archive" fans out one PATCH per selected session.
+//   - Both sessions get `archived_at` set on the server and sink into the
+//     collapsible "Snoozed & archived" footer.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+base.describe("sidebar bulk archive via multi-select (#1724)", () => {
+  base("selecting two rows and bulk-archiving persists both", async ({
+    page,
+  }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: (env) => {
+        seedSessionViaAoeAdd({ title: "alpha", subdir: "proj-a" })(env);
+        seedSessionViaAoeAdd({ title: "beta", subdir: "proj-b" })(env);
+      },
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      expect(sessions).toHaveLength(2);
+
+      await page.goto(`${serve.baseUrl}/`);
+      const rows = page.locator("[data-testid='sidebar-session-row']");
+      await expect(rows).toHaveCount(2, { timeout: 10_000 });
+
+      // Cmd/Ctrl+click both rows into the selection; neither click should
+      // navigate to a session route.
+      await rows.nth(0).click({ modifiers: ["ControlOrMeta"] });
+      await rows.nth(1).click({ modifiers: ["ControlOrMeta"] });
+      expect(page.url()).not.toContain("/session/");
+
+      const bar = page.locator("[data-testid='sidebar-bulk-bar']");
+      await expect(bar).toContainText("2 selected");
+
+      await page.locator("[data-testid='sidebar-bulk-archive']").click();
+
+      // Both sessions are archived on the server (serial fan-out).
+      await expect
+        .poll(
+          async () => {
+            const list = await listSessions(serve.baseUrl);
+            return list.filter((s) => s.archived_at).length;
+          },
+          { timeout: 10_000 },
+        )
+        .toBe(2);
+
+      // Selection clears and the rows sink into the collapsible footer.
+      await expect(bar).toHaveCount(0, { timeout: 5_000 });
+      await expect(
+        page.locator("[data-testid='sidebar-sunk-section']"),
+      ).toBeVisible({ timeout: 5_000 });
+    } finally {
+      await serve.stop();
+    }
+  });
+});

--- a/web/tests/sidebar-multi-select.spec.ts
+++ b/web/tests/sidebar-multi-select.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+
+// Mocked coverage for sidebar multi-select gestures (#1724):
+//   - Cmd/Ctrl+click toggles a row into the selection without navigating.
+//   - Shift+click selects a contiguous range across the rendered rows.
+//   - The bulk bar then fans out one PATCH per selected session.
+
+interface MockSession {
+  id: string;
+  title: string;
+  project_path: string;
+}
+
+async function mockApis(page: Page, sessions: MockSession[]) {
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: sessions.map((s) => ({
+          id: s.id,
+          title: s.title,
+          project_path: s.project_path,
+          group_path: s.project_path,
+          tool: "claude",
+          status: "Idle",
+          yolo_mode: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: null,
+          idle_entered_at: null,
+          last_error: null,
+          branch: null,
+          main_repo_path: null,
+          is_sandboxed: false,
+          has_terminal: true,
+          profile: "default",
+          workspace_repos: [],
+        })),
+        workspace_ordering: [],
+      },
+    });
+  });
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: path === "docker/status" ? {} : [] }),
+    );
+  }
+}
+
+const THREE: MockSession[] = [
+  { id: "s-1", title: "Mongols", project_path: "/tmp/repo-a" },
+  { id: "s-2", title: "Goths", project_path: "/tmp/repo-b" },
+  { id: "s-3", title: "Persians", project_path: "/tmp/repo-c" },
+];
+
+test.describe("Sidebar multi-select (#1724)", () => {
+  test("Cmd/Ctrl+click toggles selection without navigating", async ({
+    page,
+  }) => {
+    await mockApis(page, THREE);
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const rows = page.locator("[data-testid='sidebar-session-row']");
+    await expect(rows).toHaveCount(3);
+
+    // Additive toggle on two rows; the bulk bar reflects the count and the
+    // route never changes to a /session/ path.
+    await rows.nth(0).click({ modifiers: ["ControlOrMeta"] });
+    await rows.nth(1).click({ modifiers: ["ControlOrMeta"] });
+
+    const bar = page.locator("[data-testid='sidebar-bulk-bar']");
+    await expect(bar).toBeVisible();
+    await expect(bar).toContainText("2 selected");
+    expect(page.url()).not.toContain("/session/");
+
+    // Toggling the first row off drops it back out of the selection.
+    await rows.nth(0).click({ modifiers: ["ControlOrMeta"] });
+    await expect(bar).toContainText("1 selected");
+
+    // Clear empties the selection and hides the bar.
+    await page.locator("[data-testid='sidebar-bulk-clear']").click();
+    await expect(bar).toHaveCount(0);
+  });
+
+  test("Shift+click range selects every row in between, then bulk archives", async ({
+    page,
+  }) => {
+    await mockApis(page, THREE);
+    const archived: Array<{ id: string; body: unknown }> = [];
+    await page.route("**/api/sessions/*/archive", (r) => {
+      const m = r.request().url().match(/\/api\/sessions\/([^/]+)\/archive$/);
+      archived.push({ id: m?.[1] ?? "?", body: r.request().postDataJSON() });
+      return r.fulfill({ json: { id: m?.[1] ?? "?", archived_at: "now" } });
+    });
+
+    await page.goto("/");
+    const rows = page.locator("[data-testid='sidebar-session-row']");
+    await expect(rows).toHaveCount(3);
+
+    // Anchor on the first row (Cmd+click avoids navigating), then Shift+click
+    // the last to select the contiguous range.
+    await rows.nth(0).click({ modifiers: ["ControlOrMeta"] });
+    await rows.nth(2).click({ modifiers: ["Shift"] });
+
+    const bar = page.locator("[data-testid='sidebar-bulk-bar']");
+    await expect(bar).toContainText("3 selected");
+
+    const archiveBtn = page.locator("[data-testid='sidebar-bulk-archive']");
+    await expect(archiveBtn).toContainText("Archive 3");
+    await archiveBtn.click();
+
+    // Serial fan-out hits all three sessions with the archive payload.
+    await expect.poll(() => archived.length).toBe(3);
+    expect(archived.map((a) => a.id).sort()).toEqual(["s-1", "s-2", "s-3"]);
+    for (const a of archived) {
+      expect(a.body).toEqual({ archived: true, kill_pane: true });
+    }
+    // Selection clears once the bulk action completes.
+    await expect(bar).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds multi-select to the web dashboard sidebar so several sessions can be triaged in one pass instead of opening each row's context menu one at a time.

Selection uses the standard gestures: `Cmd/Ctrl+click` toggles a row in or out of the selection without navigating, `Shift+click` selects the contiguous range across the rendered rows, and a plain click still clears the selection and opens that session. While a selection is active, a bulk action bar appears above the list with count-split, eligibility-aware actions: Pin / Archive / Snooze apply to the live rows, Unpin / Unarchive / Unsnooze to their already-triaged counterparts, so a mixed selection never shows a contradictory toggle. Snooze offers the same duration presets as the single-row menu.

The bulk actions are best-effort, not atomic: they fan out the existing single-id `pin` / `archive` / `snooze` PATCH endpoints serially (serial keeps the per-profile persist from racing), apply the optimistic overlay so rows flip immediately, then report one summary toast (succeeded / failed / skipped) and clear the selection. No new server endpoints: keeping the bulk handlers thin leaves a clean path to dedicated bulk routes later if scale ever calls for it.

The enabling change is structural: triage optimistic state and the mutation calls used to live inside each `SessionRow` as per-row `useState`, which a bulk toolbar cannot drive cleanly. That state moved into a sidebar-scoped controller (`useSidebarTriage`) keyed by workspace id, with the pure overlay and selection logic extracted to `sidebarOptimistic.ts` / `sidebarSelection.ts` for unit testing; `SessionRow` is now a presentational consumer. Single-row triage behavior is unchanged. Range selection spans only visible rows (collapsed groups and the collapsed footer contribute nothing, a filter trims to matches), and the selection is ephemeral: it survives collapse and filtering, is dropped only when a session stops existing, and is hidden in read-only mode.

Closes #1724

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the dashboard with at least two sessions. `Cmd/Ctrl+click` two rows and confirm a bulk bar appears reading "2 selected" and neither click navigated to a session.
- [ ] `Shift+click` a row a few positions away from another selected row and confirm every row in between becomes selected.
- [ ] With several live rows selected, click **Archive N** and confirm all of them sink into the "Snoozed & archived" footer and a summary toast appears.
- [ ] Select a mix of live, pinned, and snoozed rows and confirm the bar splits into count-labelled buttons (e.g. "Pin 2", "Unpin 1", "Unsnooze 1") instead of one ambiguous toggle, and that an action only affects its compatible rows.
- [ ] Collapse a group or type in the filter while rows are selected and confirm the selection is preserved; delete a selected session elsewhere and confirm it drops out of the selection.
- [ ] Run `aoe serve --read-only` and confirm no bulk bar appears.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Mocked Playwright (`web/tests/sidebar-multi-select.spec.ts`) covers the Cmd/Ctrl toggle-without-navigation and the Shift range plus bulk-archive fan-out payloads; live Playwright (`web/tests/live/sidebar-bulk-triage.spec.ts`) drives two seeded sessions through select + bulk archive and asserts both persist. Vitest covers the pure selection reducer, optimistic overlay/reconcile, and bulk bucketing/summary logic.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (pressure-tested with a multi-model design debate), and implementation were drafted by Claude under my direction. I made the design calls, including choosing client-side fan-out over new bulk endpoints for this PR, and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request adds **multi-select and bulk triage capabilities** to the web dashboard sidebar, enabling users to select multiple session rows and perform batch operations (Pin, Archive, Snooze) without opening individual context menus.

### What Was Added

- **New bulk action bar component** (`BulkActionBar.tsx`) that appears when rows are selected, displaying action buttons with eligibility-aware counts (e.g., "Pin 2" vs "Unpin 1") and a dropdown snooze menu
- **Selection model and gesture support** via `sidebarSelection.ts` with Cmd/Ctrl+click to toggle rows, Shift+click for contiguous range selection, and plain click to navigate (when no multi-selection is active)
- **Triage state management hook** (`useSidebarTriage.ts`) that centralizes pin/archive/snooze logic with optimistic overlays and serial bulk mutation execution
- **Helper utilities** for optimistic state tracking (`sidebarOptimistic.ts`), bulk bucketing and result summarization (`sidebarBulk.ts`), and selection state reduction (`sidebarSelection.ts`)
- **Comprehensive test coverage** including unit tests for selection, optimistic overlays, and bulk logic; mocked and live Playwright specs validating gesture semantics and end-to-end bulk flows
- **Documentation** in the dashboard guide explaining multi-select mechanics, action eligibility, and selection persistence

### What Changed

- **`WorkspaceSidebar.tsx`** refactored to manage sidebar-level selection state and triage operations instead of per-row state, wiring bulk bar visibility and action callbacks
- **`SessionRow` component** converted from interactive (with built-in mutation calls) to presentational—now accepts selection state, optimistic overrides, and action callbacks from the sidebar controller
- **Existing tests** updated to integrate with the new sidebar-owned triage hook (`SessionRowTriage.test.tsx`, `WorkdirNameEdit.test.tsx`)

### What Was Removed

- Per-row `useState` for triage state and mutations (now centralized in `useSidebarTriage`)
- Per-row PATCH call logic from `SessionRow` (delegated to sidebar controller)

### Benefits

- **Improved batch workflows**: Users can triage multiple sessions in one action without repetitive menu interactions
- **Optimistic updates**: UI reflects changes immediately with client-side overlays, improving perceived responsiveness
- **Extensible architecture**: Pure helper functions and a dedicated hook make testing and future server-side bulk endpoints straightforward
- **Non-breaking**: Existing single-row behavior and accessibility are preserved; bulk UI is hidden in read-only mode; selection survives collapse/filter but clears on session removal
- **No new server endpoints**: Bulk actions use existing single-session PATCH endpoints (serial, best-effort fan-out)

---

## Technical Details

**Architecture changes:**
- Moved triage state (optimistic overlays) from per-row components to a workspace-scoped `useSidebarTriage` hook keyed by workspace ID
- Extracted pure helpers for selection logic (`selectionReducer`, `rangeBetween`, `classifyClick`), optimistic reconciliation (`reconcileOptimistic`, effective-field combinators), and bulk action grouping (`bucketSelectionForBulk`)
- `SessionRow` now accepts callbacks (`onActivate` for modifier-key-aware navigation, `onPin/Archive/Snooze` for triage) and optimistic state (`optimistic: OptimisticTriage`) rather than managing its own mutations

**Selection semantics:**
- Range selection (`rangeBetween`) respects visible rendered order, ignoring collapsed groups and the footer; single-element ranges when anchor equals target
- Selection state pruned automatically when a workspace is removed; anchor reset if it becomes invalid
- Selection persists across collapse/filter operations but clears on reload

**Bulk mutation execution:**
- Serial (non-concurrent) PATCH calls via `runBulk` helper to avoid race conditions
- Optimistic overlays applied before each request, rolled back on failure
- Single summary toast with count-aware singular/plural formatting ("1 session" vs "2 sessions")

**Optimistic reconciliation:**
- `reconcileOptimistic` removes overrides once server catches up, with snooze deadline matching using `snoozeTimestampCloseEnough` tolerance
- `withOverride` merges partial patch objects while preserving unmentioned fields and respecting null/undefined clear semantics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->