### PR TITLE
feat(web): show empty-state hint in sidebar when no sessions

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -12,7 +12,8 @@ auth, see the [Web Dashboard overview](../web-dashboard.md).
 
 - **Workspace sidebar** (left) lists every session grouped by repo, with
   a live status glyph per row. On phones it collapses behind a toggle in
-  the top bar.
+  the top bar. With no sessions yet, the sidebar shows a short hint and a
+  **New session** button that opens the wizard.
 - **Main pane** shows the selected session: the agent terminal (or
   cockpit view), with the diff and paired terminal reachable from the
   top bar.

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2810,6 +2810,40 @@ export function WorkspaceSidebar({
               </p>
             </div>
           )}
+
+          {!hasResults && !filterQuery && (
+            <div
+              className="px-4 py-10 text-center"
+              data-testid="sidebar-empty-state"
+            >
+              <p className="text-sm font-medium text-text-secondary">
+                No sessions yet
+              </p>
+              <p className="mt-1 text-[13px] text-text-muted">
+                Create a session to start working in a repo.
+              </p>
+              <button
+                onClick={onNew}
+                disabled={offline}
+                className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-brand-600 px-3 py-1.5 text-[13px] font-medium text-white hover:bg-brand-500 cursor-pointer transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-brand-600"
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="12" y1="5" x2="12" y2="19" />
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+                New session
+              </button>
+            </div>
+          )}
         </div>
 
         <div className="border-t border-surface-700/20 p-2 flex items-center gap-1">

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -601,6 +601,17 @@
       ]
     },
     {
+      "id": "sidebar.empty-state",
+      "kind": "mocked-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/sidebar-empty-state.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "sidebar.reorder-stationary-click",
       "kind": "mocked-playwright",
       "risk": "medium",

--- a/web/tests/sidebar-empty-state.spec.ts
+++ b/web/tests/sidebar-empty-state.spec.ts
@@ -1,0 +1,49 @@
+// With no sessions and no active filter, the sidebar body used to render
+// blank (only the filtered "No matches" message existed). It now shows a
+// hint plus a New session button wired to the same wizard trigger as the
+// top + button. See #1835.
+
+import { test, expect } from "./helpers/mockedTest";
+import { installSidebarMocks } from "./helpers/sidebarMocks";
+
+test("empty sidebar shows a hint and opens the wizard from its button", async ({
+  page,
+}) => {
+  await installSidebarMocks(page, { sessions: [] });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  const empty = page.getByTestId("sidebar-empty-state");
+  await expect(empty).toBeVisible();
+  await expect(empty).toContainText("No sessions yet");
+
+  // No rows render when the list is empty.
+  await expect(page.getByTestId("sidebar-session-row")).toHaveCount(0);
+
+  // The CTA opens the session wizard (heading is distinct from the
+  // button's own "New session" label).
+  await empty.getByRole("button", { name: "New session" }).click();
+  await expect(
+    page.getByRole("heading", { name: "New session" }),
+  ).toBeVisible();
+});
+
+test("empty-state hint is hidden once a session exists", async ({ page }) => {
+  await installSidebarMocks(page, {
+    sessions: [
+      {
+        id: "s-a",
+        title: "alpha",
+        project_path: "/tmp/repo",
+        branch: "feature/a",
+      },
+    ],
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  await expect(page.getByTestId("sidebar-session-row")).toHaveCount(1);
+  await expect(page.getByTestId("sidebar-empty-state")).toHaveCount(0);
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

When the web dashboard's workspace sidebar had no sessions and no active filter, the sidebar body rendered completely blank. The only empty state that existed was the filtered "No matches for ..." message, so a first-run user with nothing yet just saw an empty pane with no indication of what to do.

This adds an empty-state hint in that case: a short "No sessions yet" message plus a **New session** button wired to the same wizard trigger (`onNew`) as the top "+" button. The button is disabled offline, mirroring the existing top "New session" button. The hint only shows when there are no rendered groups and no filter query, so the existing filtered "No matches" message is untouched and the hint disappears as soon as a session exists.

Closes #1835

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard with no sessions and no projects; confirm the sidebar shows "No sessions yet" and a "New session" button instead of a blank pane.
- [ ] Click that button; confirm the New session wizard opens.
- [ ] Create a session; confirm the hint disappears and the session list renders as before.
- [ ] Open the filter and type a non-matching query while sessions exist; confirm the "No matches for ..." message still shows (not the empty-state hint).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (CTA opens the session wizard, wording) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR improves the user experience for new users of the web dashboard by adding a helpful empty-state message to the sidebar. When users first open the dashboard with no sessions created yet, instead of seeing a blank sidebar, they now see a clear message ("No sessions yet") with a "New session" button that guides them on what to do next.

## What Changed

**Component Updates:**
- Modified the sidebar component (`WorkspaceSidebar.tsx`) to detect when there are no sessions and no active filters, and display an empty-state panel with explanatory text and a call-to-action button
- The "New session" button in the empty-state is wired to the same session creation wizard as the top "+" button and is disabled when the application is offline

**Documentation:**
- Updated the dashboard guide to document the new empty-state behavior and explain how it appears on mobile devices

**Testing:**
- Added comprehensive Playwright tests (`sidebar-empty-state.spec.ts`) that verify the empty-state appears and functions correctly, and that it disappears once a session is created
- Updated the test coverage matrix to track the new empty-state surface

## Benefits

- **Better onboarding:** New users immediately understand what they need to do next instead of staring at an empty sidebar
- **Consistent experience:** The empty-state only appears when appropriate—it doesn't interfere with filtered search results ("No matches for...") and disappears automatically once sessions exist
- **Accessibility & offline support:** The button respects the offline state, preventing actions that would fail without a connection

## Technical Details

The implementation is non-invasive: the empty-state is a conditional render in the sidebar that only displays when `sessionGroups.length === 0` and the filter query is empty. It follows the existing pattern for disabled states and integrates seamlessly with the current session creation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->