### PR TITLE
feat(cockpit): open transcript path:line file links in the in-app viewer

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -103,7 +103,12 @@ uses text attributes only (bold, italic, dim) so it tracks your theme
 colors. Code-block syntax highlighting is deferred; press `o` to open
 the web dashboard for full-fidelity rendering. In the web dashboard,
 links inside transcript messages open in a new browser tab so following
-a docs, CI, or repo link keeps your cockpit session open.
+a docs, CI, or repo link keeps your cockpit session open. Local file
+references (the `path:line` links agents like Codex emit when citing
+source) are an exception: clicking one opens that file in the in-app
+diff/file viewer and keeps you on the current session, instead of
+navigating away. A file that is not inside the session's repo shows a
+brief notice and leaves the view unchanged.
 
 **Tool cards.** Tool calls in the transcript render per kind rather than
 as a single generic line. An edit or write shows the file path and a

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,6 +41,7 @@ import {
   useIdleDecayWindowMs,
 } from "./lib/idleDecay";
 import { toastBus } from "./lib/toastBus";
+import { resolveToRepoRelative, type FileRef } from "./lib/fileRef";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
 import {
   dispatchFocusTerminal,
@@ -590,6 +591,28 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     [],
   );
 
+  // Open a local file reference cited in a cockpit transcript (Codex
+  // `path:line` markdown links). Resolve the absolute path back to a
+  // repo-relative path for the active session and open it in the in-app
+  // diff/file viewer, keeping the current session route. A path outside
+  // the session's known repo roots surfaces a non-destructive toast
+  // rather than navigating away. Line/column are parsed but not yet
+  // wired to viewer scroll-to-line. See #1718.
+  const handleOpenFileRef = useCallback(
+    (ref: FileRef) => {
+      if (!activeSession) return;
+      const resolved = resolveToRepoRelative(ref.path, activeSession);
+      if (!resolved) {
+        toastBus.handler?.error(
+          `Could not open ${ref.path}: not inside this session's repo`,
+        );
+        return;
+      }
+      handleSelectFile(resolved.relativePath, resolved.repoName);
+    },
+    [activeSession, handleSelectFile],
+  );
+
   const handleCloseFile = useCallback(() => {
     setSelectedFile(null);
   }, []);
@@ -871,6 +894,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           warning={warning}
           diffFilesLoading={diffFilesLoading}
           onSelectFile={handleSelectFile}
+          onOpenFileRef={handleOpenFileRef}
           onCloseFile={handleCloseFile}
           onDiffRefresh={refreshDiffFiles}
           commentsEnabled={commentsEnabled}
@@ -909,6 +933,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                       tool={activeSession.tool}
                       archivedAt={activeSession.archived_at ?? null}
                       snoozedUntil={activeSession.snoozed_until ?? null}
