### PR TITLE
feat(cockpit): approval-card command preview and a compact-tools density toggle

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -296,3 +296,12 @@ TodoWrite sandwiched between real tool work (Read, Edit) stays inline as
 its own card rather than being hidden inside a group, so a status update
 between actions is never buried. Two-in-a-row stays inline as well; the
 fold threshold is three.
+
+Automatic grouping needs an unbroken run, so a phase where the agent
+narrates between each action (common right after a plan is approved)
+produces a long stream of individual cards instead. The **Compact
+tools** toggle at the top of the transcript collapses every tool card to
+its header for scanning, and new cards arrive collapsed while it stays
+on; the agent's narration stays visible and errored cards stay open so a
+failure is never hidden. It is a per-browser preference saved locally,
+and you can still expand any single card while compact mode is on.

--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -94,6 +94,16 @@ when the approval card itself has focus. Typing "always allow" into
 the composer will never silently approve a pending tool; the
 composer captures every keystroke, including those letters.
 
+**Approval card detail.** The web dashboard approval card shows a
+one-line preview of the tool call in its header (the command for a
+shell call, the path for a read or edit) so you can act without
+expanding. A benign approval starts collapsed with that preview; a
+destructive one starts expanded so the full arguments are in view
+before a hold-to-allow. Click the header to toggle the full argument
+list, and the Allow / Always / Deny buttons stay reachable in either
+state. The toggle is per-card and never re-expands on its own after a
+plan is approved.
+
 **Markdown rendering.** Agent messages in the transcript are parsed as
 markdown and rendered with styling: headings and `**bold**` show in
 bold, `*italics*` in italic, `` `inline code` `` and fenced code blocks

--- a/web/src/components/cockpit/ApprovalCard.test.tsx
+++ b/web/src/components/cockpit/ApprovalCard.test.tsx
@@ -55,7 +55,32 @@ describe("ApprovalCard (benign)", () => {
     expect(screen.getByText("Bash")).toBeTruthy();
   });
 
