### PR TITLE
feat(cockpit): honor agent_command_override on cockpit spawn and preview it in the wizard

### DIFF
--- a/docs/cockpit/setup.md
+++ b/docs/cockpit/setup.md
@@ -80,6 +80,33 @@ aoe add . --cockpit --agent aoe-agent --model llama3.3:ollama
 aoe add . --cockpit --agent gemini
 ```
 
+### Launch command and session name
+
+`--cmd <tool>` resolves through `session.agent_command_override` for
+cockpit sessions, the same as for tmux sessions. With
+
+```toml
+[session.agent_command_override]
+opencode = "opencode-plannotator"
+```
+
+`aoe add . --cmd opencode --cockpit` launches `opencode-plannotator`,
+not the bare `opencode` binary; the override's binary replaces the
+registry command and the agent's required ACP args are preserved (so
+`opencode acp` becomes `opencode-plannotator acp`). The override is
+applied only to a built-in agent whose registry binary matches the
+tool's own binary; adapter-backed agents such as Claude keep using
+`session.agent_cockpit_cmd` for a full command swap.
+
+The web new-session wizard shows the resolved launch command read-only
+so you can confirm it before the session starts.
+
+Session naming differs by entry point. `aoe add` is non-interactive: it
+uses `--title` when given, otherwise the worktree branch name, otherwise
+a generated name; it never prompts. The TUI `n` flow and the web
+new-session wizard prompt for a name interactively. To name a session
+created from the CLI, pass `--title "<name>"`.
+
 ### Globally
 
 The settings live in `config.toml` under `[cockpit]`:

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -611,17 +611,23 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// argv. Never mutates the registry, so two profiles defining the
     /// same custom name with different commands don't clobber each other
     /// and `/cockpit/switch-agent` validation stays per-session.
+    ///
+    /// The returned bool is true when the spec came from the built-in
+    /// registry (vs an `agent_cockpit_cmd` custom spec); callers use it
+    /// to decide whether a command override may overlay the spec without
+    /// taking the registry lock a second time. See #1766.
     pub async fn resolve_agent_spec(
         &self,
         name: &str,
         config: &crate::session::config::SessionConfig,
-    ) -> Result<AgentSpec, SupervisorError> {
+    ) -> Result<(AgentSpec, bool), SupervisorError> {
         if let Some(spec) = self.registry.lock().await.get(name).cloned() {
-            return Ok(spec);
+            return Ok((spec, true));
         }
         if let Some(cmd) = config.agent_cockpit_cmd.get(name) {
-            return AgentSpec::from_cockpit_cmd(name, cmd)
-                .map_err(SupervisorError::InvalidAgentCommand);
+            let spec = AgentSpec::from_cockpit_cmd(name, cmd)
+                .map_err(SupervisorError::InvalidAgentCommand)?;
+            return Ok((spec, false));
         }
         Err(SupervisorError::UnknownAgent(name.into()))
     }
@@ -1196,12 +1202,12 @@ impl<S: BroadcastSink> Supervisor<S> {
         .map_err(|e| {
             SupervisorError::InvalidAgentCommand(format!("config load task failed: {e}"))
         })?;
-        // Whether the resolved spec came from the built-in registry
-        // (vs an `agent_cockpit_cmd` custom spec). The command override
-        // only overlays registry specs; custom ACP commands own their
-        // full argv already.
-        let spec_from_registry = self.registry.lock().await.get(&agent).is_some();
-        let mut spec = self
+        // `spec_from_registry` distinguishes a built-in registry spec
+        // from an `agent_cockpit_cmd` custom spec: the command override
+        // only overlays registry specs (custom ACP commands own their
+        // full argv already). Returned by `resolve_agent_spec` so the
+        // registry is locked once, not raced across two reads.
+        let (mut spec, spec_from_registry) = self
             .resolve_agent_spec(&agent, &resolved_cfg.session)
             .await?;
         // Overlay the instance command override (e.g. opencode →

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -400,10 +400,24 @@ impl Drop for ResumeReservation {
     }
 }
 
+/// Instance-level command override carried from the stored session
+/// (`Instance.command`, populated by `session.agent_command_override`
+/// or `--cmd-override` in `aoe add`). The tmux substrate already
+/// honors `Instance.command`; this lets the cockpit substrate do the
+/// same so a session launches the same binary regardless of substrate.
+/// `logical_tool` is the instance's tool (e.g. `opencode`), kept
+/// separate from the launched binary so agent-name-keyed behavior
+/// (tool-kind mapping, status, `_meta`) stays correct. See #1766.
+#[derive(Debug, Clone)]
+pub struct AgentCommandOverride {
+    pub logical_tool: String,
+    pub command: String,
+}
+
 /// Inputs to `Supervisor::spawn`. A struct (rather than seven
 /// positional params with `#[allow(clippy::too_many_arguments)]`)
 /// because the previous signature was the kind that produces real
