### PR TITLE
feat: add split (side-by-side) diff view to web and TUI

### DIFF
--- a/docs/guides/diff-view.md
+++ b/docs/guides/diff-view.md
@@ -21,6 +21,13 @@ Auto-detection scores every configured remote, not just `origin`. In a fork plus
 | `PgUp` / `PgDn` | Page through diff |
 | `g` / `G` | Jump to top / bottom of diff |
 
+## Split view
+
+Diffs can be shown in a **split** layout (side-by-side: old on the left, new on the right) in addition to the default unified layout. Pure additions and deletions appear on their own side with an aligned placeholder opposite them; context lines show on both sides.
+
+- **TUI**: press `s` to toggle split vs unified. The choice is saved to `[diff].split_view` and restored on the next launch (also editable in the settings TUI under **Diff**). On a narrow diff pane the view falls back to unified automatically.
+- **Web dashboard**: use the **Unified/Split** toggle in the diff header, or **Settings → Diff**. The preference is stored per browser and the view falls back to unified on narrow screens. Inline comments work in either layout.
+
 ## Editing Files
 
 Press `e` or `Enter` to open the selected file in your editor (`$EDITOR`, or vim/nano if not set).
@@ -31,6 +38,7 @@ After saving and exiting, the diff view refreshes automatically to show your cha
 
 | Key | Action |
 |-----|--------|
+| `s` | Toggle split/unified layout |
 | `b` | Change base branch (persists per-session as `base_branch_override`) |
 | `r` | Refresh the diff |
 | `?` | Show help |
@@ -99,6 +107,9 @@ default_branch = "main"
 
 # Lines of context around changes (default: 3)
 context_lines = 3