-  it("renders the args JSON as a key/value list", () => {
+  it("collapses to a command preview and hides args until expanded", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({
+          tool_call: {
+            id: "t-1",
+            name: "Bash",
+            kind: "execute",
+            args_preview: JSON.stringify({ command: "ls -al", cwd: "/tmp" }),
+            started_at: "2026-05-21T00:00:00Z",
+          },
+        })}
+        onResolve={onResolve}
+      />,
+    );
+    // Command preview is in the collapsed header; the args <dl> is not.
+    expect(screen.getByText("ls -al")).toBeTruthy();
+    expect(screen.queryByText("cwd")).toBeNull();
+    expect(screen.queryByText("/tmp")).toBeNull();
+    // Action surface stays reachable without expanding.
+    expect(screen.getByText("Allow")).toBeTruthy();
+    expect(screen.getByText("Deny")).toBeTruthy();
+  });
+
+  it("renders the args JSON as a key/value list once expanded", () => {
     const onResolve = vi.fn().mockResolvedValue(undefined);
     render(
       <ApprovalCard
@@ -71,13 +96,39 @@ describe("ApprovalCard (benign)", () => {
         onResolve={onResolve}
       />,
     );
+    fireEvent.click(screen.getByRole("button", { name: /Approval needed/i }));
     expect(screen.getByText("command")).toBeTruthy();
-    expect(screen.getByText("ls")).toBeTruthy();
+    // "ls" shows in both the header preview and the expanded args row.
+    expect(screen.getAllByText("ls")).toHaveLength(2);
     expect(screen.getByText("cwd")).toBeTruthy();
     expect(screen.getByText("/tmp")).toBeTruthy();
   });
 
-  it("hides bookkeeping keys whose name starts with _aoe_", () => {
+  it("toggles the args open and closed on header clicks", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({
+          tool_call: {
+            id: "t-1",
+            name: "Bash",
+            kind: "execute",
+            args_preview: JSON.stringify({ command: "ls", cwd: "/tmp" }),
+            started_at: "2026-05-21T00:00:00Z",
+          },
+        })}
+        onResolve={onResolve}
+      />,
+    );
+    const header = screen.getByRole("button", { name: /Approval needed/i });
+    expect(screen.queryByText("cwd")).toBeNull();
+    fireEvent.click(header);
+    expect(screen.getByText("cwd")).toBeTruthy();
+    fireEvent.click(header);
+    expect(screen.queryByText("cwd")).toBeNull();
+  });
+
+  it("hides bookkeeping keys whose name starts with _aoe_ when expanded", () => {
     const onResolve = vi.fn().mockResolvedValue(undefined);
     render(
       <ApprovalCard
@@ -96,6 +147,7 @@ describe("ApprovalCard (benign)", () => {
         onResolve={onResolve}
       />,
     );
+    fireEvent.click(screen.getByRole("button", { name: /Approval needed/i }));
     expect(screen.queryByText("_aoe_parent_tool_call_id")).toBeNull();
     expect(screen.queryByText("parent-123")).toBeNull();
     expect(screen.getByText("command")).toBeTruthy();
@@ -117,7 +169,29 @@ describe("ApprovalCard (benign)", () => {
         onResolve={onResolve}
       />,
     );
+    fireEvent.click(screen.getByRole("button", { name: /Approval needed/i }));
     expect(screen.getByText("raw text [truncated]")).toBeTruthy();
+  });
+
+  it("offers no expand toggle when there is no args body", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({
+          tool_call: {
+            id: "t-1",
+            name: "Bash",
+            kind: "execute",
+            args_preview: JSON.stringify({ _aoe_title: "noop" }),
+            started_at: "2026-05-21T00:00:00Z",
+          },
+        })}
+        onResolve={onResolve}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Approval needed/i }),
+    ).toBeNull();
   });
 
   it("routes the Allow button to onResolve('Allow')", async () => {
@@ -173,6 +247,18 @@ describe("ApprovalCard (destructive)", () => {
     expect(screen.getByText("Destructive action")).toBeTruthy();
     expect(screen.getByText("Hold to allow")).toBeTruthy();
     expect(screen.queryByText("Always")).toBeNull();
+  });
+
+  it("defaults to expanded so the full command is in view", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({ destructive: true })}
+        onResolve={onResolve}
+      />,
+    );
+    // The args <dl> renders without a click in the destructive branch.
+    expect(screen.getByText("command")).toBeTruthy();
   });
 
   it("does not approve on a quick click of Hold to allow", () => {

--- a/web/src/components/cockpit/ApprovalCard.tsx
+++ b/web/src/components/cockpit/ApprovalCard.tsx
@@ -11,10 +11,14 @@
 // the approval from CockpitState.pendingApprovals.
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, Check, Shield, X } from "lucide-react";
+import { AlertTriangle, Check, ChevronDown, Shield, X } from "lucide-react";
 import type { Approval, ApprovalDecision } from "../../lib/cockpitTypes";
 import { useServerDown, OFFLINE_TITLE } from "../../lib/connectionState";
-import { parseJsonObject } from "../../lib/cockpitArgs";
+import {
+  hasArgsBody,
+  parseJsonObject,
+  previewFromArgs,
+} from "../../lib/cockpitArgs";
 
 interface Props {
   approval: Approval;
@@ -31,6 +35,16 @@ export function ApprovalCard({ approval, onResolve }: Props) {
   const [progress, setProgress] = useState(0);
   const pressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const progressTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const raw = approval.tool_call.args_preview;
+  // Benign approvals collapse to a one-line preview so the queue stays
+  // scannable; destructive ones default expanded so the full command is
+  // in view before a hold-to-allow. Either way the toggle stays under
+  // user control and nothing re-expands it on plan approval. See #1767.
+  const [expanded, setExpanded] = useState(approval.destructive);
+  const preview = useMemo(() => previewFromArgs(raw), [raw]);
+  const canExpand = useMemo(() => hasArgsBody(raw), [raw]);
+  const Header = canExpand ? "button" : "div";
 
   useEffect(() => {
     return () => {
@@ -98,26 +112,47 @@ export function ApprovalCard({ approval, onResolve }: Props) {
       role="alertdialog"
       aria-label={`Approval needed: ${approval.tool_call.name}`}
     >
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-surface-800/60">
+      <Header
+        type={canExpand ? "button" : undefined}
+        onClick={canExpand ? () => setExpanded((v) => !v) : undefined}
+        aria-expanded={canExpand ? expanded : undefined}
+        className={[
+          "flex w-full items-center gap-2 px-3 py-2 text-left border-b border-surface-800/60",
+          canExpand ? "cursor-pointer hover:bg-surface-800/40" : "",
+        ].join(" ")}
+      >
         {approval.destructive ? (
-          <AlertTriangle className="h-3.5 w-3.5 text-rose-400" />
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-rose-400" />
         ) : (
-          <Shield className="h-3.5 w-3.5 text-brand-500" />
+          <Shield className="h-3.5 w-3.5 shrink-0 text-brand-500" />
         )}
         <span
           className={[
-            "text-[11px] uppercase tracking-wider",
+            "shrink-0 text-[11px] uppercase tracking-wider",
             approval.destructive ? "text-rose-400" : "text-brand-500",
           ].join(" ")}
         >
           {approval.destructive ? "Destructive action" : "Approval needed"}
         </span>
-        <span className="truncate font-mono text-xs text-text-secondary">
+        <span className="shrink-0 font-mono text-xs text-text-secondary">
           {approval.tool_call.name}
         </span>
-      </div>
+        {preview && (
+          <span className="min-w-0 flex-1 truncate font-mono text-xs text-text-dim">
+            {preview}
+          </span>
+        )}
+        {canExpand && (
+          <ChevronDown
+            className={[
+              "ml-auto h-3.5 w-3.5 shrink-0 text-text-dim transition-transform",
+              expanded ? "rotate-180" : "",
+            ].join(" ")}
+          />
+        )}
+      </Header>
 
-      <ArgsView raw={approval.tool_call.args_preview} />
+      {expanded && <ArgsView raw={raw} />}
 
       {phase === "rolled-back" && (
         <p className="px-3 pt-2 text-rose-400 text-xs">

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -34,6 +34,11 @@ import { ApprovalCard } from "./ApprovalCard";
 import { CockpitFileRefContext } from "./CockpitFileRefContext";
 import type { FileRef } from "../../lib/fileRef";
 import {
+  ToolDensityToggle,
+  ToolDisplayModeProvider,
+  useToolDensityPref,
+} from "./ToolDisplayMode";
+import {
   CockpitRuntime,
   SUBAGENT_TASK_NAME,
   TODO_GROUP_NAME,
@@ -137,28 +142,35 @@ export function CockpitView({
   // the view (not the reducer) because it's a UI preference, not
   // event-log state. See #1101.
   const [showClearedTurns, setShowClearedTurns] = useState(false);
+  // Tool-card density is a client-side view preference (localStorage),
+  // not reducer state and not a daemon config field. See #1767.
+  const [toolDensity, toggleToolDensity] = useToolDensityPref();
   return (
     <CockpitFileRefContext.Provider value={{ onOpenFileRef }}>
       <AgentProfileProvider toolKey={tool}>
-        <CockpitRuntime
-          sessionId={sessionId}
-          cockpitWorkerState={cockpitWorkerState}
-          archivedAt={archivedAt}
-          snoozedUntil={snoozedUntil}
-          showClearedTurns={showClearedTurns}
-        >
-          {(ctx) => (
-            <CockpitChrome
-              sessionId={sessionId}
-              cockpitWorkerState={cockpitWorkerState}
-              showClearedTurns={showClearedTurns}
-              onToggleClearedTurns={() => setShowClearedTurns((v) => !v)}
-              archivedAt={archivedAt}
-              snoozedUntil={snoozedUntil}
-              {...ctx}
-            />
-          )}
-        </CockpitRuntime>
+        <ToolDisplayModeProvider density={toolDensity}>
+          <CockpitRuntime
+            sessionId={sessionId}
+            cockpitWorkerState={cockpitWorkerState}
+            archivedAt={archivedAt}
+            snoozedUntil={snoozedUntil}
+            showClearedTurns={showClearedTurns}
+          >
+            {(ctx) => (
+              <CockpitChrome
+                sessionId={sessionId}
+                cockpitWorkerState={cockpitWorkerState}
+                showClearedTurns={showClearedTurns}
+                onToggleClearedTurns={() => setShowClearedTurns((v) => !v)}
+                toolDensity={toolDensity}
+                onToggleToolDensity={toggleToolDensity}
+                archivedAt={archivedAt}
+                snoozedUntil={snoozedUntil}
+                {...ctx}
+              />
+            )}
+          </CockpitRuntime>
+        </ToolDisplayModeProvider>
       </AgentProfileProvider>
     </CockpitFileRefContext.Provider>
   );
@@ -169,6 +181,8 @@ function CockpitChrome({
   cockpitWorkerState,
   showClearedTurns,
   onToggleClearedTurns,
+  toolDensity,
+  onToggleToolDensity,
   archivedAt,
   snoozedUntil,
   state,
@@ -199,6 +213,8 @@ function CockpitChrome({
   cockpitWorkerState: "absent" | "resuming" | "running";
   showClearedTurns: boolean;
   onToggleClearedTurns: () => void;
+  toolDensity: "detailed" | "compact";
+  onToggleToolDensity: () => void;
   archivedAt: string | null;
   snoozedUntil: string | null;
 }) {
@@ -393,6 +409,15 @@ function CockpitChrome({
             <ThreadPrimitive.Empty>
               <EmptyState onPick={sendPrompt} />
             </ThreadPrimitive.Empty>
+
+            {state.activity.length > 0 && (
+              <div className="mb-2 flex">
+                <ToolDensityToggle
+                  density={toolDensity}
+                  onToggle={onToggleToolDensity}
+                />
+              </div>
+            )}
 
             {clearedSummary && clearedSummary.hiddenCount > 0 && (
               <ClearedTurnsBanner

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -62,6 +62,7 @@ import {
 } from "../../lib/memoryClassify";
 import { reclassifyBash } from "../../lib/toolReclassify";
 import { useAgentProfile } from "../../lib/agentProfileContext";
+import { useToolDisplayMode, type ToolDensity } from "./ToolDisplayMode";
 import type { AgentProfile, CardKind } from "../../lib/agentProfiles";
 
 interface Props {
@@ -243,24 +244,42 @@ function statusFor(result?: ActivityRow): Status {
 
 // Per-card expand state for tool cards. Failed cards auto-open so the
 // user sees the error immediately, but the chevron must still fold them
-// once read. We model the user's choice as a nullable override: while
-// it is null we derive openness from the current props
-// (`status === "err" || defaultOpen`), so both a replayed already-failed
+// once read. We model the user's choice as an override scoped to the
+// active tool density: while no override matches the current density we
+// derive openness from the baseline, so both a replayed already-failed
 // card (mounts as err) and a live card that fails mid-stream
 // (running -> err) open during render with no effect and no one-frame
-// collapse flash. The first user toggle pins `userOpen` and is respected
-// from then on, even if the card later re-enters err. See #1467.
+// collapse flash. The first user toggle pins the override and is
+// respected from then on, even if the card later re-enters err. See
+// #1467.
+//
+// The baseline folds in the transcript density (#1767): "compact" makes
+// every card default collapsed, "detailed" keeps the caller's
+// `defaultOpen`. Errored cards always auto-open regardless of density so
+// compact mode never hides a failure. Scoping the override to the
+// density means flipping the global toggle re-applies the baseline for
+// every untouched card without a useEffect.
 function useToolCardExpansion(status: Status, defaultOpen = false) {
-  const [userOpen, setUserOpen] = useState<boolean | null>(null);
-  const open = userOpen ?? (status === "err" || defaultOpen);
+  const density = useToolDisplayMode();
+  const baseline =
+    status === "err" ? true : density === "compact" ? false : defaultOpen;
+  const [override, setOverride] = useState<{
+    density: ToolDensity;
+    open: boolean;
+  } | null>(null);
+  const active =
+    override && override.density === density ? override.open : null;
+  const open = active ?? baseline;
   const setOpen = useCallback(
     (action: SetStateAction<boolean>) => {
-      setUserOpen((prev) => {
-        const current = prev ?? (status === "err" || defaultOpen);
-        return typeof action === "function" ? action(current) : action;
+      setOverride((prev) => {
+        const current =
+          prev && prev.density === density ? prev.open : baseline;
+        const next = typeof action === "function" ? action(current) : action;
+        return { density, open: next };
       });
     },
-    [status, defaultOpen],
+    [density, baseline],
   );
   return [open, setOpen] as const;
 }
@@ -1318,9 +1337,6 @@ interface ToolGroupItem {
  *  matching how the Claude Code CLI condenses silent investigation
  *  phases. See #1057. */
 export function ToolGroupCard({ items }: { items: ToolGroupItem[] }) {
-  const [open, setOpen] = useState(false);
-  if (items.length === 0) return null;
-
   const runningCount = items.filter((i) => !i.result).length;
   const errorCount = items.filter(
     (i) => i.result && i.result.kind === "tool_error",
@@ -1329,6 +1345,11 @@ export function ToolGroupCard({ items }: { items: ToolGroupItem[] }) {
   // 11-step investigation doesn't make the whole investigation
   // failed; per-child status stays on the inner cards. See #1102.
   const status: Status = runningCount > 0 ? "running" : "ok";
+  // Route through the shared hook (not a bare useState) so the group
+  // folds with the transcript density toggle too. Called before the
+  // empty-items guard to keep hook order stable. See #1767.
+  const [open, setOpen] = useToolCardExpansion(status, false);
+  if (items.length === 0) return null;
 
   const breakdown = summariseKinds(items, errorCount);
 

--- a/web/src/components/cockpit/ToolDisplayMode.test.tsx
+++ b/web/src/components/cockpit/ToolDisplayMode.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+//
+// Transcript tool-card density (#1767). Pins the pieces that give the
+// user back a scannable view after plan approval without touching the
+// automatic grouping in CockpitRuntime:
+//   - useToolDensityPref persists to localStorage and defaults detailed,
+//   - ToolDensityToggle reflects state via aria-pressed,
+//   - compact mode collapses an otherwise-open card (a <=5 item todo),
+//   - a user's per-card toggle is scoped to the active density, so
+//     flipping the global toggle re-collapses an expanded card,
+//   - errored cards stay auto-open even in compact mode so a failure is
+//     never hidden (#1467).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("../../lib/highlighter", () => ({
+  ensureThemeLoaded: vi.fn().mockResolvedValue("dark-plus"),
+  getHighlighter: vi.fn().mockResolvedValue({
+    codeToHtml: (code: string) => `<pre>${code}</pre>`,
+  }),
+  langKeyForExt: (s: string) => s,
+  loadLanguage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../hooks/useShikiTheme", () => ({
+  useShikiTheme: () => ({ theme: "dark-plus", appearance: "dark" }),
+}));
+
+import {
+  ToolDensityToggle,
+  ToolDisplayModeProvider,
+  useToolDensityPref,
+  useToolDisplayMode,
+  type ToolDensity,
+} from "./ToolDisplayMode";
+import { ToolCard } from "./ToolCards";
+import { AgentProfileProvider } from "../../lib/agentProfileContext";
+import { fixtures, makeError } from "./__fixtures__/toolCalls";
+
+const STORAGE_KEY = "aoe.cockpit.toolDensity.v1";
+
+function Wrap({
+  density,
+  toolKey,
+  children,
+}: {
+  density: ToolDensity;
+  toolKey?: string;
+  children: ReactNode;
+}) {
+  return (
+    <AgentProfileProvider toolKey={toolKey ?? null}>
+      <ToolDisplayModeProvider density={density}>
+        {children}
+      </ToolDisplayModeProvider>
+    </AgentProfileProvider>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useToolDisplayMode", () => {
+  it("defaults to detailed outside a provider", () => {
+    const { result } = renderHook(() => useToolDisplayMode());
+    expect(result.current).toBe("detailed");
+  });
+
+  it("reads the provided density inside a provider", () => {
+    const { result } = renderHook(() => useToolDisplayMode(), {
+      wrapper: ({ children }) => (
+        <ToolDisplayModeProvider density="compact">
+          {children}
+        </ToolDisplayModeProvider>
+      ),
+    });
+    expect(result.current).toBe("compact");
+  });
+});
+
+describe("useToolDensityPref", () => {
+  it("defaults detailed and toggles to compact, persisting to storage", () => {
+    const { result } = renderHook(() => useToolDensityPref());
+    expect(result.current[0]).toBe("detailed");
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe("compact");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("compact");
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe("detailed");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("detailed");
+  });
+
+  it("initialises from a previously stored compact preference", () => {
+    window.localStorage.setItem(STORAGE_KEY, "compact");
+    const { result } = renderHook(() => useToolDensityPref());
+    expect(result.current[0]).toBe("compact");
+  });
+});
+
+describe("ToolDensityToggle", () => {
+  it("reflects density via aria-pressed and fires onToggle", () => {
+    const onToggle = vi.fn();
+    const { rerender } = render(
+      <ToolDensityToggle density="detailed" onToggle={onToggle} />,
+    );
+    const btn = screen.getByRole("button", { name: /compact tools/i });
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(btn);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    rerender(<ToolDensityToggle density="compact" onToggle={onToggle} />);
+    expect(
+      screen.getByRole("button", { name: /compact tools/i }).getAttribute(
+        "aria-pressed",
+      ),
+    ).toBe("true");
+  });
+});
+
+describe("tool-card density", () => {
+  it("compact collapses an otherwise-open todo card", () => {
+    const { container, rerender } = render(
+      <Wrap density="detailed" toolKey="claude">
+        <ToolCard tool={fixtures.todoWrite} result={undefined} />
+      </Wrap>,
+    );
+    // <=5 todos default open in detailed mode, so the list body shows.
+    expect(container.textContent).toContain("Step one");
+
+    rerender(
+      <Wrap density="compact" toolKey="claude">
+        <ToolCard tool={fixtures.todoWrite} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).not.toContain("Step one");
+  });
+
+  it("re-collapses a user-expanded card when density flips", () => {
+    const { container, rerender } = render(
+      <Wrap density="detailed" toolKey="claude">
+        <ToolCard tool={fixtures.todoWrite} result={undefined} />
+      </Wrap>,
+    );
+    // Collapse it by hand in detailed mode.
+    fireEvent.click(screen.getByRole("button", { name: /items/i }));
+    expect(container.textContent).not.toContain("Step one");
+
+    // Flipping to compact must not leak the detailed-mode override; the
+    // compact baseline (collapsed) applies.
+    rerender(
+      <Wrap density="compact" toolKey="claude">
+        <ToolCard tool={fixtures.todoWrite} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).not.toContain("Step one");
+
+    // And expanding it in compact works.
+    fireEvent.click(screen.getByRole("button", { name: /items/i }));
+    expect(container.textContent).toContain("Step one");
+  });
+
+  it("keeps an errored card open even in compact mode", () => {
+    const { container } = render(
+      <Wrap density="compact">
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeError({ toolCallId: "bash-1", text: "boom" })}
+        />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("boom");
+  });
+});

--- a/web/src/components/cockpit/ToolDisplayMode.tsx
+++ b/web/src/components/cockpit/ToolDisplayMode.tsx
@@ -1,0 +1,95 @@
+// Transcript-level tool-card density. A purely client-side view
+// preference (no daemon config, no settings parity): "detailed" keeps
+// the existing per-card defaults; "compact" makes every tool card
+// default collapsed so a long post-plan implementation stream stays
+// scannable without touching the automatic grouping in
+// CockpitRuntime.tsx. See #1767.
+//
+// The override model lives in useToolCardExpansion (ToolCards.tsx):
+// a user's per-card toggle is scoped to the active density, so flipping
+// the toggle re-applies the baseline for every card without an effect.
+
+import { createContext, useCallback, useContext, useState } from "react";
+import { ListCollapse } from "lucide-react";
+import { safeGetItem, safeSetItem } from "../../lib/safeStorage";
+
+export type ToolDensity = "detailed" | "compact";
+
+const STORAGE_KEY = "aoe.cockpit.toolDensity.v1";
+
+function readStoredDensity(): ToolDensity {
+  return safeGetItem(STORAGE_KEY) === "compact" ? "compact" : "detailed";
+}
+
+/** Client-side density preference, persisted in localStorage so it
+ *  survives reloads. Defaults to "detailed" so existing users and
+ *  snapshots are unaffected. */
+export function useToolDensityPref(): [ToolDensity, () => void] {
+  const [density, setDensity] = useState<ToolDensity>(readStoredDensity);
+  const toggle = useCallback(() => {
+    setDensity((prev) => {
+      const next: ToolDensity = prev === "compact" ? "detailed" : "compact";
+      safeSetItem(STORAGE_KEY, next);
+      return next;
+    });
+  }, []);
+  return [density, toggle];
+}
+
+const ToolDisplayModeContext = createContext<ToolDensity>("detailed");
+
+export function ToolDisplayModeProvider({
+  density,
+  children,
+}: {
+  density: ToolDensity;
+  children: React.ReactNode;
+}) {
+  return (
+    <ToolDisplayModeContext.Provider value={density}>
+      {children}
+    </ToolDisplayModeContext.Provider>
+  );
+}
+
+/** Active tool-card density. Defaults to "detailed" outside a provider
+ *  so cards rendered in isolation (tests, storybook) keep their
+ *  pre-existing expansion behaviour. */
+export function useToolDisplayMode(): ToolDensity {
+  return useContext(ToolDisplayModeContext);
+}
+
+/** Transcript control that flips tool-card density. `aria-pressed`
+ *  carries the on/off state; the label stays constant so the control
+ *  reads the same whether or not it is engaged. */
+export function ToolDensityToggle({
+  density,
+  onToggle,
+}: {
+  density: ToolDensity;
+  onToggle: () => void;
+}) {
+  const compact = density === "compact";
+  return (
+    <button
+      type="button"
+      aria-pressed={compact}
+      onClick={onToggle}
+      title={
+        compact
+          ? "Tool cards collapsed for scanning; click to restore detail"
+          : "Collapse every tool card to its header for scanning"
+      }
+      className={[
+        "ml-auto inline-flex items-center gap-1.5 rounded-md border px-2 py-1",
+        "text-[11px] uppercase tracking-wider transition-colors",
+        compact
+          ? "border-brand-700/50 bg-brand-700/10 text-brand-400"
+          : "border-surface-700 bg-surface-800 text-text-dim hover:bg-surface-700",
+      ].join(" ")}
+    >
+      <ListCollapse className="h-3.5 w-3.5" />
+      Compact tools
+    </button>
+  );
+}

--- a/web/src/lib/cockpitArgs.test.ts
+++ b/web/src/lib/cockpitArgs.test.ts
@@ -5,7 +5,13 @@
 
 import { describe, expect, it } from "vitest";
 
-import { parseJsonObject, pickFirst, pickStr } from "./cockpitArgs";
+import {
+  hasArgsBody,
+  parseJsonObject,
+  pickFirst,
+  pickStr,
+  previewFromArgs,
+} from "./cockpitArgs";
 
 describe("parseJsonObject", () => {
   it("returns the object for valid JSON object input", () => {
@@ -95,5 +101,54 @@ describe("pickFirst", () => {
     expect(pickFirst(null, undefined, "")).toBeNull();
     expect(pickFirst()).toBeNull();
     expect(pickFirst("   ", "\t")).toBeNull();
+  });
+});
+
+describe("previewFromArgs", () => {
+  it("prefers a shell command", () => {
+    expect(previewFromArgs(JSON.stringify({ command: "ls -al" }))).toBe(
+      "ls -al",
+    );
+  });
+
+  it("falls back to a file path for read/edit shapes", () => {
+    expect(previewFromArgs(JSON.stringify({ file_path: "src/a.ts" }))).toBe(
+      "src/a.ts",
+    );
+  });
+
+  it("surfaces query/pattern and url shapes", () => {
+    expect(previewFromArgs(JSON.stringify({ pattern: "TODO" }))).toBe("TODO");
+    expect(previewFromArgs(JSON.stringify({ url: "https://x" }))).toBe(
+      "https://x",
+    );
+  });
+
+  it("falls back to the ACP-forwarded _aoe_title", () => {
+    expect(
+      previewFromArgs(JSON.stringify({ _aoe_title: "Run the suite" })),
+    ).toBe("Run the suite");
+  });
+
+  it("returns null when no usable primary argument is present", () => {
+    expect(previewFromArgs("{}")).toBeNull();
+    expect(previewFromArgs(JSON.stringify({ _aoe_parent: "p" }))).toBeNull();
+    expect(previewFromArgs("not json")).toBeNull();
+  });
+});
+
+describe("hasArgsBody", () => {
+  it("is true for an object with a non-bookkeeping key", () => {
+    expect(hasArgsBody(JSON.stringify({ command: "ls" }))).toBe(true);
+  });
+
+  it("is false for an empty object or _aoe_-only object", () => {
+    expect(hasArgsBody("{}")).toBe(false);
+    expect(hasArgsBody(JSON.stringify({ _aoe_title: "x" }))).toBe(false);
+  });
+
+  it("is true for non-blank non-object payloads, false when blank", () => {
+    expect(hasArgsBody("raw text [truncated]")).toBe(true);
+    expect(hasArgsBody("   ")).toBe(false);
   });
 });

--- a/web/src/lib/cockpitArgs.ts
+++ b/web/src/lib/cockpitArgs.ts
@@ -41,3 +41,31 @@ export function pickFirst(
   }
   return null;
 }
+
+/** Derive a one-line preview from a tool call's `args_preview`, mirroring
+ *  the per-card primary-arg extraction in ToolCards.tsx: command for
+ *  execute, path for read/edit/delete, query/pattern for search, url for
+ *  fetch, then the ACP-forwarded `_aoe_title`. Returns null when the
+ *  payload carries no usable primary argument (e.g. an adapter that ships
+ *  an empty `{}` for bash); callers fall back to the tool name. */
+export function previewFromArgs(argsPreview: string): string | null {
+  const args = parseJsonObject(argsPreview);
+  return pickFirst(
+    pickStr(args, "command", "cmd", "args"),
+    pickStr(args, "path", "file_path", "filePath", "filename"),
+    pickStr(args, "query", "pattern"),
+    pickStr(args, "url"),
+    pickStr(args, "_aoe_title"),
+  );
+}
+
+/** Whether an `args_preview` has body content worth expanding: a
+ *  non-object payload counts when non-blank; an object counts when it
+ *  has at least one non-`_aoe_` key. Mirrors ArgsView's render gate so
+ *  the approval card only shows an expand affordance when there is
+ *  something behind it. */
+export function hasArgsBody(argsPreview: string): boolean {
+  const parsed = parseJsonObject(argsPreview);
+  if (!parsed) return argsPreview.trim().length > 0;
+  return Object.keys(parsed).some((k) => !k.startsWith("_aoe_"));
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1363,6 +1363,17 @@
       ]
     },
     {
+      "id": "cockpit.tool-density",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/ToolDisplayMode.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/ToolDisplayMode.tsx"
+      ]
+    },
+    {
       "id": "cockpit.queued-prompt-expand-bounds",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two related cockpit tool-call card UX problems from #1767, both fixed in `web/` with no backend changes.

**1. Collapsed "Approval needed" card showed only the tool name.** The approval card rendered the full args block unconditionally and had no preview, so when an adapter shipped args the args renderer dropped (e.g. opencode bash with no usable command field), a collapsed card surfaced just "bash" with nothing to act on. The card now mirrors the bash tool-card standard: a one-line command preview in the header (command for a shell call, path for a read/edit) plus a per-card expand toggle. Benign approvals start collapsed with the preview; destructive ones start expanded so the full command is in view before a hold-to-allow. Allow / Always / Deny stay reachable in either state, and nothing re-expands on its own after a plan is approved.

**2. After plan approval, tool cards could not be re-collapsed into a scannable view.** Automatic grouping (the "Actions" fold) needs an unbroken run of three or more tool calls, so the post-plan phase, where the agent narrates between each action (and a plannotator "proceed" message is injected), splits every run and produces a long stream of individual cards with no way back to the compact view. Rather than weaken the tuned grouping heuristics, this adds a transcript-level **Compact tools** toggle that collapses every tool card to its header for scanning. It is a per-browser localStorage preference (default detailed, no daemon config), the agent's narration stays visible, errored cards stay open so a failure is never hidden, new cards arrive collapsed while it is on, and you can still expand any single card.

The grouping logic in `collapseToolRuns` is untouched; both fixes live in the card rendering and a small display-mode context.

Closes #1767

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web cockpit and trigger a benign tool approval (a bash call that needs approval); confirm the collapsed card shows a one-line command preview in the header, not just "bash".
- [ ] Click the approval card header; confirm the full argument list expands and collapses, and that Allow / Always / Deny stay clickable in both states.
- [ ] Trigger a destructive approval; confirm it starts expanded with the full command visible before the hold-to-allow.
- [ ] In a session with a long stream of tool cards, click "Compact tools" at the top of the transcript; confirm every tool card collapses to its header while the agent's narration stays visible.
- [ ] With compact mode on, confirm new tool cards arrive collapsed, an errored card stays open, and the preference survives a reload.
- [ ] Toggle back to detailed; confirm cards return to their normal expansion and any single card can still be expanded while compact.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Skipped a test, because:

Note: this is component-render and pure-helper logic, so per `AGENTS.md` the regression tests are Vitest + RTL rather than Playwright: `ApprovalCard.test.tsx` (collapsed preview, toggle, destructive default, buttons reachable while collapsed), `cockpitArgs.test.ts` (`previewFromArgs` / `hasArgsBody`), and a new `ToolDisplayMode.test.tsx` (pref persistence, compact collapses an open card, density-scoped override, errored cards stay open). `web/tests/coverage-matrix.json` gains a `cockpit.tool-density` entry; `cockpit.approval-card` and `cockpit.args` already map the rest.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` pass on the part-2 design. I reviewed each commit, made the design calls (collapsed-by-default split, density toggle over grouping changes), and own the manual test steps above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR delivers two Cockpit UX improvements (no backend changes):

- Approval-card previews: Collapsed "Approval needed" cards now show a one-line preview (command, path, pattern, or title) in the header and provide a per-card expand/collapse toggle. Benign approvals default collapsed; destructive approvals default expanded. Approval actions remain reachable in either state and cards do not auto-re-expand after plan approval.

- Compact tools density toggle: Adds a transcript-level "Compact tools" toggle (stored in browser localStorage, default "detailed") that collapses tool cards to their headers to make transcripts more scannable while keeping agent narration visible. Errored cards stay open; new cards arrive collapsed when compact mode is on; individual cards can still be expanded.

## What Was Added

- UI: Transcript-level Tool Density toggle and provider to propagate density.
- Helpers: previewFromArgs() and hasArgsBody() to extract one-line previews and detect expandable bodies.
- Tests: Comprehensive Vitest + React Testing Library coverage for approval-card behavior, cockpit args helpers, and tool-display density.
- Docs: Cockpit interface doc updated to describe the approval-card preview and compact tools behavior.
- Coverage matrix: New entry for cockpit tool-density tests.

## What Was Modified

- ApprovalCard: shows truncated preview in header, adds header-toggle, renders args only when expanded (benign collapsed / destructive expanded defaults).
- CockpitView: wires density preference/provider and surfaces the ToolDensity toggle in the chrome.
- ToolCards / collapse behavior: expansion baseline now respects density; user toggles are scoped so density changes re-apply baseline to untouched cards; error cards always open.
- Tests and coverage configuration updated.

## Benefits

- Faster assessment of approvals without expanding every card.
- Restores a compact, scannable transcript when narration or injected messages break grouping.
- Keeps destructive approvals visible by default while letting benign approvals stay unobtrusive.
- Preserves user control (per-card expand/collapse) and persists display preference across sessions.
- Error visibility is preserved.

## Technical details (short)

- New ToolDensity type ("detailed" | "compact"), ToolDisplayModeProvider, useToolDensityPref() hook (persists to localStorage key aoe.cockpit.toolDensity.v1), and ToolDensityToggle component.
- previewFromArgs(argsPreview: string): parses JSON-ish args_preview and returns prioritized preview (command → path/file → pattern/url → _aoe_title) or null.
- hasArgsBody(argsPreview: string): determines whether args_preview contains non-bookkeeping content (top-level keys not starting with _aoe_) or a non-empty non-object payload.
- useToolCardExpansion() now seeds baseline from current density and scopes user overrides to the density at the time of toggle; status === "err" forces open baseline.
- Tests added/expanded: ApprovalCard.test.tsx, ToolDisplayMode.test.tsx, cockpitArgs.test.ts, and updated coverage-matrix.json.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->