### PR TITLE
feat: copy a changed file's relative path from the diff file list (web + TUI)

### DIFF
--- a/docs/guides/diff-view.md
+++ b/docs/guides/diff-view.md
@@ -33,8 +33,18 @@ After saving and exiting, the diff view refreshes automatically to show your cha
 |-----|--------|
 | `b` | Change base branch (persists per-session as `base_branch_override`) |
 | `r` | Refresh the diff |
+| `y` | Copy the selected file's relative path to the clipboard |
 | `?` | Show help |
 | `Esc` | Close diff view |
+
+## Copying a file's path
+
+Copy a changed file's repo-relative path to the clipboard:
+
+- **TUI**: press `y` (yank) on the selected file. A `Copied <path>` confirmation shows in the footer.
+- **Web dashboard**: right-click a file in the Changes list (or a folder row in tree view) and choose **Copy relative path**.
+
+The path is relative to the file's repository root, so it pastes straight into commands or comments.
 
 ## Commenting on the diff (web only, cockpit sessions)
 

--- a/docs/guides/diff-view.md
+++ b/docs/guides/diff-view.md
@@ -42,7 +42,7 @@ After saving and exiting, the diff view refreshes automatically to show your cha
 Copy a changed file's repo-relative path to the clipboard:
 
 - **TUI**: press `y` (yank) on the selected file. A `Copied <path>` confirmation shows in the footer.
-- **Web dashboard**: right-click a file in the Changes list (or a folder row in tree view) and choose **Copy relative path**.
+- **Web dashboard**: right-click a file in the Changes list (or a folder row in tree view) and choose **Copy relative path**. A `Copied <path>` toast confirms it.
 
 The path is relative to the file's repository root, so it pastes straight into commands or comments.
 

--- a/src/tui/diff/input.rs
+++ b/src/tui/diff/input.rs
@@ -140,6 +140,12 @@ impl DiffView {
                 DiffAction::Continue
             }
 
+            // Copy the selected file's repo-relative path to the clipboard
+            (KeyCode::Char('y'), _) => {
+                self.copy_selected_path();
+                DiffAction::Continue
+            }
+
             // Resize file list panel
             (KeyCode::Char('h'), _) | (KeyCode::Left, _) => {
                 self.shrink_file_list();
@@ -249,5 +255,55 @@ mod tests {
         // 'q' should close the view when no dialog
         let action = view.handle_key(key(KeyCode::Char('q')));
         assert!(matches!(action, DiffAction::Close));
+    }
+
+    fn diff_file(path: &str) -> crate::git::diff::DiffFile {
+        crate::git::diff::DiffFile {
+            path: std::path::PathBuf::from(path),
+            old_path: None,
+            status: crate::git::diff::FileStatus::Modified,
+            additions: 0,
+            deletions: 0,
+        }
+    }
+
+    #[test]
+    fn selected_path_string_returns_the_selected_file_path() {
+        let mut view = make_diff_view_no_warning();
+        view.files = vec![diff_file("src/app/foo.rs"), diff_file("README.md")];
+        view.selected_file = 1;
+        assert_eq!(view.selected_path_string().as_deref(), Some("README.md"));
+    }
+
+    #[test]
+    fn selected_path_string_is_none_without_files() {
+        let view = make_diff_view_no_warning();
+        assert_eq!(view.selected_path_string(), None);
+    }
+
+    #[test]
+    fn y_key_is_wired_and_continues() {
+        // Empty file list: the handler short-circuits before touching the
+        // clipboard, so this asserts the binding without a real clipboard write.
+        let mut view = make_diff_view_no_warning();
+        let action = view.handle_key(key(KeyCode::Char('y')));
+        assert!(matches!(action, DiffAction::Continue));
+    }
+
+    #[test]
+    fn y_key_sets_copied_confirmation() {
+        // Exercises the message path the empty-list test skips. This goes
+        // through the best-effort clipboard helper: a no-op in CI without a
+        // clipboard tool, and a local `cargo test` briefly writes the path to
+        // the system clipboard.
+        let mut view = make_diff_view_no_warning();
+        view.files = vec![diff_file("src/app/foo.rs")];
+        view.selected_file = 0;
+        let action = view.handle_key(key(KeyCode::Char('y')));
+        assert!(matches!(action, DiffAction::Continue));
+        assert_eq!(
+            view.success_message.as_deref(),
+            Some("Copied src/app/foo.rs")
+        );
     }
 }

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -170,6 +170,21 @@ impl DiffView {
         self.files.get(self.selected_file)
     }
 