+
+# Show diffs in a split layout instead of unified (default: false)
+split_view = false
 ```
 
 ## Tips: See Changes While Editing

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -926,6 +926,10 @@ pub struct DiffConfig {
     /// Number of context lines to show around changes
     #[serde(default = "default_context_lines")]
     pub context_lines: usize,
+
+    /// Render diffs side-by-side (split) instead of unified.
+    #[serde(default)]
+    pub split_view: bool,
 }
 
 impl Default for DiffConfig {
@@ -933,6 +937,7 @@ impl Default for DiffConfig {
         Self {
             default_branch: None,
             context_lines: 3,
+            split_view: false,
         }
     }
 }
@@ -2160,6 +2165,16 @@ mod tests {
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.diff.default_branch, Some("main".to_string()));
         assert_eq!(config.diff.context_lines, 10);
+    }
+
+    #[test]
+    fn diff_config_split_view_roundtrips() {
+        let mut cfg = DiffConfig::default();
+        assert!(!cfg.split_view);
+        cfg.split_view = true;
+        let toml = toml::to_string(&cfg).unwrap();
+        let back: DiffConfig = toml::from_str(&toml).unwrap();
+        assert!(back.split_view);
     }
 
     #[test]

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -53,6 +53,9 @@ pub struct ProfileConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cockpit: Option<CockpitConfigOverride>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<DiffConfigOverride>,
+
     /// Per-profile override for the host-side `environment` list. When
     /// `Some`, replaces the global list entirely (matching the existing
     /// `sandbox.environment` override semantics). `None` inherits the
@@ -285,6 +288,13 @@ pub struct SessionConfigOverride {
     pub click_action: Option<super::config::ClickAction>,
 }
 
+/// Per-profile override for diff view preferences.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DiffConfigOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub split_view: Option<bool>,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HooksConfigOverride {
     #[serde(
@@ -357,6 +367,7 @@ pub fn profile_has_overrides(config: &ProfileConfig) -> bool {
         || config.sound.is_some()
         || config.status_hooks.is_some()
         || config.cockpit.is_some()
+        || config.diff.is_some()
         || config.environment.is_some()
 }
 
@@ -662,6 +673,12 @@ pub fn merge_configs(mut global: Config, profile: &ProfileConfig) -> Config {
         }
         if let Some(v) = cockpit_override.auto_stop_idle_secs {
             global.cockpit.auto_stop_idle_secs = v;
+        }
+    }
+
+    if let Some(ref diff_override) = profile.diff {
+        if let Some(split_view) = diff_override.split_view {
+            global.diff.split_view = split_view;
         }
     }
 
@@ -1196,5 +1213,19 @@ mod tests {
 
         let merged = merge_configs(global, &profile);
         assert_eq!(merged.environment, vec!["FROM_GLOBAL=1".to_string()]);
+    }
+
+    #[test]
+    fn profile_diff_split_view_override_applies() {
+        let mut global = Config::default();
+        global.diff.split_view = false;
+        let profile = ProfileConfig {
+            diff: Some(DiffConfigOverride {
+                split_view: Some(true),
+            }),
+            ..Default::default()
+        };
+        let merged = merge_configs(global, &profile);
+        assert!(merged.diff.split_view);
     }
 }

--- a/src/tui/diff/input.rs
+++ b/src/tui/diff/input.rs
@@ -140,6 +140,13 @@ impl DiffView {
                 DiffAction::Continue
             }
 
+            // Toggle side-by-side (split) layout
+            (KeyCode::Char('s'), _) => {
+                self.split_view = !self.split_view;
+                self.persist_split_view();
+                DiffAction::Continue
+            }
+
             // Resize file list panel
             (KeyCode::Char('h'), _) | (KeyCode::Left, _) => {
                 self.shrink_file_list();
@@ -249,5 +256,20 @@ mod tests {
         // 'q' should close the view when no dialog
         let action = view.handle_key(key(KeyCode::Char('q')));
         assert!(matches!(action, DiffAction::Close));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn s_key_toggles_split_view() {
+        let temp_home = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let mut view = make_diff_view_no_warning();
+        let before = view.split_view;
+        let action = view.handle_key(key(KeyCode::Char('s')));
+        assert!(matches!(action, DiffAction::Continue));
+        assert_eq!(view.split_view, !before);
     }
 }

--- a/src/tui/diff/input.rs
+++ b/src/tui/diff/input.rs
@@ -261,6 +261,29 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn s_key_toggles_split_view() {
+        // Restore HOME/XDG on drop (even on panic) so later serial tests don't
+        // inherit a temp HOME pointing at a since-deleted directory.
+        struct EnvGuard {
+            home: Option<std::ffi::OsString>,
+            xdg: Option<std::ffi::OsString>,
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match self.home.take() {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+                match self.xdg.take() {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+        }
+        let _env = EnvGuard {
+            home: std::env::var_os("HOME"),
+            xdg: std::env::var_os("XDG_CONFIG_HOME"),
+        };
+
         let temp_home = tempfile::TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
         #[cfg(target_os = "linux")]

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -2,6 +2,7 @@
 
 mod input;
 mod render;
+mod split;
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -71,6 +71,9 @@ pub struct DiffView {
     /// Context lines for diff
     pub(crate) context_lines: usize,
 
+    /// Render the selected file's diff side-by-side instead of unified.
+    pub(crate) split_view: bool,
+
     /// Show help overlay
     pub(crate) show_help: bool,
 
@@ -125,6 +128,7 @@ impl DiffView {
             .unwrap_or_else(|| "main".to_string());
 
         let context_lines = config.diff.context_lines;
+        let split_view = config.diff.split_view;
 
         let warning_dialog = check_merge_base_status(&repo_path, &base_branch)
             .map(|msg| InfoDialog::new("Warning", &msg));
@@ -144,6 +148,7 @@ impl DiffView {
             error_message: None,
             success_message: None,
             context_lines,
+            split_view,
             show_help: false,
             file_list_width: config.app_state.diff_file_list_width.unwrap_or(35),
             warning_dialog,
@@ -341,6 +346,7 @@ impl DiffView {
             error_message: None,
             success_message: None,
             context_lines: 3,
+            split_view: false,
             show_help: false,
             file_list_width: 35,
             warning_dialog: None,

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -12,7 +12,7 @@ use crate::git::diff::{
     list_branches, DiffFile, FileDiff,
 };
 use crate::session::config::{load_config, save_config};
-use crate::session::Config;
+use crate::session::{load_profile_config, resolve_config_or_warn, save_profile_config, Config};
 use crate::tui::dialogs::InfoDialog;
 
 pub use input::DiffAction;
@@ -116,7 +116,14 @@ impl DiffView {
         profile: String,
         base_override: Option<String>,
     ) -> anyhow::Result<Self> {
-        let config = Config::load_or_warn();
+        // Use the profile-merged config so a per-profile Diff override (e.g.
+        // split_view) is honored on open. The session-agnostic path (empty
+        // profile) falls back to the global config.
+        let config = if profile.is_empty() {
+            Config::load_or_warn()
+        } else {
+            resolve_config_or_warn(&profile)
+        };
 
         let base_branch = base_override
             .as_deref()
@@ -327,13 +334,35 @@ impl DiffView {
         }
     }
 
-    /// Persist the current `split_view` choice to the global config so it
-    /// survives restarts and stays in sync with the settings TUI.
+    /// Persist the current `split_view` choice so it survives restarts and
+    /// stays in sync with the settings TUI. A profile-scoped session writes the
+    /// choice to that profile's override; a session-agnostic view writes the
+    /// global default.
     pub(crate) fn persist_split_view(&self) {
-        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
-            config.diff.split_view = self.split_view;
-            if let Err(e) = save_config(&config) {
-                tracing::warn!("failed to persist diff split_view: {e}");
+        if self.profile.is_empty() {
+            if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
+                config.diff.split_view = self.split_view;
+                if let Err(e) = save_config(&config) {
+                    tracing::warn!("failed to persist diff split_view: {e}");
+                }
+            }
+            return;
+        }
+        match load_profile_config(&self.profile) {
+            Ok(mut profile_config) => {
+                profile_config
+                    .diff
+                    .get_or_insert_with(Default::default)
+                    .split_view = Some(self.split_view);
+                if let Err(e) = save_profile_config(&self.profile, &profile_config) {
+                    tracing::warn!(
+                        "failed to persist diff split_view for profile {}: {e}",
+                        self.profile
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!("failed to load profile config {}: {e}", self.profile);
             }
         }
     }

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -327,6 +327,17 @@ impl DiffView {
         }
     }
 
+    /// Persist the current `split_view` choice to the global config so it
+    /// survives restarts and stays in sync with the settings TUI.
+    pub(crate) fn persist_split_view(&self) {
+        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
+            config.diff.split_view = self.split_view;
+            if let Err(e) = save_config(&config) {
+                tracing::warn!("failed to persist diff split_view: {e}");
+            }
+        }
+    }
+
     /// Minimal DiffView for unit tests. Centralised so new fields only need
     /// a default value in one place.
     #[cfg(test)]

--- a/src/tui/diff/render.rs
+++ b/src/tui/diff/render.rs
@@ -219,16 +219,12 @@ impl DiffView {
         content_w: usize,
         theme: &Theme,
     ) -> Vec<Span<'a>> {
+        // Every cell occupies exactly this width (line number + space + marker
+        // + padded content) so both columns line up and the divider draws as a
+        // straight vertical line regardless of content length.
+        let cell_w = num_width + 2 + content_w;
         match line {
-            None => vec![Span::styled(
-                format!(
-                    "{} {} {}",
-                    " ".repeat(num_width),
-                    " ",
-                    " ".repeat(content_w)
-                ),
-                Style::default().fg(theme.dimmed),
-            )],
+            None => vec![Span::raw(" ".repeat(cell_w))],
             Some(l) => {
                 let (prefix, style) = match l.tag {
                     ChangeTag::Delete => ("-", Style::default().fg(theme.diff_delete)),
@@ -244,12 +240,15 @@ impl DiffView {
                     .map(|n| format!("{:>w$}", n, w = num_width))
                     .unwrap_or_else(|| " ".repeat(num_width));
                 let mut content = l.content.trim_end_matches('\n').to_string();
-                if content.chars().count() > content_w {
+                let display_w = content.chars().count();
+                if display_w > content_w {
                     content = content
                         .chars()
                         .take(content_w.saturating_sub(1))
                         .collect::<String>()
                         + "\u{2026}";
+                } else {
+                    content.push_str(&" ".repeat(content_w - display_w));
                 }
                 vec![
                     Span::styled(format!("{} ", num_str), Style::default().fg(theme.dimmed)),
@@ -432,6 +431,17 @@ impl DiffView {
                 Span::styled(": edit  ", Style::default().fg(theme.dimmed)),
                 Span::styled("b", Style::default().fg(theme.accent)),
                 Span::styled(": branch  ", Style::default().fg(theme.dimmed)),
+                Span::styled("s", Style::default().fg(theme.accent)),
+                // Name the layout `s` switches TO, so the hint stays correct
+                // once you are already in split view.
+                Span::styled(
+                    if self.split_view {
+                        ": unified  "
+                    } else {
+                        ": split  "
+                    },
+                    Style::default().fg(theme.dimmed),
+                ),
                 Span::styled("?", Style::default().fg(theme.accent)),
                 Span::styled(": help  ", Style::default().fg(theme.dimmed)),
                 Span::styled("q/Esc", Style::default().fg(theme.accent)),
@@ -611,6 +621,7 @@ impl DiffView {
                     ("e/Enter", "Edit file in external editor"),
                     ("b", "Select base branch"),
                     ("r", "Refresh diff"),
+                    ("s", "Toggle side-by-side (split) layout"),
                 ],
             ),
             (
@@ -791,6 +802,70 @@ mod tests {
         assert!(
             out.contains("NEWCONTENT"),
             "expected new content on right side, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn split_view_aligns_divider_into_one_column() {
+        use crate::git::diff::{DiffFile, DiffHunk, DiffLine, FileDiff};
+        use std::path::PathBuf;
+
+        let path = PathBuf::from("a.txt");
+        let dl = |tag, o: Option<usize>, n: Option<usize>, c: &str| DiffLine {
+            tag,
+            old_line_num: o,
+            new_line_num: n,
+            content: format!("{c}\n"),
+        };
+        let file = DiffFile {
+            path: path.clone(),
+            old_path: None,
+            status: FileStatus::Modified,
+            additions: 1,
+            deletions: 1,
+        };
+        let diff = FileDiff {
+            file: file.clone(),
+            hunks: vec![DiffHunk {
+                old_start: 1,
+                old_lines: 3,
+                new_start: 1,
+                new_lines: 3,
+                lines: vec![
+                    // Deliberately varied left-content lengths: an unpadded
+                    // column would put the divider at different offsets.
+                    dl(ChangeTag::Equal, Some(1), Some(1), "short"),
+                    dl(
+                        ChangeTag::Delete,
+                        Some(2),
+                        None,
+                        "a considerably longer line of content",
+                    ),
+                    dl(ChangeTag::Insert, None, Some(2), "x"),
+                    dl(ChangeTag::Equal, Some(3), Some(3), "mid length"),
+                ],
+            }],
+            is_binary: false,
+        };
+
+        let mut view = DiffView::test_default();
+        view.files = vec![file];
+        view.selected_file = 0;
+        view.diff_cache.insert(path, diff);
+        view.split_view = true;
+
+        let out = render_diff_to_string(&mut view, 200, 20);
+        // The split divider is rendered as " | " (space-pipe-space); panel
+        // borders never have spaces on both sides, so this finds only the
+        // split dividers. Every one must sit in the same column.
+        let cols: Vec<usize> = out.lines().filter_map(|l| l.find(" \u{2502} ")).collect();
+        assert!(
+            cols.len() >= 3,
+            "expected a divider on each split row, got {cols:?}:\n{out}"
+        );
+        assert!(
+            cols.iter().all(|&c| c == cols[0]),
+            "split divider must align into one column, got {cols:?}:\n{out}"
         );
     }
 

--- a/src/tui/diff/render.rs
+++ b/src/tui/diff/render.rs
@@ -11,6 +11,7 @@ use ratatui::{
     Frame,
 };
 use similar::ChangeTag;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::DiffView;
 use crate::git::diff::FileStatus;
@@ -239,16 +240,29 @@ impl DiffView {
                 let num_str = num
                     .map(|n| format!("{:>w$}", n, w = num_width))
                     .unwrap_or_else(|| " ".repeat(num_width));
-                let mut content = l.content.trim_end_matches('\n').to_string();
-                let display_w = content.chars().count();
-                if display_w > content_w {
-                    content = content
-                        .chars()
-                        .take(content_w.saturating_sub(1))
-                        .collect::<String>()
-                        + "\u{2026}";
+                // Measure and pad by terminal column width, not scalar count,
+                // so wide (CJK/emoji) characters keep the two columns aligned.
+                let raw = l.content.trim_end_matches('\n');
+                let mut content = if UnicodeWidthStr::width(raw) > content_w {
+                    let budget = content_w.saturating_sub(1);
+                    let mut used = 0usize;
+                    let mut truncated = String::new();
+                    for ch in raw.chars() {
+                        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+                        if used + cw > budget {
+                            break;
+                        }
+                        used += cw;
+                        truncated.push(ch);
+                    }
+                    truncated.push('\u{2026}');
+                    truncated
                 } else {
-                    content.push_str(&" ".repeat(content_w - display_w));
+                    raw.to_string()
+                };
+                let used = UnicodeWidthStr::width(content.as_str());
+                if used < content_w {
+                    content.push_str(&" ".repeat(content_w - used));
                 }
                 vec![
                     Span::styled(format!("{} ", num_str), Style::default().fg(theme.dimmed)),

--- a/src/tui/diff/render.rs
+++ b/src/tui/diff/render.rs
@@ -209,6 +209,57 @@ impl DiffView {
         frame.render_widget(list, inner);
     }
 
+    /// Build one side of a split row: right-justified line number, a +/-/space
+    /// marker, and content truncated to `content_w` columns. `None` renders an
+    /// empty cell of the same width.
+    fn split_cell<'a>(
+        line: Option<&'a crate::git::diff::DiffLine>,
+        is_left: bool,
+        num_width: usize,
+        content_w: usize,
+        theme: &Theme,
+    ) -> Vec<Span<'a>> {
+        match line {
+            None => vec![Span::styled(
+                format!(
+                    "{} {} {}",
+                    " ".repeat(num_width),
+                    " ",
+                    " ".repeat(content_w)
+                ),
+                Style::default().fg(theme.dimmed),
+            )],
+            Some(l) => {
+                let (prefix, style) = match l.tag {
+                    ChangeTag::Delete => ("-", Style::default().fg(theme.diff_delete)),
+                    ChangeTag::Insert => ("+", Style::default().fg(theme.diff_add)),
+                    ChangeTag::Equal => (" ", Style::default().fg(theme.dimmed)),
+                };
+                let num = if is_left {
+                    l.old_line_num
+                } else {
+                    l.new_line_num
+                };
+                let num_str = num
+                    .map(|n| format!("{:>w$}", n, w = num_width))
+                    .unwrap_or_else(|| " ".repeat(num_width));
+                let mut content = l.content.trim_end_matches('\n').to_string();
+                if content.chars().count() > content_w {
+                    content = content
+                        .chars()
+                        .take(content_w.saturating_sub(1))
+                        .collect::<String>()
+                        + "\u{2026}";
+                }
+                vec![
+                    Span::styled(format!("{} ", num_str), Style::default().fg(theme.dimmed)),
+                    Span::styled(prefix.to_string(), style),
+                    Span::styled(content, style),
+                ]
+            }
+        }
+    }
+
     fn render_diff_content(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let title = self
             .selected_file()
@@ -244,6 +295,10 @@ impl DiffView {
                 let num_width = max_line_num.max(1).ilog10() as usize + 1;
                 let blank: String = " ".repeat(num_width);
 
+                let split = self.split_view && inner.width >= 80;
+                let half_content_w =
+                    ((inner.width as usize).saturating_sub(2) / 2).saturating_sub(num_width + 3);
+
                 // Build all diff lines
                 let mut lines: Vec<Line> = Vec::new();
 
@@ -257,32 +312,51 @@ impl DiffView {
                         Style::default().fg(theme.diff_header),
                     )));
 
-                    for line in &hunk.lines {
-                        let (prefix, style) = match line.tag {
-                            ChangeTag::Delete => ("-", Style::default().fg(theme.diff_delete)),
-                            ChangeTag::Insert => ("+", Style::default().fg(theme.diff_add)),
-                            ChangeTag::Equal => (" ", Style::default().fg(theme.dimmed)),
-                        };
+                    if split {
+                        for row in super::split::build_split_rows(hunk) {
+                            let mut spans =
+                                Self::split_cell(row.left, true, num_width, half_content_w, theme);
+                            spans.push(Span::styled(
+                                " \u{2502} ",
+                                Style::default().fg(theme.border),
+                            ));
+                            spans.extend(Self::split_cell(
+                                row.right,
+                                false,
+                                num_width,
+                                half_content_w,
+                                theme,
+                            ));
+                            lines.push(Line::from(spans));
+                        }
+                    } else {
+                        for line in &hunk.lines {
+                            let (prefix, style) = match line.tag {
+                                ChangeTag::Delete => ("-", Style::default().fg(theme.diff_delete)),
+                                ChangeTag::Insert => ("+", Style::default().fg(theme.diff_add)),
+                                ChangeTag::Equal => (" ", Style::default().fg(theme.dimmed)),
+                            };
 
-                        let old_num = line
-                            .old_line_num
-                            .map(|n| format!("{:>w$}", n, w = num_width))
-                            .unwrap_or_else(|| blank.clone());
-                        let new_num = line
-                            .new_line_num
-                            .map(|n| format!("{:>w$}", n, w = num_width))
-                            .unwrap_or_else(|| blank.clone());
+                            let old_num = line
+                                .old_line_num
+                                .map(|n| format!("{:>w$}", n, w = num_width))
+                                .unwrap_or_else(|| blank.clone());
+                            let new_num = line
+                                .new_line_num
+                                .map(|n| format!("{:>w$}", n, w = num_width))
+                                .unwrap_or_else(|| blank.clone());
 
-                        let content = line.content.trim_end_matches('\n');
+                            let content = line.content.trim_end_matches('\n');
 
-                        lines.push(Line::from(vec![
-                            Span::styled(
-                                format!("{} {} ", old_num, new_num),
-                                Style::default().fg(theme.dimmed),
-                            ),
-                            Span::styled(prefix, style),
-                            Span::styled(content, style),
-                        ]));
+                            lines.push(Line::from(vec![
+                                Span::styled(
+                                    format!("{} {} ", old_num, new_num),
+                                    Style::default().fg(theme.dimmed),
+                                ),
+                                Span::styled(prefix, style),
+                                Span::styled(content, style),
+                            ]));
+                        }
                     }
 
                     lines.push(Line::from(""));
@@ -637,6 +711,86 @@ mod tests {
         assert!(
             out.contains("branch-39"),
             "selected branch must be rendered, got:\n{out}"
+        );
+    }
+
+    fn render_diff_to_string(view: &mut DiffView, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = load_theme("empire");
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                view.render(f, area, &theme);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn split_view_renders_divider_and_both_sides() {
+        use crate::git::diff::{DiffFile, DiffHunk, DiffLine, FileDiff};
+        use std::path::PathBuf;
+
+        let path = PathBuf::from("example.txt");
+        let file = DiffFile {
+            path: path.clone(),
+            old_path: None,
+            status: FileStatus::Modified,
+            additions: 1,
+            deletions: 1,
+        };
+        let diff = FileDiff {
+            file: file.clone(),
+            hunks: vec![DiffHunk {
+                old_start: 1,
+                old_lines: 1,
+                new_start: 1,
+                new_lines: 1,
+                lines: vec![
+                    DiffLine {
+                        tag: ChangeTag::Delete,
+                        old_line_num: Some(1),
+                        new_line_num: None,
+                        content: "OLDCONTENT\n".to_string(),
+                    },
+                    DiffLine {
+                        tag: ChangeTag::Insert,
+                        old_line_num: None,
+                        new_line_num: Some(1),
+                        content: "NEWCONTENT\n".to_string(),
+                    },
+                ],
+            }],
+            is_binary: false,
+        };
+
+        let mut view = DiffView::test_default();
+        view.files = vec![file];
+        view.selected_file = 0;
+        view.diff_cache.insert(path, diff);
+        view.split_view = true;
+
+        let out = render_diff_to_string(&mut view, 120, 24);
+        assert!(
+            out.contains('\u{2502}'),
+            "expected the split divider, got:\n{out}"
+        );
+        assert!(
+            out.contains("OLDCONTENT"),
+            "expected old content on left side, got:\n{out}"
+        );
+        assert!(
+            out.contains("NEWCONTENT"),
+            "expected new content on right side, got:\n{out}"
         );
     }
 

--- a/src/tui/diff/split.rs
+++ b/src/tui/diff/split.rs
@@ -1,0 +1,114 @@
+//! Pair a hunk's unified line list into side-by-side rows.
+
+use crate::git::diff::{DiffHunk, DiffLine};
+use similar::ChangeTag;
+
+/// One row of a split diff. `left` is the old side, `right` the new side;
+/// either is `None` where that side has no line for this row.
+#[allow(dead_code)] // removed in the next task once render uses it
+pub struct SplitRow<'a> {
+    pub left: Option<&'a DiffLine>,
+    pub right: Option<&'a DiffLine>,
+}
+
+fn flush<'a>(
+    rows: &mut Vec<SplitRow<'a>>,
+    dels: &mut Vec<&'a DiffLine>,
+    adds: &mut Vec<&'a DiffLine>,
+) {
+    let n = dels.len().max(adds.len());
+    for k in 0..n {
+        rows.push(SplitRow {
+            left: dels.get(k).copied(),
+            right: adds.get(k).copied(),
+        });
+    }
+    dels.clear();
+    adds.clear();
+}
+
+/// Pair `hunk.lines` into side-by-side rows. A maximal run of non-equal
+/// lines is one change block: its deletions and additions are zipped
+/// index-by-index, surplus lines get a `None` placeholder opposite them.
+#[allow(dead_code)] // removed in the next task once render uses it
+pub fn build_split_rows(hunk: &DiffHunk) -> Vec<SplitRow<'_>> {
+    let mut rows: Vec<SplitRow> = Vec::new();
+    let mut dels: Vec<&DiffLine> = Vec::new();
+    let mut adds: Vec<&DiffLine> = Vec::new();
+
+    for line in &hunk.lines {
+        match line.tag {
+            ChangeTag::Equal => {
+                flush(&mut rows, &mut dels, &mut adds);
+                rows.push(SplitRow {
+                    left: Some(line),
+                    right: Some(line),
+                });
+            }
+            ChangeTag::Delete => dels.push(line),
+            ChangeTag::Insert => adds.push(line),
+        }
+    }
+    flush(&mut rows, &mut dels, &mut adds);
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::diff::{DiffHunk, DiffLine};
+
+    fn dl(tag: ChangeTag, old: Option<usize>, new: Option<usize>, content: &str) -> DiffLine {
+        DiffLine {
+            tag,
+            old_line_num: old,
+            new_line_num: new,
+            content: content.to_string(),
+        }
+    }
+
+    fn hunk(lines: Vec<DiffLine>) -> DiffHunk {
+        DiffHunk {
+            old_start: 1,
+            old_lines: 1,
+            new_start: 1,
+            new_lines: 1,
+            lines,
+        }
+    }
+
+    #[test]
+    fn context_appears_on_both_sides() {
+        let h = hunk(vec![dl(ChangeTag::Equal, Some(1), Some(1), "ctx")]);
+        let rows = build_split_rows(&h);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].left.unwrap().content, "ctx");
+        assert_eq!(rows[0].right.unwrap().content, "ctx");
+    }
+
+    #[test]
+    fn deletion_left_addition_right_when_paired() {
+        let h = hunk(vec![
+            dl(ChangeTag::Delete, Some(2), None, "old"),
+            dl(ChangeTag::Insert, None, Some(2), "new"),
+        ]);
+        let rows = build_split_rows(&h);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].left.unwrap().content, "old");
+        assert_eq!(rows[0].right.unwrap().content, "new");
+    }
+
+    #[test]
+    fn uneven_block_pads_shorter_side() {
+        let h = hunk(vec![
+            dl(ChangeTag::Delete, Some(2), None, "old"),
+            dl(ChangeTag::Insert, None, Some(2), "new a"),
+            dl(ChangeTag::Insert, None, Some(3), "new b"),
+        ]);
+        let rows = build_split_rows(&h);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].left.unwrap().content, "old");
+        assert!(rows[1].left.is_none());
+        assert_eq!(rows[1].right.unwrap().content, "new b");
+    }
+}

--- a/src/tui/diff/split.rs
+++ b/src/tui/diff/split.rs
@@ -5,7 +5,6 @@ use similar::ChangeTag;
 
 /// One row of a split diff. `left` is the old side, `right` the new side;
 /// either is `None` where that side has no line for this row.
-#[allow(dead_code)] // removed in the next task once render uses it
 pub struct SplitRow<'a> {
     pub left: Option<&'a DiffLine>,
     pub right: Option<&'a DiffLine>,
@@ -30,7 +29,6 @@ fn flush<'a>(
 /// Pair `hunk.lines` into side-by-side rows. A maximal run of non-equal
 /// lines is one change block: its deletions and additions are zipped
 /// index-by-index, surplus lines get a `None` placeholder opposite them.
-#[allow(dead_code)] // removed in the next task once render uses it
 pub fn build_split_rows(hunk: &DiffHunk) -> Vec<SplitRow<'_>> {
     let mut rows: Vec<SplitRow> = Vec::new();
     let mut dels: Vec<&DiffLine> = Vec::new();

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -28,6 +28,7 @@ pub enum SettingsCategory {
     Hooks,
     Web,
     Cockpit,
+    Diff,
     Logging,
 }
 
@@ -47,6 +48,7 @@ impl SettingsCategory {
             Self::Hooks => "Lifecycle Hooks",
             Self::Web => "Web",
             Self::Cockpit => "Cockpit",
+            Self::Diff => "Diff",
             Self::Logging => "Logging",
         }
     }
@@ -162,6 +164,8 @@ pub enum FieldKey {
     CockpitSilentOrphanGraceSecs,
     CockpitSilentOrphanFastGraceSecs,
     CockpitAutoStopIdleSecs,
+    // Diff
+    DiffSplitView,
     // Logging
     LoggingDefaultLevel,
     /// Per-target override; carries an index into `crate::logging::KNOWN_SUB_TARGETS`
@@ -383,6 +387,7 @@ pub fn build_fields_for_category(
         SettingsCategory::Hooks => build_hooks_fields(scope, global, profile),
         SettingsCategory::Web => build_web_fields(scope, global, profile),
         SettingsCategory::Cockpit => build_cockpit_fields(scope, global, profile),
+        SettingsCategory::Diff => build_diff_fields(scope, global, profile),
         SettingsCategory::Logging => build_logging_fields(global),
     }
 }
@@ -876,6 +881,30 @@ fn build_web_fields(
             inherited_display: None,
         },
     ]
+}
+
+fn build_diff_fields(
+    scope: SettingsScope,
+    global: &Config,
+    profile: &ProfileConfig,
+) -> Vec<SettingField> {
+    let diff = profile.diff.as_ref();
+
+    let (split_view, has_override) = resolve_value(
+        scope,
+        global.diff.split_view,
+        diff.and_then(|d| d.split_view),
+    );
+
+    vec![SettingField {
+        key: FieldKey::DiffSplitView,
+        label: "Side-by-side diff",
+        description: "Show diffs in a split (side-by-side) layout instead of unified",
+        value: FieldValue::Bool(split_view),
+        category: SettingsCategory::Diff,
+        has_override,
+        inherited_display: inherited_if(has_override, FieldValue::Bool(global.diff.split_view)),
+    }]
 }
 
 fn build_theme_fields(
@@ -2865,6 +2894,8 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::WebNotifyOnError, FieldValue::Bool(v)) => {
             config.web.notify_on_error = *v;
         }
+        // Diff
+        (FieldKey::DiffSplitView, FieldValue::Bool(v)) => config.diff.split_view = *v,
         // Cockpit
         (FieldKey::CockpitEnabled, FieldValue::Bool(v)) => config.cockpit.enabled = *v,
         (FieldKey::CockpitDefaultForClaude, FieldValue::Bool(v)) => {
@@ -3064,6 +3095,10 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
         }
         (FieldKey::InitSubmodules, FieldValue::Bool(v)) => {
             set_profile_override(*v, &mut config.worktree, |s, val| s.init_submodules = val);
+        }
+        // Diff
+        (FieldKey::DiffSplitView, FieldValue::Bool(v)) => {
+            set_profile_override(*v, &mut config.diff, |d, val| d.split_view = val);
         }
         // Sandbox
         (FieldKey::SandboxEnabledByDefault, FieldValue::Bool(v)) => {
@@ -3779,6 +3814,25 @@ mod tests {
 
         assert!(field.has_override);
         assert!(matches!(field.value, FieldValue::Bool(true)));
+    }
+
+    #[test]
+    fn test_diff_split_view_applies_to_global() {
+        let mut global = Config::default();
+        assert!(!global.diff.split_view);
+
+        let field = SettingField {
+            key: FieldKey::DiffSplitView,
+            label: "Side-by-side diff",
+            description: "",
+            value: FieldValue::Bool(true),
+            category: SettingsCategory::Diff,
+            has_override: false,
+            inherited_display: None,
+        };
+        apply_field_to_global(&field, &mut global);
+
+        assert!(global.diff.split_view);
     }
 
     #[test]

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -710,6 +710,12 @@ impl SettingsView {
                     w.init_submodules = None;
                 }
             }
+            // Diff
+            FieldKey::DiffSplitView => {
+                if let Some(d) = config.diff.as_mut() {
+                    d.split_view = None;
+                }
+            }
             // Sandbox
             FieldKey::DefaultImage => {
                 if let Some(ref mut s) = config.sandbox {

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -284,6 +284,7 @@ impl SettingsView {
         push_tab(&mut rows, SettingsCategory::Session);
         push_tab(&mut rows, SettingsCategory::Agents);
         push_tab(&mut rows, SettingsCategory::Interaction);
+        push_tab(&mut rows, SettingsCategory::Diff);
         push_tab(&mut rows, SettingsCategory::Cockpit);
 
         push_section(&mut rows, "Hooks");

--- a/tests/integration/diff_integration.rs
+++ b/tests/integration/diff_integration.rs
@@ -202,5 +202,6 @@ mod config {
 
         assert_eq!(config.default_branch, deserialized.default_branch);
         assert_eq!(config.context_lines, deserialized.context_lines);
+        assert_eq!(config.split_view, deserialized.split_view);
     }
 }

--- a/tests/integration/diff_integration.rs
+++ b/tests/integration/diff_integration.rs
@@ -194,6 +194,7 @@ mod config {
         let config = DiffConfig {
             default_branch: Some("main".to_string()),
             context_lines: 10,
+            split_view: false,
         };
 
         let serialized = toml::to_string(&config).unwrap();

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -22,6 +22,7 @@ import {
   ToggleField,
 } from "./settings/FormFields";
 import { ThemeSettings } from "./settings/ThemeSettings";
+import { DiffSettings } from "./settings/DiffSettings";
 import { SoundSettings } from "./settings/SoundSettings";
 import { UpdateSettings } from "./settings/UpdateSettings";
 import { TmuxSettings } from "./settings/TmuxSettings";
@@ -33,6 +34,7 @@ type TabId =
   | "sandbox"
   | "worktree"
   | "theme"
+  | "diff"
   | "sound"
   | "tmux"
   | "updates"
@@ -60,6 +62,7 @@ export function buildSidebar(): SidebarItem[] {
   return [
     { kind: "divider", label: "Appearance" },
     { kind: "tab", id: "theme", label: "Theme" },
+    { kind: "tab", id: "diff", label: "Diff" },
     { kind: "divider", label: "Sessions" },
     { kind: "tab", id: "session", label: "Session" },
     { kind: "tab", id: "cockpit", label: "Cockpit" },
@@ -93,6 +96,7 @@ const ALL_TAB_IDS = new Set<TabId>([
   "sandbox",
   "worktree",
   "theme",
+  "diff",
   "sound",
   "tmux",
   "updates",
@@ -457,6 +461,8 @@ export function SettingsView({
 
       case "theme":
         return <ThemeSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
+      case "diff":
+        return <DiffSettings />;
       case "sound":
         return <SoundSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
       case "tmux":

--- a/web/src/components/__tests__/SettingsView.diffTab.test.tsx
+++ b/web/src/components/__tests__/SettingsView.diffTab.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SettingsView } from "../SettingsView";
+
+const PROFILES = [{ name: "main", is_default: true }];
+
+vi.mock("../../lib/api", () => ({
+  fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchSettings: vi.fn(() =>
+    Promise.resolve({ cockpit: {}, sandbox: {}, worktree: {} }),
+  ),
+  updateProfileSettings: vi.fn(() => Promise.resolve(true)),
+  setCockpitMaster: vi.fn(() => Promise.resolve(true)),
+  setDefaultProfile: vi.fn(() => Promise.resolve(true)),
+  createProfile: vi.fn(() => Promise.resolve(true)),
+  renameProfile: vi.fn(() => Promise.resolve(true)),
+  deleteProfile: vi.fn(() => Promise.resolve(true)),
+}));
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("SettingsView diff tab", () => {
+  it("renders the Diff section (split + tree toggles)", async () => {
+    render(
+      <SettingsView
+        onClose={() => {}}
+        tab="diff"
+        onSelectTab={vi.fn()}
+        serverAbout={null}
+        onServerAboutRefresh={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("Side-by-side diff")).toBeTruthy();
+    expect(screen.getByText("Tree file list")).toBeTruthy();
+  });
+});

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -21,6 +21,7 @@ describe("buildSidebar", () => {
     expect(buildSidebar()).toEqual([
       { kind: "divider", label: "Appearance" },
       { kind: "tab", id: "theme", label: "Theme" },
+      { kind: "tab", id: "diff", label: "Diff" },
       { kind: "divider", label: "Sessions" },
       { kind: "tab", id: "session", label: "Session" },
       { kind: "tab", id: "cockpit", label: "Cockpit" },

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -524,7 +524,24 @@ export function DiffFileViewer({
                 <SplitHunkView
                   key={`${hunk.old_start}-${hunk.new_start}`}
                   hunk={hunk}
+                  hunkIndex={hi}
                   lineTokens={tokenGrid?.[hi]}
+                  commentsEnabled={commentsEnabled && !!commentsStore}
+                  cardsByEndRow={cardsByHunkRow.get(hi) ?? EMPTY_MAP}
+                  formRowIndex={draft?.hunkIndex === hi ? draft.endRowIndex : null}
+                  draftSide={draft?.hunkIndex === hi ? draft.side : null}
+                  draftStartLine={draft?.hunkIndex === hi ? draft.startLine : null}
+                  draftEndLine={draft?.hunkIndex === hi ? draft.endLine : null}
+                  rangeStart={
+                    rangeStart?.hunkIndex === hi
+                      ? { side: rangeStart.side, line: rangeStart.line }
+                      : null
+                  }
+                  onPlusClick={handlePlusClick}
+                  onCommentSave={handleCommentSave}
+                  onCommentDelete={handleCommentDelete}
+                  onDraftSave={handleDraftSave}
+                  onDraftCancel={handleDraftCancel}
                 />
               ) : (
                 <HunkView

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -236,18 +236,23 @@ export function DiffFileViewer({
   );
 
   const { settings, update } = useWebSettings();
-  const scrollRef = useRef<HTMLDivElement | null>(null);
   const [isWide, setIsWide] = useState(true);
+  const widthObserverRef = useRef<ResizeObserver | null>(null);
 
-  useEffect(() => {
-    const el = scrollRef.current;
+  // Callback ref: the scroll container is rendered only after the loading /
+  // error / empty guards below, so it may mount well after first paint. A
+  // callback ref attaches the observer the moment the node mounts (and tears it
+  // down on unmount), unlike a one-shot mount effect that would miss the late
+  // mount and never measure width.
+  const measureRef = useCallback((el: HTMLDivElement | null) => {
+    widthObserverRef.current?.disconnect();
+    widthObserverRef.current = null;
     if (!el || typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver((entries) => {
-      const w = entries[0]?.contentRect.width ?? 0;
-      setIsWide(w >= 640);
+      setIsWide((entries[0]?.contentRect.width ?? 0) >= 640);
     });
     ro.observe(el);
-    return () => ro.disconnect();
+    widthObserverRef.current = ro;
   }, []);
 
   const splitActive = settings.diffViewLayout === "split" && isWide;
@@ -477,7 +482,7 @@ export function DiffFileViewer({
       </div>
 
       {/* Diff content */}
-      <div ref={scrollRef} className="flex-1 overflow-auto">
+      <div ref={measureRef} className="flex-1 overflow-auto">
         {diff.is_binary ? (
           <div className="flex items-center justify-center h-full text-text-dim">
             <span className="text-sm">Binary file changed</span>

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -458,6 +458,7 @@ export function DiffFileViewer({
             type="button"
             onClick={() => update({ diffViewLayout: "unified" })}
             aria-pressed={settings.diffViewLayout === "unified"}
+            title="Unified diff"
             className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
               settings.diffViewLayout === "unified"
                 ? "bg-brand-600 text-white"
@@ -470,9 +471,16 @@ export function DiffFileViewer({
             type="button"
             onClick={() => update({ diffViewLayout: "split" })}
             aria-pressed={settings.diffViewLayout === "split"}
+            title={
+              settings.diffViewLayout === "split" && !isWide
+                ? "Split selected, but this pane is too narrow; showing unified"
+                : "Side-by-side diff"
+            }
             className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
               settings.diffViewLayout === "split"
-                ? "bg-brand-600 text-white"
+                ? splitActive
+                  ? "bg-brand-600 text-white"
+                  : "bg-brand-600/40 text-white/80"
                 : "text-text-dim hover:text-text-secondary"
             }`}
           >

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -1,9 +1,11 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFileDiff } from "../../hooks/useFileDiff";
 import {
   useHighlightedLines,
   type SyntaxToken,
 } from "../../hooks/useHighlightedLines";
