### PR TITLE
docs: clarify web dashboard dev/user split and lead cockpit docs with the web wizard

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -69,21 +69,30 @@ For the full per-agent feature matrix, see [Multi-agent support](cockpit/multi-a
 
 ## Quickstart
 
-```bash
-# 1. Confirm prerequisites: aoe, Node.js >= 20, claude login.
-aoe cockpit doctor
+The web new-session wizard is the primary way to start a cockpit session.
+You do not need the CLI.
 
-# 2. Create a Claude Code session in cockpit mode.
-aoe add . --cmd claude --cockpit
-
-# 3. Open the dashboard, pick the session, and you should see the
-#    structured plan + tool-call cards instead of a terminal.
-aoe serve
-```
+1. Enable cockpit once: the **Cockpit** tab in dashboard settings, or set
+   `[cockpit] enabled = true` in `config.toml`.
+2. Run `aoe serve` and open the dashboard.
+3. Click **New session**, pick your project, and choose an agent. Leave
+   the **Use cockpit** toggle on (it defaults on for supported agents).
+4. Create and open the session: you see the structured plan and tool-call
+   cards instead of a terminal.
 
 A first-time mobile user pointed at a remote `aoe serve` will install
 the PWA, tap the session, and see the plan panel render the moment the
 agent emits its first plan event.
+
+The CLI is the optional path for scripting or headless launches:
+
+```bash
+# Confirm prerequisites: aoe, Node.js >= 20, claude login.
+aoe cockpit doctor
+
+# Create a Claude Code session in cockpit mode (optional, CLI path).
+aoe add . --cmd claude --cockpit
+```
 
 Full setup detail, including the prerequisites check and how to enable
 cockpit per session or globally, lives in [Setup](cockpit/setup.md).

--- a/docs/cockpit/setup.md
+++ b/docs/cockpit/setup.md
@@ -67,6 +67,19 @@ it exits 2; otherwise 0. Pass `--json` for machine-readable output.
 
 ### Per session
 
+#### From the web wizard (primary)
+
+When the cockpit master switch is on, the web new-session wizard shows a
+per-session **Use cockpit** toggle, on by default for supported agents.
+Open `aoe serve`, click **New session**, pick the agent, leave the toggle
+on, and create. No CLI required. Tools without a verified ACP adapter (and
+custom agents without `agent_cockpit_cmd`) have no toggle and stay in tmux.
+
+#### From the CLI (optional)
+
+For scripting, headless, or non-interactive launches, `aoe add` starts
+cockpit sessions too:
+
 ```bash
 # Force cockpit on for this session, regardless of defaults.
 aoe add . --cmd claude --cockpit

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,6 +10,8 @@ cargo build --profile dev-release  # Optimized build without LTO (faster compile
 
 The release binary is at `target/release/aoe`.
 
+The web dashboard needs the `serve` feature and Node.js: `cargo build --release --features serve`. See [Web Dashboard Development](development/web-dashboard.md).
+
 ## Running
 
 ```bash

--- a/docs/development/web-dashboard.md
+++ b/docs/development/web-dashboard.md
@@ -1,0 +1,59 @@
+# Web Dashboard Development
+
+Contributor notes for building, running, and hacking on the web dashboard. End users do not need any of this; the dashboard ships in every release binary. See the [Web Dashboard guide](../guides/web-dashboard.md) for how to launch and use it.
+
+## Building from source
+
+The dashboard needs the `serve` Cargo feature and Node.js/npm:
+
+```bash
+cargo build --release --features serve
+```
+
+The build automatically runs `npm install && npm run build` in the `web/` directory to compile the React frontend. The output is embedded in the binary, so there are no separate files to deploy. A plain `cargo build` (without `--features serve`) needs no JS tooling and produces a TUI-only binary.
+
+## One-command development
+
+On Unix, `cargo xtask dev` is the fastest inner loop. It builds the serve binary, then runs `aoe serve` (port 8081) and the Vite dev server (port 5173, with HMR) together, pointing Vite at the backend via `VITE_PROXY` so `/api` and the `/sessions/*/ws` relays resolve:
+
+```bash
+cargo xtask dev
+# Open http://localhost:5173
+# Ctrl-C stops both processes
+```
+
+## Manual frontend development
+
+If you prefer to run the pieces by hand, the React frontend lives in `web/`:
+
+```bash
+cd web
+npm install
+npm run dev     # Vite dev server with HMR on port 5173
+```
+
+For API/WebSocket requests, run the Rust server simultaneously:
+
+```bash
+cargo run --features serve -- serve
+```
+
+To work on the frontend against a "production" backend instead of a local build, set `VITE_PROXY` (shell env or `web/.env`) to that `aoe serve` origin, including a non-cargo install on a custom port, and the dev server forwards `/api` and `/sessions/*/ws` (terminal + cockpit) there:
+
+```bash
+VITE_PROXY=http://localhost:50106 npm run dev
+```
+
+Without it the dev server behaves as before; HMR is unaffected either way.
+
+## Architecture
+
+The server embeds an axum web server that serves the React frontend and provides:
+
+- REST API for session listing and control (`/api/sessions`); see the [HTTP API Reference](../api.md) for the orchestration endpoints (`send`, `output`)
+- WebSocket PTY relay for terminal streaming (`/sessions/:id/ws`)
+- Token-based authentication via cookie, query parameter, or WebSocket protocol header
+- Rate limiting, token rotation, and device tracking
+- Security headers (X-Frame-Options, Referrer-Policy)
+
+Each terminal connection spawns `tmux attach-session` inside a PTY and relays the raw byte stream bidirectionally over WebSocket. This gives the browser a real terminal experience identical to SSH, and is why sessions survive browser crashes and network drops.

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -19,15 +19,7 @@ Mobile and touch behavior is documented inline on each page, next to the surface
 
 The web dashboard is included in all release binaries: [GitHub Releases](https://github.com/agent-of-empires/agent-of-empires/releases), the [quick install script](../installation.md#quick-install-recommended), and Homebrew (`brew install aoe`). No extra build steps needed, just run `aoe serve`.
 
-## Building from source
-
-If building from source, you need the `serve` Cargo feature and Node.js/npm:
-
-```bash
-cargo build --release --features serve
-```
-
-The build automatically runs `npm install && npm run build` in the `web/` directory to compile the React frontend. The output is embedded in the binary, so there are no separate files to deploy.
+If you build from source, the dashboard requires the `serve` Cargo feature (and Node.js to compile the embedded frontend); see [Web Dashboard Development](../development/web-dashboard.md).
 
 ## Starting the server
 
@@ -234,34 +226,10 @@ aoe serve --daemon
 
 `Ctrl-C` on a foreground `aoe serve`, and `aoe serve --stop` against a daemon, both exit within ~5 seconds even with open dashboard tabs. Live cockpit and terminal WebSocket clients receive a close frame with code `1001` ("going away") so the browser logs a clean reason and skips its transient-error reconnect backoff for one cycle. The reconnect resumes normally once a fresh `aoe serve` is running. A 5-second hard cap acts as a safety net: if any handler fails to honor the shutdown signal, the process still exits and emits `WARN shutdown: graceful shutdown exceeded grace window, forcing exit`.
 
-## Architecture
+## How it works
 
-The server embeds an axum web server that serves a React frontend and provides:
-
-- REST API for session listing and control (`/api/sessions`); see the [HTTP API Reference](../api.md) for the orchestration endpoints (`send`, `output`)
-- WebSocket PTY relay for terminal streaming (`/sessions/:id/ws`)
-- Token-based authentication via cookie, query parameter, or WebSocket protocol header
-- Rate limiting, token rotation, and device tracking
-- Security headers (X-Frame-Options, Referrer-Policy)
-
-Each terminal connection spawns `tmux attach-session` inside a PTY and relays the raw byte stream bidirectionally over WebSocket. This gives the browser a real terminal experience identical to SSH.
+`aoe serve` runs an embedded server inside the `aoe` process; your browser connects to it to list sessions, stream terminal output, and (when write access is enabled) send input. Each terminal is backed by a real `tmux` session, so your work survives browser crashes, network drops, and reconnects.
 
 The terminal disconnect banner surfaces a WebSocket close code when it can't reach a working pane. The decoder ring for those codes lives on the [Terminal view](web/terminal.md#terminal-websocket-close-codes) page.
 
-## Frontend development
-
-The React frontend lives in `web/`:
-
-```bash
-cd web
-npm install
-npm run dev     # Vite dev server with HMR on port 5173
-```
-
-For API/WebSocket requests, run the Rust server simultaneously:
-
-```bash
-cargo run --features serve -- serve
-```
-
-If you are making only frontend changes and want to work on the local frontend against a "production" backend instead of a local build, set `VITE_PROXY` (shell env or `web/.env`) to that `aoe serve` origin, including a non-cargo install on a custom port, and the dev server forwards `/api` and `/sessions/*/ws` (terminal + cockpit) there: `VITE_PROXY=http://localhost:50106 npm run dev`. Without it the dev server behaves as before; HMR is unaffected either way.
+For build, architecture, and frontend-development details, see [Web Dashboard Development](../development/web-dashboard.md).

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -490,6 +490,17 @@
       ]
     },
     {
+      "id": "wizard.cockpit-mode-creation",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/wizard-cockpit-create-session.spec.ts"],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/steps/AgentStep.tsx",
+        "web/src/components/session-wizard/steps/ReviewStep.tsx"
+      ]
+    },
+    {
       "id": "wizard.scratch-delete-cleans-tempdir",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/wizard-cockpit-create-session.spec.ts
+++ b/web/tests/live/wizard-cockpit-create-session.spec.ts
@@ -1,0 +1,65 @@
+// User story: starting a session from the web wizard with the
+// "Use cockpit" toggle on creates a cockpit session end to end, with no
+// CLI command. Locks the primary-path behavior the cockpit Quickstart and
+// Setup docs now promise. Closes #1841.
+
+import { test, expect } from "@playwright/test";
+import { listSessions, spawnAoeServe } from "../helpers/aoeServe";
+
+test("wizard with Use cockpit on creates a cockpit_mode session", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page
+      .getByRole("button", { name: "New session", exact: true })
+      .first()
+      .click();
+
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    await expect(wizard).toBeVisible({ timeout: 15_000 });
+
+    // ProjectStep: a scratch dir keeps the test self-contained, advance.
+    await wizard.getByRole("switch", { name: "Skip project folder" }).click();
+    await wizard.getByRole("button", { name: "Next" }).click();
+
+    // SessionStep: title is auto-generated, advance.
+    await expect(
+      wizard.getByRole("heading", { name: "Name your session", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+    await wizard.getByRole("button", { name: "Next" }).click();
+
+    // AgentStep: claude is the default ACP-capable agent and the cockpit
+    // master switch is on, so the "Use cockpit" toggle is shown and
+    // defaults on. The docs tell the user to leave it on; assert that,
+    // then advance.
+    const cockpitToggle = wizard.getByRole("switch", { name: "Use cockpit" });
+    await expect(cockpitToggle).toBeVisible({ timeout: 10_000 });
+    await expect(cockpitToggle).toBeChecked();
+    await wizard.getByRole("button", { name: "Next" }).click();
+
+    // ReviewStep: launch the session.
+    await wizard.getByRole("button", { name: /Launch session/ }).click();
+
+    // Server-side: one session exists and is persisted with cockpit_mode
+    // true, the behavior the rewritten docs describe.
+    await expect
+      .poll(async () => (await listSessions(serve.baseUrl)).length, {
+        timeout: 15_000,
+      })
+      .toBeGreaterThan(0);
+
+    const sessions = await listSessions(serve.baseUrl);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.cockpit_mode).toBe(true);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -196,6 +196,13 @@ const PAGES = [
       "Weekly release cadence, automated staging PR, post-merge tagger, and emergency-release path for Agent of Empires maintainers.",
   },
   {
+    source: "docs/development/web-dashboard.md",
+    dest: "docs/development/web-dashboard.md",
+    title: "Web Dashboard Development",
+    description:
+      "Build the web dashboard from source, run the frontend dev workflow (cargo xtask dev and manual Vite + VITE_PROXY), and the server architecture.",
+  },
+  {
     source: "docs/sounds.md",
     dest: "docs/sounds.md",
     title: "Sound Effects",
@@ -331,6 +338,7 @@ const URL_MAP = {
   "docs/development/logging.md": "/docs/development/logging/",
   "docs/development/playwright.md": "/docs/development/playwright/",
   "docs/development/releases.md": "/docs/development/releases/",
+  "docs/development/web-dashboard.md": "/docs/development/web-dashboard/",
   "docs/guides/configuration.md": "/docs/guides/configuration/",
   "docs/cli/reference.md": "/docs/cli/reference/",
   "docs/cockpit.md": "/docs/cockpit/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -79,6 +79,10 @@ export const docsNav: NavSection[] = [
       { title: "Logging", href: "/docs/development/logging/" },
       { title: "Playwright + Vitest testing", href: "/docs/development/playwright/" },
       { title: "Releases", href: "/docs/development/releases/" },
+      {
+        title: "Web Dashboard Development",
+        href: "/docs/development/web-dashboard/",
+      },
     ],
   },
 ];


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two documentation-clarity changes that continue the user-facing-docs arc from #973 and #1631.

**Web dashboard guide (#1838).** The user-facing `docs/guides/web-dashboard.md` overview mixed user content (launch, access, auth, security, PWA) with three developer-only sections: build-from-source, internal architecture (axum / React / WebSocket PTY relay), and the frontend dev workflow. A new user had to wade through all of it. Those three sections move into a new `docs/development/web-dashboard.md` under the Development nav section, which also documents the `cargo xtask dev` one-command hot-reload loop that the old guide never mentioned. The user guide keeps a one-line source-build pointer and a short non-internal "How it works" note (the terminal is a real tmux session, so work survives reconnects). The canonical `/guides/web-dashboard/` URL is unchanged.

**Cockpit docs (#1841).** The cockpit Quickstart and the Setup "Per session" section read as if `aoe add --cockpit` is the way to start a cockpit session, with the web wizard mentioned only in asides. That is backwards: cockpit is web-first, and the new-session wizard creates cockpit sessions end to end. Both sections now lead with the web wizard as the primary path and frame the CLI as the optional scripting/headless path. To lock the behavior the rewritten docs promise, a new live Playwright spec drives the wizard with the "Use cockpit" toggle on and asserts the created session persists `cockpit_mode: true`.

No runtime code changes. The only non-docs addition is the Playwright spec plus its coverage-matrix entry.

Closes #1838
Closes #1841

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Read `docs/guides/web-dashboard.md`: it covers launch / access / auth / security / PWA with no build-from-source, architecture, or frontend-dev sections.
- [ ] Open `docs/development/web-dashboard.md`: build-from-source, `cargo xtask dev`, manual Vite + `VITE_PROXY`, and the architecture notes all live here, reachable from the Development nav.
- [ ] `node website/scripts/sync-docs.mjs` exits 0 and the new "Web Dashboard Development" page is wired into the Development section.
- [ ] Read the cockpit Quickstart in `docs/cockpit.md` and the "Per session" section in `docs/cockpit/setup.md`: the web wizard is presented as primary, the CLI as optional.
- [ ] With cockpit enabled, run `aoe serve`, open the wizard, leave "Use cockpit" on, pick an agent, and create: the session opens in cockpit (plan + tool cards), no CLI needed.
- [ ] `cd web && npx playwright test --config=playwright.live.config.ts wizard-cockpit-create-session` passes.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

`web/tests/live/wizard-cockpit-create-session.spec.ts` drives the new-session wizard with the "Use cockpit" toggle on and asserts the created session is `cockpit_mode: true`, mapped via the new `wizard.cockpit-mode-creation` matrix entry. The web-dashboard guide split is pure docs and has no flow change.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the dev/user split (informed by a multi-model design debate), the doc rewrites, and the Playwright spec were drafted by Claude under my direction. I made the scope calls, reviewed each commit, and confirmed the live test passes and the nav gate is green.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR reorganizes and rewrites documentation to better serve both end users and developers, and adds an automated test to verify the documented web wizard behavior works as intended.

### Documentation Reorganization

**Web Dashboard**: Split the user-facing guide from developer-focused material:
- The user guide (docs/guides/web-dashboard.md) now focuses on launching, accessing, and using the web dashboard with a short "How it works" section pointing to development docs
- A new dedicated development page (docs/development/web-dashboard.md) houses build instructions, the `cargo xtask dev` hot-reload workflow, and architecture details
- Both pages are wired into the website navigation

**Cockpit Documentation**: Rewrote to prioritize the web wizard as the primary path:
- Quickstart section now leads with the web "new-session" wizard workflow (with cockpit toggle) instead of CLI commands
- "Per session" section was expanded with dedicated web wizard instructions and now presents the CLI (`aoe add --cockpit`) as an optional scripting/headless alternative
- Maintained the canonical URLs and kept all existing content accessible

### New Test Coverage

Added a Playwright live spec (`wizard-cockpit-create-session.spec.ts`) that:
- Spawns a local AOE server with cockpit enabled
- Exercises the web wizard's "Use cockpit" toggle
- Verifies the created session persists with `cockpit_mode: true`

The test is mapped to the coverage matrix, tracking the SessionWizard components involved.

### Site Integration

Updated website sync script and navigation to expose the new web dashboard development page alongside existing documentation.

---

## Benefits

- **Better User Onboarding**: New users see the web wizard first, with developer content clearly separated
- **Clearer Developer Workflow**: Build and development instructions are now in a dedicated space, including the simpler `cargo xtask dev` one-command setup
- **Documented Behavior Is Tested**: The Playwright spec anchors the docs-to-behavior guarantee for the web wizard's cockpit creation path
- **Improved Information Architecture**: Documentation is split by audience (user vs. developer) while preserving searchability and URL stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->