### PR TITLE
feat(cockpit): opt-in auto-resume after rate-limit reset

### DIFF
--- a/docs/cockpit/troubleshooting.md
+++ b/docs/cockpit/troubleshooting.md
@@ -136,8 +136,25 @@ Stopping the agent while a tool call is mid-execution settles that tool's card t
 When the active ACP backend reports `errorKind: "rate_limit"` on `session/prompt` (Claude's adapter does this when the Anthropic account is over its limit), aoe treats this as a non-crash terminal state rather than as a worker crash:
 
 - The connection task emits a typed `RateLimit` event (which the dashboard banner reads to show the reset time) and a `Stopped { reason: "rate_limited" }` lifecycle event, then exits cleanly.
-- The supervisor drops the worker handle and does NOT respawn. Earlier behaviour respawned the runner inside the restart budget, then immediately hit the same limit on the next `session/prompt` and burned the budget. The session now sits parked until the user explicitly retries or hands off.
-- `aoe serve` restart while a session is parked respects the `Stopped { reason: "rate_limited" }` signal in the on-disk event log and does NOT auto-resume the worker; otherwise daemon restart at minute 30 of a 90-minute window would undo the fix.
+- The supervisor drops the worker handle and does NOT respawn. Earlier behaviour respawned the runner inside the restart budget, then immediately hit the same limit on the next `session/prompt` and burned the budget. By default the session now sits parked until the user explicitly retries or hands off.
+- `aoe serve` restart while a session is parked respects the `Stopped { reason: "rate_limited" }` signal in the on-disk event log and does NOT auto-resume the worker by default; otherwise daemon restart at minute 30 of a 90-minute window would undo the fix.
+
+#### Optional auto-resume after reset
+
+If you would rather stay on the same backend and have AoE pick the session back up automatically once the limit clears, enable the opt-in setting (off by default):
+
+```toml
+[cockpit]
+rate_limit_auto_resume = true
+rate_limit_auto_resume_grace_secs = 15   # cushion added to the reported reset time
+```
+
+Both knobs are editable in the cockpit settings (TUI and web dashboard, under "Advanced") and can be overridden per profile. When enabled, the reconciler watches a parked session and, once the adapter-reported `resets_at` (plus the grace) has passed, publishes a `RateLimitAutoResumed` breadcrumb and respawns the same worker through the normal resume path. Any prompt you queued during the wait is dispatched once the worker is back. Notes:
+
+- The reset time is read from the persisted `RateLimit` event, so the timer survives an `aoe serve` restart: a daemon that comes up after the window has elapsed resumes on its next reconciler pass, and one that comes up mid-window keeps waiting.
+- It is vendor-agnostic. Any ACP backend that reports `errorKind: "rate_limit"` is eligible, not just Claude.
+- It does not reintroduce a restart loop. If the resumed worker hits the limit again, the adapter reports a fresh `resets_at` and auto-resume waits for that new window. A hardcoded minimum park window also applies, so a misbehaving adapter that reports a reset in the past (or a zero grace) still cannot drive a tight respawn.
+- The manual "Continue in another agent" and reconnect paths below stay available regardless of the setting.
 
 The rate-limit banner offers a primary "Continue in another agent" CTA. Clicking it opens a modal that lists the cockpit ACP registry (claude / codex / opencode / gemini / vibe / pi / aoe-agent by default, plus anything you've added via the settings TUI) and preselects `codex` when installed. Picking a target calls `POST /api/sessions/{id}/cockpit/switch-agent`, which:
 

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -864,6 +864,7 @@ fn event_kind(event: &crate::cockpit::Event) -> &'static str {
         Event::ThinkingStarted => "thinking_started",
         Event::ThinkingEnded => "thinking_ended",
         Event::RateLimit { .. } => "rate_limit",
+        Event::RateLimitAutoResumed { .. } => "rate_limit_auto_resumed",
         Event::UsageUpdated { .. } => "usage_updated",
         Event::ModeChanged { .. } => "mode_changed",
         Event::ModesAvailable { .. } => "modes_available",

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -2479,4 +2479,73 @@ mod tests {
         // Unrelated session must not bleed into the query.
         assert!(store.unresolved_approval_nonces("s-2").is_empty());
     }
+
+    fn rate_limit_event(secs_until_reset: i64) -> Event {
+        Event::RateLimit {
+            info: RateLimitInfo {
+                status: "usage limit reached".into(),
+                resets_at: Utc::now() + chrono::Duration::seconds(secs_until_reset),
+                kind: "rate_limit".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn latest_rate_limit_event_returns_most_recent_with_recorded_at() {
+        let (_tmp, store) = open_store(1000);
+        let before = Utc::now().timestamp_millis();
+        store.record("s-1", 1, &rate_limit_event(3600)).unwrap();
+        // A second, later rate limit supersedes the first (new resets_at).
+        let second = rate_limit_event(7200);
+        let Event::RateLimit { info: ref expected } = second else {
+            unreachable!()
+        };
+        let expected_resets = expected.resets_at;
+        store.record("s-1", 2, &second).unwrap();
+        let after = Utc::now().timestamp_millis();
+
+        let (info, recorded_at) = store
+            .latest_rate_limit_event("s-1")
+            .expect("a rate-limit event is stored");
+        assert_eq!(info.resets_at, expected_resets, "latest event wins");
+        assert!(
+            recorded_at >= before && recorded_at <= after,
+            "recorded_at ({recorded_at}) is the row's created_at within [{before}, {after}]"
+        );
+        // A session with no rate-limit event returns None.
+        assert!(store.latest_rate_limit_event("s-2").is_none());
+    }
+
+    #[test]
+    fn rate_limit_auto_resumed_supersedes_stopped_in_latest_status() {
+        let (_tmp, store) = open_store(1000);
+        store.record("s-1", 1, &rate_limit_event(60)).unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::Stopped {
+                    reason: "rate_limited".into(),
+                },
+            )
+            .unwrap();
+        // While parked, the latest status is the rate-limit Stopped.
+        assert!(matches!(
+            store.latest_status_event("s-1"),
+            Some(Event::Stopped { reason }) if reason == "rate_limited"
+        ));
+        // The auto-resume breadcrumb must become the latest status event so
+        // the reconciler's resume loop stops seeing the park. See #1722.
+        let resets_at = Utc::now();
+        store
+            .record("s-1", 3, &Event::RateLimitAutoResumed { resets_at })
+            .unwrap();
+        assert!(
+            matches!(
+                store.latest_status_event("s-1"),
+                Some(Event::RateLimitAutoResumed { .. })
+            ),
+            "RateLimitAutoResumed must supersede Stopped{{rate_limited}}"
+        );
+    }
 }

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -1028,8 +1028,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let placeholders = std::iter::repeat("?")
-            .take(session_ids.len())
+        let placeholders = std::iter::repeat_n("?", session_ids.len())
             .collect::<Vec<_>>()
             .join(",");
         // Exclude non-substantive lifecycle/metadata events so they do not

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -55,7 +55,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 use tracing::{debug, trace, warn};
 
 use super::approvals::Nonce;
-use super::state::{Event, Plan};
+use super::state::{Event, Plan, RateLimitInfo};
 
 /// Externally-tagged JSON discriminants for non-substantive cockpit
 /// events: lifecycle and metadata snapshots the agent emits once per
@@ -541,6 +541,40 @@ impl EventStore {
         }
     }
 
+    /// Return the most recent `Event::RateLimit` stored for `session_id`
+    /// together with the wall-clock millis it was recorded (the
+    /// `created_at` row column). The reconciler's rate-limit auto-resume
+    /// pass reads this to decide whether `resets_at + grace` has elapsed,
+    /// using `created_at` as the floor for a minimum park window so a
+    /// buggy adapter reporting a past `resets_at` cannot trigger a tight
+    /// respawn loop. Latest event wins (a re-rate-limit supersedes the
+    /// prior reset time). See #1722.
+    pub fn latest_rate_limit_event(&self, session_id: &str) -> Option<(RateLimitInfo, i64)> {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let row: Option<(String, i64)> = conn
+            .query_row(
+                "SELECT event_json, created_at FROM cockpit_events
+                 WHERE session_id = ?1
+                   AND event_json LIKE '{\"RateLimit\":%'
+                 ORDER BY seq DESC LIMIT 1",
+                params![session_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+            .ok()
+            .flatten();
+        let (json, created_at) = row?;
+        let event: Event = serde_json::from_str(&json).ok()?;
+        if let Event::RateLimit { info } = event {
+            Some((info, created_at))
+        } else {
+            None
+        }
+    }
+
     /// Return the most recent unfired `WakeupScheduled` for `session_id`.
     /// "Pending" means the latest scheduled `at` is still in the future;
     /// the previous heuristic (any `UserPromptSent` with a higher seq
@@ -838,6 +872,14 @@ impl EventStore {
     /// cockpit events don't survive restart, so without this scan a
     /// session that was mid-turn when the previous daemon died would
     /// render Idle until the next lifecycle event arrived. See #1103.
+    ///
+    /// `RateLimitAutoResumed` is included deliberately: the rate-limit
+    /// auto-resume reconciler pass publishes it to supersede the terminal
+    /// `Stopped{rate_limited}`, so this query stops reporting the park and
+    /// the main resume loop falls through to a fresh spawn instead of
+    /// re-parking. A new status event added here also participates in
+    /// park supersession; keep that in mind before extending the set. See
+    /// #1722.
     pub fn latest_status_event(&self, session_id: &str) -> Option<Event> {
         let conn = match self.conn.lock() {
             Ok(g) => g,
@@ -851,6 +893,7 @@ impl EventStore {
                      OR json_extract(event_json, '$.ApprovalRequested') IS NOT NULL
                      OR json_extract(event_json, '$.ApprovalResolved') IS NOT NULL
                      OR json_extract(event_json, '$.Stopped') IS NOT NULL
+                     OR json_extract(event_json, '$.RateLimitAutoResumed') IS NOT NULL
                      OR json_extract(event_json, '$.AgentStartupError') IS NOT NULL)
                  ORDER BY seq DESC
                  LIMIT 1",
@@ -1223,6 +1266,7 @@ fn event_kind(event: &Event) -> &'static str {
         Event::ThinkingStarted => "thinking_started",
         Event::ThinkingEnded => "thinking_ended",
         Event::RateLimit { .. } => "rate_limit",
+        Event::RateLimitAutoResumed { .. } => "rate_limit_auto_resumed",
         Event::UsageUpdated { .. } => "usage_updated",
         Event::ModeChanged { .. } => "mode_changed",
         Event::ModesAvailable { .. } => "modes_available",

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -532,6 +532,16 @@ pub enum Event {
     RateLimit {
         info: RateLimitInfo,
     },
+    /// Opt-in auto-resume breadcrumb. Published by the reconciler (not the
+    /// agent) when a session parked on `Stopped { reason: "rate_limited" }`
+    /// crosses its reset deadline and `cockpit.rate_limit_auto_resume` is
+    /// enabled, just before the same worker is respawned. Carries the
+    /// `resets_at` that gated the resume so the timeline can show why the
+    /// worker came back, and so the web reducer can clear the rate-limit
+    /// lock and drain any queued prompt. See #1722.
+    RateLimitAutoResumed {
+        resets_at: DateTime<Utc>,
+    },
     /// Agent-reported context-window usage. Comes from ACP
     /// `SessionUpdate::UsageUpdate` (gated on the
     /// `unstable_session_usage` schema feature). Latest snapshot wins;
@@ -832,6 +842,11 @@ impl CockpitState {
             }
             Event::ThinkingEnded => self.thinking = None,
             Event::RateLimit { info } => self.rate_limit = Some(info),
+            // Auto-resume fired: the park is over and a fresh worker is
+            // being respawned. Clear the rate-limit snapshot so a client
+            // seeding state from the store (or the persistent reducer)
+            // doesn't keep showing the parked banner after the resume.
+            Event::RateLimitAutoResumed { .. } => self.rate_limit = None,
             Event::UsageUpdated { usage } => self.usage = Some(usage),
             Event::ModeChanged { mode } => self.mode = mode,
             // ModesAvailable + CurrentModeChanged carry the real ACP-

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -1342,4 +1342,26 @@ mod tests {
         assert_eq!(u.used, 5_000);
         assert_eq!(u.cost.as_ref().unwrap().currency, "USD");
     }
+
+    #[test]
+    fn rate_limit_auto_resumed_clears_rate_limit_snapshot() {
+        let mut s = fresh_state();
+        s.apply_event(Event::RateLimit {
+            info: RateLimitInfo {
+                status: "usage limit reached".into(),
+                resets_at: Utc::now(),
+                kind: "rate_limit".into(),
+            },
+        })
+        .unwrap();
+        assert!(s.rate_limit.is_some(), "RateLimit seeds the park snapshot");
+        s.apply_event(Event::RateLimitAutoResumed {
+            resets_at: Utc::now(),
+        })
+        .unwrap();
+        assert!(
+            s.rate_limit.is_none(),
+            "RateLimitAutoResumed must clear the rate-limit snapshot"
+        );
+    }
 }

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -702,6 +702,26 @@ impl<S: BroadcastSink> Supervisor<S> {
         seq
     }
 
+    /// Publish a `RateLimitAutoResumed` breadcrumb for a session the
+    /// reconciler is about to auto-respawn after a rate-limit park. The
+    /// `resets_at` is the adapter-reported reset time that gated the
+    /// resume. This event doubles as the supersede marker: it becomes the
+    /// session's latest status event (see `latest_status_event`'s filter),
+    /// so the next reconciler tick no longer sees `Stopped{rate_limited}`
+    /// and falls through to a fresh spawn instead of re-parking. The web
+    /// reducer also keys off it to clear the rate-limit banner and drain a
+    /// queued prompt. See #1722.
+    pub fn publish_rate_limit_auto_resumed(
+        &self,
+        session_id: &str,
+        resets_at: chrono::DateTime<chrono::Utc>,
+    ) -> u64 {
+        let seq = next_seq(&self.next_seqs, session_id);
+        self.sink
+            .publish(session_id, seq, &Event::RateLimitAutoResumed { resets_at });
+        seq
+    }
+
     /// Like `shutdown` but waits for the runner process to actually exit
     /// before returning, so a subsequent `spawn` for the same session id
     /// doesn't race the SIGTERM and collide on the worker socket file.

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -3820,6 +3820,32 @@ mod tests {
         assert_eq!(drained_seq, 2, "drain seq must follow startup-error seq");
     }
 
+    /// `publish_rate_limit_auto_resumed` must emit a `RateLimitAutoResumed`
+    /// carrying the exact `resets_at` and allocate monotonic per-session
+    /// seqs, so the reconciler breadcrumb supersedes `Stopped{rate_limited}`
+    /// in the replay/store ordering. See #1722.
+    #[tokio::test]
+    async fn publish_rate_limit_auto_resumed_emits_event_with_monotonic_seq() {
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink.clone());
+        let resets_at = chrono::Utc::now();
+
+        let seq1 = sup.publish_rate_limit_auto_resumed("s-rl", resets_at);
+        let seq2 = sup.publish_rate_limit_auto_resumed("s-rl", resets_at);
+        assert_eq!(seq1, 1);
+        assert_eq!(seq2, 2, "seq must be monotonic per session");
+
+        let frames = sink.frames.lock().unwrap();
+        let first = frames
+            .iter()
+            .find(|(sid, seq, _)| sid == "s-rl" && *seq == 1)
+            .expect("first breadcrumb frame published");
+        assert!(matches!(
+            &first.2,
+            Event::RateLimitAutoResumed { resets_at: ts } if *ts == resets_at
+        ));
+    }
+
     /// `with_capacity` enforces the configured cap. Past the cap,
     /// new spawns return `CapacityFull` instead of starting another
     /// worker. The error must include `current` and `limit` so the

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -644,6 +644,26 @@ const RATE_LIMIT_MIN_PARK_SECS: i64 = 30;
 /// event store, never from memory. A re-rate-limit writes a fresh
 /// `RateLimit` event with a new `resets_at`, so the next auto-resume waits
 /// for the new window rather than looping.
+/// Wall-clock instant at which a rate-limit-parked session becomes
+/// eligible for auto-resume: the later of the adapter-reported reset
+/// (plus the configured grace) and a hardcoded minimum park measured from
+/// when the `RateLimit` event was recorded. The floor keeps a buggy
+/// adapter that reports a past `resets_at` (or a zero grace) from driving
+/// a tight respawn loop. See #1722.
+fn rate_limit_resume_at(
+    resets_at: chrono::DateTime<chrono::Utc>,
+    recorded_at_ms: i64,
+    grace_secs: u32,
+) -> chrono::DateTime<chrono::Utc> {
+    let resets_plus_grace = resets_at + chrono::Duration::seconds(i64::from(grace_secs));
+    match chrono::DateTime::from_timestamp_millis(recorded_at_ms)
+        .map(|t| t + chrono::Duration::seconds(RATE_LIMIT_MIN_PARK_SECS))
+    {
+        Some(floor) if floor > resets_plus_grace => floor,
+        _ => resets_plus_grace,
+    }
+}
+
 async fn reap_rate_limit_resumes(state: &Arc<AppState>, attempted: &mut HashSet<String>) {
     // Candidates: cockpit sessions currently parked (recorded in
     // `attempted`, no live worker). Snapshot (id, profile) under the read
@@ -746,15 +766,7 @@ async fn reap_rate_limit_resumes(state: &Arc<AppState>, attempted: &mut HashSet<
         let Some((info, recorded_at_ms)) = rate_limit else {
             continue;
         };
-        // resume_at = max(resets_at + grace, recorded_at + MIN_PARK).
-        let resets_plus_grace = info.resets_at + chrono::Duration::seconds(i64::from(grace_secs));
-        let resume_at = match chrono::DateTime::from_timestamp_millis(recorded_at_ms)
-            .map(|t| t + chrono::Duration::seconds(RATE_LIMIT_MIN_PARK_SECS))
-        {
-            Some(floor) if floor > resets_plus_grace => floor,
-            _ => resets_plus_grace,
-        };
-        if now < resume_at {
+        if now < rate_limit_resume_at(info.resets_at, recorded_at_ms, grace_secs) {
             continue;
         }
         // Eligible: publish the breadcrumb (supersedes Stopped{rate_limited})
@@ -1170,7 +1182,11 @@ async fn sweep_orphan_workers(state: &Arc<AppState>, live: &HashSet<&String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{adopt_decision, should_auto_stop, AdoptDecision};
+    use super::{
+        adopt_decision, rate_limit_resume_at, should_auto_stop, AdoptDecision,
+        RATE_LIMIT_MIN_PARK_SECS,
+    };
+    use chrono::{Duration, TimeZone, Utc};
 
     const HOUR_MS: i64 = 3_600_000;
 
@@ -1215,6 +1231,38 @@ mod tests {
             AdoptDecision::FreshSpawn
         );
         assert_eq!(adopt_decision(false, true, true), AdoptDecision::FreshSpawn);
+    }
+
+    #[test]
+    fn resume_at_is_reset_plus_grace_when_far_in_future() {
+        // A reset an hour out dominates the 30s recorded-at floor, so the
+        // resume instant is exactly resets_at + grace.
+        let recorded_at = Utc.timestamp_opt(1_000_000, 0).unwrap();
+        let resets_at = recorded_at + Duration::hours(1);
+        let got = rate_limit_resume_at(resets_at, recorded_at.timestamp_millis(), 15);
+        assert_eq!(got, resets_at + Duration::seconds(15));
+    }
+
+    #[test]
+    fn resume_at_floors_on_recorded_at_for_past_reset() {
+        // Adapter reported a reset in the past with zero grace; without the
+        // floor this would resume immediately. The floor pins it to
+        // recorded_at + MIN_PARK so there is no tight respawn loop.
+        let recorded_at = Utc.timestamp_opt(2_000_000, 0).unwrap();
+        let resets_at = recorded_at - Duration::seconds(5); // already elapsed
+        let got = rate_limit_resume_at(resets_at, recorded_at.timestamp_millis(), 0);
+        assert_eq!(
+            got,
+            recorded_at + Duration::seconds(RATE_LIMIT_MIN_PARK_SECS)
+        );
+    }
+
+    #[test]
+    fn resume_at_grace_wins_when_above_floor() {
+        // resets_at == recorded_at, grace 120s > 30s floor: grace wins.
+        let recorded_at = Utc.timestamp_opt(3_000_000, 0).unwrap();
+        let got = rate_limit_resume_at(recorded_at, recorded_at.timestamp_millis(), 120);
+        assert_eq!(got, recorded_at + Duration::seconds(120));
     }
 
     #[test]

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -769,6 +769,15 @@ async fn reap_rate_limit_resumes(state: &Arc<AppState>, attempted: &mut HashSet<
         if now < rate_limit_resume_at(info.resets_at, recorded_at_ms, grace_secs) {
             continue;
         }
+        // Re-check liveness right before publishing: several awaits sit
+        // between the candidate snapshot and here, so a manual
+        // `/cockpit/spawn` could have brought the worker back in the gap.
+        // Without this guard we would emit a spurious auto-resume
+        // breadcrumb (and clear `attempted`) for an already-running
+        // session. Let the manual resume win. See #1722.
+        if state.cockpit_supervisor.is_running(&id).await {
+            continue;
+        }
         // Eligible: publish the breadcrumb (supersedes Stopped{rate_limited})
         // and free the `attempted` slot so the main resume loop spawns a
         // fresh worker this tick.

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -81,6 +81,7 @@ pub async fn reconcile_cockpit_workers(
     state: &Arc<AppState>,
     attempted: &mut HashSet<String>,
     last_idle_reap: &mut Option<std::time::Instant>,
+    last_rate_limit_reap: &mut Option<std::time::Instant>,
 ) {
     // Honor `cockpit.enabled = false` from config.toml — the persistent
     // master switch. Mirrored as an atomic; `PATCH /api/cockpit/master`
@@ -125,6 +126,18 @@ pub async fn reconcile_cockpit_workers(
     if last_idle_reap.is_none_or(|t| t.elapsed() >= IDLE_REAP_INTERVAL) {
         reap_idle_workers(state).await;
         *last_idle_reap = Some(std::time::Instant::now());
+    }
+
+    // Rate-limit auto-resume (#1722). Cadence-gated like the idle reaper:
+    // reset windows are long, so probing every 2s tick is wasteful. Runs
+    // BEFORE the resume snapshot so a session whose reset just elapsed is
+    // un-parked (breadcrumb published + cleared from `attempted`) in time
+    // for this same tick's spawn pass to bring its worker back. The pass is
+    // a no-op for the default-off case: profiles that did not opt in are
+    // dropped before any event-store probe.
+    if last_rate_limit_reap.is_none_or(|t| t.elapsed() >= RATE_LIMIT_RESUME_INTERVAL) {
+        reap_rate_limit_resumes(state, attempted).await;
+        *last_rate_limit_reap = Some(std::time::Instant::now());
     }
 
     // Snapshot per-target resume inputs under the instances read lock.
@@ -596,6 +609,167 @@ fn adopt_decision(live: bool, build_current: bool, in_flight_turn: bool) -> Adop
         AdoptDecision::AdoptStaleForDrain
     } else {
         AdoptDecision::RespawnStaleIdle
+    }
+}
+
+/// How often the rate-limit auto-resume pass runs. Reset windows are
+/// minutes to hours, so the 2s reconciler tick would re-probe far more
+/// often than needed; this gates it to a coarse cadence. See #1722.
+const RATE_LIMIT_RESUME_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Hardcoded floor on the park window, measured from when the `RateLimit`
+/// event was recorded. A misbehaving adapter could report a `resets_at`
+/// already in the past (or with `grace_secs == 0`); without this floor the
+/// reconciler would respawn the worker on the very next pass and could
+/// thrash if the adapter keeps emitting past resets. 30s preserves the
+/// spirit of the #1281 "no eager restart loop" fix. See #1722.
+const RATE_LIMIT_MIN_PARK_SECS: i64 = 30;
+
+/// Opt-in rate-limit auto-resume pass (#1722). For cockpit sessions parked
+/// on `Stopped { reason: "rate_limited" }` whose profile enabled
+/// `cockpit.rate_limit_auto_resume`, respawn the worker once the
+/// adapter-reported `resets_at` (plus the configured grace, floored by
+/// `RATE_LIMIT_MIN_PARK_SECS` from when the limit was recorded) has passed.
+///
+/// Mechanism: publish a `RateLimitAutoResumed` breadcrumb (which supersedes
+/// the terminal `Stopped{rate_limited}` in `latest_status_event`) and clear
+/// the id from `attempted`. The main resume loop on the same tick then sees
+/// a non-park latest status and a clear `attempted` slot, so it fresh-spawns
+/// the worker through the existing path. Both the in-process park (id was
+/// inserted into `attempted` while the worker ran) and the daemon-restart
+/// park (the main loop parks it on the first tick) are covered because the
+/// candidate set is exactly `attempted` minus running workers.
+///
+/// Durable across daemon restart: `resets_at` is read from the persisted
+/// event store, never from memory. A re-rate-limit writes a fresh
+/// `RateLimit` event with a new `resets_at`, so the next auto-resume waits
+/// for the new window rather than looping.
+async fn reap_rate_limit_resumes(state: &Arc<AppState>, attempted: &mut HashSet<String>) {
+    // Candidates: cockpit sessions currently parked (recorded in
+    // `attempted`, no live worker). Snapshot (id, profile) under the read
+    // lock so we don't hold it across awaits. Archived/snoozed/dormant
+    // sessions are excluded for the same reasons as the resume snapshot.
+    let candidates: Vec<(String, String)> = {
+        let instances = state.instances.read().await;
+        instances
+            .iter()
+            .filter(|i| {
+                i.cockpit_mode
+                    && !i.is_archived()
+                    && !i.is_snoozed()
+                    && !i.is_idle_dormant()
+                    && attempted.contains(&i.id)
+            })
+            .map(|i| (i.id.clone(), i.source_profile.clone()))
+            .collect()
+    };
+    if candidates.is_empty() {
+        return;
+    }
+    // Only sessions without a live worker are parked; a running worker in
+    // `attempted` is the steady-state perf entry, not a park.
+    let mut parked: Vec<(String, String)> = Vec::new();
+    for (id, profile) in candidates {
+        if !state.cockpit_supervisor.is_running(&id).await {
+            parked.push((id, profile));
+        }
+    }
+    if parked.is_empty() {
+        return;
+    }
+    // Resolve the auto-resume config per distinct profile off-thread (it
+    // touches disk). Sessions on a profile that did not opt in are dropped
+    // before any per-session event-store probe, so the feature is free for
+    // the default-off case.
+    let distinct_profiles: Vec<String> = {
+        let mut seen = HashSet::new();
+        parked
+            .iter()
+            .map(|(_, p)| p.clone())
+            .filter(|p| seen.insert(p.clone()))
+            .collect()
+    };
+    let cfg_by_profile: std::collections::HashMap<String, (bool, u32)> =
+        tokio::task::spawn_blocking(move || {
+            distinct_profiles
+                .into_iter()
+                .map(|p| {
+                    let cockpit =
+                        crate::session::profile_config::resolve_config_or_warn(&p).cockpit;
+                    (
+                        p,
+                        (
+                            cockpit.rate_limit_auto_resume,
+                            cockpit.rate_limit_auto_resume_grace_secs,
+                        ),
+                    )
+                })
+                .collect()
+        })
+        .await
+        .unwrap_or_default();
+
+    let now = chrono::Utc::now();
+    for (id, profile) in parked {
+        let (enabled, grace_secs) = cfg_by_profile.get(&profile).copied().unwrap_or((false, 0));
+        if !enabled {
+            continue;
+        }
+        // Confirm the session is actually parked on a rate-limit stop (not
+        // some other terminal state that happens to sit in `attempted`) and
+        // read the reset time, both off-thread.
+        let store = Arc::clone(&state.cockpit_event_store);
+        let id_probe = id.clone();
+        let (is_rate_limit_parked, rate_limit) = match tokio::task::spawn_blocking(move || {
+            let parked = matches!(
+                store.latest_status_event(&id_probe),
+                Some(crate::cockpit::Event::Stopped { reason }) if reason == "rate_limited"
+            );
+            (parked, store.latest_rate_limit_event(&id_probe))
+        })
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    target: "cockpit.supervisor",
+                    session = %id,
+                    error = %e,
+                    "rate-limit auto-resume probe failed"
+                );
+                continue;
+            }
+        };
+        if !is_rate_limit_parked {
+            continue;
+        }
+        let Some((info, recorded_at_ms)) = rate_limit else {
+            continue;
+        };
+        // resume_at = max(resets_at + grace, recorded_at + MIN_PARK).
+        let resets_plus_grace = info.resets_at + chrono::Duration::seconds(i64::from(grace_secs));
+        let resume_at = match chrono::DateTime::from_timestamp_millis(recorded_at_ms)
+            .map(|t| t + chrono::Duration::seconds(RATE_LIMIT_MIN_PARK_SECS))
+        {
+            Some(floor) if floor > resets_plus_grace => floor,
+            _ => resets_plus_grace,
+        };
+        if now < resume_at {
+            continue;
+        }
+        // Eligible: publish the breadcrumb (supersedes Stopped{rate_limited})
+        // and free the `attempted` slot so the main resume loop spawns a
+        // fresh worker this tick.
+        state
+            .cockpit_supervisor
+            .publish_rate_limit_auto_resumed(&id, info.resets_at);
+        attempted.remove(&id);
+        tracing::info!(
+            target: "cockpit.supervisor",
+            session = %id,
+            resets_at = %info.resets_at,
+            "rate-limit auto-resume: reset window elapsed; respawning worker"
+        );
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1621,6 +1621,8 @@ async fn status_poll_loop(state: Arc<AppState>) {
         std::collections::HashSet::new();
     #[cfg(feature = "serve")]
     let mut last_idle_reap: Option<std::time::Instant> = None;
+    #[cfg(feature = "serve")]
+    let mut last_rate_limit_reap: Option<std::time::Instant> = None;
     loop {
         interval.tick().await;
 
@@ -1753,6 +1755,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
                 &state,
                 &mut attempted_cockpit_spawns,
                 &mut last_idle_reap,
+                &mut last_rate_limit_reap,
             )
             .await;
         }
@@ -2430,6 +2433,10 @@ pub(crate) fn derive_cockpit_status(event: &crate::cockpit::Event) -> Option<Sta
         // Running/Waiting turn (a respawn during an active turn
         // would otherwise stop the spinner mid-stream).
         Event::AcpSessionAssigned { .. } => Some(StatusIntent::HealError),
+        // Auto-resume after a rate-limit park: the worker is coming back.
+        // Heal any sticky error so the sidebar dot recovers; the imminent
+        // fresh spawn emits AcpSessionAssigned and live events right after.
+        Event::RateLimitAutoResumed { .. } => Some(StatusIntent::HealError),
         _ => None,
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2522,6 +2522,15 @@ mod tests {
             }),
             Some(StatusIntent::HealError)
         );
+        // Rate-limit auto-resume breadcrumb heals like AcpSessionAssigned:
+        // the worker is coming back, so clear a sticky error without
+        // clobbering an in-progress turn. See #1722.
+        assert_eq!(
+            derive_cockpit_status(&Event::RateLimitAutoResumed {
+                resets_at: chrono::Utc::now()
+            }),
+            Some(StatusIntent::HealError)
+        );
     }
 
     #[cfg(feature = "serve")]

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -312,6 +312,34 @@ pub struct CockpitConfig {
     /// #1689.
     #[serde(default = "default_auto_stop_idle_secs")]
     pub auto_stop_idle_secs: u32,
+    /// Opt-in auto-resume after a provider usage/rate-limit reset. When a
+    /// cockpit worker stops with `Stopped { reason: "rate_limited" }`, the
+    /// session is parked and (by default) waits for explicit user
+    /// recovery via `/cockpit/spawn` or agent handoff (the #1281
+    /// behavior). With this enabled, the reconciler instead respawns the
+    /// same worker automatically once the adapter-reported reset time
+    /// (plus `rate_limit_auto_resume_grace_secs`) has passed, publishing a
+    /// `RateLimitAutoResumed` breadcrumb for timeline clarity. Resume
+    /// timing is read from the persisted `RateLimit` event, so it survives
+    /// a daemon restart; a re-rate-limit writes a fresh reset time, so
+    /// there is no tight restart loop. Vendor-agnostic: any ACP backend
+    /// that reports `kind == "rate_limit"` is eligible. Default false,
+    /// preserving the manual-first behavior. See #1722.
+    #[serde(default)]
+    pub rate_limit_auto_resume: bool,
+    /// Seconds added to the adapter-reported `resets_at` before
+    /// auto-resume fires, to absorb clock skew and adapter jitter. Only
+    /// meaningful when `rate_limit_auto_resume` is true. Default 15. The
+    /// reconciler also enforces a hardcoded minimum park window from the
+    /// moment the rate limit was recorded, so a buggy adapter reporting a
+    /// past `resets_at` with grace 0 still cannot cause a tight respawn
+    /// loop. See #1722.
+    #[serde(default = "default_rate_limit_auto_resume_grace_secs")]
+    pub rate_limit_auto_resume_grace_secs: u32,
+}
+
+fn default_rate_limit_auto_resume_grace_secs() -> u32 {
+    15
 }
 
 fn default_auto_stop_idle_secs() -> u32 {
@@ -384,6 +412,8 @@ impl Default for CockpitConfig {
             silent_orphan_grace_secs: default_silent_orphan_grace_secs(),
             silent_orphan_fast_grace_secs: default_silent_orphan_fast_grace_secs(),
             auto_stop_idle_secs: default_auto_stop_idle_secs(),
+            rate_limit_auto_resume: false,
+            rate_limit_auto_resume_grace_secs: default_rate_limit_auto_resume_grace_secs(),
         }
     }
 }

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -98,6 +98,10 @@ pub struct CockpitConfigOverride {
     pub silent_orphan_fast_grace_secs: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_stop_idle_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit_auto_resume: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit_auto_resume_grace_secs: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -662,6 +666,12 @@ pub fn merge_configs(mut global: Config, profile: &ProfileConfig) -> Config {
         }
         if let Some(v) = cockpit_override.auto_stop_idle_secs {
             global.cockpit.auto_stop_idle_secs = v;
+        }
+        if let Some(v) = cockpit_override.rate_limit_auto_resume {
+            global.cockpit.rate_limit_auto_resume = v;
+        }
+        if let Some(v) = cockpit_override.rate_limit_auto_resume_grace_secs {
+            global.cockpit.rate_limit_auto_resume_grace_secs = v;
         }
     }
 

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -426,9 +426,19 @@ impl CockpitTranscript {
                 // renderer is followup work (see the no-op group below).
                 self.turn_active = false;
             }
+            Event::RateLimitAutoResumed { resets_at } => {
+                // Timeline breadcrumb: the reconciler auto-resumed the
+                // worker after the rate-limit reset elapsed. Surface it so
+                // the transcript explains why the agent came back on its
+                // own. See #1722.
+                self.flush_pending_chunk();
+                self.rows.push(ActivityRow::Note {
+                    kind: NoteKind::Info,
+                    text: format!("auto-resumed after rate-limit reset ({resets_at})"),
+                });
+            }
             Event::DiffEmitted { .. }
             | Event::RateLimit { .. }
-            | Event::RateLimitAutoResumed { .. }
             | Event::UsageUpdated { .. }
             | Event::RawAgentUpdate { .. }
             | Event::WakeupScheduled { .. }

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -428,6 +428,7 @@ impl CockpitTranscript {
             }
             Event::DiffEmitted { .. }
             | Event::RateLimit { .. }
+            | Event::RateLimitAutoResumed { .. }
             | Event::UsageUpdated { .. }
             | Event::RawAgentUpdate { .. }
             | Event::WakeupScheduled { .. }

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -742,6 +742,15 @@ fn build_cockpit_fields(
             inherited_display: None,
         },
         SettingField {
+            key: FieldKey::CockpitRateLimitAutoResume,
+            label: "Auto-resume after rate limit",
+            description: "When a cockpit worker stops because the provider reported a usage/rate limit, automatically respawn it once the reported reset time has passed instead of waiting for manual recovery. Default off, which keeps the parked-until-you-act behavior. Vendor-agnostic: any ACP backend reporting a rate limit is eligible. The reset time is read from the stored event, so the timer survives a daemon restart. See #1722.",
+            value: FieldValue::Bool(rate_limit_auto_resume),
+            category: SettingsCategory::Cockpit,
+            has_override: rlar_override,
+            inherited_display: None,
+        },
+        SettingField {
             key: FieldKey::SectionMarker,
             label: "Advanced",
             description: "Operational tuning, rarely needed after first setup. Adjust only if you've read the description and know what you're changing.",
@@ -826,15 +835,6 @@ fn build_cockpit_fields(
             value: FieldValue::Number(u64::from(auto_stop_idle_secs)),
             category: SettingsCategory::Cockpit,
             has_override: asis_override,
-            inherited_display: None,
-        },
-        SettingField {
-            key: FieldKey::CockpitRateLimitAutoResume,
-            label: "Auto-resume after rate limit",
-            description: "When a cockpit worker stops because the provider reported a usage/rate limit, automatically respawn it once the reported reset time has passed instead of waiting for manual recovery. Default off, which keeps the parked-until-you-act behavior. Vendor-agnostic: any ACP backend reporting a rate limit is eligible. The reset time is read from the stored event, so the timer survives a daemon restart. See #1722.",
-            value: FieldValue::Bool(rate_limit_auto_resume),
-            category: SettingsCategory::Cockpit,
-            has_override: rlar_override,
             inherited_display: None,
         },
         SettingField {
@@ -3931,6 +3931,7 @@ mod tests {
             FieldKey::CockpitReplayEvents,
             FieldKey::CockpitNodePath,
             FieldKey::CockpitShowToolDurations,
+            FieldKey::CockpitRateLimitAutoResume,
         ];
         for k in common_keys {
             let pos = fields.iter().position(|f| f.key == k).unwrap();
@@ -3952,7 +3953,6 @@ mod tests {
             FieldKey::CockpitSilentOrphanGraceSecs,
             FieldKey::CockpitSilentOrphanFastGraceSecs,
             FieldKey::CockpitAutoStopIdleSecs,
-            FieldKey::CockpitRateLimitAutoResume,
             FieldKey::CockpitRateLimitAutoResumeGraceSecs,
         ];
         for k in advanced_keys {

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -162,6 +162,8 @@ pub enum FieldKey {
     CockpitSilentOrphanGraceSecs,
     CockpitSilentOrphanFastGraceSecs,
     CockpitAutoStopIdleSecs,
+    CockpitRateLimitAutoResume,
+    CockpitRateLimitAutoResumeGraceSecs,
     // Logging
     LoggingDefaultLevel,
     /// Per-target override; carries an index into `crate::logging::KNOWN_SUB_TARGETS`
@@ -673,6 +675,16 @@ fn build_cockpit_fields(
         global.cockpit.auto_stop_idle_secs,
         p.and_then(|c| c.auto_stop_idle_secs),
     );
+    let (rate_limit_auto_resume, rlar_override) = resolve_value(
+        scope,
+        global.cockpit.rate_limit_auto_resume,
+        p.and_then(|c| c.rate_limit_auto_resume),
+    );
+    let (rate_limit_auto_resume_grace_secs, rlargs_override) = resolve_value(
+        scope,
+        global.cockpit.rate_limit_auto_resume_grace_secs,
+        p.and_then(|c| c.rate_limit_auto_resume_grace_secs),
+    );
 
     vec![
         SettingField {
@@ -814,6 +826,24 @@ fn build_cockpit_fields(
             value: FieldValue::Number(u64::from(auto_stop_idle_secs)),
             category: SettingsCategory::Cockpit,
             has_override: asis_override,
+            inherited_display: None,
+        },
+        SettingField {
+            key: FieldKey::CockpitRateLimitAutoResume,
+            label: "Auto-resume after rate limit",
+            description: "When a cockpit worker stops because the provider reported a usage/rate limit, automatically respawn it once the reported reset time has passed instead of waiting for manual recovery. Default off, which keeps the parked-until-you-act behavior. Vendor-agnostic: any ACP backend reporting a rate limit is eligible. The reset time is read from the stored event, so the timer survives a daemon restart. See #1722.",
+            value: FieldValue::Bool(rate_limit_auto_resume),
+            category: SettingsCategory::Cockpit,
+            has_override: rlar_override,
+            inherited_display: None,
+        },
+        SettingField {
+            key: FieldKey::CockpitRateLimitAutoResumeGraceSecs,
+            label: "Auto-resume grace (s)",
+            description: "Seconds added to the reported reset time before auto-resume fires, to absorb clock skew and adapter jitter. Only used when \"Auto-resume after rate limit\" is on. Default 15. A hardcoded minimum park window also applies, so a zero grace cannot cause a tight respawn loop. See #1722.",
+            value: FieldValue::Number(u64::from(rate_limit_auto_resume_grace_secs)),
+            category: SettingsCategory::Cockpit,
+            has_override: rlargs_override,
             inherited_display: None,
         },
     ]
@@ -2919,6 +2949,12 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::CockpitAutoStopIdleSecs, FieldValue::Number(v)) => {
             config.cockpit.auto_stop_idle_secs = (*v).min(u32::MAX as u64) as u32;
         }
+        (FieldKey::CockpitRateLimitAutoResume, FieldValue::Bool(v)) => {
+            config.cockpit.rate_limit_auto_resume = *v
+        }
+        (FieldKey::CockpitRateLimitAutoResumeGraceSecs, FieldValue::Number(v)) => {
+            config.cockpit.rate_limit_auto_resume_grace_secs = (*v).min(u32::MAX as u64) as u32;
+        }
         // Logging
         (FieldKey::LoggingDefaultLevel, FieldValue::Select { selected, options }) => {
             if let Some(level) = options.get(*selected) {
@@ -3473,6 +3509,17 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 s.auto_stop_idle_secs = val
             });
         }
+        (FieldKey::CockpitRateLimitAutoResume, FieldValue::Bool(v)) => {
+            set_profile_override(*v, &mut config.cockpit, |s, val| {
+                s.rate_limit_auto_resume = val
+            });
+        }
+        (FieldKey::CockpitRateLimitAutoResumeGraceSecs, FieldValue::Number(v)) => {
+            let clamped = (*v).min(u32::MAX as u64) as u32;
+            set_profile_override(clamped, &mut config.cockpit, |s, val| {
+                s.rate_limit_auto_resume_grace_secs = val
+            });
+        }
         (FieldKey::HostEnvironment, FieldValue::List(v)) => {
             // Empty list clears the override (no env entries); otherwise store
             // the list as the profile-scope replacement of the global list.
@@ -3905,6 +3952,8 @@ mod tests {
             FieldKey::CockpitSilentOrphanGraceSecs,
             FieldKey::CockpitSilentOrphanFastGraceSecs,
             FieldKey::CockpitAutoStopIdleSecs,
+            FieldKey::CockpitRateLimitAutoResume,
+            FieldKey::CockpitRateLimitAutoResumeGraceSecs,
         ];
         for k in advanced_keys {
             let pos = fields.iter().position(|f| f.key == k).unwrap();

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -1073,6 +1073,16 @@ impl SettingsView {
                     c.auto_stop_idle_secs = None;
                 }
             }
+            FieldKey::CockpitRateLimitAutoResume => {
+                if let Some(c) = config.cockpit.as_mut() {
+                    c.rate_limit_auto_resume = None;
+                }
+            }
+            FieldKey::CockpitRateLimitAutoResumeGraceSecs => {
+                if let Some(c) = config.cockpit.as_mut() {
+                    c.rate_limit_auto_resume_grace_secs = None;
+                }
+            }
             // Logging is global-only for v1 (no profile overrides); the
             // "clear override" gesture is a no-op for these keys.
             // SessionIdPollerMaxThreads and ConfirmBeforeQuit are also

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -736,6 +736,15 @@ function CockpitSettings({
         </button>
       </div>
 
+      <div className="border-t border-surface-800 pt-3">
+        <ToggleField
+          label="Auto-resume after rate limit"
+          description="When a cockpit worker stops because the provider reported a usage/rate limit, automatically respawn it once the reported reset time has passed instead of waiting for manual recovery. Off by default (the session stays parked until you act). Vendor-agnostic: any ACP backend that reports a rate limit is eligible. The reset time is read from the stored event, so the timer survives a daemon restart. Persists to config.toml as cockpit.rate_limit_auto_resume; cross-device. See #1722."
+          checked={(cockpit.rate_limit_auto_resume as boolean) ?? false}
+          onChange={(v) => onSaveField("cockpit", "rate_limit_auto_resume", v)}
+        />
+      </div>
+
       <div className="flex items-start justify-between gap-3 py-1 border-t border-surface-800 pt-3">
         <div>
           <div className="text-sm text-text-bright">Queue drain mode</div>
@@ -836,12 +845,6 @@ function CockpitSettings({
           }
           min={0}
           onChange={(v) => onSaveField("cockpit", "auto_stop_idle_secs", v)}
-        />
-        <ToggleField
-          label="Auto-resume after rate limit"
-          description="When a cockpit worker stops because the provider reported a usage/rate limit, automatically respawn it once the reported reset time has passed instead of waiting for manual recovery. Off by default (the session stays parked until you act). Vendor-agnostic: any ACP backend that reports a rate limit is eligible. The reset time is read from the stored event, so the timer survives a daemon restart. Persists to config.toml as cockpit.rate_limit_auto_resume; cross-device. See #1722."
-          checked={(cockpit.rate_limit_auto_resume as boolean) ?? false}
-          onChange={(v) => onSaveField("cockpit", "rate_limit_auto_resume", v)}
         />
         <NumberField
           label="Auto-resume grace (s)"

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -837,6 +837,25 @@ function CockpitSettings({
           min={0}
           onChange={(v) => onSaveField("cockpit", "auto_stop_idle_secs", v)}
         />
+        <ToggleField
+          label="Auto-resume after rate limit"
+          description="When a cockpit worker stops because the provider reported a usage/rate limit, automatically respawn it once the reported reset time has passed instead of waiting for manual recovery. Off by default (the session stays parked until you act). Vendor-agnostic: any ACP backend that reports a rate limit is eligible. The reset time is read from the stored event, so the timer survives a daemon restart. Persists to config.toml as cockpit.rate_limit_auto_resume; cross-device. See #1722."
+          checked={(cockpit.rate_limit_auto_resume as boolean) ?? false}
+          onChange={(v) => onSaveField("cockpit", "rate_limit_auto_resume", v)}
+        />
+        <NumberField
+          label="Auto-resume grace (s)"
+          description="Seconds added to the reported reset time before auto-resume fires, to absorb clock skew and adapter jitter. Only used when 'Auto-resume after rate limit' is on. Default 15. A hardcoded minimum park window also applies, so a zero grace cannot cause a tight respawn loop. Persists to config.toml as cockpit.rate_limit_auto_resume_grace_secs; cross-device. See #1722."
+          value={
+            typeof cockpit.rate_limit_auto_resume_grace_secs === "number"
+              ? (cockpit.rate_limit_auto_resume_grace_secs as number)
+              : 15
+          }
+          min={0}
+          onChange={(v) =>
+            onSaveField("cockpit", "rate_limit_auto_resume_grace_secs", v)
+          }
+        />
       </CollapsibleSection>
 
       {error && <div className="text-xs text-rose-400">{error}</div>}

--- a/web/src/components/__tests__/SettingsView.folds.test.tsx
+++ b/web/src/components/__tests__/SettingsView.folds.test.tsx
@@ -200,6 +200,11 @@ describe("Settings Advanced fold", () => {
       fieldInputByLabel(container, "Auto-stop idle workers (s)", "number"),
       "28800",
     );
+    commit(
+      fieldInputByLabel(container, "Auto-resume grace (s)", "number"),
+      "20",
+    );
+    clickToggle(container, "Auto-resume after rate limit");
 
     await waitFor(() =>
       expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith(
@@ -212,6 +217,12 @@ describe("Settings Advanced fold", () => {
     });
     expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
       cockpit: { auto_stop_idle_secs: 28800 },
+    });
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      cockpit: { rate_limit_auto_resume_grace_secs: 20 },
+    });
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      cockpit: { rate_limit_auto_resume: true },
     });
   });
 

--- a/web/src/components/__tests__/SettingsView.folds.test.tsx
+++ b/web/src/components/__tests__/SettingsView.folds.test.tsx
@@ -204,7 +204,6 @@ describe("Settings Advanced fold", () => {
       fieldInputByLabel(container, "Auto-resume grace (s)", "number"),
       "20",
     );
-    clickToggle(container, "Auto-resume after rate limit");
 
     await waitFor(() =>
       expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith(
@@ -220,9 +219,6 @@ describe("Settings Advanced fold", () => {
     });
     expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
       cockpit: { rate_limit_auto_resume_grace_secs: 20 },
-    });
-    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
-      cockpit: { rate_limit_auto_resume: true },
     });
   });
 
@@ -240,11 +236,18 @@ describe("Settings Advanced fold", () => {
     ) as HTMLButtonElement;
     fireEvent.click(serial);
 
+    // Rate-limit auto-resume is a high-level toggle now: reachable without
+    // expanding the Advanced fold. See #1722.
+    clickToggle(container, "Auto-resume after rate limit");
+
     await waitFor(() =>
       expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
         cockpit: { queue_drain_mode: "serial" },
       }),
     );
+    expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+      cockpit: { rate_limit_auto_resume: true },
+    });
   });
 
   it("expands the worktree fold and saves every advanced field", async () => {

--- a/web/src/hooks/useCockpit.queue.test.ts
+++ b/web/src/hooks/useCockpit.queue.test.ts
@@ -603,6 +603,89 @@ describe("useCockpit drain race (#1144)", () => {
     expect(result.current.state.queuedPrompts).toEqual([]);
   });
 
+  it("drains a queued prompt only after rate-limit auto-resume (#1722)", async () => {
+    // Worker is absent while parked on a rate limit; once the daemon
+    // auto-resumes (breadcrumb clears the banner, REST poll flips the
+    // worker to running, AcpSessionAssigned lands) the drain effect must
+    // dispatch the prompt the user queued during the wait, and not before.
+    const { result, rerender } = renderHook(
+      ({ ws }: { ws: "absent" | "resuming" | "running" }) =>
+        useCockpit("sess-rl-resume", ws),
+      { initialProps: { ws: "absent" as const } },
+    );
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+
+    // The provider reported a usage limit; the worker parks.
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-rl-resume",
+          seq: 1,
+          event: {
+            RateLimit: {
+              info: {
+                status: "usage limit reached",
+                resets_at: "2026-06-01T12:10:00Z",
+                kind: "rate_limit",
+              },
+            },
+          },
+        }),
+      } as MessageEvent);
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-rl-resume",
+          seq: 2,
+          event: { Stopped: { reason: "rate_limited" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.rateLimit).not.toBeNull();
+
+    // The user queues a follow-up during the park. Worker is absent, so
+    // it must NOT POST yet.
+    act(() => {
+      void result.current.sendPrompt("run after the reset");
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(0);
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+
+    // Auto-resume fires: the breadcrumb clears the banner, the reconciler
+    // respawns the worker (REST poll -> running) and emits
+    // AcpSessionAssigned. The drain effect now dispatches the queued prompt.
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-rl-resume",
+          seq: 3,
+          event: { RateLimitAutoResumed: { resets_at: "2026-06-01T12:10:00Z" } },
+        }),
+      } as MessageEvent);
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-rl-resume",
+          seq: 4,
+          event: { AcpSessionAssigned: { acp_session_id: "acp-1" } },
+        }),
+      } as MessageEvent);
+    });
+    rerender({ ws: "running" as const });
+    await flushAsync();
+
+    expect(result.current.state.rateLimit).toBeNull();
+    expect(promptPostCount).toBe(1);
+    expect(promptPostBodies[0]).toContain("run after the reset");
+    expect(result.current.state.queuedPrompts).toEqual([]);
+  });
+
   it("retires the optimistic turn when prompt POST is rejected with 4xx", async () => {
     const { result } = renderHook(() => useCockpit("sess-reject-4xx"));
     await flushAsync();

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -2423,3 +2423,29 @@ describe("applyEvent / thinking-state honesty (#1213)", () => {
     expect(state.inFlightTool).not.toBeNull();
   });
 });