+import { useWebSettings } from "../../hooks/useWebSettings";
+import { SplitHunkView } from "./SplitHunkView";
 import type { RichDiffHunk, RichDiffLine } from "../../lib/types";
 import { DiffLine } from "./DiffLine";
 import type { UseDiffCommentsResult } from "../../hooks/useDiffComments";
@@ -233,6 +235,23 @@ export function DiffFileViewer({
     diff?.file.path ?? filePath,
   );
 
+  const { settings, update } = useWebSettings();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [isWide, setIsWide] = useState(true);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      setIsWide(w >= 640);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const splitActive = settings.diffViewLayout === "split" && isWide;
+
   const [rangeStart, setRangeStart] = useState<RangeStart | null>(null);
   const [draft, setDraft] = useState<DraftRange | null>(null);
 
@@ -429,10 +448,36 @@ export function DiffFileViewer({
             <span className="text-status-error">-{diff.file.deletions}</span>
           )}
         </span>
+        <div className="ml-auto flex items-center rounded border border-surface-700/40 overflow-hidden">
+          <button
+            type="button"
+            onClick={() => update({ diffViewLayout: "unified" })}
+            aria-pressed={settings.diffViewLayout === "unified"}
+            className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
+              settings.diffViewLayout === "unified"
+                ? "bg-brand-600 text-white"
+                : "text-text-dim hover:text-text-secondary"
+            }`}
+          >
+            Unified
+          </button>
+          <button
+            type="button"
+            onClick={() => update({ diffViewLayout: "split" })}
+            aria-pressed={settings.diffViewLayout === "split"}
+            className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
+              settings.diffViewLayout === "split"
+                ? "bg-brand-600 text-white"
+                : "text-text-dim hover:text-text-secondary"
+            }`}
+          >
+            Split
+          </button>
+        </div>
       </div>
 
       {/* Diff content */}
