### PR TITLE
fix(cockpit): show file path and structured diffs on Codex edit cards

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -127,8 +127,12 @@ an execute shows the command and a bounded preview of its output; a read
 shows the path and a content preview; a delete shows the target path.
 The diff is capped at 20 changed lines and previews at 12 lines, with a
 "+N more" footer when there is more; press `o` to open the web dashboard
-for the full diff and output. Any other tool kind falls back to the
-generic one-liner (name, arguments, output snapshot).
+for the full diff and output. Edit cards read the path and diff from the
+structured diff content the agent emits (Codex routes `apply_patch` edits
+this way, one entry per file), falling back to the legacy argument shape
+when an agent sends that instead; a single patch touching several files
+shows each file's path and diff in one card. Any other tool kind falls
+back to the generic one-liner (name, arguments, output snapshot).
 
 **File-mention picker.** Typing `@` in the composer opens a picker
 listing the session's workspace files, fetched once per session from

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2799,6 +2799,11 @@ fn map_update_to_events(
             } else {
                 None
             };
+            // Codex (and any ACP agent) can attach structured file diffs to
+            // the initial tool_call via `ToolCallContent::Diff`. Bridge them
+            // onto the ToolCall so the edit card shows the path + preview
+            // instead of "(unknown file)". See #1721.
+            let diffs = extract_diffs_from_content(&tc.content);
             let tool_call = ToolCall {
                 id: tc.tool_call_id.0.to_string(),
                 name: tc.title.clone(),
@@ -2807,14 +2812,11 @@ fn map_update_to_events(
                 started_at: chrono::Utc::now(),
                 parent_tool_call_id,
                 memory_recall,
+                diffs,
             };
             let mut events = vec![Event::ToolCallStarted { tool_call }];
             if is_destructive(&tc.title, &args_preview) {
                 debug!(target: "cockpit.acp", "tool {} flagged destructive on tool_call ingest", tc.title);
-            }
-            // If the same payload carries diff content, surface it.
-            if let Some(diff) = extract_diff_from_locations(&tc.locations) {
-                events.push(Event::DiffEmitted { diff });
             }
             // claude-agent-acp routes Claude's built-in ExitPlanMode through
             // the tool channel (kind=switch_mode, plan markdown in
@@ -2873,10 +2875,25 @@ fn map_update_to_events(
                 .as_ref()
                 .map(|blocks| extract_tool_content_text(blocks))
                 .unwrap_or_default();
+            // Codex emits `apply_patch` diffs on the in-progress and
+            // completion updates, not only the initial tool_call. Pull any
+            // Diff blocks off this frame so the edit card's path + preview
+            // survive when they arrive late. `Some` here REPLACES the card's
+            // diffs in the reducer; absent diff blocks stay `None` so a
+            // text-only update can't wipe diffs from an earlier frame. See
+            // #1721.
+            let new_diffs = update.fields.content.as_ref().and_then(|blocks| {
+                let diffs = extract_diffs_from_content(blocks);
+                (!diffs.is_empty()).then_some(diffs)
+            });
             let new_args_preview = update.fields.raw_input.as_ref().map(preview_args);
             let new_title = update.fields.title.clone();
             let mut events: Vec<Event> = Vec::new();
-            if new_title.is_some() || new_args_preview.is_some() || in_progress {
+            if new_title.is_some()
+                || new_args_preview.is_some()
+                || in_progress
+                || new_diffs.is_some()
+            {
                 events.push(Event::ToolCallUpdated {
                     tool_call_id: id.clone(),
                     title: new_title,
@@ -2886,6 +2903,7 @@ fn map_update_to_events(
                     } else {
                         None
                     },
+                    diffs: new_diffs,
                 });
             }
             if completed {
@@ -2976,6 +2994,7 @@ fn map_update_to_events(
                         started_at: now,
                         parent_tool_call_id: None,
                         memory_recall: None,
+                        diffs: Vec::new(),
                     },
                 },
                 Event::PlanUpdated {
@@ -3222,9 +3241,8 @@ fn preview_args(raw: &serde_json::Value) -> String {
 
 /// Concat the textual portion of a tool call's `content` array. Drops
 /// non-text content blocks (images, resources, embedded terminals); the
-/// per-tool renderer fall-back path only knows how to display text. Diffs
-/// are surfaced separately via `extract_diff_from_locations` (and could
-/// later be picked up here too via `ToolCallContent::Diff`).
+/// per-tool renderer fall-back path only knows how to display text. Diff
+/// blocks are bridged separately by `extract_diffs_from_content`.
 fn extract_tool_content_text(blocks: &[agent_client_protocol::schema::ToolCallContent]) -> String {
     use agent_client_protocol::schema::ToolCallContent;
     let mut out = String::new();
@@ -3288,13 +3306,59 @@ fn extract_memory_recall(
     })
 }
 
-fn extract_diff_from_locations(
-    _locations: &[agent_client_protocol::schema::ToolCallLocation],
-) -> Option<DiffPreview> {
-    // Pulling structured diffs out of a ToolCall update requires reading
-    // the `content` array (ToolCallContent::Diff). Left as a follow-up;
-    // the cockpit UI already reuses the existing diff viewer for this.
-    None
+/// Max bytes of diff text kept per side (old/new) when bridging an ACP
+/// `ToolCallContent::Diff` into a cockpit `DiffPreview`. The card only
+/// previews ~20 lines, but the untrimmed text is persisted in the event
+/// store and shipped over every WS replay frame, so a large `apply_patch`
+/// would bloat both without a cap here. Mirrors `preview_args`' 16 KB ceiling.
+const MAX_DIFF_TEXT_BYTES: usize = 16 * 1024;
+
+/// Max number of per-file diffs kept from a single tool call. A patch
+/// touching more files than this keeps the first `MAX_TOOL_DIFFS` rather
+/// than letting one event grow unbounded.
+const MAX_TOOL_DIFFS: usize = 16;
+
+/// Truncate diff text to `MAX_DIFF_TEXT_BYTES` on a UTF-8 char boundary,
+/// appending a sentinel so the cut reads as intentional rather than as a
+/// corrupt diff.
+fn cap_diff_text(text: &str) -> String {
+    if text.len() <= MAX_DIFF_TEXT_BYTES {
+        return text.to_string();
+    }
+    let mut end = MAX_DIFF_TEXT_BYTES;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = text[..end].to_string();
+    out.push_str("\n\u{2026}[truncated]");
+    out
+}
+
+/// Bridge ACP `ToolCallContent::Diff` blocks into cockpit `DiffPreview`
+/// entries. Codex routes `apply_patch` edits through this channel (one
+/// block per touched file) instead of the legacy `old_string`/`new_string`
+/// raw_input keys, so the edit card reads the path and +/- preview from
+/// here. Non-diff blocks (text, images, terminals) are ignored; the enum
+/// is `#[non_exhaustive]`, so the wildcard arm keeps this compiling as the
+/// schema grows. Per-side text is capped and the list bounded. See #1721.
+fn extract_diffs_from_content(
+    blocks: &[agent_client_protocol::schema::ToolCallContent],
+) -> Vec<DiffPreview> {
+    use agent_client_protocol::schema::ToolCallContent;
+    let created_at = chrono::Utc::now();
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            ToolCallContent::Diff(d) => Some(DiffPreview {
+                path: d.path.to_string_lossy().to_string(),
+                old_text: d.old_text.as_deref().map(cap_diff_text),
+                new_text: Some(cap_diff_text(&d.new_text)),
+                created_at,
+            }),
+            _ => None,
+        })
+        .take(MAX_TOOL_DIFFS)
+        .collect()
 }
 
 /// Dispatch the experimental `session/delete` RPC from the connect
@@ -5200,6 +5264,7 @@ async fn handle_permission_request(
         started_at: chrono::Utc::now(),
         parent_tool_call_id: profile.parent_tool_use_id_from_meta(&request.tool_call.meta),
         memory_recall: None,
+        diffs: Vec::new(),
     };
     let approval = build_approval(tool_call);
     let nonce = approval.nonce.clone();
@@ -6769,6 +6834,7 @@ mod tests {
                 started_at,
                 title,
                 args_preview,
+                diffs,
             } => {
                 assert_eq!(tool_call_id, "tc-3");
                 assert!(
@@ -6777,8 +6843,138 @@ mod tests {
                 );
                 assert!(title.is_none());
                 assert!(args_preview.is_none());
+                assert!(diffs.is_none());
             }
             other => panic!("expected ToolCallUpdated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_diffs_from_content_bridges_diff_blocks_and_ignores_others() {
+        use agent_client_protocol::schema::{Content, Diff, ToolCallContent};
+        let blocks = vec![
+            ToolCallContent::Content(Content::new("some text")),
+            ToolCallContent::Diff(Diff::new("src/foo.rs", "new body").old_text("old body")),
+            // New-file diff: old_text is None.
+            ToolCallContent::Diff(Diff::new("src/new.rs", "created")),
+        ];
+        let diffs = extract_diffs_from_content(&blocks);
+        assert_eq!(diffs.len(), 2, "text blocks must be ignored");
+        assert_eq!(diffs[0].path, "src/foo.rs");
+        assert_eq!(diffs[0].old_text.as_deref(), Some("old body"));
+        assert_eq!(diffs[0].new_text.as_deref(), Some("new body"));
+        assert_eq!(diffs[1].path, "src/new.rs");
+        assert_eq!(diffs[1].old_text, None, "new file carries no old_text");
+        assert_eq!(diffs[1].new_text.as_deref(), Some("created"));
+    }
+
+    #[test]
+    fn extract_diffs_from_content_caps_per_side_text() {
+        use agent_client_protocol::schema::{Diff, ToolCallContent};
+        let huge = "x".repeat(MAX_DIFF_TEXT_BYTES + 4096);
+        let blocks = vec![ToolCallContent::Diff(
+            Diff::new("src/big.rs", huge.clone()).old_text(huge),
+        )];
+        let diffs = extract_diffs_from_content(&blocks);
+        assert_eq!(diffs.len(), 1);
+        let new_len = diffs[0].new_text.as_deref().unwrap().len();
+        let old_len = diffs[0].old_text.as_deref().unwrap().len();
+        assert!(
+            new_len < MAX_DIFF_TEXT_BYTES + 64,
+            "new_text must be capped, got {new_len}"
+        );
+        assert!(
+            old_len < MAX_DIFF_TEXT_BYTES + 64,
+            "old_text must be capped, got {old_len}"
+        );
+        assert!(diffs[0]
+            .new_text
+            .as_deref()
+            .unwrap()
+            .contains("[truncated]"));
+    }
+
+    #[test]
+    fn extract_diffs_from_content_caps_diff_count() {
+        use agent_client_protocol::schema::{Diff, ToolCallContent};
+        let blocks: Vec<ToolCallContent> = (0..MAX_TOOL_DIFFS + 8)
+            .map(|i| ToolCallContent::Diff(Diff::new(format!("f{i}.rs"), "x")))
+            .collect();
+        let diffs = extract_diffs_from_content(&blocks);
+        assert_eq!(diffs.len(), MAX_TOOL_DIFFS, "diff count must be bounded");
+    }
+
+    #[test]
+    fn map_tool_call_bridges_diff_content_onto_started_tool() {
+        // Codex attaches the apply_patch diff to the initial `tool_call`
+        // frame as ToolCallContent::Diff. The edit card reads path + preview
+        // from ToolCall.diffs, so it must survive ingest. See #1721.
+        use agent_client_protocol::schema::{Diff, ToolCall, ToolCallContent, ToolKind};
+        let mut tc = ToolCall::new("tc-edit-1", "Edit src/foo.rs");
+        tc.kind = ToolKind::Edit;
+        tc.content = vec![ToolCallContent::Diff(
+            Diff::new("src/foo.rs", "new").old_text("old"),
+        )];
+        let events = map_update_to_events(SessionUpdate::ToolCall(tc), &agent_profiles::CODEX);
+        match &events[0] {
+            Event::ToolCallStarted { tool_call } => {
+                assert_eq!(tool_call.diffs.len(), 1);
+                assert_eq!(tool_call.diffs[0].path, "src/foo.rs");
+                assert_eq!(tool_call.diffs[0].new_text.as_deref(), Some("new"));
+            }
+            other => panic!("expected ToolCallStarted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_tool_call_update_carries_diff_content() {
+        // Codex also re-sends the diff on the in-progress and completion
+        // updates; those must reach the reducer via ToolCallUpdated.diffs so
+        // a late-arriving diff still lands on the card. See #1721.
+        use agent_client_protocol::schema::{
+            Diff, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        };
+        let fields = ToolCallUpdateFields::new()
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::Diff(
+                Diff::new("src/foo.rs", "new").old_text("old"),
+            )]);
+        let update = ToolCallUpdate::new("tc-edit-1", fields);
+        let events = map_update_to_events(
+            SessionUpdate::ToolCallUpdate(update),
+            &agent_profiles::CODEX,
+        );
+        let updated = events
+            .iter()
+            .find_map(|e| match e {
+                Event::ToolCallUpdated { diffs, .. } => Some(diffs),
+                _ => None,
+            })
+            .expect("a ToolCallUpdated event must be emitted for a diff-only update");
+        let diffs = updated.as_ref().expect("diffs must be Some");
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].path, "src/foo.rs");
+    }
+
+    #[test]
+    fn map_tool_call_update_text_only_leaves_diffs_none() {
+        // A text-only update must not carry Some([]) (which would wipe an
+        // earlier frame's diffs in the reducer). See #1721.
+        use agent_client_protocol::schema::{
+            Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        };
+        let fields = ToolCallUpdateFields::new()
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::Content(Content::new("done"))]);
+        let update = ToolCallUpdate::new("tc-edit-1", fields);
+        let events = map_update_to_events(
+            SessionUpdate::ToolCallUpdate(update),
+            &agent_profiles::CODEX,
+        );
+        for e in &events {
+            if let Event::ToolCallUpdated { diffs, .. } = e {
+                assert!(diffs.is_none(), "text-only update must leave diffs None");
+            }
         }
     }
 

