### PR TITLE
feat(serve): restart the aoe serve daemon after update

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -965,6 +965,7 @@ Start a web dashboard for remote session access
    `--status` is read-only and incompatible with every flag that would change daemon state (`--stop`, `--daemon`, `--remote`) or the bind config of a fresh daemon (`--no-auth`, `--auth`, `--behind-proxy`, `--read-only`, `--passphrase`, `--port`, `--tunnel-name`, `--no-tailscale`, `--tunnel-url`, `--open`). Clap reports the misuse instead of silently ignoring the extras.
 * `--passphrase <PASSPHRASE>` — Require a passphrase for login (second-factor auth). Can also be set via AOE_SERVE_PASSPHRASE environment variable
 * `--open` — Open the dashboard URL in the default browser once the server is ready. Ignored under --daemon, --remote, SSH (SSH_CONNECTION/SSH_TTY), or when no display server is reachable on Linux/BSD
+* `--restart` — Restart a running `aoe serve` daemon, replaying the host, port, mode, and auth it was launched with (read from `serve.launch`). The passphrase is recalled from `AOE_SERVE_PASSPHRASE` or the running daemon's `serve.passphrase` before the old daemon is stopped, so a passphrase-protected daemon is never left down. Incompatible with the flags that would change the daemon's bind config: that config comes from the persisted launch state
 
 
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -965,7 +965,7 @@ Start a web dashboard for remote session access
    `--status` is read-only and incompatible with every flag that would change daemon state (`--stop`, `--daemon`, `--remote`) or the bind config of a fresh daemon (`--no-auth`, `--auth`, `--behind-proxy`, `--read-only`, `--passphrase`, `--port`, `--tunnel-name`, `--no-tailscale`, `--tunnel-url`, `--open`). Clap reports the misuse instead of silently ignoring the extras.
 * `--passphrase <PASSPHRASE>` — Require a passphrase for login (second-factor auth). Can also be set via AOE_SERVE_PASSPHRASE environment variable
 * `--open` — Open the dashboard URL in the default browser once the server is ready. Ignored under --daemon, --remote, SSH (SSH_CONNECTION/SSH_TTY), or when no display server is reachable on Linux/BSD
-* `--restart` — Restart a running `aoe serve` daemon, replaying the host, port, mode, and auth it was launched with (read from `serve.launch`). The passphrase is recalled from `AOE_SERVE_PASSPHRASE` or the running daemon's `serve.passphrase` before the old daemon is stopped, so a passphrase-protected daemon is never left down. Incompatible with the flags that would change the daemon's bind config: that config comes from the persisted launch state
+* `--restart` — Restart a running `aoe serve` daemon, replaying the host, port, mode, and auth it was launched with (read from `serve.launch`). The passphrase is recalled from `serve.passphrase` or `AOE_SERVE_PASSPHRASE` before the old daemon is stopped, so a passphrase-protected daemon is never left down. Incompatible with the flags that would change the daemon's bind config: that config comes from the persisted launch state
 
 
 

--- a/docs/cockpit/persistence.md
+++ b/docs/cockpit/persistence.md
@@ -31,9 +31,10 @@ files. `aoe cockpit ps` lists running workers.
 
 Practical implications:
 
