### PR TITLE
fix(cockpit): gemini permissioned tools, fix null args and missing tool cards

### DIFF
--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -109,6 +109,13 @@ This is what you reach for after a rate-limit hand-off: switch claude to codex w
   observed on the cockpit side and we'll update the profile.
 - Gemini's `save_memory` tool lands on the generic card today. A dedicated
   card is a follow-up.
+- Gemini permissioned tools (`run_shell_command` / `write_file` / `replace`)
+  now render an approval card with a clean empty-state when the agent ships
+  no raw arguments (rather than a literal `null`), and the tool card always
+  appears in the transcript even when the agent sends a completion without a
+  start frame. Tool completions can still collapse to a bare `completed`
+  label when the agent returns non-text output (shell `AnsiOutput`,
+  structured results); richer completion rendering is a follow-up.
 - Multimodal input (image upload in the composer) is not implemented;
   gemini is the canonical target when it lands.
 - Runtime capability discovery from the ACP `InitializeResponse` isn't

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2780,7 +2780,10 @@ fn map_update_to_events(
         SessionUpdate::AgentThoughtChunk(_) => vec![Event::ThinkingStarted],
         SessionUpdate::ToolCall(tc) => {
             let raw_args = tc.raw_input.clone().unwrap_or(serde_json::Value::Null);
-            let args_preview = preview_args(&raw_args);
+            // Empty (not the literal "null") when the agent ships no
+            // raw_input, so argless tool cards render a clean empty-state.
+            // See #1713.
+            let args_preview = preview_optional_args(tc.raw_input.as_ref());
             let parent_tool_call_id = profile.parent_tool_use_id_from_meta(&tc.meta);
             if let Some(parent) = parent_tool_call_id.as_deref() {
                 // Breadcrumb so AOE_ACP_TRACE=1 sessions can verify the
@@ -3237,6 +3240,34 @@ fn preview_args(raw: &serde_json::Value) -> String {
         out.push(c);
     }
     out
+}
+
+/// Preview for an optional ACP `raw_input`. Treats both a missing field
+/// (`None`) and an explicit JSON `null` as "no args provided", returning
+/// an empty string. The empty string lets the UI render a dedicated
+/// empty-state instead of the literal text "null" that
+/// `preview_args(&Value::Null)` would otherwise produce. Gemini's
+/// permission flow ships argless tool calls this way. See #1713.
+fn preview_optional_args(raw: Option<&serde_json::Value>) -> String {
+    match raw {
+        Some(value) if !value.is_null() => preview_args(value),
+        _ => String::new(),
+    }
+}
+
+/// Close a permission-request tool card with a terminal error row when
+/// the user denies (or no compatible option exists). Pairs the start
+/// frame emitted in `handle_permission_request`; without it a denied tool
+/// hangs on "running" until the turn ends. See #1713.
+async fn emit_permission_denied(event_tx: &mpsc::Sender<Event>, tool_call_id: &str, content: &str) {
+    let _ = event_tx
+        .send(Event::ToolCallCompleted {
+            tool_call_id: tool_call_id.to_string(),
+            is_error: true,
+            content: content.to_string(),
+            completed_at: chrono::Utc::now(),
+        })
+        .await;
 }
 
 /// Concat the textual portion of a tool call's `content` array. Drops
@@ -5243,13 +5274,10 @@ async fn handle_permission_request(
         .title
         .clone()
         .unwrap_or_else(|| "tool call".into());
-    let raw_args = request
-        .tool_call
-        .fields
-        .raw_input
-        .clone()
-        .unwrap_or(serde_json::Value::Null);
-    let args_preview = preview_args(&raw_args);
+    // Empty (not the literal "null") when the permission request ships no
+    // raw_input, which Gemini's confirm-required tools routinely do. The
+    // approval card then renders a clean empty-state. See #1713.
+    let args_preview = preview_optional_args(request.tool_call.fields.raw_input.as_ref());
     let tool_call = ToolCall {
         id: request.tool_call.tool_call_id.0.to_string(),
         name: title,
@@ -5266,6 +5294,18 @@ async fn handle_permission_request(
         memory_recall: None,
         diffs: Vec::new(),
     };
+    // Gemini's confirm-required tools never send a standalone `tool_call`
+    // start frame (only requestPermission, then a completion update), so
+    // without this the approved tool would have no transcript card and
+    // its later completion would render nothing. Emit a start frame from
+    // the ToolCall we just built; the reducer dedupes tool_start by id,
+    // so a later real start frame merges in place rather than doubling
+    // the card. See #1713.
+    let _ = event_tx
+        .send(Event::ToolCallStarted {
+            tool_call: tool_call.clone(),
+        })
+        .await;
     let approval = build_approval(tool_call);
     let nonce = approval.nonce.clone();
 
@@ -5324,6 +5364,13 @@ async fn handle_permission_request(
                         decision,
                     })
                     .await;
+                // A denied tool will not run, so the start frame emitted
+                // above would otherwise hang on "running" until the turn
+                // ends. Close it immediately with a terminal error row.
+                // See #1713.
+                if matches!(decision, ApprovalDecision::Deny) {
+                    emit_permission_denied(&event_tx, &tool_call_id, "permission denied").await;
+                }
                 (
                     RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(option_id)),
                     "selected",
@@ -5333,6 +5380,16 @@ async fn handle_permission_request(
                     target: "cockpit.acp",
                     "agent did not offer a {decision:?}-compatible option; cancelling"
                 );
+                // No compatible option: the agent gets Cancelled, but the
+                // user still acted, so clear the approval card and close
+                // the hanging start frame. See #1713.
+                let _ = event_tx
+                    .send(Event::ApprovalResolved {
+                        nonce: nonce.clone(),
+                        decision: ApprovalDecision::Cancelled,
+                    })
+                    .await;
+                emit_permission_denied(&event_tx, &tool_call_id, "permission cancelled").await;
                 (RequestPermissionOutcome::Cancelled, "cancelled")
             }
         }
@@ -6273,6 +6330,17 @@ mod tests {
         // AllowAlways. Falls back gracefully.
         let id = pick_option_id(&options, ApprovalDecision::Allow).unwrap();
         assert_eq!(id.0.as_ref(), "always");
+    }
+
+    #[test]
+    fn preview_optional_args_empty_for_missing_or_null() {
+        // #1713: a missing or explicitly-null raw_input must preview as
+        // empty (so the UI shows a clean empty-state) rather than the
+        // literal "null" that preview_args(&Value::Null) would produce.
+        assert_eq!(preview_optional_args(None), "");
+        assert_eq!(preview_optional_args(Some(&serde_json::Value::Null)), "");
+        let obj = serde_json::json!({ "command": "ls" });
+        assert_eq!(preview_optional_args(Some(&obj)), r#"{"command":"ls"}"#);
     }
 
     #[test]

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2889,7 +2889,16 @@ fn map_update_to_events(
                 let diffs = extract_diffs_from_content(blocks);
                 (!diffs.is_empty()).then_some(diffs)
             });
-            let new_args_preview = update.fields.raw_input.as_ref().map(preview_args);
+            // Drop an explicit JSON null so a late-arriving update never
+            // patches the card's args with the literal "null"; leaving it
+            // None means the reducer keeps whatever args it already has.
+            // See #1713.
+            let new_args_preview = update
+                .fields
+                .raw_input
+                .as_ref()
+                .filter(|value| !value.is_null())
+                .map(preview_args);
             let new_title = update.fields.title.clone();
             let mut events: Vec<Event> = Vec::new();
             if new_title.is_some()
@@ -5394,6 +5403,16 @@ async fn handle_permission_request(
             }
         }
         Ok(ApprovalResolutionMessage::Cancelled) | Err(_) => {
+            // Cancellation (explicit cancel_permission, or the resolver
+            // dropped on teardown) emits no agent completion, so close the
+            // start frame and clear the approval here too. See #1713.
+            let _ = event_tx
+                .send(Event::ApprovalResolved {
+                    nonce: nonce.clone(),
+                    decision: ApprovalDecision::Cancelled,
+                })
+                .await;
+            emit_permission_denied(&event_tx, &tool_call_id, "permission cancelled").await;
             (RequestPermissionOutcome::Cancelled, "cancelled")
         }
     };