-      <div className="flex-1 overflow-auto">
+      <div ref={scrollRef} className="flex-1 overflow-auto">
         {diff.is_binary ? (
           <div className="flex items-center justify-center h-full text-text-dim">
             <span className="text-sm">Binary file changed</span>
@@ -474,26 +519,34 @@ export function DiffFileViewer({
                 No changes in this file
               </div>
             )}
-            {diff.hunks.map((hunk, hi) => (
-              <HunkView
-                key={`${hunk.old_start}-${hunk.new_start}`}
-                hunk={hunk}
-                hunkIndex={hi}
-                lineTokens={tokenGrid?.[hi]}
-                rangeStart={rangeStart}
-                draft={draft?.hunkIndex === hi ? draft : null}
-                cardsByEndRow={cardsByHunkRow.get(hi) ?? EMPTY_MAP}
-                formRowIndex={
-                  draft?.hunkIndex === hi ? draft.endRowIndex : null
-                }
-                commentsEnabled={commentsEnabled && !!commentsStore}
-                onPlusClick={handlePlusClick}
-                onCommentSave={handleCommentSave}
-                onCommentDelete={handleCommentDelete}
-                onDraftSave={handleDraftSave}
-                onDraftCancel={handleDraftCancel}
-              />
-            ))}
+            {diff.hunks.map((hunk, hi) =>
+              splitActive ? (
+                <SplitHunkView
+                  key={`${hunk.old_start}-${hunk.new_start}`}
+                  hunk={hunk}
+                  lineTokens={tokenGrid?.[hi]}
+                />
+              ) : (
+                <HunkView
+                  key={`${hunk.old_start}-${hunk.new_start}`}
+                  hunk={hunk}
+                  hunkIndex={hi}
+                  lineTokens={tokenGrid?.[hi]}
+                  rangeStart={rangeStart}
+                  draft={draft?.hunkIndex === hi ? draft : null}
+                  cardsByEndRow={cardsByHunkRow.get(hi) ?? EMPTY_MAP}
+                  formRowIndex={
+                    draft?.hunkIndex === hi ? draft.endRowIndex : null
+                  }
+                  commentsEnabled={commentsEnabled && !!commentsStore}
+                  onPlusClick={handlePlusClick}
+                  onCommentSave={handleCommentSave}
+                  onCommentDelete={handleCommentDelete}
+                  onDraftSave={handleDraftSave}
+                  onDraftCancel={handleDraftCancel}
+                />
+              ),
+            )}
           </div>
         )}
       </div>

