### PR TITLE
refactor(session): plumb is_existing through start_with_size_opts return

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1604,7 +1604,6 @@ fn merge_runtime_fields(prior: Instance, mut fresh: Instance) -> Instance {
     fresh.last_error = prior.last_error;
     fresh.session_id_poller = prior.session_id_poller;
     fresh.retroactive_capture_excludes = prior.retroactive_capture_excludes;
-    fresh.last_acquired_existing_sid = prior.last_acquired_existing_sid;
     fresh
 }
 
@@ -2438,19 +2437,6 @@ pub(crate) fn derive_cockpit_status(event: &crate::cockpit::Event) -> Option<Sta
 mod tests {
     use super::*;
 
-    #[test]
-    fn merge_runtime_fields_carries_last_acquired_existing_sid() {
-        let mut prior = crate::session::Instance::new("title", "/tmp/x");
-        prior.last_acquired_existing_sid = true;
-        let fresh = crate::session::Instance::new("title", "/tmp/x");
-        assert!(!fresh.last_acquired_existing_sid);
-
-        let merged = merge_runtime_fields(prior, fresh);
-        assert!(
-            merged.last_acquired_existing_sid,
-            "merge_runtime_fields must carry last_acquired_existing_sid across status_poll reloads",
-        );
-    }
     #[cfg(feature = "serve")]
     #[test]
     fn derive_cockpit_status_maps_terminal_events() {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -89,6 +89,27 @@ pub enum StartOutcome {
     Fresh,
 }
 
+/// What `start_with_size_opts` did with the agent's session id this call.
+/// `start_with_resume_fallback` matches on `Existing` to gate the Tier-1
+/// settle probe; without the gate, fresh Claude launches mislabel as
+/// `StartOutcome::Resumed` because `acquire_session_id` always assigns a
+/// UUID for Claude.
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaunchSidOutcome {
+    /// `acquire_session_id` reused a prior sid: `ResumeIntent::Use(sid)`,
+    /// observed `agent_session_id`, or retroactive-capture hit. The launch
+    /// command embedded the agent's resume flag.
+    Existing,
+    /// `acquire_session_id` returned a fresh sid (Claude UUID generation)
+    /// or `None`. No prior conversation continued.
+    Fresh,
+    /// `start_with_size_opts` short-circuited before `apply_session_flags`
+    /// ran: cockpit-mode session, or pre-existing tmux pane (kill_clean
+    /// cache race). `agent_session_id` was not mutated this call.
+    Skipped,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProbeResult {
     Alive,
@@ -512,15 +533,6 @@ pub struct Instance {
     /// will re-set it within one tick if the pane is genuinely dead).
     #[serde(skip)]
     pub pane_dead_observed: bool,
-
-    /// Mirrors the `is_existing` flag from the most recent
-    /// `acquire_session_id`. `start_with_resume_fallback` reads it
-    /// post-call to gate the settle probe; without this gate, every
-    /// fresh Claude launch would mislabel as `StartOutcome::Resumed`
-    /// because acquire always assigns a UUID. Stale-between-launches
-    /// is benign: every fallback re-runs acquire before reading.
-    #[serde(skip)]
-    pub(crate) last_acquired_existing_sid: bool,
 }
 
 /// Append yolo-mode flags or environment variables to a launch command.
@@ -838,7 +850,6 @@ impl Instance {
             session_id_poller: None,
             retroactive_capture_excludes: HashSet::new(),
             pane_dead_observed: false,
-            last_acquired_existing_sid: false,
         }
     }
 
@@ -928,11 +939,10 @@ impl Instance {
         // Carry runtime-only fields (`#[serde(skip)]`) and locally-mutated
         // launch-time state from `self` onto the disk snapshot. This carry
         // set is not required to match `merge_runtime_fields` exactly: each
-        // reconciliation path feeds a different consumer, and each
-        // consumer rewrites the runtime field it observes before reading
-        // (`last_acquired_existing_sid` is reset at the entry of
-        // `start_with_resume_fallback`; `pane_dead_observed` is rewritten
-        // by the TUI's status poller before its TUI-only consumers read).
+        // reconciliation path feeds a different consumer, and each consumer
+        // rewrites the runtime field it observes before reading
+        // (`pane_dead_observed` is rewritten by the TUI's status poller
+        // before its TUI-only consumers read).
         disk.last_error_check = self.last_error_check;
         disk.last_start_time = self.last_start_time;
         disk.last_error = self.last_error.take();
@@ -1295,12 +1305,6 @@ impl Instance {
     /// (`agent_session_id`), then retroactive capture, then fresh UUID for
     /// Claude.
     pub fn acquire_session_id(&mut self) -> (Option<String>, bool) {
-        let result = self.acquire_session_id_inner();
-        self.last_acquired_existing_sid = result.1;
-        result
-    }
-
-    fn acquire_session_id_inner(&mut self) -> (Option<String>, bool) {
         match &self.resume_intent {
             ResumeIntent::Use(sid) => {
                 let sid = sid.clone();
@@ -1449,9 +1453,10 @@ impl Instance {
         result.and_then(validated_session_id)
     }
 
-    fn apply_session_flags(&mut self, cmd: &mut String, context: &str) {
+    fn apply_session_flags(&mut self, cmd: &mut String, context: &str) -> bool {
         let (session_id, is_existing) = self.acquire_session_id();
         append_resume_flags(&self.tool, session_id.as_deref(), is_existing, cmd, context);
+        is_existing
     }
 
     pub fn has_custom_command(&self) -> bool {
@@ -1669,7 +1674,7 @@ impl Instance {
     }
 
     pub fn start_with_size(&mut self, size: Option<(u16, u16)>) -> Result<()> {
-        self.start_with_size_opts(size, false)
+        self.start_with_size_opts(size, false).map(|_| ())
     }
 
     /// Start the session, optionally skipping on_launch hooks (e.g. when they
@@ -1678,20 +1683,20 @@ impl Instance {
         &mut self,
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
-    ) -> Result<()> {
+    ) -> Result<LaunchSidOutcome> {
         // Cockpit-mode sessions are not backed by tmux. The cockpit
         // worker supervisor spawns the ACP agent process directly;
         // calling start() on a cockpit session is a no-op (status
         // updates flow through the ACP event channel, not tmux).
         #[cfg(feature = "serve")]
         if self.cockpit_mode {
-            return Ok(());
+            return Ok(LaunchSidOutcome::Skipped);
         }
 
         let session = self.tmux_session()?;
 
         if session.exists() {
-            return Ok(());
+            return Ok(LaunchSidOutcome::Skipped);
         }
 
         // Refresh peer-writable persisted fields (`agent_session_id`,
@@ -1711,7 +1716,7 @@ impl Instance {
         let expected_prior_intent = self.resume_intent.clone();
 
         let profile = self.effective_profile();
-        let cmd = self.build_launch_command(skip_on_launch, &profile)?;
+        let (cmd, is_existing) = self.build_launch_command(skip_on_launch, &profile)?;
 
         tracing::debug!(target: "session.store",
             "container cmd: {}",
@@ -1734,7 +1739,11 @@ impl Instance {
             expected_prior_intent,
         );
 
-        Ok(())
+        Ok(if is_existing {
+            LaunchSidOutcome::Existing
+        } else {
+            LaunchSidOutcome::Fresh
+        })
     }
 
     /// Build the launch command string the way `start_with_size_opts` would,
@@ -1747,14 +1756,14 @@ impl Instance {
         &mut self,
         skip_on_launch: bool,
         profile: &str,
-    ) -> Result<Option<String>> {
+    ) -> Result<(Option<String>, bool)> {
         let on_launch_hooks = self.resolve_on_launch_hooks(skip_on_launch, profile);
 
         let agent = crate::agents::get_agent(&self.tool)
             .or_else(|| crate::agents::get_agent(&self.detect_as));
         self.install_agent_status_hooks(agent);
 
-        let cmd = if self.is_sandboxed() {
+        let (cmd, is_existing) = if self.is_sandboxed() {
             let container = self.get_container_for_instance()?;
             if let Some(ref hook_cmds) = on_launch_hooks {
                 let hook_env = super::repo_config::lifecycle_env_vars(self);
@@ -1804,7 +1813,7 @@ impl Instance {
                 }
             }
 
-            self.apply_session_flags(&mut tool_cmd, "sandboxed");
+            let is_existing = self.apply_session_flags(&mut tool_cmd, "sandboxed");
             apply_agent_launch_env(&mut tool_cmd, agent);
 
             let sandbox = self
@@ -1816,17 +1825,19 @@ impl Instance {
                 sandbox,
                 std::path::Path::new(&self.project_path),
             );
-            // AOE_INSTANCE_ID is not secret, goes directly in docker args
             let docker_args = format!("{} -e AOE_INSTANCE_ID={}", env_info.docker_args, self.id);
             let env_part = format!("{} ", docker_args);
             let wrapped =
                 wrap_command_ignore_suspend(&container.exec_command(Some(&env_part), &tool_cmd));
-            Some(prepend_exports(&env_info.exports, wrapped))
+            (
+                Some(prepend_exports(&env_info.exports, wrapped)),
+                is_existing,
+            )
         } else {
             self.build_host_command(agent, &on_launch_hooks)
         };
 
-        Ok(cmd)
+        Ok((cmd, is_existing))
     }
 
     /// Resolve on_launch hooks from the full config chain (global > profile > repo).
@@ -1948,8 +1959,7 @@ impl Instance {
         &mut self,
         agent: Option<&'static crate::agents::AgentDef>,
         on_launch_hooks: &Option<Vec<String>>,
-    ) -> Option<String> {
-        // Run on_launch hooks on host for non-sandboxed sessions
+    ) -> (Option<String>, bool) {
         if let Some(ref hook_cmds) = on_launch_hooks {
             let hook_env = super::repo_config::lifecycle_env_vars(self);
             if let Err(e) = super::repo_config::execute_hooks(
@@ -1961,7 +1971,6 @@ impl Instance {
             }
         }
 
-        // Prepend AOE_INSTANCE_ID env var if this agent supports hooks.
         let mut env_prefix = status_hook_env_prefix(&self.id, &self.tool, agent);
 
         // Profile-scoped host environment entries (KEY=value, KEY=$VAR,
@@ -1979,20 +1988,29 @@ impl Instance {
         }
 
         if self.command.is_empty() {
-            crate::agents::get_agent(&self.tool).map(|a| {
-                let mut cmd = a.binary.to_string();
-                if !self.extra_args.is_empty() {
-                    cmd = format!("{} {}", cmd, self.extra_args);
-                }
-                if self.is_yolo_mode() {
-                    if let Some(ref yolo) = a.yolo {
-                        apply_yolo_mode(&mut cmd, yolo, false);
+            match crate::agents::get_agent(&self.tool) {
+                Some(a) => {
+                    let mut cmd = a.binary.to_string();
+                    if !self.extra_args.is_empty() {
+                        cmd = format!("{} {}", cmd, self.extra_args);
                     }
+                    if self.is_yolo_mode() {
+                        if let Some(ref yolo) = a.yolo {
+                            apply_yolo_mode(&mut cmd, yolo, false);
+                        }
+                    }
+                    let is_existing = self.apply_session_flags(&mut cmd, "host agent");
+                    apply_agent_launch_env(&mut cmd, agent);
+                    (
+                        Some(wrap_command_ignore_suspend(&format!(
+                            "{}{}",
+                            env_prefix, cmd
+                        ))),
+                        is_existing,
+                    )
                 }
-                self.apply_session_flags(&mut cmd, "host agent");
-                apply_agent_launch_env(&mut cmd, agent);
-                wrap_command_ignore_suspend(&format!("{}{}", env_prefix, cmd))
-            })
+                None => (None, false),
+            }
         } else {
             let mut cmd = self.command.clone();
             if !self.extra_args.is_empty() {
@@ -2003,12 +2021,15 @@ impl Instance {
                     apply_yolo_mode(&mut cmd, yolo, false);
                 }
             }
-            self.apply_session_flags(&mut cmd, "host custom");
+            let is_existing = self.apply_session_flags(&mut cmd, "host custom");
             apply_agent_launch_env(&mut cmd, agent);
-            Some(wrap_command_ignore_suspend(&format!(
-                "{}{}",
-                env_prefix, cmd
-            )))
+            (
+                Some(wrap_command_ignore_suspend(&format!(
+                    "{}{}",
+                    env_prefix, cmd
+                ))),
+                is_existing,
+            )
         }
     }
 
@@ -2085,7 +2106,7 @@ impl Instance {
     /// Atomic single-flock CAS+write of `agent_session_id` and (when
     /// `expected_prior_intent == Cleared`) the auto-promote to `Default`.
     /// A split would let a daemon crash freeze disk at `(new_sid, Cleared)`,
-    /// which the next launch's `acquire_session_id_inner` short-circuits
+    /// which the next launch's `acquire_session_id` short-circuits
     /// on, orphaning the conversation just created with `new_sid`.
     ///
     /// On sid CAS skip: rollback both fields from disk.
@@ -2630,7 +2651,7 @@ impl Instance {
 
         #[cfg(feature = "serve")]
         if self.cockpit_mode {
-            self.start_with_size_opts(size, skip_on_launch)?;
+            let _ = self.start_with_size_opts(size, skip_on_launch)?;
             return Ok(StartOutcome::Fresh);
         }
 
@@ -2650,16 +2671,7 @@ impl Instance {
         // attempted, the race is just kill_clean cache staleness).
         let pane_was_preexisting = self.tmux_session().is_ok_and(|s| s.exists());
 
-        // Reset before `start_with_size_opts` so the post-call read at line
-        // ~2562 reflects THIS call's `acquire_session_id` decision. Without
-        // this, when `pane_was_preexisting=true` (rare `kill_clean` cache
-        // race) `start_with_size_opts` short-circuits without running
-        // `acquire_session_id`, and the diagnostic warning below would emit
-        // the wrong branch using a value carried from a prior launch via
-        // `merge_runtime_fields`.
-        self.last_acquired_existing_sid = false;
-
-        self.start_with_size_opts(size, skip_on_launch)?;
+        let outcome = self.start_with_size_opts(size, skip_on_launch)?;
 
         // Computed post-`start_with_size_opts` so it reflects post-reconcile
         // state. A pre-call read would miss a peer-CLI `Use(X)` write that
@@ -2667,12 +2679,12 @@ impl Instance {
         // to skip the very Use(X_dead) case Tier-1's downgrade is meant to
         // handle.
         //
-        // Gated on `last_acquired_existing_sid` so fresh launches (Cleared,
+        // Gated on `LaunchSidOutcome::Existing` so fresh launches (Cleared,
         // no observed sid + Claude UUID generation) skip the probe and
         // honestly report `Fresh`. Without this gate, every Claude launch
         // would probe (~2s) and return `Resumed` because acquire always
         // assigns a UUID, even when no `--resume` was passed.
-        let attempting_resume = self.last_acquired_existing_sid
+        let attempting_resume = matches!(outcome, LaunchSidOutcome::Existing)
             && should_attempt_resume(self.agent_session_id.as_deref(), &self.tool);
 
         if pane_was_preexisting {
@@ -2703,6 +2715,10 @@ impl Instance {
             self.id
         );
 
+        // Defensive `|| pane_was_preexisting`: covers the TOCTOU window
+        // where a peer killed the pane between the snapshot above and
+        // `start_with_size_opts`'s internal `session.exists()` check, in
+        // which case `outcome` could be `Existing` despite the snapshot.
         if !attempting_resume || pane_was_preexisting {
             return Ok(StartOutcome::Fresh);
         }
@@ -2767,7 +2783,7 @@ impl Instance {
             }
         }
 
-        self.start_with_size_opts(size, true).with_context(|| {
+        let _ = self.start_with_size_opts(size, true).with_context(|| {
             format!(
                 "fresh restart after resume fallback failed for {} (stale sid {} was cleared)",
                 self.id, stale_sid,
@@ -4907,29 +4923,21 @@ mod tests {
     }
 
     #[test]
-    fn last_acquired_existing_sid_mirrors_acquire_bool() {
+    fn apply_session_flags_returns_acquire_is_existing() {
         let mut inst = Instance::new("Test", "/tmp/test");
         inst.tool = "claude".to_string();
-        assert!(!inst.last_acquired_existing_sid);
+        let mut cmd = String::from("claude");
+        assert!(!inst.apply_session_flags(&mut cmd, "test"));
+        assert!(inst.apply_session_flags(&mut cmd, "test"));
+    }
 
-        let (sid_fresh, fresh_existing) = inst.acquire_session_id();
-        assert!(sid_fresh.is_some());
-        assert!(!fresh_existing);
-        assert!(!inst.last_acquired_existing_sid);
-
-        let (_, second_existing) = inst.acquire_session_id();
-        assert!(second_existing);
-        assert!(inst.last_acquired_existing_sid);
-
-        inst.resume_intent = ResumeIntent::Cleared;
-        let (_, cleared_existing) = inst.acquire_session_id();
-        assert!(!cleared_existing);
-        assert!(!inst.last_acquired_existing_sid);
-
-        inst.resume_intent = ResumeIntent::Use("019342ab-1234-7def-8901-abcdef012345".to_string());
-        let (_, use_existing) = inst.acquire_session_id();
-        assert!(use_existing);
-        assert!(inst.last_acquired_existing_sid);
+    #[cfg(feature = "serve")]
+    #[test]
+    fn start_with_size_opts_returns_skipped_for_cockpit_mode() {
+        let mut inst = Instance::new("Test", "/tmp/test");
+        inst.cockpit_mode = true;
+        let outcome = inst.start_with_size_opts(None, false).unwrap();
+        assert_eq!(outcome, LaunchSidOutcome::Skipped);
     }
 
     #[test]
@@ -5025,7 +5033,7 @@ mod tests {
     fn test_build_host_command_basic() {
         let mut inst = Instance::new("test", "/tmp/test");
         inst.tool = "codex".to_string();
-        let cmd = inst.build_host_command(crate::agents::get_agent("codex"), &None);
+        let (cmd, _) = inst.build_host_command(crate::agents::get_agent("codex"), &None);
         assert!(cmd.is_some());
         assert!(cmd.as_ref().unwrap().contains("codex"));
     }
@@ -5035,7 +5043,7 @@ mod tests {
         let mut inst = Instance::new("test", "/tmp/test");
         inst.tool = "codex".to_string();
         inst.yolo_mode = true;
-        let cmd = inst.build_host_command(crate::agents::get_agent("codex"), &None);
+        let (cmd, _) = inst.build_host_command(crate::agents::get_agent("codex"), &None);
         let cmd_str = cmd.unwrap();
         let agent = crate::agents::get_agent("codex").unwrap();
         match agent.yolo.as_ref().unwrap() {
@@ -5050,7 +5058,7 @@ mod tests {
         let mut inst = Instance::new("test", "/tmp/test");
         inst.tool = "claude".to_string();
         inst.agent_session_id = Some("ses_abc123def456".to_string());
-        let cmd = inst.build_host_command(crate::agents::get_agent("claude"), &None);
+        let (cmd, _) = inst.build_host_command(crate::agents::get_agent("claude"), &None);
         let cmd_str = cmd.unwrap();
         assert!(cmd_str.contains("ses_abc123def456"));
         assert!(cmd_str.contains("--session-id") || cmd_str.contains("--resume"));
@@ -5060,7 +5068,7 @@ mod tests {
     fn test_build_host_command_antigravity_forces_color() {
         let mut inst = Instance::new("test", "/tmp/test");
         inst.tool = "antigravity".to_string();
-        let cmd = inst.build_host_command(crate::agents::get_agent("antigravity"), &None);
+        let (cmd, _) = inst.build_host_command(crate::agents::get_agent("antigravity"), &None);
         let cmd_str = cmd.unwrap();
 
         assert!(cmd_str.contains("env -u NO_COLOR"));
@@ -5074,7 +5082,7 @@ mod tests {
         let mut inst = Instance::new("test", "/tmp/test");
         inst.tool = "antigravity".to_string();
         inst.command = "agy --some-flag".to_string();
-        let cmd = inst.build_host_command(crate::agents::get_agent("antigravity"), &None);
+        let (cmd, _) = inst.build_host_command(crate::agents::get_agent("antigravity"), &None);
         let cmd_str = cmd.unwrap();
 
         assert!(cmd_str.contains("env -u NO_COLOR"));
@@ -5087,7 +5095,7 @@ mod tests {
     fn test_build_host_command_codex_forces_color() {
         let mut inst = Instance::new("test", "/tmp/test");
         inst.tool = "codex".to_string();
-        let cmd = inst.build_host_command(crate::agents::get_agent("codex"), &None);
+        let (cmd, _) = inst.build_host_command(crate::agents::get_agent("codex"), &None);
         let cmd_str = cmd.unwrap();
 
         assert!(cmd_str.contains("env -u NO_COLOR"));
@@ -5100,7 +5108,7 @@ mod tests {
     fn test_build_host_command_color_env_is_limited_to_color_sensitive_agents() {
         let mut inst = Instance::new("test", "/tmp/test");
         inst.tool = "cursor".to_string();
-        let cmd = inst.build_host_command(crate::agents::get_agent("cursor"), &None);
+        let (cmd, _) = inst.build_host_command(crate::agents::get_agent("cursor"), &None);
         let cmd_str = cmd.unwrap();
 
         assert!(!cmd_str.contains("env -u NO_COLOR"));

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -585,13 +585,13 @@ fn append_resume_flags(
     is_existing_session: bool,
     cmd: &mut String,
     context: &str,
-) {
+) -> bool {
     use crate::agents::{get_agent, ResumeStrategy};
 
     if let Some(session_id) = session_id {
         let resume_part = build_resume_flags(tool, session_id, is_existing_session);
         if resume_part.is_empty() {
-            return;
+            return false;
         }
         let is_subcommand = matches!(
             get_agent(tool).map(|a| &a.resume_strategy),
@@ -609,7 +609,9 @@ fn append_resume_flags(
             *cmd = format!("{} {}", cmd, resume_part);
         }
         tracing::debug!(target: "session.store", "Added resume flags to {} command: {}", context, resume_part);
+        return true;
     }
+    false
 }
 
 /// Outcome of a CAS-guarded `agent_session_id` or `resume_intent` write.
@@ -1455,8 +1457,9 @@ impl Instance {
 
     fn apply_session_flags(&mut self, cmd: &mut String, context: &str) -> bool {
         let (session_id, is_existing) = self.acquire_session_id();
-        append_resume_flags(&self.tool, session_id.as_deref(), is_existing, cmd, context);
-        is_existing
+        let emitted =
+            append_resume_flags(&self.tool, session_id.as_deref(), is_existing, cmd, context);
+        is_existing && emitted
     }
 
     pub fn has_custom_command(&self) -> bool {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -38,8 +38,8 @@ pub use groups::{
 };
 pub(crate) use instance::{persist_session_to_storage, ResumeIntent, SidWrite};
 pub use instance::{
-    EnsureReadyError, EnsureReadyOutcome, Instance, SandboxInfo, StartOutcome, Status,
-    TerminalInfo, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
+    EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome, SandboxInfo, StartOutcome,
+    Status, TerminalInfo, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
 };
 pub use profile_config::{
     load_profile_config, merge_configs, resolve_config, resolve_config_or_warn,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -20,6 +20,7 @@ mod parallel_capture;
 mod profile_management;
 mod repo_config;
 mod sandbox_integration;
+mod session_id_acquisition;
 mod session_lifecycle;
 mod status_detection;
 mod storage_concurrency;

--- a/tests/integration/session_id_acquisition.rs
+++ b/tests/integration/session_id_acquisition.rs
@@ -43,10 +43,14 @@ fn start_with_size_opts_returns_skipped_when_pane_preexists() {
     inst.agent_session_id = Some(VALID_CLAUDE_UUID.to_string());
     let session_name = tmux::Session::generate_name(&inst.id, &inst.title);
 
-    Command::new("tmux")
+    let status = Command::new("tmux")
         .args(["new-session", "-d", "-s", &session_name])
         .status()
         .expect("tmux new-session");
+    assert!(
+        status.success(),
+        "tmux new-session failed for {session_name}"
+    );
     let _cleanup = TmuxCleanup(&session_name);
 
     // `Session::exists()` consults a 2s-TTL cache; refresh after the raw

--- a/tests/integration/session_id_acquisition.rs
+++ b/tests/integration/session_id_acquisition.rs
@@ -1,0 +1,66 @@
+//! `start_with_size_opts` must return `LaunchSidOutcome::Skipped` when the
+//! tmux session already exists, short-circuiting before `apply_session_flags`.
+
+use agent_of_empires::session::{Instance, LaunchSidOutcome};
+use agent_of_empires::tmux;
+use serial_test::serial;
+use std::process::Command;
+
+use crate::common::setup_temp_home;
+
+const VALID_CLAUDE_UUID: &str = "019342ab-1234-7def-8901-abcdef012345";
+
+struct TmuxCleanup<'a>(&'a str);
+
+impl Drop for TmuxCleanup<'_> {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", self.0])
+            .output();
+    }
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+#[serial]
+fn start_with_size_opts_returns_skipped_when_pane_preexists() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not on PATH");
+        return;
+    }
+    let _temp = setup_temp_home();
+    let mut inst = Instance::new("F1Regression", "/tmp/aoe-f1-regression");
+    inst.tool = "claude".to_string();
+    // Make is_existing=true the path acquire would take if reached, so any
+    // fall-through regression builds a real launch command and fails loudly.
+    inst.agent_session_id = Some(VALID_CLAUDE_UUID.to_string());
+    let session_name = tmux::Session::generate_name(&inst.id, &inst.title);
+
+    Command::new("tmux")
+        .args(["new-session", "-d", "-s", &session_name])
+        .status()
+        .expect("tmux new-session");
+    let _cleanup = TmuxCleanup(&session_name);
+
+    // `Session::exists()` consults a 2s-TTL cache; refresh after the raw
+    // `new-session` so a prior `#[serial]` test's stale snapshot can't
+    // make `exists()` miss our session.
+    tmux::refresh_session_cache();
+
+    let outcome = inst
+        .start_with_size_opts(None, false)
+        .expect("start_with_size_opts must succeed on preexisting pane");
+
+    assert_eq!(
+        outcome,
+        LaunchSidOutcome::Skipped,
+        "preexisting pane must short-circuit before apply_session_flags"
+    );
+}


### PR DESCRIPTION
## Description

Replaces `Instance.last_acquired_existing_sid` (a `#[serde(skip)]` runtime mirror of `acquire_session_id`'s `is_existing` return) with a `LaunchSidOutcome` enum returned by `start_with_size_opts`. `start_with_resume_fallback` now matches on the returned outcome instead of reading a stashed field.

The new `Skipped` variant disambiguates the `kill_clean` cache race and cockpit short-circuit from a real launch, which the old boolean could not. The defensive `|| pane_was_preexisting` clause in the cascade is preserved to cover the TOCTOU window where a peer kills the pane between the snapshot and `start_with_size_opts`'s internal `session.exists()` check.

Removed alongside the field: the F-1 entry reset at `start_with_resume_fallback`, the `merge_runtime_fields` carry, and the two tests pinned to the field (`last_acquired_existing_sid_mirrors_acquire_bool`, `merge_runtime_fields_carries_last_acquired_existing_sid`).

Closes #1743.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Added `tests/integration/session_id_acquisition.rs` pinning the F-1 invariant: `start_with_size_opts` must return `LaunchSidOutcome::Skipped` when the tmux session already exists, short-circuiting before `apply_session_flags`. Plus two unit tests in `src/session/instance.rs` (`apply_session_flags_returns_acquire_is_existing`, `start_with_size_opts_returns_skipped_for_cockpit_mode`).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude (Sisyphus orchestration agent) for design, audit, and implementation.

**Any Additional AI Details you'd like to share:**
Design + audit done via parallel multi-agent fan-out + cross-validation before implementation. The original issue analysis (#1743 body) was a human-controlled audit cycle on PR #1731.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Session startup now reports whether a launch reused an existing session, created a fresh one, or was skipped by returning that outcome from the call chain instead of storing it in a mutable runtime field.

## What Was Added

- New public enum LaunchSidOutcome with variants Existing, Fresh, and Skipped.
- start_with_size_opts now returns Result<LaunchSidOutcome> (propagating existence info).
- apply_session_flags, build_launch_command, and related helpers now surface the "is existing" boolean so callers can map it into LaunchSidOutcome.
- A new integration test ensuring start_with_size_opts returns Skipped when the tmux session already exists, plus two unit tests covering the new return behaviors.
- LaunchSidOutcome is re-exported from the session module.

## What Was Removed

- Removed the runtime field Instance::last_acquired_existing_sid and its reset logic at start_with_resume_fallback.
- Removed tests that depended on the removed field and the merge_runtime_fields carry for that field.

## What Moved/Changed

- The decision about "existing vs fresh vs skipped" is computed during launch-command construction and returned to callers; callers match on LaunchSidOutcome instead of reading a stashed field.
- Cockpit short-circuits and pane-exists short-circuits are disambiguated as LaunchSidOutcome::Skipped.
- start_with_resume_fallback and related resume gating now use the returned LaunchSidOutcome rather than a mutable flag.
- LaunchSidOutcome::Existing semantics were tightened: it now implies both that acquire_session_id reused a prior SID and that the launch command emitted a resume flag.

## Benefits

- Removes hidden mutable runtime state in favor of explicit return values, improving clarity and reducing subtle state bugs.
- Makes resume-vs-fresh logic easier to reason about and test.
- Preserves behavior for TOCTOU edge cases (defensive checks retained) while clarifying outcomes.
- Tests now verify the explicit return semantics rather than relying on in-memory mirrors.

## Technical notes (brief)

- New signature: Instance::start_with_size_opts(&mut self, size: Option<(u16, u16)>, skip_on_launch: bool) -> Result<LaunchSidOutcome>
- apply_session_flags now returns a bool indicating whether acquire_session_id considered the SID existing and whether resume flags were emitted; build_launch_command/build_host_command return (Option<String>, bool).
- merge_runtime_fields no longer needs to carry last_acquired_existing_sid.
- Added integration test: tests/integration/session_id_acquisition.rs and updated tests/integration/main.rs to include it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->