+                      onOpenFileRef={handleOpenFileRef}
                     />
                   </Suspense>
                 ) : (

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -10,6 +10,7 @@ import type { RightPanelView } from "../lib/rightPanelView";
 import type { ServerAbout } from "../lib/api";
 import type { RepoBase, RichDiffFile, SessionResponse } from "../lib/types";
 import type { useDiffComments } from "../hooks/useDiffComments";
+import type { FileRef } from "../lib/fileRef";
 
 const CockpitView = lazy(() =>
   import("./cockpit/CockpitView").then((m) => ({ default: m.CockpitView })),
@@ -32,6 +33,7 @@ interface Props {
   warning: string | null;
   diffFilesLoading: boolean;
   onSelectFile: (path: string, repoName?: string) => void;
+  onOpenFileRef: (ref: FileRef) => void;
   onCloseFile: () => void;
   onDiffRefresh: () => void;
   commentsEnabled: boolean;
@@ -72,6 +74,7 @@ export function MobileMainPane({
   warning,
   diffFilesLoading,
   onSelectFile,
+  onOpenFileRef,
   onCloseFile,
   onDiffRefresh,
   commentsEnabled,
@@ -111,6 +114,7 @@ export function MobileMainPane({
                 tool={activeSession.tool}
                 archivedAt={activeSession.archived_at ?? null}
                 snoozedUntil={activeSession.snoozed_until ?? null}
+                onOpenFileRef={onOpenFileRef}
               />
             </Suspense>
           ) : (

--- a/web/src/components/cockpit/CockpitFileRefContext.tsx
+++ b/web/src/components/cockpit/CockpitFileRefContext.tsx
@@ -1,0 +1,24 @@
+// Bridges a file-open handler from App down into the cockpit markdown
+// anchor override. The transcript text nodes are mounted by
+// assistant-ui's MessagePrimitive.Parts, so we cannot prop-drill a
+// callback to the Markdown component; context is the only injection
+// point. CockpitView provides the handler; the anchor override in
+// Markdown.tsx consumes it. See #1718.
+
+import { createContext, useContext } from "react";
+import type { FileRef } from "../../lib/fileRef";
+
+export interface CockpitFileRefContextValue {
+  /** Open a local file reference cited in the transcript. Absent when
+   *  the cockpit is rendered without a file-open target, in which case
+   *  the anchor override leaves links as normal (new-tab) anchors. */
+  onOpenFileRef?: (ref: FileRef) => void;
+}
+
+export const CockpitFileRefContext = createContext<CockpitFileRefContextValue>(
+  {},
+);
+
+export function useCockpitFileRef(): CockpitFileRefContextValue {
+  return useContext(CockpitFileRefContext);
+}

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -31,6 +31,8 @@ import {
 } from "lucide-react";
 
 import { ApprovalCard } from "./ApprovalCard";
+import { CockpitFileRefContext } from "./CockpitFileRefContext";
+import type { FileRef } from "../../lib/fileRef";
 import {
   CockpitRuntime,
   SUBAGENT_TASK_NAME,
@@ -108,6 +110,12 @@ interface Props {
    *  timestamps come back as null and we fall through to the live
    *  variant. See #1581. */
   snoozedUntil: string | null;
+  /** Open a local file reference cited in the transcript (Codex
+   *  `path:line` markdown links). Provided to the markdown anchor
+   *  override via context so a click opens the in-app file viewer
+   *  instead of navigating away. Omit to leave such links as normal
+   *  anchors. See #1718. */
+  onOpenFileRef?: (ref: FileRef) => void;
 }
 
 const STARTER_PROMPTS = [
@@ -122,6 +130,7 @@ export function CockpitView({
   tool,
   archivedAt,
   snoozedUntil,
+  onOpenFileRef,
 }: Props) {
   // Folds rows above the most recent `/clear` divider out of the
   // thread by default; the disclosure banner toggles this. Lives on
@@ -129,27 +138,29 @@ export function CockpitView({
   // event-log state. See #1101.
   const [showClearedTurns, setShowClearedTurns] = useState(false);
   return (
-    <AgentProfileProvider toolKey={tool}>
-      <CockpitRuntime
-        sessionId={sessionId}
-        cockpitWorkerState={cockpitWorkerState}
-        archivedAt={archivedAt}
-        snoozedUntil={snoozedUntil}
-        showClearedTurns={showClearedTurns}
-      >
-        {(ctx) => (
-          <CockpitChrome
-            sessionId={sessionId}
-            cockpitWorkerState={cockpitWorkerState}
-            showClearedTurns={showClearedTurns}
-            onToggleClearedTurns={() => setShowClearedTurns((v) => !v)}
-            archivedAt={archivedAt}
-            snoozedUntil={snoozedUntil}
-            {...ctx}
-          />
-        )}
-      </CockpitRuntime>
-    </AgentProfileProvider>
+    <CockpitFileRefContext.Provider value={{ onOpenFileRef }}>
+      <AgentProfileProvider toolKey={tool}>
+        <CockpitRuntime
+          sessionId={sessionId}
+          cockpitWorkerState={cockpitWorkerState}
+          archivedAt={archivedAt}
+          snoozedUntil={snoozedUntil}
+          showClearedTurns={showClearedTurns}
+        >
+          {(ctx) => (
+            <CockpitChrome
+              sessionId={sessionId}
+              cockpitWorkerState={cockpitWorkerState}
+              showClearedTurns={showClearedTurns}
+              onToggleClearedTurns={() => setShowClearedTurns((v) => !v)}
+              archivedAt={archivedAt}
+              snoozedUntil={snoozedUntil}
+              {...ctx}
+            />
+          )}
+        </CockpitRuntime>
+      </AgentProfileProvider>
+    </CockpitFileRefContext.Provider>
   );
 }
 

--- a/web/src/components/cockpit/Markdown.test.tsx
+++ b/web/src/components/cockpit/Markdown.test.tsx
@@ -60,6 +60,7 @@ vi.mock("@assistant-ui/react-markdown", () => ({
 }));
 
 import { Markdown } from "./Markdown";
+import { CockpitFileRefContext } from "./CockpitFileRefContext";
 
 beforeEach(() => {
   primitiveCalls.length = 0;
@@ -205,6 +206,69 @@ describe("anchor override", () => {
     expect(a?.getAttribute("href")).toBe("https://example.com/path");
     expect(a?.getAttribute("title")).toBe("t");
     expect(a?.textContent).toBe("link text");
+  });
+});
+
+// #1718: a local file reference (Codex `path:line` markdown link) is
+// intercepted and routed to the in-app file viewer instead of opening a
+// dead new tab. External links keep the #1714 new-tab behavior.
+describe("anchor file-ref interception", () => {
+  function getAnchor(): React.ComponentType<
+    React.ComponentPropsWithoutRef<"a">
+  > {
+    render(<Markdown text="x" />);
+    return primitiveCalls.at(-1)!.components.a as React.ComponentType<
+      React.ComponentPropsWithoutRef<"a">
+    >;
+  }
+
+  it("intercepts a local file link and calls the file-ref handler", () => {
+    const Anchor = getAnchor();
+    const onOpenFileRef = vi.fn();
+    const { container } = render(
+      <CockpitFileRefContext.Provider value={{ onOpenFileRef }}>
+        <Anchor href="/Users/me/repo/src/app.ts:42">app.ts</Anchor>
+      </CockpitFileRefContext.Provider>,
+    );
+    const a = container.querySelector("a")!;
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    fireEvent(a, event);
+    expect(onOpenFileRef).toHaveBeenCalledWith({
+      path: "/Users/me/repo/src/app.ts",
+      line: 42,
+    });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not intercept an external link even with a handler present", () => {
+    const Anchor = getAnchor();
+    const onOpenFileRef = vi.fn();
+    const { container } = render(
+      <CockpitFileRefContext.Provider value={{ onOpenFileRef }}>
+        <Anchor href="https://example.com">docs</Anchor>
+      </CockpitFileRefContext.Provider>,
+    );
+    const a = container.querySelector("a")!;
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    fireEvent(a, event);
+    expect(onOpenFileRef).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    expect(a.getAttribute("target")).toBe("_blank");
+    expect(a.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("leaves links untouched when no handler is provided", () => {
+    const Anchor = getAnchor();
+    const { container } = render(
+      <Anchor href="/Users/me/repo/src/app.ts:42">app.ts</Anchor>,
+    );
+    const a = container.querySelector("a")!;
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    fireEvent(a, event);
+    // No handler in context, so the file link falls through to the
+    // default new-tab anchor without preventing navigation.
+    expect(event.defaultPrevented).toBe(false);
+    expect(a.getAttribute("target")).toBe("_blank");
   });
 });
 

--- a/web/src/components/cockpit/Markdown.tsx
+++ b/web/src/components/cockpit/Markdown.tsx
@@ -29,6 +29,8 @@ import {
   loadLanguage,
 } from "../../lib/highlighter";
 import { useShikiTheme } from "../../hooks/useShikiTheme";
+import { parseFileRef } from "../../lib/fileRef";
+import { useCockpitFileRef } from "./CockpitFileRefContext";
 
 interface Props {
   text: string;
@@ -84,17 +86,52 @@ export function Markdown({ text, smooth = false, breaks = false }: Props) {
 }
 
 /**
- * Transcript link. Cockpit is a long-running debugging surface, so a
- * link that navigates the current tab pulls the user out of the live
- * session. Force every transcript anchor to open a new tab with the
- * dashboard-standard safe rel (matches AboutModal, Dashboard, etc., and
- * guards against tabnabbing). Existing anchor props (href, title,
- * className, children) are forwarded untouched. See #1714.
+ * Transcript link. Two behaviors:
+ *
+ *  - Local file references (e.g. Codex's `[app.ts](/repo/src/app.ts:42)`)
+ *    are intercepted: clicking opens the file in the in-app diff/file
+ *    viewer via the cockpit file-ref handler, keeping the current
+ *    `/session/<id>` route instead of navigating the tab to a dead
+ *    filesystem path. Only active when a handler is provided and the
+ *    href parses as a local file ref. See #1718.
+ *  - Everything else (docs, CI, repo links) keeps the same-tab-is-bad
+ *    treatment from #1714: open in a new tab with the dashboard-standard
+ *    safe rel (guards against tabnabbing), so following a link does not
+ *    replace the live cockpit session.
+ *
+ * Existing anchor props (href, title, className, children) are forwarded
+ * untouched, and the `target`/`rel` fallback is preserved so a
+ * non-intercepted link (or a middle-click / "open in new tab") still
+ * behaves as before.
  */
 function TranscriptLink({
+  href,
+  onClick,
   ...rest
 }: React.ComponentPropsWithoutRef<"a">) {
-  return <a {...rest} target="_blank" rel="noopener noreferrer" />;
+  const { onOpenFileRef } = useCockpitFileRef();
+
+  function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
+    if (href && onOpenFileRef) {
+      const ref = parseFileRef(href);
+      if (ref) {
+        e.preventDefault();
+        onOpenFileRef(ref);
+        return;
+      }
+    }
+    onClick?.(e);
+  }
+
+  return (
+    <a
+      {...rest}
+      href={href}
+      onClick={handleClick}
+      target="_blank"
+      rel="noopener noreferrer"
+    />
+  );
 }
 
 /**

--- a/web/src/lib/__tests__/fileRef.test.ts
+++ b/web/src/lib/__tests__/fileRef.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseFileRef,
+  resolveToRepoRelative,
+  type FileRefSession,
+} from "../fileRef";
+
+describe("parseFileRef", () => {
+  it("parses an absolute path with a line suffix", () => {
+    expect(parseFileRef("/Users/me/repo/src/app.ts:42")).toEqual({
+      path: "/Users/me/repo/src/app.ts",
+      line: 42,
+    });
+  });
+
+  it("parses a line:column suffix", () => {
+    expect(parseFileRef("/repo/src/app.ts:42:7")).toEqual({
+      path: "/repo/src/app.ts",
+      line: 42,
+      column: 7,
+    });
+  });
+
+  it("parses the #Lline (GitHub blob) suffix", () => {
+    expect(parseFileRef("/repo/src/app.ts#L99")).toEqual({
+      path: "/repo/src/app.ts",
+      line: 99,
+    });
+  });
+
+  it("parses an absolute path with no suffix", () => {
+    expect(parseFileRef("/repo/src/app.ts")).toEqual({
+      path: "/repo/src/app.ts",
+    });
+  });
+
+  it("treats a relative path as a file reference", () => {
+    expect(parseFileRef("src/app.ts:10")).toEqual({
+      path: "src/app.ts",
+      line: 10,
+    });
+  });
+
+  it("normalizes Windows backslashes and keeps the drive letter", () => {
+    expect(parseFileRef("C:\\repo\\src\\app.ts:5")).toEqual({
+      path: "C:/repo/src/app.ts",
+      line: 5,
+    });
+  });
+
+  it("does not eat a bare Windows drive colon", () => {
+    // No numeric line here, so nothing should be stripped.
+    expect(parseFileRef("C:\\repo\\app.ts")).toEqual({
+      path: "C:/repo/app.ts",
+    });
+  });
+
+  it("strips a file:// scheme", () => {
+    expect(parseFileRef("file:///Users/me/repo/app.ts:3")).toEqual({
+      path: "/Users/me/repo/app.ts",
+      line: 3,
+    });
+  });
+
+  it("strips a Windows file:// scheme to a drive-led path", () => {
+    expect(parseFileRef("file:///C:/repo/app.ts")).toEqual({
+      path: "C:/repo/app.ts",
+    });
+  });
+
+  it("decodes percent-encoded characters (spaces)", () => {
+    expect(parseFileRef("/repo/my%20dir/app.ts:1")).toEqual({
+      path: "/repo/my dir/app.ts",
+      line: 1,
+    });
+  });
+
+  it("survives malformed percent-encoding", () => {
+    expect(parseFileRef("/repo/a%ZZb.ts")).toEqual({ path: "/repo/a%ZZb.ts" });
+  });
+
+  it.each([
+    "https://example.com/a.ts",
+    "http://example.com",
+    "mailto:me@example.com",
+    "tel:+15551234",
+    "data:text/plain,hi",
+    "javascript:alert(1)",
+    "vscode://file/x",
+    "//cdn.example.com/x.js",
+    "#section",
+  ])("returns null for non-file href %s", (href) => {
+    expect(parseFileRef(href)).toBeNull();
+  });
+
+  it("returns null for empty/whitespace href", () => {
+    expect(parseFileRef("")).toBeNull();
+    expect(parseFileRef("   ")).toBeNull();
+  });
+});
+
+describe("resolveToRepoRelative", () => {
+  const single: FileRefSession = {
+    project_path: "/Users/me/.aoe/worktrees/feat",
+    main_repo_path: "/Users/me/repo",
+    workspace_repos: [],
+  };
+
+  it("resolves a path inside the worktree to a repo-relative path", () => {
+    expect(
+      resolveToRepoRelative("/Users/me/.aoe/worktrees/feat/src/app.ts", single),
+    ).toEqual({ relativePath: "src/app.ts" });
+  });
+
+  it("falls back to the main repo path", () => {
+    expect(
+      resolveToRepoRelative("/Users/me/repo/src/app.ts", single),
+    ).toEqual({ relativePath: "src/app.ts" });
+  });
+
+  it("does not match a sibling dir with a shared prefix", () => {
+    // `/Users/me/repo` must not match `/Users/me/repo_old/...`.
+    expect(
+      resolveToRepoRelative("/Users/me/repo_old/src/app.ts", single),
+    ).toBeNull();
+  });
+
+  it("returns null when the path is outside any known root", () => {
+    expect(
+      resolveToRepoRelative("/etc/passwd", single),
+    ).toBeNull();
+  });
+
+  it("treats a relative path as already repo-relative", () => {
+    expect(resolveToRepoRelative("src/app.ts", single)).toEqual({
+      relativePath: "src/app.ts",
+    });
+  });
+
+  it("strips a leading ./ from a relative path", () => {
+    expect(resolveToRepoRelative("./src/app.ts", single)).toEqual({
+      relativePath: "src/app.ts",
+    });
+  });
+
+  it("resolves against a workspace repo root and returns its name", () => {
+    const workspace: FileRefSession = {
+      project_path: "/Users/me/.aoe/worktrees/ws",
+      main_repo_path: null,
+      workspace_repos: [
+        { name: "api", source_path: "/Users/me/api" },
+        { name: "web", source_path: "/Users/me/web" },
+      ],
+    };
+    expect(
+      resolveToRepoRelative("/Users/me/web/src/app.ts", workspace),
+    ).toEqual({ relativePath: "src/app.ts", repoName: "web" });
+  });
+});

--- a/web/src/lib/__tests__/fileRef.test.ts
+++ b/web/src/lib/__tests__/fileRef.test.ts
@@ -143,6 +143,17 @@ describe("resolveToRepoRelative", () => {
     });
   });
 
+  it("matches a Windows drive root case-insensitively", () => {
+    const win: FileRefSession = {
+      project_path: "C:\\Users\\me\\repo",
+      main_repo_path: null,
+      workspace_repos: [],
+    };
+    expect(
+      resolveToRepoRelative("c:\\Users\\me\\repo\\src\\app.ts", win),
+    ).toEqual({ relativePath: "src/app.ts" });
+  });
+
   it("resolves against a workspace repo root and returns its name", () => {
     const workspace: FileRefSession = {
       project_path: "/Users/me/.aoe/worktrees/ws",

--- a/web/src/lib/fileRef.ts
+++ b/web/src/lib/fileRef.ts
@@ -1,0 +1,154 @@
+// Parsing and resolution for local file references that agents emit in
+// cockpit transcript markdown. Codex (and similar agents) cite source
+// locations as markdown links whose href is a filesystem path with an
+// optional line/column suffix, e.g. `[app.ts](/Users/me/repo/src/app.ts:42)`.
+// We intercept those in the markdown anchor override (see Markdown.tsx)
+// and open the file in the in-app diff viewer instead of letting the
+// browser navigate to a dead filesystem URL. External links (http(s),
+// mailto, ...) are left untouched. See #1718.
+
+/** A parsed local file reference. `line`/`column` are 1-based when the
+ *  href carried a suffix; they are parsed but not yet wired to viewer
+ *  scroll-to-line (follow-up). */
+export interface FileRef {
+  path: string;
+  line?: number;
+  column?: number;
+}
+
+/** Minimal session shape needed to resolve an absolute agent path back
+ *  to a repo-relative path. Mirrors the relevant fields of
+ *  `SessionResponse`; kept structural so the pure resolver stays
+ *  testable without constructing a full session object. */
+export interface FileRefSession {
+  project_path: string;
+  main_repo_path: string | null;
+  workspace_repos: { name: string; source_path: string }[];
+}
+
+// Web/app URL schemes that are never local file references. Anything
+// matching here keeps default (new-tab) anchor behavior.
+const NON_FILE_SCHEME = /^(?:https?|mailto|tel|data|javascript|ftp|vscode|vscode-insiders|blob):/i;
+
+/**
+ * Classify an anchor href as a local file reference and split off any
+ * trailing line/column suffix. Returns null for anything that is not a
+ * local file path (external URLs, in-page anchors, protocol-relative
+ * links), in which case the caller should fall back to normal anchor
+ * behavior.
+ *
+ * Recognised suffixes: `:line`, `:line:col`, and `#Lline` (the GitHub
+ * blob style). The suffix is stripped from `path` and surfaced as
+ * `line`/`column`.
+ */
+export function parseFileRef(href: string): FileRef | null {
+  if (!href) return null;
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  // External/app schemes, protocol-relative `//host`, and bare in-page
+  // `#anchor` links are not file references.
+  if (NON_FILE_SCHEME.test(trimmed)) return null;
+  if (trimmed.startsWith("//")) return null;
+  if (trimmed.startsWith("#")) return null;
+
+  let raw = trimmed;
+
+  // `file://` URIs: strip the scheme. On Windows these come through as
+  // `file:///C:/foo` -> `/C:/foo`; drop the leading slash so the drive
+  // letter leads.
+  if (/^file:\/\//i.test(raw)) {
+    raw = raw.replace(/^file:\/\//i, "");
+    if (/^\/[a-zA-Z]:[/\\]/.test(raw)) raw = raw.slice(1);
+  }
+
+  try {
+    raw = decodeURIComponent(raw);
+  } catch {
+    // Malformed percent-encoding: fall through with the raw string.
+  }
+
+  let path = raw;
+  let line: number | undefined;
+  let column: number | undefined;
+
+  // `#Lline` (GitHub blob fragment).
+  const hashMatch = path.match(/#L(\d+)$/);
+  if (hashMatch) {
+    path = path.slice(0, -hashMatch[0].length);
+    line = Number(hashMatch[1]);
+  } else {
+    // `:line` or `:line:col`. Guard against eating a bare Windows drive
+    // colon (`C:`) by requiring the stripped remainder to be more than a
+    // drive letter.
+    const colonMatch = path.match(/:(\d+)(?::(\d+))?$/);
+    if (colonMatch) {
+      const stripped = path.slice(0, -colonMatch[0].length);
+      if (stripped && !/^[a-zA-Z]:$/.test(stripped)) {
+        path = stripped;
+        line = Number(colonMatch[1]);
+        if (colonMatch[2] !== undefined) column = Number(colonMatch[2]);
+      }
+    }
+  }
+
+  // Normalize separators so downstream prefix matching is uniform.
+  path = path.replace(/\\/g, "/");
+  if (!path) return null;
+
+  return { path, line, column };
+}
+
+function normalizeRoot(root: string): string {
+  let norm = root.replace(/\\/g, "/");
+  if (!norm.endsWith("/")) norm += "/";
+  return norm;
+}
+
+/**
+ * Resolve a parsed file path to the repo-relative path (and repo name
+ * for multi-repo workspaces) expected by the diff/file API. Returns null
+ * when the path is not inside any known repo root, so the caller can
+ * surface a non-destructive toast instead of opening the wrong file.
+ *
+ * A relative path (no leading slash, no Windows drive) is assumed to be
+ * already repo-relative and returned as-is. Absolute paths are matched
+ * by exact, trailing-slash-guarded prefix against the workspace repo
+ * roots, then the session worktree (`project_path`), then the source
+ * repo (`main_repo_path`). The trailing-slash guard prevents
+ * `/a/app` from spuriously matching `/a/app_old`.
+ */
+export function resolveToRepoRelative(
+  path: string,
+  session: FileRefSession,
+): { relativePath: string; repoName?: string } | null {
+  const target = path.replace(/\\/g, "/");
+
+  const isAbsolute = target.startsWith("/") || /^[a-zA-Z]:\//.test(target);
+  if (!isAbsolute) {
+    // Already repo-relative; strip a leading `./` for cleanliness.
+    const rel = target.replace(/^\.\//, "");
+    return rel ? { relativePath: rel } : null;
+  }
+
+  for (const repo of session.workspace_repos) {
+    const root = normalizeRoot(repo.source_path);
+    if (target.startsWith(root)) {
+      return { relativePath: target.slice(root.length), repoName: repo.name };
+    }
+  }
+
+  const root = normalizeRoot(session.project_path);
+  if (target.startsWith(root)) {
+    return { relativePath: target.slice(root.length) };
+  }
+
+  if (session.main_repo_path) {
+    const mainRoot = normalizeRoot(session.main_repo_path);
+    if (target.startsWith(mainRoot)) {
+      return { relativePath: target.slice(mainRoot.length) };
+    }
+  }
+
+  return null;
+}

--- a/web/src/lib/fileRef.ts
+++ b/web/src/lib/fileRef.ts
@@ -99,10 +99,18 @@ export function parseFileRef(href: string): FileRef | null {
   return { path, line, column };
 }
 
+// Forward-slash separators, a trailing slash, and a lowercased Windows
+// drive letter so prefix matching is uniform. Drive-letter case is the
+// only case folding applied: POSIX paths stay case-sensitive, and the
+// drive prefix is stripped from the returned relative path anyway, so
+// folding it never leaks into output.
+function normalizePathForMatch(p: string): string {
+  return p.replace(/\\/g, "/").replace(/^([a-zA-Z]):\//, (_, d) => `${d.toLowerCase()}:/`);
+}
+
 function normalizeRoot(root: string): string {
-  let norm = root.replace(/\\/g, "/");
-  if (!norm.endsWith("/")) norm += "/";
-  return norm;
+  const norm = normalizePathForMatch(root);
+  return norm.endsWith("/") ? norm : `${norm}/`;
 }
 
 /**
@@ -122,9 +130,9 @@ export function resolveToRepoRelative(
   path: string,
   session: FileRefSession,
 ): { relativePath: string; repoName?: string } | null {
-  const target = path.replace(/\\/g, "/");
+  const target = normalizePathForMatch(path);
 
-  const isAbsolute = target.startsWith("/") || /^[a-zA-Z]:\//.test(target);
+  const isAbsolute = target.startsWith("/") || /^[a-z]:\//.test(target);
   if (!isAbsolute) {
     // Already repo-relative; strip a leading `./` for cleanliness.
     const rel = target.replace(/^\.\//, "");

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1323,6 +1323,21 @@
       ]
     },
     {
+      "id": "cockpit.file-links",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-file-links.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitFileRefContext.tsx",
+        "web/src/components/cockpit/Markdown.tsx",
+        "web/src/components/cockpit/CockpitView.tsx",
+        "web/src/components/MobileMainPane.tsx",
+        "web/src/components/diff/DiffFileViewer.tsx"
+      ]
+    },
+    {
       "id": "cockpit.story.composer-single-newline",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/cockpit-file-links.spec.ts
+++ b/web/tests/live/cockpit-file-links.spec.ts
@@ -1,0 +1,124 @@
+// Live-backend spec: cockpit transcript local file links (#1718).
+//
+// Seeds a git repo with a committed-then-modified file so the diff
+// endpoint returns real content, registers it as a cockpit session, and
+// scripts the fake ACP agent to emit an assistant message containing two
+// markdown links: one local file reference inside the worktree and one
+// absolute path outside any repo root. Drives the real UI:
+//   - clicking the in-repo link opens the file in the in-app diff viewer
+//     and keeps the /session/<id> route (no navigation away),
+//   - clicking the out-of-repo link surfaces a non-destructive toast and
+//     leaves the route unchanged.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, resolveAoeBinary } from "../helpers/aoeServe";
+import { commitAll, initWorkingRepo, writeFiles } from "../helpers/gitFixture";
+import { enableCockpitAndWait, waitForCockpitView } from "../helpers/cockpit";
+
+base(
+  "cockpit transcript file links open in-app and toast on miss",
+  async ({ page }, testInfo) => {
+    const scriptDir = mkdtempSync(join(tmpdir(), "aoe-acp-filelink-"));
+    const scriptPath = join(scriptDir, "script.json");
+    const outsidePath = "/tmp/aoe-1718-not-a-repo/missing.ts:1";
+
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: ({ home, env }) => {
+        const projectDir = join(home, "project");
+        initWorkingRepo(projectDir);
+        writeFiles(projectDir, { "src/a.ts": "export const a = 1;\n" });
+        commitAll(projectDir, "baseline");
+        writeFiles(projectDir, { "src/a.ts": "export const a = 11;\n" });
+
+        // `aoe add <dir>` makes project_path the modified working tree,
+        // so an absolute path under projectDir resolves to a repo file.
+        // Bake that path into the agent message now that home is known.
+        const inRepoLink = `${projectDir}/src/a.ts:1`;
+        writeFileSync(
+          scriptPath,
+          JSON.stringify({
+            turns: [
+              {
+                updates: [
+                  {
+                    sessionUpdate: "agent_message_chunk",
+                    content: {
+                      type: "text",
+                      text: `See [a.ts](${inRepoLink}) and [missing](${outsidePath}).`,
+                    },
+                  },
+                ],
+                stopReason: "end_turn",
+              },
+            ],
+          }),
+        );
+
+        const addRes = spawnSync(
+          resolveAoeBinary(),
+          ["add", projectDir, "-t", "cockpit-filelink", "-c", "claude"],
+          { env },
+        );
+        if (addRes.status !== 0) {
+          throw new Error(
+            `aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`,
+          );
+        }
+      },
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+      await page.goto(`${serve.baseUrl}/session/${sessionId}`);
+      await waitForCockpitView(page);
+
+      // Trigger the scripted agent turn that emits the two links.
+      const promptRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/prompt`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text: "show me the file" }),
+        },
+      );
+      expect(promptRes.status).toBeGreaterThanOrEqual(200);
+      expect(promptRes.status).toBeLessThan(300);
+
+      const sessionUrl = new RegExp(`/session/${sessionId}`);
+
+      // Out-of-repo link: clicking surfaces a toast and does not navigate.
+      const missingLink = page.getByRole("link", { name: "missing" });
+      await expect(missingLink).toBeVisible({ timeout: 15_000 });
+      await missingLink.click();
+      await expect(page.locator('[role="alert"]')).toContainText(
+        /Could not open/i,
+        { timeout: 10_000 },
+      );
+      await expect(page).toHaveURL(sessionUrl);
+
+      // In-repo link: clicking opens the file in the in-app diff viewer,
+      // showing the modified content, still on the same session route.
+      const fileLink = page.getByRole("link", { name: "a.ts" });
+      await expect(fileLink).toBeVisible();
+      await fileLink.click();
+      await expect(page.getByText(/export const a = 11/).first()).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(page).toHaveURL(sessionUrl);
+    } finally {
+      await serve.stop();
+    }
+  },
+);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Codex (and similar agents) cite source locations in the cockpit transcript as markdown links whose href is a filesystem path with an optional line suffix, for example `[app.ts](/Users/me/repo/src/app.ts:42)`. Since #1780 every transcript anchor opens in a new tab, so clicking one of these local file links opened a dead browser tab at a filesystem path instead of doing anything useful.

This makes those links open the cited file in AoE's existing in-app diff/file viewer while keeping you on the current `/session/<id>` route. External links (docs, CI, repo) keep the #1780 new-tab behavior untouched.

How it works:

- A pure helper (`web/src/lib/fileRef.ts`) classifies an anchor href as a local file reference (rejecting `http(s)`, `mailto`, protocol-relative, and in-page anchors), strips a trailing `:line` / `:line:col` / `#Lline` suffix, and resolves an absolute path back to a repo-relative path via trailing-slash-guarded prefix matching over the session's workspace repos, worktree, then source repo.
- The cockpit markdown anchor override consumes a handler through `CockpitFileRefContext` (the transcript text nodes are mounted by assistant-ui, so a callback cannot be prop-drilled to them). A local file ref with a handler present is intercepted (`preventDefault` + open in viewer); anything else falls through to the existing new-tab anchor.
- `App` resolves the path against the active session and opens it through the same `selectedFile` path the right panel already uses, so the diff viewer mounts with no route change on both desktop and mobile. A path outside the session's repo surfaces a non-destructive toast instead of navigating away.

Scope calls (discussed up front): multi-repo resolution uses exact prefix matching only (toast on miss); a cited file with no diff opens the diff viewer's empty state (full-file viewing is a follow-up, #1810); the line/column suffix is parsed but scroll-to-line is a follow-up, #1809.

Closes #1718

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] In a cockpit session, have the agent emit a markdown link to a changed file with a line, e.g. `[app.ts](<worktree>/src/app.ts:42)`; click it and confirm the file opens in the in-app diff viewer and the URL stays on `/session/<id>`.
- [x] Click an external link (e.g. `https://example.com`) in the transcript; confirm it still opens in a new tab and does not touch the file viewer.
- [x] Click a link to a path outside the session's repo (e.g. `/etc/hosts`); confirm a toast appears and the cockpit view does not navigate away.
- [x] Repeat the first step on a mobile viewport; confirm the file viewer opens there too.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. I made the design calls (resolver placement, multi-repo scoping, follow-up split), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR Summary: Local File References Open in In-App Viewer

## What Changed

This PR enables cockpit transcripts to display clickable file references (in the format `path/to/file:42`) that open files directly in the in-app viewer without leaving the current session. Previously, these links would either navigate away or open in a new tab.

**Key additions:**
- New file reference parsing and resolution library that extracts file paths and line numbers from various link formats (including GitHub-style `#L42` anchors and Windows paths)
- A React context system to wire file-open handlers from the app level down through the UI components
- Updated transcript markdown renderer to intercept local file links and route them through the handler instead of the default browser navigation
- Modified main UI components (App, MobileMainPane, CockpitView) to accept and pass through the file-open callback
- Documentation clarifying the new behavior
- Unit tests and end-to-end Playwright tests validating both in-repo and out-of-repo link handling

## Technical Details

**New utilities** (`web/src/lib/fileRef.ts`):
- `parseFileRef(href)`: Classifies hrefs as local file references, strips line/column suffixes (`:line`, `:line:col`, `#Lline`), handles `file://` URIs, normalizes separators, and decodes percent-encoded characters
- `resolveToRepoRelative(path, session)`: Maps absolute paths to repo-relative coordinates by matching against workspace repo roots, worktree path, and main repo path in sequence; returns `null` if no match or path is outside known roots

**Context and interception** (`web/src/components/cockpit/CockpitFileRefContext.tsx`, updated `Markdown.tsx`):
- New context carries an optional `onOpenFileRef` callback through the cockpit component tree
- Markdown anchor renderer intercepts clicks on local file links, calls the handler with parsed `{path, line, column}`, and prevents default navigation
- External links and local links without a handler maintain the previous new-tab behavior with `target="_blank"` and `rel="noopener noreferrer"`

**Integration** (updated `App.tsx`, `MobileMainPane.tsx`, `CockpitView.tsx`):
- App implements the handler to resolve absolute paths against the active session's roots, emit a toast for out-of-repo paths, and select the file in the diff viewer via the existing `handleSelectFile` mechanism
- All paths are wired through the component tree so the behavior works in both desktop and mobile layouts

**Testing**:
- Unit tests (`fileRef.test.ts`) cover path parsing, suffix extraction, Windows drive normalization, percent-decoding, and repo-relative resolution
- Markdown component tests verify anchor interception for local vs. external links
- End-to-end test (`cockpit-file-links.spec.ts`) seeds a mock repo and agent, verifies in-repo links open the diff viewer in-place, and out-of-repo links show a non-destructive toast

## Benefits

- **Seamless navigation**: Users stay in their cockpit session while exploring referenced files
- **Contextual awareness**: File references automatically resolve within the session's repo context without manual path manipulation
- **Safe handling**: Out-of-repo paths display a brief notice instead of unexpected navigation
- **Flexible link formats**: Supports multiple link syntaxes (Codex `:line`, GitHub `#L42`, file URIs) out of the box
- **Non-breaking**: External documentation and CI/repo links continue to open normally in new tabs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->