--- a/web/src/components/diff/SplitHunkView.tsx
+++ b/web/src/components/diff/SplitHunkView.tsx
@@ -1,0 +1,94 @@
+import { Fragment } from "react";
+import type { SyntaxToken } from "../../hooks/useHighlightedLines";
+import type { RichDiffHunk, RichDiffLine } from "../../lib/types";
+import { buildSplitRows } from "../../lib/splitDiff";
+
+interface Props {
+  hunk: RichDiffHunk;
+  /** Tokens for this hunk, indexed by the line's index within `hunk.lines`. */
+  lineTokens?: SyntaxToken[][];
+}
+
+function renderTokens(line: RichDiffLine, tokens?: SyntaxToken[]) {
+  const content = line.content.replace(/\r?\n$/, "");
+  if (tokens && tokens.length > 0) {
+    const opacity = line.type === "equal" ? 1 : 0.7;
+    return tokens.map((tok, i) => (
+      <span key={i} style={tok.color ? { color: tok.color, opacity } : { opacity }}>
+        {tok.content}
+      </span>
+    ));
+  }
+  return content || " ";
+}
+
+/** One side (column) of a split row. A null line renders an empty,
+ *  subtly-tinted placeholder cell with no gutter number. */
+function SplitCell({
+  line,
+  lineNum,
+  tokens,
+}: {
+  line: RichDiffLine | null;
+  lineNum: number | null;
+  tokens?: SyntaxToken[];
+}) {
+  if (!line) {
+    return <div className="flex flex-1 min-w-0 bg-surface-850/40" />;
+  }
+  let bgClass = "";
+  let textClass = "text-text-secondary";
+  let prefix = " ";
+  if (line.type === "add") {
+    bgClass = "bg-status-running/5";
+    textClass = "text-status-running";
+    prefix = "+";
+  } else if (line.type === "delete") {
+    bgClass = "bg-status-error/5";
+    textClass = "text-status-error";
+    prefix = "-";
+  }
+  return (
+    <div className={`flex flex-1 min-w-0 ${bgClass}`}>
+      <span className="shrink-0 w-[50px] text-right pr-2 font-mono text-[11px] text-text-dim select-none border-r border-surface-700/30">
+        {lineNum ?? ""}
+      </span>
+      <span className={`shrink-0 w-4 text-center font-mono text-[12px] ${textClass} select-none`}>
+        {prefix}
+      </span>
+      <span className="flex-1 min-w-0 font-mono text-[12px] whitespace-pre overflow-hidden">
+        {renderTokens(line, tokens)}
+      </span>
+    </div>
+  );
+}
+
+export function SplitHunkView({ hunk, lineTokens }: Props) {
+  const rows = buildSplitRows(hunk);
+  return (
+    <div>
+      <div className="flex bg-surface-850 border-y border-surface-700/20 sticky top-0 z-[1]">
+        <span className="flex-1 font-mono text-[11px] text-accent-600 py-0.5 px-1">
+          @@ -{hunk.old_start},{hunk.old_lines} +{hunk.new_start},{hunk.new_lines} @@
+        </span>
+      </div>
+      {rows.map((row, i) => (
+        <Fragment key={i}>
+          <div className="flex">
+            <SplitCell
+              line={row.left}
+              lineNum={row.left?.old_line_num ?? null}
+              tokens={row.leftIndex != null ? lineTokens?.[row.leftIndex] : undefined}
+            />
+            <div className="w-px bg-surface-700/40 shrink-0" />
+            <SplitCell
+              line={row.right}
+              lineNum={row.right?.new_line_num ?? null}
+              tokens={row.rightIndex != null ? lineTokens?.[row.rightIndex] : undefined}
+            />
+          </div>
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/diff/SplitHunkView.tsx
+++ b/web/src/components/diff/SplitHunkView.tsx
@@ -2,11 +2,29 @@ import { Fragment } from "react";
 import type { SyntaxToken } from "../../hooks/useHighlightedLines";
 import type { RichDiffHunk, RichDiffLine } from "../../lib/types";
 import { buildSplitRows } from "../../lib/splitDiff";
+import { CommentCard } from "./comments/CommentCard";
+import { CommentForm } from "./comments/CommentForm";
+import type { AnchoredComment, DiffSide } from "./comments/types";
 
 interface Props {
   hunk: RichDiffHunk;
-  /** Tokens for this hunk, indexed by the line's index within `hunk.lines`. */
+  hunkIndex: number;
   lineTokens?: SyntaxToken[][];
+  commentsEnabled: boolean;
+  /** Active comment cards for this hunk, keyed by the row index (within
+   *  `hunk.lines`) of the anchor's end line. */
+  cardsByEndRow: Map<number, AnchoredComment[]>;
+  /** Row index (within `hunk.lines`) at which to render the draft form. */
+  formRowIndex: number | null;
+  draftSide: DiffSide | null;
+  draftStartLine: number | null;
+  draftEndLine: number | null;
+  rangeStart: { side: DiffSide; line: number } | null;
+  onPlusClick: (hunkIndex: number, side: DiffSide, lineNum: number) => void;
+  onCommentSave: (id: string, body: string) => void;
+  onCommentDelete: (id: string) => void;
+  onDraftSave: (body: string) => void;
+  onDraftCancel: () => void;
 }
 
 function renderTokens(line: RichDiffLine, tokens?: SyntaxToken[]) {
@@ -28,10 +46,20 @@ function SplitCell({
   line,
   lineNum,
   tokens,
+  side,
+  hunkIndex,
+  commentsEnabled,
+  plusActive,
+  onPlusClick,
 }: {
   line: RichDiffLine | null;
   lineNum: number | null;
   tokens?: SyntaxToken[];
+  side: DiffSide;
+  hunkIndex: number;
+  commentsEnabled: boolean;
+  plusActive: boolean;
+  onPlusClick: (hunkIndex: number, side: DiffSide, lineNum: number) => void;
 }) {
   if (!line) {
     return <div className="flex flex-1 min-w-0 bg-surface-850/40" />;
@@ -48,9 +76,25 @@ function SplitCell({
     textClass = "text-status-error";
     prefix = "-";
   }
+  const showPlus = commentsEnabled && lineNum != null;
   return (
-    <div className={`flex flex-1 min-w-0 ${bgClass}`}>
-      <span className="shrink-0 w-[50px] text-right pr-2 font-mono text-[11px] text-text-dim select-none border-r border-surface-700/30">
+    <div className={`group/cell flex flex-1 min-w-0 ${bgClass}`}>
+      <span className="shrink-0 w-[50px] text-right pr-2 font-mono text-[11px] text-text-dim select-none border-r border-surface-700/30 relative">
+        {showPlus && (
+          <button
+            type="button"
+            onClick={() => onPlusClick(hunkIndex, side, lineNum)}
+            aria-label={`Add comment on ${side} line ${lineNum}`}
+            tabIndex={-1}
+            className={`absolute left-0 top-0 h-full w-4 flex items-center justify-center text-white text-[11px] leading-none cursor-pointer transition-opacity ${
+              plusActive
+                ? "bg-brand-600 opacity-100"
+                : "bg-brand-600 opacity-0 group-hover/cell:opacity-100 hover:bg-brand-500"
+            }`}
+          >
+            +
+          </button>
+        )}
         {lineNum ?? ""}
       </span>
       <span className={`shrink-0 w-4 text-center font-mono text-[12px] ${textClass} select-none`}>
@@ -63,7 +107,23 @@ function SplitCell({
   );
 }
 
-export function SplitHunkView({ hunk, lineTokens }: Props) {
+export function SplitHunkView({
+  hunk,
+  hunkIndex,
+  lineTokens,
+  commentsEnabled,
+  cardsByEndRow,
+  formRowIndex,
+  draftSide,
+  draftStartLine,
+  draftEndLine,
+  rangeStart,
+  onPlusClick,
+  onCommentSave,
+  onCommentDelete,
+  onDraftSave,
+  onDraftCancel,
+}: Props) {
   const rows = buildSplitRows(hunk);
   return (
     <div>
@@ -72,23 +132,64 @@ export function SplitHunkView({ hunk, lineTokens }: Props) {
           @@ -{hunk.old_start},{hunk.old_lines} +{hunk.new_start},{hunk.new_lines} @@
         </span>
       </div>
-      {rows.map((row, i) => (
-        <Fragment key={i}>
-          <div className="flex">
-            <SplitCell
-              line={row.left}
-              lineNum={row.left?.old_line_num ?? null}
-              tokens={row.leftIndex != null ? lineTokens?.[row.leftIndex] : undefined}
-            />
-            <div className="w-px bg-surface-700/40 shrink-0" />
-            <SplitCell
-              line={row.right}
-              lineNum={row.right?.new_line_num ?? null}
-              tokens={row.rightIndex != null ? lineTokens?.[row.rightIndex] : undefined}
-            />
-          </div>
-        </Fragment>
-      ))}
+      {rows.map((row, i) => {
+        // A row's "source index" for card/form anchoring is the index of
+        // whichever side carries the change (new side preferred, matching
+        // unified's side preference).
+        const anchorIndex = row.rightIndex ?? row.leftIndex;
+        const cards = anchorIndex != null ? cardsByEndRow.get(anchorIndex) : undefined;
+        const showForm =
+          formRowIndex != null && anchorIndex === formRowIndex && draftSide != null;
+        const leftActive =
+          rangeStart?.side === "old" && rangeStart.line === row.left?.old_line_num;
+        const rightActive =
+          rangeStart?.side === "new" && rangeStart.line === row.right?.new_line_num;
+        return (
+          <Fragment key={i}>
+            <div className="flex">
+              <SplitCell
+                line={row.left}
+                lineNum={row.left?.old_line_num ?? null}
+                tokens={row.leftIndex != null ? lineTokens?.[row.leftIndex] : undefined}
+                side="old"
+                hunkIndex={hunkIndex}
+                commentsEnabled={commentsEnabled}
+                plusActive={!!leftActive}
+                onPlusClick={onPlusClick}
+              />
+              <div className="w-px bg-surface-700/40 shrink-0" />
+              <SplitCell
+                line={row.right}
+                lineNum={row.right?.new_line_num ?? null}
+                tokens={row.rightIndex != null ? lineTokens?.[row.rightIndex] : undefined}
+                side="new"
+                hunkIndex={hunkIndex}
+                commentsEnabled={commentsEnabled}
+                plusActive={!!rightActive}
+                onPlusClick={onPlusClick}
+              />
+            </div>
+            {cards?.map((anchored) => (
+              <CommentCard
+                key={`card-${anchored.comment.id}`}
+                anchored={anchored}
+                onSave={onCommentSave}
+                onDelete={onCommentDelete}
+              />
+            ))}
+            {showForm && draftSide && draftStartLine != null && draftEndLine != null && (
+              <CommentForm
+                key={`form-${hunkIndex}-${i}`}
+                startLine={draftStartLine}
+                endLine={draftEndLine}
+                side={draftSide}
+                onSave={onDraftSave}
+                onCancel={onDraftCancel}
+              />
+            )}
+          </Fragment>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/components/diff/SplitHunkView.tsx
+++ b/web/src/components/diff/SplitHunkView.tsx
@@ -100,7 +100,7 @@ function SplitCell({
       <span className={`shrink-0 w-4 text-center font-mono text-[12px] ${textClass} select-none`}>
         {prefix}
       </span>
-      <span className="flex-1 min-w-0 font-mono text-[12px] whitespace-pre overflow-hidden">
+      <span className="flex-1 min-w-0 font-mono text-[12px] whitespace-pre-wrap break-words">
         {renderTokens(line, tokens)}
       </span>
     </div>
@@ -178,7 +178,7 @@ export function SplitHunkView({
                 onPlusClick={onPlusClick}
               />
             </div>
-            {cards?.map((anchored) => (
+            {cards.map((anchored) => (
               <CommentCard
                 key={`card-${anchored.comment.id}`}
                 anchored={anchored}

--- a/web/src/components/diff/SplitHunkView.tsx
+++ b/web/src/components/diff/SplitHunkView.tsx
@@ -133,13 +133,22 @@ export function SplitHunkView({
         </span>
       </div>
       {rows.map((row, i) => {
-        // A row's "source index" for card/form anchoring is the index of
-        // whichever side carries the change (new side preferred, matching
-        // unified's side preference).
-        const anchorIndex = row.rightIndex ?? row.leftIndex;
-        const cards = anchorIndex != null ? cardsByEndRow.get(anchorIndex) : undefined;
+        // Cards and forms anchor to a line's index within the hunk, but a
+        // modify row carries two lines (old on the left, new on the right).
+        // Look up both sides so an old-side comment on a modify row isn't
+        // dropped; context rows share one index, so guard against
+        // double-counting.
+        const leftCards =
+          row.leftIndex != null ? cardsByEndRow.get(row.leftIndex) : undefined;
+        const rightCards =
+          row.rightIndex != null && row.rightIndex !== row.leftIndex
+            ? cardsByEndRow.get(row.rightIndex)
+            : undefined;
+        const cards = [...(leftCards ?? []), ...(rightCards ?? [])];
         const showForm =
-          formRowIndex != null && anchorIndex === formRowIndex && draftSide != null;
+          formRowIndex != null &&
+          draftSide != null &&
+          (formRowIndex === row.leftIndex || formRowIndex === row.rightIndex);
         const leftActive =
           rangeStart?.side === "old" && rangeStart.line === row.left?.old_line_num;
         const rightActive =

--- a/web/src/components/diff/__tests__/DiffFileViewer.split.test.tsx
+++ b/web/src/components/diff/__tests__/DiffFileViewer.split.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+//
+// Covers the unified/split toggle in DiffFileViewer and its localStorage
+// persistence via useWebSettings. The ResizeObserver is stubbed to report
+// a wide viewport so the split branch actually activates on toggle.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DiffFileViewer } from "../DiffFileViewer";
+import type { RichFileDiffResponse } from "../../../lib/types";
+
+const diff: RichFileDiffResponse = {
+  file: {
+    path: "a.ts",
+    old_path: null,
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+  },
+  hunks: [
+    {
+      old_start: 1,
+      old_lines: 2,
+      new_start: 1,
+      new_lines: 2,
+      lines: [
+        { type: "equal", old_line_num: 1, new_line_num: 1, content: "ctx\n" },
+        { type: "delete", old_line_num: 2, new_line_num: null, content: "old\n" },
+        { type: "add", old_line_num: null, new_line_num: 2, content: "new\n" },
+      ],
+    },
+  ],
+  is_binary: false,
+  truncated: false,
+};
+
+vi.mock("../../../hooks/useFileDiff", () => ({
+  useFileDiff: () => ({ diff, loading: false, error: null, refresh: vi.fn() }),
+}));
+
+vi.mock("../../../hooks/useHighlightedLines", () => ({
+  useHighlightedLines: () => ({ tokens: null }),
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  // Stub ResizeObserver to immediately report a wide viewport so the split
+  // path is available when the toggle is activated.
+  class WideRO {
+    cb: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb(
+        [{ contentRect: { width: 1000 } } as ResizeObserverEntry],
+        this as unknown as ResizeObserver,
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", WideRO);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.localStorage.clear();
+});
+
+describe("DiffFileViewer split layout", () => {
+  it("defaults to unified (Split toggle not pressed)", async () => {
+    render(<DiffFileViewer sessionId="s1" filePath="a.ts" />);
+    await screen.findByText(/Modified/i);
+    expect(
+      screen.getByRole("button", { name: "Split" }).getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("switches to split and persists the preference", async () => {
+    render(<DiffFileViewer sessionId="s1" filePath="a.ts" />);
+    await screen.findByText(/Modified/i);
+
+    fireEvent.click(screen.getByRole("button", { name: "Split" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Split" }).getAttribute("aria-pressed"),
+      ).toBe("true");
+    });
+
+    expect(
+      JSON.parse(window.localStorage.getItem("aoe-web-settings") ?? "{}").diffViewLayout,
+    ).toBe("split");
+  });
+});

--- a/web/src/components/diff/__tests__/DiffFileViewer.split.test.tsx
+++ b/web/src/components/diff/__tests__/DiffFileViewer.split.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 //
-// Covers the unified/split toggle in DiffFileViewer and its localStorage
-// persistence via useWebSettings. The ResizeObserver is stubbed to report
-// a wide viewport so the split branch actually activates on toggle.
+// Covers the unified/split toggle in DiffFileViewer, its localStorage
+// persistence via useWebSettings, and that the width ResizeObserver attaches
+// even when the diff container mounts after an initial loading phase.
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,8 +34,20 @@ const diff: RichFileDiffResponse = {
   truncated: false,
 };
 
+// Mutable mock state so a test can start in the loading phase (no diff) and
+// then have the diff arrive, exercising the late-mount path of the container.
+const mock = vi.hoisted(() => ({
+  diff: undefined as RichFileDiffResponse | undefined,
+  observe: vi.fn(),
+}));
+
 vi.mock("../../../hooks/useFileDiff", () => ({
-  useFileDiff: () => ({ diff, loading: false, error: null, refresh: vi.fn() }),
+  useFileDiff: () => ({
+    diff: mock.diff,
+    loading: mock.diff === undefined,
+    error: null,
+    refresh: vi.fn(),
+  }),
 }));
 
 vi.mock("../../../hooks/useHighlightedLines", () => ({
@@ -44,14 +56,17 @@ vi.mock("../../../hooks/useHighlightedLines", () => ({
 
 beforeEach(() => {
   window.localStorage.clear();
-  // Stub ResizeObserver to immediately report a wide viewport so the split
-  // path is available when the toggle is activated.
+  mock.diff = diff;
+  mock.observe.mockClear();
+  // Stub ResizeObserver to immediately report a wide viewport (and record
+  // observe calls) so the split path is available when the toggle is activated.
   class WideRO {
     cb: ResizeObserverCallback;
     constructor(cb: ResizeObserverCallback) {
       this.cb = cb;
     }
-    observe() {
+    observe(el: Element) {
+      mock.observe(el);
       this.cb(
         [{ contentRect: { width: 1000 } } as ResizeObserverEntry],
         this as unknown as ResizeObserver,
@@ -92,5 +107,20 @@ describe("DiffFileViewer split layout", () => {
     expect(
       JSON.parse(window.localStorage.getItem("aoe-web-settings") ?? "{}").diffViewLayout,
     ).toBe("split");
+  });
+
+  it("attaches the width observer when the diff container mounts after loading", async () => {
+    // Start in the loading phase: the scroll container is behind the early
+    // returns, so it is not mounted and the observer must not have attached.
+    mock.diff = undefined;
+    const { rerender } = render(<DiffFileViewer sessionId="s1" filePath="a.ts" />);
+    expect(mock.observe).not.toHaveBeenCalled();
+
+    // Diff arrives: the container mounts and the callback ref must attach the
+    // observer (a one-shot mount effect would have missed this late mount).
+    mock.diff = diff;
+    rerender(<DiffFileViewer sessionId="s1" filePath="a.ts" />);
+    await screen.findByText(/Modified/i);
+    expect(mock.observe).toHaveBeenCalled();
   });
 });

--- a/web/src/components/diff/__tests__/SplitHunkView.test.tsx
+++ b/web/src/components/diff/__tests__/SplitHunkView.test.tsx
@@ -6,7 +6,6 @@ import type { RichDiffHunk } from "../../../lib/types";
 import type { AnchoredComment } from "../comments/types";
 
 // A modify row: delete at line index 0 (old side), add at index 1 (new side).
-// buildSplitRows pairs them into one row with leftIndex=0, rightIndex=1.
 const modifyHunk: RichDiffHunk = {
   old_start: 1,
   old_lines: 1,
@@ -18,17 +17,32 @@ const modifyHunk: RichDiffHunk = {
   ],
 };
 
-function oldSideCard(body: string): AnchoredComment {
+// Context + a pure deletion (placeholder on the right) + another context +
+// a pure addition (placeholder on the left).
+const richHunk: RichDiffHunk = {
+  old_start: 1,
+  old_lines: 3,
+  new_start: 1,
+  new_lines: 3,
+  lines: [
+    { type: "equal", old_line_num: 1, new_line_num: 1, content: "ctx\n" },
+    { type: "delete", old_line_num: 2, new_line_num: null, content: "removed\n" },
+    { type: "equal", old_line_num: 3, new_line_num: 2, content: "mid\n" },
+    { type: "add", old_line_num: null, new_line_num: 3, content: "added\n" },
+  ],
+};
+
+function card(side: "old" | "new", body: string): AnchoredComment {
   return {
     status: "active",
     comment: {
-      id: "c1",
+      id: `c-${side}`,
       filePath: "a.ts",
-      side: "old",
+      side,
       startLine: 1,
       endLine: 1,
       body,
-      capturedSnippet: "old line",
+      capturedSnippet: "snippet",
       createdAt: "2025-01-01T00:00:00Z",
     },
   } as AnchoredComment;
@@ -36,31 +50,88 @@ function oldSideCard(body: string): AnchoredComment {
 
 const noop = () => {};
 
-describe("SplitHunkView comment anchoring", () => {
-  it("renders an old-side card on a modify row (anchored to the left index)", () => {
-    // The card is anchored to the old line's index (0). The previous code only
-    // consulted the right index, so old-side cards on modify rows were dropped.
-    const cards = new Map<number, AnchoredComment[]>([
-      [0, [oldSideCard("OLD SIDE NOTE")]],
-    ]);
-    render(
-      <SplitHunkView
-        hunk={modifyHunk}
-        hunkIndex={0}
-        commentsEnabled
-        cardsByEndRow={cards}
-        formRowIndex={null}
-        draftSide={null}
-        draftStartLine={null}
-        draftEndLine={null}
-        rangeStart={null}
-        onPlusClick={noop}
-        onCommentSave={noop}
-        onCommentDelete={noop}
-        onDraftSave={vi.fn()}
-        onDraftCancel={noop}
-      />,
-    );
+type Props = Parameters<typeof SplitHunkView>[0];
+
+function renderHunk(overrides: Partial<Props> = {}) {
+  const base: Props = {
+    hunk: modifyHunk,
+    hunkIndex: 0,
+    commentsEnabled: false,
+    cardsByEndRow: new Map(),
+    formRowIndex: null,
+    draftSide: null,
+    draftStartLine: null,
+    draftEndLine: null,
+    rangeStart: null,
+    onPlusClick: noop,
+    onCommentSave: noop,
+    onCommentDelete: noop,
+    onDraftSave: noop,
+    onDraftCancel: noop,
+  };
+  return render(<SplitHunkView {...base} {...overrides} />);
+}
+
+describe("SplitHunkView", () => {
+  it("renders the hunk header, context rows, and pure add/delete rows", () => {
+    renderHunk({ hunk: richHunk });
+    expect(screen.getByText(/-1,3 \+1,3/)).toBeTruthy(); // hunk header
+    expect(screen.getByText("removed")).toBeTruthy(); // delete-only row (left)
+    expect(screen.getByText("added")).toBeTruthy(); // add-only row (right)
+    // Context lines render on both the old and new side.
+    expect(screen.getAllByText("ctx")).toHaveLength(2);
+    expect(screen.getAllByText("mid")).toHaveLength(2);
+  });
+
+  it("renders syntax tokens when provided", () => {
+    renderHunk({
+      hunk: richHunk,
+      lineTokens: [[{ content: "CTXTOKEN", color: "#abcdef" }]],
+    });
+    // The token-backed context line renders on both sides.
+    expect(screen.getAllByText("CTXTOKEN")).toHaveLength(2);
+  });
+
+  it("shows the active + gutter button for a started range", () => {
+    renderHunk({
+      hunk: richHunk,
+      commentsEnabled: true,
+      rangeStart: { side: "old", line: 2 },
+    });
+    expect(
+      screen.getByLabelText("Add comment on old line 2"),
+    ).toBeTruthy();
+  });
+
+  it("renders the draft form at the target row", () => {
+    // Draft on the new side of the modify row (rightIndex = 1).
+    renderHunk({
+      hunk: modifyHunk,
+      commentsEnabled: true,
+      formRowIndex: 1,
+      draftSide: "new",
+      draftStartLine: 1,
+      draftEndLine: 1,
+      onDraftSave: vi.fn(),
+    });
+    expect(screen.getByPlaceholderText(/Leave a comment/)).toBeTruthy();
+  });
+
+  it("renders an old-side card on a modify row (left index)", () => {
+    renderHunk({
+      hunk: modifyHunk,
+      commentsEnabled: true,
+      cardsByEndRow: new Map([[0, [card("old", "OLD SIDE NOTE")]]]),
+    });
     expect(screen.getByText("OLD SIDE NOTE")).toBeTruthy();
+  });
+
+  it("renders a new-side card on a modify row (right index)", () => {
+    renderHunk({
+      hunk: modifyHunk,
+      commentsEnabled: true,
+      cardsByEndRow: new Map([[1, [card("new", "NEW SIDE NOTE")]]]),
+    });
+    expect(screen.getByText("NEW SIDE NOTE")).toBeTruthy();
   });
 });

--- a/web/src/components/diff/__tests__/SplitHunkView.test.tsx
+++ b/web/src/components/diff/__tests__/SplitHunkView.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SplitHunkView } from "../SplitHunkView";
+import type { RichDiffHunk } from "../../../lib/types";
+import type { AnchoredComment } from "../comments/types";
+
+// A modify row: delete at line index 0 (old side), add at index 1 (new side).
+// buildSplitRows pairs them into one row with leftIndex=0, rightIndex=1.
+const modifyHunk: RichDiffHunk = {
+  old_start: 1,
+  old_lines: 1,
+  new_start: 1,
+  new_lines: 1,
+  lines: [
+    { type: "delete", old_line_num: 1, new_line_num: null, content: "old line\n" },
+    { type: "add", old_line_num: null, new_line_num: 1, content: "new line\n" },
+  ],
+};
+
+function oldSideCard(body: string): AnchoredComment {
+  return {
+    status: "active",
+    comment: {
+      id: "c1",
+      filePath: "a.ts",
+      side: "old",
+      startLine: 1,
+      endLine: 1,
+      body,
+      capturedSnippet: "old line",
+      createdAt: "2025-01-01T00:00:00Z",
+    },
+  } as AnchoredComment;
+}
+
+const noop = () => {};
+
+describe("SplitHunkView comment anchoring", () => {
+  it("renders an old-side card on a modify row (anchored to the left index)", () => {
+    // The card is anchored to the old line's index (0). The previous code only
+    // consulted the right index, so old-side cards on modify rows were dropped.
+    const cards = new Map<number, AnchoredComment[]>([
+      [0, [oldSideCard("OLD SIDE NOTE")]],
+    ]);
+    render(
+      <SplitHunkView
+        hunk={modifyHunk}
+        hunkIndex={0}
+        commentsEnabled
+        cardsByEndRow={cards}
+        formRowIndex={null}
+        draftSide={null}
+        draftStartLine={null}
+        draftEndLine={null}
+        rangeStart={null}
+        onPlusClick={noop}
+        onCommentSave={noop}
+        onCommentDelete={noop}
+        onDraftSave={vi.fn()}
+        onDraftCancel={noop}
+      />,
+    );
+    expect(screen.getByText("OLD SIDE NOTE")).toBeTruthy();
+  });
+});

--- a/web/src/components/settings/DiffSettings.tsx
+++ b/web/src/components/settings/DiffSettings.tsx
@@ -1,0 +1,59 @@
+import { useWebSettings } from "../../hooks/useWebSettings";
+
+/// Client-side diff view preferences. These are pure rendering choices stored
+/// per browser in `localStorage` (like the Terminal section), not backend
+/// config, so they need no server round-trip or elevation. The same toggles
+/// are also reachable inline from the diff view itself.
+export function DiffSettings() {
+  const { settings, update } = useWebSettings();
+
+  return (
+    <div>
+      <div className="space-y-4">
+        <div>
+          <label className="flex items-center justify-between gap-3 cursor-pointer">
+            <div>
+              <div className="text-[13px] text-text-secondary">
+                Side-by-side diff
+              </div>
+              <p className="text-[11px] text-text-muted mt-1">
+                Show diffs in a split (side-by-side) layout instead of unified.
+                On narrow screens the diff falls back to unified automatically.
+              </p>
+            </div>
+            <input
+              type="checkbox"
+              checked={settings.diffViewLayout === "split"}
+              onChange={(e) =>
+                update({ diffViewLayout: e.target.checked ? "split" : "unified" })
+              }
+              className="accent-brand-600 w-4 h-4 shrink-0"
+            />
+          </label>
+        </div>
+
+        <div>
+          <label className="flex items-center justify-between gap-3 cursor-pointer">
+            <div>
+              <div className="text-[13px] text-text-secondary">
+                Tree file list
+              </div>
+              <p className="text-[11px] text-text-muted mt-1">
+                Group changed files into a collapsible directory tree. Turn off
+                for a flat list of file paths.
+              </p>
+            </div>
+            <input
+              type="checkbox"
+              checked={settings.diffViewMode === "tree"}
+              onChange={(e) =>
+                update({ diffViewMode: e.target.checked ? "tree" : "flat" })
+              }
+              className="accent-brand-600 w-4 h-4 shrink-0"
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/__tests__/DiffSettings.test.tsx
+++ b/web/src/components/settings/__tests__/DiffSettings.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+//
+// Contract test for the DiffSettings panel. Like TerminalSettings (and unlike
+// the server-backed panels under settings/), this persists through
+// useWebSettings + localStorage (key `aoe-web-settings`), not PATCH
+// /api/settings. The contract is the JSON shape written to that key.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { DiffSettings } from "../DiffSettings";
+
+const KEY = "aoe-web-settings";
+
+function readStored(): Record<string, unknown> {
+  const raw = window.localStorage.getItem(KEY);
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("DiffSettings localStorage contract", () => {
+  it("toggling side-by-side writes diffViewLayout", () => {
+    const { getByText, container } = render(<DiffSettings />);
+    const splitBox = container.querySelectorAll(
+      "input[type=checkbox]",
+    )[0] as HTMLInputElement;
+
+    expect(getByText("Side-by-side diff")).toBeTruthy();
+    expect(splitBox.checked).toBe(false); // defaults to unified
+
+    fireEvent.click(splitBox);
+    expect(readStored().diffViewLayout).toBe("split");
+
+    fireEvent.click(splitBox);
+    expect(readStored().diffViewLayout).toBe("unified");
+  });
+
+  it("toggling tree file list writes diffViewMode", () => {
+    const { getByText, container } = render(<DiffSettings />);
+    const treeBox = container.querySelectorAll(
+      "input[type=checkbox]",
+    )[1] as HTMLInputElement;
+
+    expect(getByText("Tree file list")).toBeTruthy();
+    fireEvent.click(treeBox);
+    const mode = readStored().diffViewMode;
+    expect(mode === "tree" || mode === "flat").toBe(true);
+    // Flipping again yields the opposite value.
+    fireEvent.click(treeBox);
+    expect(readStored().diffViewMode).toBe(mode === "tree" ? "flat" : "tree");
+  });
+});

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -15,6 +15,7 @@ export interface WebSettings {
   persistentTerminals: boolean;
   maxPersistentTerminals: number;
   diffViewMode: "flat" | "tree";
+  diffViewLayout: "unified" | "split";
   collapsedDiffDirs: string[];
 }
 
@@ -26,6 +27,7 @@ function getDefaults(): WebSettings {
     persistentTerminals: false,
     maxPersistentTerminals: DEFAULT_PERSISTENT_TERMINALS,
     diffViewMode: window.innerWidth < 768 ? "flat" : "tree",
+    diffViewLayout: "unified",
     collapsedDiffDirs: [],
   };
 }

--- a/web/src/lib/__tests__/splitDiff.test.ts
+++ b/web/src/lib/__tests__/splitDiff.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { buildSplitRows, type SplitRow } from "../splitDiff";
+import type { RichDiffHunk, RichDiffLine } from "../types";
+
+function line(
+  type: RichDiffLine["type"],
+  oldNum: number | null,
+  newNum: number | null,
+  content: string,
+): RichDiffLine {
+  return { type, old_line_num: oldNum, new_line_num: newNum, content };
+}
+
+function hunk(lines: RichDiffLine[]): RichDiffHunk {
+  return { old_start: 1, old_lines: 1, new_start: 1, new_lines: 1, lines };
+}
+
+describe("buildSplitRows", () => {
+  it("puts a context line on both sides with its original index", () => {
+    const rows = buildSplitRows(hunk([line("equal", 1, 1, "ctx")]));
+    expect(rows).toEqual<SplitRow[]>([
+      {
+        left: line("equal", 1, 1, "ctx"),
+        right: line("equal", 1, 1, "ctx"),
+        leftIndex: 0,
+        rightIndex: 0,
+      },
+    ]);
+  });
+
+  it("places a pure deletion on the left with an empty right", () => {
+    const rows = buildSplitRows(hunk([line("delete", 5, null, "gone")]));
+    expect(rows).toEqual<SplitRow[]>([
+      {
+        left: line("delete", 5, null, "gone"),
+        right: null,
+        leftIndex: 0,
+        rightIndex: null,
+      },
+    ]);
+  });
+
+  it("places a pure addition on the right with an empty left", () => {
+    const rows = buildSplitRows(hunk([line("add", null, 5, "new")]));
+    expect(rows).toEqual<SplitRow[]>([
+      {
+        left: null,
+        right: line("add", null, 5, "new"),
+        leftIndex: null,
+        rightIndex: 0,
+      },
+    ]);
+  });
+
+  it("pairs a delete+add block into modified rows", () => {
+    const rows = buildSplitRows(
+      hunk([
+        line("delete", 5, null, "old a"),
+        line("delete", 6, null, "old b"),
+        line("add", null, 5, "new a"),
+        line("add", null, 6, "new b"),
+      ]),
+    );
+    expect(rows.map((r) => [r.left?.content, r.right?.content])).toEqual([
+      ["old a", "new a"],
+      ["old b", "new b"],
+    ]);
+    expect(rows.map((r) => [r.leftIndex, r.rightIndex])).toEqual([
+      [0, 2],
+      [1, 3],
+    ]);
+  });
+
+  it("pads the shorter side of an uneven block with placeholders", () => {
+    const rows = buildSplitRows(
+      hunk([
+        line("delete", 5, null, "old a"),
+        line("add", null, 5, "new a"),
+        line("add", null, 6, "new b"),
+      ]),
+    );
+    expect(rows.map((r) => [r.left?.content ?? null, r.right?.content ?? null])).toEqual([
+      ["old a", "new a"],
+      [null, "new b"],
+    ]);
+  });
+
+  it("flushes blocks independently around context lines", () => {
+    const rows = buildSplitRows(
+      hunk([
+        line("equal", 1, 1, "ctx1"),
+        line("delete", 2, null, "del"),
+        line("add", null, 2, "ins"),
+        line("equal", 3, 3, "ctx2"),
+        line("add", null, 4, "tail add"),
+      ]),
+    );
+    expect(rows.map((r) => [r.left?.content ?? null, r.right?.content ?? null])).toEqual([
+      ["ctx1", "ctx1"],
+      ["del", "ins"],
+      ["ctx2", "ctx2"],
+      [null, "tail add"],
+    ]);
+  });
+});

--- a/web/src/lib/splitDiff.ts
+++ b/web/src/lib/splitDiff.ts
@@ -1,0 +1,59 @@
+import type { RichDiffHunk, RichDiffLine } from "./types";
+
+/** One row of a side-by-side diff. `left` is the old/before side, `right`
+ *  the new/after side; either is null when that side has no line for the
+ *  row (a placeholder cell). `leftIndex`/`rightIndex` are the line's index
+ *  within the source hunk's `lines`, used to look up its syntax tokens. */
+export interface SplitRow {
+  left: RichDiffLine | null;
+  right: RichDiffLine | null;
+  leftIndex: number | null;
+  rightIndex: number | null;
+}
+
+interface Indexed {
+  line: RichDiffLine;
+  index: number;
+}
+
+/** Pair a hunk's ordered unified lines into side-by-side rows.
+ *
+ * A maximal run of non-equal lines is one change block: its deletions and
+ * additions are zipped index-by-index, so row k holds the k-th deletion on
+ * the left and the k-th addition on the right. Surplus lines on the longer
+ * side get a placeholder opposite them. Equal lines appear on both sides. */
+export function buildSplitRows(hunk: RichDiffHunk): SplitRow[] {
+  const rows: SplitRow[] = [];
+  let dels: Indexed[] = [];
+  let adds: Indexed[] = [];
+
+  const flush = () => {
+    const n = Math.max(dels.length, adds.length);
+    for (let k = 0; k < n; k++) {
+      const d = dels[k];
+      const a = adds[k];
+      rows.push({
+        left: d?.line ?? null,
+        right: a?.line ?? null,
+        leftIndex: d?.index ?? null,
+        rightIndex: a?.index ?? null,
+      });
+    }
+    dels = [];
+    adds = [];
+  };
+
+  hunk.lines.forEach((line, index) => {
+    if (line.type === "equal") {
+      flush();
+      rows.push({ left: line, right: line, leftIndex: index, rightIndex: index });
+    } else if (line.type === "delete") {
+      dels.push({ line, index });
+    } else {
+      adds.push({ line, index });
+    }
+  });
+  flush();
+
+  return rows;
+}

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -9,3 +9,98 @@ import { cleanup } from "@testing-library/react";
 afterEach(() => {
   cleanup();
 });
+
+// Node >= 22 ships a native `localStorage`/`sessionStorage` gated behind
+// `--localstorage-file`. On newer majors (observed on Node 26) that native
+// global occupies the slot and is unusable without the flag, and jsdom then
+// installs no Storage of its own, so every test that touches storage fails with
+// "Cannot read properties of undefined". CI runs Node 22, where jsdom's Storage
+// works and this whole block is skipped via the feature probe below.
+//
+// When storage is broken, install a self-contained in-memory implementation.
+// A real class is used (not a bare object) and assigned to `globalThis.Storage`
+// so both access patterns the suite relies on keep working: direct
+// `localStorage.setItem(...)` and `vi.spyOn(Storage.prototype, "setItem")` (used
+// to simulate quota/security errors). A matching lenient `StorageEvent` is
+// installed too, since jsdom's brand-checks its `storageArea` against jsdom's
+// own Storage, which no longer exists once we replace it.
+function storageWorks(name: "localStorage" | "sessionStorage"): boolean {
+  try {
+    const s = (globalThis as Record<string, unknown>)[name] as
+      | Storage
+      | undefined;
+    if (!s || typeof s.setItem !== "function") return false;
+    s.setItem("__aoe_probe__", "1");
+    s.removeItem("__aoe_probe__");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function installInMemoryStorage(): void {
+  class MemoryStorage {
+    private store = new Map<string, string>();
+    get length(): number {
+      return this.store.size;
+    }
+    clear(): void {
+      this.store.clear();
+    }
+    getItem(key: string): string | null {
+      return this.store.has(key) ? (this.store.get(key) as string) : null;
+    }
+    key(index: number): string | null {
+      return Array.from(this.store.keys())[index] ?? null;
+    }
+    removeItem(key: string): void {
+      this.store.delete(key);
+    }
+    setItem(key: string, value: string): void {
+      this.store.set(String(key), String(value));
+    }
+  }
+
+  // Lenient StorageEvent: jsdom's validates `storageArea` is a jsdom Storage,
+  // which we have replaced. Extends the (working) global Event so dispatch and
+  // `instanceof` behave normally.
+  interface StorageEventInitLike extends EventInit {
+    key?: string | null;
+    oldValue?: string | null;
+    newValue?: string | null;
+    url?: string;
+    storageArea?: Storage | null;
+  }
+  class MemoryStorageEvent extends Event {
+    key: string | null;
+    oldValue: string | null;
+    newValue: string | null;
+    url: string;
+    storageArea: Storage | null;
+    constructor(type: string, init: StorageEventInitLike = {}) {
+      super(type, init);
+      this.key = init.key ?? null;
+      this.oldValue = init.oldValue ?? null;
+      this.newValue = init.newValue ?? null;
+      this.url = init.url ?? "";
+      this.storageArea = init.storageArea ?? null;
+    }
+  }
+
+  const define = (name: string, value: unknown): void => {
+    Object.defineProperty(globalThis, name, {
+      value,
+      configurable: true,
+      writable: true,
+    });
+  };
+
+  define("Storage", MemoryStorage);
+  define("localStorage", new MemoryStorage());
+  define("sessionStorage", new MemoryStorage());
+  define("StorageEvent", MemoryStorageEvent);
+}
+
+if (!storageWorks("localStorage") || !storageWorks("sessionStorage")) {
+  installInMemoryStorage();
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -957,7 +957,8 @@
       "kind": "vitest",
       "risk": "medium",
       "specs": [
-        "src/components/diff/__tests__/DiffFileViewer.split.test.tsx"
+        "src/components/diff/__tests__/DiffFileViewer.split.test.tsx",
+        "src/components/diff/__tests__/SplitHunkView.test.tsx"
       ],
       "components": [
         "web/src/components/diff/DiffFileViewer.tsx",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -965,6 +965,18 @@
       ]
     },
     {
+      "id": "settings.diff-section",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": [
+        "src/components/settings/__tests__/DiffSettings.test.tsx"
+      ],
+      "components": [
+        "web/src/components/settings/DiffSettings.tsx",
+        "web/src/components/SettingsView.tsx"
+      ]
+    },
+    {
       "id": "devices",
       "kind": "live-playwright",
       "risk": "low",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -953,6 +953,18 @@
       ]
     },
     {
+      "id": "right-panel.diff-split-toggle",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/diff/__tests__/DiffFileViewer.split.test.tsx"
+      ],
+      "components": [
+        "web/src/components/diff/DiffFileViewer.tsx",
+        "web/src/components/diff/SplitHunkView.tsx"
+      ]
+    },
+    {
       "id": "devices",
       "kind": "live-playwright",
       "risk": "low",


### PR DESCRIPTION
## Description

Adds a GitHub-Desktop-style **split diff view** (side-by-side) to both surfaces, alongside the existing unified view.

**Web dashboard**
- Unified/Split toggle in the diff header; preference persists in `localStorage` (defaults to unified).
- Two-column renderer (`SplitHunkView`) reusing the existing hunk/line model and syntax tokens; old on the left, new on the right, with aligned placeholder cells for pure adds/deletes.
- Auto-falls back to unified below ~640px (via `ResizeObserver` on the diff pane), preserving the saved choice.
- Inline review comments are preserved in split view (the `+` gutter works on each column).
- New **Diff** section in Settings (Appearance group) exposing the split/unified and flat/tree preferences, `localStorage`-backed like the existing Terminal section.

**Native TUI**
- Two-column render with a straight vertical divider; falls back to unified when the diff pane is too narrow.
- `s` toggles split/unified; the footer hint names the layout it will switch to.
- Persisted via a new `DiffConfig.split_view` (with per-profile override) and editable in the settings TUI under a new "Diff" section.

**Test harness**
- `web/src/test-setup.ts` now installs a feature-gated in-memory `Storage` so the jsdom vitest suite passes on Node 26+ (its native `localStorage` shadows jsdom's; CI on Node 22 was unaffected). No-op on Node 22.

No backend diff-computation changes — split is purely a new rendering of the data the API already returns.

### Try it locally

```bash
# 1. A throwaway repo whose working-tree diff vs main spans nested dirs and
#    exercises adds/deletes/modifications/context:
DIR=/tmp/aoe-split-diff-demo; rm -rf "$DIR"; mkdir -p "$DIR/src/app" "$DIR/src/db" "$DIR/docs" "$DIR/tests"; cd "$DIR"
git init -q && git config user.email d@e.com && git config user.name demo
printf '# Demo\n' > README.md
printf 'def render(n):\n    return "rows: "+n\n' > src/db/models.py
printf 'def greet(name):\n    print("hello "+name)\n\ndef to_be_deleted():\n    return None\n' > src/app/greet.py
printf 'def test():\n    pass\n' > tests/test_greet.py
git add -A && git commit -q -m base && git branch -M main
# working-tree changes vs main:
printf 'def greet(name, greeting="hello"):\n    print(greeting+" "+name)\n    print("welcome!")\n\ndef brand_new():\n    return 42\n' > src/app/greet.py
printf 'def render(n):\n    return "ROWS: "+n.upper()\n' > src/db/models.py
printf '# Demo\n\nExpanded.\n' > README.md
mkdir -p src/api && printf 'def list_users():\n    return []\n' > src/api/routes.py
rm tests/test_greet.py

# 2. Register a session (the agent is never launched, only the diff is viewed):
aoe add "$DIR" -c claude -t split-demo

# 3. TUI:  run `aoe`, highlight split-demo, press `D` (diff), then `s` (split).
#    Web:  run `aoe serve`, open the session diff, use the Unified/Split toggle;
#          the Files panel's tree/list icon toggles flat vs tree.
```

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary <!-- docs/guides/diff-view.md: split-view section, `s` keybind, `split_view` config -->
- [ ] For UI changes: included screenshot or recording <!-- will attach web + TUI split screenshots after the PR is created -->

## Test Coverage Analysis

**Web dashboard / cockpit**
- [x] Added/updated tests and `web/tests/coverage-matrix.json`. These are **Vitest + RTL** (`DiffFileViewer.split.test.tsx`, `DiffSettings.test.tsx`, `splitDiff.test.ts`) rather than Playwright: per CONTRIBUTING/CLAUDE.md, request-payload and rendering-logic surfaces use Vitest, with matrix entries `right-panel.diff-split-toggle` and `settings.diff-section`.

**TUI / CLI (e2e test)**
- [ ] Added an e2e test under `tests/e2e/`
- [x] Skipped a full e2e, because: the split renderer, the `s` keybind, and the pairing function are covered by deterministic in-module tests (`TestBackend` render snapshot incl. a divider-alignment regression test, an input toggle test, and `build_split_rows` unit tests). Happy to add a `tests/e2e/` tmux test if preferred.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Opus)

**Any Additional AI Details you'd like to share:** Collaborative effort — I specified the feature, made the design and scoping decisions, and steered and reviewed throughout; the AI (Claude Opus, via Claude Code) wrote the implementation under that direction.

- [x] I am an AI Agent filling out this form (check box if true)

---

## Screenshots

<img width="1492" height="868" alt="image" src="https://github.com/user-attachments/assets/35f90643-b023-40e5-957a-4284920182ca" />


<img width="1503" height="490" alt="image" src="https://github.com/user-attachments/assets/c6bf851b-d8cd-4479-81c6-66d093a6c311" />


<img width="1329" height="532" alt="image" src="https://github.com/user-attachments/assets/9fb016bb-b369-42b2-9ae4-71738f2678fd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds a side-by-side (split) diff view to both the web dashboard and the native TUI while keeping the existing unified view. Users can toggle layouts (web button / TUI 's' key); choices persist (global or per-profile). Split view auto-falls back to unified when the pane is too narrow. Inline review comments, per-column gutters, and existing commenting UX are preserved.

## What changed (non-technical)

- Web: Unified/Split toggle in the diff header; new two-column renderer that lines up old (left) and new (right) lines with aligned placeholders for pure adds/deletes; responsive fallback below ~640px; inline review comments and per-column gutter preserved; new "Diff" settings under Appearance; preference persisted to localStorage.
- TUI: Two-column renderer with vertical divider and automatic fallback when narrow; 's' key toggles split/unified with footer hint; preference editable in TUI Settings Diff section and supports per-profile overrides.
- Config: Added DiffConfig.split_view (defaults to unified) and per-profile override support with correct load/save behavior.
- Tests & docs: Added unit and integration tests for both web and TUI (including split-specific suites), a Node/jsdom storage shim for tests, coverage-matrix updates, and docs/guides/diff-view.md updates. PR images show terminal and IDE split views and the new settings UI. Implementation was AI-assisted.

## Benefits

- Makes side-by-side comparison easier and faster for reviewers.
- Brings feature parity between web and TUI clients.
- Persistent, per-profile preferences and responsive fallback improve usability across devices and workflows.
- No backend changes required — purely UI/config additions.

## Technical details (concise)

- Core pairing logic: buildSplitRows / build_split_rows (web + TUI) convert unified hunks into paired left/right rows by buffering contiguous non-equal blocks and padding the shorter side; equal/context lines are emitted on both sides.
- Web:
  - New SplitHunkView component and web/src/lib/splitDiff.ts utility.
  - useWebSettings extended with diffViewLayout ("unified" | "split"); toggle persists to aoe-web-settings (localStorage).
  - DiffFileViewer uses ResizeObserver to detect width and mount SplitHunkView only when split is active and wide enough; tests stub ResizeObserver and validate persistence.
  - test-setup installs an in-memory Storage shim for Node/jsdom when needed.
- TUI:
  - DiffView gains split_view state and persist_split_view() which writes either global config or a profile-scoped override.
  - New split.rs and render helpers (split_cell) produce side-by-side rows, vertical divider, and updated footer/help hints.
  - Settings wiring: SettingsCategory::Diff, FieldKey::DiffSplitView, and settings apply/clear logic support per-profile overrides.
- Tests:
  - Rust: config serialization, split pairing, TUI rendering and 's' key toggle tests.
  - Web: Vitest + RTL tests for SplitHunkView, DiffFileViewer split behavior, DiffSettings persistence, splitDiff utility tests, and coverage-matrix entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->