-- `aoe update` followed by `aoe serve --stop` + `aoe serve` keeps
-  every cockpit agent's in-flight turn alive; a worker left on the old
-  build then respawns on the new binary once its turn finishes (see
+- `aoe update` followed by a daemon restart (`aoe serve --restart`, or
+  the restart prompt `aoe update` now shows) keeps every cockpit agent's
+  in-flight turn alive; a worker left on the old build then respawns on
+  the new binary once its turn finishes (see
   [Build-version upgrade after `aoe update`](#build-version-upgrade-after-aoe-update)).
 - Closing the laptop or restarting the host with `aoe serve` running:
   the daemon dies on suspend, but the runner continues. On wake the
@@ -104,13 +105,22 @@ compares it against its own on every reattach:
 `aoe cockpit ps` tags any such not-yet-respawned worker `(stale)` in its
 `BUILD` column so a mixed-version state is visible rather than silent.
 
-Note that the new binary takes effect only once the daemon itself
-restarts: `aoe update` swaps the binary on disk but does not restart a
-running `aoe serve`, so you must `aoe serve --stop` and start it again
-for the reconciler pass above to run. A worker's build identity pairs the
-package version with a git commit hash, so local rebuilds across commits
-are detected, not just shipped release upgrades. See
-[#1754](https://github.com/agent-of-empires/agent-of-empires/issues/1754).
+The new binary takes effect only once the daemon itself restarts.
+`aoe update` closes this loop: after an in-place (tarball) update it
+detects a running self-managed daemon and offers to restart it
+(prompting by default, automatic with `aoe update -y`) so the reconciler
+pass above runs against the new binary. You can also bounce a running
+daemon at any time with `aoe serve --restart`, which replays the host,
+port, mode, and auth it was launched with; the passphrase is recalled
+from `serve.passphrase` or `AOE_SERVE_PASSPHRASE` before the old daemon
+is stopped, so a passphrase-protected daemon is never left down. A daemon
+run in the foreground or under a service supervisor (systemd, launchd) is
+left to its manager: restart only touches daemons started by
+`aoe serve --daemon`. A worker's build identity pairs the package version
+with a git commit hash, so local rebuilds across commits are detected,
+not just shipped release upgrades. See
+[#1754](https://github.com/agent-of-empires/agent-of-empires/issues/1754)
+and [#1794](https://github.com/agent-of-empires/agent-of-empires/issues/1794).
 
 ## Session deletion
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -142,9 +142,9 @@ pub struct ServeArgs {
 
     /// Restart a running `aoe serve` daemon, replaying the host, port,
     /// mode, and auth it was launched with (read from `serve.launch`).
-    /// The passphrase is recalled from `AOE_SERVE_PASSPHRASE` or the
-    /// running daemon's `serve.passphrase` before the old daemon is
-    /// stopped, so a passphrase-protected daemon is never left down.
+    /// The passphrase is recalled from `serve.passphrase` or
+    /// `AOE_SERVE_PASSPHRASE` before the old daemon is stopped, so a
+    /// passphrase-protected daemon is never left down.
     /// Incompatible with the flags that would change the daemon's bind
     /// config: that config comes from the persisted launch state.
     #[arg(
@@ -365,23 +365,25 @@ fn read_serve_launch() -> Result<ServeLaunch> {
     serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
 }
 
-/// Recall the daemon passphrase for a restart: the env override first,
-/// then the plaintext `serve.passphrase` file the server writes while
-/// running. Returns None when neither yields a non-empty value.
+/// Recall the daemon passphrase for a restart: the plaintext
+/// `serve.passphrase` file the server writes while running first,
+/// then the `AOE_SERVE_PASSPHRASE` env override. Returns None when
+/// neither yields a non-empty value.
 fn recall_serve_passphrase() -> Option<String> {
+    if let Ok(dir) = crate::session::get_app_dir() {
+        if let Ok(raw) = std::fs::read_to_string(dir.join("serve.passphrase")) {
+            let trimmed = raw.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
     if let Ok(p) = std::env::var("AOE_SERVE_PASSPHRASE") {
         if !p.is_empty() {
             return Some(p);
         }
     }
-    let dir = crate::session::get_app_dir().ok()?;
-    let raw = std::fs::read_to_string(dir.join("serve.passphrase")).ok()?;
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
+    None
 }
 
 /// One URL we can show in the Active state. Tunnel mode has exactly one.
@@ -541,9 +543,10 @@ pub fn daemon_pid() -> Option<u32> {
             // Stale PID file; the ESRCH case is handled the same as any
             // other error — the process is not reachable.
             let _ = std::fs::remove_file(&path);
-            // Drop the launch state too so `serve_launch_exists()` does
-            // not keep reporting a self-managed daemon that has died.
             if let Ok(dir) = crate::session::get_app_dir() {
+                let _ = std::fs::remove_file(dir.join("serve.url"));
+                let _ = std::fs::remove_file(dir.join("serve.mode"));
+                let _ = std::fs::remove_file(dir.join("serve.passphrase"));
                 let _ = std::fs::remove_file(dir.join("serve.launch"));
             }
             None

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1,6 +1,6 @@
 //! `aoe serve` command -- start a web dashboard for remote session access
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::{Args, ValueEnum};
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -12,8 +12,9 @@ use std::sync::Mutex;
 /// login wall as the sole human gate (useful behind a reverse proxy
 /// where pasting a token URL on mobile is too high friction).
 /// `None` disables both, equivalent to legacy `--no-auth`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, serde::Serialize, serde::Deserialize)]
 #[value(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum AuthMode {
     Token,
     Passphrase,
@@ -112,7 +113,7 @@ pub struct ServeArgs {
     #[arg(
         long,
         conflicts_with_all = [
-            "stop", "daemon", "remote",
+            "stop", "daemon", "remote", "restart",
             "no_auth", "auth", "behind_proxy",
             "read_only", "passphrase", "port",
             "tunnel_name", "no_tailscale", "tunnel_url", "open",
@@ -138,6 +139,24 @@ pub struct ServeArgs {
     /// stdout/stderr are detached). Hidden from `--help`.
     #[arg(long, hide = true)]
     pub daemon_child: bool,
+
+    /// Restart a running `aoe serve` daemon, replaying the host, port,
+    /// mode, and auth it was launched with (read from `serve.launch`).
+    /// The passphrase is recalled from `AOE_SERVE_PASSPHRASE` or the
+    /// running daemon's `serve.passphrase` before the old daemon is
+    /// stopped, so a passphrase-protected daemon is never left down.
+    /// Incompatible with the flags that would change the daemon's bind
+    /// config: that config comes from the persisted launch state.
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "stop", "daemon", "remote",
+            "no_auth", "auth", "behind_proxy",
+            "read_only", "passphrase", "port", "host",
+            "tunnel_name", "no_tailscale", "tunnel_url", "open",
+        ],
+    )]
+    pub restart: bool,
 }
 
 impl ServeArgs {
@@ -247,6 +266,122 @@ fn cloudflared_required(
 pub fn pid_file_path() -> Result<PathBuf> {
     let dir = crate::session::get_app_dir()?;
     Ok(dir.join("serve.pid"))
+}
+
+/// Persisted launch state for a running `aoe serve --daemon`. Written
+/// only by `start_daemon`, so its presence is the signal that the daemon
+/// is self-managed (started by `aoe serve --daemon`) rather than run in
+/// the foreground or under a service supervisor; that is what lets
+/// `aoe update` decide whether it may restart the daemon. `aoe serve
+/// --restart` and the post-update restart replay it. It is removed on
+/// stop, on the daemon's own graceful exit, and in `daemon_pid`'s
+/// stale-PID sweep, so nothing relies on a stale copy. The passphrase is
+/// never stored here; it is recalled from `serve.passphrase` /
+/// `AOE_SERVE_PASSPHRASE` at restart time.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ServeLaunch {
+    pub schema: u32,
+    pub pid: u32,
+    pub profile: String,
+    pub host: String,
+    pub port: u16,
+    pub auth_mode: AuthMode,
+    pub behind_proxy: bool,
+    pub read_only: bool,
+    pub remote: bool,
+    pub tunnel_name: Option<String>,
+    pub tunnel_url: Option<String>,
+    pub no_tailscale: bool,
+}
+
+const SERVE_LAUNCH_SCHEMA: u32 = 1;
+
+impl ServeLaunch {
+    /// Rebuild the `ServeArgs` needed to relaunch this daemon. The
+    /// effective auth mode is replayed via `--auth`; clap's `--no-auth`
+    /// alias is not needed since `--auth=none` covers it. The passphrase
+    /// is injected by the caller after recall.
+    fn to_serve_args(&self, passphrase: Option<String>) -> ServeArgs {
+        ServeArgs {
+            port: Some(self.port),
+            host: self.host.clone(),
+            auth: Some(self.auth_mode),
+            no_auth: false,
+            behind_proxy: self.behind_proxy,
+            read_only: self.read_only,
+            remote: self.remote,
+            tunnel_name: self.tunnel_name.clone(),
+            no_tailscale: self.no_tailscale,
+            tunnel_url: self.tunnel_url.clone(),
+            daemon: true,
+            stop: false,
+            status: false,
+            passphrase,
+            open: false,
+            daemon_child: false,
+            restart: false,
+        }
+    }
+}
+
+/// True when relaunching this config requires a passphrase that must be
+/// recovered before the running daemon is stopped: remote mode mandates
+/// one, and `--auth=passphrase` is meaningless without it.
+fn launch_needs_passphrase(launch: &ServeLaunch) -> bool {
+    launch.remote || matches!(launch.auth_mode, AuthMode::Passphrase)
+}
+
+fn serve_launch_path() -> Result<PathBuf> {
+    let dir = crate::session::get_app_dir()?;
+    Ok(dir.join("serve.launch"))
+}
+
+/// True when a `serve.launch` file exists, i.e. a daemon started by
+/// `aoe serve --daemon` recorded its launch state. `aoe update` uses this
+/// to decide whether a running daemon is one it may restart.
+pub fn serve_launch_exists() -> bool {
+    serve_launch_path().map(|p| p.exists()).unwrap_or(false)
+}
+
+/// Write `serve.launch` with owner-only (0600) permissions: it records
+/// the daemon's bind host/port, tunnel URL, auth posture, and profile,
+/// which should not be world-readable on a shared machine.
+fn write_serve_launch(state: &ServeLaunch) -> Result<()> {
+    let path = serve_launch_path()?;
+    let json = serde_json::to_string_pretty(state)?;
+    std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+fn read_serve_launch() -> Result<ServeLaunch> {
+    let path = serve_launch_path()?;
+    let raw =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+/// Recall the daemon passphrase for a restart: the env override first,
+/// then the plaintext `serve.passphrase` file the server writes while
+/// running. Returns None when neither yields a non-empty value.
+fn recall_serve_passphrase() -> Option<String> {
+    if let Ok(p) = std::env::var("AOE_SERVE_PASSPHRASE") {
+        if !p.is_empty() {
+            return Some(p);
+        }
+    }
+    let dir = crate::session::get_app_dir().ok()?;
+    let raw = std::fs::read_to_string(dir.join("serve.passphrase")).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 /// One URL we can show in the Active state. Tunnel mode has exactly one.
@@ -397,6 +532,7 @@ pub fn daemon_pid() -> Option<u32> {
                     let _ = std::fs::remove_file(dir.join("serve.url"));
                     let _ = std::fs::remove_file(dir.join("serve.mode"));
                     let _ = std::fs::remove_file(dir.join("serve.passphrase"));
+                    let _ = std::fs::remove_file(dir.join("serve.launch"));
                 }
                 None
             }
@@ -418,6 +554,10 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
 
     if args.status {
         return print_status().await;
+    }
+
+    if args.restart {
+        return restart_daemon().await;
     }
 
     // Refuse to start a second instance (daemon or foreground) while another
@@ -598,6 +738,7 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
                 let _ = tokio::fs::remove_file(dir.join("serve.url")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.mode")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.passphrase")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.launch")).await;
             }
         }
     }
@@ -727,9 +868,101 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
         tracing::debug!(target: "serve.lifecycle", path = %path.display(), pid, "wrote pid file");
     }
 
+    // Persist the launch state so `aoe serve --restart` and the
+    // post-update restart can replay this daemon's exact config. Mirrors
+    // the argv reconstruction above; the passphrase is deliberately left
+    // out (recalled from serve.passphrase / the env on restart).
+    let launch = ServeLaunch {
+        schema: SERVE_LAUNCH_SCHEMA,
+        pid,
+        profile: profile.to_string(),
+        host: args.host.clone(),
+        port: args.resolved_port(),
+        auth_mode: resolve_auth_mode(args.auth, args.no_auth),
+        behind_proxy: args.behind_proxy,
+        read_only: args.read_only,
+        remote: args.remote,
+        tunnel_name: args.tunnel_name.clone(),
+        tunnel_url: args.tunnel_url.clone(),
+        no_tailscale: args.no_tailscale,
+    };
+    if let Err(e) = write_serve_launch(&launch) {
+        tracing::warn!(target: "serve.lifecycle", error = %e, "failed to write serve.launch");
+    }
+
     println!("aoe serve started as daemon (PID {})", pid);
     println!("Stop with: aoe serve --stop");
     Ok(())
+}
+
+/// Restart the running `aoe serve` daemon from its persisted launch state
+/// (`serve.launch`). Everything needed to relaunch is read into memory
+/// before the old daemon is stopped, because `stop_daemon` deletes
+/// `serve.passphrase`; a daemon that needs a passphrase is never killed
+/// without the means to bring it back. The replacement is spawned via
+/// `start_daemon`, which uses the current executable. That is correct
+/// both for a hand-run `aoe serve --restart` and for the post-update
+/// path, where `aoe update` re-execs the freshly installed binary as
+/// `aoe serve --restart` so the new code spawns the new daemon.
+#[tracing::instrument(target = "serve.lifecycle", skip_all)]
+pub async fn restart_daemon() -> Result<()> {
+    let Some(pid) = daemon_pid() else {
+        bail!(
+            "No running aoe serve daemon to restart.\n\
+             Start one with: aoe serve --daemon"
+        );
+    };
+
+    let launch = read_serve_launch().map_err(|e| {
+        anyhow::anyhow!(
+            "Cannot restart: no usable launch state ({e}).\n\
+             This daemon was not started by `aoe serve --daemon`; foreground\n\
+             or service-supervised daemons must be restarted by their manager."
+        )
+    })?;
+
+    if launch.pid != pid {
+        bail!(
+            "serve.launch records PID {} but the running daemon is PID {}; \
+             refusing to restart stale state.",
+            launch.pid,
+            pid
+        );
+    }
+
+    // Recall the passphrase BEFORE stopping: stop_daemon() deletes
+    // serve.passphrase, so reading it afterwards would always fail.
+    let passphrase = recall_serve_passphrase();
+    if launch_needs_passphrase(&launch) && passphrase.is_none() {
+        bail!(
+            "Cannot restart: this daemon uses {} auth but no passphrase is \
+             recoverable (set AOE_SERVE_PASSPHRASE).\n\
+             Leaving the running daemon untouched.",
+            if launch.remote {
+                "remote"
+            } else {
+                "passphrase"
+            }
+        );
+    }
+
+    // Re-validate the persisted config before tearing anything down, so a
+    // config that can no longer start (e.g. policy changed) fails loudly
+    // instead of leaving the user with no daemon.
+    validate_auth_combination(
+        launch.auth_mode,
+        passphrase.is_some(),
+        host_is_localhost(&launch.host),
+        launch.behind_proxy,
+        launch.remote,
+        &launch.host,
+    )?;
+
+    let args = launch.to_serve_args(passphrase);
+
+    println!("Restarting aoe serve daemon (PID {pid})…");
+    stop_daemon().await?;
+    start_daemon(&launch.profile, &args)
 }
 
 #[tracing::instrument(target = "serve.shutdown", skip_all)]
@@ -794,6 +1027,7 @@ async fn stop_daemon() -> Result<()> {
                 let _ = tokio::fs::remove_file(dir.join("serve.url")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.mode")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.passphrase")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.launch")).await;
             }
             println!("Stopped aoe serve daemon (PID {})", pid);
         }
@@ -804,6 +1038,7 @@ async fn stop_daemon() -> Result<()> {
                 let _ = tokio::fs::remove_file(dir.join("serve.url")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.mode")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.passphrase")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.launch")).await;
             }
             println!("Daemon was not running (stale PID file cleaned up)");
         }
@@ -1062,5 +1297,93 @@ mod tests {
                 .expect("non-skipped variant has a PossibleValue");
             assert_eq!(pv.get_name(), cli_str);
         }
+    }
+
+    #[test]
+    fn auth_mode_serde_matches_cli_str() {
+        // serve.launch persists the auth mode as JSON; the serde
+        // representation must match clap's `--auth=<mode>` spelling so a
+        // restart replays the same flag. Guards the serde `rename_all`
+        // against drift from `as_cli_str()`.
+        for variant in <AuthMode as ValueEnum>::value_variants() {
+            let json = serde_json::to_string(variant).expect("serialize AuthMode");
+            assert_eq!(json, format!("\"{}\"", variant.as_cli_str()));
+            let back: AuthMode = serde_json::from_str(&json).expect("deserialize AuthMode");
+            assert_eq!(back, *variant);
+        }
+    }
+
+    fn sample_launch() -> ServeLaunch {
+        ServeLaunch {
+            schema: SERVE_LAUNCH_SCHEMA,
+            pid: 4242,
+            profile: "work".to_string(),
+            host: "0.0.0.0".to_string(),
+            port: 9090,
+            auth_mode: AuthMode::Passphrase,
+            behind_proxy: true,
+            read_only: true,
+            remote: false,
+            tunnel_name: Some("named".to_string()),
+            tunnel_url: Some("aoe.example.com".to_string()),
+            no_tailscale: true,
+        }
+    }
+
+    #[test]
+    fn serve_launch_json_round_trips() {
+        let launch = sample_launch();
+        let json = serde_json::to_string(&launch).expect("serialize");
+        let back: ServeLaunch = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.pid, launch.pid);
+        assert_eq!(back.profile, launch.profile);
+        assert_eq!(back.host, launch.host);
+        assert_eq!(back.port, launch.port);
+        assert_eq!(back.auth_mode, launch.auth_mode);
+        assert_eq!(back.behind_proxy, launch.behind_proxy);
+        assert_eq!(back.read_only, launch.read_only);
+        assert_eq!(back.remote, launch.remote);
+        assert_eq!(back.tunnel_name, launch.tunnel_name);
+        assert_eq!(back.tunnel_url, launch.tunnel_url);
+        assert_eq!(back.no_tailscale, launch.no_tailscale);
+    }
+
+    #[test]
+    fn to_serve_args_replays_launch_config() {
+        let launch = sample_launch();
+        let args = launch.to_serve_args(Some("hunter2".to_string()));
+        // Bind config is replayed; auth goes through --auth, never the
+        // --no-auth alias; daemon mode is forced; the child markers and
+        // restart flag are cleared so re-entry does not loop.
+        assert_eq!(args.port, Some(9090));
+        assert_eq!(args.host, "0.0.0.0");
+        assert_eq!(args.auth, Some(AuthMode::Passphrase));
+        assert!(!args.no_auth);
+        assert!(args.behind_proxy);
+        assert!(args.read_only);
+        assert_eq!(args.tunnel_name.as_deref(), Some("named"));
+        assert_eq!(args.tunnel_url.as_deref(), Some("aoe.example.com"));
+        assert!(args.no_tailscale);
+        assert!(args.daemon);
+        assert!(!args.daemon_child);
+        assert!(!args.restart);
+        assert!(!args.stop);
+        assert_eq!(args.passphrase.as_deref(), Some("hunter2"));
+    }
+
+    #[test]
+    fn launch_needs_passphrase_for_remote_and_passphrase_auth() {
+        let mut launch = sample_launch();
+        launch.auth_mode = AuthMode::Passphrase;
+        launch.remote = false;
+        assert!(launch_needs_passphrase(&launch));
+
+        launch.auth_mode = AuthMode::Token;
+        launch.remote = true;
+        assert!(launch_needs_passphrase(&launch));
+
+        launch.auth_mode = AuthMode::Token;
+        launch.remote = false;
+        assert!(!launch_needs_passphrase(&launch));
     }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -541,6 +541,11 @@ pub fn daemon_pid() -> Option<u32> {
             // Stale PID file; the ESRCH case is handled the same as any
             // other error — the process is not reachable.
             let _ = std::fs::remove_file(&path);
+            // Drop the launch state too so `serve_launch_exists()` does
+            // not keep reporting a self-managed daemon that has died.
+            if let Ok(dir) = crate::session::get_app_dir() {
+                let _ = std::fs::remove_file(dir.join("serve.launch"));
+            }
             None
         }
     }

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -3,6 +3,8 @@
 use anyhow::{bail, Context, Result};
 use clap::Args;
 use std::io::{self, IsTerminal, Write};
+#[cfg(feature = "serve")]
+use std::path::Path;
 
 use crate::update::check_for_update;
 use crate::update::install::{
@@ -102,18 +104,132 @@ pub async fn run(args: UpdateArgs) -> Result<()> {
         }
     };
     perform_update(&method, &info.latest_version, Some(&mut on_progress)).await?;
-    if matches!(&method, InstallMethod::Tarball { .. }) {
+    if let InstallMethod::Tarball { binary_path } = &method {
         eprintln!();
         println!(
             "✓ Updated to v{}. Restart `aoe` to use the new version.",
             info.latest_version
         );
-        println!("{}", daemon_restart_hint());
+        #[cfg(feature = "serve")]
+        handle_daemon_restart_after_update(binary_path, args.yes)?;
+        #[cfg(not(feature = "serve"))]
+        {
+            let _ = binary_path;
+            println!("{}", daemon_restart_hint());
+        }
         println!("{}", completion_refresh_hint());
     } else if matches!(&method, InstallMethod::Homebrew) {
         println!("✓ brew upgrade complete.");
+        // Homebrew swaps a Cellar/bin binary whose path we cannot reliably
+        // resolve from this process, so we never auto-restart; point the
+        // user at the manual step when a daemon is up.
+        #[cfg(feature = "serve")]
+        if crate::cli::serve::daemon_pid().is_some() {
+            println!("{}", daemon_restart_hint());
+        }
     }
     Ok(())
+}
+
+/// What to do with a running daemon after a successful in-place update.
+#[cfg(feature = "serve")]
+#[derive(Debug, PartialEq, Eq)]
+enum RestartDecision {
+    /// Nothing to restart automatically: no self-managed daemon is up, or
+    /// the context (non-interactive, no `-y`) cannot drive a restart.
+    NotApplicable,
+    /// Interactive terminal: ask before restarting.
+    Prompt,
+    /// Restart without asking (`-y`).
+    Auto,
+}
+
+/// Decide whether to restart the daemon after an update. A daemon is only
+/// restartable when it is both running AND left a `serve.launch` behind
+/// (i.e. it was started by `aoe serve --daemon`, not run in the
+/// foreground or under a service supervisor). Pure so the matrix is unit
+/// testable.
+#[cfg(feature = "serve")]
+fn restart_decision(
+    running: bool,
+    launch_present: bool,
+    is_tty: bool,
+    yes: bool,
+) -> RestartDecision {
+    if !running || !launch_present {
+        return RestartDecision::NotApplicable;
+    }
+    if yes {
+        RestartDecision::Auto
+    } else if is_tty {
+        RestartDecision::Prompt
+    } else {
+        // Non-TTY without -y: cannot prompt, so fall back to the hint.
+        RestartDecision::NotApplicable
+    }
+}
+
+/// After an in-place tarball update, offer to restart a self-managed
+/// `aoe serve` daemon so it runs the new binary. The restart re-execs the
+/// freshly installed binary as `aoe serve --restart` so the new code, not
+/// this old in-memory image (whose `current_exe()` may now point at the
+/// replaced/unlinked inode), spawns the replacement daemon.
+#[cfg(feature = "serve")]
+fn handle_daemon_restart_after_update(binary_path: &Path, yes: bool) -> Result<()> {
+    use crate::cli::serve;
+    let running = serve::daemon_pid().is_some();
+    let decision = restart_decision(
+        running,
+        serve::serve_launch_exists(),
+        io::stdin().is_terminal(),
+        yes,
+    );
+    match decision {
+        RestartDecision::NotApplicable => {
+            // Something is up that we will not restart for the user
+            // (foreground / supervised, or non-interactive): point at the
+            // manual step. Nothing running means no hint is needed.
+            if running {
+                println!("{}", daemon_restart_hint());
+            }
+        }
+        RestartDecision::Prompt => {
+            print!("Restart the running aoe serve daemon now? [Y/n] ");
+            io::stdout().flush()?;
+            let mut answer = String::new();
+            io::stdin().read_line(&mut answer)?;
+            let answer = answer.trim().to_lowercase();
+            if answer.is_empty() || answer == "y" || answer == "yes" {
+                restart_via_new_binary(binary_path);
+            } else {
+                println!("{}", daemon_restart_hint());
+            }
+        }
+        RestartDecision::Auto => restart_via_new_binary(binary_path),
+    }
+    Ok(())
+}
+
+/// Spawn the freshly installed binary as `aoe serve --restart`. Best
+/// effort: on any failure we fall back to the manual hint rather than
+/// failing the whole update, which already succeeded.
+#[cfg(feature = "serve")]
+fn restart_via_new_binary(binary_path: &Path) {
+    println!("Restarting daemon…");
+    match std::process::Command::new(binary_path)
+        .args(["serve", "--restart"])
+        .status()
+    {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            eprintln!("Daemon restart exited with status {status}.");
+            println!("{}", daemon_restart_hint());
+        }
+        Err(e) => {
+            eprintln!("Failed to launch `aoe serve --restart`: {e}");
+            println!("{}", daemon_restart_hint());
+        }
+    }
 }
 
 /// Reminder printed after a successful in-place update: a running
@@ -125,9 +241,9 @@ pub async fn run(args: UpdateArgs) -> Result<()> {
 /// build automatically (see #1754). Surfacing this avoids the silent
 /// mixed-version trap where a freshly-shipped fix appears not to work.
 fn daemon_restart_hint() -> &'static str {
-    "  If `aoe serve` is running, restart it (`aoe serve --stop`, then start it\n  \
-     again) so the daemon picks up the new binary. Cockpit workers from the old\n  \
-     build finish their current turn, then respawn on the new build."
+    "  If `aoe serve` is running, restart it (`aoe serve --restart`) so the daemon\n  \
+     picks up the new binary. Cockpit workers from the old build finish their\n  \
+     current turn, then respawn on the new build."
 }
 
 /// Reminder printed after a successful in-place update. A static completion
@@ -159,8 +275,39 @@ mod tests {
     fn daemon_hint_mentions_restart_and_respawn() {
         let hint = daemon_restart_hint();
         // Points the user at the restart that actually applies the binary.
-        assert!(hint.contains("aoe serve --stop"));
+        assert!(hint.contains("aoe serve --restart"));
         // Sets the expectation that workers converge to the new build.
         assert!(hint.to_lowercase().contains("respawn"));
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn restart_decision_matrix() {
+        use super::{restart_decision, RestartDecision};
+        // Nothing running: never restart.
+        assert_eq!(
+            restart_decision(false, false, true, true),
+            RestartDecision::NotApplicable
+        );
+        // Running but no launch state (foreground / supervised): hands off.
+        assert_eq!(
+            restart_decision(true, false, true, true),
+            RestartDecision::NotApplicable
+        );
+        // Self-managed daemon + -y: restart without asking.
+        assert_eq!(
+            restart_decision(true, true, false, true),
+            RestartDecision::Auto
+        );
+        // Self-managed daemon on a TTY without -y: prompt.
+        assert_eq!(
+            restart_decision(true, true, true, false),
+            RestartDecision::Prompt
+        );
+        // Self-managed daemon, non-TTY, no -y: cannot prompt, fall back.
+        assert_eq!(
+            restart_decision(true, true, false, false),
+            RestartDecision::NotApplicable
+        );
     }
 }

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -178,19 +178,19 @@ fn restart_decision(
 fn handle_daemon_restart_after_update(binary_path: &Path, yes: bool) -> Result<()> {
     use crate::cli::serve;
     let running = serve::daemon_pid().is_some();
-    let decision = restart_decision(
-        running,
-        serve::serve_launch_exists(),
-        io::stdin().is_terminal(),
-        yes,
-    );
-    match decision {
+    let launch_present = serve::serve_launch_exists();
+    match restart_decision(running, launch_present, io::stdin().is_terminal(), yes) {
         RestartDecision::NotApplicable => {
-            // Something is up that we will not restart for the user
-            // (foreground / supervised, or non-interactive): point at the
-            // manual step. Nothing running means no hint is needed.
-            if running {
+            // Nothing running means no hint is needed. Otherwise point at
+            // the right manual step: a self-managed daemon we just cannot
+            // drive right now (non-interactive, no -y) restarts with
+            // `aoe serve --restart`, but a foreground or supervised daemon
+            // (no launch state) must be bounced by its own manager, for
+            // which --restart would correctly refuse.
+            if running && launch_present {
                 println!("{}", daemon_restart_hint());
+            } else if running {
+                println!("{}", external_restart_hint());
             }
         }
         RestartDecision::Prompt => {
@@ -208,6 +208,17 @@ fn handle_daemon_restart_after_update(binary_path: &Path, yes: bool) -> Result<(
         RestartDecision::Auto => restart_via_new_binary(binary_path),
     }
     Ok(())
+}
+
+/// Hint for a running daemon that aoe did not start itself (foreground,
+/// or under systemd/launchd): `aoe serve --restart` would refuse it, so
+/// point the user at the supervisor that owns the process instead.
+#[cfg(feature = "serve")]
+fn external_restart_hint() -> &'static str {
+    "  An `aoe serve` daemon is running but was not started by\n  \
+     `aoe serve --daemon`; restart it through whatever launched it (your\n  \
+     service manager, or the terminal it runs in) so it picks up the new\n  \
+     binary."
 }
 
 /// Spawn the freshly installed binary as `aoe serve --restart`. Best

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -23,6 +23,12 @@ fn daemon_pid_path(h: &TuiTestHarness) -> PathBuf {
     crate::harness::app_dir_in(h.home_path()).join("serve.pid")
 }
 
+/// Resolve the daemon's persisted launch-state file inside the harness's
+/// isolated home.
+fn daemon_launch_path(h: &TuiTestHarness) -> PathBuf {
+    crate::harness::app_dir_in(h.home_path()).join("serve.launch")
+}
+
 /// True iff the kernel still has a process with this PID.
 fn pid_alive(pid: i32) -> bool {
     nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
@@ -135,6 +141,90 @@ fn cli_serve_daemon_starts_and_stops_cleanly() {
         !pid_path.exists(),
         "serve.pid should be cleaned up after --stop, found at {}",
         pid_path.display()
+    );
+}
+
+/// `aoe serve --restart` must stop the running daemon and spawn a fresh
+/// one from the persisted launch state: a new PID, the old one gone, the
+/// same port rebound, and `serve.launch` rewritten. Locks in #1794's
+/// restart primitive end to end.
+#[test]
+#[serial]
+fn cli_serve_restart_replays_launch_state() {
+    let h = TuiTestHarness::new("serve_restart_replays");
+    let port = pick_free_port();
+    let port_s = port.to_string();
+
+    let start = h.run_cli(&["serve", "--daemon", "--port", &port_s, "--no-auth"]);
+    assert!(
+        start.status.success(),
+        "initial --daemon failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {port}"
+    );
+
+    let pid_path = daemon_pid_path(&h);
+    let launch_path = daemon_launch_path(&h);
+    let pid1: i32 = std::fs::read_to_string(&pid_path)
+        .expect("serve.pid after start")
+        .trim()
+        .parse()
+        .expect("serve.pid holds an integer");
+    assert!(
+        launch_path.exists(),
+        "serve.launch should be written on daemon start, missing at {}",
+        launch_path.display()
+    );
+
+    let restart = h.run_cli(&["serve", "--restart"]);
+    assert!(
+        restart.status.success(),
+        "aoe serve --restart failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&restart.stdout),
+        String::from_utf8_lossy(&restart.stderr),
+    );
+
+    // The replacement child rebinds the same persisted port.
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "restarted daemon never rebound port {port}"
+    );
+
+    // serve.pid now names a different, live process; the old one is gone.
+    let pid2: i32 = std::fs::read_to_string(&pid_path)
+        .expect("serve.pid after restart")
+        .trim()
+        .parse()
+        .expect("serve.pid holds an integer");
+    assert_ne!(pid1, pid2, "restart should spawn a new daemon PID");
+    assert!(
+        pid_alive(pid2),
+        "restarted daemon PID {pid2} should be alive"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while pid_alive(pid1) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        !pid_alive(pid1),
+        "old daemon PID {pid1} still alive after restart"
+    );
+    assert!(
+        launch_path.exists(),
+        "serve.launch should be rewritten by the restart"
+    );
+
+    let stop = h.run_cli(&["serve", "--stop"]);
+    assert!(
+        stop.status.success(),
+        "--stop after restart failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&stop.stdout),
+        String::from_utf8_lossy(&stop.stderr),
     );
 }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`aoe update` swaps the binary on disk but never restarts a running `aoe serve` daemon, so the daemon keeps executing the code it already loaded until the user stops and starts it by hand. This is the deferred "layer 1" of #1754: that PR made the reconciler respawn build-stale cockpit workers, but the respawn pass only runs when the daemon itself restarts.

This closes the loop. The daemon now persists its launch config (host, port, mode, auth, profile) to an owner-only (0600) `serve.launch` file when `start_daemon` spawns the detached child, and a new `aoe serve --restart` flag replays it: it recalls the passphrase from `serve.passphrase` or `AOE_SERVE_PASSPHRASE` and re-validates the config *before* stopping, so a passphrase-protected daemon is never left down, then stops and respawns. After a successful in-place (tarball) update, `aoe update` detects a self-managed daemon and offers to restart it: it prompts by default on a TTY, restarts automatically with `-y`, and falls back to a manual hint when non-interactive.

The restart re-execs the freshly installed binary as `aoe serve --restart` rather than restarting in-process, because after the binary is replaced on disk this process's `current_exe()` may point at the unlinked old inode. `serve.launch` is written only on the `--daemon` path, so its presence marks a self-managed daemon; a foreground or service-supervised daemon (systemd, launchd) leaves none, and both `--restart` and the update flow leave it to its own manager rather than fighting the supervisor. Homebrew installs still print the manual hint, since their binary path is not reliably resolvable from the update process.

Closes #1794

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

(Added `cli_serve_restart_replays_launch_state` in `tests/e2e/serve.rs`, plus unit tests for `ServeLaunch` serde, `to_serve_args` replay, `launch_needs_passphrase`, the `AuthMode` serde round-trip, and the `restart_decision` matrix.)

## How to test

- [ ] `aoe serve --daemon --port 8090 --no-auth`, confirm `serve.launch` appears in the app dir at mode `0600`, then `aoe serve --restart`: the daemon comes back on the same port with a new PID, old PID gone.
- [ ] `aoe serve --daemon --remote --passphrase secret`, then `aoe serve --restart`: it relaunches in remote mode without re-prompting for the passphrase.
- [ ] With a daemon running, run `aoe update` on a TTY (when an update is available): confirm it prompts `Restart the running aoe serve daemon now? [Y/n]` and restarts on accept.
- [ ] With a daemon running, `aoe update -y`: confirm it prints `Restarting daemon…` and restarts without asking.
- [ ] `aoe serve --restart` with no daemon running: confirm it bails with a clear "no running daemon" message rather than starting one.
- [ ] Run `aoe serve` in the foreground under a supervisor, then `aoe update`: confirm it points you at your process manager, not at `aoe serve --restart`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan (refined with a `/debate` consult), and implementation drafted by Claude under my direction. I made the design calls (the `--restart` flag shape, re-exec-the-new-binary semantics, supervised-daemon handling) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR adds a restart primitive for self-managed aoe serve daemons and integrates it with aoe update so updated binaries take effect without manual restart.

### High-level (non-technical)
- New ability to restart a daemon in-place after updating the binary, using the original launch settings.
- Restart is safe: the tool re-checks credentials and PID/state before stopping the old daemon so passphrase-protected services are not left down.
- aoe update can detect a self-managed daemon and prompt to restart it (interactive), auto-restart with -y, or print a manual hint in non-interactive cases.
- Supervisor-managed or foreground daemons are not affected — the restart persistence is only written for daemonized runs.
- Tests and docs updated to cover the feature and its user-facing behavior.

### Benefits
- Immediate adoption of updated code without manual daemon juggling.
- Preserves in-flight work and worker-respawn semantics across upgrades.
- Safer, predictable restarts (replays original launch config and validates state first).
- Clear UX: interactive prompts, automated option (-y), and helpful non-interactive hints.

### Technical details
- Added a ServeLaunch JSON file (owner-only 0600) to persist daemon launch configuration and pid for the daemonized path.
- New CLI: aoe serve --restart (conflicts with flags that change bind/config) reconstructs ServeArgs from ServeLaunch, retrieves passphrase from serve.passphrase or AOE_SERVE_PASSPHRASE, validates state, stops the running daemon, and respawns it (re-execing the new binary).
- start_daemon() now writes serve.launch after spawning; cleanup removes it on stop or stale PID handling.
- aoe update gains RestartDecision logic and will prompt/auto-run aoe serve --restart for tarball installs; Homebrew installs print a manual hint due to path resolution issues.
- AuthMode gained serde derives and lowercased names for stable round-tripping.
- New public items: ServeLaunch struct, serve_launch_exists(), and restart_daemon() function; ServeArgs exposes a pub restart flag.
- Tests: unit tests for AuthMode serde, ServeLaunch serde and replay, passphrase logic, restart decision matrix; e2e test that restart rebinds the port and replaces the PID.

### Files touched (summary)
- docs/cli/reference.md — documented --restart
- docs/cockpit/persistence.md — documented restart behavior after update
- src/cli/serve.rs — core restart impl, ServeLaunch, AuthMode serde, daemon persistence
- src/cli/update.rs — update post-install restart decision/UX
- tests/e2e/serve.rs — end-to-end restart regression test
<!-- end of auto-generated comment: release notes by coderabbit.ai -->