### PR TITLE
feat(worktree): edit a session's workdir name after creation

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -21,6 +21,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe session attach`↴](#aoe-session-attach)
 * [`aoe session show`↴](#aoe-session-show)
 * [`aoe session rename`↴](#aoe-session-rename)
+* [`aoe session set-worktree-name`↴](#aoe-session-set-worktree-name)
 * [`aoe session capture`↴](#aoe-session-capture)
 * [`aoe session current`↴](#aoe-session-current)
 * [`aoe session set-session-id`↴](#aoe-session-set-session-id)
@@ -293,6 +294,7 @@ Manage session lifecycle (start, stop, attach, etc.)
 * `attach` — Attach to session interactively
 * `show` — Show session details
 * `rename` — Rename a session
+* `set-worktree-name` — Edit a managed worktree session's workdir directory name (and, optionally, its git branch). Moves the worktree directory in place; the session must not be running. See #1723
 * `capture` — Capture tmux pane output
 * `current` — Auto-detect current session
 * `set-session-id` — Set the resume target for a session (pin a conversation or force a one-shot fresh start)
@@ -391,6 +393,23 @@ Rename a session
 
 * `-t`, `--title <TITLE>` — New title for the session
 * `-g`, `--group <GROUP>` — New group for the session (empty string to ungroup)
+
+
+
+## `aoe session set-worktree-name`
+
+Edit a managed worktree session's workdir directory name (and, optionally, its git branch). Moves the worktree directory in place; the session must not be running. See #1723
+
+**Usage:** `aoe session set-worktree-name [OPTIONS] --name <NAME> [IDENTIFIER]`
+
+###### **Arguments:**
+
+* `<IDENTIFIER>` — Session ID or title (optional, auto-detects in tmux)
+
+###### **Options:**
+
+* `--name <NAME>` — New workdir (worktree directory) name
+* `--rename-branch` — Also rename the underlying git branch to match the new name
 
 
 

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -72,6 +72,21 @@ In the TUI, enable the Worktree checkbox to create a new branch and worktree. By
 
 The web dashboard's new-session wizard folds the worktree controls behind an "Advanced" disclosure on the session step, leaving only the session title visible by default. Inside Advanced, a "Base branch" disclosure beneath the worktree name input shows a typeahead populated from local + remote branches via `GET /api/git/branches?include_remote=true`. The same Advanced section also exposes an "Attach to existing branch" toggle that flips the request from "create new branch" to "attach to whichever branch is named": when on, the server re-uses any existing worktree for that branch and otherwise checks the branch out into a new worktree. Mirrors the TUI / CLI behavior (CLI: omit `-b`). See #969 and #1514.
 
+## Editing the Workdir Name After Creation
+
+When a worktree session was created with an auto-generated name, you can change its workdir (worktree directory) name later. The worktree directory is moved in place via `git worktree move`, keeping its parent directory and swapping only the final path component (the new name's path-safe slug). Renaming the underlying git branch is opt-in, since a session may already have meaningful work or an upstream on its branch.
+
+v1 supports only sessions whose worktree is aoe-managed (`worktree_info.managed_by_aoe = true`), and the session must not be running; otherwise you get a clear validation error and no change is made. The session title is left untouched.
+
+| Surface | How |
+|---------|-----|
+| CLI | `aoe session set-worktree-name <session> --name <new-name>` (add `--rename-branch` to also rename the git branch) |
+| TUI | Select the session, press `W` (or open the command palette and pick "Edit worktree workdir name"). Toggle "Also rename git branch" in the dialog. |
+| Web | Right-click the session row, choose "Edit workdir name", enter a name, and optionally check "Also rename git branch". |
+| REST | `PATCH /api/sessions/{id}/worktree-name` with `{ "name": "<new-name>", "rename_branch": <bool> }` |
+
+The new directory and branch persist across reload and restart. See #1723.
+
 ## Configuration
 
 ```toml

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -34,6 +34,11 @@ pub enum SessionCommands {
     /// Rename a session
     Rename(RenameArgs),
 
+    /// Edit a managed worktree session's workdir directory name (and,
+    /// optionally, its git branch). Moves the worktree directory in place;
+    /// the session must not be running. See #1723.
+    SetWorktreeName(SetWorktreeNameArgs),
+
     /// Capture tmux pane output
     Capture(CaptureArgs),
 
@@ -139,6 +144,20 @@ pub struct RenameArgs {
 }
 
 #[derive(Args)]
+pub struct SetWorktreeNameArgs {
+    /// Session ID or title (optional, auto-detects in tmux)
+    identifier: Option<String>,
+
+    /// New workdir (worktree directory) name
+    #[arg(long)]
+    name: String,
+
+    /// Also rename the underlying git branch to match the new name
+    #[arg(long)]
+    rename_branch: bool,
+}
+
+#[derive(Args)]
 pub struct ShowArgs {
     /// Session ID or title (optional, auto-detects in tmux)
     identifier: Option<String>,
@@ -235,6 +254,7 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
         SessionCommands::Show(args) => show_session(profile, args).await,
         SessionCommands::Capture(args) => capture_session(profile, args).await,
         SessionCommands::Rename(args) => rename_session(profile, args).await,
+        SessionCommands::SetWorktreeName(args) => set_worktree_name(profile, args).await,
         SessionCommands::Current(args) => current_session(args).await,
         SessionCommands::SetSessionId(args) => set_session_id(profile, args).await,
         SessionCommands::SetBase(args) => set_base(profile, args).await,
@@ -1040,6 +1060,72 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         println!("✓ Updated session: {}", effective_title);
     }
 
+    Ok(())
+}
+
+async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<()> {
+    let storage = Storage::new(profile)?;
+    let (instances, _groups) = storage.load_with_groups()?;
+    let inst = if let Some(id) = &args.identifier {
+        super::resolve_session(id, &instances)?
+    } else {
+        let current_session = std::env::var("TMUX_PANE")
+            .ok()
+            .and_then(|_| crate::tmux::get_current_session_name());
+        if let Some(session_name) = current_session {
+            instances
+                .iter()
+                .find(|i| {
+                    let tmux_name = crate::tmux::Session::generate_name(&i.id, &i.title);
+                    tmux_name == session_name
+                })
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Current tmux session is not an Agent of Empires session")
+                })?
+        } else {
+            bail!("Not in a tmux session. Specify a session ID or run inside tmux.");
+        }
+    };
+
+    let id = inst.id.clone();
+    let status = inst.status;
+    let current_path = inst.project_path.clone();
+    let Some(worktree_info) = inst.worktree_info.clone() else {
+        bail!("Session does not use a worktree");
+    };
+    if status.blocks_worktree_edit() {
+        bail!("Cannot edit the workdir name while the session is active; stop it first");
+    }
+
+    let outcome = crate::session::worktree_edit::edit_worktree_workdir(
+        crate::session::worktree_edit::WorktreeEditRequest {
+            worktree_info: &worktree_info,
+            current_path: std::path::Path::new(&current_path),
+            new_name: args.name.trim(),
+            rename_branch: args.rename_branch,
+        },
+    )?;
+    let new_path = outcome.new_path.to_string_lossy().to_string();
+    let new_branch = outcome.new_branch.clone();
+
+    storage.update(|instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
+        inst.project_path = new_path.clone();
+        if let Some(branch) = &new_branch {
+            if let Some(wt) = inst.worktree_info.as_mut() {
+                wt.branch = branch.clone();
+            }
+        }
+        Ok(())
+    })?;
+
+    println!("✓ Worktree moved to: {}", new_path);
+    if let Some(branch) = &new_branch {
+        println!("  Branch renamed to: {}", branch);
+    }
     Ok(())
 }
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1088,12 +1088,17 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
     };
 
     let id = inst.id.clone();
-    let status = inst.status;
     let current_path = inst.project_path.clone();
     let Some(worktree_info) = inst.worktree_info.clone() else {
         bail!("Session does not use a worktree");
     };