--- a/src/cockpit/context_primer.rs
+++ b/src/cockpit/context_primer.rs
@@ -750,6 +750,7 @@ mod tests {
                     started_at: Utc::now(),
                     parent_tool_call_id: None,
                     memory_recall: None,
+                    diffs: Vec::new(),
                 },
             },
         )
@@ -834,6 +835,7 @@ mod tests {
                         r#"{"file_path":"src/foo.rs","old_string":"x","new_string":"y"}"#.into(),
                     ),
                     started_at: None,
+                    diffs: None,
                 },
             ),
             completed_event(4, "t1", false),
@@ -949,6 +951,7 @@ mod tests {
                             started_at: Utc::now(),
                             parent_tool_call_id: None,
                             memory_recall: None,
+                            diffs: Vec::new(),
                         },
                         destructive: false,
                         requested_at: Utc::now(),

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -2406,6 +2406,7 @@ mod tests {
             started_at: Utc::now(),
             parent_tool_call_id: None,
             memory_recall: None,
+            diffs: Vec::new(),
         };
         let nonce_a = Nonce("aaaa".into());
         let nonce_b = Nonce("bbbb".into());

--- a/src/cockpit/permissions.rs
+++ b/src/cockpit/permissions.rs
@@ -55,6 +55,7 @@ mod tests {
             started_at: Utc::now(),
             parent_tool_call_id: None,
             memory_recall: None,
+            diffs: Vec::new(),
         };
         let a = build_approval(tc);
         assert!(a.destructive);