-/// bugs the next time someone adds a field — the auto-spawn caller in
+/// bugs the next time someone adds a field; the auto-spawn caller in
 /// `create_session` had to thread six identical values through the
 /// API plus a seventh on this PR.
 #[derive(Debug, Clone)]
@@ -438,6 +452,64 @@ pub struct SpawnRequest {
     /// Best-effort: adapters that don't advertise bypass mode log a
     /// warning and stay in default. See #1142.
     pub yolo_mode: bool,
+    /// When `Some`, overlay the instance's resolved launch command on
+    /// the registry `AgentSpec` so cockpit honors
+    /// `session.agent_command_override` like tmux does. Applied only
+    /// to registry-backed, same-tool specs whose binary matches the
+    /// tool's built-in binary (see `apply_agent_command_override`).
+    /// See #1766.
+    pub agent_command_override: Option<AgentCommandOverride>,
+}
+
+/// True when `command` names the same executable as `binary`, comparing
+/// the file name so an absolute path (`/usr/local/bin/opencode`) still
+/// matches the built-in binary name (`opencode`).
+fn command_matches_binary(command: &str, binary: &str) -> bool {
+    command == binary
+        || std::path::Path::new(command)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .is_some_and(|name| name == binary)
+}
+
+/// Overlay an instance command override onto a resolved `AgentSpec`.
+///
+/// Applies only when the override is safe: the spec came from the
+/// built-in registry, the selected agent is the override's logical
+/// tool, and the spec's command is that tool's built-in binary. This
+/// keeps `agent_command_override.opencode = "opencode-plannotator"`
+/// working (registry `opencode` → binary `opencode`) while leaving
+/// adapter-backed agents like Claude (`claude-agent-acp`) untouched,
+/// where `agent_cockpit_cmd` is the right knob for a full argv swap.
+///
+/// The override is treated as a command prefix: its first word replaces
+/// `spec.command`, any remaining words are prepended to `spec.args`, so
+/// the registry's ACP args (e.g. `acp`) are preserved
+/// (`opencode-plannotator` → `opencode-plannotator acp`). See #1766.
+fn apply_agent_command_override(
+    selected_agent: &str,
+    spec_from_registry: bool,
+    ovr: &AgentCommandOverride,
+    spec: &mut AgentSpec,
+) -> Result<(), SupervisorError> {
+    if !spec_from_registry || selected_agent != ovr.logical_tool {
+        return Ok(());
+    }
+    let Some(agent_def) = crate::agents::get_agent(&ovr.logical_tool) else {
+        return Ok(());
+    };
+    if !command_matches_binary(&spec.command, agent_def.binary) {
+        return Ok(());
+    }
+    let mut argv = shell_words::split(&ovr.command)
+        .map_err(|e| SupervisorError::InvalidAgentCommand(format!("{e}")))?;
+    if argv.is_empty() || argv[0].trim().is_empty() {
+        return Ok(());
+    }
+    spec.command = argv.remove(0);
+    argv.append(&mut spec.args);
+    spec.args = argv;
+    Ok(())
 }
 
 impl<S: BroadcastSink> Supervisor<S> {
@@ -1082,6 +1154,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             sandbox_info,
             source_profile,
             yolo_mode,
+            agent_command_override,
         } = req;
 
         // Per-agent install gate. claude-agent-acp lazy-installs its
