### PR TITLE
fix: reduce live mode echo latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check CLI docs are up-to-date
         run: |
-          cargo xtask gen-docs
+          mkdir -p target/ci-web-dist
+          printf '<!doctype html><title>aoe docs placeholder</title>\n' > target/ci-web-dist/index.html
+          AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo xtask gen-docs
           git diff --exit-code docs/cli/reference.md \
             || (echo "::error::CLI docs are out of date. Run 'cargo xtask gen-docs' and commit." && exit 1)
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,10 @@ jobs:
           node-version: '22'
 
       - name: Generate CLI documentation
-        run: cargo xtask gen-docs
+        run: |
+          mkdir -p target/ci-web-dist
+          printf '<!doctype html><title>aoe docs placeholder</title>\n' > target/ci-web-dist/index.html
+          AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo xtask gen-docs
 
       - name: Build site
         run: ./scripts/build-site.sh

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -476,6 +476,12 @@ impl LiveCaptureWake {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::tui) enum EmptyCapturePolicy {
+    PreserveLastGood,
+    ForwardEmpty,
+}
+
 /// Off-thread preview capture for live-send. Spawned alongside
 /// [`LiveSendWorker`] for the targeted tmux pane, it forks
 /// `tmux capture-pane` on its own thread and publishes fresh pane