-    if status.blocks_worktree_edit() {
+    // Persisted status can lag the real tmux pane, and moving the worktree of
+    // a still-running session is unsafe. Recompute from live tmux state before
+    // enforcing the guard.
+    let mut live = inst.clone();
+    crate::tmux::refresh_session_cache();
+    live.update_status();
+    if live.status.blocks_worktree_edit() {
         bail!("Cannot edit the workdir name while the session is active; stop it first");
     }
 
@@ -1108,19 +1113,25 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
     let new_path = outcome.new_path.to_string_lossy().to_string();
     let new_branch = outcome.new_branch.clone();
 
-    storage.update(|instances, _groups| {
-        let inst = instances
-            .iter_mut()
-            .find(|i| i.id == id)
-            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
-        inst.project_path = new_path.clone();
-        if let Some(branch) = &new_branch {
-            if let Some(wt) = inst.worktree_info.as_mut() {
-                wt.branch = branch.clone();
+    storage
+        .update(|instances, _groups| {
+            let inst = instances
+                .iter_mut()
+                .find(|i| i.id == id)
+                .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
+            inst.project_path = new_path.clone();
+            if let Some(branch) = &new_branch {
+                if let Some(wt) = inst.worktree_info.as_mut() {
+                    wt.branch = branch.clone();
+                }
             }
-        }
-        Ok(())
-    })?;
+            Ok(())
+        })
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Worktree was moved on disk to {new_path}, but persisting the new session metadata failed: {e}. Re-run to retry."
+            )
+        })?;
 
     println!("✓ Worktree moved to: {}", new_path);
     if let Some(branch) = &new_branch {

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -988,6 +988,67 @@ impl GitWorktree {
         Ok(())
     }
 
+    /// Whether a local branch `refs/heads/<branch>` exists in this repo.
+    pub fn branch_exists(&self, branch: &str) -> bool {
+        let refname = format!("refs/heads/{branch}");
+        match super::command::run_git(
+            &self.repo_path,
+            ["show-ref", "--verify", "--quiet", &refname],
+        ) {
+            Ok(output) => output.status.success(),
+            Err(_) => false,
+        }
+    }
+
+    /// Move a managed worktree directory via `git worktree move`, which
+    /// relocates the checkout and updates the linked-worktree gitdir
+    /// metadata. A plain filesystem rename would leave git's bookkeeping
+    /// pointing at the old path, so always go through git here.
+    pub fn move_worktree(&self, from: &Path, to: &Path) -> Result<()> {
+        if !from.exists() {
+            return Err(GitError::WorktreeNotFound(from.to_path_buf()));
+        }
+        if to.exists() {
+            return Err(GitError::WorktreeAlreadyExists(to.to_path_buf()));
+        }
+        let from_str = from
+            .to_str()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
+        let to_str = to
+            .to_str()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
+
+        tracing::info!(target: "git.worktree",
+            from = %from.display(),
+            to = %to.display(),
+            "move_worktree: invoking `git worktree move`"
+        );
+        let output =
+            super::command::run_git(&self.repo_path, ["worktree", "move", from_str, to_str])?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(GitError::WorktreeCommandFailed(stderr));
+        }
+        Ok(())
+    }
+
+    /// Rename a local branch via `git branch -m`. Works while the branch is
+    /// checked out in a worktree (git updates that worktree's HEAD). Errors
+    /// if `old` does not exist or `new` already exists.
+    pub fn rename_branch(&self, old: &str, new: &str) -> Result<()> {
+        tracing::info!(target: "git.worktree",
+            old, new,
+            repo = %self.repo_path.display(),
+            "rename_branch: invoking `git branch -m`"
+        );
+        let output = super::command::run_git(&self.repo_path, ["branch", "-m", old, new])?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(GitError::WorktreeCommandFailed(stderr));
+        }
+        Ok(())
+    }
+
     pub fn compute_path(&self, branch: &str, template: &str, session_id: &str) -> Result<PathBuf> {
         let repo_name = self
             .repo_path

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -37,7 +37,7 @@ pub use projects::{create_project, delete_project, list_projects};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
     list_sessions, read_output, rename_session, send_message, session_diff_file,
-    session_diff_files, update_session_archive, update_session_diff_base,
+    session_diff_files, set_worktree_name, update_session_archive, update_session_diff_base,
     update_session_notifications, update_session_pin, update_session_snooze,
     update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
 };
@@ -248,6 +248,7 @@ mod tests {
                     "create_session",
                     "delete_session",
                     "rename_session",
+                    "set_worktree_name",
                     "send_message",
                     "ensure_session",
                     "ensure_terminal",
@@ -379,6 +380,7 @@ mod tests {
                     "create_session",
                     "delete_session",
                     "rename_session",
+                    "set_worktree_name",
                     "send_message",
                     "ensure_session",
                     "ensure_terminal",

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -807,6 +807,10 @@ fn worktree_edit_error_response(
             StatusCode::CONFLICT,
             format!("Branch '{name}' already exists"),
         ),
+        E::RollbackFailed { .. } => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to move the worktree, and rolling back the branch rename also failed; the repository may be left on the new branch".to_string(),
+        ),
         E::Git(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "Failed to move the worktree".to_string(),
@@ -921,6 +925,52 @@ pub async fn set_worktree_name(
         }
     };
 
+    // The git move has already landed, so persist to disk BEFORE mutating
+    // in-memory state. A silent persist failure here would leave stale
+    // metadata that points at the old (now-moved) path after a daemon
+    // restart, so any failure returns 500 instead of a misleading 200.
+    let persist_failed = || {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "persist_failed",
+                "message": "Worktree was moved on disk, but persisting the new session metadata failed"
+            })),
+        )
+            .into_response()
+    };
+
+    let storage = match Storage::new(&profile) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(target: "http.api.sessions", session = %id, "Storage::new failed after worktree edit: {e}");
+            return persist_failed();
+        }
+    };
+    let id_clone = id.clone();
+    let new_path_clone = new_path.clone();
+    let new_branch_clone = new_branch.clone();
+    match tokio::task::spawn_blocking(move || {
+        storage.update(|instances, _groups| {
+            if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
+                apply_worktree_name_edit(inst, &new_path_clone, new_branch_clone.as_deref());
+            }
+            Ok(())
+        })
+    })
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::error!(target: "http.api.sessions", "Failed to save after worktree edit: {e}");
+            return persist_failed();
+        }
+        Err(e) => {
+            tracing::error!(target: "http.api.sessions", "Worktree edit persist join failed: {e}");
+            return persist_failed();
+        }
+    }
+
     let response = {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
@@ -933,30 +983,6 @@ pub async fn set_worktree_name(
         apply_worktree_name_edit(inst, &new_path, new_branch.as_deref());
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen())
     };
-
-    if let Ok(storage) = Storage::new(&profile) {
-        let id_clone = id.clone();
-        let new_path_clone = new_path.clone();
-        let new_branch_clone = new_branch.clone();
-        match tokio::task::spawn_blocking(move || {
-            storage.update(|instances, _groups| {
-                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
-                    apply_worktree_name_edit(inst, &new_path_clone, new_branch_clone.as_deref());
-                }
-                Ok(())
-            })
-        })
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                tracing::error!(target: "http.api.sessions", "Failed to save after worktree edit: {e}")
-            }
-            Err(e) => {
-                tracing::error!(target: "http.api.sessions", "Worktree edit persist join failed: {e}")
-            }
-        }
-    }
 
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
 }

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -760,6 +760,216 @@ pub async fn rename_session(
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
 }
 
+// --- Edit worktree workdir name ---
+
+#[derive(Deserialize)]
+pub struct SetWorktreeNameBody {
+    pub name: String,
+    /// Also rename the underlying git branch to match. Off by default: the
+    /// session may have done meaningful work on its branch already.
+    #[serde(default)]
+    pub rename_branch: bool,
+}
+
+/// Map a worktree-edit failure to an HTTP status + client-safe message.
+/// Validation failures are 400/409; git/IO failures stay generic (raw git
+/// stderr and IO paths must not reach the wire).
+fn worktree_edit_error_response(
+    e: &crate::session::worktree_edit::WorktreeEditError,
+) -> (StatusCode, String) {
+    use crate::session::worktree_edit::WorktreeEditError as E;
+    match e {
+        E::NotManaged => (
+            StatusCode::BAD_REQUEST,
+            "This worktree is not managed by aoe; its workdir name cannot be edited".to_string(),
+        ),
+        E::EmptyName => (
+            StatusCode::BAD_REQUEST,
+            "Workdir name cannot be empty".to_string(),
+        ),
+        E::Unchanged => (
+            StatusCode::BAD_REQUEST,
+            "The workdir name is unchanged".to_string(),
+        ),
+        E::NoParent(_) => (
+            StatusCode::BAD_REQUEST,
+            "Cannot determine the worktree's parent directory".to_string(),
+        ),
+        E::SourceMissing(_) => (
+            StatusCode::CONFLICT,
+            "The worktree directory no longer exists on disk".to_string(),
+        ),
+        E::TargetExists(_) => (
+            StatusCode::CONFLICT,
+            "A directory with that name already exists".to_string(),
+        ),
+        E::BranchExists(name) => (
+            StatusCode::CONFLICT,
+            format!("Branch '{name}' already exists"),
+        ),
+        E::Git(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to move the worktree".to_string(),
+        ),
+    }
+}
+
+pub async fn set_worktree_name(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    body: Result<Json<SetWorktreeNameBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    let Json(body) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+    let name = body.name.trim().to_string();
+    if name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "message": "Workdir name cannot be empty" })),
+        )
+            .into_response();
+    }
+    if let Err(msg) = validate_no_shell_injection(&name, "name") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "message": msg })),
+        )
+            .into_response();
+    }
+
+    // Serialize against other mutations on this session (start, delete,
+    // another rename) so the git ops and the metadata write don't race.
+    let lock = state.instance_lock(&id).await;
+    let _guard = lock.lock().await;
+
+    let (worktree_info, current_path, status, profile) = {
+        let instances = state.instances.read().await;
+        let Some(inst) = instances.iter().find(|i| i.id == id) else {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "message": "Session not found" })),
+            )
+                .into_response();
+        };
+        (
+            inst.worktree_info.clone(),
+            inst.project_path.clone(),
+            inst.status,
+            inst.source_profile.clone(),
+        )
+    };
+
+    let Some(worktree_info) = worktree_info else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "message": "Session does not use a worktree" })),
+        )
+            .into_response();
+    };
+    if status.blocks_worktree_edit() {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "message": "Cannot edit the workdir name while the session is active; stop it first"
+            })),
+        )
+            .into_response();
+    }
+
+    let wt = worktree_info.clone();
+    let cur = current_path.clone();
+    let new_name = name.clone();
+    let rename_branch = body.rename_branch;
+    let edit = tokio::task::spawn_blocking(move || {
+        crate::session::worktree_edit::edit_worktree_workdir(
+            crate::session::worktree_edit::WorktreeEditRequest {
+                worktree_info: &wt,
+                current_path: std::path::Path::new(&cur),
+                new_name: &new_name,
+                rename_branch,
+            },
+        )
+        .map(|o| (o.new_path.to_string_lossy().to_string(), o.new_branch))
+    })
+    .await;
+
+    let (new_path, new_branch) = match edit {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            tracing::warn!(target: "http.api.sessions", session = %id, "worktree edit failed: {e}");
+            let (code, msg) = worktree_edit_error_response(&e);
+            return (code, Json(serde_json::json!({ "message": msg }))).into_response();
+        }
+        Err(e) => {
+            tracing::error!(target: "http.api.sessions", "worktree edit join failed: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "message": "Worktree edit task failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let response = {
+        let mut instances = state.instances.write().await;
+        let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "message": "Session not found" })),
+            )
+                .into_response();
+        };
+        apply_worktree_name_edit(inst, &new_path, new_branch.as_deref());
+        SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen())
+    };
+
+    if let Ok(storage) = Storage::new(&profile) {
+        let id_clone = id.clone();
+        let new_path_clone = new_path.clone();
+        let new_branch_clone = new_branch.clone();
+        match tokio::task::spawn_blocking(move || {
+            storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
+                    apply_worktree_name_edit(inst, &new_path_clone, new_branch_clone.as_deref());
+                }
+                Ok(())
+            })
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::error!(target: "http.api.sessions", "Failed to save after worktree edit: {e}")
+            }
+            Err(e) => {
+                tracing::error!(target: "http.api.sessions", "Worktree edit persist join failed: {e}")
+            }
+        }
+    }
+
+    (StatusCode::OK, Json(serde_json::json!(response))).into_response()
+}
+
+fn apply_worktree_name_edit(inst: &mut Instance, new_path: &str, new_branch: Option<&str>) {
+    inst.project_path = new_path.to_string();
+    if let Some(branch) = new_branch {
+        if let Some(wt) = inst.worktree_info.as_mut() {
+            wt.branch = branch.to_string();
+        }
+    }
+}
+
 // --- Update session notification preferences ---
 
 /// Body for `PATCH /api/sessions/:id/notifications`. Each field is an