@@ -1123,9 +1196,20 @@ impl<S: BroadcastSink> Supervisor<S> {
         .map_err(|e| {
             SupervisorError::InvalidAgentCommand(format!("config load task failed: {e}"))
         })?;
+        // Whether the resolved spec came from the built-in registry
+        // (vs an `agent_cockpit_cmd` custom spec). The command override
+        // only overlays registry specs; custom ACP commands own their
+        // full argv already.
+        let spec_from_registry = self.registry.lock().await.get(&agent).is_some();
         let mut spec = self
             .resolve_agent_spec(&agent, &resolved_cfg.session)
             .await?;
+        // Overlay the instance command override (e.g. opencode →
+        // opencode-plannotator from `session.agent_command_override`)
+        // so cockpit launches the same binary tmux would. See #1766.
+        if let Some(ref ovr) = agent_command_override {
+            apply_agent_command_override(&agent, spec_from_registry, ovr, &mut spec)?;
+        }
         // Apply ${aoe_data_dir} placeholder substitution against the
         // appropriate path; if the placeholder is not consumed it stays
         // as-is and the spawn will fail with a clear error.
@@ -2596,6 +2680,90 @@ impl BroadcastSink for ChannelSink {
 mod tests {
     use super::*;
 
+    fn spec(command: &str, args: &[&str]) -> AgentSpec {
+        AgentSpec {
+            command: command.into(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            description: "test".into(),
+            env_allowlist: None,
+        }
+    }
+
+    fn ovr(tool: &str, command: &str) -> AgentCommandOverride {
+        AgentCommandOverride {
+            logical_tool: tool.into(),
+            command: command.into(),
+        }
+    }
+
+    #[test]
+    fn command_override_replaces_binary_and_preserves_registry_args() {
+        // The #1766 case: opencode → opencode-plannotator, keep `acp`.
+        let mut s = spec("opencode", &["acp"]);
+        apply_agent_command_override(
+            "opencode",
+            true,
+            &ovr("opencode", "opencode-plannotator"),
+            &mut s,
+        )
+        .unwrap();
+        assert_eq!(s.command, "opencode-plannotator");
+        assert_eq!(s.args, vec!["acp".to_string()]);
+    }
+
+    #[test]
+    fn command_override_splits_args_and_prepends_before_registry_args() {
+        let mut s = spec("opencode", &["acp"]);
+        apply_agent_command_override(
+            "opencode",
+            true,
+            &ovr("opencode", "opencode-plannotator --profile plan"),
+            &mut s,
+        )
+        .unwrap();
+        assert_eq!(s.command, "opencode-plannotator");
+        assert_eq!(s.args, vec!["--profile", "plan", "acp"]);
+    }
+
+    #[test]
+    fn command_override_skips_non_registry_spec() {
+        let mut s = spec("opencode", &["acp"]);
+        apply_agent_command_override(
+            "opencode",
+            false,
+            &ovr("opencode", "opencode-plannotator"),
+            &mut s,
+        )
+        .unwrap();
+        assert_eq!(s.command, "opencode");
+        assert_eq!(s.args, vec!["acp".to_string()]);
+    }
+
+    #[test]
+    fn command_override_skips_adapter_binary_mismatch() {
+        // Claude's cockpit binary is the adapter `claude-agent-acp`, not
+        // `claude`, so a terminal `agent_command_override.claude` must
+        // not rewrite the adapter command.
+        let mut s = spec("claude-agent-acp", &[]);
+        apply_agent_command_override("claude", true, &ovr("claude", "claude-wrapper"), &mut s)
+            .unwrap();
+        assert_eq!(s.command, "claude-agent-acp");
+        assert!(s.args.is_empty());
+    }
+
+    #[test]
+    fn command_override_skips_when_agent_differs_from_logical_tool() {
+        let mut s = spec("aoe-agent", &[]);
+        apply_agent_command_override(
+            "aoe-agent",
+            true,
+            &ovr("opencode", "opencode-plannotator"),
+            &mut s,
+        )
+        .unwrap();
+        assert_eq!(s.command, "aoe-agent");
+    }
+
     /// In-memory sink that captures published frames.
     struct VecSink {
         frames: std::sync::Mutex<Vec<(String, u64, Event)>>,
@@ -2643,6 +2811,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                agent_command_override: None,
             })
             .await;
         assert!(matches!(result, Err(SupervisorError::UnknownAgent(_))));
@@ -2681,6 +2850,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                agent_command_override: None,
             })
             .await;
         assert!(matches!(result, Err(SupervisorError::AlreadyRunning(_))));
@@ -3890,6 +4060,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                agent_command_override: None,
             })
             .await;
         match result {
@@ -3962,6 +4133,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                agent_command_override: None,
             })
             .await;
         match result {
@@ -4181,6 +4353,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                agent_command_override: None,
             })
             .await;
         match result {
@@ -4232,6 +4405,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                agent_command_override: None,
             })
             .await;
         match result {

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -351,6 +351,10 @@ pub async fn spawn_cockpit(
             sandbox_info,
             source_profile,
             yolo_mode,
+            agent_command_override: crate::server::cockpit_reconciler::command_override_for_spawn(
+                &instance.tool,
+                &instance.command,
+            ),
         })
         .await
     {
@@ -554,6 +558,13 @@ pub async fn switch_cockpit_agent(
             sandbox_info,
             source_profile,
             yolo_mode: instance.yolo_mode,
+            // Gated in the supervisor: only applies when the selected
+            // agent equals the instance tool and its binary matches, so
+            // an explicit switch to a different agent is unaffected.
+            agent_command_override: crate::server::cockpit_reconciler::command_override_for_spawn(
+                &instance.tool,
+                &instance.command,
+            ),
         })
         .await;
     if let Err(e) = spawn_result {
@@ -1338,6 +1349,10 @@ pub async fn cockpit_enable(
     let stored_acp_session_id = instance.cockpit_acp_session_id.clone();
     let yolo_mode = instance.yolo_mode;
     let profile_for_spawn = profile.clone();
+    let command_override = crate::server::cockpit_reconciler::command_override_for_spawn(
+        &instance.tool,
+        &instance.command,
+    );
     let state_for_spawn = state.clone();
     tokio::spawn(async move {
         let inst_lock = state_for_spawn.instance_lock(&session_id).await;
@@ -1373,6 +1388,7 @@ pub async fn cockpit_enable(
                 sandbox_info,
                 source_profile,
                 yolo_mode,
+                agent_command_override: command_override,
             })
             .await
         {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2470,6 +2470,7 @@ pub async fn create_session(
                     instance.cockpit_acp_session_id.clone(),
                     instance.source_profile.clone(),
                     instance.yolo_mode,
+                    instance.command.clone(),
                 ))
             } else {
                 None
@@ -2488,6 +2489,7 @@ pub async fn create_session(
                 stored_acp_session_id,
                 source_profile,
                 yolo_mode,
+                command,
             )) = cockpit_spawn_target
             {
                 let agent = state
@@ -2499,6 +2501,8 @@ pub async fn create_session(
                         std::path::Path::new(&project_path),
                     )
                     .await;
+                let command_override =
+                    crate::server::cockpit_reconciler::command_override_for_spawn(&tool, &command);
                 let cwd = std::path::PathBuf::from(project_path);
                 let supervisor = state.cockpit_supervisor.clone();
                 let state_for_check = state.clone();
@@ -2546,6 +2550,7 @@ pub async fn create_session(
                             sandbox_info,
                             source_profile: source_profile_for_spawn,
                             yolo_mode,
+                            agent_command_override: command_override,
                         })
                         .await
                     {

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -61,6 +61,10 @@ struct ResumeTarget {
     source_profile: String,
     in_flight_turn: bool,
     yolo_mode: bool,
+    /// `Instance.command`: the resolved launch command (from
+    /// `session.agent_command_override` / `--cmd-override`). Threaded
+    /// into `SpawnRequest` so cockpit honors it like tmux. See #1766.
+    command: String,
 }
 
 /// Tuple shape used by the instance-list snapshot. Aliased to dodge
@@ -75,6 +79,7 @@ type RawTargetTuple = (
     Option<String>,
     String,
     bool,
+    String,
 );
 
 pub async fn reconcile_cockpit_workers(
@@ -168,6 +173,7 @@ pub async fn reconcile_cockpit_workers(
                     i.cockpit_acp_session_id.clone(),
                     i.source_profile.clone(),
                     i.yolo_mode,
+                    i.command.clone(),
                 )
             })
             .collect()
@@ -200,6 +206,7 @@ pub async fn reconcile_cockpit_workers(
         stored_acp_session_id,
         source_profile,
         yolo_mode,
+        command,
     ) in raw_targets
     {
         if attempted.contains(&id) {
@@ -272,6 +279,7 @@ pub async fn reconcile_cockpit_workers(
             source_profile,
             in_flight_turn,
             yolo_mode,
+            command,
         });
     }
 
@@ -805,6 +813,7 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
         source_profile,
         in_flight_turn,
         yolo_mode,
+        command,
     } = target;
 
     // Reattach path: if a previous daemon detached a runner for this
@@ -944,6 +953,7 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
         source_profile,
         in_flight_turn,
         yolo_mode,
+        command,
     };
     let req = match build_spawn_request(&state, &resume_target).await {
         Ok(req) => req,
@@ -1037,6 +1047,26 @@ async fn build_spawn_request(
         sandbox_info,
         source_profile: Some(target.source_profile.clone()),
         yolo_mode: target.yolo_mode,
+        agent_command_override: command_override_for_spawn(&target.tool, &target.command),
+    })
+}
+
+/// Build a cockpit command override from the instance's persisted
+/// launch command. Returns `None` for an empty command so the spawn
+/// keeps the registry default. Applicability gating (registry-backed,
+/// matching binary) lives in the supervisor where the resolved
+/// `AgentSpec` is available. See #1766.
+pub(crate) fn command_override_for_spawn(
+    tool: &str,
+    command: &str,
+) -> Option<crate::cockpit::supervisor::AgentCommandOverride> {
+    let command = command.trim();
+    if command.is_empty() {
+        return None;
+    }
+    Some(crate::cockpit::supervisor::AgentCommandOverride {
+        logical_tool: tool.to_string(),
+        command: command.to_string(),
     })
 }
 