+    /// Repo-relative path of the selected file as a string, if any.
+    pub(crate) fn selected_path_string(&self) -> Option<String> {
+        self.selected_file()
+            .map(|f| f.path.to_string_lossy().to_string())
+    }
+
+    /// Copy the selected file's repo-relative path to the system clipboard and
+    /// surface a confirmation in the footer.
+    pub(crate) fn copy_selected_path(&mut self) {
+        if let Some(path) = self.selected_path_string() {
+            crate::tui::clipboard::copy_to_clipboard(&path);
+            self.success_message = Some(format!("Copied {path}"));
+        }
+    }
+
     /// Get or compute the diff for the selected file
     pub fn get_current_diff(&mut self) -> Option<&FileDiff> {
         let file = self.files.get(self.selected_file)?;

--- a/src/tui/diff/render.rs
+++ b/src/tui/diff/render.rs
@@ -358,6 +358,8 @@ impl DiffView {
                 Span::styled(": edit  ", Style::default().fg(theme.dimmed)),
                 Span::styled("b", Style::default().fg(theme.accent)),
                 Span::styled(": branch  ", Style::default().fg(theme.dimmed)),
+                Span::styled("y", Style::default().fg(theme.accent)),
+                Span::styled(": copy path  ", Style::default().fg(theme.dimmed)),
                 Span::styled("?", Style::default().fg(theme.accent)),
                 Span::styled(": help  ", Style::default().fg(theme.dimmed)),
                 Span::styled("q/Esc", Style::default().fg(theme.accent)),
@@ -491,7 +493,7 @@ impl DiffView {
 
     fn render_help(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_width = 55u16;
-        let dialog_height = 19u16;
+        let dialog_height = 20u16;
 
         let x = area.x + (area.width.saturating_sub(dialog_width)) / 2;
         let y = area.y + (area.height.saturating_sub(dialog_height)) / 2;
@@ -537,6 +539,7 @@ impl DiffView {
                     ("e/Enter", "Edit file in external editor"),
                     ("b", "Select base branch"),
                     ("r", "Refresh diff"),
+                    ("y", "Copy file path to clipboard"),
                 ],
             ),
             (

--- a/web/src/components/diff/CopyPathContextMenu.tsx
+++ b/web/src/components/diff/CopyPathContextMenu.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+export interface PathMenuState {
+  x: number;
+  y: number;
+  /** Repo-relative path of the right-clicked file or folder. */
+  path: string;
+}
+
+interface Props {
+  menu: PathMenuState | null;
+  onClose: () => void;
+}
+
+/// A minimal right-click menu for the diff file list offering "Copy relative
+/// path". Rendered in a portal at the click position and dismissed on any
+/// outside click, another right-click, or Escape.
+export function CopyPathContextMenu({ menu, onClose }: Props) {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!menu) return;
+    const close = () => onClose();
+    const onDocClick = (e: MouseEvent) => {
+      // Clicks inside the menu are handled by the item's onClick.
+      if (menuRef.current?.contains(e.target as Node)) return;
+      close();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    // Defer so the contextmenu event that opened this menu finishes bubbling
+    // first; otherwise React flushes this effect synchronously for the discrete
+    // event and the same right-click immediately hits the document listener,
+    // closing the menu before it ever paints.
+    const raf = requestAnimationFrame(() => {
+      document.addEventListener("click", onDocClick);
+      document.addEventListener("contextmenu", close);
+      document.addEventListener("keydown", onKey);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("contextmenu", close);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [menu, onClose]);
+
+  if (!menu) return null;
+
+  const copy = () => {
+    navigator.clipboard?.writeText(menu.path).catch(() => {});
+    onClose();
+  };
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      role="menu"
+      className="fixed z-50 min-w-[160px] rounded-md border border-surface-700 bg-surface-850 py-1 shadow-lg"
+      style={{ left: menu.x, top: menu.y }}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={copy}
+        className="w-full px-3 py-1.5 text-left text-[13px] text-text-secondary hover:bg-surface-800 cursor-pointer"
+      >
+        Copy relative path
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/diff/CopyPathContextMenu.tsx
+++ b/web/src/components/diff/CopyPathContextMenu.tsx
@@ -1,5 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useClampedMenuPosition } from "../../lib/menuPosition";
+import { writeClipboard } from "../../lib/clipboard";
+import { toastBus } from "../../lib/toastBus";
 
 export interface PathMenuState {
   x: number;
@@ -13,11 +16,26 @@ interface Props {
   onClose: () => void;
 }
 
-/// A minimal right-click menu for the diff file list offering "Copy relative
-/// path". Rendered in a portal at the click position and dismissed on any
-/// outside click, another right-click, or Escape.
+/** A minimal right-click menu for the diff file list offering "Copy relative
+ *  path". Rendered in a portal at the click position, clamped inside the
+ *  viewport, and dismissed on any outside click, another right-click, or
+ *  Escape. */
 export function CopyPathContextMenu({ menu, onClose }: Props) {
   const menuRef = useRef<HTMLDivElement | null>(null);
+
+  // Mirror the click position into local state so the clamp hook can nudge it
+  // inside the viewport. The initial open is seeded by the lazy initializer;
+  // a layout effect re-seeds on reopen at a new spot. Both run before paint
+  // (initializer at mount, layout effect before the browser draws), so the
+  // clamp hook below lands the menu on-screen without flashing at the raw
+  // coordinates first.
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(
+    menu ? { x: menu.x, y: menu.y } : null,
+  );
+  useLayoutEffect(() => {
+    setPos(menu ? { x: menu.x, y: menu.y } : null);
+  }, [menu]);
+  useClampedMenuPosition(pos, menuRef, setPos);
 
   useEffect(() => {
     if (!menu) return;
@@ -47,10 +65,14 @@ export function CopyPathContextMenu({ menu, onClose }: Props) {
     };
   }, [menu, onClose]);
 
-  if (!menu) return null;
+  if (!menu || !pos) return null;
 
+  const path = menu.path;
   const copy = () => {
-    navigator.clipboard?.writeText(menu.path).catch(() => {});
+    void writeClipboard(path).then((ok) => {
+      if (ok) toastBus.handler?.info(`Copied ${path}`);
+      else toastBus.handler?.error("Couldn't copy path to clipboard");
+    });
     onClose();
   };
 
@@ -59,7 +81,7 @@ export function CopyPathContextMenu({ menu, onClose }: Props) {
       ref={menuRef}
       role="menu"
       className="fixed z-50 min-w-[160px] rounded-md border border-surface-700 bg-surface-850 py-1 shadow-lg"
-      style={{ left: menu.x, top: menu.y }}
+      style={{ left: pos.x, top: pos.y }}
       onContextMenu={(e) => e.preventDefault()}
     >
       <button

--- a/web/src/components/diff/DiffFileList.tsx
+++ b/web/src/components/diff/DiffFileList.tsx
@@ -4,6 +4,10 @@ import type { BranchInfo } from "../../lib/api";
 import { buildDiffTree, type DiffTreeNode } from "../../lib/diffTree";
 import { useWebSettings } from "../../hooks/useWebSettings";
 import { fetchBranches, setSessionDiffBase } from "../../lib/api";
+import {
+  CopyPathContextMenu,
+  type PathMenuState,
+} from "./CopyPathContextMenu";
 
 interface Props {
   files: RichDiffFile[];
@@ -85,6 +89,7 @@ function FlatList({
           <button
             key={`${file.repo_name ?? ""}::${file.path}`}
             data-index={i}
+            data-path={file.path}
             onClick={() => onSelectFile(file.path, file.repo_name)}
             onMouseEnter={() => onFocusIndex(i)}
             className={`w-full text-left px-3 py-1.5 cursor-pointer transition-colors flex items-center gap-2 ${
@@ -161,6 +166,7 @@ function TreeView({
             <button
               key={nodeKey(node)}
               data-index={i}
+              data-path={node.path}
               onClick={() => onToggleDir(node.path)}
               onMouseEnter={() => onFocusIndex(i)}
               aria-expanded={!node.collapsed}
@@ -203,6 +209,7 @@ function TreeView({
           <button
             key={`${file.repo_name ?? ""}::${file.path}`}
             data-index={i}
+            data-path={file.path}
             onClick={() =>
               onSelectFile(file.path, repoNameForSelect ?? file.repo_name)
             }
@@ -390,8 +397,22 @@ export function DiffFileList({
     [itemCount, clampedFocusedIndex, viewMode, treeNodes, files, toggleDir, onSelectFile],
   );
 
+  const [pathMenu, setPathMenu] = useState<PathMenuState | null>(null);
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    const el = (e.target as HTMLElement).closest<HTMLElement>("[data-path]");
+    const path = el?.getAttribute("data-path");
+    if (!path) return; // not on a file/folder row: let the native menu show
+    e.preventDefault();
+    setPathMenu({ x: e.clientX, y: e.clientY, path });
+  }, []);
+  const closePathMenu = useCallback(() => setPathMenu(null), []);
+
   return (
-    <div className="flex flex-col h-full bg-surface-900 overflow-hidden">
+    <div
+      className="flex flex-col h-full bg-surface-900 overflow-hidden"
+      onContextMenu={handleContextMenu}
+    >
+      <CopyPathContextMenu menu={pathMenu} onClose={closePathMenu} />
       {/* Header */}
       <div className="px-3 py-2 border-b border-surface-700/20 shrink-0">
         <div className="flex items-center gap-2 flex-wrap">
@@ -680,6 +701,7 @@ function RepoBody({
           <button
             key={`${file.repo_name ?? ""}::${file.path}`}
             type="button"
+            data-path={file.path}
             onClick={() => onSelectFile(file.path, file.repo_name)}
             className={`w-full text-left px-6 py-1.5 cursor-pointer transition-colors flex items-center gap-2 ${
               isSelected

--- a/web/src/components/diff/__tests__/CopyPathContextMenu.test.tsx
+++ b/web/src/components/diff/__tests__/CopyPathContextMenu.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { CopyPathContextMenu } from "../CopyPathContextMenu";
+
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  return writeText;
+}
+
+// The dismiss listeners attach on the next animation frame (so the opening
+// right-click doesn't immediately re-trigger them); wait one frame before
+// dispatching events that should close the menu.
+async function flushFrame() {
+  await act(async () => {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  });
+}
+
+function openMenu(onClose: () => void) {
+  return render(
+    <CopyPathContextMenu menu={{ x: 12, y: 34, path: "src/app/foo.rs" }} onClose={onClose} />,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CopyPathContextMenu", () => {
+  it("renders nothing when there is no open menu", () => {
+    const { container } = render(
+      <CopyPathContextMenu menu={null} onClose={() => {}} />,
+    );
+    expect(container.querySelector("button")).toBeNull();
+    expect(screen.queryByText("Copy relative path")).toBeNull();
+  });
+
+  it("copies the path to the clipboard and closes on click", () => {
+    const writeText = stubClipboard();
+    const onClose = vi.fn();
+    openMenu(onClose);
+
+    fireEvent.click(screen.getByText("Copy relative path"));
+
+    expect(writeText).toHaveBeenCalledWith("src/app/foo.rs");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes on an outside click once the listeners attach", async () => {
+    const onClose = vi.fn();
+    openMenu(onClose);
+    await flushFrame();
+
+    fireEvent.click(document.body);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes on Escape", async () => {
+    const onClose = vi.fn();
+    openMenu(onClose);
+    await flushFrame();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes on another right-click", async () => {
+    const onClose = vi.fn();
+    openMenu(onClose);
+    await flushFrame();
+
+    fireEvent.contextMenu(document.body);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not double-close when the click lands inside the menu", async () => {
+    const writeText = stubClipboard();
+    const onClose = vi.fn();
+    openMenu(onClose);
+    await flushFrame();
+
+    // The document listener must skip clicks inside the menu (menuRef guard);
+    // the item's own onClick performs the copy + the single close.
+    fireEvent.click(screen.getByText("Copy relative path"));
+    expect(writeText).toHaveBeenCalledWith("src/app/foo.rs");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/diff/__tests__/CopyPathContextMenu.test.tsx
+++ b/web/src/components/diff/__tests__/CopyPathContextMenu.test.tsx
@@ -2,14 +2,30 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { CopyPathContextMenu } from "../CopyPathContextMenu";
+import { toastBus } from "../../../lib/toastBus";
+
+function setSecureContext(secure: boolean) {
+  Object.defineProperty(window, "isSecureContext", {
+    value: secure,
+    configurable: true,
+  });
+}
 
 function stubClipboard() {
+  setSecureContext(true);
   const writeText = vi.fn().mockResolvedValue(undefined);
   Object.defineProperty(navigator, "clipboard", {
     value: { writeText },
     configurable: true,
   });
   return writeText;
+}
+
+function stubToasts() {
+  const info = vi.fn();
+  const error = vi.fn();
+  toastBus.handler = { push: vi.fn(), info, error };
+  return { info, error };
 }
 
 // The dismiss listeners attach on the next animation frame (so the opening
@@ -21,6 +37,15 @@ async function flushFrame() {
   });
 }
 
+// The copy path resolves a promise before toasting; flush microtasks so the
+// toast assertion sees the settled result.
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 function openMenu(onClose: () => void) {
   return render(
     <CopyPathContextMenu menu={{ x: 12, y: 34, path: "src/app/foo.rs" }} onClose={onClose} />,
@@ -29,6 +54,7 @@ function openMenu(onClose: () => void) {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  toastBus.handler = null;
 });
 
 describe("CopyPathContextMenu", () => {
@@ -49,6 +75,59 @@ describe("CopyPathContextMenu", () => {
 
     expect(writeText).toHaveBeenCalledWith("src/app/foo.rs");
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("toasts a confirmation after a successful copy", async () => {
+    stubClipboard();
+    const { info, error } = stubToasts();
+    openMenu(vi.fn());
+
+    fireEvent.click(screen.getByText("Copy relative path"));
+    await flushMicrotasks();
+
+    expect(info).toHaveBeenCalledWith("Copied src/app/foo.rs");
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand and toasts when the clipboard API is unavailable", async () => {
+    // Insecure context (plain-HTTP `aoe serve`): navigator.clipboard is absent.
+    setSecureContext(false);
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    // jsdom has no execCommand by default; install a stub.
+    (document as unknown as { execCommand: typeof execCommand }).execCommand =
+      execCommand;
+    const { info, error } = stubToasts();
+    openMenu(vi.fn());
+
+    fireEvent.click(screen.getByText("Copy relative path"));
+    await flushMicrotasks();
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(info).toHaveBeenCalledWith("Copied src/app/foo.rs");
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("toasts an error when copying fails entirely", async () => {
+    setSecureContext(false);
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    (document as unknown as { execCommand: () => boolean }).execCommand = vi
+      .fn()
+      .mockReturnValue(false);
+    const { info, error } = stubToasts();
+    openMenu(vi.fn());
+
+    fireEvent.click(screen.getByText("Copy relative path"));
+    await flushMicrotasks();
+
+    expect(error).toHaveBeenCalledWith("Couldn't copy path to clipboard");
+    expect(info).not.toHaveBeenCalled();
   });
 
   it("closes on an outside click once the listeners attach", async () => {

--- a/web/src/components/diff/__tests__/DiffFileList.copyPath.test.tsx
+++ b/web/src/components/diff/__tests__/DiffFileList.copyPath.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { DiffFileList } from "../DiffFileList";
+import type { RepoBase, RichDiffFile } from "../../../lib/types";
+
+const files: RichDiffFile[] = [
+  {
+    path: "src/app/foo.rs",
+    old_path: null,
+    status: "modified",
+    additions: 1,
+    deletions: 0,
+  },
+];
+
+const perRepoBases: RepoBase[] = [{ base_branch: "main" }];
+
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  return writeText;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("DiffFileList copy relative path", () => {
+  it("right-clicking a file row offers Copy relative path and copies it", () => {
+    const writeText = stubClipboard();
+    render(
+      <DiffFileList
+        files={files}
+        perRepoBases={perRepoBases}
+        warning={null}
+        selectedPath={null}
+        selectedRepoName={undefined}
+        loading={false}
+        onSelectFile={() => {}}
+      />,
+    );
+
+    const row = screen.getByText("foo.rs").closest("button");
+    expect(row).not.toBeNull();
+    fireEvent.contextMenu(row as HTMLElement);
+
+    fireEvent.click(screen.getByText("Copy relative path"));
+    expect(writeText).toHaveBeenCalledWith("src/app/foo.rs");
+  });
+
+  it("does not open the menu when right-clicking off a file row", () => {
+    render(
+      <DiffFileList
+        files={files}
+        perRepoBases={perRepoBases}
+        warning={null}
+        selectedPath={null}
+        selectedRepoName={undefined}
+        loading={false}
+        onSelectFile={() => {}}
+      />,
+    );
+
+    // The "Changes" header has no data-path ancestor, so the delegated handler
+    // bails and no menu opens (the native menu is left to the browser).
+    fireEvent.contextMenu(screen.getByText("Changes"));
+    expect(screen.queryByText("Copy relative path")).toBeNull();
+  });
+
+  it("copies from a flat-list row too", () => {
+    const writeText = stubClipboard();
+    window.localStorage.setItem(
+      "aoe-web-settings",
+      JSON.stringify({ diffViewMode: "flat" }),
+    );
+    render(
+      <DiffFileList
+        files={files}
+        perRepoBases={perRepoBases}
+        warning={null}
+        selectedPath={null}
+        selectedRepoName={undefined}
+        loading={false}
+        onSelectFile={() => {}}
+      />,
+    );
+
+    const row = screen.getByText("foo.rs").closest("button");
+    fireEvent.contextMenu(row as HTMLElement);
+    fireEvent.click(screen.getByText("Copy relative path"));
+    expect(writeText).toHaveBeenCalledWith("src/app/foo.rs");
+  });
+});

--- a/web/src/components/diff/__tests__/DiffFileList.copyPath.test.tsx
+++ b/web/src/components/diff/__tests__/DiffFileList.copyPath.test.tsx
@@ -17,6 +17,10 @@ const files: RichDiffFile[] = [
 const perRepoBases: RepoBase[] = [{ base_branch: "main" }];
 
 function stubClipboard() {
+  Object.defineProperty(window, "isSecureContext", {
+    value: true,
+    configurable: true,
+  });
   const writeText = vi.fn().mockResolvedValue(undefined);
   Object.defineProperty(navigator, "clipboard", {
     value: { writeText },
@@ -91,6 +95,10 @@ describe("DiffFileList copy relative path", () => {
     );
 
     const row = screen.getByText("foo.rs").closest("button");
+    // Sanity-check we're actually in flat mode: FlatList renders the dir
+    // prefix inline on the row, so the test stays honest if the view-mode
+    // wiring changes.
+    expect(row?.textContent).toContain("src/app/");
     fireEvent.contextMenu(row as HTMLElement);
     fireEvent.click(screen.getByText("Copy relative path"));
     expect(writeText).toHaveBeenCalledWith("src/app/foo.rs");

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,0 +1,39 @@
+/** Write `text` to the clipboard, returning whether it succeeded.
+ *
+ *  Prefers the async Clipboard API, but that is only defined in secure
+ *  contexts (HTTPS or `localhost`). `aoe serve` is frequently reached
+ *  over plain HTTP on a LAN or Tailscale IP, where `navigator.clipboard`
+ *  is `undefined`, so fall back to a hidden-textarea `execCommand("copy")`
+ *  (same approach the mobile terminal toolbar uses for its paste path). */
+export async function writeClipboard(text: string): Promise<boolean> {
+  if (window.isSecureContext && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied, no document focus, etc. Fall through to the
+      // execCommand path rather than failing outright.
+    }
+  }
+  return legacyCopy(text);
+}
+
+function legacyCopy(text: string): boolean {
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  // Keep it off-screen and non-interactive so selecting it neither scrolls
+  // the page nor steals focus visibly.
+  ta.setAttribute("readonly", "");
+  ta.style.position = "fixed";
+  ta.style.top = "-9999px";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(ta);
+  }
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -854,6 +854,19 @@
       ]
     },
     {
+      "id": "right-panel.diff-copy-path",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": [
+        "src/components/diff/__tests__/CopyPathContextMenu.test.tsx",
+        "src/components/diff/__tests__/DiffFileList.copyPath.test.tsx"
+      ],
+      "components": [
+        "web/src/components/diff/CopyPathContextMenu.tsx",
+        "web/src/components/diff/DiffFileList.tsx"
+      ]
+    },
+    {
       "id": "right-panel.diff",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -863,7 +863,8 @@
       ],
       "components": [
         "web/src/components/diff/CopyPathContextMenu.tsx",
-        "web/src/components/diff/DiffFileList.tsx"
+        "web/src/components/diff/DiffFileList.tsx",
+        "web/src/lib/clipboard.ts"
       ]
     },
     {


### PR DESCRIPTION
## Description

Adds a quick way to copy a changed file's **repo-relative path** from the diff/Changes file list, on both surfaces.

**Web dashboard**
- Right-click any file row (or a folder row in tree view) in the Changes list to get a small **"Copy relative path"** menu that writes the path to the clipboard.
- Wired via a `data-path` attribute on each row plus one delegated `onContextMenu` handler, with a portal-rendered `CopyPathContextMenu` dismissed on outside click, another right-click, or Escape. The close listeners are attached on the next animation frame so the opening right-click doesn't immediately re-trigger them (same pattern as the existing sidebar menu).

**Native TUI**
- Press `y` (yank) in the diff view to copy the selected file's path via the existing OSC 52 clipboard helper, with a `Copied <path>` confirmation in the footer. Advertised in the footer hint and help overlay.

Paths come straight from the diff model (`DiffFile.path` / `RichDiffFile.path`), which are already relative to the file's repository root, so they paste straight into commands or comments and are correct in multi-repo workspaces. No backend changes.

### Try it locally

```
# TUI:  aoe -> open a session's diff (D) -> highlight a file -> press `y` (yank)
# Web:  aoe serve -> open a session's diff -> right-click a file (or a tree folder) -> "Copy relative path"
```

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary <!-- docs/guides/diff-view.md: `y` keybind + web right-click -->
- [x] For UI changes: included screenshot or recording <!-- will attach the web context-menu screenshot -->

## Test Coverage Analysis

**Web dashboard / cockpit**
- [x] Added tests and updated `web/tests/coverage-matrix.json`. These are **Vitest + RTL** (`CopyPathContextMenu.test.tsx`, `DiffFileList.copyPath.test.tsx`) rather than Playwright: per CONTRIBUTING/CLAUDE.md, rendering-logic surfaces use Vitest. Matrix entry `right-panel.diff-copy-path`.

**TUI / CLI (e2e test)**
- [x] Skipped a full e2e, because: the path extraction and the `y` keybinding are covered by deterministic in-module unit tests (`selected_path_string`, `y_key_is_wired_and_continues`). Copying itself goes through the existing OSC 52 helper, which is best-effort I/O not worth asserting against the real clipboard in a test.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Opus)

**Any Additional AI Details you'd like to share:** Collaborative effort — I specified the feature, made the design and scoping decisions (keybinding choice, right-click UX, manual verification), and steered and reviewed throughout; the AI wrote the implementation under that direction.

- [x] I am an AI Agent filling out this form (check box if true)

## Screenshots

<img width="1258" height="868" alt="image" src="https://github.com/user-attachments/assets/6e903062-1e5a-4a41-95e7-4c2c88459f53" />


<img width="404" height="418" alt="image" src="https://github.com/user-attachments/assets/46496e0b-8ed2-41cc-bb98-f01794ca25f8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a “copy relative path” feature to the Changes/diff views in both the web dashboard and the native TUI so users can quickly copy a changed file’s repository‑relative path to the clipboard.

What changed (high level)
- Web dashboard
  - New CopyPathContextMenu component: portal-rendered right-click menu with a “Copy relative path” action.
  - DiffFileList augmented to add data-path attributes to file/folder rows and open the context menu via a delegated onContextMenu handler (works in tree and flat list modes, per-repo bodies included).
  - Menu dismissal: outside click, another right-click, or Escape — dismissal listeners are attached via requestAnimationFrame to avoid immediate close.
  - Clipboard write uses navigator.clipboard.writeText (failures ignored).
  - Tests: Vitest + React Testing Library cover the context menu (open/close/inside-click guard) and DiffFileList delegated behavior; coverage-matrix updated.
- Native TUI
  - New normal-mode keybinding: press "y" to copy the selected file’s repo-relative path.
  - DiffView helpers: selected_path_string() and copy_selected_path(); copy_selected_path uses the existing OSC 52 clipboard helper and sets a footer success_message "Copied <path>".
  - Help overlay/footer hints updated to advertise the new keybinding.
  - Tests: Rust unit test asserts y-key behavior and footer confirmation; OSC 52 is best-effort/no-op in CI without clipboard tooling.
- Documentation
  - Diff view guide updated with a “Copying a file’s path” section, try-it instructions, screenshots, and the 'y' key added to command lists.
- Tests & CI
  - Web tests increase CopyPathContextMenu coverage and exercise dismissal edge cases; DiffFileList.copyPath tests exercise flat/tree modes. TUI unit test verifies user-visible confirmation. Coverage mapping added for the new web surface.

Benefits
- Quicker workflows: single right-click (web) or keystroke (TUI) to copy repo-relative paths, useful in multi-repo workspaces and for pasting into commands, PRs, or comments.
- Low-risk: no backend changes and reuses existing clipboard helpers and UI patterns.
- Better test coverage for the new UI surface and dismissal edge cases.

Potential improvements
- Surface a visible fallback/toast when navigator.clipboard is unavailable or write fails (current web implementation ignores failures).
- Make the TUI keybinding configurable; optionally offer absolute-path copy.
- Add an end-to-end web test (Playwright) to exercise context-menu UX and clipboard behavior.

Technical notes (concise)
- Web: CopyPathContextMenu is exported with PathMenuState {x,y,path}; rendered via createPortal at click coords; installs deferred document listeners and suppresses native contextmenu on the menu; copy action attempts navigator.clipboard.writeText(menu.path) then calls onClose().
- DiffFileList: rows in tree and flat modes (including per-repo RepoBody) now carry data-path attributes; a delegated onContextMenu handler finds the nearest data-path ancestor, prevents default, and sets PathMenuState to open the menu.
- TUI: handle_normal_key maps 'y' to copy_selected_path(), which reads selected_path_string(), invokes crate::tui::clipboard::copy_to_clipboard (OSC 52), and sets success_message = Some(format!("Copied {path}")).
- Tests: Vitest + RTL for web components (CopyPathContextMenu and DiffFileList copy-path behavior); Rust in-module tests for TUI input/path helpers; coverage-matrix JSON updated to include the new surface mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->