@@ -3563,6 +3773,38 @@ mod tests {
         assert_eq!(
             inst.worktree_info.as_ref().map(|wt| wt.branch.as_str()),
             Some("feature/test")
+        );
+    }
+
+    #[test]
+    fn worktree_name_edit_updates_path_and_optionally_branch() {
+        let mut inst = make_test_instance();
+        inst.project_path = "/tmp/repo-worktrees/old".to_string();
+        inst.title = "My Session".to_string();
+        inst.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "old".to_string(),
+            main_repo_path: "/tmp/repo".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+
+        // Path-only edit leaves the branch and title untouched.
+        apply_worktree_name_edit(&mut inst, "/tmp/repo-worktrees/new", None);
+        assert_eq!(inst.project_path, "/tmp/repo-worktrees/new");
+        assert_eq!(inst.title, "My Session");
+        assert_eq!(
+            inst.worktree_info.as_ref().map(|wt| wt.branch.as_str()),
+            Some("old")
+        );
+
+        // Branch rename also updates worktree_info.branch.
+        apply_worktree_name_edit(&mut inst, "/tmp/repo-worktrees/newer", Some("newer"));
+        assert_eq!(inst.project_path, "/tmp/repo-worktrees/newer");
+        assert_eq!(inst.title, "My Session");
+        assert_eq!(
+            inst.worktree_info.as_ref().map(|wt| wt.branch.as_str()),
+            Some("newer")
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1106,6 +1106,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/diff-base",
             patch(api::update_session_diff_base),
         )
+        .route(
+            "/api/sessions/{id}/worktree-name",
+            patch(api::set_worktree_name),
+        )
         .route("/api/sessions/{id}/pin", patch(api::update_session_pin))
         .route(
             "/api/sessions/{id}/archive",

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -719,7 +719,7 @@ fn resolve_worktree_branch(
 /// `git-check-ref-format(1)`) with '-'. Unlike `branch_name_from_title`
 /// this keeps the user's casing and preserves '/' so `feat/auth`-style
 /// branches survive when the user types them explicitly.
-fn git_sanitize_branch_name(s: &str) -> String {
+pub(crate) fn git_sanitize_branch_name(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut last_was_dash = false;
     for ch in s.trim().chars() {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -64,6 +64,22 @@ impl Status {
             Status::Creating => "creating",
         }
     }
+
+    /// Whether this status blocks an in-place worktree edit (move dir /
+    /// rename branch). The worktree's checkout must be quiescent: an
+    /// actively running agent, a session mid-start, or one being
+    /// created/deleted can hold the directory or race the metadata write.
+    /// Idle/Stopped/Error/Unknown sessions are safe to edit.
+    pub fn blocks_worktree_edit(self) -> bool {
+        matches!(
+            self,
+            Status::Running
+                | Status::Waiting
+                | Status::Starting
+                | Status::Creating
+                | Status::Deleting
+        )
+    }
 }
 
 /// Outcome of a `start_with_resume_fallback` cascade.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -191,7 +191,7 @@ impl std::fmt::Display for EnsureReadyError {
 
 impl std::error::Error for EnsureReadyError {}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorktreeInfo {
     pub branch: String,
     pub main_repo_path: String,
@@ -1045,6 +1045,15 @@ impl Instance {
         }
         if pre.base_branch_override != post.base_branch_override {
             self.base_branch_override = post.base_branch_override.clone();
+        }
+        // Worktree workdir edit (move dir / rename branch) mutates these two;
+        // both the TUI and the CLI can write them, so they go through the
+        // same conditional-diff path as the triage fields. See #1723.
+        if pre.project_path != post.project_path {
+            self.project_path = post.project_path.clone();
+        }
+        if pre.worktree_info != post.worktree_info {
+            self.worktree_info = post.worktree_info.clone();
         }
         if pre.status != post.status {
             self.status = post.status;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -18,6 +18,7 @@ pub mod scratch;
 pub(crate) mod serde_helpers;
 pub mod stop;
 mod storage;
+pub mod worktree_edit;
 
 pub use crate::sound::{SoundConfig, SoundConfigOverride};
 pub use crate::status_hooks::{StatusHookConfig, StatusHookConfigOverride};

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -66,6 +66,14 @@ pub enum WorktreeEditError {
     TargetExists(PathBuf),
     #[error("branch '{0}' already exists")]
     BranchExists(String),
+    #[error(
+        "worktree move failed ({move_err}), and rolling the branch rename back to '{branch}' also failed ({rollback_err}); the repo may be left on the new branch"
+    )]
+    RollbackFailed {
+        move_err: String,
+        rollback_err: String,
+        branch: String,
+    },
     #[error(transparent)]
     Git(#[from] GitError),
 }
@@ -137,6 +145,14 @@ pub fn edit_worktree_workdir(
                         old = %req.worktree_info.branch,
                         "worktree edit: branch-rename rollback failed after move error: {rollback}"
                     );
+                    // The repo is now on `new_branch` with the directory still
+                    // at its old path. Surface both failures so the caller does
+                    // not treat this as a clean "move failed, nothing changed".
+                    return Err(WorktreeEditError::RollbackFailed {
+                        move_err: e.to_string(),
+                        rollback_err: rollback.to_string(),
+                        branch: new_branch.clone(),
+                    });
                 }
             }
             return Err(e.into());

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -1,0 +1,207 @@
+//! Post-create editing of a managed worktree session's workdir name.
+//!
+//! A session created in worktree mode bakes its directory name (and,
+//! optionally, its branch) at creation time. This module performs the
+//! in-place edit the user asks for later: move the worktree directory to a
+//! new leaf name and, when opted in, rename the underlying git branch.
+//!
+//! Design notes (see #1723):
+//!   - The new directory is a *sibling-leaf* rename: we keep the existing
+//!     parent directory and only swap the final path component. We do NOT
+//!     recompute the path from the current config template, because the
+//!     random session-id seed used at creation is unrecoverable and the
+//!     template may have drifted since, either of which would silently
+//!     relocate the session somewhere unexpected.
+//!   - Branch rename is opt-in. A session may have already done meaningful
+//!     work on its branch (commits, an upstream), so renaming the branch is
+//!     a separate, explicit choice from renaming the workdir directory.
+//!   - Ordering is branch-rename first, then `git worktree move`. The
+//!     filesystem move is the more failure-prone step (open handles, locks),
+//!     so it goes last where a best-effort rollback of the branch rename is
+//!     a cheap ref operation.
+
+use std::path::{Path, PathBuf};
+
+use crate::git::error::GitError;
+use crate::git::template::sanitize_branch_name;
+use crate::git::GitWorktree;
+use crate::session::builder::git_sanitize_branch_name;
+use crate::session::WorktreeInfo;
+
+/// Inputs for an in-place worktree workdir edit.
+pub struct WorktreeEditRequest<'a> {
+    /// The session's current worktree metadata.
+    pub worktree_info: &'a WorktreeInfo,
+    /// The session's current `project_path` (the worktree directory).
+    pub current_path: &'a Path,
+    /// User-supplied new workdir name (raw; sanitized here).
+    pub new_name: &'a str,
+    /// Whether to also rename the git branch to match the new name.
+    pub rename_branch: bool,
+}
+
+/// Result of a successful edit: the values the caller must persist.
+#[derive(Debug)]
+pub struct WorktreeEditOutcome {
+    /// New worktree directory; assign to `Instance.project_path`.
+    pub new_path: PathBuf,
+    /// `Some(new_branch)` when the branch was renamed; assign to
+    /// `worktree_info.branch`. `None` means the branch was left untouched.
+    pub new_branch: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WorktreeEditError {
+    #[error("this worktree is not managed by aoe; its workdir name cannot be edited")]
+    NotManaged,
+    #[error("the new workdir name is empty")]
+    EmptyName,
+    #[error("the workdir name is unchanged")]
+    Unchanged,
+    #[error("cannot determine the parent directory of {}", .0.display())]
+    NoParent(PathBuf),
+    #[error("the current worktree directory {} does not exist", .0.display())]
+    SourceMissing(PathBuf),
+    #[error("a directory already exists at {}", .0.display())]
+    TargetExists(PathBuf),
+    #[error("branch '{0}' already exists")]
+    BranchExists(String),
+    #[error(transparent)]
+    Git(#[from] GitError),
+}
+
+/// Validate and apply an in-place worktree workdir edit.
+///
+/// On success the git side effects (optional branch rename, directory move)
+/// have already been applied; the returned [`WorktreeEditOutcome`] carries
+/// the values the caller must persist to storage and in-memory state. On
+/// error nothing is left partially applied: a failed directory move rolls
+/// back any branch rename performed in the same call.
+pub fn edit_worktree_workdir(
+    req: WorktreeEditRequest,
+) -> Result<WorktreeEditOutcome, WorktreeEditError> {
+    if !req.worktree_info.managed_by_aoe {
+        return Err(WorktreeEditError::NotManaged);
+    }
+    if req.new_name.trim().is_empty() {
+        return Err(WorktreeEditError::EmptyName);
+    }
+
+    // The new branch name uses the same git-ref sanitizer as creation; the
+    // directory leaf uses the path-safe sanitizer (slashes become dashes),
+    // mirroring how `resolve_template` derives a leaf from a branch.
+    let new_branch = git_sanitize_branch_name(req.new_name);
+    let new_leaf = sanitize_branch_name(&new_branch);
+
+    let parent = req
+        .current_path
+        .parent()
+        .ok_or_else(|| WorktreeEditError::NoParent(req.current_path.to_path_buf()))?;
+    let new_path = parent.join(&new_leaf);
+
+    let branch_changes = req.rename_branch && new_branch != req.worktree_info.branch;
+    let path_changes = new_path != req.current_path;
+    if !branch_changes && !path_changes {
+        return Err(WorktreeEditError::Unchanged);
+    }
+
+    let git = GitWorktree::new(PathBuf::from(&req.worktree_info.main_repo_path))?;
+
+    if !req.current_path.exists() {
+        return Err(WorktreeEditError::SourceMissing(
+            req.current_path.to_path_buf(),
+        ));
+    }
+    if branch_changes && git.branch_exists(&new_branch) {
+        return Err(WorktreeEditError::BranchExists(new_branch));
+    }
+    if path_changes && new_path.exists() {
+        return Err(WorktreeEditError::TargetExists(new_path));
+    }
+
+    // Branch first: a ref rename is cheap to undo if the directory move
+    // (the riskier step) then fails.
+    let mut renamed_branch = false;
+    if branch_changes {
+        git.rename_branch(&req.worktree_info.branch, &new_branch)?;
+        renamed_branch = true;
+    }
+
+    if path_changes {
+        if let Err(e) = git.move_worktree(req.current_path, &new_path) {
+            if renamed_branch {
+                if let Err(rollback) = git.rename_branch(&new_branch, &req.worktree_info.branch) {
+                    tracing::error!(
+                        target: "git.worktree",
+                        new = %new_branch,
+                        old = %req.worktree_info.branch,
+                        "worktree edit: branch-rename rollback failed after move error: {rollback}"
+                    );
+                }
+            }
+            return Err(e.into());
+        }
+    }
+
+    Ok(WorktreeEditOutcome {
+        new_path,
+        new_branch: renamed_branch.then_some(new_branch),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn wt_info(branch: &str, main_repo: &str, managed: bool) -> WorktreeInfo {
+        WorktreeInfo {
+            branch: branch.to_string(),
+            main_repo_path: main_repo.to_string(),
+            managed_by_aoe: managed,
+            created_at: Utc::now(),
+            base_branch: None,
+        }
+    }
+
+    #[test]
+    fn rejects_unmanaged_worktree() {
+        let info = wt_info("old", "/tmp/repo", false);
+        let err = edit_worktree_workdir(WorktreeEditRequest {
+            worktree_info: &info,
+            current_path: Path::new("/tmp/wt/old"),
+            new_name: "new",
+            rename_branch: false,
+        })
+        .unwrap_err();
+        assert!(matches!(err, WorktreeEditError::NotManaged));
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        let info = wt_info("old", "/tmp/repo", true);
+        let err = edit_worktree_workdir(WorktreeEditRequest {
+            worktree_info: &info,
+            current_path: Path::new("/tmp/wt/old"),
+            new_name: "   ",
+            rename_branch: false,
+        })
+        .unwrap_err();
+        assert!(matches!(err, WorktreeEditError::EmptyName));
+    }
+
+    #[test]
+    fn rejects_unchanged_name_without_branch_rename() {
+        // Leaf derived from "old" is "old", so the path does not change and
+        // branch rename is off: nothing would happen.
+        let info = wt_info("old", "/tmp/repo", true);
+        let err = edit_worktree_workdir(WorktreeEditRequest {
+            worktree_info: &info,
+            current_path: Path::new("/tmp/wt/old"),
+            new_name: "old",
+            rename_branch: false,
+        })
+        .unwrap_err();
+        assert!(matches!(err, WorktreeEditError::Unchanged));
+    }
+}

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -26,6 +26,7 @@ mod snooze_duration;
 mod sort_picker;
 mod tool_picker;
 mod update_confirm;
+mod worktree_name;
 
 pub use changelog::ChangelogDialog;
 pub use command_palette::{
@@ -56,6 +57,7 @@ pub use snooze_duration::SnoozeDurationDialog;
 pub use sort_picker::SortPickerDialog;
 pub use tool_picker::ToolPickerDialog;
 pub use update_confirm::UpdateConfirmDialog;
+pub use worktree_name::{WorktreeNameData, WorktreeNameDialog};
 
 pub enum DialogResult<T> {
     Continue,

--- a/src/tui/dialogs/worktree_name.rs
+++ b/src/tui/dialogs/worktree_name.rs
@@ -100,6 +100,7 @@ impl WorktreeNameDialog {
         let block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
+            .padding(Padding::horizontal(1))
             .border_style(Style::default().fg(theme.accent))
             .title(" Edit Workdir Name ")
             .title_style(Style::default().fg(theme.title).bold());

--- a/src/tui/dialogs/worktree_name.rs
+++ b/src/tui/dialogs/worktree_name.rs
@@ -1,0 +1,232 @@
+//! Edit-worktree-workdir-name dialog.
+//!
+//! A focused dialog (separate from the title/group rename flow) for changing
+//! a managed worktree session's directory name, with an opt-in to also rename
+//! the git branch. See #1723.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+use tui_input::backend::crossterm::EventHandler;
+use tui_input::Input;
+
+use super::DialogResult;
+use crate::tui::components::render_text_field;
+use crate::tui::styles::Theme;
+
+/// Data returned when the dialog is submitted.
+#[derive(Debug, Clone)]
+pub struct WorktreeNameData {
+    /// New workdir name (raw; sanitized downstream).
+    pub name: String,
+    /// Whether to also rename the underlying git branch.
+    pub rename_branch: bool,
+}
+
+pub struct WorktreeNameDialog {
+    current_dir: String,
+    current_branch: String,
+    new_name: Input,
+    rename_branch: bool,
+    /// 0 = name input, 1 = "rename branch" toggle.
+    focused_field: usize,
+}
+
+impl WorktreeNameDialog {
+    pub fn new(current_dir: &str, current_branch: &str) -> Self {
+        Self {
+            current_dir: current_dir.to_string(),
+            current_branch: current_branch.to_string(),
+            new_name: Input::default(),
+            rename_branch: false,
+            focused_field: 0,
+        }
+    }
+
+    fn toggle_focused(&self) -> bool {
+        self.focused_field == 1
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<WorktreeNameData> {
+        match key.code {
+            KeyCode::Esc => DialogResult::Cancel,
+            KeyCode::Enter => {
+                let name = self.new_name.value().trim().to_string();
+                if name.is_empty() {
+                    return DialogResult::Cancel;
+                }
+                DialogResult::Submit(WorktreeNameData {
+                    name,
+                    rename_branch: self.rename_branch,
+                })
+            }
+            KeyCode::Tab | KeyCode::Down => {
+                self.focused_field = (self.focused_field + 1) % 2;
+                DialogResult::Continue
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                self.focused_field = if self.focused_field == 0 { 1 } else { 0 };
+                DialogResult::Continue
+            }
+            KeyCode::Char(' ') if self.toggle_focused() => {
+                self.rename_branch = !self.rename_branch;
+                DialogResult::Continue
+            }
+            _ => {
+                if !self.toggle_focused() {
+                    self.new_name
+                        .handle_event(&crossterm::event::Event::Key(key));
+                }
+                DialogResult::Continue
+            }
+        }
+    }
+
+    pub fn handle_paste(&mut self, text: &str) {
+        if self.toggle_focused() {
+            return;
+        }
+        let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+        for ch in sanitized.chars() {
+            self.new_name
+                .handle(tui_input::InputRequest::InsertChar(ch));
+        }
+    }
+
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let dialog_area = super::centered_rect(area, 54, 13);
+        frame.render_widget(Clear, dialog_area);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .title(" Edit Workdir Name ")
+            .title_style(Style::default().fg(theme.title).bold());
+        let inner = block.inner(dialog_area);
+        frame.render_widget(block, dialog_area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints([
+                Constraint::Length(1), // current dir
+                Constraint::Length(1), // current branch
+                Constraint::Length(1), // spacer
+                Constraint::Length(1), // new name field
+                Constraint::Length(1), // rename-branch toggle
+                Constraint::Length(1), // spacer
+                Constraint::Min(1),    // hint
+            ])
+            .split(inner);
+
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Current dir:    ", Style::default().fg(theme.dimmed)),
+                Span::styled(&self.current_dir, Style::default().fg(theme.text)),
+            ])),
+            chunks[0],
+        );
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Current branch: ", Style::default().fg(theme.dimmed)),
+                Span::styled(&self.current_branch, Style::default().fg(theme.text)),
+            ])),
+            chunks[1],
+        );
+
+        render_text_field(
+            frame,
+            chunks[3],
+            "New name:",
+            &self.new_name,
+            self.focused_field == 0,
+            None,
+            theme,
+        );
+
+        let checkbox = if self.rename_branch { "[x]" } else { "[ ]" };
+        let toggle_style = if self.toggle_focused() {
+            Style::default().fg(theme.accent)
+        } else {
+            Style::default().fg(theme.text)
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(format!("{checkbox} "), toggle_style),
+                Span::styled("Also rename git branch", toggle_style),
+            ])),
+            chunks[4],
+        );
+
+        let hint = Line::from(vec![
+            Span::styled("Tab", Style::default().fg(theme.hint)),
+            Span::raw(" switch  "),
+            Span::styled("Space", Style::default().fg(theme.hint)),
+            Span::raw(" toggle  "),
+            Span::styled("Enter", Style::default().fg(theme.hint)),
+            Span::raw(" save  "),
+            Span::styled("Esc", Style::default().fg(theme.hint)),
+            Span::raw(" cancel"),
+        ]);
+        frame.render_widget(Paragraph::new(hint), chunks[6]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn empty_name_cancels() {
+        let mut d = WorktreeNameDialog::new("old", "old");
+        assert!(matches!(
+            d.handle_key(key(KeyCode::Enter)),
+            DialogResult::Cancel
+        ));
+    }
+
+    #[test]
+    fn types_name_and_submits() {
+        let mut d = WorktreeNameDialog::new("old", "old");
+        for c in "new-name".chars() {
+            d.handle_key(key(KeyCode::Char(c)));
+        }
+        match d.handle_key(key(KeyCode::Enter)) {
+            DialogResult::Submit(data) => {
+                assert_eq!(data.name, "new-name");
+                assert!(!data.rename_branch);
+            }
+            _ => panic!("expected submit"),
+        }
+    }
+
+    #[test]
+    fn toggle_enables_branch_rename() {
+        let mut d = WorktreeNameDialog::new("old", "old");
+        for c in "x".chars() {
+            d.handle_key(key(KeyCode::Char(c)));
+        }
+        d.handle_key(key(KeyCode::Tab)); // focus toggle
+        d.handle_key(key(KeyCode::Char(' '))); // toggle on
+        match d.handle_key(key(KeyCode::Enter)) {
+            DialogResult::Submit(data) => assert!(data.rename_branch),
+            _ => panic!("expected submit"),
+        }
+    }
+
+    #[test]
+    fn space_on_name_field_types_space_not_toggle() {
+        let mut d = WorktreeNameDialog::new("old", "old");
+        d.handle_key(key(KeyCode::Char('a')));
+        d.handle_key(key(KeyCode::Char(' ')));
+        d.handle_key(key(KeyCode::Char('b')));
+        assert_eq!(d.new_name.value(), "a b");
+        assert!(!d.rename_branch);
+    }
+}

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -45,6 +45,7 @@ pub enum ActionId {
     Stop,
     Delete,
     Rename,
+    SetWorktreeName,
     Diff,
     Serve,
     Settings,
@@ -452,6 +453,22 @@ pub static BINDINGS: &[Binding] = &[
         }),
     },
     Binding {
+        id: ActionId::SetWorktreeName,
+        non_strict: &[k('W')],
+        strict: &[ctrl('w')],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "Edit worktree workdir name",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Edit worktree workdir name",
+            keywords: &["worktree", "workdir", "directory", "branch", "rename"],
+            group: PaletteGroup::Actions,
+            serve_only: false,
+        }),
+    },
+    Binding {
         id: ActionId::Diff,
         non_strict: &[k('D')],
         strict: &[ctrl('d')],
@@ -656,6 +673,7 @@ pub fn palette_id(id: ActionId) -> &'static str {
         ActionId::Stop => "stop",
         ActionId::Delete => "delete",
         ActionId::Rename => "rename",
+        ActionId::SetWorktreeName => "set-worktree-name",
         ActionId::Diff => "diff",
         ActionId::Serve => "serve",
         ActionId::Settings => "settings",

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -17,7 +17,7 @@ use crate::tui::dialogs::{
     DeleteDialogConfig, DialogResult, GroupDeleteOptionsDialog, HookTrustAction,
     HooksInstallDialog, InfoDialog, IntroOutcome, NewSessionData, NewSessionDialog, NoAgentsAction,
     PaletteAction, PaletteCommand, PaletteGroup, ProfilePickerAction, ProjectsDialog, RenameDialog,
-    RenameMode, RestartDialog, SendMessageDialog, UnifiedDeleteDialog,
+    RenameMode, RestartDialog, SendMessageDialog, UnifiedDeleteDialog, WorktreeNameDialog,
 };
 use crate::tui::diff::{DiffAction, DiffView};
 use crate::tui::responsive;
@@ -863,6 +863,11 @@ impl HomeView {
             let _ = dialog.handle_click(col, row);
             return true;
         }
+        if self.worktree_name_dialog.is_some() {
+            // Keyboard-driven dialog; swallow clicks so the list underneath
+            // doesn't react while it's open.
+            return true;
+        }
         if let Some(dialog) = &mut self.restart_dialog {
             let _ = dialog.handle_click(col, row);
             return true;
@@ -1528,6 +1533,27 @@ impl HomeView {
             return None;
         }
 
+        if let Some(dialog) = &mut self.worktree_name_dialog {
+            match dialog.handle_key(key) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel => {
+                    self.worktree_name_dialog = None;
+                }
+                DialogResult::Submit(data) => {
+                    self.worktree_name_dialog = None;
+                    if let Err(e) =
+                        self.set_worktree_name_for_selected(&data.name, data.rename_branch)
+                    {
+                        self.info_dialog = Some(InfoDialog::new(
+                            "Edit Workdir Name Failed",
+                            &format!("Could not edit the workdir name: {e}"),
+                        ));
+                    }
+                }
+            }
+            return None;
+        }
+
         if let Some(dialog) = &mut self.restart_dialog {
             match dialog.handle_key(key) {
                 DialogResult::Continue => {}
@@ -1954,6 +1980,7 @@ impl HomeView {
             ActionId::Stop => self.stop_selected(),
             ActionId::Delete => self.open_delete_for_selected(),
             ActionId::Rename => self.open_rename_for_selected(),
+            ActionId::SetWorktreeName => self.open_worktree_name_for_selected(),
             ActionId::Diff => self.open_diff_for_selected(),
             ActionId::Serve => self.open_serve(),
             ActionId::Settings => self.open_settings(),
@@ -3068,6 +3095,52 @@ impl HomeView {
         }
     }
 
+    /// Open the edit-workdir-name dialog for the selected session. Only
+    /// valid for an aoe-managed worktree session that is not running; other
+    /// cases surface an info dialog explaining why.
+    pub(super) fn open_worktree_name_for_selected(&mut self) {
+        let Some(id) = self.selected_session.clone() else {
+            return;
+        };
+        let snapshot = self.get_instance(&id).map(|inst| {
+            (
+                inst.worktree_info.clone(),
+                inst.status,
+                inst.project_path.clone(),
+            )
+        });
+        let Some((worktree_info, status, project_path)) = snapshot else {
+            return;
+        };
+        let Some(wt) = worktree_info else {
+            self.info_dialog = Some(InfoDialog::new(
+                "Not a Worktree Session",
+                "This session does not use a worktree, so it has no workdir name to edit.",
+            ));
+            return;
+        };
+        if !wt.managed_by_aoe {
+            self.info_dialog = Some(InfoDialog::new(
+                "Worktree Not Managed by AoE",
+                "This worktree was attached rather than created by AoE, so its workdir name cannot be edited.",
+            ));
+            return;
+        }
+        if status.blocks_worktree_edit() {
+            self.info_dialog = Some(InfoDialog::new(
+                "Session Active",
+                "Stop the session before editing its workdir name.",
+            ));
+            return;
+        }
+        let current_dir = std::path::Path::new(&project_path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(&project_path)
+            .to_string();
+        self.worktree_name_dialog = Some(WorktreeNameDialog::new(&current_dir, &wt.branch));
+    }
+
     /// Open the delete dialog (or a force-remove confirm, or a group
     /// delete-options dialog) for the sidebar's current selection. Mirrors
     /// the gating of the historical `'d'` / `'D'` key handlers:
@@ -3413,6 +3486,10 @@ impl HomeView {
             return;
         }
         if let Some(ref mut dialog) = self.rename_dialog {
+            dialog.handle_paste(text);
+            return;
+        }
+        if let Some(ref mut dialog) = self.worktree_name_dialog {
             dialog.handle_paste(text);
             return;
         }
@@ -3833,6 +3910,10 @@ impl HomeView {
             return;
         }
         if let Some(ref mut dialog) = self.rename_dialog {
+            dialog.handle_paste(&s);
+            return;
+        }
+        if let Some(ref mut dialog) = self.worktree_name_dialog {
             dialog.handle_paste(&s);
             return;
         }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -36,7 +36,7 @@ use super::dialogs::{
     GroupDeleteOptionsDialog, GroupPickerDialog, HookTrustDialog, HooksInstallDialog, InfoDialog,
     IntroDialog, NewSessionData, NewSessionDialog, NoAgentsDialog, ProfilePickerDialog,
     ProjectSessionPickerDialog, ProjectsDialog, RenameDialog, RestartDialog, SnoozeDurationDialog,
-    SortPickerDialog, UnifiedDeleteDialog, UpdateConfirmDialog,
+    SortPickerDialog, UnifiedDeleteDialog, UpdateConfirmDialog, WorktreeNameDialog,
 };
 use super::diff::DiffView;
 use super::settings::SettingsView;
@@ -399,6 +399,7 @@ pub struct HomeView {
     pub(super) unified_delete_dialog: Option<UnifiedDeleteDialog>,
     pub(super) group_delete_options_dialog: Option<GroupDeleteOptionsDialog>,
     pub(super) rename_dialog: Option<RenameDialog>,
+    pub(super) worktree_name_dialog: Option<WorktreeNameDialog>,
     pub(super) restart_dialog: Option<RestartDialog>,
     /// Right-click popup on the sidebar list. Anchored to a screen
     /// position when opened; the renderer clamps it into view.
@@ -840,6 +841,7 @@ impl HomeView {
             unified_delete_dialog: None,
             group_delete_options_dialog: None,
             rename_dialog: None,
+            worktree_name_dialog: None,
             restart_dialog: None,
             context_menu: None,
             group_rename_context: None,
@@ -2268,6 +2270,7 @@ impl HomeView {
             || self.unified_delete_dialog.is_some()
             || self.group_delete_options_dialog.is_some()
             || self.rename_dialog.is_some()
+            || self.worktree_name_dialog.is_some()
             || self.restart_dialog.is_some()
             || self.context_menu.is_some()
             || self.hook_trust_dialog.is_some()
@@ -2303,6 +2306,7 @@ impl HomeView {
             || self.unified_delete_dialog.is_some()
             || self.group_delete_options_dialog.is_some()
             || self.rename_dialog.is_some()
+            || self.worktree_name_dialog.is_some()
             || self.restart_dialog.is_some()
             || self.context_menu.is_some()
             || self.hook_trust_dialog.is_some()

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -623,6 +623,56 @@ impl HomeView {
         Ok(())
     }
 
+    /// Edit the selected session's worktree workdir name: move the worktree
+    /// directory and, optionally, rename its git branch. Persists the new
+    /// `project_path` (and branch) through `apply_user_action`. See #1723.
+    pub(super) fn set_worktree_name_for_selected(
+        &mut self,
+        new_name: &str,
+        rename_branch: bool,
+    ) -> anyhow::Result<()> {
+        let Some(id) = self.selected_session.clone() else {
+            return Ok(());
+        };
+        let snapshot = self
+            .get_instance(&id)
+            .map(|i| (i.worktree_info.clone(), i.status, i.project_path.clone()));
+        let Some((worktree_info, status, project_path)) = snapshot else {
+            anyhow::bail!("Session not found");
+        };
+        let Some(worktree_info) = worktree_info else {
+            anyhow::bail!("Session does not use a worktree");
+        };
+        if status.blocks_worktree_edit() {
+            anyhow::bail!("Stop the session before editing its workdir name");
+        }
+
+        let outcome = crate::session::worktree_edit::edit_worktree_workdir(
+            crate::session::worktree_edit::WorktreeEditRequest {
+                worktree_info: &worktree_info,
+                current_path: std::path::Path::new(&project_path),
+                new_name,
+                rename_branch,
+            },
+        )?;
+        let new_path = outcome.new_path.to_string_lossy().to_string();
+        let new_branch = outcome.new_branch.clone();
+
+        self.apply_user_action(&id, |inst| {
+            inst.project_path = new_path.clone();
+            if let Some(branch) = &new_branch {
+                if let Some(wt) = inst.worktree_info.as_mut() {
+                    wt.branch = branch.clone();
+                }
+            }
+        })?;
+
+        self.rebuild_group_trees();
+        self.save()?;
+        self.reload()?;
+        Ok(())
+    }
+
     pub(super) fn rename_selected(
         &mut self,
         new_title: &str,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -829,6 +829,7 @@ impl HomeView {
             || self.unified_delete_dialog.is_some()
             || self.group_delete_options_dialog.is_some()
             || self.rename_dialog.is_some()
+            || self.worktree_name_dialog.is_some()
             || self.hook_trust_dialog.is_some()
             || self.hooks_install_dialog.is_some()
             || self.intro_dialog.is_some()

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -595,6 +595,7 @@ impl HomeView {
             unified_delete_dialog,
             group_delete_options_dialog,
             rename_dialog,
+            worktree_name_dialog,
             restart_dialog,
             hooks_install_dialog,
             hook_trust_dialog,

--- a/tests/integration/worktree_integration.rs
+++ b/tests/integration/worktree_integration.rs
@@ -271,3 +271,119 @@ fn test_create_new_branch_with_b_flag() {
         .is_ok();
     assert!(branch_exists_after);
 }
+
+// --- Edit-workdir-name (#1723) ---
+
+use agent_of_empires::session::worktree_edit::{
+    edit_worktree_workdir, WorktreeEditError, WorktreeEditRequest,
+};
+
+fn managed_info(branch: &str, repo: &std::path::Path) -> WorktreeInfo {
+    WorktreeInfo {
+        branch: branch.to_string(),
+        main_repo_path: repo.to_string_lossy().to_string(),
+        managed_by_aoe: true,
+        created_at: Utc::now(),
+        base_branch: None,
+    }
+}
+
+#[test]
+#[serial]
+fn edit_workdir_moves_dir_and_optionally_renames_branch() {
+    let (repo_dir, _repo, _config_dir) = setup_test_environment();
+    let git_wt = GitWorktree::new(repo_dir.path().to_path_buf()).unwrap();
+
+    let old_path = repo_dir.path().join("old-name");
+    git_wt
+        .create_worktree("old-name", &old_path, true, None)
+        .unwrap();
+    assert!(old_path.exists());
+    let info = managed_info("old-name", repo_dir.path());
+
+    // Path-only edit: directory moves, branch untouched.
+    let outcome = edit_worktree_workdir(WorktreeEditRequest {
+        worktree_info: &info,
+        current_path: &old_path,
+        new_name: "fresh-name",
+        rename_branch: false,
+    })
+    .unwrap();
+    let fresh_path = repo_dir.path().join("fresh-name");
+    assert_eq!(outcome.new_path, fresh_path);
+    assert_eq!(outcome.new_branch, None);
+    assert!(!old_path.exists());
+    assert!(fresh_path.exists());
+    assert!(git_wt.branch_exists("old-name"));
+
+    // Branch rename opted in: directory moves and branch is renamed.
+    let outcome2 = edit_worktree_workdir(WorktreeEditRequest {
+        worktree_info: &info,
+        current_path: &fresh_path,
+        new_name: "renamed",
+        rename_branch: true,
+    })
+    .unwrap();
+    let renamed_path = repo_dir.path().join("renamed");
+    assert_eq!(outcome2.new_branch.as_deref(), Some("renamed"));
+    assert!(!fresh_path.exists());
+    assert!(renamed_path.exists());
+    assert!(git_wt.branch_exists("renamed"));
+    assert!(!git_wt.branch_exists("old-name"));
+}
+
+#[test]
+#[serial]
+fn edit_workdir_rejects_invalid_cases_without_partial_changes() {
+    let (repo_dir, _repo, _config_dir) = setup_test_environment();
+    let git_wt = GitWorktree::new(repo_dir.path().to_path_buf()).unwrap();
+
+    let old_path = repo_dir.path().join("aaa");
+    git_wt
+        .create_worktree("aaa", &old_path, true, None)
+        .unwrap();
+    let occupied = repo_dir.path().join("bbb");
+    git_wt
+        .create_worktree("bbb", &occupied, true, None)
+        .unwrap();
+    let info = managed_info("aaa", repo_dir.path());
+
+    // Target directory already exists: nothing moves.
+    let err = edit_worktree_workdir(WorktreeEditRequest {
+        worktree_info: &info,
+        current_path: &old_path,
+        new_name: "bbb",
+        rename_branch: false,
+    })
+    .unwrap_err();
+    assert!(matches!(err, WorktreeEditError::TargetExists(_)));
+    assert!(old_path.exists());
+
+    // Branch rename onto an existing branch is rejected; the source
+    // directory and branch are untouched.
+    let err = edit_worktree_workdir(WorktreeEditRequest {
+        worktree_info: &info,
+        current_path: &old_path,
+        new_name: "test-feature",
+        rename_branch: true,
+    })
+    .unwrap_err();
+    assert!(matches!(err, WorktreeEditError::BranchExists(_)));
+    assert!(old_path.exists());
+    assert!(git_wt.branch_exists("aaa"));
+
+    // Unmanaged worktrees cannot be edited.
+    let unmanaged = WorktreeInfo {
+        managed_by_aoe: false,
+        ..info.clone()
+    };
+    let err = edit_worktree_workdir(WorktreeEditRequest {
+        worktree_info: &unmanaged,
+        current_path: &old_path,
+        new_name: "ccc",
+        rename_branch: false,
+    })
+    .unwrap_err();
+    assert!(matches!(err, WorktreeEditError::NotManaged));
+    assert!(old_path.exists());
+}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1304,6 +1304,7 @@ export function WorkdirNameModal({
   }, [onCancel]);
 
   const submit = async () => {
+    if (busy) return;
     const trimmed = name.trim();
     if (!trimmed) {
       setError("Enter a new workdir name.");
@@ -1351,21 +1352,27 @@ export function WorkdirNameModal({
           <input
             type="text"
             autoFocus
+            aria-label="New workdir name"
+            disabled={busy}
             value={name}
             onChange={(e) => {
               setName(e.target.value);
               setError(null);
             }}
             onKeyDown={(e) => {
-              if (e.key === "Enter") void submit();
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void submit();
+              }
             }}
             placeholder="new-workdir-name"
             data-testid="workdir-modal-name"
-            className="w-full bg-surface-900 border border-surface-700 rounded px-2 py-1 text-[13px] md:text-[14px] font-mono text-text-primary focus:outline-none focus:border-brand-600"
+            className="w-full bg-surface-900 border border-surface-700 rounded px-2 py-1 text-[13px] md:text-[14px] font-mono text-text-primary focus:outline-none focus:border-brand-600 disabled:opacity-50"
           />
           <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer">
             <input
               type="checkbox"
+              disabled={busy}
               checked={renameBranch}
               onChange={(e) => setRenameBranch(e.target.checked)}
               data-testid="workdir-modal-rename-branch"

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -67,6 +67,7 @@ import {
   setSessionNotifications,
   setSessionPin,
   setSessionSnooze,
+  setWorktreeName,
 } from "../lib/api";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { requestOpenSession } from "../lib/sessionRoute";
@@ -657,6 +658,9 @@ export const SessionRow = memo(function SessionRow({
   // independent of the context menu's lifecycle so the parent-menu
   // dismissal listener cannot close the picker out from under us.
   const [snoozeModalOpen, setSnoozeModalOpen] = useState(false);
+  // Edit-workdir-name picker, also in its own portal-rendered modal so the
+  // context-menu dismissal listener does not close it. See #1723.
+  const [workdirModalOpen, setWorkdirModalOpen] = useState(false);
   useEffect(() => {
     if (optimisticPinned !== null && optimisticPinned === isPinned) {
       setOptimisticPinned(null);
@@ -869,6 +873,17 @@ export const SessionRow = memo(function SessionRow({
     // the prefilled value should still set the title.
     if (!trimmed || trimmed === sessionTitle || !sessionId) return;
     await renameSession(sessionId, trimmed);
+  };
+
+  // Editing the workdir name moves the worktree directory, so it is only
+  // offered for an aoe-managed worktree session that is not running. See
+  // #1723.
+  const canEditWorkdir =
+    !!firstSession?.has_managed_worktree && !runningSession && !!sessionId;
+
+  const openWorkdirModal = () => {
+    setContextMenu(null);
+    setWorkdirModalOpen(true);
   };
 
   const handleDelete = () => {
@@ -1086,6 +1101,15 @@ export const SessionRow = memo(function SessionRow({
           >
             Rename
           </button>
+          {!readOnly && canEditWorkdir && (
+            <button
+              onClick={openWorkdirModal}
+              data-testid="sidebar-context-menu-edit-workdir"
+              className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+            >
+              Edit workdir name
+            </button>
+          )}
           {!readOnly && cockpitSession && (
             <button
               onClick={handleSwitchAgent}
@@ -1230,9 +1254,153 @@ export const SessionRow = memo(function SessionRow({
           />,
           document.body,
         )}
+      {workdirModalOpen &&
+        sessionId &&
+        createPortal(
+          <WorkdirNameModal
+            title={label}
+            currentBranch={branchLabel}
+            onCancel={() => setWorkdirModalOpen(false)}
+            onSubmit={async (name, renameBranch) => {
+              const res = await setWorktreeName(sessionId, name, renameBranch);
+              if (res.ok) setWorkdirModalOpen(false);
+              return res;
+            }}
+          />,
+          document.body,
+        )}
     </>
   );
 });
+
+/** Edit-workdir-name modal. Renamed the worktree directory and, when the
+ *  user opts in, the git branch. Rendered as its own portal so it is
+ *  independent of the row's context menu. See #1723. */
+export function WorkdirNameModal({
+  title,
+  currentBranch,
+  onCancel,
+  onSubmit,
+}: {
+  title: string;
+  currentBranch: string | null;
+  onCancel: () => void;
+  onSubmit: (
+    name: string,
+    renameBranch: boolean,
+  ) => Promise<{ ok: boolean; message?: string }>;
+}) {
+  const [name, setName] = useState("");
+  const [renameBranch, setRenameBranch] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  const submit = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Enter a new workdir name.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    const res = await onSubmit(trimmed, renameBranch);
+    setBusy(false);
+    if (!res.ok) {
+      setError(res.message ?? "Failed to edit the workdir name.");
+    }
+  };
+
+  return (
+    <div
+      data-testid="workdir-modal-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 px-4 py-8 overflow-y-auto"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Edit workdir name"
+    >
+      <div
+        data-testid="workdir-modal"
+        className="w-full max-w-sm rounded-lg border border-surface-700 bg-surface-800 shadow-xl"
+      >
+        <div className="px-4 py-3 border-b border-surface-700/40">
+          <div
+            className="text-sm font-mono text-text-primary truncate"
+            title={title}
+          >
+            Edit workdir name
+            <span className="text-text-muted"> · {title}</span>
+          </div>
+          {currentBranch && (
+            <div className="mt-1 text-[11px] text-text-dim font-mono">
+              Current branch: {currentBranch}
+            </div>
+          )}
+        </div>
+        <div className="px-4 py-3 flex flex-col gap-3">
+          <input
+            type="text"
+            autoFocus
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void submit();
+            }}
+            placeholder="new-workdir-name"
+            data-testid="workdir-modal-name"
+            className="w-full bg-surface-900 border border-surface-700 rounded px-2 py-1 text-[13px] md:text-[14px] font-mono text-text-primary focus:outline-none focus:border-brand-600"
+          />
+          <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer">
+            <input
+              type="checkbox"
+              checked={renameBranch}
+              onChange={(e) => setRenameBranch(e.target.checked)}
+              data-testid="workdir-modal-rename-branch"
+            />
+            Also rename git branch
+          </label>
+          {error && (
+            <div
+              data-testid="workdir-modal-error"
+              className="text-[11px] text-status-error"
+            >
+              {error}
+            </div>
+          )}
+        </div>
+        <div className="px-4 py-3 border-t border-surface-700/40 flex justify-end gap-2">
+          <button
+            onClick={onCancel}
+            className="px-3 py-1 text-sm text-text-secondary hover:bg-surface-700/50 rounded cursor-pointer transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void submit()}
+            disabled={busy}
+            data-testid="workdir-modal-save"
+            className="px-3 py-1 text-sm text-text-primary bg-brand-600 hover:bg-brand-500 rounded cursor-pointer transition-colors disabled:opacity-50"
+          >
+            {busy ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 /** Bounds for `validate_snooze_duration` on the server. Mirrored
  *  client-side so the modal can pre-validate and disable the submit

--- a/web/src/components/__tests__/WorkdirNameEdit.test.tsx
+++ b/web/src/components/__tests__/WorkdirNameEdit.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+//
+// RTL coverage for the sidebar "Edit workdir name" flow (#1723): the
+// context-menu gating (managed worktree + not running), and the modal's
+// request payload (name + rename_branch) plus its error surface. Mirrors
+// SessionRowTriage.test.tsx for the SessionRow + DragSuppressContext setup.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useRef, type ReactNode } from "react";
+
+import { DragSuppressContext, SessionRow } from "../WorkspaceSidebar";
+import type { SessionResponse, Workspace } from "../../lib/types";
+
+function session(over: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: "s1",
+    title: "row title",
+    project_path: "/p/old-name",
+    group_path: "/p",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: "old-name",
+    main_repo_path: "/p",
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: true,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+    },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+    ...over,
+  };
+}
+
+function workspace(id: string, sessions: SessionResponse[]): Workspace {
+  return {
+    id,
+    branch: "old-name",
+    projectPath: "/p",
+    displayName: id,
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    sessions,
+  };
+}
+
+function Wrap({ children }: { children: ReactNode }) {
+  const ref = useRef(0);
+  return (
+    <DragSuppressContext.Provider value={ref}>
+      {children}
+    </DragSuppressContext.Provider>
+  );
+}
+
+const fetchSpy = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+  fetchSpy.mockImplementation(
+    async () =>
+      new Response(JSON.stringify({ id: "s1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function openMenu(ws: Workspace) {
+  render(
+    <Wrap>
+      <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+    </Wrap>,
+  );
+  fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+}
+
+describe("sidebar Edit workdir name", () => {
+  it("offers the action for a managed, idle worktree session", () => {
+    openMenu(workspace("w", [session()]));
+    expect(
+      screen.queryByTestId("sidebar-context-menu-edit-workdir"),
+    ).not.toBeNull();
+  });
+
+  it("hides the action for a non-managed worktree", () => {
+    openMenu(workspace("w", [session({ has_managed_worktree: false })]));
+    expect(
+      screen.queryByTestId("sidebar-context-menu-edit-workdir"),
+    ).toBeNull();
+  });
+
+  it("hides the action while the session is running", () => {
+    openMenu(workspace("w", [session({ status: "Running" })]));
+    expect(
+      screen.queryByTestId("sidebar-context-menu-edit-workdir"),
+    ).toBeNull();
+  });
+
+  it("PATCHes the worktree-name endpoint with name and rename_branch", async () => {
+    openMenu(workspace("w", [session()]));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-edit-workdir"));
+
+    fireEvent.change(screen.getByTestId("workdir-modal-name"), {
+      target: { value: "fresh-name" },
+    });
+    fireEvent.click(screen.getByTestId("workdir-modal-rename-branch"));
+    fireEvent.click(screen.getByTestId("workdir-modal-save"));
+
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/sessions/s1/worktree-name");
+    expect(init?.method).toBe("PATCH");
+    expect(JSON.parse(init?.body as string)).toEqual({
+      name: "fresh-name",
+      rename_branch: true,
+    });
+  });
+
+  it("surfaces the server validation message on failure", async () => {
+    fetchSpy.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ message: "Branch 'x' already exists" }), {
+          status: 409,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    openMenu(workspace("w", [session()]));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-edit-workdir"));
+    fireEvent.change(screen.getByTestId("workdir-modal-name"), {
+      target: { value: "x" },
+    });
+    fireEvent.click(screen.getByTestId("workdir-modal-save"));
+
+    await vi.waitFor(() =>
+      expect(screen.getByTestId("workdir-modal-error").textContent).toContain(
+        "already exists",
+      ),
+    );
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -840,6 +840,37 @@ export async function renameSession(
   }
 }
 
+/**
+ * Edit a managed worktree session's workdir name: move the worktree
+ * directory and, optionally, rename its git branch. The session must not be
+ * running. Returns the server's validation message on failure so the caller
+ * can surface it. See #1723.
+ */
+export async function setWorktreeName(
+  id: string,
+  name: string,
+  renameBranch: boolean,
+): Promise<{ ok: boolean; message?: string }> {
+  try {
+    const res = await fetch(`/api/sessions/${id}/worktree-name`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, rename_branch: renameBranch }),
+    });
+    if (res.ok) return { ok: true };
+    let message: string | undefined;
+    try {
+      const body = await res.json();
+      message = typeof body?.message === "string" ? body.message : undefined;
+    } catch {
+      // non-JSON error body; fall through with no message
+    }
+    return { ok: false, message };
+  } catch {
+    return { ok: false };
+  }
+}
+
 /** Three-preset helper for the sidebar context menu:
  *  - "off":     set all three overrides to false (silence this session)
  *  - "default": clear all three overrides (inherit server defaults)

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2632,6 +2632,18 @@
       ]
     },
     {
+      "id": "sidebar.edit-workdir-name",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/WorkdirNameEdit.test.tsx"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/lib/api.ts"
+      ]
+    },
+    {
       "id": "sidebar.context-menu-clamp",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a dedicated operation to edit a managed worktree session's workdir (worktree directory) name after creation, closing the long-standing gap where a session created with an auto-generated civilization name could be re-titled but never re-homed: the visible label changed while the on-disk directory and branch stayed frozen at creation time.

The new operation moves the worktree directory in place via `git worktree move`, doing a sibling-leaf rename (keep the parent directory, swap only the final path component for the new name's path-safe slug). It deliberately does **not** recompute the path from the current config template, because the random session-id seed used at creation is unrecoverable and the template may have drifted since, either of which would silently relocate the session somewhere unexpected. Renaming the underlying git branch is opt-in (`--rename-branch` / a checkbox), since a session may already carry meaningful commits or an upstream on its branch. Ordering is branch-rename first, then the directory move, so the riskier filesystem step is last and a failed move rolls back the branch rename. The session title is never touched.

v1 is scoped to safe, deterministic cases: the worktree must be aoe-managed (`worktree_info.managed_by_aoe = true`) and the session must not be running. Otherwise the caller gets a clear validation error and no metadata is changed.

The operation is wired across all four surfaces: a reusable core op (`session::worktree_edit`), a REST endpoint, a CLI subcommand, a TUI dialog, and a web sidebar action. The new `project_path` and (optional) branch persist across reload and restart.

Closes #1723

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a worktree session (`aoe add . -w my-feature -b`), stop it, then run `aoe session set-worktree-name <session> --name cleaner-name`; confirm the worktree directory is renamed on disk and `worktree_info.branch` is unchanged.
- [ ] Re-run with `--rename-branch` and confirm `git branch` in the worktree shows the new branch name and the old one is gone.
- [ ] In the TUI, select an idle managed worktree session, press `W`, enter a new name (optionally toggle "Also rename git branch"), Save; confirm the row/preview reflects the new dir and that it survives quitting and relaunching `aoe`.
- [ ] In the web dashboard, right-click a managed worktree session row, choose "Edit workdir name", enter a name and optionally check "Also rename git branch", Save; refresh the page and confirm the change persisted and the session is still attachable.
- [ ] Attempt the edit on a running session (TUI/web/CLI) and confirm you get a clear "stop the session first" error with no change.
- [ ] Attempt to rename onto a branch/directory that already exists and confirm a clear validation error with no partial change.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a test and updated `web/tests/coverage-matrix.json`. Per the coverage-matrix mandate, this request-payload + gating flow is covered by a Vitest + RTL spec (`web/src/components/__tests__/WorkdirNameEdit.test.tsx`, matrix id `sidebar.edit-workdir-name`): it asserts the context-menu gating (managed + not running), the `PATCH /api/sessions/{id}/worktree-name` payload (`name` + `rename_branch`), and the server-error surface.

**TUI / CLI (e2e test)**
- [x] Skipped a full `tests/e2e/` tmux spec, because: the behavior is covered by real-git integration tests (`tests/integration/worktree_integration.rs`: directory move, optional branch rename, and the TargetExists / BranchExists / NotManaged validation rejections), plus unit tests for the core op, the server metadata-apply helper, and the TUI dialog. A tmux-driven e2e for this stop-then-edit dialog is a reasonable follow-up.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, design debate, and implementation were drafted by Claude under my direction. I made the scoping calls (optional branch rename, sibling-leaf move over template recompute, all four surfaces), reviewed each commit, and will run the manual test steps above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a new, cross-surface feature to rename an AOE-managed worktree’s on-disk directory name after creation. The operation is available via REST, CLI, TUI, and the Web UI, and optionally renames the underlying git branch. Edits persist across reloads and restarts and are guarded to avoid unsafe or partial state changes.

### What changed (high-level)
- Added a dedicated worktree-edit operation that moves the worktree directory (sibling-leaf move) and can optionally rename the git branch.
- Exposed the operation in:
  - REST API: PATCH /api/sessions/{id}/worktree-name
  - CLI: aoe session set-worktree-name
  - TUI: WorktreeNameDialog + keybinding (W / Ctrl+W)
  - Web: sidebar “Edit workdir name” action + modal
- Safety and validation:
  - Only allowed for aoe-managed worktrees and stopped sessions; running or unmanaged sessions are rejected with clear errors.
  - Sanitizes names using existing branch-sanitization rules.
  - Performs branch rename first, then directory move; attempts rollback if move fails.
  - Uses per-session locking and persisted metadata updates so changes survive restarts.
- Added Git helpers (branch_exists, move_worktree, rename_branch) and made branch sanitizer reusable.
- Tests and docs:
  - Unit, integration, and real-git tests for move/rename and failure/rollback cases.
  - Web Vitest + RTL test for sidebar flow and API integration.
  - CLI docs and worktrees guide updated; coverage matrix entry added.

### Benefits
- Provides a clear, focused action to change a worktree’s on-disk name without touching session titles.
- Reduces risk of partial changes via ordered operations and rollback handling.
- Consistent UX across CLI, TUI, Web, and API.
- Persisted metadata ensures the change is durable.

### Technical notes (concise)
- Core logic: new session.worktree_edit module with edit_worktree_workdir returning an outcome (new path, optional new branch) or granular errors (validation, conflicts, git/IO, rollback failure).
- Git layer: new GitWorktree methods for checking/renaming branches and invoking git worktree move.
- Session: status guard blocks_worktree_edit(), WorktreeInfo now derives PartialEq for conditional merges, project_path and worktree_info persisted on success.
- UI: TUI dialog component and HomeView wiring; Web modal + API helper setWorktreeName; CLI subcommand implemented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->