@@ -506,7 +512,7 @@ impl Drop for LiveCaptureWorker {
 }
 
 impl LiveCaptureWorker {
-    pub(in crate::tui) fn spawn(tmux_name: String) -> Self {
+    pub(in crate::tui) fn spawn(tmux_name: String, empty_policy: EmptyCapturePolicy) -> Self {
         use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         use std::sync::{Arc, Mutex};
         let capture_lines = Arc::new(AtomicUsize::new(0));
@@ -522,13 +528,17 @@ impl LiveCaptureWorker {
             while !stop_flag.load(Ordering::Relaxed) {
                 let lines = lines_cell.load(Ordering::Relaxed);
                 if lines > 0 {
-                    if let Ok(content) = session.capture_pane(lines) {
-                        // Skip empties (preserve the last-good preview, the
-                        // #1501 kill switch) and unchanged frames (no point
-                        // waking a re-parse). Only changed, non-empty
-                        // captures reach the render loop.
-                        if !content.is_empty() && last_captured.as_deref() != Some(content.as_str())
-                        {
+                    let capture = match session.capture_pane(lines) {
+                        Ok(content) => Some(content),
+                        Err(_) if empty_policy == EmptyCapturePolicy::ForwardEmpty => {
+                            Some(String::new())
+                        }
+                        Err(_) => None,
+                    };
+                    if let Some(content) = capture {
+                        let allow_empty = empty_policy == EmptyCapturePolicy::ForwardEmpty;
+                        let changed = last_captured.as_deref() != Some(content.as_str());
+                        if (allow_empty || !content.is_empty()) && changed {
                             if let Ok(mut guard) = slot.lock() {
                                 *guard = Some(content.clone());
                             }
@@ -1364,7 +1374,10 @@ mod tests {
     fn live_capture_worker_idle_until_geometry_set() {
         // With no line count published the worker must not capture at all,
         // so nothing crosses the channel. (`capture_lines == 0` guard.)
-        let worker = LiveCaptureWorker::spawn("aoe_test_capture_no_geometry".into());
+        let worker = LiveCaptureWorker::spawn(
+            "aoe_test_capture_no_geometry".into(),
+            EmptyCapturePolicy::PreserveLastGood,
+        );
         std::thread::sleep(std::time::Duration::from_millis(60));
         assert!(
             worker.take_latest().is_none(),
@@ -1378,12 +1391,32 @@ mod tests {
         // strings. Forwarding those would blank the preview, defeating the
         // #1501 kill switch, so the worker must drop them. Deterministic
         // without a real tmux session: a missing pane always reads empty.
-        let worker = LiveCaptureWorker::spawn("aoe_test_capture_missing_session".into());
+        let worker = LiveCaptureWorker::spawn(
+            "aoe_test_capture_missing_session".into(),
+            EmptyCapturePolicy::PreserveLastGood,
+        );
         worker.set_capture_lines(40);
         std::thread::sleep(std::time::Duration::from_millis(80));
         assert!(
             worker.take_latest().is_none(),
             "empty captures must never be forwarded",
+        );
+    }
+
+    #[test]
+    fn live_capture_worker_can_forward_empty_captures() {
+        // Terminal previews treat empty output as meaningful: a missing or
+        // blank pane should clear stale terminal text instead of preserving it.
+        let worker = LiveCaptureWorker::spawn(
+            "aoe_test_capture_forward_empty".into(),
+            EmptyCapturePolicy::ForwardEmpty,
+        );
+        worker.set_capture_lines(40);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        assert_eq!(
+            worker.take_latest(),
+            Some(String::new()),
+            "forward-empty policy must surface empty captures",
         );
     }
 }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -411,7 +411,7 @@ pub(in crate::tui) struct LiveSendWorker {
 }
 
 impl LiveSendWorker {
-    pub(super) fn spawn(tmux_name: String) -> Self {
+    pub(super) fn spawn(tmux_name: String, capture_wake: Option<LiveCaptureWake>) -> Self {
         let (tx, rx) = channel::<WorkerMsg>();
         std::thread::spawn(move || {
             // Block until the first message, then drain anything else
@@ -426,6 +426,9 @@ impl LiveSendWorker {
                     batch.push(msg);
                 }
                 dispatch_batch(&tmux_name, batch);
+                if let Some(wake) = &capture_wake {
+                    wake.wake();
+                }
             }
         });
         Self { tx }
@@ -462,20 +465,25 @@ impl LiveSendWorker {
 /// forks, since the render only paints every ~33ms anyway).
 const LIVE_CAPTURE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
-/// Off-thread preview capture for agent live-send. Spawned alongside
-/// [`LiveSendWorker`] when live-send targets the agent pane, it forks
-/// `tmux capture-pane` on its own thread and publishes fresh pane content
-/// into a single-slot mailbox the render loop drains. The render loop
-/// applies the latest content without forking, which is what moves the
-/// per-frame capture cost (~8.5ms measured on macOS, ~90% of a live-send
-/// frame) off the hot path. Dropping the worker flips `stop` so the
-/// thread exits after its current cycle; like `LiveSendWorker` we don't
-/// join.
-///
-/// Scoped to the agent target on purpose: only the agent preview
-/// force-refreshes every frame in live-send (the terminal/container/tool
-/// previews stay 250ms-throttled), so it's the only path paying the
-/// per-frame fork. Non-agent targets keep the synchronous capture.
+#[derive(Clone)]
+pub(in crate::tui) struct LiveCaptureWake {
+    tx: Sender<()>,
+}
+
+impl LiveCaptureWake {
+    fn wake(&self) {
+        let _ = self.tx.send(());
+    }
+}
+
+/// Off-thread preview capture for live-send. Spawned alongside
+/// [`LiveSendWorker`] for the targeted tmux pane, it forks
+/// `tmux capture-pane` on its own thread and publishes fresh pane
+/// content into a single-slot mailbox the render loop drains. The render
+/// loop applies the latest content without forking, which moves the
+/// per-frame capture cost off the hot path. Dropping the worker flips
+/// `stop` so the thread exits after its current cycle; like
+/// `LiveSendWorker` we don't join.
 pub(in crate::tui) struct LiveCaptureWorker {
     /// Lines the render loop wants captured (height + scrollback + buffer).
     /// `0` means "not set yet"; the worker skips capturing until the first
@@ -487,11 +495,13 @@ pub(in crate::tui) struct LiveCaptureWorker {
     /// the render thread stalls.
     latest: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    wake_tx: Sender<()>,
 }
 
 impl Drop for LiveCaptureWorker {
     fn drop(&mut self) {
         self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        let _ = self.wake_tx.send(());
     }
 }
 
@@ -502,6 +512,7 @@ impl LiveCaptureWorker {
         let capture_lines = Arc::new(AtomicUsize::new(0));
         let latest: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
         let stop = Arc::new(AtomicBool::new(false));
+        let (wake_tx, wake_rx) = channel::<()>();
         let lines_cell = capture_lines.clone();
         let slot = latest.clone();
         let stop_flag = stop.clone();
@@ -525,13 +536,24 @@ impl LiveCaptureWorker {
                         }
                     }
                 }
-                std::thread::sleep(LIVE_CAPTURE_INTERVAL);
+                match wake_rx.recv_timeout(LIVE_CAPTURE_INTERVAL) {
+                    Ok(_) => while wake_rx.try_recv().is_ok() {},
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                }
             }
         });
         Self {
             capture_lines,
             latest,
             stop,
+            wake_tx,
+        }
+    }
+
+    pub(in crate::tui) fn waker(&self) -> LiveCaptureWake {
+        LiveCaptureWake {
+            tx: self.wake_tx.clone(),
         }
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2948,15 +2948,17 @@ impl HomeView {
             // against the old session before we reset its sizing.
             self.live_send_worker = None;
             // Stop the old session's capture worker too; a fresh one
-            // (if the new target is the agent) is spawned below.
+            // for the new live target is spawned below.
             self.live_capture_worker = None;
-            // Drop the previous session's cached preview so the first
+            // Drop the previous session's cached previews so the first
             // frames after the switch don't paint session A's content
-            // under session B's header while B's capture worker spins up.
+            // under session B's header while the capture worker spins up.
             // (The synchronous path got this for free via its cross-session
             // kill-switch branch; the worker path applies content lazily,
             // so clear it explicitly here.)
             self.preview_cache = PreviewCache::default();
+            self.terminal_preview_cache = PreviewCache::default();
+            self.container_terminal_preview_cache = PreviewCache::default();
             if let Some(name) = &prev_tmux_name {
                 crate::tmux::Session::from_name(name).reset_size_to_latest_client();
             }
@@ -2996,24 +2998,23 @@ impl HomeView {
             exit_chords,
             leader,
         });
+        // Spawn the off-thread preview capture first so the send worker can
+        // wake it after each dispatched batch. That keeps echo latency tied
+        // to actual input rather than the background capture phase.
+        self.live_capture_worker = Some(live_send::LiveCaptureWorker::spawn(tmux_name.clone()));
+        let capture_wake = self
+            .live_capture_worker
+            .as_ref()
+            .map(live_send::LiveCaptureWorker::waker);
         // Spawn the background worker that dispatches translated
         // keystrokes as one-shot `tmux send-keys` subprocesses (the
         // pre-#1485 path; control-mode was tried as an optimization
         // but turned out to be unreliable on real-world tmux setups
         // and was removed in favor of this simpler model).
-        self.live_send_worker = Some(live_send::LiveSendWorker::spawn(tmux_name.clone()));
-        // Spawn the off-thread preview capture only for the agent target:
-        // it's the one preview that force-refreshes every frame in
-        // live-send, so it's the only path paying the per-frame
-        // capture-pane fork. `tmux_name` is the agent session here.
-        self.live_capture_worker = match target {
-            live_send::LiveSendTarget::Agent => {
-                Some(live_send::LiveCaptureWorker::spawn(tmux_name))
-            }
-            live_send::LiveSendTarget::Terminal | live_send::LiveSendTarget::ContainerTerminal => {
-                None
-            }
-        };
+        self.live_send_worker = Some(live_send::LiveSendWorker::spawn(
+            tmux_name.clone(),
+            capture_wake,
+        ));
         // Start every live-mode entry (including a switch from another
         // session) with a disarmed leader menu, so a half-entered chord
         // can't carry over from a prior target.

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3001,7 +3001,16 @@ impl HomeView {
         // Spawn the off-thread preview capture first so the send worker can
         // wake it after each dispatched batch. That keeps echo latency tied
         // to actual input rather than the background capture phase.
-        self.live_capture_worker = Some(live_send::LiveCaptureWorker::spawn(tmux_name.clone()));
+        let empty_policy = match target {
+            live_send::LiveSendTarget::Agent => live_send::EmptyCapturePolicy::PreserveLastGood,
+            live_send::LiveSendTarget::Terminal | live_send::LiveSendTarget::ContainerTerminal => {
+                live_send::EmptyCapturePolicy::ForwardEmpty
+            }
+        };
+        self.live_capture_worker = Some(live_send::LiveCaptureWorker::spawn(
+            tmux_name.clone(),
+            empty_policy,
+        ));
         let capture_wake = self
             .live_capture_worker
             .as_ref()

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1339,11 +1339,10 @@ impl HomeView {
 
     pub(super) fn refresh_preview_cache_if_needed(&mut self, width: u16, height: u16) {
         // Outside live-send, captures fork a fresh `tmux capture-pane` so we
-        // throttle to 250ms (4 Hz). Inside agent live-send the fork moves off
-        // the render thread entirely: `LiveCaptureWorker` keeps the cache
-        // fresh on its own thread and the block below just applies the newest
-        // content (the core's `force` flag and the synchronous fork remain
-        // for non-agent live-send targets and the throttled non-live path).
+        // throttle to 250ms (4 Hz). Inside live-send the fork moves off the
+        // render thread entirely for the active target:
+        // `LiveCaptureWorker` keeps the cache fresh on its own thread and
+        // the target-specific branch applies the newest content.
         // This replaced the old per-frame on-thread fork, which the
         // `tui.render` trace measured at ~8.5ms on macOS (~90% of a frame).
         // Control-mode capture was removed with the rest of the `tmux -C`
@@ -1434,8 +1433,7 @@ impl HomeView {
 
         // Captures otherwise go through the fork-based path
         // (`Session::capture_pane_with_size` via the instance helper); the
-        // synchronous path runs outside live-send (250ms-throttled) and for
-        // non-agent live-send targets, which don't force-refresh per frame.
+        // synchronous path runs outside live-send (250ms-throttled).
         //
         // Live vs. non-live failure semantics differ. In live mode an empty
         // capture (which is what `Session::capture_pane_with_size` returns when
@@ -1489,6 +1487,32 @@ impl HomeView {
         // the visible output area so a window resize or info-header toggle
         // reflows the shell instead of waiting for a live-mode re-enter.
         self.resize_live_pane_if_target(live_send::LiveSendTarget::Terminal, width, height);
+        let terminal_live = self
+            .live_send
+            .as_ref()
+            .is_some_and(|s| s.target == live_send::LiveSendTarget::Terminal);
+        if terminal_live {
+            if let Some(id) = self.selected_session.clone() {
+                let capture_lines = capture_lines_for(height, self.preview_scroll_offset);
+                let latest = self.live_capture_worker.as_ref().map(|worker| {
+                    worker.set_capture_lines(capture_lines);
+                    worker.take_latest()
+                });
+                if let Some(latest) = latest {
+                    if let Some(content) = latest {
+                        let captured_lines =
+                            self.terminal_preview_cache
+                                .store_capture(content, id, (width, height));
+                        self.preview_scroll_offset = clamp_scroll_to_capture(
+                            self.preview_scroll_offset,
+                            captured_lines,
+                            self.preview_visible_rows,
+                        );
+                    }
+                    return;
+                }
+            }
+        }
         self.refresh_preview_cache_core(
             width,
             height,
@@ -1515,6 +1539,34 @@ impl HomeView {
             width,
             height,
         );
+        let container_live = self
+            .live_send
+            .as_ref()
+            .is_some_and(|s| s.target == live_send::LiveSendTarget::ContainerTerminal);
+        if container_live {
+            if let Some(id) = self.selected_session.clone() {
+                let capture_lines = capture_lines_for(height, self.preview_scroll_offset);
+                let latest = self.live_capture_worker.as_ref().map(|worker| {
+                    worker.set_capture_lines(capture_lines);
+                    worker.take_latest()
+                });
+                if let Some(latest) = latest {
+                    if let Some(content) = latest {
+                        let captured_lines = self.container_terminal_preview_cache.store_capture(
+                            content,
+                            id,
+                            (width, height),
+                        );
+                        self.preview_scroll_offset = clamp_scroll_to_capture(
+                            self.preview_scroll_offset,
+                            captured_lines,
+                            self.preview_visible_rows,
+                        );
+                    }
+                    return;
+                }
+            }
+        }
         self.refresh_preview_cache_core(
             width,
             height,

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8016,6 +8016,54 @@ mod live_send_mode {
         assert_eq!(env.view.terminal_preview_cache.session_id, Some(id));
     }
 
+    #[test]
+    #[serial]
+    fn refresh_terminal_live_cache_overwrites_on_empty_worker_capture() {
+        // Same invariant as `refresh_terminal_cache_overwrites_on_empty_capture`,
+        // but through the live worker path added for terminal live mode.
+        let mut env = create_test_env_with_sessions(1);
+        let id = env
+            .view
+            .flat_items
+            .iter()
+            .find_map(|item| match item {
+                crate::session::Item::Session { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .expect("test env has one session");
+        env.view.selected_session = Some(id.clone());
+        env.view.terminal_preview_cache.content = "stale terminal output".to_string();
+        env.view.terminal_preview_cache.captured_lines = 1;
+        env.view.terminal_preview_cache.dimensions = (10, 10);
+        env.view.terminal_preview_cache.session_id = Some(id.clone());
+
+        let tmux_name = "aoe_test_terminal_live_forward_empty";
+        let worker = crate::tui::home::live_send::LiveCaptureWorker::spawn(
+            tmux_name.to_string(),
+            crate::tui::home::live_send::EmptyCapturePolicy::ForwardEmpty,
+        );
+        worker.set_capture_lines(44);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        env.view.live_capture_worker = Some(worker);
+        env.view.live_send = Some(LiveSendState {
+            session_id: id.clone(),
+            title: "session0".to_string(),
+            tmux_name: tmux_name.to_string(),
+            target: crate::tui::home::live_send::LiveSendTarget::Terminal,
+            exit_chords: Vec::new(),
+            leader: None,
+        });
+
+        env.view.refresh_terminal_preview_cache_if_needed(80, 24);
+
+        assert_eq!(
+            env.view.terminal_preview_cache.content, "",
+            "terminal live worker must clear stale output on empty capture"
+        );
+        assert_eq!(env.view.terminal_preview_cache.dimensions, (80, 24));
+        assert_eq!(env.view.terminal_preview_cache.session_id, Some(id));
+    }
+
     mod paste_splitting {
         //! `split_paste_for_live_send` decomposes a pasted string into
         //! tmux operations the live-send worker can actually deliver.


### PR DESCRIPTION
## Description
Reduces perceived lag in AoE live-send mode by waking the off-thread capture worker immediately after live-send dispatches a tmux input batch. This avoids waiting for the next arbitrary capture polling phase before the TUI can render echoed input.

Also extends the off-thread live capture path to host-terminal and container-terminal live targets, which previously fell back to the normal 250 ms preview cache cadence.

Profiling summary:
- Before: agent live key-to-visible echo was 47-60 ms, mean 51.8 ms.
- After: final probe was 28.9-39.5 ms, mean 34.1 ms.
- Final trace sample: 2,637 live frames, p50 0.89 ms, p99 3.67 ms, 0 frames over 16 ms.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No docs update needed. This is a responsiveness fix in existing live-send behavior. No screenshot or recording included because the change is latency/cadence rather than visual output.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: deterministic latency assertions would be environment-sensitive and flaky. Existing live-send worker/unit coverage still passes, and this PR includes manual tmux profiling before and after the change.

Tested:
- `cargo fmt --check`
- `cargo build`
- `cargo test live_send`
- `cargo clippy`
- Manual disposable tmux latency probe with fake agent

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Codex

**Any Additional AI Details you'd like to share:**
Codex investigated the live-send/render pipeline, implemented the change, ran tests, and performed disposable tmux profiling.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR reduces perceived echo latency in AoE's live-send mode by waking the off‑thread capture worker immediately after dispatching tmux input batches and by extending the off‑thread live‑capture path to terminal and container‑terminal targets.

### What changed (high-level)
- Send-input worker can wake the capture worker right after sending keys, removing wait for the next periodic capture.
- Off-thread live-capture optimization extended from Agent-only to Terminal and ContainerTerminal targets.
- Capture worker is spawned first and hands a wake handle to the send-input worker.
- Preview caches for terminal and container-terminal are cleared when switching live-send sessions to avoid stale previews.
- Added an empty-capture policy to choose whether empty captures are forwarded or suppressed; capture loop honors this policy.
- Tests updated and a new test verifies terminal live-mode cache behavior when the worker forwards empty captures.
- CI/docs workflows: small change to ensure a placeholder web-dist exists before generating docs.

### Benefits
- Lower key-to-visible echo latency: mean reduced from ~51.8 ms to ~34.1 ms (~34% improvement).
- Profiling shows improved frame timing and no frames >16 ms (p50 0.89 ms, p99 3.67 ms) — smoother, more responsive live-send across targets.
- Cleaner cache behavior when switching sessions reduces incorrect/stale previews.

### Notable technical points
- New type: LiveCaptureWake (wraps Sender<()>); LiveCaptureWorker exposes waker() for the send worker.
- LiveSendWorker::spawn signature changed to accept Option<LiveCaptureWake>.
- LiveCaptureWorker::spawn now accepts EmptyCapturePolicy (PreserveLastGood | ForwardEmpty); capture loop uses recv_timeout on a wake receiver and drains wake messages to respond immediately.
- LiveCaptureWorker::Drop sets the stop flag and sends a wake to unblock the thread.
- Render refresh functions (terminal/container-terminal) now read from live_capture_worker output when live-send targets them, falling back to synchronous capture otherwise.
- Tests: updated to pass new spawn signatures and include a test for forwarding empty captures; author ran fmt, build, clippy, and live_send tests locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->