### PR TITLE
fix(web): add sidebar separator borders and align the sort tooltip style

### DIFF
--- a/web/src/components/SidebarSortPicker.tsx
+++ b/web/src/components/SidebarSortPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, Clock, ListOrdered, Siren } from "lucide-react";
 import type { SidebarSortMode } from "../lib/sidebarSort";
+import { Tooltip } from "./Tooltip";
 
 // Sidebar sort picker (#1640). Replaces the former two-state Clock /
 // ListOrdered toggle now that there are three modes; a cycle button gets
@@ -58,22 +59,23 @@ export function SidebarSortPicker({ sortMode, onSortModeChange }: Props) {
 
   return (
     <div ref={ref} className="relative">
-      <button
-        onClick={() => setOpen((o) => !o)}
-        title={TRIGGER_TOOLTIP[sortMode]}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-label={`Sort sessions, current: ${active.label}`}
-        data-testid="sidebar-sort-toggle"
-        data-sort-mode={sortMode}
-        className={`w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors ${
-          sortMode !== "manual"
-            ? "text-brand-500"
-            : "text-text-dim hover:text-text-secondary"
-        }`}
-      >
-        <ActiveIcon className="h-3.5 w-3.5" />
-      </button>
+      <Tooltip text={TRIGGER_TOOLTIP[sortMode]}>
+        <button
+          onClick={() => setOpen((o) => !o)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={`Sort sessions, current: ${active.label}`}
+          data-testid="sidebar-sort-toggle"
+          data-sort-mode={sortMode}
+          className={`w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors ${
+            sortMode !== "manual"
+              ? "text-brand-500"
+              : "text-text-dim hover:text-text-secondary"
+          }`}
+        >
+          <ActiveIcon className="h-3.5 w-3.5" />
+        </button>
+      </Tooltip>
 
       {open && (
         <div

--- a/web/src/components/Tooltip.tsx
+++ b/web/src/components/Tooltip.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+// Shared hover tooltip used by the sidebar control row (grouping axis, filter,
+// new session) and the sort picker. Renders a custom styled span instead of
+// the native browser `title` so every control shares one look. Lives in its
+// own module so SidebarSortPicker can import it without a cycle back through
+// WorkspaceSidebar (which imports SidebarSortPicker).
+export function Tooltip({
+  text,
+  children,
+}: {
+  text: string;
+  children: ReactNode;
+}) {
+  return (
+    <span className="relative group/tip inline-flex">
+      {children}
+      <span className="pointer-events-none absolute left-1/2 -translate-x-1/2 top-full mt-1.5 px-2 py-1 rounded bg-surface-950 border border-surface-700 text-[11px] text-text-secondary whitespace-nowrap opacity-0 scale-95 transition-all duration-100 group-hover/tip:opacity-100 group-hover/tip:scale-100 z-50">
+        {text}
+      </span>
+    </span>
+  );
+}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -108,6 +108,7 @@ import { StatusGlyph } from "./StatusGlyph";
 import { OwnerAvatar } from "./OwnerAvatar";
 import { SessionGroupModal } from "./SessionGroupModal";
 import { SidebarSortPicker } from "./SidebarSortPicker";
+import { Tooltip } from "./Tooltip";
 
 const SIDEBAR_WIDTH_KEY = "aoe-sidebar-width";
 const SUNK_EXPANDED_KEY = "aoe-sidebar-sunk-expanded";
@@ -1936,17 +1937,6 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
     </>
   );
 });
-
-function Tooltip({ text, children }: { text: string; children: React.ReactNode }) {
-  return (
-    <span className="relative group/tip inline-flex">
-      {children}
-      <span className="pointer-events-none absolute left-1/2 -translate-x-1/2 top-full mt-1.5 px-2 py-1 rounded bg-surface-950 border border-surface-700 text-[11px] text-text-secondary whitespace-nowrap opacity-0 scale-95 transition-all duration-100 group-hover/tip:opacity-100 group-hover/tip:scale-100 z-50">
-        {text}
-      </span>
-    </span>
-  );
-}
 
 function workspaceMatchesFilter(ws: Workspace, q: string): boolean {
   return (

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2375,7 +2375,7 @@ export function WorkspaceSidebar({
       <div
         {...tourAnchor(TOUR_ANCHORS.sidebar)}
         style={{ width }}
-        className={`fixed top-12 bottom-0 left-0 z-40 md:static md:z-auto bg-surface-800 flex flex-col md:h-full shrink-0 transition-transform duration-300 ease-in-out md:transition-none ${
+        className={`fixed top-12 bottom-0 left-0 z-40 md:static md:z-auto bg-surface-800 border-r border-surface-700/60 flex flex-col md:h-full shrink-0 transition-transform duration-300 ease-in-out md:transition-none ${
           open ? "translate-x-0" : "-translate-x-full md:hidden"
         }`}
       >
@@ -2491,7 +2491,7 @@ export function WorkspaceSidebar({
           />
         )}
 
-        <div className="flex-1 overflow-y-auto overflow-x-hidden">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden border-t border-surface-700/60">
           {!isNested && (
           <DragSuppressContext.Provider value={dragSuppressRef}>
           <DndContext

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -766,7 +766,8 @@
       ],
       "components": [
         "web/src/components/WorkspaceSidebar.tsx",
-        "web/src/components/SidebarSortPicker.tsx"
+        "web/src/components/SidebarSortPicker.tsx",
+        "web/src/components/Tooltip.tsx"
       ]
     },
     {

--- a/web/tests/sidebar-sort-mode.spec.ts
+++ b/web/tests/sidebar-sort-mode.spec.ts
@@ -411,4 +411,45 @@ test.describe("Sidebar sort picker (#1418, #1640)", () => {
     );
     expect(stored).toBe("attention");
   });
+
+  // #1836: the sort trigger used a native browser `title`, so its tooltip
+  // looked different from the grouping and filter controls (which wrap their
+  // buttons in the shared styled Tooltip). It now uses that same component,
+  // and the sidebar gained separator borders.
+  test("sort tooltip matches the styled group/filter tooltip; sidebar has separators (#1836)", async ({
+    page,
+  }) => {
+    const sessions: MockSession[] = [
+      {
+        id: "s1",
+        title: "alpha",
+        project_path: "/tmp/repo",
+        branch: "feature/a",
+        created_at: "2025-01-01T00:00:00Z",
+      },
+    ];
+    await mockApis(
+      page,
+      () => sessions,
+      () => ["/tmp/repo::feature/a"],
+    );
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    const toggle = page.locator(TOGGLE);
+    await expect(toggle).toBeVisible({ timeout: 8000 });
+
+    // No native browser tooltip on the trigger any more.
+    await expect(toggle).not.toHaveAttribute("title", /.+/);
+
+    // The active-mode label now lives in the shared Tooltip span, carrying
+    // the same surface-950 styling the group/filter tooltips use.
+    const tip = page.getByText("Sort: manual, drag enabled", { exact: true });
+    await expect(tip).toHaveClass(/bg-surface-950/);
+    await expect(tip).toHaveClass(/group-hover\/tip:opacity-100/);
+
+    // The scrollable session list is separated from the control row by a top
+    // border (the explicit ask in #1836).
+    await expect(page.locator("div.overflow-y-auto.border-t")).toHaveCount(1);
+  });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two small web dashboard UI nitpicks from #1836.

1. **Sidebar separators.** The sidebar header (project/group label plus the grouping, sort, filter, and new-session controls) ran straight into the scrollable session list with no visual break, and the sidebar had no edge against the main panel. Added a top border above the session list to separate it from the control row, and a right border on the sidebar to delimit it from the content area. Both use the `surface-700` divider token from `DESIGN.md`, at `/60` opacity so they read as subtle dividers rather than hard lines.

2. **Sort tooltip parity.** The sort picker trigger used a native browser `title` attribute, so its tooltip rendered with default OS styling while the grouping-axis and filter controls wrap their buttons in a custom styled `Tooltip`. Extracted that `Tooltip` out of `WorkspaceSidebar.tsx` into its own module (`web/src/components/Tooltip.tsx`) so `SidebarSortPicker` can reuse it without an import cycle, and wrapped the sort trigger in it. The sort tooltip now matches the group and filter tooltips exactly.

The changed components (`WorkspaceSidebar.tsx`, `SidebarSortPicker.tsx`) are already mapped in `web/tests/coverage-matrix.json` via the existing `sidebar.sort-toggle-ui` entry, so no new matrix entry was required.

Closes #1836

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard. In the sidebar, confirm a horizontal divider separates the control row (project/group label, grouping, sort, filter, new-session) from the session list below it.
- [ ] Confirm the sidebar has a visible right-edge border separating it from the main content panel.
- [ ] Hover the sort control (the icon between the grouping and filter buttons). Confirm its tooltip appears with the same dark styled look (surface-950 background, thin border, small text) as the grouping and filter tooltips, not a plain native browser tooltip.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added a case to the existing `web/tests/sidebar-sort-mode.spec.ts` asserting the sort trigger no longer carries a native `title`, renders the shared styled `Tooltip` span like group/filter, and that the session list has the new top-border separator. It fails on the pre-fix tree (verified). The coverage matrix already maps both changed components, so no new entry was needed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (border placement and opacity, extracting the shared Tooltip), reviewed each commit, and confirmed the reproduce-then-fix test goes red on the pre-fix tree.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR makes two small UI fixes to the web dashboard sidebar for improved visual separation and consistent tooltip styling:

1. Extracts a shared Tooltip component (web/src/components/Tooltip.tsx) so multiple sidebar controls can use the same styled tooltip.
2. Adds subtle divider borders: a top border above the session list and a right-edge border on the sidebar to separate controls from the scrollable sessions and the main content.
3. Replaces the sort control's native title tooltip with the shared styled Tooltip for parity with grouping/filter tooltips.
4. Adds Playwright test assertions to verify the tooltip replacement and the new separators, and updates the coverage matrix mapping.

What changed (files)
- Added: web/src/components/Tooltip.tsx
- Modified: web/src/components/SidebarSortPicker.tsx — trigger now wrapped with the shared Tooltip (removed native title)
- Modified: web/src/components/WorkspaceSidebar.tsx — imports Tooltip and adds right-edge + top-divider border styles
- Modified: web/tests/sidebar-sort-mode.spec.ts — tests assert no native title, shared Tooltip usage, and session-list top border
- Modified: web/tests/coverage-matrix.json — include Tooltip.tsx under existing sidebar surface mapping

Benefits
- Visual consistency: tooltips for sort/group/filter now match.
- Improved clarity: divider lines create clear separation between header/controls and the session list and between sidebar and main content.
- Maintainability: a single Tooltip component reduces duplication and avoids import cycles.
- Test coverage: automated checks protect against regressions in tooltip behavior and layout.

Technical notes (brief)
- Tooltip implemented as a small React component using Tailwind utility classes and group-hover to show an absolutely-positioned tooltip span.
- Sidebar borders use the design token surface-700 at 60% opacity per the linked issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->