### PR TITLE
feat(web): pick a theme during first-run onboarding

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -58,9 +58,11 @@ open settings, start a new session, toggle the right panel. It is the
 fastest path to anything the dashboard can do without reaching for the
 mouse.
 
-## First-run tutorial
+## First-run onboarding
 
-The first time you open the dashboard in a browser, an interactive walkthrough launches automatically and highlights the major regions: the command bar, the workspace sidebar, how to start a session, settings, and (inside a session) the diff panel and composer. Each step lists the keyboard shortcuts that apply to it, and every step has a **Skip** button so you can dismiss the whole tour in one click.
+The first time you open the dashboard in a browser, a **Choose your theme** card appears before anything else, so you can set the look of the dashboard and TUI right away. Picking a theme applies it live and saves it to your default profile; you can switch between themes as many times as you like, then click **Continue**. You can always change the theme later from Settings, under Appearance. The card is skipped in read-only mode (where it cannot save) and for anyone who already finished the tutorial in an earlier version. Dismissing it records a per-browser `aoe-welcome-seen` flag in `localStorage` so it does not show again.
+
+After the theme card, an interactive walkthrough launches automatically and highlights the major regions: the command bar, the workspace sidebar, how to start a session, settings, and (inside a session) the diff panel and composer. Each step lists the keyboard shortcuts that apply to it, and every step has a **Skip** button so you can dismiss the whole tour in one click.
 
 Completing or skipping the tour records that you have seen it (a per-browser `aoe-tour-seen` flag in `localStorage`), so it does not launch again on reload. Because the flag is per origin, a debug build on port 8081 and a release build on port 8080 each track it separately.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,6 +71,8 @@ import { SettingsView } from "./components/SettingsView";
 import { ProjectsView } from "./components/ProjectsView";
 import { HelpOverlay } from "./components/HelpOverlay";
 import { useTour } from "./hooks/useTour";
+import { useWelcomePhase } from "./hooks/useWelcomePhase";
+import { ThemeIntro } from "./components/onboarding/ThemeIntro";
 import type { TourScope } from "./lib/tourSteps";
 import { SessionWizard } from "./components/session-wizard/SessionWizard";
 import type { WizardPrefill } from "./components/session-wizard/SessionWizard";
@@ -1082,11 +1084,19 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     !showHelp &&
     !showAbout &&
     !showPalette;
+  // First-run theme choice is phase one of onboarding. It decides on the same
+  // settled-dashboard gate as the tour, then the tour follows once the modal
+  // resolves so the two never overlap on first load.
+  const welcome = useWelcomePhase({
+    scope: tourScope,
+    readOnly: !!serverAbout?.read_only,
+    autoLaunchReady: tourAutoLaunchReady,
+  });
   const tour = useTour({
     scope: tourScope,
     readOnly: !!serverAbout?.read_only,
     isDesktop: !isCoarse,
-    autoLaunchReady: tourAutoLaunchReady,
+    autoLaunchReady: tourAutoLaunchReady && welcome.resolved,
   });
 
   return (
@@ -1165,6 +1175,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           }
         />
       )}
+
+      {welcome.showWelcome && <ThemeIntro onDone={welcome.dismissWelcome} />}
 
       {tour.tourElement}
 

