### PR TITLE
feat(web): add attention sort mode to the sidebar

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -69,11 +69,17 @@ To replay it at any time, open the overflow menu (the three-dot **More options**
 
 By default the sidebar shows your manually-ordered list. Drag a row with a press-and-hold gesture to move it; the new order persists across browsers and devices via `workspace-ordering.json`.
 
-To reorder whole projects, grab the drag handle on the left of a project/group header and drag it up or down. This sets an explicit group order instead of leaving project placement to be derived from whichever session sits highest. Unlike row ordering, the group order is per-browser (localStorage), not synced across devices. A project that appears after you have set an order slots in at the top. The Multi-repo and Scratch groups default to the bottom but are draggable too, so you can lift them anywhere; once dragged they hold their chosen spot. Group drag is disabled while a filter is active or while Recent activity sort is selected, since the order is computed in those cases.
+To reorder whole projects, grab the drag handle on the left of a project/group header and drag it up or down. This sets an explicit group order instead of leaving project placement to be derived from whichever session sits highest. Unlike row ordering, the group order is per-browser (localStorage), not synced across devices. A project that appears after you have set an order slots in at the top. The Multi-repo and Scratch groups default to the bottom but are draggable too, so you can lift them anywhere; once dragged they hold their chosen spot. Group drag is disabled while a filter is active or while a computed sort mode (Recent activity or Attention) is selected, since the order is derived in those cases.
 
-A sort toggle next to the filter button in the sidebar header switches to **Recent activity** mode, which orders workspaces by the most recent of `last_accessed_at`, `idle_entered_at`, and `created_at` across each workspace's sessions, descending. Drag-to-reorder is disabled while Recent activity is selected, because the order is computed; the press-and-hold gesture does nothing in that mode.
+A sort picker next to the filter button in the sidebar header offers three modes:
 
-The toggle's state is per-browser (localStorage), not synced across devices and not tied to your profile. Toggling back to manual restores the stored manual order and re-enables drag. The Multi-repo group defaults to the bottom; in manual mode you can drag it anywhere and it holds that spot, while in Recent activity mode group drag is disabled and it stays at the bottom.
+- **Manual** (default) keeps your drag-ordered list and leaves drag-to-reorder enabled.
+- **Recent activity** orders workspaces by the most recent of `last_accessed_at`, `idle_entered_at`, and `created_at` across each workspace's sessions, descending.
+- **Attention** floats the sessions that need a human to the top, mirroring the TUI's Attention sort. Within each triage tier it ranks by status (Waiting first, then Error, then Idle, Unknown, Running, Stopped, and transient lifecycle states last), and any session an agent has flagged urgent via the `attention-urgent` hook rises above all non-urgent rows in its tier. Within a status rank, favorited rows come first and ties break by most-recent activity. Unlike the TUI it orders by newest activity rather than longest-aging within a rank; that finer ordering is tracked as a follow-up.
+
+Drag-to-reorder is disabled while Recent activity or Attention is selected, because the order is computed; the press-and-hold gesture does nothing in those modes. The within-group row order also follows the selected mode in the **By group** and **By repo and group** axes.
+
+The picker's state is per-browser (localStorage), not synced across devices and not tied to your profile. Selecting Manual again restores the stored manual order and re-enables drag. The Multi-repo and Scratch groups default to the bottom; in manual mode you can drag them anywhere and they hold that spot, while in the computed modes group drag is disabled and they stay at the bottom (even when a Scratch session is waiting or urgent, so their placement stays predictable across toggles).
 
 ## Sidebar grouping: by repo, by group, or both
 
@@ -91,7 +97,7 @@ The choice is per-browser (localStorage). Collapse state is tracked separately f
 
 The sidebar exposes three triage primitives via the right-click (long-press on touch) context menu on any session row:
 
-- **Pin** floats the workspace to the top of the sidebar in every sort mode (manual and Recent activity). Pin is web-only and intentionally distinct from the TUI's favorite mark, which is a within-tier signal for the Attention sort. The web pin renders as a pushpin glyph next to the row title; the TUI favorite keeps its `*` star marker.
+- **Pin** floats the workspace to the top of the sidebar in every sort mode (Manual, Recent activity, and Attention). Pin is web-only and intentionally distinct from the favorite mark, which is a within-tier signal for the Attention sort on both surfaces. The web pin renders as a pushpin glyph next to the row title; the TUI favorite keeps its `*` star marker.
 - **Archive** kills the session's tmux pane (or shuts down the cockpit worker for ACP-cockpit sessions) and sinks the row into the collapsible "Snoozed & archived" footer of its repo group. Sending a message to the row from the dashboard wakes it back into the live list automatically. Daemon restarts and the cockpit worker reconciler both skip archived sessions, so a row stays parked until you explicitly unarchive it.
 - **Snooze** sinks the row into the same footer for a chosen duration. The menu offers the same eight presets as the TUI snooze dialog: 1h, 2h, 3h, 4h, 5h, 6h, 1d, 1w. The row wakes automatically when the timer expires; sending a message wakes it early.
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -57,6 +57,14 @@ pub struct SessionResponse {
     /// favorited rows and render the `*` marker without re-implementing
     /// the predicate. Cross-feature parity with the TUI's `f`/`F` keybind.
     pub favorited: bool,
+    /// True when the agent has flagged this session as urgent via the
+    /// `attention-urgent` hook (read from `/tmp/aoe-hooks/{id}/attention.json`
+    /// by `Instance::is_urgent()`). The web sidebar's Attention sort floats
+    /// urgent rows above all non-urgent ones within their triage tier,
+    /// matching the TUI's `attention_session_key` urgent-bias. `is_urgent()`
+    /// returns false for archived/snoozed sessions, so a sunk row never
+    /// claws back to the top. See #1640.
+    pub urgent: bool,
     /// RFC3339 timestamp at which the session was web-pinned, or omitted
     /// when not pinned. Distinct from `favorited`: favorite is the TUI
     /// within-tier attention-sort signal, while pin is the hard
@@ -229,6 +237,7 @@ impl SessionResponse {
             is_sandboxed: inst.is_sandboxed(),
             scratch: inst.scratch,
             favorited: inst.is_favorited(),
+            urgent: inst.is_urgent(),
             pinned_at: inst.pinned_at.map(|t| t.to_rfc3339()),
             archived_at: inst.archived_at.map(|t| t.to_rfc3339()),
             // Surface `snoozed_until` only when the snooze is still
@@ -3543,6 +3552,32 @@ mod tests {
     }
 
     #[test]
+    fn from_instance_surfaces_hook_urgent_flag() {
+        // #1640: the web Attention sort needs `Instance::is_urgent()` on the
+        // wire. Write the hook-side attention.json the agent would emit and
+        // confirm it round-trips onto the response, then confirm a session
+        // with no hook file reports urgent: false.
+        let inst = make_test_instance();
+        let dir = crate::hooks::hook_status_dir(&inst.id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("attention.json"),
+            r#"{"urgent":true,"urgent_reason":"needs input"}"#,
+        )
+        .unwrap();
+
+        let urgent_resp = SessionResponse::from_instance(&inst, false);
+        assert!(urgent_resp.urgent, "hook-flagged session must be urgent");
+
+        crate::hooks::cleanup_hook_status_dir(&inst.id);
+        let plain_resp = SessionResponse::from_instance(&inst, false);
+        assert!(
+            !plain_resp.urgent,
+            "session with no hook file must not be urgent"
+        );
+    }
+
+    #[test]
     fn public_create_session_error_forwards_whitelisted_git_errors() {
         let dup: anyhow::Error =
             GitError::WorktreeAlreadyExists(std::path::PathBuf::from("/tmp/repo-worktrees/foo"))
@@ -4964,6 +4999,7 @@ mod workspace_ordering_tests {
             next_wakeup_at: None,
             next_wakeup_reason: None,
             favorited: false,
+            urgent: false,
             pinned_at: None,
             archived_at: None,
             snoozed_until: None,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -245,13 +245,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     reorderRepoGroups,
   } = useRepoGroups(workspaces, workspaceOrdering, sidebarSortMode);
   const { groups: sessionGroups, toggleGroupCollapsed } =
-    useSessionGroups(workspaces);
+    useSessionGroups(workspaces, sidebarSortMode);
   // The nested `repo+group` axis reuses the already-built repo groups for
   // its top level (so repo collapse, appearance, and ordering are shared
   // with the repo axis) and splits each repo by `group_path` underneath.
   // See #1720.
   const { groups: nestedGroups, toggleSubgroupCollapsed } =
-    useNestedSidebarGroups(repoGroups);
+    useNestedSidebarGroups(repoGroups, sidebarSortMode);
 
   // The sidebar render path consumes one honest model (SidebarGroup): the
   // repo axis maps in via an adapter, the user-group axis is already in

--- a/web/src/components/SidebarSortPicker.tsx
+++ b/web/src/components/SidebarSortPicker.tsx
@@ -52,7 +52,8 @@ export function SidebarSortPicker({ sortMode, onSortModeChange }: Props) {
     };
   }, [open]);
 
-  const active = MODES.find((m) => m.mode === sortMode) ?? MODES[0];
+  // MODES is non-empty by construction, so the fallback is always defined.
+  const active = MODES.find((m) => m.mode === sortMode) ?? MODES[0]!;
   const ActiveIcon = active.Icon;
 
   return (

--- a/web/src/components/SidebarSortPicker.tsx
+++ b/web/src/components/SidebarSortPicker.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, Clock, ListOrdered, Siren } from "lucide-react";
+import type { SidebarSortMode } from "../lib/sidebarSort";
+
+// Sidebar sort picker (#1640). Replaces the former two-state Clock /
+// ListOrdered toggle now that there are three modes; a cycle button gets
+// opaque past two states, so this is an explicit labeled dropdown. The
+// trigger shows the active mode's icon and tints brand when any non-manual
+// (computed) mode is active, matching the axis toggle's affordance. Outside
+// click and Escape close it, mirroring OverflowMenu.
+
+interface ModeSpec {
+  mode: SidebarSortMode;
+  label: string;
+  Icon: typeof Clock;
+}
+
+const MODES: readonly ModeSpec[] = [
+  { mode: "manual", label: "Manual", Icon: ListOrdered },
+  { mode: "lastActivity", label: "Last activity", Icon: Clock },
+  { mode: "attention", label: "Attention", Icon: Siren },
+];
+
+const TRIGGER_TOOLTIP: Record<SidebarSortMode, string> = {
+  manual: "Sort: manual, drag enabled",
+  lastActivity: "Sort: last activity, drag disabled",
+  attention: "Sort: attention, drag disabled",
+};
+
+interface Props {
+  sortMode: SidebarSortMode;
+  onSortModeChange: (mode: SidebarSortMode) => void;
+}
+
+export function SidebarSortPicker({ sortMode, onSortModeChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKeydown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKeydown);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKeydown);
+    };
+  }, [open]);
+
+  const active = MODES.find((m) => m.mode === sortMode) ?? MODES[0];
+  const ActiveIcon = active.Icon;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        title={TRIGGER_TOOLTIP[sortMode]}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`Sort sessions, current: ${active.label}`}
+        data-testid="sidebar-sort-toggle"
+        data-sort-mode={sortMode}
+        className={`w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors ${
+          sortMode !== "manual"
+            ? "text-brand-500"
+            : "text-text-dim hover:text-text-secondary"
+        }`}
+      >
+        <ActiveIcon className="h-3.5 w-3.5" />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          data-testid="sidebar-sort-menu"
+          className="absolute right-0 top-full mt-1 min-w-[160px] bg-surface-800 border border-surface-700/50 rounded-md shadow-xl py-1 z-50 animate-fade-in"
+        >
+          {MODES.map(({ mode, label, Icon }) => {
+            const selected = mode === sortMode;
+            return (
+              <button
+                key={mode}
+                role="menuitemradio"
+                aria-checked={selected}
+                data-testid={`sidebar-sort-option-${mode}`}
+                onClick={() => {
+                  setOpen(false);
+                  if (mode !== sortMode) onSortModeChange(mode);
+                }}
+                className={`w-full flex items-center gap-2 px-3 py-1.5 text-sm cursor-pointer hover:bg-surface-700/60 ${
+                  selected
+                    ? "text-brand-500"
+                    : "text-text-secondary hover:text-text-primary"
+                }`}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" />
+                <span className="flex-1 text-left">{label}</span>
+                {selected && <Check className="h-3.5 w-3.5 shrink-0" />}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -14,11 +14,9 @@ import { createPortal } from "react-dom";
 import {
   Archive,
   ArrowLeftRight,
-  Clock,
   GripVertical,
   Hourglass,
   Layers,
-  ListOrdered,
   Moon,
   Pencil,
   Pin,
@@ -109,6 +107,7 @@ export { makeOptimisticSnoozedUntil } from "../lib/sidebarOptimistic";
 import { StatusGlyph } from "./StatusGlyph";
 import { OwnerAvatar } from "./OwnerAvatar";
 import { SessionGroupModal } from "./SessionGroupModal";
+import { SidebarSortPicker } from "./SidebarSortPicker";
 
 const SIDEBAR_WIDTH_KEY = "aoe-sidebar-width";
 const SUNK_EXPANDED_KEY = "aoe-sidebar-sunk-expanded";
@@ -2414,40 +2413,10 @@ export function WorkspaceSidebar({
               <Layers className="h-3.5 w-3.5" />
             </button>
           </Tooltip>
-          <Tooltip
-            text={
-              sortMode === "lastActivity"
-                ? "Sort: last activity, drag disabled"
-                : "Sort: manual, drag enabled"
-            }
-          >
-            <button
-              onClick={() =>
-                onSortModeChange(
-                  sortMode === "manual" ? "lastActivity" : "manual",
-                )
-              }
-              aria-pressed={sortMode === "lastActivity"}
-              aria-label={
-                sortMode === "lastActivity"
-                  ? "Sort by last activity, currently pressed"
-                  : "Sort by manual order"
-              }
-              data-testid="sidebar-sort-toggle"
-              data-sort-mode={sortMode}
-              className={`w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors ${
-                sortMode === "lastActivity"
-                  ? "text-brand-500"
-                  : "text-text-dim hover:text-text-secondary"
-              }`}
-            >
-              {sortMode === "lastActivity" ? (
-                <Clock className="h-3.5 w-3.5" />
-              ) : (
-                <ListOrdered className="h-3.5 w-3.5" />
-              )}
-            </button>
-          </Tooltip>
+          <SidebarSortPicker
+            sortMode={sortMode}
+            onSortModeChange={onSortModeChange}
+          />
           <Tooltip text="Filter">
             <button
               onClick={toggleFilter}

--- a/web/src/hooks/useNestedSidebarGroups.ts
+++ b/web/src/hooks/useNestedSidebarGroups.ts
@@ -5,6 +5,7 @@ import {
   buildNestedSidebarGroups,
   type NestedSidebarGroup,
 } from "../lib/sidebarGroups";
+import type { SidebarSortMode } from "../lib/sidebarSort";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 
 // Distinct from both the repo prefix (`aoe-repo-collapsed-`) and the flat
@@ -25,7 +26,10 @@ function loadCollapsed(key: string): boolean {
   return safeGetItem(`${COLLAPSED_KEY_PREFIX}${key}`) === "1";
 }
 
-export function useNestedSidebarGroups(repoGroups: RepoGroup[]): {
+export function useNestedSidebarGroups(
+  repoGroups: RepoGroup[],
+  sortMode: SidebarSortMode,
+): {
   groups: NestedSidebarGroup[];
   toggleSubgroupCollapsed: (repoId: string, groupPath: string) => void;
 } {
@@ -36,12 +40,13 @@ export function useNestedSidebarGroups(repoGroups: RepoGroup[]): {
     () =>
       buildNestedSidebarGroups(repoGroups, {
         idleDecayWindowMs,
+        sortMode,
         isSubgroupCollapsed: (repoId, groupPath) => {
           const key = subgroupKey(repoId, groupPath);
           return collapsedMap[key] ?? loadCollapsed(key);
         },
       }),
-    [repoGroups, idleDecayWindowMs, collapsedMap],
+    [repoGroups, idleDecayWindowMs, sortMode, collapsedMap],
   );
 
   // The updater stays pure and persistence runs in an effect, for the same

--- a/web/src/hooks/useRepoGroups.test.ts
+++ b/web/src/hooks/useRepoGroups.test.ts
@@ -516,3 +516,58 @@ describe("useRepoGroups manual group order (#1644)", () => {
     );
   });
 });
+
+describe("useRepoGroups sortMode = attention (#1640)", () => {
+  it("orders workspaces inside a group by status attention, ignoring workspaceOrdering", () => {
+    const wRunning = workspace("running", "/repo-a", [
+      session({ id: "s-run", status: "Running" }),
+    ]);
+    const wWaiting = workspace("waiting", "/repo-a", [
+      session({ id: "s-wait", status: "Waiting" }),
+    ]);
+    // Server pins running first; attention floats the Waiting workspace.
+    const { result } = renderHook(() =>
+      useRepoGroups([wRunning, wWaiting], ["running", "waiting"], "attention"),
+    );
+    expect(result.current.groups[0].workspaces.map((w) => w.id)).toEqual([
+      "waiting",
+      "running",
+    ]);
+  });
+
+  it("floats a group holding a Waiting session above one whose best is Running", () => {
+    const wA = workspace("a1", "/repo-a", [
+      session({ id: "s-a", status: "Running" }),
+    ]);
+    const wB = workspace("b1", "/repo-b", [
+      session({ id: "s-b", status: "Waiting" }),
+    ]);
+    const { result } = renderHook(() =>
+      useRepoGroups([wA, wB], ["a1", "b1"], "attention"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-b",
+      "/repo-a",
+    ]);
+  });
+
+  it("keeps synthetic groups pinned at the bottom even with an urgent session", () => {
+    const wReal = workspace("real", "/repo-a", [
+      session({ id: "s-real", status: "Idle" }),
+    ]);
+    const wScratch = workspace(
+      "sc",
+      "/home/u/.agent-of-empires/scratch/aaa",
+      [session({ id: "s-sc", status: "Waiting", urgent: true, scratch: true })],
+    );
+    const { result } = renderHook(() =>
+      useRepoGroups([wScratch, wReal], ["sc", "real"], "attention"),
+    );
+    // Scratch stays bottom for stable cross-toggle placement, matching
+    // lastActivity, even though it holds an urgent Waiting session.
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-a",
+      SCRATCH_GROUP_ID,
+    ]);
+  });
+});

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -12,7 +12,11 @@ import {
   persistRepoGroupOrder,
 } from "../lib/repoGroupOrder";
 import {
+  compareWorkspacesByAttention,
   compareWorkspacesByLastActivityDesc,
+  repoGroupAttentionRank,
+  repoGroupIsFavorited,
+  repoGroupIsUrgent,
   repoGroupLastActivityMs,
   workspaceTriageTier,
   type SidebarSortMode,
@@ -49,8 +53,11 @@ function isScratchWorkspace(ws: Workspace): boolean {
 // When `sortMode === "lastActivity"` (opt-in, per-browser, #1418), the
 // manual rank is bypassed in favour of a recency comparator that keys on
 // max(last_accessed_at, idle_entered_at, created_at) across each
-// workspace's sessions. The multi-repo group stays pinned to the bottom
-// in both modes so its position is predictable across toggles.
+// workspace's sessions. When `sortMode === "attention"` (#1640) it is
+// bypassed in favour of the status-triage comparator (urgent, then
+// Waiting / Error first). The synthetic multi-repo and scratch groups stay
+// pinned to the bottom in every computed mode so their position is
+// predictable across toggles.
 export function useRepoGroups(
   workspaces: Workspace[],
   workspaceOrdering: readonly string[] = [],
@@ -96,10 +103,15 @@ export function useRepoGroups(
         if (ar > br) return 1;
         return a.id.localeCompare(b.id);
       });
-    const sortByActivity = (list: Workspace[]) =>
-      [...list].sort(compareWorkspacesByLastActivityDesc);
-    const sortWorkspaces =
-      sortMode === "lastActivity" ? sortByActivity : sortByRank;
+    const sortWorkspaces = (list: Workspace[]) => {
+      if (sortMode === "attention") {
+        return [...list].sort(compareWorkspacesByAttention);
+      }
+      if (sortMode === "lastActivity") {
+        return [...list].sort(compareWorkspacesByLastActivityDesc);
+      }
+      return sortByRank(list);
+    };
 
     const byRepo = new Map<string, Workspace[]>();
     const multiRepo: Workspace[] = [];
@@ -194,6 +206,33 @@ export function useRepoGroups(
       id === MULTI_REPO_GROUP_ID || id === SCRATCH_GROUP_ID;
 
     repoGroups.sort((a, b) => {
+      if (sortMode === "attention") {
+        // Computed order, like lastActivity: manual group drag does not
+        // apply and synthetic groups stay pinned to the bottom in a stable
+        // order (real repos, then multi-repo, then scratch), kept
+        // consistent with lastActivity rather than letting a scratch group
+        // with one Waiting session leapfrog every real repo. Among real
+        // groups: urgent first, then best attention rank, then favorited,
+        // then most-recent activity, then a deterministic repoPath
+        // tie-break. See #1640.
+        if (a.id === SCRATCH_GROUP_ID) return 1;
+        if (b.id === SCRATCH_GROUP_ID) return -1;
+        if (a.id === MULTI_REPO_GROUP_ID) return 1;
+        if (b.id === MULTI_REPO_GROUP_ID) return -1;
+        const au = repoGroupIsUrgent(a.workspaces);
+        const bu = repoGroupIsUrgent(b.workspaces);
+        if (au !== bu) return au ? -1 : 1;
+        const ar = repoGroupAttentionRank(a.workspaces);
+        const br = repoGroupAttentionRank(b.workspaces);
+        if (ar !== br) return ar - br;
+        const af = repoGroupIsFavorited(a.workspaces);
+        const bf = repoGroupIsFavorited(b.workspaces);
+        if (af !== bf) return af ? -1 : 1;
+        const ak = repoGroupLastActivityMs(a.workspaces);
+        const bk = repoGroupLastActivityMs(b.workspaces);
+        if (ak !== bk) return bk - ak;
+        return a.repoPath.localeCompare(b.repoPath);
+      }
       if (sortMode === "lastActivity") {
         // The order is computed here, so manual group order (and group
         // drag) does not apply; synthetic groups stay pinned to the

--- a/web/src/hooks/useSessionGroups.ts
+++ b/web/src/hooks/useSessionGroups.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Workspace } from "../lib/types";
 import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
 import { buildSessionGroups, type SidebarGroup } from "../lib/sidebarGroups";
+import type { SidebarSortMode } from "../lib/sidebarSort";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 
 // Distinct from the repo axis prefix (`aoe-repo-collapsed-`) so collapse
@@ -13,7 +14,10 @@ function loadCollapsed(id: string): boolean {
   return safeGetItem(`${COLLAPSED_KEY_PREFIX}${id}`) === "1";
 }
 
-export function useSessionGroups(workspaces: Workspace[]): {
+export function useSessionGroups(
+  workspaces: Workspace[],
+  sortMode: SidebarSortMode,
+): {
   groups: SidebarGroup[];
   toggleGroupCollapsed: (groupId: string) => void;
 } {
@@ -24,9 +28,10 @@ export function useSessionGroups(workspaces: Workspace[]): {
     () =>
       buildSessionGroups(workspaces, {
         idleDecayWindowMs,
+        sortMode,
         isCollapsed: (id) => collapsedMap[id] ?? loadCollapsed(id),
       }),
-    [workspaces, idleDecayWindowMs, collapsedMap],
+    [workspaces, idleDecayWindowMs, sortMode, collapsedMap],
   );
 
   // The updater stays pure: it reads the current value but performs no

--- a/web/src/lib/__tests__/sidebarGroups.test.ts
+++ b/web/src/lib/__tests__/sidebarGroups.test.ts
@@ -19,6 +19,7 @@ import {
   UNGROUPED_GROUP_ID,
 } from "../sidebarGroups";
 import { MULTI_REPO_GROUP_ID } from "../../hooks/useRepoGroups";
+import type { SidebarSortMode } from "../sidebarSort";
 import { IDLE_DECAY_WINDOW_MS } from "../session";
 import type { RepoGroup, SessionResponse, Workspace } from "../types";
 
@@ -79,13 +80,39 @@ function workspace(
 const build = (
   workspaces: Workspace[],
   isCollapsed: (id: string) => boolean = () => false,
+  sortMode: SidebarSortMode = "lastActivity",
 ) =>
   buildSessionGroups(workspaces, {
     idleDecayWindowMs: IDLE_DECAY_WINDOW_MS,
+    sortMode,
     isCollapsed,
   });
 
 describe("buildSessionGroups", () => {
+  it("orders within-group rows by attention when sortMode is attention (#1640)", () => {
+    const groups = build(
+      [
+        workspace("w-running", [
+          session({ id: "r", group_path: "feature", status: "Running" }),
+        ]),
+        workspace("w-waiting", [
+          session({ id: "w", group_path: "feature", status: "Waiting" }),
+        ]),
+        workspace("w-idle", [
+          session({ id: "i", group_path: "feature", status: "Idle" }),
+        ]),
+      ],
+      () => false,
+      "attention",
+    );
+    const feature = groups.find((g) => g.id === "feature")!;
+    expect(feature.workspaces.map((v) => v.workspace.id)).toEqual([
+      "w-waiting",
+      "w-idle",
+      "w-running",
+    ]);
+  });
+
   it("buckets workspaces by group_path, named groups alphabetical", () => {
     const groups = build([
       workspace("w1", [session({ id: "s1", group_path: "refactor" })]),
@@ -244,9 +271,11 @@ describe("buildNestedSidebarGroups", () => {
     repoGroups: RepoGroup[],
     isSubgroupCollapsed: (repoId: string, groupPath: string) => boolean = () =>
       false,
+    sortMode: SidebarSortMode = "lastActivity",
   ) =>
     buildNestedSidebarGroups(repoGroups, {
       idleDecayWindowMs: IDLE_DECAY_WINDOW_MS,
+      sortMode,
       isSubgroupCollapsed,
     });
 

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -4,17 +4,25 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { RepoGroup, SessionResponse, Workspace } from "../types";
 import {
   SIDEBAR_SORT_MODE_KEY,
+  compareWorkspacesByAttention,
   compareWorkspacesByLastActivityDesc,
+  compareWorkspacesForComputedSortMode,
   loadSidebarSortMode,
+  repoGroupAttentionRank,
   repoGroupHasLiveWorkspace,
+  repoGroupIsUrgent,
   repoGroupLastActivityMs,
   resolveEffectiveSnoozedUntil,
   saveSidebarSortMode,
+  sessionAttentionRank,
   snoozeTimestampCloseEnough,
   triageMenuShape,
   triageStateOf,
+  workspaceAttentionRank,
+  workspaceIsFavorited,
   workspaceIsPinned,
   workspaceIsSunk,
+  workspaceIsUrgent,
   workspaceLastActivityMs,
   workspaceTriageTier,
 } from "../sidebarSort";
@@ -651,5 +659,229 @@ describe("repoGroupHasLiveWorkspace", () => {
       ]),
     ]);
     expect(repoGroupHasLiveWorkspace(g)).toBe(true);
+  });
+});
+
+describe("sessionAttentionRank (#1640)", () => {
+  it("ranks live statuses in the TUI attention_tier order", () => {
+    const rank = (status: string) =>
+      sessionAttentionRank(session({ status: status as never }));
+    expect(rank("Waiting")).toBe(0);
+    expect(rank("Error")).toBe(1);
+    expect(rank("Idle")).toBe(2);
+    expect(rank("Unknown")).toBe(3);
+    expect(rank("Running")).toBe(4);
+    expect(rank("Stopped")).toBe(5);
+    expect(rank("Starting")).toBe(6);
+    expect(rank("Creating")).toBe(6);
+    expect(rank("Deleting")).toBe(6);
+  });
+
+  it("sinks archived and snoozed sessions to rank 99 regardless of status", () => {
+    expect(
+      sessionAttentionRank(
+        session({ status: "Waiting", archived_at: "2026-01-01T00:00:00Z" }),
+      ),
+    ).toBe(99);
+    expect(
+      sessionAttentionRank(
+        session({ status: "Error", snoozed_until: "2999-01-01T00:00:00Z" }),
+      ),
+    ).toBe(99);
+  });
+});
+
+describe("workspaceAttentionRank (#1640)", () => {
+  it("returns the best (lowest) rank across sessions", () => {
+    const ws = workspace("w", [
+      session({ id: "a", status: "Running" }),
+      session({ id: "b", status: "Waiting" }),
+      session({ id: "c", status: "Idle" }),
+    ]);
+    expect(workspaceAttentionRank(ws)).toBe(0);
+  });
+
+  it("ignores a snoozed Waiting session so it does not falsely lift the workspace", () => {
+    const ws = workspace("w", [
+      session({ id: "live", status: "Running" }),
+      session({
+        id: "snoozed",
+        status: "Waiting",
+        snoozed_until: "2999-01-01T00:00:00Z",
+      }),
+    ]);
+    // Running (4) wins over the sunk snoozed Waiting (99).
+    expect(workspaceAttentionRank(ws)).toBe(4);
+  });
+});
+
+describe("workspaceIsUrgent / workspaceIsFavorited (#1640)", () => {
+  it("is urgent when any session carries the flag", () => {
+    expect(
+      workspaceIsUrgent(
+        workspace("w", [session({ id: "a" }), session({ id: "b", urgent: true })]),
+      ),
+    ).toBe(true);
+    expect(workspaceIsUrgent(workspace("w", [session({ id: "a" })]))).toBe(
+      false,
+    );
+  });
+
+  it("is favorited when any session is favorited", () => {
+    expect(
+      workspaceIsFavorited(
+        workspace("w", [session({ id: "a", favorited: true })]),
+      ),
+    ).toBe(true);
+    expect(workspaceIsFavorited(workspace("w", [session({ id: "a" })]))).toBe(
+      false,
+    );
+  });
+});
+
+describe("compareWorkspacesByAttention (#1640)", () => {
+  // Shared activity timestamp so the status rank, not the within-tier
+  // recency key, drives ordering in the pure-rank cases.
+  const TS = "2025-06-01T00:00:00Z";
+  const wsStatus = (id: string, status: string) =>
+    workspace(id, [session({ id: `${id}-s`, status: status as never, created_at: TS })]);
+
+  function order(list: Workspace[]): string[] {
+    return [...list].sort(compareWorkspacesByAttention).map((w) => w.id);
+  }
+
+  it("floats Waiting and Error above Idle, Running, and Stopped", () => {
+    const list = [
+      wsStatus("stopped", "Stopped"),
+      wsStatus("running", "Running"),
+      wsStatus("idle", "Idle"),
+      wsStatus("error", "Error"),
+      wsStatus("waiting", "Waiting"),
+    ];
+    expect(order(list)).toEqual([
+      "waiting",
+      "error",
+      "idle",
+      "running",
+      "stopped",
+    ]);
+  });
+
+  it("promotes an urgent workspace above all non-urgent regardless of status rank", () => {
+    const urgentRunning = workspace("urgent", [
+      session({ id: "u", status: "Running", urgent: true, created_at: TS }),
+    ]);
+    const plainWaiting = wsStatus("waiting", "Waiting");
+    expect(order([plainWaiting, urgentRunning])).toEqual([
+      "urgent",
+      "waiting",
+    ]);
+  });
+
+  it("breaks ties within a rank by favorite, then newest activity, then id", () => {
+    const favorited = workspace("fav", [
+      session({ id: "f", status: "Idle", favorited: true, created_at: TS }),
+    ]);
+    const plain = wsStatus("plain", "Idle");
+    expect(order([plain, favorited])).toEqual(["fav", "plain"]);
+
+    const newer = workspace("newer", [
+      session({ id: "n", status: "Idle", created_at: "2025-07-01T00:00:00Z" }),
+    ]);
+    const older = workspace("older", [
+      session({ id: "o", status: "Idle", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    expect(order([older, newer])).toEqual(["newer", "older"]);
+  });
+
+  it("keeps pinned at the top tier and sunk at the bottom tier", () => {
+    const pinned = workspace("pinned", [
+      session({ id: "p", status: "Stopped", pinned_at: TS, created_at: TS }),
+    ]);
+    const liveWaiting = wsStatus("waiting", "Waiting");
+    const sunk = workspace("sunk", [
+      session({ id: "s", status: "Waiting", archived_at: TS, created_at: TS }),
+    ]);
+    expect(order([liveWaiting, sunk, pinned])).toEqual([
+      "pinned",
+      "waiting",
+      "sunk",
+    ]);
+  });
+
+  it("is deterministic when both workspaces have no usable timestamp", () => {
+    const a = workspace("a", [
+      session({
+        id: "a-s",
+        status: "Idle",
+        created_at: "bad",
+        idle_entered_at: null,
+        last_accessed_at: null,
+      }),
+    ]);
+    const b = workspace("b", [
+      session({
+        id: "b-s",
+        status: "Idle",
+        created_at: "bad",
+        idle_entered_at: null,
+        last_accessed_at: null,
+      }),
+    ]);
+    // -Infinity vs -Infinity must not poison the comparator into skipping
+    // the id tie-break; "a" sorts before "b".
+    expect(order([b, a])).toEqual(["a", "b"]);
+  });
+});
+
+describe("compareWorkspacesForComputedSortMode (#1640)", () => {
+  it("returns the attention comparator only for attention mode", () => {
+    expect(compareWorkspacesForComputedSortMode("attention")).toBe(
+      compareWorkspacesByAttention,
+    );
+    expect(compareWorkspacesForComputedSortMode("lastActivity")).toBe(
+      compareWorkspacesByLastActivityDesc,
+    );
+    // The group/nested axes have no manual order, so manual falls back to
+    // last-activity there.
+    expect(compareWorkspacesForComputedSortMode("manual")).toBe(
+      compareWorkspacesByLastActivityDesc,
+    );
+  });
+});
+
+describe("repoGroup attention helpers (#1640)", () => {
+  it("repoGroupAttentionRank takes the best rank across the group", () => {
+    const workspaces = [
+      workspace("w1", [session({ id: "a", status: "Running" })]),
+      workspace("w2", [session({ id: "b", status: "Waiting" })]),
+    ];
+    expect(repoGroupAttentionRank(workspaces)).toBe(0);
+  });
+
+  it("repoGroupIsUrgent is true when any workspace is urgent", () => {
+    expect(
+      repoGroupIsUrgent([
+        workspace("w1", [session({ id: "a" })]),
+        workspace("w2", [session({ id: "b", urgent: true })]),
+      ]),
+    ).toBe(true);
+    expect(
+      repoGroupIsUrgent([workspace("w1", [session({ id: "a" })])]),
+    ).toBe(false);
+  });
+});
+
+describe("loadSidebarSortMode accepts attention (#1640)", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("round-trips the attention mode through storage", () => {
+    saveSidebarSortMode("attention");
+    expect(loadSidebarSortMode()).toBe("attention");
+  });
+
+  it("falls back to manual for an unknown stored value", () => {
+    window.localStorage.setItem(SIDEBAR_SORT_MODE_KEY, "bogus");
+    expect(loadSidebarSortMode()).toBe("manual");
   });
 });

--- a/web/src/lib/sidebarGroups.ts
+++ b/web/src/lib/sidebarGroups.ts
@@ -7,7 +7,8 @@ import type {
 } from "./types";
 import { isSessionActive } from "./session";
 import {
-  compareWorkspacesByLastActivityDesc,
+  compareWorkspacesForComputedSortMode,
+  type SidebarSortMode,
   workspaceIsSunk,
 } from "./sidebarSort";
 import { MULTI_REPO_GROUP_ID, SCRATCH_GROUP_ID } from "../hooks/useRepoGroups";
@@ -112,13 +113,17 @@ function groupDisplayName(path: string): string {
 // so a workspace whose sessions span groups is split into one view per
 // group, each carrying only that group's sessions. Sessions with an empty
 // `group_path` collect into the Ungrouped bucket. Within a group, rows
-// sort by the shared last-activity comparator (the group axis has no
-// manual order in v1); named groups sort alphabetically with Ungrouped
-// pinned to the bottom.
+// sort by the selected sort mode (the group axis has no manual order in
+// v1, so `manual` falls back to last-activity); named groups sort
+// alphabetically with Ungrouped pinned to the bottom regardless of mode.
 export function buildSessionGroups(
   workspaces: Workspace[],
   opts: {
     idleDecayWindowMs: number;
+    // Drives the within-group row comparator. `manual` falls back to
+    // last-activity here (this axis has no manual drag order), while
+    // `lastActivity` and `attention` are honored. See #1640.
+    sortMode: SidebarSortMode;
     // `groupPath` is the normalized path ("" for Ungrouped), passed
     // alongside the synthetic id so nested callers can key collapse state
     // on the path and dodge the `UNGROUPED_GROUP_ID` sentinel. Flat callers
@@ -126,6 +131,7 @@ export function buildSessionGroups(
     isCollapsed: (groupId: string, groupPath: string) => boolean;
   },
 ): SidebarGroup[] {
+  const compareWorkspace = compareWorkspacesForComputedSortMode(opts.sortMode);
   const byGroup = new Map<string, SidebarWorkspaceView[]>();
   const order: string[] = [];
 
@@ -160,9 +166,7 @@ export function buildSessionGroups(
   const groups: SidebarGroup[] = [];
   for (const gp of order) {
     const views = byGroup.get(gp)!;
-    views.sort((a, b) =>
-      compareWorkspacesByLastActivityDesc(a.workspace, b.workspace),
-    );
+    views.sort((a, b) => compareWorkspace(a.workspace, b.workspace));
     const id = gp === "" ? UNGROUPED_GROUP_ID : gp;
     const hasActive = views.some((v) => v.workspace.status === "active");
     groups.push({
@@ -219,6 +223,10 @@ export function buildNestedSidebarGroups(
   repoGroups: RepoGroup[],
   opts: {
     idleDecayWindowMs: number;
+    // Forwarded to the per-repo subgroup builder so subgroup rows honor the
+    // selected sort mode. Top-level repo order is inherited from the repo
+    // axis (already sorted by `useRepoGroups`), so it is not re-sorted here.
+    sortMode: SidebarSortMode;
     isSubgroupCollapsed: (repoId: string, groupPath: string) => boolean;
   },
 ): NestedSidebarGroup[] {
@@ -226,6 +234,7 @@ export function buildNestedSidebarGroups(
     const repo = repoGroupToSidebarGroup(repoGroup);
     const subgroups = buildSessionGroups(repoGroup.workspaces, {
       idleDecayWindowMs: opts.idleDecayWindowMs,
+      sortMode: opts.sortMode,
       isCollapsed: (_groupId, groupPath) =>
         opts.isSubgroupCollapsed(repo.id, groupPath),
     });

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -1,11 +1,15 @@
-import type { RepoGroup, Workspace } from "./types";
+import type { RepoGroup, SessionResponse, Workspace } from "./types";
 import { safeGetItem, safeSetItem } from "./safeStorage";
 
-export type SidebarSortMode = "manual" | "lastActivity";
+export type SidebarSortMode = "manual" | "lastActivity" | "attention";
 
 export const SIDEBAR_SORT_MODE_KEY = "aoe-sidebar-sort-mode";
 
-const VALID_MODES: readonly SidebarSortMode[] = ["manual", "lastActivity"];
+const VALID_MODES: readonly SidebarSortMode[] = [
+  "manual",
+  "lastActivity",
+  "attention",
+];
 
 export function loadSidebarSortMode(): SidebarSortMode {
   const raw = safeGetItem(SIDEBAR_SORT_MODE_KEY);
@@ -229,4 +233,152 @@ export function compareWorkspacesByLastActivityDesc(
   if (aMs < bMs) return 1;
   if (aMs > bMs) return -1;
   return a.id.localeCompare(b.id);
+}
+
+/** Sink rank for the Attention sort, mirroring the TUI's tier-99 bucket
+ *  (`attention_tier`, src/session/groups.rs). Archived and snoozed sessions
+ *  get this rank so they never lift their workspace toward the top, even
+ *  when their last live status was Waiting or Error. */
+const ATTENTION_SINK_RANK = 99;
+
+/** Priority rank for a single session under the Attention sort. Lower =
+ *  higher priority = closer to the top. Mirrors the TUI `attention_tier`
+ *  status taxonomy: Waiting needs a human (top), then Error, then the rest
+ *  of the live states, with transient lifecycle states at the bottom.
+ *  Archived / snoozed sessions short-circuit to the sink rank so a snoozed
+ *  Waiting session cannot make its workspace look urgent. The `urgent`
+ *  hook flag is handled separately as a cross-rank promoter in
+ *  `compareWorkspacesByAttention`, matching the TUI's `attention_session_key`
+ *  where urgent is the primary term and status tier is secondary. */
+export function sessionAttentionRank(s: SessionResponse): number {
+  if (s.archived_at != null || s.snoozed_until != null) {
+    return ATTENTION_SINK_RANK;
+  }
+  switch (s.status) {
+    case "Waiting":
+      return 0;
+    case "Error":
+      return 1;
+    case "Idle":
+      return 2;
+    case "Unknown":
+      return 3;
+    case "Running":
+      return 4;
+    case "Stopped":
+      return 5;
+    case "Starting":
+    case "Creating":
+    case "Deleting":
+      return 6;
+    default:
+      // Defensive: an unknown status string from a newer server reads as
+      // "glance warranted", matching the Unknown rank rather than sinking.
+      return 3;
+  }
+}
+
+/** Best (lowest) attention rank across a workspace's sessions. A workspace
+ *  is as urgent as its most-urgent session. */
+export function workspaceAttentionRank(ws: Workspace): number {
+  let best = ATTENTION_SINK_RANK;
+  for (const s of ws.sessions) {
+    const rank = sessionAttentionRank(s);
+    if (rank < best) best = rank;
+  }
+  return best;
+}
+
+/** True when any of the workspace's sessions is a user favorite. */
+export function workspaceIsFavorited(ws: Workspace): boolean {
+  return ws.sessions.some((s) => s.favorited);
+}
+
+/** True when any of the workspace's sessions carries the agent-raised
+ *  `urgent` hook flag. The server clears urgent for archived / snoozed
+ *  sessions (`Instance::is_urgent()`), so a sunk workspace never reports
+ *  urgent and cannot claw back above live rows. See #1640. */
+export function workspaceIsUrgent(ws: Workspace): boolean {
+  return ws.sessions.some((s) => s.urgent === true);
+}
+
+/** Attention-sort comparator. Key chain, all deterministic with an id
+ *  tie-break so equal keys never flake the render order:
+ *    1. triage tier (pinned floats, sunk sinks, same web invariant as
+ *       last-activity sort);
+ *    2. urgent first (cross-rank promoter, mirrors the TUI urgent-bias);
+ *    3. attention rank ascending (Waiting above Error above Idle ...);
+ *    4. favorited first within a rank;
+ *    5. last activity descending (newest-first, matching the existing web
+ *       feel; the TUI's longest-aging-first is deferred until the server
+ *       exposes a status-entry timestamp, see #1640);
+ *    6. id ascending.
+ *  Activity keys use `<` / `>` rather than subtraction because
+ *  `workspaceLastActivityMs` can return `Number.NEGATIVE_INFINITY`, and
+ *  `-Infinity - -Infinity` is `NaN`, which `Array.prototype.sort` treats as
+ *  equal and would silently skip the id tie-break. */
+export function compareWorkspacesByAttention(
+  a: Workspace,
+  b: Workspace,
+): number {
+  const aTier = workspaceTriageTier(a);
+  const bTier = workspaceTriageTier(b);
+  if (aTier !== bTier) return aTier - bTier;
+
+  const aUrgent = workspaceIsUrgent(a);
+  const bUrgent = workspaceIsUrgent(b);
+  if (aUrgent !== bUrgent) return aUrgent ? -1 : 1;
+
+  const aRank = workspaceAttentionRank(a);
+  const bRank = workspaceAttentionRank(b);
+  if (aRank !== bRank) return aRank - bRank;
+
+  const aFav = workspaceIsFavorited(a);
+  const bFav = workspaceIsFavorited(b);
+  if (aFav !== bFav) return aFav ? -1 : 1;
+
+  const aMs = workspaceLastActivityMs(a);
+  const bMs = workspaceLastActivityMs(b);
+  if (aMs < bMs) return 1;
+  if (aMs > bMs) return -1;
+  return a.id.localeCompare(b.id);
+}
+
+/** Comparator for the axes that compute their own row order (the user-group
+ *  and nested subgroup axes), which have no manual drag order. `manual`
+ *  falls back to last-activity there, preserving the pre-#1640 behavior
+ *  where those axes always sorted by last activity; `lastActivity` and
+ *  `attention` are honored when selected. The repo axis does NOT use this
+ *  (it special-cases `manual` with the persisted workspace rank). */
+export function compareWorkspacesForComputedSortMode(
+  mode: SidebarSortMode,
+): (a: Workspace, b: Workspace) => number {
+  if (mode === "attention") return compareWorkspacesByAttention;
+  return compareWorkspacesByLastActivityDesc;
+}
+
+/** Best (lowest) attention rank across a repo group's workspaces, so a
+ *  group holding a Waiting session floats above one whose best session is
+ *  merely Running. */
+export function repoGroupAttentionRank(
+  workspaces: readonly Workspace[],
+): number {
+  let best = ATTENTION_SINK_RANK;
+  for (const ws of workspaces) {
+    const rank = workspaceAttentionRank(ws);
+    if (rank < best) best = rank;
+  }
+  return best;
+}
+
+/** True when any workspace in the group carries the urgent hook flag. */
+export function repoGroupIsUrgent(workspaces: readonly Workspace[]): boolean {
+  return workspaces.some(workspaceIsUrgent);
+}
+
+/** True when any workspace in the group is favorited. */
+export function repoGroupIsFavorited(
+  workspaces: readonly Workspace[],
+): boolean {
+  return workspaces.some(workspaceIsFavorited);
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -41,6 +41,13 @@ export interface SessionResponse {
    *  rows and prepends a `*` marker. Toggled via the TUI `f`/`F` keybind
    *  or `aoe session favorite|unfavorite`. */
   favorited: boolean;
+  /** True when the agent has flagged this session as urgent via the
+   *  `attention-urgent` hook. Mirrors `Instance::is_urgent()` server-side
+   *  (false for archived / snoozed sessions). The sidebar's Attention sort
+   *  floats urgent rows above non-urgent ones within their triage tier.
+   *  Optional so older payloads and test fixtures without the field read as
+   *  not-urgent. See #1640. */
+  urgent?: boolean;
   /** RFC3339 timestamp at which the session was web-pinned, or null /
    *  undefined when not pinned. Distinct from `favorited`: favorite is
    *  the TUI within-tier attention-sort signal; pin is the hard

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -765,7 +765,8 @@
         "tests/sidebar-sort-mode.spec.ts"
       ],
       "components": [
-        "web/src/components/WorkspaceSidebar.tsx"
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/SidebarSortPicker.tsx"
       ]
     },
     {
@@ -776,7 +777,8 @@
         "tests/live/sidebar-sort-mode.spec.ts"
       ],
       "components": [
-        "web/src/components/WorkspaceSidebar.tsx"
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/SidebarSortPicker.tsx"
       ]
     },
     {

--- a/web/tests/live/sidebar-sort-mode.spec.ts
+++ b/web/tests/live/sidebar-sort-mode.spec.ts
@@ -1,17 +1,19 @@
-// Live coverage for the sidebar sort-mode toggle (#1418).
+// Live coverage for the sidebar sort picker (#1418, #1640).
 //
 // Drives a real `aoe serve` subprocess against three seeded sessions
 // whose `created_at` timestamps differ by ~1.2s each. Asserts that
-// flipping the toggle to "lastActivity" reorders the sidebar rows by
-// newest-created first, and that the localStorage-backed preference
-// survives a page reload.
+// selecting "Last activity" reorders the sidebar rows by newest-created
+// first, that selecting "Attention" is reachable and persists, and that
+// the localStorage-backed preference survives a page reload.
 //
-// Pure comparator semantics across `last_accessed_at`, `idle_entered_at`,
-// and `created_at` (including null fallback) are covered by the Vitest
-// suite at web/src/lib/__tests__/sidebarSort.test.ts. The mocked
-// Playwright suite at web/tests/sidebar-sort-mode.spec.ts covers drag
-// disablement and the multi-repo pin. This spec proves the wiring boots
-// against the real server end-to-end.
+// Pure comparator semantics (status ranks, urgent promotion, null
+// fallback) are covered by the Vitest suite at
+// web/src/lib/__tests__/sidebarSort.test.ts, and status-differentiated
+// Attention ordering by the mocked Playwright suite at
+// web/tests/sidebar-sort-mode.spec.ts (live sessions all share a status,
+// so the live spec proves wiring, not the status comparator). The mocked
+// suite also covers drag disablement and the multi-repo pin. This spec
+// proves the wiring boots against the real server end-to-end.
 //
 // Pairs with web/tests/live/workspace-ordering.spec.ts for manual-mode
 // regressions.
@@ -97,9 +99,19 @@ async function readWorkspaceTitles(page: import("@playwright/test").Page) {
 
 const TOGGLE = "[data-testid='sidebar-sort-toggle']";
 
-base.describe("sidebar sort-mode live (#1418)", () => {
+// The control is a dropdown picker: open it, then click the labeled option.
+async function selectSortMode(
+  page: import("@playwright/test").Page,
+  mode: string,
+) {
+  await page.locator(TOGGLE).click();
+  await page.locator(`[data-testid='sidebar-sort-option-${mode}']`).click();
+  await expect(page.locator(TOGGLE)).toHaveAttribute("data-sort-mode", mode);
+}
+
+base.describe("sidebar sort picker live (#1418, #1640)", () => {
   base(
-    "toggle reorders by newest-created and persists across reload",
+    "picker reorders by newest-created, reaches attention, and persists across reload",
     async ({ page }, testInfo) => {
       const serve = await spawnAoeServe({
         authMode: "none",
@@ -140,11 +152,7 @@ base.describe("sidebar sort-mode live (#1418)", () => {
           "oldest-session",
         ]);
 
-        await page.locator(TOGGLE).click();
-        await expect(page.locator(TOGGLE)).toHaveAttribute(
-          "data-sort-mode",
-          "lastActivity",
-        );
+        await selectSortMode(page, "lastActivity");
 
         await expect
           .poll(() => readWorkspaceTitles(page), { timeout: 5000 })
@@ -154,7 +162,7 @@ base.describe("sidebar sort-mode live (#1418)", () => {
             "oldest-session",
           ]);
 
-        // Reload: localStorage carries the toggle state across reloads
+        // Reload: localStorage carries the picker state across reloads
         // even against the live server.
         await page.reload();
         await expect(rows).toHaveCount(3, { timeout: 10_000 });
@@ -170,16 +178,23 @@ base.describe("sidebar sort-mode live (#1418)", () => {
             "oldest-session",
           ]);
 
-        // Toggle back: returns to whatever the server has as manual
+        // Attention is reachable end-to-end and persists. All three live
+        // sessions share a status, so the rendered order is not asserted
+        // here (the mocked suite covers status-differentiated ordering);
+        // this proves the third mode boots against the real server.
+        await selectSortMode(page, "attention");
+        await expect(rows).toHaveCount(3, { timeout: 5000 });
+        const storedAttention = await page.evaluate(() =>
+          window.localStorage.getItem("aoe-sidebar-sort-mode"),
+        );
+        expect(storedAttention).toBe("attention");
+
+        // Back to manual: returns to whatever the server has as manual
         // order. We don't assert a specific order here because the
         // server's workspace-ordering merge produces an order that's
         // valid but depends on observation timing; the contract we
-        // care about is "toggle back exits last-activity mode."
-        await page.locator(TOGGLE).click();
-        await expect(page.locator(TOGGLE)).toHaveAttribute(
-          "data-sort-mode",
-          "manual",
-        );
+        // care about is "selecting manual exits the computed modes."
+        await selectSortMode(page, "manual");
       } finally {
         await serve.stop();
       }

--- a/web/tests/sidebar-sort-mode.spec.ts
+++ b/web/tests/sidebar-sort-mode.spec.ts
@@ -1,14 +1,17 @@
-// Mocked-Playwright coverage for the sidebar sort-mode toggle (#1418).
+// Mocked-Playwright coverage for the sidebar sort picker (#1418, #1640).
 //
-// Drives the WorkspaceSidebar header toggle through its two states
-// (manual, lastActivity) against fully-stubbed /api responses, so the
-// only thing under test is the React + dnd-kit wiring:
+// Drives the WorkspaceSidebar header sort picker against fully-stubbed
+// /api responses, so the only thing under test is the React + dnd-kit
+// wiring:
 //   1. Default is manual; rows honor server-supplied workspace_ordering.
-//   2. Toggling to lastActivity reorders client-side by the issue's
-//      sort key (max of last_accessed_at, idle_entered_at, created_at).
-//   3. localStorage persists across reloads; the toggle starts pressed.
-//   4. Press-and-hold in lastActivity mode does not lift or PUT.
-//   5. Multi-repo group stays pinned at the bottom in lastActivity mode.
+//   2. Selecting "Last activity" reorders client-side by the issue's sort
+//      key (max of last_accessed_at, idle_entered_at, created_at).
+//   3. localStorage persists across reloads; the picker reopens on the
+//      stored mode.
+//   4. Drag affordances are absent in non-manual modes and no PUT fires.
+//   5. Multi-repo group stays pinned at the bottom in last-activity mode.
+//   6. Selecting "Attention" floats Waiting / Error rows above Running /
+//      Idle / Stopped, and an urgent flag promotes its row within the tier.
 //
 // Live persistence semantics (real aoe serve, real last_accessed_at
 // bump) live in the matching tests/live/sidebar-sort-mode.spec.ts.
@@ -22,6 +25,9 @@ interface MockSession {
   project_path: string;
   branch: string | null;
   created_at: string;
+  status?: string;
+  urgent?: boolean;
+  favorited?: boolean;
   last_accessed_at?: string | null;
   idle_entered_at?: string | null;
   workspace_repos?: { name: string; source_path: string; branch: string }[];
@@ -34,7 +40,7 @@ function sessionResponse(s: MockSession) {
     project_path: s.project_path,
     group_path: s.project_path,
     tool: "claude",
-    status: "Idle",
+    status: s.status ?? "Idle",
     yolo_mode: false,
     created_at: s.created_at,
     last_accessed_at: s.last_accessed_at ?? null,
@@ -43,6 +49,8 @@ function sessionResponse(s: MockSession) {
     branch: s.branch,
     main_repo_path: null,
     is_sandboxed: false,
+    favorited: s.favorited ?? false,
+    urgent: s.urgent ?? false,
     has_terminal: true,
     profile: "default",
     workspace_repos: s.workspace_repos ?? [],
@@ -105,7 +113,15 @@ async function readWorkspaceTitles(page: Page): Promise<string[]> {
 
 const TOGGLE = "[data-testid='sidebar-sort-toggle']";
 
-test.describe("Sidebar sort-mode toggle (#1418)", () => {
+// The control is now a dropdown picker, not a cycle button: open it, then
+// click the labeled option for the target mode.
+async function selectSortMode(page: Page, mode: string): Promise<void> {
+  await page.locator(TOGGLE).click();
+  await page.locator(`[data-testid='sidebar-sort-option-${mode}']`).click();
+  await expect(page.locator(TOGGLE)).toHaveAttribute("data-sort-mode", mode);
+}
+
+test.describe("Sidebar sort picker (#1418, #1640)", () => {
   test("default is manual; rows follow server workspace_ordering", async ({
     page,
   }) => {
@@ -140,16 +156,12 @@ test.describe("Sidebar sort-mode toggle (#1418)", () => {
       "data-sort-mode",
       "manual",
     );
-    await expect(page.locator(TOGGLE)).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
     await expect
       .poll(() => readWorkspaceTitles(page), { timeout: 8000 })
       .toEqual(["old-ws", "new-ws"]);
   });
 
-  test("clicking toggle reorders by last-activity desc and persists", async ({
+  test("selecting last-activity reorders desc and persists", async ({
     page,
     context,
   }) => {
@@ -182,15 +194,7 @@ test.describe("Sidebar sort-mode toggle (#1418)", () => {
       .poll(() => readWorkspaceTitles(page), { timeout: 8000 })
       .toEqual(["old-ws", "new-ws"]);
 
-    await page.locator(TOGGLE).click();
-    await expect(page.locator(TOGGLE)).toHaveAttribute(
-      "data-sort-mode",
-      "lastActivity",
-    );
-    await expect(page.locator(TOGGLE)).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    await selectSortMode(page, "lastActivity");
     await expect
       .poll(() => readWorkspaceTitles(page), { timeout: 4000 })
       .toEqual(["new-ws", "old-ws"]);
@@ -201,7 +205,7 @@ test.describe("Sidebar sort-mode toggle (#1418)", () => {
     expect(stored).toBe("lastActivity");
 
     // Reload: mode and order persist on first paint without another
-    // toggle click. Use the same browser context so localStorage carries.
+    // selection. Use the same browser context so localStorage carries.
     await page.reload();
     await expect(page.locator(TOGGLE)).toHaveAttribute(
       "data-sort-mode",
@@ -211,12 +215,8 @@ test.describe("Sidebar sort-mode toggle (#1418)", () => {
       .poll(() => readWorkspaceTitles(page), { timeout: 8000 })
       .toEqual(["new-ws", "old-ws"]);
 
-    // Toggling back restores manual order.
-    await page.locator(TOGGLE).click();
-    await expect(page.locator(TOGGLE)).toHaveAttribute(
-      "data-sort-mode",
-      "manual",
-    );
+    // Selecting manual restores the server order.
+    await selectSortMode(page, "manual");
     await expect
       .poll(() => readWorkspaceTitles(page), { timeout: 4000 })
       .toEqual(["old-ws", "new-ws"]);
@@ -256,11 +256,7 @@ test.describe("Sidebar sort-mode toggle (#1418)", () => {
       page.locator("[aria-roledescription='Press and hold to reorder']"),
     ).toHaveCount(2, { timeout: 8000 });
 
-    await page.locator(TOGGLE).click();
-    await expect(page.locator(TOGGLE)).toHaveAttribute(
-      "data-sort-mode",
-      "lastActivity",
-    );
+    await selectSortMode(page, "lastActivity");
 
     // Drag wrappers gone in last-activity mode.
     await expect(
@@ -280,8 +276,8 @@ test.describe("Sidebar sort-mode toggle (#1418)", () => {
     await page.mouse.move(sourceBox.x + 4, sourceBox.y + 4, { steps: 6 });
     await page.mouse.up();
 
-    // Toggle back to manual: drag affordances return.
-    await page.locator(TOGGLE).click();
+    // Selecting manual: drag affordances return.
+    await selectSortMode(page, "manual");
     await expect(
       page.locator("[aria-roledescription='Press and hold to reorder']"),
     ).toHaveCount(2);
@@ -319,10 +315,7 @@ test.describe("Sidebar sort-mode toggle (#1418)", () => {
     await mockApis(
       page,
       () => sessions,
-      () => [
-        "/tmp/repo::feature/multi",
-        "/tmp/repo::feature/single",
-      ],
+      () => ["/tmp/repo::feature/multi", "/tmp/repo::feature/single"],
     );
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
@@ -332,16 +325,90 @@ test.describe("Sidebar sort-mode toggle (#1418)", () => {
       page.locator("[data-testid='sidebar-session-row']"),
     ).toHaveCount(2, { timeout: 8000 });
 
-    await page.locator(TOGGLE).click();
-    await expect(page.locator(TOGGLE)).toHaveAttribute(
-      "data-sort-mode",
-      "lastActivity",
-    );
+    await selectSortMode(page, "lastActivity");
 
     // Multi-repo group's row stays last even though its workspace has
     // the freshest activity. Single-repo row renders first.
     await expect
       .poll(() => readWorkspaceTitles(page), { timeout: 4000 })
       .toEqual(["single-old", "multi-recent"]);
+  });
+
+  test("attention sort floats waiting and urgent rows to the top (#1640)", async ({
+    page,
+  }) => {
+    // Same repo so all four sessions sit in one group; manual order is
+    // newest-first by created_at. last_accessed_at is identical so the
+    // within-tier tie-break does not interfere with the status ordering.
+    const sessions: MockSession[] = [
+      {
+        id: "s-running",
+        title: "running-ws",
+        project_path: "/tmp/repo",
+        branch: "feature/running",
+        status: "Running",
+        created_at: "2025-01-04T00:00:00Z",
+        last_accessed_at: "2025-06-01T00:00:00Z",
+      },
+      {
+        id: "s-waiting",
+        title: "waiting-ws",
+        project_path: "/tmp/repo",
+        branch: "feature/waiting",
+        status: "Waiting",
+        created_at: "2025-01-03T00:00:00Z",
+        last_accessed_at: "2025-06-01T00:00:00Z",
+      },
+      {
+        id: "s-error",
+        title: "error-ws",
+        project_path: "/tmp/repo",
+        branch: "feature/error",
+        status: "Error",
+        created_at: "2025-01-02T00:00:00Z",
+        last_accessed_at: "2025-06-01T00:00:00Z",
+      },
+      {
+        id: "s-urgent",
+        title: "urgent-ws",
+        project_path: "/tmp/repo",
+        branch: "feature/urgent",
+        // Running status, but agent-flagged urgent: must float above the
+        // plain Waiting row despite a lower status rank.
+        status: "Running",
+        urgent: true,
+        created_at: "2025-01-01T00:00:00Z",
+        last_accessed_at: "2025-06-01T00:00:00Z",
+      },
+    ];
+    await mockApis(
+      page,
+      () => sessions,
+      () => [
+        "/tmp/repo::feature/running",
+        "/tmp/repo::feature/waiting",
+        "/tmp/repo::feature/error",
+        "/tmp/repo::feature/urgent",
+      ],
+    );
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    await expect(
+      page.locator("[data-testid='sidebar-session-row']"),
+    ).toHaveCount(4, { timeout: 8000 });
+
+    await selectSortMode(page, "attention");
+
+    // urgent (cross-rank promoter) first, then Waiting, then Error, then
+    // the plain Running row last.
+    await expect
+      .poll(() => readWorkspaceTitles(page), { timeout: 4000 })
+      .toEqual(["urgent-ws", "waiting-ws", "error-ws", "running-ws"]);
+
+    const stored = await page.evaluate(() =>
+      window.localStorage.getItem("aoe-sidebar-sort-mode"),
+    );
+    expect(stored).toBe("attention");
   });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds an **Attention** sort mode to the web dashboard sidebar, parity with the TUI's `SortOrder::Attention`. The web sidebar previously had only Manual and Recent activity; users running many sessions had no way to float the sessions that need a human (Waiting, Error) to the top without scanning every status dot. This is the unbuilt follow-up of #1418, which ported Last activity to the web and noted the front-ends had diverged because the TUI also had Attention.

Attention orders within each existing triage tier (pinned floats, sunk sinks) by: the agent-raised `urgent` hook flag first, then status rank (Waiting, Error, Idle, Unknown, Running, Stopped, then transient lifecycle states), then favorite, then most-recent activity, with a deterministic id tie-break. Archived and snoozed sessions sink to the bottom rank so a snoozed Waiting session cannot make its workspace look urgent.

True parity needs the agent urgent flag, which was not on the wire, so the server now serializes `Instance::is_urgent()` as a bool on the session API. The sort comparator threads through all three grouping axes (repo, group, nested), where it previously only affected the repo axis. The two-state sort toggle becomes an explicit three-mode picker (Manual, Last activity, Attention), since three modes outgrow a cycle button.

The one deliberate divergence from the TUI: within a status rank the web orders by newest activity, not the TUI's longest-aging-first, because the web has no status-entry timestamp to age against. That finer ordering is the remaining follow-up.

Closes #1640

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard with several sessions in mixed states (at least one Waiting or Error and one Running). Click the sort picker next to the filter button and choose **Attention**; confirm the Waiting/Error rows float above Running/Idle/Stopped.
- [ ] With Attention selected, push a session into Error (or Waiting); confirm it rises toward the top without any manual reorder.
- [ ] Flag a session urgent via the `attention-urgent` hook; confirm it floats above all non-urgent rows in its tier even if its status rank is lower.
- [ ] Switch the grouping axis (layers icon) to **By group** and **By repo and group**; confirm Attention still orders rows inside each group (not just the repo axis).
- [ ] Reload the page; confirm the Attention selection persists and that drag-to-reorder is disabled while Attention or Recent activity is selected.
- [ ] Select **Manual** again; confirm the stored manual order returns and drag re-enables.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (with a multi-model `/debate` consult on the design questions), and implementation were drafted by Claude under my direction. I made the design calls (land the urgent flag now, newest-first within rank, picker over cycle button), reviewed each commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds an "Attention" sort mode to the web dashboard sidebar, bringing feature parity with the TUI's triage view. It enables users to surface sessions needing human attention (e.g., those with errors or waiting status) without manually scanning session status indicators.

## What Changed

### UI & User Experience
- Replaced the previous two-state sort toggle (Manual / Last Activity) with a new three-mode dropdown picker (Manual / Last Activity / Attention)
- Created a new `SidebarSortPicker` component to replace inline toggle controls
- Manual drag-to-reorder is now disabled when Attention or Last Activity modes are selected

### Sorting Logic
- Implemented "Attention" mode that orders sessions by:
  - Triage tier (pinned / live / sunk)
  - Agent-raised urgent flag (high-priority sessions float up)
  - Status rank (Waiting and Error sessions rank higher than others)
  - Favorite status
  - Most recent activity
  - Deterministic ID for tie-breaking
- Archived and snoozed sessions automatically sink to the bottom
- Sort comparators now apply consistently across repo, group, and nested grouping axes (previously only affected the repo axis)

### Server API
- Extended `SessionResponse` to include an `urgent: bool` field derived from hook-side urgency (`attention.json`)
- This exposes the agent-raised urgent flag that was previously unavailable on the web

### Documentation
- Updated sidebar sort mode documentation to describe the three modes and their behaviors
- Clarified when drag-to-reorder is enabled vs. disabled
- Documented that sort preference is stored per-browser in localStorage

## Benefits
- Users can now prioritize sessions by urgency and status without manual intervention
- Web dashboard now has feature parity with the TUI's Attention triage view
- The new three-mode picker provides more explicit control than a toggle
- Consistent sorting across all sidebar grouping levels ensures coherent workspace organization

## Testing
- Added comprehensive unit tests (Vitest) validating attention ranking, urgent promotion, and archived/snoozed sinking
- Added end-to-end tests (Playwright) covering picker UI interaction and localStorage persistence
- Updated test fixtures to support the new `urgent` field

<!-- end of auto-generated comment: release notes by coderabbit.ai -->