@@ -1065,6 +1095,7 @@ async fn resume_target_for_session(state: &Arc<AppState>, id: &str) -> Option<Re
         source_profile: inst.source_profile.clone(),
         in_flight_turn: false,
         yolo_mode: inst.yolo_mode,
+        command: inst.command.clone(),
     })
 }
 

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -146,6 +146,9 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
 
   useEffect(() => {
     let cancelled = false;
+    // Clear immediately so a profile switch never shows the previous
+    // profile's override while the new fetch is in flight.
+    setCommandMaps({ agentCommandOverride: {}, customAgents: {} });
     void (async () => {
       const settings = await fetchSettings(data.profile || undefined);
       if (cancelled || !settings) return;

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { AgentInfo, ProfileInfo } from "../../../lib/types";
 import { fetchSettings } from "../../../lib/api";
 import { isAcpCapable } from "../../../lib/acpCapableTools";
+import { resolveLaunchCommand } from "../../../lib/launchCommand";
 
 interface WizardData {
   tool: string;
@@ -134,6 +135,46 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
   const isHostOnly = selectedAgent?.host_only ?? false;
   const [showAdvanced, setShowAdvanced] = useState(data.advancedEnabled);
   const showProfilePicker = profiles.length > 1;
+
+  // Command-override maps from the profile-resolved config, used to
+  // preview the exact launch command (#1766). Read-only; mirrors the
+  // backend `resolve_tool_command` precedence.
+  const [commandMaps, setCommandMaps] = useState<{
+    agentCommandOverride: Record<string, string>;
+    customAgents: Record<string, string>;
+  }>({ agentCommandOverride: {}, customAgents: {} });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const settings = await fetchSettings(data.profile || undefined);
+      if (cancelled || !settings) return;
+      const session = settings.session as Record<string, unknown> | undefined;
+      const asMap = (v: unknown): Record<string, string> =>
+        v && typeof v === "object"
+          ? Object.fromEntries(
+              Object.entries(v as Record<string, unknown>).filter(
+                ([, val]) => typeof val === "string",
+              ) as [string, string][],
+            )
+          : {};
+      setCommandMaps({
+        agentCommandOverride: asMap(session?.agent_command_override),
+        customAgents: asMap(session?.custom_agents),
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [data.profile]);
+
+  const resolvedCommand = resolveLaunchCommand({
+    tool: data.tool,
+    binary: selectedAgent?.binary,
+    manualOverride: data.commandOverride,
+    agentCommandOverride: commandMaps.agentCommandOverride,
+    customAgents: commandMaps.customAgents,
+  });
 
   const handleProfileChange = useCallback(async (profileName: string) => {
     // If user had manual edits, confirm before overwriting
@@ -424,6 +465,17 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
               placeholder="Override the agent launch command"
               className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
             />
+            {resolvedCommand && (
+              <p
+                className="mt-1.5 text-xs text-text-dim"
+                data-testid="resolved-launch-command"
+              >
+                Resolved launch command:{" "}
+                <code className="font-mono text-text-secondary">
+                  {resolvedCommand}
+                </code>
+              </p>
+            )}
           </div>
         </div>
       )}

--- a/web/src/lib/launchCommand.test.ts
+++ b/web/src/lib/launchCommand.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { resolveLaunchCommand } from "./launchCommand";
+
+describe("resolveLaunchCommand", () => {
+  it("uses session.agent_command_override when no manual override (the #1766 case)", () => {
+    expect(
+      resolveLaunchCommand({
+        tool: "opencode",
+        binary: "opencode",
+        agentCommandOverride: { opencode: "opencode-plannotator" },
+      }),
+    ).toBe("opencode-plannotator");
+  });
+
+  it("manual override wins over the config override", () => {
+    expect(
+      resolveLaunchCommand({
+        tool: "opencode",
+        binary: "opencode",
+        manualOverride: "opencode --foo",
+        agentCommandOverride: { opencode: "opencode-plannotator" },
+      }),
+    ).toBe("opencode --foo");
+  });
+
+  it("falls back to custom_agents when no manual or agent override", () => {
+    expect(
+      resolveLaunchCommand({
+        tool: "my-agent",
+        binary: "my-agent",
+        customAgents: { "my-agent": "my-agent-wrapper run" },
+      }),
+    ).toBe("my-agent-wrapper run");
+  });
+
+  it("falls back to the agent binary when nothing is overridden", () => {
+    expect(resolveLaunchCommand({ tool: "claude", binary: "claude-agent-acp" })).toBe(
+      "claude-agent-acp",
+    );
+  });
+
+  it("falls back to the tool name when no binary is known", () => {
+    expect(resolveLaunchCommand({ tool: "opencode" })).toBe("opencode");
+  });
+
+  it("ignores a whitespace-only manual override", () => {
+    expect(
+      resolveLaunchCommand({
+        tool: "opencode",
+        binary: "opencode",
+        manualOverride: "   ",
+        agentCommandOverride: { opencode: "opencode-plannotator" },
+      }),
+    ).toBe("opencode-plannotator");
+  });
+
+  it("ignores an empty-string config override entry", () => {
+    expect(
+      resolveLaunchCommand({
+        tool: "opencode",
+        binary: "opencode",
+        agentCommandOverride: { opencode: "" },
+      }),
+    ).toBe("opencode");
+  });
+});

--- a/web/src/lib/launchCommand.ts
+++ b/web/src/lib/launchCommand.ts
@@ -1,0 +1,36 @@
+// Resolve the launch command a session will run for a given tool,
+// mirroring the backend `SessionConfig::resolve_tool_command`
+// precedence (src/session/config.rs): a manual per-session override
+// wins, then `session.agent_command_override`, then `custom_agents`,
+// otherwise the agent's own binary (or the tool name as a last resort).
+//
+// Used by the new-session wizard to preview the exact command before a
+// session starts, so a configured override (e.g. opencode →
+// opencode-plannotator) is visible up front rather than a surprise once
+// the agent launches. See #1766.
+
+export interface ResolveLaunchCommandInput {
+  /** Selected tool / agent name, e.g. "opencode". */
+  tool: string;
+  /** The agent's built-in binary, shown when no override applies. */
+  binary?: string;
+  /** Manual per-session override typed in the wizard. Wins when set. */
+  manualOverride?: string;
+  /** `session.agent_command_override` map from settings. */
+  agentCommandOverride?: Record<string, string>;
+  /** `session.custom_agents` map from settings. */
+  customAgents?: Record<string, string>;
+}
+
+export function resolveLaunchCommand(input: ResolveLaunchCommandInput): string {
+  const manual = input.manualOverride?.trim();
+  if (manual) return manual;
+
+  const override = input.agentCommandOverride?.[input.tool]?.trim();
+  if (override) return override;
+
+  const custom = input.customAgents?.[input.tool]?.trim();
+  if (custom) return custom;
+
+  return (input.binary || input.tool).trim();
+}

--- a/web/src/lib/launchCommand.ts
+++ b/web/src/lib/launchCommand.ts
@@ -32,5 +32,5 @@ export function resolveLaunchCommand(input: ResolveLaunchCommandInput): string {
   const custom = input.customAgents?.[input.tool]?.trim();
   if (custom) return custom;
 
-  return (input.binary || input.tool).trim();
+  return input.binary?.trim() || input.tool.trim();
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Cockpit sessions ignored `session.agent_command_override`. With

```toml
[session.agent_command_override]
opencode = "opencode-plannotator"
```

`aoe add . --cmd opencode --cockpit` then `aoe serve` launched plain `opencode`, while the equivalent tmux session correctly launched `opencode-plannotator`. The override was resolved onto `instance.command` in `aoe add`, and the tmux substrate honors it, but the cockpit spawn path dropped it: `ResumeTarget` carried no command and every spawn site resolved only an agent name from the registry, then launched the registry's `AgentSpec.command`.

This threads the instance's resolved command through the reconciler resume path and all four REST spawn sites into a new `SpawnRequest.agent_command_override`, and overlays it on the resolved `AgentSpec` in `spawn_inner`. The override's first word replaces the spec command and any remaining words prepend to the registry args, so `opencode acp` becomes `opencode-plannotator acp`. It is gated to a registry-backed, same-tool spec whose binary matches the tool's built-in binary, so adapter-backed agents like Claude (`claude-agent-acp`) are left untouched and keep using `session.agent_cockpit_cmd` for a full command swap.

The web new-session wizard now shows a read-only "Resolved launch command" line under the Command override field, computed by a `resolveLaunchCommand` helper that mirrors the backend `resolve_tool_command` precedence (manual override, then `agent_command_override`, then `custom_agents`, else the agent binary), so a configured override is visible before the session starts rather than a surprise once the agent launches.

Docs note the new cockpit override behavior, the wizard preview, and that `aoe add` is non-interactive (uses `--title` or a derived name) while the TUI and web new-session flows prompt for a name.

This is the OpenCode command-override slice of epic #1828. The mode-picker work (#1764, #1827) lands in #1770; the tool-card UX items (#1767) are deferred pending a live Plannotator reproduction.

Closes #1766

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Add `[session.agent_command_override]` with `opencode = "opencode-plannotator"` (or any wrapper binary you have) to `config.toml`, run `aoe add . --cmd opencode --cockpit`, then `aoe serve`, open the session, and confirm the launched process is the override binary, not bare `opencode`.
- [ ] Remove the override and confirm a cockpit OpenCode session still launches plain `opencode acp` (no regression).
- [ ] Confirm a Claude cockpit session still launches via the `claude-agent-acp` adapter (the override gate skips it).
- [ ] In the web new-session wizard, pick OpenCode, expand Advanced, and confirm a "Resolved launch command" line under Command override reflects the configured override (and the agent binary when none is set).
- [ ] Type a value into the wizard's Command override field and confirm the preview updates to that manual value.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a Playwright spec, because: the wizard preview's logic lives in a pure helper (`web/src/lib/launchCommand.ts`) covered by a new Vitest suite (`launchCommand.test.ts`); the display is a thin presentational wrapper over it, and `AgentStep.tsx` is already mapped in `web/tests/coverage-matrix.json` via the existing `wizard-agent-step` entry.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Skipped an e2e test, because: the override-application behavior is covered by Rust unit tests on `apply_agent_command_override` (registry-binary swap, arg splitting/prepend, no-op for non-registry specs, no-op for adapter-binary mismatch, no-op when the agent differs from the tool); a full e2e would need a real wrapper binary on `PATH` to observe the launched process.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction; the spawn-path design was vetted through a multi-model debate. I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR ensures Cockpit session launches honor per-instance agent command overrides and surfaces the resolved launch command in the web new-session wizard. It fixes cases where Cockpit previously dropped session.agent_command_override during spawn/resume, so registry-backed agents now launch with the same resolved command seen elsewhere (TUI, aoe add).

## What changed (high level)

- Backend: Thread instance-level command overrides through the reconciler resume path and into all Cockpit spawn sites by adding an agent_command_override to spawn requests. When appropriate, overlay the override onto registry-backed agent specs so the resolved binary and args are used at spawn time.
- Web UI: Add a read-only "Resolved launch command" preview in the Agent step of the new-session wizard, computed with the same precedence rules used by the backend.
- Docs/tests: Documented the override behavior and session-naming differences across entry points; added Rust unit tests for override application and Vitest tests for the wizard helper.

## Key technical notes

- New types/fields: AgentCommandOverride struct and SpawnRequest.agent_command_override.
- Supervisor changes: resolve_agent_spec now indicates whether a spec is registry-backed; new helpers command_matches_binary and apply_agent_command_override safely apply overrides.
- Override semantics: override's first token replaces the agent binary; remaining tokens are prepended to registry args (e.g., "opencode acp" → "opencode-plannotator acp").
- Gating: Only applied for same-tool, registry-backed specs whose binary matches the built-in binary. Adapter-backed agents (e.g., Claude) are unaffected and continue to use session.agent_cockpit_cmd.
- Frontend resolver: resolveLaunchCommand mirrors backend precedence (manual override → session agent_command_override → custom_agents → agent binary → tool name) and trims/ignores empty overrides.
- Reconciler: ResumeTarget now carries the instance command so auto-resume and prompt-wake resume use the same resolved command.

## Benefits

- Restores parity between Cockpit and TUI/CLI launches for command overrides.
- Makes the final launch command visible to users before starting a session, reducing surprises.
- Preserves required registry args while allowing safe local command swaps.
- Keeps adapter-backed agent behavior unchanged for safety.

## Potential follow-ups / enhancements

- Consider offering an editable preview in the wizard (currently read-only) to allow on-the-fly adjustments.
- Harmonize CLI interactive naming behavior (aoe add non-interactive vs TUI prompt) if consistent UX is desired across entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->