--- a/web/src/components/onboarding/ThemeIntro.tsx
+++ b/web/src/components/onboarding/ThemeIntro.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchThemes } from "../../lib/api";
+import { useThemeMutation } from "../../hooks/useThemeMutation";
+
+interface Props {
+  /** Dismiss the welcome modal and hand off to the tour. Called for both the
+   *  Continue button and Escape; the seen flag is owned by the caller. */
+  onDone: () => void;
+}
+
+/**
+ * First-run "Choose your theme" modal, phase one of onboarding. Selecting a
+ * theme persists it to the default profile and repaints the whole dashboard
+ * live (persist-then-paint via useThemeMutation), so the grid doubles as the
+ * preview; the user can re-pick freely before continuing. Shown on any pointer
+ * type, unlike the desktop-only tour. Dismissing hands off to the tour.
+ */
+export function ThemeIntro({ onDone }: Props) {
+  const [themes, setThemes] = useState<string[]>([]);
+  const [selected, setSelected] = useState<string | null>(
+    () =>
+      (typeof document !== "undefined"
+        ? document.documentElement.dataset.theme
+        : undefined) ?? null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const { select, pending } = useThemeMutation();
+  const continueRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    fetchThemes().then(setThemes);
+    continueRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onDone();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onDone]);
+
+  const pick = useCallback(
+    async (name: string) => {
+      if (pending || name === selected) return;
+      const prev = selected;
+      setSelected(name);
+      setError(null);
+      const result = await select(name);
+      // Persist-then-paint already repainted on success; on failure restore the
+      // prior highlight so the grid never claims an unsaved theme is active.
+      if (!result.ok) {
+        setSelected(prev);
+        setError(result.error);
+      }
+    },
+    [pending, selected, select],
+  );
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="theme-intro-title"
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in p-4"
+    >
+      <div className="bg-surface-800 border border-surface-700/50 rounded-lg w-[460px] max-w-[92vw] shadow-2xl animate-slide-up">
+        <div className="px-5 py-4 border-b border-surface-700">
+          <h2
+            id="theme-intro-title"
+            className="text-sm font-semibold text-text-bright"
+          >
+            Welcome! Choose your theme
+          </h2>
+          <p className="mt-1 text-xs text-text-dim">
+            Pick a look for the dashboard and TUI. You can change it any time
+            from Settings, under Appearance.
+          </p>
+        </div>
+
+        <div className="p-5 space-y-4">
+          <div
+            role="listbox"
+            aria-label="Themes"
+            className="grid grid-cols-2 gap-2 max-h-64 overflow-y-auto"
+          >
+            {themes.map((t) => {
+              const active = t === selected;
+              return (
+                <button
+                  key={t}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  disabled={pending}
+                  onClick={() => pick(t)}
+                  className={`text-left text-sm rounded-md border px-3 py-2 cursor-pointer transition-colors disabled:opacity-60 disabled:cursor-not-allowed ${
+                    active
+                      ? "border-brand-500 bg-surface-700 text-text-bright"
+                      : "border-surface-700 text-text-secondary hover:border-brand-600 hover:text-text-primary"
+                  }`}
+                >
+                  {t}
+                </button>
+              );
+            })}
+          </div>
+          {error && (
+            <p role="alert" className="text-xs text-status-error">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end px-5 py-4 border-t border-surface-700">
+          <button
+            ref={continueRef}
+            type="button"
+            onClick={onDone}
+            className="text-sm font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-surface-950 px-4 py-1.5 cursor-pointer transition-colors"
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/onboarding/ThemeIntro.tsx
+++ b/web/src/components/onboarding/ThemeIntro.tsx
@@ -2,6 +2,84 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchThemes } from "../../lib/api";
 import { useThemeMutation } from "../../hooks/useThemeMutation";
 
+const PANEL = "hidden lg:flex lg:w-64 lg:flex-col gap-2 bg-surface-900/40 p-4";
+const PANEL_LABEL =
+  "text-[10px] font-medium uppercase tracking-wide text-text-muted";
+
+/** Static cockpit-style preview: a couple of turns plus the composer. Built
+ *  from the same theme tokens the real surfaces use, so it repaints with the
+ *  selected theme and shows the user what a session looks like. Decorative and
+ *  aria-hidden; the live theme grid is the only interactive control. */
+function ComposerPreview() {
+  return (
+    <div className={`${PANEL} border-r border-surface-700`} aria-hidden="true">
+      <span className={PANEL_LABEL}>Composer</span>
+      <p className="text-[11px] leading-relaxed text-text-primary">
+        Sure, I'll harden the token expiry check.
+      </p>
+      <div className="flex items-center gap-2 rounded-md border border-surface-700 bg-surface-800/50 px-2 py-1">
+        <span className="h-1.5 w-1.5 rounded-full bg-status-running" />
+        <span className="font-mono text-[10px] text-text-secondary">
+          Edit src/auth.ts
+        </span>
+      </div>
+      <span className="self-end rounded-2xl rounded-br-sm border border-surface-700 bg-surface-800/70 px-3 py-1.5 text-[11px] text-text-primary">
+        Ship it
+      </span>
+      <div className="mt-auto flex items-center justify-between rounded-xl border border-surface-700 bg-surface-850 px-3 py-2">
+        <span className="text-[11px] text-text-dim">Message the agent...</span>
+        <span className="rounded bg-brand-600 px-2 py-0.5 text-[10px] text-white">
+          Send
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function DiffRow({
+  num,
+  text,
+  kind,
+}: {
+  num: string;
+  text: string;
+  kind?: "add" | "del";
+}) {
+  const body =
+    kind === "add"
+      ? "bg-status-running/5 text-status-running"
+      : kind === "del"
+        ? "bg-status-error/5 text-status-error"
+        : "text-text-secondary";
+  return (
+    <div className="flex">
+      <span className="w-7 shrink-0 border-r border-surface-700/30 px-1 text-right text-text-dim">
+        {num}
+      </span>
+      <span className={`flex-1 whitespace-pre px-2 ${body}`}>{text}</span>
+    </div>
+  );
+}
+
+/** Static diff-viewer preview, mirroring DiffFileViewer's tokens so the user
+ *  sees what review will look like in the chosen theme. Decorative. */
+function DiffPreview() {
+  return (
+    <div className={`${PANEL} border-l border-surface-700`} aria-hidden="true">
+      <span className={PANEL_LABEL}>Diff viewer</span>
+      <div className="overflow-hidden rounded-md border border-surface-700/40 bg-surface-900 font-mono text-[11px]">
+        <div className="border-y border-surface-700/20 bg-surface-850 px-2 py-1 text-accent-600">
+          @@ src/auth.ts @@
+        </div>
+        <DiffRow num="11" text="   const now = Date.now();" />
+        <DiffRow num="" text=" - if (exp < now) reject();" kind="del" />
+        <DiffRow num="12" text=" + if (exp <= now) reject();" kind="add" />
+        <DiffRow num="13" text="   next();" />
+      </div>
+    </div>
+  );
+}
+
 interface Props {
   /** Dismiss the welcome modal and hand off to the tour. Called for both the
    *  Continue button and Escape; the seen flag is owned by the caller. */
@@ -64,7 +142,10 @@ export function ThemeIntro({ onDone }: Props) {
       aria-labelledby="theme-intro-title"
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in p-4"
     >
-      <div className="bg-surface-800 border border-surface-700/50 rounded-lg w-[460px] max-w-[92vw] shadow-2xl animate-slide-up">
+      <div className="bg-surface-800 border border-surface-700/50 rounded-lg w-[460px] max-w-[92vw] lg:w-auto lg:max-w-[1024px] shadow-2xl animate-slide-up overflow-hidden">
+       <div className="lg:flex lg:items-stretch">
+        <ComposerPreview />
+        <div className="lg:flex-1 lg:min-w-[380px]">
         <div className="px-5 py-4 border-b border-surface-700">
           <h2
             id="theme-intro-title"
@@ -122,6 +203,9 @@ export function ThemeIntro({ onDone }: Props) {
             Continue
           </button>
         </div>
+        </div>
+        <DiffPreview />
+       </div>
       </div>
     </div>
   );

--- a/web/src/components/onboarding/ThemeIntro.tsx
+++ b/web/src/components/onboarding/ThemeIntro.tsx
@@ -104,10 +104,18 @@ export function ThemeIntro({ onDone }: Props) {
   const [error, setError] = useState<string | null>(null);
   const { select, pending } = useThemeMutation();
   const continueRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
+  // Capture the previously focused element on mount and restore it on unmount
+  // so keyboard users return to where they were instead of losing focus to
+  // document.body, matching DeleteSessionDialog and CommandPalette.
   useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
     fetchThemes().then(setThemes);
     continueRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus?.();
+    };
   }, []);
 
   useEffect(() => {
@@ -173,7 +181,7 @@ export function ThemeIntro({ onDone }: Props) {
                   type="button"
                   role="option"
                   aria-selected={active}
-                  disabled={pending}
+                  disabled={pending && !active}
                   onClick={() => pick(t)}
                   className={`text-left text-sm rounded-md border px-3 py-2 cursor-pointer transition-colors disabled:opacity-60 disabled:cursor-not-allowed ${
                     active

--- a/web/src/components/onboarding/__tests__/ThemeIntro.test.tsx
+++ b/web/src/components/onboarding/__tests__/ThemeIntro.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+//
+// Contract test for the first-run theme welcome modal. Live behavior (auto
+// show, persistence across reload, handoff to the tour) is covered by
+// tests/live/theme-onboarding.spec.ts; this file drills into the click ->
+// persist -> dispatch flow, the persist-then-paint failure path, and dismiss.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+const updateProfileSettings = vi.fn(() => Promise.resolve(true));
+vi.mock("../../../lib/api", () => ({
+  fetchThemes: vi.fn(() =>
+    Promise.resolve(["default", "modus-vivendi", "empire"]),
+  ),
+  fetchProfiles: vi.fn(() =>
+    Promise.resolve([
+      { name: "work", is_default: false },
+      { name: "default", is_default: true },
+    ]),
+  ),
+  updateProfileSettings: (name: string, updates: Record<string, unknown>) =>
+    updateProfileSettings(name, updates),
+}));
+
+const dispatchSpy = vi.fn();
+vi.mock("../../../hooks/useResolvedTheme", () => ({
+  dispatchThemePickerChanged: (name?: string) => dispatchSpy(name),
+}));
+
+import { ThemeIntro } from "../ThemeIntro";
+
+afterEach(() => {
+  cleanup();
+  dispatchSpy.mockClear();
+  updateProfileSettings.mockClear();
+  updateProfileSettings.mockImplementation(() => Promise.resolve(true));
+});
+
+async function mount() {
+  const onDone = vi.fn();
+  render(<ThemeIntro onDone={onDone} />);
+  await waitFor(() =>
+    expect(screen.getByRole("option", { name: "modus-vivendi" })).toBeTruthy(),
+  );
+  return { onDone };
+}
+
+describe("ThemeIntro", () => {
+  it("loads the available themes as options", async () => {
+    await mount();
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+
+  it("persists the picked theme to the default profile and repaints", async () => {
+    await mount();
+    fireEvent.click(screen.getByRole("option", { name: "modus-vivendi" }));
+    await waitFor(() =>
+      expect(updateProfileSettings).toHaveBeenCalledWith("default", {
+        theme: { name: "modus-vivendi" },
+      }),
+    );
+    expect(dispatchSpy).toHaveBeenCalledWith("modus-vivendi");
+    expect(
+      screen.getByRole("option", { name: "modus-vivendi" }).getAttribute(
+        "aria-selected",
+      ),
+    ).toBe("true");
+  });
+
+  it("lets the user re-pick another theme", async () => {
+    await mount();
+    fireEvent.click(screen.getByRole("option", { name: "modus-vivendi" }));
+    await waitFor(() => expect(dispatchSpy).toHaveBeenCalledWith("modus-vivendi"));
+    fireEvent.click(screen.getByRole("option", { name: "empire" }));
+    await waitFor(() => expect(dispatchSpy).toHaveBeenCalledWith("empire"));
+    expect(updateProfileSettings).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows an error and does not repaint when the save fails", async () => {
+    updateProfileSettings.mockImplementation(() => Promise.resolve(false));
+    await mount();
+    fireEvent.click(screen.getByRole("option", { name: "empire" }));
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    // Highlight reverts so the grid never claims an unsaved theme is active.
+    expect(
+      screen.getByRole("option", { name: "empire" }).getAttribute(
+        "aria-selected",
+      ),
+    ).toBe("false");
+  });
+
+  it("dismisses via Continue", async () => {
+    const { onDone } = await mount();
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses via Escape", async () => {
+    const { onDone } = await mount();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/useThemeMutation.ts
+++ b/web/src/hooks/useThemeMutation.ts
@@ -1,0 +1,48 @@
+import { useCallback, useState } from "react";
+import { fetchProfiles, updateProfileSettings } from "../lib/api";
+import { dispatchThemePickerChanged } from "./useResolvedTheme";
+
+export type ThemeSelectResult = { ok: true } | { ok: false; error: string };
+
+const SAVE_ERROR = "Could not save theme. Please try again.";
+
+/** The profile a first-run user has no reason to pick yet: the default one,
+ *  matching how the settings profile picker resolves the active profile. */
+async function resolveDefaultProfile(): Promise<string> {
+  const profiles = await fetchProfiles();
+  return profiles.find((p) => p.is_default)?.name ?? "default";
+}
+
+/**
+ * Persist a theme selection to the default profile and repaint, used by the
+ * first-run theme welcome modal. Persist-then-paint: the dashboard only
+ * repaints after the PATCH lands (via dispatchThemePickerChanged, which routes
+ * through useResolvedTheme's single apply path), so a failed save never leaves
+ * the applied/cached theme ahead of what is on disk (the #1510 bug class).
+ */
+export function useThemeMutation(): {
+  select: (name: string) => Promise<ThemeSelectResult>;
+  pending: boolean;
+} {
+  const [pending, setPending] = useState(false);
+
+  const select = useCallback(
+    async (name: string): Promise<ThemeSelectResult> => {
+      setPending(true);
+      try {
+        const profile = await resolveDefaultProfile();
+        const ok = await updateProfileSettings(profile, { theme: { name } });
+        if (!ok) return { ok: false, error: SAVE_ERROR };
+        dispatchThemePickerChanged(name);
+        return { ok: true };
+      } catch {
+        return { ok: false, error: SAVE_ERROR };
+      } finally {
+        setPending(false);
+      }
+    },
+    [],
+  );
+
+  return { select, pending };
+}

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -18,11 +18,7 @@ import {
   type TourScope,
   type TourStep,
 } from "../lib/tourSteps";
-import { safeGetItem, safeSetItem } from "../lib/safeStorage";
-
-// Per-origin localStorage already isolates dev (port 8081) from release (8080),
-// so a flat key needs no app-dir namespace.
-const TOUR_SEEN_KEY = "aoe-tour-seen";
+import { hasSeenTour, isAutomatedSession, markTourSeen } from "../lib/onboarding";
 
 const TourRunner = lazy(() => import("../components/tour/TourRunner"));
 
@@ -59,10 +55,6 @@ export function shouldAutoLaunch(args: {
     !args.seen &&
     !args.automated
   );
-}
-
-function isAutomatedSession(): boolean {
-  return typeof navigator !== "undefined" && navigator.webdriver === true;
 }
 
 export interface UseTourResult {
@@ -121,7 +113,7 @@ export function useTour({
   // is painted yet does not permanently suppress the auto-launch.
   useEffect(() => {
     if (autoStartedRef.current) return;
-    const seen = safeGetItem(TOUR_SEEN_KEY) === "1";
+    const seen = hasSeenTour();
     const automated = isAutomatedSession();
     if (!shouldAutoLaunch({ autoLaunchReady, scope, isDesktop, seen, automated }))
       return;
@@ -142,7 +134,7 @@ export function useTour({
 
   const handleFinish = useCallback((markSeen: boolean) => {
     setRun(false);
-    if (markSeen) safeSetItem(TOUR_SEEN_KEY, "1");
+    if (markSeen) markTourSeen();
   }, []);
 
   const tourElement = run ? (

--- a/web/src/hooks/useWelcomePhase.ts
+++ b/web/src/hooks/useWelcomePhase.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  hasSeenTour,
+  hasSeenWelcome,
+  isAutomatedSession,
+  markWelcomeSeen,
+  shouldShowWelcome,
+} from "../lib/onboarding";
+import type { TourScope } from "../lib/tourSteps";
+
+type Phase = "pending" | "showing" | "done";
+
+export interface UseWelcomePhaseOptions {
+  scope: TourScope;
+  readOnly: boolean;
+  /** The same settled-dashboard gate the tour uses; the welcome decision waits
+   *  for it so the modal never flashes over a half-painted dashboard. */
+  autoLaunchReady: boolean;
+}
+
+export interface UseWelcomePhaseResult {
+  showWelcome: boolean;
+  /** True once the welcome phase is resolved: either shown and dismissed, or
+   *  decided not-applicable. The tour gates its auto-launch on this so the two
+   *  first-run phases never overlap. */
+  resolved: boolean;
+  dismissWelcome: () => void;
+}
+
+/**
+ * Owns the first-run theme welcome phase: decides once (when the dashboard
+ * settles) whether to show the modal, and resolves when it is dismissed or
+ * skipped. Leaves the tour's own auto-launch ownership intact; the caller wires
+ * `resolved` into the tour's `autoLaunchReady` so the tour follows the modal.
+ */
+export function useWelcomePhase({
+  scope,
+  readOnly,
+  autoLaunchReady,
+}: UseWelcomePhaseOptions): UseWelcomePhaseResult {
+  const [phase, setPhase] = useState<Phase>("pending");
+  const decidedRef = useRef(false);
+
+  // Decide exactly once, the first frame the dashboard is settled, mirroring
+  // the tour's auto-start latch so a later re-render cannot re-open the modal.
+  useEffect(() => {
+    if (decidedRef.current || !autoLaunchReady) return;
+    decidedRef.current = true;
+    const show = shouldShowWelcome({
+      autoLaunchReady,
+      scope,
+      readOnly,
+      automated: isAutomatedSession(),
+      tourSeen: hasSeenTour(),
+      welcomeSeen: hasSeenWelcome(),
+    });
+    setPhase(show ? "showing" : "done");
+  }, [autoLaunchReady, scope, readOnly]);
+
+  const dismissWelcome = useCallback(() => {
+    markWelcomeSeen();
+    setPhase("done");
+  }, []);
+
+  return {
+    showWelcome: phase === "showing",
+    resolved: phase === "done",
+    dismissWelcome,
+  };
+}

--- a/web/src/lib/__tests__/onboarding.test.ts
+++ b/web/src/lib/__tests__/onboarding.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowWelcome } from "../onboarding";
+
+const base = {
+  autoLaunchReady: true,
+  scope: "dashboard" as const,
+  readOnly: false,
+  automated: false,
+  tourSeen: false,
+  welcomeSeen: false,
+};
+
+describe("shouldShowWelcome", () => {
+  it("shows on a settled, writable, never-onboarded dashboard", () => {
+    expect(shouldShowWelcome(base)).toBe(true);
+  });
+
+  it("waits until the dashboard is settled", () => {
+    expect(shouldShowWelcome({ ...base, autoLaunchReady: false })).toBe(false);
+  });
+
+  it("only shows on the dashboard scope", () => {
+    expect(shouldShowWelcome({ ...base, scope: "session" })).toBe(false);
+    expect(shouldShowWelcome({ ...base, scope: "cockpit" })).toBe(false);
+  });
+
+  it("is suppressed in read-only mode (cannot persist a theme)", () => {
+    expect(shouldShowWelcome({ ...base, readOnly: true })).toBe(false);
+  });
+
+  it("is suppressed in automated sessions", () => {
+    expect(shouldShowWelcome({ ...base, automated: true })).toBe(false);
+  });
+
+  it("does not re-prompt users who already finished the tour (upgraders)", () => {
+    expect(shouldShowWelcome({ ...base, tourSeen: true })).toBe(false);
+  });
+
+  it("does not show once the welcome has been seen", () => {
+    expect(shouldShowWelcome({ ...base, welcomeSeen: true })).toBe(false);
+  });
+
+  it("ignores pointer type: shows on touch (unlike the tour auto-launch)", () => {
+    // No isDesktop input by design; the predicate has no pointer clause.
+    expect(shouldShowWelcome(base)).toBe(true);
+  });
+});

--- a/web/src/lib/onboarding.ts
+++ b/web/src/lib/onboarding.ts
@@ -1,0 +1,67 @@
+// First-run onboarding policy and persistence, shared by the theme welcome
+// modal (useWelcomePhase) and the tutorial tour (useTour). Kept framework-free
+// and pure where possible so the launch decisions are unit-testable without
+// React, rAF, or the lazy joyride engine.
+//
+// Onboarding has two first-run phases with different policies: the theme
+// welcome modal (mutates the profile, shown on any pointer, suppressed in
+// read-only) runs first; the informational tour (read-only, desktop-only
+// auto-launch, replayable from the menu) runs second. Each owns its own seen
+// flag so the two never conflate.
+import { safeGetItem, safeSetItem } from "./safeStorage";
+import type { TourScope } from "./tourSteps";
+
+// Per-origin localStorage already isolates dev (port 8081) from release (8080),
+// so flat keys need no app-dir namespace.
+export const TOUR_SEEN_KEY = "aoe-tour-seen";
+export const WELCOME_SEEN_KEY = "aoe-welcome-seen";
+
+/** Auto-launch and the welcome modal are both suppressed inside automated
+ *  browser sessions (a synthetic monitor, a scraper, our Playwright suites):
+ *  an onboarding overlay would otherwise intercept clicks in unrelated flows. */
+export function isAutomatedSession(): boolean {
+  return typeof navigator !== "undefined" && navigator.webdriver === true;
+}
+
+export function hasSeenTour(): boolean {
+  return safeGetItem(TOUR_SEEN_KEY) === "1";
+}
+
+export function markTourSeen(): void {
+  safeSetItem(TOUR_SEEN_KEY, "1");
+}
+
+export function hasSeenWelcome(): boolean {
+  return safeGetItem(WELCOME_SEEN_KEY) === "1";
+}
+
+export function markWelcomeSeen(): void {
+  safeSetItem(WELCOME_SEEN_KEY, "1");
+}
+
+/**
+ * Pure decision for the first-run theme welcome modal. Shown only on a settled
+ * dashboard, outside automated sessions, when the profile is writable (the
+ * modal persists a theme), and only for users who have not yet completed either
+ * onboarding phase. The `!tourSeen` clause means users upgrading from before
+ * this feature (who already finished the tour) are never re-prompted. Unlike
+ * the tour it does not gate on a fine pointer: theme choice is just as relevant
+ * on touch, and the modal is responsive.
+ */
+export function shouldShowWelcome(args: {
+  autoLaunchReady: boolean;
+  scope: TourScope;
+  readOnly: boolean;
+  automated: boolean;
+  tourSeen: boolean;
+  welcomeSeen: boolean;
+}): boolean {
+  return (
+    args.autoLaunchReady &&
+    args.scope === "dashboard" &&
+    !args.readOnly &&
+    !args.automated &&
+    !args.tourSeen &&
+    !args.welcomeSeen
+  );
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2872,6 +2872,29 @@
       ]
     },
     {
+      "id": "onboarding.theme-welcome",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/theme-onboarding.spec.ts"
+      ],
+      "components": [
+        "web/src/components/onboarding/ThemeIntro.tsx"
+      ]
+    },
+    {
+      "id": "onboarding.theme-welcome-unit",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": [
+        "src/components/onboarding/__tests__/ThemeIntro.test.tsx",
+        "src/lib/__tests__/onboarding.test.ts"
+      ],
+      "components": [
+        "web/src/components/onboarding/ThemeIntro.tsx"
+      ]
+    },
+    {
       "id": "shortcuts.single-source",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/live/theme-onboarding.spec.ts
+++ b/web/tests/live/theme-onboarding.spec.ts
@@ -23,6 +23,10 @@ base("theme onboarding: pick, persist, hand off to tour", async ({ page }, testI
 
     // The welcome modal appears first, with the available themes as options.
     await expect(page.getByText("Choose your theme")).toBeVisible({ timeout: 10_000 });
+    // Desktop viewport (>= lg): the composer and diff preview panels flank the
+    // picker so the user sees the chosen theme on representative surfaces.
+    await expect(page.getByText("Composer")).toBeVisible();
+    await expect(page.getByText("Diff viewer")).toBeVisible();
     const options = page.getByRole("option");
     await expect(options.first()).toBeVisible();
 

--- a/web/tests/live/theme-onboarding.spec.ts
+++ b/web/tests/live/theme-onboarding.spec.ts
@@ -1,0 +1,77 @@
+// First-run theme selection as part of onboarding (issue #1834): a fresh
+// browser shows a "Choose your theme" modal before the tour. Picking a theme
+// repaints the dashboard live and persists to the default profile (survives a
+// reload). The modal is suppressed in automated sessions, like the tour.
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+base("theme onboarding: pick, persist, hand off to tour", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    // Present as a real (non-automated) browser so first-run onboarding runs;
+    // every other live spec keeps webdriver=true and never sees the modal.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "webdriver", { get: () => false });
+    });
+
+    await page.goto(serve.baseUrl);
+
+    // The welcome modal appears first, with the available themes as options.
+    await expect(page.getByText("Choose your theme")).toBeVisible({ timeout: 10_000 });
+    const options = page.getByRole("option");
+    await expect(options.first()).toBeVisible();
+
+    // Pick a theme other than the one currently applied; the dashboard repaints
+    // live (dataset.theme tracks the applied theme).
+    const names = await options.allInnerTexts();
+    const current = await page.evaluate(() => document.documentElement.dataset.theme);
+    const pick = names.find((n) => n.trim() !== current) ?? names[0];
+    const picked = pick.trim();
+    await page.getByRole("option", { name: picked, exact: true }).click();
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.dataset.theme))
+      .toBe(picked);
+
+    // Continue dismisses the modal and hands off to the tour.
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByText("Choose your theme")).toBeHidden();
+    await expect(page.getByText("Command bar")).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("button", { name: "Skip" }).click();
+
+    // The pick persisted to the profile: a reload re-applies it server-side and
+    // shows neither the modal nor the tour again.
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible();
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.dataset.theme))
+      .toBe(picked);
+    await expect(page.getByText("Choose your theme")).toBeHidden();
+  } finally {
+    await serve.stop();
+  }
+});
+
+base("theme onboarding: suppressed in automated sessions", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    // Default Playwright sessions report navigator.webdriver === true, so the
+    // modal must never appear and the dashboard must be reachable.
+    await page.goto(serve.baseUrl);
+    await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("Choose your theme")).toBeHidden();
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -29,7 +29,14 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
 
     await page.goto(serve.baseUrl);
 
-    // Story 1: auto-launches on first load, with a Skip button on the step.
+    // Phase 1 of onboarding (#1834): the theme welcome modal shows first on a
+    // fresh browser. Dismiss it; the tour then takes over.
+    await expect(page.getByText("Choose your theme")).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Story 1: tour auto-launches once the welcome closes, with a Skip button.
     await expect(page.getByText(FIRST_STEP)).toBeVisible({ timeout: 10_000 });
     const skip = page.getByRole("button", { name: "Skip" });
     await expect(skip).toBeVisible();
@@ -41,10 +48,12 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
       .poll(() => page.evaluate(() => localStorage.getItem("aoe-tour-seen")))
       .toBe("1");
 
-    // Story 1 (persistence): a reload must not auto-launch again.
+    // Story 1 (persistence): a reload must not auto-launch the tour or
+    // re-show the theme welcome modal.
     await page.reload();
     await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible();
     await expect(page.getByText(FIRST_STEP)).toBeHidden();
+    await expect(page.getByText("Choose your theme")).toBeHidden();
 
     // Story 2: re-trigger from the fixed entry point (TopBar overflow menu).
     await page.getByRole("button", { name: "More options" }).click();


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds theme selection to the web dashboard's first-run onboarding (#1834). The first time you open the dashboard in a browser, a **Choose your theme** modal now appears before the tutorial. Picking a theme applies it live and persists it to the default profile; you can switch between themes freely, then click **Continue** to hand off to the existing tour.

The modal is a separate onboarding phase, not a step inside the joyride tour. That choice keeps the tour's deliberately read-only, engine-agnostic, declarative contract intact (no changes to `tourSteps.ts`, `TourRunner.tsx`, or the drift guard), and keeps "Show tutorial" replays from re-prompting a theme mutation. Sequencing is handled by gating the tour's existing `autoLaunchReady` on the welcome being resolved, so the two never overlap and the tour follows once the modal closes.

Persistence uses persist-then-paint: the dashboard repaints only after the profile PATCH lands (via the existing `dispatchThemePickerChanged` path), so a failed save never leaves the applied or cached theme ahead of what is on disk (the #1510 bug class). The modal is suppressed in read-only mode (where it cannot save), in automated browser sessions (`navigator.webdriver`, same as the tour), and for users who already finished the tutorial in an earlier version, so upgraders are never re-prompted.

Note on scope: the approved plan mentioned routing `ThemeSettings` through the new `useThemeMutation` hook as a drive-by dedup. On inspection that would bypass the settings panel's selected-profile and optimistic-update machinery (and `SettingsView` already surfaces save errors), so `ThemeSettings` is left untouched; `useThemeMutation` is used by the onboarding modal only.

Closes #1834

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In a fresh browser profile (or clear `localStorage`), open the dashboard: a **Choose your theme** modal appears before the tour.
- [ ] Click a theme: the dashboard repaints to it immediately; click another to confirm you can re-switch.
- [ ] Click **Continue**: the modal closes and the tutorial auto-launches.
- [ ] Reload: the picked theme is still applied, and neither the modal nor the tour reappears.
- [ ] Re-open from a clean state with the dashboard in read-only mode: the modal does not appear.
- [ ] Confirm the theme you picked is reflected in Settings, under Appearance.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added `web/tests/live/theme-onboarding.spec.ts` (pick, repaint, persist across reload, automated-session suppression), updated `web/tests/live/tutorial.spec.ts` for the welcome-then-tour sequence, and added Vitest coverage (`ThemeIntro.test.tsx`, `onboarding.test.ts`). Mapped the new component in the coverage matrix.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (pressure-tested with a multi-model design debate), and implementation were drafted by Claude under my direction. I made the design calls, reviewed each commit, and the listed manual test steps mirror the automated Playwright and Vitest coverage.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a first-run "Choose your theme" modal to the web dashboard onboarding that appears before the interactive tutorial. Users pick a theme, the choice is persisted to their default profile, and the theme is applied only after the save succeeds (persist-then-paint). The modal is skipped for read-only sessions, automated browser sessions, and users who already completed onboarding. After dismissal the existing tour proceeds as before.

What was added
- ThemeIntro component: a modal with selectable themes, decorative previews, error handling, and dismissal via Continue or Escape.
- useThemeMutation hook: persists the selected theme to the default profile and dispatches the theme change only after a successful save; exposes a pending flag and result type.
- useWelcomePhase hook: manages the welcome/modal phase (show/dismiss/resolved) to sequence the tour.
- web/src/lib/onboarding.ts: shared onboarding helpers, localStorage seen-flags, automated-session detection, and shouldShowWelcome predicate.
- Tests and CI config: Playwright live tests and Vitest unit tests covering the theme onboarding flow and predicate; coverage-matrix entries updated.
- Docs: dashboard first-run onboarding docs updated to include the theme selection step.

What changed / moved
- App.tsx: integrates the welcome phase and renders ThemeIntro when appropriate, gating tour auto-launch on the welcome resolution.
- useTour: delegates seen/automation detection and marking to shared onboarding helpers.
- Onboarding logic previously inline was centralized into web/src/lib/onboarding.ts for reuse and testability.

Benefits
- Improved first-run UX by letting users choose their dashboard theme upfront.
- Persistence and consistency: chosen theme is saved and survives reloads.
- Safer updates: theme is applied after successful persistence to avoid showing unsaved state.
- Cleaner, testable onboarding logic and coverage for the new flow.
- Modal is robustly suppressed in automated or read-only contexts to avoid unwanted prompts.

Technical details (concise)
- Persist-then-paint: useThemeMutation calls fetchProfiles() → updateProfileSettings(profile, { theme }) and only on success calls dispatchThemePickerChanged(name).
- Sequencing: the tour’s auto-launch is gated on welcome.resolved so the tutorial starts after the welcome completes.
- Seen state: localStorage keys (aoe-tour-seen, aoe-welcome-seen) track completion; shouldShowWelcome evaluates readiness, scope, readOnly, automated, and seen flags.
- New/changed exports: ThemeIntro component; useThemeMutation and ThemeSelectResult; useWelcomePhase hook; onboarding helpers/constants in web/src/lib/onboarding.ts; tests and coverage entries.

Potential improvements
- Improve theme previews / layout for small screens.
- Add telemetry for onboarding engagement and drop-off.
- Add retry/backoff or clearer user-facing errors for profile-save failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->