+
+describe("applyEvent / RateLimitAutoResumed (#1722)", () => {
+  it("clears the rate-limit banner so the composer unlocks", () => {
+    let state: CockpitState = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        RateLimit: {
+          info: {
+            status: "usage limit reached",
+            resets_at: "2026-06-01T12:10:00Z",
+            kind: "rate_limit",
+          },
+        },
+      },
+    });
+    expect(state.rateLimit).not.toBeNull();
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { RateLimitAutoResumed: { resets_at: "2026-06-01T12:10:00Z" } },
+    });
+    expect(state.rateLimit).toBeNull();
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -258,6 +258,7 @@ export type CockpitEvent =
   | "ThinkingStarted"
   | "ThinkingEnded"
   | { RateLimit: { info: RateLimitInfo } }
+  | { RateLimitAutoResumed: { resets_at: string } }
   | { UsageUpdated: { usage: SessionUsage } }
   | { ModeChanged: { mode: SessionMode } }
   | {
@@ -986,6 +987,15 @@ export function applyEvent(
   }
   if ("RateLimit" in event) {
     next.rateLimit = event.RateLimit.info;
+    return next;
+  }
+  if ("RateLimitAutoResumed" in event) {
+    // The reconciler crossed the reset deadline and is respawning the
+    // worker (opt-in cockpit.rate_limit_auto_resume). Clear the parked
+    // banner so the composer unlocks; the imminent AcpSessionAssigned and
+    // the running worker let the drain effect dispatch any prompt the
+    // user queued during the wait. See #1722.
+    next.rateLimit = null;
     return next;
   }
   if ("UsageUpdated" in event) {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds an opt-in cockpit setting that auto-resumes a `rate_limited`-parked worker once the provider-reported reset time has passed, instead of leaving it parked for manual recovery. Default off, so current behavior is unchanged unless you turn it on.

Rate-limit detection, the `RateLimit` event (with `resets_at`), and the park-on-rate-limit policy (the #1281 fix, no eager restart loop) already existed. The missing piece was a delayed, opt-in policy keyed to that reset time. This PR adds it without weakening the no-restart-loop guarantee.

How it works:

- Two new `CockpitConfig` knobs, default off: `rate_limit_auto_resume` (bool) and `rate_limit_auto_resume_grace_secs` (u32, default 15). Both are editable across all three surfaces (config.toml, the settings TUI, and the web dashboard settings panel) and overridable per profile.
- A cadence-gated reconciler pass (`reap_rate_limit_resumes`) watches sessions parked on `Stopped { reason: "rate_limited" }`. Once `resets_at + grace` (floored by a hardcoded 30s minimum park from when the limit was recorded) has elapsed, it publishes a new `Event::RateLimitAutoResumed { resets_at }` breadcrumb and respawns the worker through the existing resume path.
- The breadcrumb is included in `latest_status_event` so it supersedes the terminal `Stopped{rate_limited}`, letting the normal resume loop fall through to a fresh spawn instead of re-parking. It also clears the rate-limit banner in the cockpit reducer, and the existing client-side drain effect then dispatches any prompt queued during the wait once the worker is back.

Design choices (the reconciler-centric approach, no attempt cap in favor of a wall-clock floor, vendor-agnostic gating, and keeping the breadcrumb out of a redundant supersede vs. an explicit park-clear) were settled via a multi-model design debate before implementation.

Durability and safety:

- The reset time is read from the persisted event store, never memory, so the timer survives an `aoe serve` restart: a daemon that comes up after the window resumes on its next pass; one that comes up mid-window keeps waiting.
- Vendor-agnostic: any ACP backend reporting `kind == "rate_limit"` is eligible, gated only on the config flag.
- No restart loop: a re-rate-limit writes a fresh `resets_at`, so the next resume waits for the new window; the 30s floor guards a misbehaving adapter that reports a past reset.
- Manual recovery ("Continue in another agent", manual reconnect) stays available regardless of the setting.

Closes #1722

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the settings TUI and the web dashboard (cockpit tab, Advanced), confirm "Auto-resume after rate limit" (toggle) and "Auto-resume grace (s)" appear, persist to `config.toml` as `cockpit.rate_limit_auto_resume` / `cockpit.rate_limit_auto_resume_grace_secs`, and round-trip per profile.
- [ ] With the setting OFF (default): drive a cockpit session into a rate limit; confirm it parks and stays parked until you manually retry or hand off (unchanged behavior).
- [ ] With the setting ON: park a session on a rate limit whose `resets_at` is near; confirm the worker respawns automatically shortly after `resets_at + grace`, the rate-limit banner clears, and a `RateLimitAutoResumed` breadcrumb shows in the transcript.
- [ ] With the setting ON, queue a follow-up prompt during the park; confirm it dispatches only after the worker auto-resumes, not before.
- [ ] With the setting ON, restart `aoe serve` while a session is parked; confirm auto-resume still waits for `resets_at + grace` and does not eager-respawn before the window.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the changed behavior is request-payload + reducer logic, which per AGENTS.md belongs in Vitest + RTL, not Playwright. Added Vitest coverage instead: `cockpitTypes.test.ts` (breadcrumb clears the banner), `useCockpit.queue.test.ts` (queued prompt drains only after auto-resume), and `SettingsView.folds.test.tsx` (both new settings inputs save through the profile path). The existing `settings.cockpit-persistence` coverage-matrix entry already maps `SettingsView.tsx`.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the auto-resume policy is daemon-internal and is covered by Rust unit + event-store tests (`rate_limit_resume_at` timing and floor, `latest_rate_limit_event`, the `RateLimitAutoResumed`-supersedes-`Stopped` query, and the `derive_cockpit_status` mapping). A full-daemon e2e would need a deterministic adapter rate-limit with a controllable near-future reset, which the fake-ACP harness cannot drive reliably without flakiness.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, a multi-model design debate, the implementation, and this write-up were drafted by Claude under my direction. I made the design calls, reviewed each commit, and ran the validation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary: Opt-in Auto-Resume After Rate-Limit Reset

What changed (high level)
- Adds an opt-in cockpit feature to automatically resume a worker that was parked because a provider reported a rate limit, once the provider-reported reset time (plus a small grace) has elapsed.
- New user-configurable cockpit options: a boolean toggle (default: off) and a grace-seconds knob (default: 15). These are editable in config.toml, the TUI, and the web settings and can be overridden per profile.
- Reconciler/scheduler logic periodically scans parked sessions stopped with reason "rate_limited", reads the persisted RateLimit event reset time, and—when the reset + grace window has passed—emits a visible breadcrumb (RateLimitAutoResumed) and resumes the worker via the normal resume path.
- UI and state updates clear the rate-limit banner and allow queued prompts to drain after the worker is live again.
- Durability and safety: reset times are read from the persisted event store (survives restarts), vendor-agnostic (works for any ACP backend reporting rate_limit), includes a hard minimum park floor to avoid immediate thrash, and preserves manual recovery paths.
- Tests and docs: unit and frontend tests were added/updated to cover timing, supersession, breadcrumb behavior, queued-prompt drain; troubleshooting docs updated. Closes `#1722`.

Technical details (concise)
- New config fields: cockpit.rate_limit_auto_resume: bool (default false) and cockpit.rate_limit_auto_resume_grace_secs: u32 (default 15) in CockpitConfig and per-profile overrides.
- Event additions: Event::RateLimitAutoResumed { resets_at }; event_store exposes latest_rate_limit_event(session_id) and treats RateLimitAutoResumed as a status lifecycle event for latest_status_event queries.
- Reconciler: new cadence-gated pass reap_rate_limit_resumes in reconcile_cockpit_workers (with a RATE_LIMIT_RESUME_INTERVAL and RATE_LIMIT_MIN_PARK_SECS floor). It publishes RateLimitAutoResumed and removes the session from the attempted set so the existing resume/spawn loop respawns the worker on the same tick.
- Supervisor API: publish_rate_limit_auto_resumed(session_id, resets_at) added to publish the breadcrumb.
- UI/reducer: TUI and web reducers now apply RateLimitAutoResumed to clear rate-limit state and append an Info note; settings components expose toggle and grace numeric field; tests updated to assert behavior.
- Safety guards: no restart loop (re-rate-limit updates resets_at), 30s minimum park enforced, manual spawn/handoff unaffected.

Benefits
- Safe-by-default opt-in behavior with explicit controls.
- Durable across daemon restarts and backend-agnostic.
- Clear visibility in timeline/state via breadcrumb and UI updates.
- Prevents unnecessary manual retry while allowing queued prompts to continue automatically after resume.

Potential enhancements
- Make minimum park floor configurable.
- Add telemetry for auto-resume success/failure and per-profile resume policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->