@@ -72,6 +73,7 @@ mod tests {
             started_at: Utc::now(),
             parent_tool_call_id: None,
             memory_recall: None,
+            diffs: Vec::new(),
         };
         let mut a = build_approval(tc);
         resolve(&mut a, ApprovalDecision::Allow, None);

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -81,6 +81,16 @@ pub struct ToolCall {
     /// generic read.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory_recall: Option<MemoryRecall>,
+    /// Structured file diffs the agent attached to this tool call via ACP
+    /// `ToolCallContent::Diff`. Codex routes `apply_patch` edits through
+    /// this channel (one entry per touched file) instead of the legacy
+    /// `old_string`/`new_string` raw_input keys, so the cockpit edit card
+    /// reads the path and +/- preview from here when present and falls
+    /// back to the args-preview shape otherwise. Text on each side is
+    /// capped at ingest (see `acp_client`) so a large patch can't bloat the
+    /// event store or WS frame. See #1721.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diffs: Vec<DiffPreview>,
 }
 
 /// Structured payload for a `memory_recall` tool call. `mode` mirrors
@@ -516,6 +526,15 @@ pub enum Event {
         /// time on completion.
         #[serde(default)]
         started_at: Option<DateTime<Utc>>,
+        /// Structured diffs carried on a late `ToolCallUpdate.fields.content`
+        /// frame (Codex emits `apply_patch` diffs on the in-progress and
+        /// completion updates, not only the initial `tool_call`). `Some`
+        /// REPLACES the tool's diff list wholesale (per ACP, content is a
+        /// replacement, not an append); `None` leaves any diffs from the
+        /// initial frame untouched so a text-only update can't erase them.
+        /// See #1721.
+        #[serde(default)]
+        diffs: Option<Vec<DiffPreview>>,
     },
     ApprovalRequested {
         approval: Approval,
@@ -802,6 +821,7 @@ impl CockpitState {
                 title,
                 args_preview,
                 started_at,
+                diffs,
             } => {
                 if let Some(tool) = self.in_flight_tool.as_mut() {
                     if tool.id == tool_call_id {
@@ -813,6 +833,9 @@ impl CockpitState {
                         }
                         if let Some(t) = started_at {
                             tool.started_at = t;
+                        }
+                        if let Some(d) = diffs {
+                            tool.diffs = d;
                         }
                     }
                 }
@@ -1071,6 +1094,7 @@ mod tests {
             started_at: Utc::now(),
             parent_tool_call_id: None,
             memory_recall: None,
+            diffs: Vec::new(),
         };
         s.apply_event(Event::ToolCallStarted {
             tool_call: tc.clone(),
@@ -1085,6 +1109,57 @@ mod tests {
         })
         .unwrap();
         assert!(s.in_flight_tool.is_none());
+    }
+
+    #[test]
+    fn tool_call_updated_replaces_diffs_on_some_and_preserves_on_none() {
+        let mut s = fresh_state();
+        s.apply_event(Event::ToolCallStarted {
+            tool_call: ToolCall {
+                id: "tc-1".into(),
+                name: "Edit".into(),
+                kind: "edit".into(),
+                args_preview: "{}".into(),
+                started_at: Utc::now(),
+                parent_tool_call_id: None,
+                memory_recall: None,
+                diffs: Vec::new(),
+            },
+        })
+        .unwrap();
+        // A later update carrying diff content populates the card.
+        s.apply_event(Event::ToolCallUpdated {
+            tool_call_id: "tc-1".into(),
+            title: None,
+            args_preview: None,
+            started_at: None,
+            diffs: Some(vec![DiffPreview {
+                path: "src/foo.rs".into(),
+                old_text: Some("old".into()),
+                new_text: Some("new".into()),
+                created_at: Utc::now(),
+            }]),
+        })
+        .unwrap();
+        assert_eq!(s.in_flight_tool.as_ref().unwrap().diffs.len(), 1);
+        assert_eq!(
+            s.in_flight_tool.as_ref().unwrap().diffs[0].path,
+            "src/foo.rs"
+        );
+        // A subsequent text-only update (diffs None) must not erase them.
+        s.apply_event(Event::ToolCallUpdated {
+            tool_call_id: "tc-1".into(),
+            title: Some("Edit src/foo.rs".into()),
+            args_preview: None,
+            started_at: None,
+            diffs: None,
+        })
+        .unwrap();
+        assert_eq!(
+            s.in_flight_tool.as_ref().unwrap().diffs.len(),
+            1,
+            "text-only update must preserve existing diffs"
+        );
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2478,6 +2478,7 @@ mod tests {
             started_at: chrono::Utc::now(),
             parent_tool_call_id: None,
             memory_recall: None,
+            diffs: Vec::new(),
         };
         assert_eq!(
             derive_cockpit_status(&Event::UserPromptSent {

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -484,6 +484,7 @@ mod tests {
             started_at: Utc::now(),
             parent_tool_call_id: None,
             memory_recall: None,
+            diffs: Vec::new(),
         }
     }
 

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -22,6 +22,7 @@ vi.mock("../../lib/highlighter", () => ({
     codeToHtml: (code: string) => `<pre>${code}</pre>`,
   }),
   langKeyForExt: (s: string) => s,
+  langImportForPath: () => null,
   loadLanguage: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -96,6 +97,39 @@ describe("ToolCards dispatch", () => {
     );
     expect(container.textContent).toContain("write");
     expect(container.textContent).toContain("/tmp/new.rs");
+  });
+
+  it("renders a Codex structured-diff edit with its path and a diff body (not '(unknown file)')", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.codexEdit} result={undefined} />
+      </Wrap>,
+    );
+    // Path shows in the (collapsed) header.
+    expect(container.textContent).toContain("edit");
+    expect(container.textContent).toContain("src/codex.rs");
+    expect(container.textContent).not.toContain("(unknown file)");
+    // Expand to reveal the diff body.
+    fireEvent.click(container.querySelector("button")!);
+    expect(
+      container.querySelector('[data-testid="string-diff"]'),
+    ).not.toBeNull();
+  });
+
+  it("renders every touched file path for a multi-file Codex patch", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.codexEditMultiFile} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("src/alpha.rs");
+    expect(container.textContent).not.toContain("(unknown file)");
+    // The second file's path lives in the expanded body.
+    fireEvent.click(container.querySelector("button")!);
+    expect(container.textContent).toContain("src/beta.rs");
+    expect(
+      container.querySelectorAll('[data-testid="string-diff"]').length,
+    ).toBe(2);
   });
 
   it("renders delete kind with a 'delete' label", () => {

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -769,18 +769,40 @@ function EditToolCard({ tool, result }: Props) {
   const args = parseJsonObject(tool.args_preview);
   const argPath = pickStr(args, "path", "file_path", "filePath", "filename");
   const title = pickStr(args, "_aoe_title");
-  const path = pickFirst(argPath, title, tool.name) ?? "(unknown file)";
-  const oldText = pickStr(args, "old_string", "oldString", "old_str") ?? "";
-  const newText =
+  // Codex (and any ACP agent) attaches structured per-file diffs via
+  // ToolCallContent::Diff; prefer those for path + body and fall back to
+  // the legacy old_string/new_string args shape otherwise. See #1721.
+  const structuredDiffs = tool.diffs ?? [];
+  const hasStructuredDiffs = structuredDiffs.length > 0;
+  const legacyOld = pickStr(args, "old_string", "oldString", "old_str") ?? "";
+  const legacyNew =
     pickStr(args, "new_string", "newString", "new_str", "content") ?? "";
+  const hasLegacyDiff = legacyOld !== "" || legacyNew !== "";
+  const path =
+    pickFirst(structuredDiffs[0]?.path, argPath, title, tool.name) ??
+    "(unknown file)";
   const [open, setOpen] = useToolCardExpansion(status);
-  const hasDiff = oldText !== "" || newText !== "";
-  const verb = oldText ? "edit" : "write";
+  const hasDiff = hasStructuredDiffs || hasLegacyDiff;
+  // "edit" when a prior version existed, "write" for a fresh file.
+  const isEdit = hasStructuredDiffs
+    ? structuredDiffs.some((d) => (d.old_text ?? "") !== "")
+    : legacyOld !== "";
+  const verb = isEdit ? "edit" : "write";
+  const multiFile = structuredDiffs.length > 1;
 
-  const { adds, dels } = useMemo(
-    () => diffPair(oldText, newText),
-    [oldText, newText],
-  );
+  const { adds, dels } = useMemo(() => {
+    const ds = tool.diffs ?? [];
+    if (ds.length > 0) {
+      return ds.reduce(
+        (acc, d) => {
+          const p = diffPair(d.old_text ?? "", d.new_text ?? "");
+          return { adds: acc.adds + p.adds, dels: acc.dels + p.dels };
+        },
+        { adds: 0, dels: 0 },
+      );
+    }
+    return diffPair(legacyOld, legacyNew);
+  }, [tool.diffs, legacyOld, legacyNew]);
   const meta = hasDiff && (adds > 0 || dels > 0) && (
     <span className="hidden md:inline text-[11px]">
       <span className="text-emerald-400">+{adds}</span>{" "}
@@ -799,7 +821,7 @@ function EditToolCard({ tool, result }: Props) {
       endedAt={result?.at}
       icon={<Pencil className="h-3.5 w-3.5" />}
       label={verb}
-      primary={path}
+      primary={multiFile ? `${path} +${structuredDiffs.length - 1} more` : path}
       meta={errorChip ? undefined : meta}
       expanded={open}
       onToggle={
@@ -807,14 +829,33 @@ function EditToolCard({ tool, result }: Props) {
       }
       body={
         <ToolErrorBody status={status} errorText={result?.text}>
-          {hasDiff && (
+          {hasStructuredDiffs ? (
             <div className="border-t border-surface-800 bg-surface-950">
-              <StringDiff
-                oldText={oldText}
-                newText={newText}
-                filePath={path}
-              />
+              {structuredDiffs.map((d, i) => (
+                <div key={`${d.path}-${i}`}>
+                  {multiFile && (
+                    <div className="px-2 py-1 text-[11px] text-text-dim">
+                      {d.path}
+                    </div>
+                  )}
+                  <StringDiff
+                    oldText={d.old_text ?? ""}
+                    newText={d.new_text ?? ""}
+                    filePath={d.path}
+                  />
+                </div>
+              ))}
             </div>
+          ) : (
+            hasLegacyDiff && (
+              <div className="border-t border-surface-800 bg-surface-950">
+                <StringDiff
+                  oldText={legacyOld}
+                  newText={legacyNew}
+                  filePath={path}
+                />
+              </div>
+            )
           )}
         </ToolErrorBody>
       }

--- a/web/src/components/cockpit/__fixtures__/toolCalls.ts
+++ b/web/src/components/cockpit/__fixtures__/toolCalls.ts
@@ -68,6 +68,44 @@ export const fixtures = {
       content: "fn main() {}",
     }),
   }),
+  // Codex apply_patch: structured diff content, no legacy old_string/
+  // new_string args. The card must read path + diff from tool.diffs and
+  // never fall back to "(unknown file)". See #1721.
+  codexEdit: makeToolCall({
+    id: "codex-edit-1",
+    name: "Edit src/codex.rs",
+    kind: "edit",
+    args_preview: "{}",
+    diffs: [
+      {
+        path: "src/codex.rs",
+        old_text: "let x = 1;",
+        new_text: "let x = 2;",
+        created_at: "2026-05-21T00:00:00Z",
+      },
+    ],
+  }),
+  // One patch touching multiple files: each path must render.
+  codexEditMultiFile: makeToolCall({
+    id: "codex-edit-multi-1",
+    name: "apply_patch",
+    kind: "edit",
+    args_preview: "{}",
+    diffs: [
+      {
+        path: "src/alpha.rs",
+        old_text: "alpha old",
+        new_text: "alpha new",
+        created_at: "2026-05-21T00:00:00Z",
+      },
+      {
+        path: "src/beta.rs",
+        old_text: null,
+        new_text: "beta created",
+        created_at: "2026-05-21T00:00:00Z",
+      },
+    ],
+  }),
   del: makeToolCall({
     id: "del-1",
     name: "Delete",

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -286,6 +286,71 @@ describe("applyEvent / UserPromptSent", () => {
     );
   });
 
+  it("patches a Codex diff onto the edit card when it arrives via ToolCallUpdated, and preserves it on a later text-only update", () => {
+    // Codex emits the apply_patch diff on the update/completion frames,
+    // not the initial tool_call. A non-empty diff list replaces the
+    // card's diffs; a later text-only update must not blank them. See
+    // #1721.
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ToolCallStarted: {
+          tool_call: {
+            id: "tc-edit",
+            name: "Edit src/foo.rs",
+            kind: "edit",
+            args_preview: "{}",
+            started_at: new Date().toISOString(),
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ToolCallUpdated: {
+          tool_call_id: "tc-edit",
+          title: null,
+          args_preview: null,
+          diffs: [
+            {
+              path: "src/foo.rs",
+              old_text: "old",
+              new_text: "new",
+              created_at: new Date().toISOString(),
+            },
+          ],
+        },
+      },
+    });
+    const row = state.activity.find(
+      (a) => a.kind === "tool_start" && a.toolCallId === "tc-edit",
+    );
+    expect(row?.tool?.diffs?.length).toBe(1);
+    expect(row?.tool?.diffs?.[0].path).toBe("src/foo.rs");
+    expect(state.inFlightTool?.diffs?.length).toBe(1);
+
+    // A subsequent text-only update (no diffs) must preserve them.
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: {
+        ToolCallUpdated: {
+          tool_call_id: "tc-edit",
+          title: "Edit src/foo.rs",
+          args_preview: null,
+          diffs: null,
+        },
+      },
+    });
+    const rowAfter = state.activity.find(
+      (a) => a.kind === "tool_start" && a.toolCallId === "tc-edit",
+    );
+    expect(rowAfter?.tool?.diffs?.length).toBe(1);
+  });
+
   it("uses 'tool failed' when error event has no content", () => {
     const state = applyEvent(emptyCockpitState(), {
       session_id: "s-1",

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -55,6 +55,13 @@ export interface ToolCall {
    *  paths the SDK loaded into the agent's context; `synthesize`
    *  mode carries the synthesised memory text. */
   memory_recall?: MemoryRecall | null;
+  /** Structured file diffs the agent attached via ACP
+   *  `ToolCallContent::Diff`. Codex routes `apply_patch` edits through
+   *  this channel (one entry per touched file) rather than the legacy
+   *  `old_string`/`new_string` args, so the edit card reads the path and
+   *  +/- preview from here when present and falls back to the args shape
+   *  otherwise. See #1721. */
+  diffs?: DiffPreview[] | null;
 }
 
 export interface MemoryRecall {
@@ -248,6 +255,11 @@ export type CockpitEvent =
          *  rather than adapter scheduling time. Null for non-status
          *  updates. */
         started_at?: string | null;
+        /** Diffs carried on a late `ToolCallUpdate.fields.content` frame
+         *  (Codex emits apply_patch diffs on the in-progress and
+         *  completion updates). A non-empty list REPLACES the card's
+         *  diffs; null/absent leaves earlier diffs untouched. See #1721. */
+        diffs?: DiffPreview[] | null;
       };
     }
   | { ApprovalRequested: { approval: Approval } }
@@ -872,7 +884,13 @@ export function applyEvent(
       const prev = next.activity[existing];
       if (prev) {
         const copy = next.activity.slice();
-        copy[existing] = { ...prev, tool: tc, text: tc.name };
+        // Keep diffs from the earlier frame if this duplicate start lacks
+        // them, so a re-delivered tool_start can't blank the edit card.
+        const mergedTool: ToolCall =
+          tc.diffs && tc.diffs.length > 0
+            ? tc
+            : { ...tc, diffs: prev.tool?.diffs };
+        copy[existing] = { ...prev, tool: mergedTool, text: tc.name };
         next.activity = copy;
       }
       return next;
@@ -930,14 +948,19 @@ export function applyEvent(
     return next;
   }
   if ("ToolCallUpdated" in event) {
-    const { tool_call_id, title, args_preview, started_at } =
+    const { tool_call_id, title, args_preview, started_at, diffs } =
       event.ToolCallUpdated;
+    // Per ACP, content is a replacement: a non-empty diff list overwrites
+    // the card's diffs; null/empty leaves an earlier frame's diffs intact
+    // so a text-only update can't blank the edit card. See #1721.
+    const incomingDiffs = diffs && diffs.length > 0 ? diffs : null;
     if (next.inFlightTool && next.inFlightTool.id === tool_call_id) {
       next.inFlightTool = {
         ...next.inFlightTool,
         name: title ?? next.inFlightTool.name,
         args_preview: args_preview ?? next.inFlightTool.args_preview,
         started_at: started_at ?? next.inFlightTool.started_at,
+        diffs: incomingDiffs ?? next.inFlightTool.diffs,
       };
     }
     // Walk activity backwards to find the matching tool_start row and
@@ -961,6 +984,7 @@ export function applyEvent(
             name: title ?? row.tool.name,
             args_preview: args_preview ?? row.tool.args_preview,
             started_at: started_at ?? row.tool.started_at,
+            diffs: incomingDiffs ?? row.tool.diffs,
           },
         };
       }


### PR DESCRIPTION
**Note:** Codex handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Codex `apply_patch` edits in cockpit lost their file path and diff body even though the agent sent structured diff content. AoE only rendered the legacy `old_string` / `new_string` args shape, so these edit cards fell back to `(unknown file)` with no visible patch.

This fixes the pipeline end to end. The ACP ingest path now preserves structured diffs from `tool_call` and later update/completion frames on `ToolCall.diffs`, the cockpit reducer carries late-arriving diffs without letting a text-only update wipe them, and the web edit card prefers structured diffs for both the path and body while keeping the legacy args fallback for agents that still use it. Multi-file patches now render every touched file in a single edit card.

The docs update also clarifies that edit cards read from structured diff content first and that a single patch touching several files renders as one card with multiple file diffs.

Closes #1721

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the behavior change is in cockpit event plumbing and tool-card rendering; this PR adds targeted Rust unit coverage plus Vitest reducer/render coverage for single-file and multi-file structured diffs instead of a new Playwright user-story.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the TUI change is reducer plumbing to retain late-arriving diffs, covered by the Rust-side unit tests around tool-call ingest/state rather than a new tmux e2e flow.

## How to test

- [ ] Start a cockpit session with Codex and ask it to edit a file via `apply_patch`. Confirm the edit card shows the real file path instead of `(unknown file)`.
- [ ] Confirm the edit card renders the structured diff body, not just legacy text args.
- [ ] Ask Codex to patch multiple files in one tool call. Confirm one edit card renders all touched file paths with their individual diffs.
- [ ] Confirm agents that still send only legacy `old_string` / `new_string` args still render correctly.
- [ ] Confirm a text-only tool update does not blank an earlier structured diff already shown on the card.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Codex (GPT-5)

**Any Additional AI Details you'd like to share:**
Investigation, implementation, and PR prose were drafted by Codex under my direction. I reviewed the scope, rebased the branch, and verified the resulting checks before opening this PR.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a critical bug where file paths and code diff previews were missing from Codex edit tool cards in Cockpit. The issue occurred because the edit card component was only reading legacy text format arguments and ignoring structured diff data that was being discarded during ingestion.

## What Changed

**Backend changes:**
- Added a new `diffs` field to the `ToolCall` data structure to store structured file differences
- Modified the ACP (Assistant Content Protocol) ingestion pipeline to extract and preserve structured diff data from Codex patches instead of discarding it
- Updated the event handling system to carry structured diffs through update events, ensuring late-arriving diffs don't get overwritten by text-only updates
- Updated test fixtures and helper functions across multiple modules to initialize the new `diffs` field

**Frontend changes:**
- Updated the edit tool card component to prefer reading structured diffs for file paths and diff bodies, with a fallback to legacy text format for backward compatibility
- Enhanced the card display to show multiple file diffs when a patch touches several files—now rendering all changes in a single card instead of creating separate entries
- Added the ability to render diff summaries (+/- counts) calculated from structured diff data
- Added new test fixtures and Vitest test cases to validate single-file and multi-file patch rendering

## Benefits

- **Restored usability**: Edit cards now display the file path and code changes (+/−) that were previously missing
- **Multi-file support**: Patches that edit multiple files now display all affected files clearly in one card
- **Robustness**: Late-arriving diff data from the server won't be lost by subsequent text-only updates
- **Backward compatibility**: Falls back to legacy text-based arguments if structured diffs aren't available
- **Well-tested**: Added comprehensive unit tests and render tests covering both single- and multi-file scenarios

## Technical Details

The fix implements a three-part solution:
1. **Diff extraction at ingest**: The `extract_diffs_from_content` function converts `ToolCallContent::Diff` blocks into bounded `DiffPreview` entries with per-side UTF-8-safe truncation (16 KB cap) and a maximum of 16 diffs per file
2. **Event-driven preservation**: The event reducer uses "replace on Some, preserve on None" semantics—only updating diffs when new ones explicitly arrive, preventing text-only updates from clearing existing structured diffs
3. **Resilient rendering**: The `EditToolCard` component checks for `tool.diffs` first, falls back to legacy `old_string`/`new_string` fields, and handles both single and multi-file cases with appropriate UI labels and stacking

All changes maintain the existing public API surface; only internal structures and private fields were extended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->