--- a/web/src/components/cockpit/ApprovalCard.tsx
+++ b/web/src/components/cockpit/ApprovalCard.tsx
@@ -258,6 +258,17 @@ export function ApprovalCard({ approval, onResolve }: Props) {
 function ArgsView({ raw }: { raw: string }) {
   const parsed = useMemo(() => parseJsonObject(raw), [raw]);
 
+  // Gemini's confirm-required tools ship no raw_input, so the backend
+  // sends an empty args_preview (rather than the literal "null"). Render
+  // a dedicated empty-state instead of an empty <pre>. See #1713.
+  if (raw.trim() === "") {
+    return (
+      <p className="border-b border-surface-800/60 bg-surface-950 px-3 py-2 font-mono text-[11px] italic text-text-dim">
+        No raw args provided by agent.
+      </p>
+    );
+  }
+
   if (!parsed) {
     return (
       <pre className="border-b border-surface-800/60 bg-surface-950 px-3 py-2 font-mono text-[11px] text-text-muted whitespace-pre-wrap break-all max-h-32 overflow-y-auto">

--- a/web/src/components/cockpit/ApprovalCard.tsx
+++ b/web/src/components/cockpit/ApprovalCard.tsx
@@ -44,6 +44,7 @@ export function ApprovalCard({ approval, onResolve }: Props) {
   const [expanded, setExpanded] = useState(approval.destructive);
   const preview = useMemo(() => previewFromArgs(raw), [raw]);
   const canExpand = useMemo(() => hasArgsBody(raw), [raw]);
+  const showEmptyArgsState = raw.trim() === "";
   const Header = canExpand ? "button" : "div";
 
   useEffect(() => {
@@ -152,7 +153,7 @@ export function ApprovalCard({ approval, onResolve }: Props) {
         )}
       </Header>
 
-      {expanded && <ArgsView raw={raw} />}
+      {(expanded || showEmptyArgsState) && <ArgsView raw={raw} />}
 
       {phase === "rolled-back" && (
         <p className="px-3 pt-2 text-rose-400 text-xs">

--- a/web/src/components/cockpit/__tests__/ApprovalCard.test.tsx
+++ b/web/src/components/cockpit/__tests__/ApprovalCard.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+//
+// #1713: Gemini's confirm-required tools ship no raw_input, so the
+// backend sends an empty args_preview (not the literal "null"). The
+// approval card must render a dedicated empty-state instead of an empty
+// <pre> or the word "null".
+
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { ApprovalCard } from "../ApprovalCard";
+import type { Approval } from "../../../lib/cockpitTypes";
+
+function approvalWith(argsPreview: string): Approval {
+  return {
+    nonce: "n1",
+    tool_call: {
+      id: "t1",
+      name: "Write file",
+      kind: "edit",
+      args_preview: argsPreview,
+      started_at: "2026-01-01T00:00:00Z",
+    },
+    destructive: false,
+    requested_at: "2026-01-01T00:00:00Z",
+    resolved: null,
+  };
+}
+
+describe("ApprovalCard args rendering (#1713)", () => {
+  it("renders an empty-state instead of literal null when no args provided", () => {
+    const { container } = render(
+      <ApprovalCard approval={approvalWith("")} onResolve={vi.fn()} />,
+    );
+    expect(container.textContent).toContain("No raw args provided by agent.");
+  });
+
+  it("still renders provided args as a definition list", () => {
+    const { container } = render(
+      <ApprovalCard
+        approval={approvalWith('{"path":"/tmp/x"}')}
+        onResolve={vi.fn()}
+      />,
+    );
+    expect(container.textContent).toContain("/tmp/x");
+    expect(container.textContent).not.toContain(
+      "No raw args provided by agent.",
+    );
+  });
+});

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -2611,6 +2611,40 @@ describe("applyEvent / start-less tool flows (#1713)", () => {
     expect(rows[0]?.tool?.args_preview).toBe('{"command":"pwd"}');
     expect(rows[0]?.tool?.kind).toBe("execute");
   });
+
+  it("prefers the later started_at when a real start follows a permission start", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ToolCallStarted: {
+          tool_call: toolCall("dup-3", {
+            kind: "other",
+            args_preview: "",
+            started_at: "2026-01-01T00:00:00Z",
+          }),
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ToolCallStarted: {
+          tool_call: toolCall("dup-3", {
+            kind: "execute",
+            args_preview: '{"command":"pwd"}',
+            started_at: "2026-01-01T00:00:05Z",
+          }),
+        },
+      },
+    });
+    const row = state.activity.find(
+      (r) => r.kind === "tool_start" && r.toolCallId === "dup-3",
+    );
+    expect(row?.tool?.started_at).toBe("2026-01-01T00:00:05Z");
+    expect(row?.at).toBe("2026-01-01T00:00:05Z");
+  });
 });
 
 describe("applyEvent / RateLimitAutoResumed (#1722)", () => {

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -2527,6 +2527,9 @@ describe("applyEvent / start-less tool flows (#1713)", () => {
       (r) => r.kind === "tool_complete" && r.toolCallId === "orphan-1",
     );
     expect(done?.text).toBe("done output");
+    // A synthesized card counts as turn output, so the turn-end logic
+    // must not append "Command produced no output."
+    expect(state.turnHasOutput).toBe(true);
   });
 
   it("synthesizes a tool_start row when an update arrives with no start", () => {

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -2489,6 +2489,127 @@ describe("applyEvent / thinking-state honesty (#1213)", () => {
   });
 });
 
+describe("applyEvent / start-less tool flows (#1713)", () => {
+  // Gemini's permission flow ships completions/updates with no preceding
+  // ToolCallStarted frame. The reducer must synthesize a start row so the
+  // card still renders, and a sparse permission start must not clobber a
+  // richer real start frame for the same id.
+
+  function toolCall(id: string, over: Partial<ToolCall> = {}): ToolCall {
+    return {
+      id,
+      name: "Write file",
+      kind: "edit",
+      args_preview: "",
+      started_at: "2026-01-01T00:00:00Z",
+      ...over,
+    };
+  }
+
+  it("synthesizes a tool_start row when a completion arrives with no start", () => {
+    const state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ToolCallCompleted: {
+          tool_call_id: "orphan-1",
+          is_error: false,
+          content: "done output",
+          completed_at: "2026-01-01T00:00:01Z",
+        },
+      },
+    });
+    const start = state.activity.find(
+      (r) => r.kind === "tool_start" && r.toolCallId === "orphan-1",
+    );
+    expect(start).toBeDefined();
+    const done = state.activity.find(
+      (r) => r.kind === "tool_complete" && r.toolCallId === "orphan-1",
+    );
+    expect(done?.text).toBe("done output");
+  });
+
+  it("synthesizes a tool_start row when an update arrives with no start", () => {
+    const state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ToolCallUpdated: {
+          tool_call_id: "orphan-2",
+          title: "run_shell_command",
+          args_preview: '{"command":"ls"}',
+        },
+      },
+    });
+    const start = state.activity.find(
+      (r) => r.kind === "tool_start" && r.toolCallId === "orphan-2",
+    );
+    expect(start).toBeDefined();
+    expect(start?.tool?.name).toBe("run_shell_command");
+    expect(start?.tool?.args_preview).toBe('{"command":"ls"}');
+  });
+
+  it("a sparse permission start does not clobber a richer real start", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ToolCallStarted: {
+          tool_call: toolCall("dup-1", {
+            kind: "execute",
+            args_preview: '{"command":"ls -la"}',
+          }),
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ToolCallStarted: {
+          tool_call: toolCall("dup-1", { kind: "other", args_preview: "" }),
+        },
+      },
+    });
+    const rows = state.activity.filter(
+      (r) => r.kind === "tool_start" && r.toolCallId === "dup-1",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.tool?.args_preview).toBe('{"command":"ls -la"}');
+    expect(rows[0]?.tool?.kind).toBe("execute");
+  });
+
+  it("a later rich start frame fills in a sparse permission start", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ToolCallStarted: {
+          tool_call: toolCall("dup-2", { kind: "other", args_preview: "" }),
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ToolCallStarted: {
+          tool_call: toolCall("dup-2", {
+            kind: "execute",
+            args_preview: '{"command":"pwd"}',
+          }),
+        },
+      },
+    });
+    const rows = state.activity.filter(
+      (r) => r.kind === "tool_start" && r.toolCallId === "dup-2",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.tool?.args_preview).toBe('{"command":"pwd"}');
+    expect(rows[0]?.tool?.kind).toBe("execute");
+  });
+});
+
 describe("applyEvent / RateLimitAutoResumed (#1722)", () => {
   it("clears the rate-limit banner so the composer unlocks", () => {
     let state: CockpitState = applyEvent(emptyCockpitState(), {

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -920,6 +920,9 @@ export function applyEvent(
         next.activity,
         synthToolStartRow(tool_call_id, { started_at: completed_at }),
       );
+      // A synthesized tool call is real turn output; without this the
+      // turn-end logic would append "Command produced no output."
+      next.turnHasOutput = true;
     }
     if (next.inFlightTool && next.inFlightTool.id === tool_call_id) {
       next.inFlightTool = null;
@@ -978,6 +981,7 @@ export function applyEvent(
           started_at: started_at ?? undefined,
         }),
       );
+      next.turnHasOutput = true;
     }
     if (next.inFlightTool && next.inFlightTool.id === tool_call_id) {
       next.inFlightTool = {

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -883,14 +883,16 @@ export function applyEvent(
     if (existing >= 0) {
       const prev = next.activity[existing];
       if (prev) {
+        // Merge rather than replace so a sparse permission start (#1713)
+        // never clobbers richer args/kind from a real start frame.
+        const merged = prev.tool ? mergeToolStart(prev.tool, tc) : tc;
         const copy = next.activity.slice();
-        // Keep diffs from the earlier frame if this duplicate start lacks
-        // them, so a re-delivered tool_start can't blank the edit card.
-        const mergedTool: ToolCall =
-          tc.diffs && tc.diffs.length > 0
-            ? tc
-            : { ...tc, diffs: prev.tool?.diffs };
-        copy[existing] = { ...prev, tool: mergedTool, text: tc.name };
+        copy[existing] = {
+          ...prev,
+          tool: merged,
+          text: merged.name,
+          at: merged.started_at,
+        };
         next.activity = copy;
       }
       return next;
@@ -909,6 +911,16 @@ export function applyEvent(
   if ("ToolCallCompleted" in event) {
     const { tool_call_id, is_error, content, completed_at } =
       event.ToolCallCompleted;
+    // #1713: a completion with no preceding start frame would render no
+    // card (the render layer only attaches results to an existing
+    // tool-call part). Synthesize a minimal start row first so the card
+    // appears.
+    if (!hasToolStart(next.activity, tool_call_id)) {
+      next.activity = pushActivity(
+        next.activity,
+        synthToolStartRow(tool_call_id, { started_at: completed_at }),
+      );
+    }
     if (next.inFlightTool && next.inFlightTool.id === tool_call_id) {
       next.inFlightTool = null;
     }
@@ -954,6 +966,19 @@ export function applyEvent(
     // the card's diffs; null/empty leaves an earlier frame's diffs intact
     // so a text-only update can't blank the edit card. See #1721.
     const incomingDiffs = diffs && diffs.length > 0 ? diffs : null;
+    // #1713: an update with no preceding start frame would be dropped
+    // (the patch loop below only touches an existing tool_start row).
+    // Synthesize one so the update lands and a card renders.
+    if (!hasToolStart(next.activity, tool_call_id)) {
+      next.activity = pushActivity(
+        next.activity,
+        synthToolStartRow(tool_call_id, {
+          name: title ?? undefined,
+          args_preview: args_preview ?? undefined,
+          started_at: started_at ?? undefined,
+        }),
+      );
+    }
     if (next.inFlightTool && next.inFlightTool.id === tool_call_id) {
       next.inFlightTool = {
         ...next.inFlightTool,
@@ -1568,6 +1593,73 @@ export function applyEvent(
   // no state mutation. The activity feed shows the raw text where
   // useful via the catch-all branch in the UI.
   return next;
+}
+
+/** True when `rows` already carries a `tool_start` row for this id. */
+function hasToolStart(rows: ActivityRow[], toolCallId: string): boolean {
+  return rows.some(
+    (r) => r.kind === "tool_start" && r.toolCallId === toolCallId,
+  );
+}
+
+/** Build a minimal `tool_start` row for a tool call we never saw start.
+ *  Some agents (Gemini's permission flow) emit updates/completions with
+ *  no preceding start frame; synthesizing one keeps the card visible.
+ *  See #1713. */
+function synthToolStartRow(
+  toolCallId: string,
+  opts: { name?: string; args_preview?: string; started_at?: string },
+): ActivityRow {
+  const startedAt = opts.started_at ?? new Date().toISOString();
+  const tool: ToolCall = {
+    id: toolCallId,
+    name: opts.name && opts.name.length > 0 ? opts.name : "tool call",
+    kind: "other",
+    args_preview: opts.args_preview ?? "",
+    started_at: startedAt,
+  };
+  return {
+    id: `start-${toolCallId}`,
+    kind: "tool_start",
+    text: tool.name,
+    toolCallId,
+    tool,
+    at: startedAt,
+  };
+}
+
+/** Merge a duplicate `ToolCallStarted` into the existing row's payload
+ *  without clobbering richer data with a sparser frame. A permission
+ *  start (#1713) carries empty args and `kind: "other"`; a later real
+ *  start frame for the same id must win, but a real start that arrives
+ *  first must not be overwritten by the sparse permission start. */
+function mergeToolStart(prev: ToolCall, incoming: ToolCall): ToolCall {
+  const startedAt =
+    !prev.started_at ||
+    (incoming.started_at.length > 0 &&
+      Date.parse(incoming.started_at) > Date.parse(prev.started_at))
+      ? incoming.started_at
+      : prev.started_at;
+
+  return {
+    ...prev,
+    ...incoming,
+    name: incoming.name.length > 0 ? incoming.name : prev.name,
+    kind:
+      incoming.kind && incoming.kind !== "other" ? incoming.kind : prev.kind,
+    args_preview:
+      incoming.args_preview.trim().length > 0
+        ? incoming.args_preview
+        : prev.args_preview,
+    started_at: startedAt,
+    diffs:
+      incoming.diffs && incoming.diffs.length > 0
+        ? incoming.diffs
+        : prev.diffs,
+    parent_tool_call_id:
+      incoming.parent_tool_call_id ?? prev.parent_tool_call_id,
+    memory_recall: incoming.memory_recall ?? prev.memory_recall,
+  };
 }
 
 function pushActivity(rows: ActivityRow[], row: ActivityRow): ActivityRow[] {

--- a/web/tests/live/cockpit-approval.spec.ts
+++ b/web/tests/live/cockpit-approval.spec.ts
@@ -43,12 +43,22 @@ const APPROVAL_SCRIPT = {
   ],
 };
 
-interface ApprovalRequestedEvent {
-  ApprovalRequested?: {
-    approval?: {
-      nonce?: string;
+interface ReplayFrame {
+  seq?: number;
+  event?: {
+    ApprovalRequested?: {
+      approval?: { nonce?: string; tool_call?: { args_preview?: string } };
     };
+    ToolCallStarted?: { tool_call?: { id?: string } };
+    ToolCallCompleted?: { tool_call_id?: string; is_error?: boolean };
   };
+}
+
+async function fetchFrames(baseUrl: string, sessionId: string): Promise<ReplayFrame[]> {
+  const replay = await fetch(
+    `${baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+  ).then((r) => r.json());
+  return Array.isArray(replay) ? replay : (replay.frames ?? []);
 }
 
 base("permission_request flows through to the server", async ({}, testInfo) => {
@@ -88,14 +98,7 @@ base("permission_request flows through to the server", async ({}, testInfo) => {
     await expect
       .poll(
         async () => {
-          const replay = await fetch(
-            `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
-          ).then((r) => r.json());
-          const frames: Array<{ event?: ApprovalRequestedEvent }> = Array.isArray(
-            replay,
-          )
-            ? replay
-            : replay.frames ?? [];
+          const frames = await fetchFrames(serve.baseUrl, sessionId);
           for (const frame of frames) {
             const candidate = frame.event?.ApprovalRequested?.approval?.nonce;
             if (candidate) {
@@ -109,6 +112,25 @@ base("permission_request flows through to the server", async ({}, testInfo) => {
       )
       .toBe(true);
     expect(nonce).toBeDefined();
+
+    // #1713: the permission request ships no raw_input, so the approval
+    // card's args_preview must be empty (the UI renders a clean
+    // empty-state) rather than the literal string "null".
+    const frames = await fetchFrames(serve.baseUrl, sessionId);
+    const approvalFrame = frames.find(
+      (f) => f.event?.ApprovalRequested?.approval?.nonce === nonce,
+    );
+    expect(approvalFrame?.event?.ApprovalRequested?.approval?.tool_call
+      ?.args_preview).toBe("");
+
+    // #1713 (proposal A): the permission handler must emit a
+    // ToolCallStarted for this tool BEFORE the ApprovalRequested, so the
+    // approved tool has a transcript card before it completes.
+    const startFrame = frames.find(
+      (f) => f.event?.ToolCallStarted?.tool_call?.id === "fake-tool-call-1",
+    );
+    expect(startFrame).toBeDefined();
+    expect(startFrame!.seq!).toBeLessThan(approvalFrame!.seq!);
 
     // Resolve via the explicit endpoint (UI click path is covered by a
     // follow-up under #1224 once cockpit UI selectors are stable).
@@ -129,3 +151,83 @@ base("permission_request flows through to the server", async ({}, testInfo) => {
     rmSync(scriptDir, { recursive: true, force: true });
   }
 });
+
+base(
+  "denied permission closes the tool card with an error completion (#1713)",
+  async ({}, testInfo) => {
+    const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-acp-script-"));
+    const scriptPath = join(scriptDir, "script.json");
+    writeFileSync(scriptPath, JSON.stringify(APPROVAL_SCRIPT));
+
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "cockpit-approval-deny" }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId = sessions[0]!.id;
+      await enableCockpitAndWait(serve.baseUrl, sessionId);
+      await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/cockpit/prompt`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "write a file" }),
+      });
+
+      let nonce: string | undefined;
+      await expect
+        .poll(
+          async () => {
+            const frames = await fetchFrames(serve.baseUrl, sessionId);
+            for (const frame of frames) {
+              const candidate = frame.event?.ApprovalRequested?.approval?.nonce;
+              if (candidate) {
+                nonce = candidate;
+                return true;
+              }
+            }
+            return false;
+          },
+          { timeout: 15_000, intervals: [100, 200, 500, 1000] },
+        )
+        .toBe(true);
+      expect(nonce).toBeDefined();
+
+      const resolveRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/approvals/${nonce}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ decision: "Deny" }),
+        },
+      );
+      expect(resolveRes.status).toBeGreaterThanOrEqual(200);
+      expect(resolveRes.status).toBeLessThan(300);
+
+      // The denied tool will never run, so the start frame emitted at
+      // permission time must be closed with a terminal error completion;
+      // otherwise the card hangs on "running" forever.
+      await expect
+        .poll(
+          async () => {
+            const frames = await fetchFrames(serve.baseUrl, sessionId);
+            return frames.some(
+              (f) =>
+                f.event?.ToolCallCompleted?.tool_call_id ===
+                  "fake-tool-call-1" &&
+                f.event?.ToolCallCompleted?.is_error === true,
+            );
+          },
+          { timeout: 15_000, intervals: [100, 200, 500, 1000] },
+        )
+        .toBe(true);
+    } finally {
+      await serve.stop();
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  },
+);

--- a/web/tests/live/sidebar-group-reorder.spec.ts
+++ b/web/tests/live/sidebar-group-reorder.spec.ts
@@ -18,6 +18,8 @@ import type { Page } from "@playwright/test";
 import { spawnAoeServe } from "../helpers/aoeServe";
 import { seedRepos } from "../helpers/sidebar";
 
+const TOGGLE = "[data-testid='sidebar-sort-toggle']";
+
 async function readGroupNames(page: Page): Promise<string[]> {
   return page.evaluate(() => {
     const headers = Array.from(
@@ -32,6 +34,12 @@ async function readGroupNames(page: Page): Promise<string[]> {
       )
       .filter(Boolean);
   });
+}
+
+async function selectSortMode(page: Page, mode: "manual" | "lastActivity") {
+  await page.locator(TOGGLE).click();
+  await page.locator(`[data-testid='sidebar-sort-option-${mode}']`).click();
+  await expect(page.locator(TOGGLE)).toHaveAttribute("data-sort-mode", mode);
 }
 
 base.describe("sidebar group-header reorder (#1644)", () => {
@@ -121,10 +129,7 @@ base.describe("sidebar group-header reorder (#1644)", () => {
 
       // Flip to last-activity sort; the order is computed there, so the
       // grips disappear, matching how within-group row drag is gated.
-      await page.locator("[data-testid='sidebar-sort-toggle']").click();
-      await expect(
-        page.locator("[data-testid='sidebar-sort-toggle']"),
-      ).toHaveAttribute("data-sort-mode", "lastActivity");
+      await selectSortMode(page, "lastActivity");
       await expect(grips).toHaveCount(0);
     } finally {
       await serve.stop();


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Gemini's confirm-required cockpit tools (`run_shell_command` / `write_file` / `replace`) broke the tool-call UX in two ways: approval cards showed a literal `null` for arguments, and after approval the tool card could be missing from the transcript entirely. Root cause: Gemini's permission flow never sends a standalone `tool_call` start frame (only `requestPermission`, then a completion update), and a missing `raw_input` was previewed as the JSON string `"null"`.

This PR scopes to issue proposals A, B, and C:

- **A. Tool-start on permission.** `handle_permission_request` now emits `Event::ToolCallStarted` (from the `ToolCall` it already builds) before `Event::ApprovalRequested`, so a permissioned tool has a transcript card while approval is pending. The reducer dedupes `tool_start` by id, so a later real start frame merges instead of doubling the card.
- **B. No more literal `null`.** A new `preview_optional_args` treats a missing or explicitly-null `raw_input` as empty (applied to the permission handler, the normal `tool_call` path, and the late-arriving `tool_call_update` path). The approval card renders a dedicated `No raw args provided by agent.` empty-state.
- **C. Resilient reducer.** When a `ToolCallUpdated` / `ToolCallCompleted` arrives with no preceding start frame, the reducer synthesizes a minimal `tool_start` row so the card always renders. The duplicate-start merge preserves richer args/kind so a sparse permission start never clobbers a real start frame.

Adjacent hardening from the design debate and review: a denied, cancelled, or torn-down permission request now closes its start frame with a terminal error completion (and clears the approval) so the card never hangs on "running"; synthesized start rows mark the turn as having output.

Out of scope (deferred to follow-ups): preserving structured completion payloads (output collapsing to `completed`), agent-specific yolo / autoEdit mode IDs, and the `unstable_session_model` model-control gap.

Closes #1713

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Add a cockpit session on Gemini (`aoe add . --cockpit --agent gemini`) and prompt it to write a file or run a shell command. When the approval card appears, confirm it shows `No raw args provided by agent.` rather than `null`.
- [ ] Confirm a tool card appears in the transcript while the approval is still pending (before you approve).
- [ ] Deny the approval. Confirm the tool card resolves to an error state ("permission denied") instead of spinning on "running" forever.
- [ ] Approve a tool. Confirm the tool card completes normally.
- [ ] For a Gemini tool that completes without a start frame, confirm a card still renders with its completion state.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Extended `web/tests/live/cockpit-approval.spec.ts` to assert the permission `ToolCallStarted` ordering, the empty `args_preview`, and the deny completion. Added Vitest reducer cases in `web/src/lib/cockpitTypes.test.ts` and a new `web/src/components/cockpit/__tests__/ApprovalCard.test.tsx`, plus a Rust unit test for `preview_optional_args`. The changed dashboard files (`cockpitTypes.ts`, `ApprovalCard.tsx`) are already mapped in `coverage-matrix.json`, so no new matrix entry was required.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (with a multi-model design debate), and implementation drafted by Claude under my direction. I made the scope and design calls, reviewed each commit, and own the manual test steps above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes Gemini permissioned-tool UX bugs and makes the cockpit transcript and approval flows more robust.

What changed (high-level)
- Docs: added a Known Limitations note describing Gemini permissioned-tool behavior (empty-state for missing args, cards appear during approval, and follow-up work on richer non-text completion rendering).
- Approval UI: approval cards now show a clear "No raw args provided by agent." message when raw args are missing or explicit JSON null, instead of rendering the literal "null".
- Permission flow: the server emits a ToolCallStarted event when permission is requested so a tool card appears while approval is pending. Deny/cancel paths emit a terminal ToolCallCompleted error so cards close instead of hanging.
- Reducer/runtime resilience: when ToolCallUpdated or ToolCallCompleted arrive without a prior ToolCallStarted, the reducer synthesizes a minimal start row so completions attach and tool cards render. Duplicate or permission-sparse starts are merged with richer later starts.
- Tests: added Playwright E2E tests, Vitest reducer tests, ApprovalCard unit tests, and a Rust unit test for preview behavior.

Benefits
- Users immediately see a tool card during approval and no longer see confusing "null" args.
- Transcript stays consistent and visible for out-of-order or sparse event streams.
- Denials and cancellations cleanly close tool cards and avoid UI hangs.

Technical details (concise)
- acp_client.rs: new preview_optional_args helper (treats missing/JSON-null raw_input as empty), emits Event::ToolCallStarted before ApprovalRequested, and emits terminal ToolCallCompleted errors on deny/cancel paths.
- web/src/components/cockpit/ApprovalCard.tsx: ArgsView renders an explicit empty-state paragraph for empty args_preview.
- web/src/lib/cockpitTypes.ts: reducer synthesizes minimal tool_start rows for start-less updates/completions, merges duplicate starts while preserving richer fields, and marks synthesized starts as producing visible output.
- Tests: Playwright tests verify frame ordering and deny-path closure; Vitest covers start-less flows; ApprovalCard unit test ensures empty-state rendering; Rust unit test verifies preview semantics.

Possible follow-ups
- Improve structured rendering for non-text or binary completion payloads (follow-up work noted in docs).
- Continue wiring session models and agent-advertised mode IDs (Gemini modes) per the original objectives.

Closes `#1713`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->