### PR TITLE
fix(infra): skip pr template check on edited dependabot prs

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -12,7 +12,13 @@ on:
 
 jobs:
   check-template:
-    if: github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]'
+    # Key the skip on the PR author, not github.actor. The actor is whoever
+    # triggered the event; on an `edited` event fired by a maintainer or
+    # another bot the actor is the editor, so a github.actor guard would let
+    # the check run against Dependabot's templateless body. Matches the
+    # close-stale job and the nix-npm-hash escape hatch, which both key on
+    # pull_request.user.login.
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
<!-- Describe your changes and the problem they solve -->

The PR Template Check is meant to skip Dependabot PRs entirely (the intent of #257). It did not, reliably. The `check-template` job gated on `github.actor`, which is whoever triggered the event, not the PR author. The trigger is `pull_request_target: [opened, edited]`. At open time the actor is `dependabot[bot]`, so the guard worked. On an `edited` event fired by anyone else (a maintainer adding notes, another bot, a GitHub-side edit), the actor is the editor, the guard passed, and the check ran against Dependabot's auto-generated templateless body, applying the `missing-template` label, posting the warning comment, and calling `core.setFailed`.

This keys the job guard on `github.event.pull_request.user.login` instead, the PR author, so an edit by any actor leaves the skip intact. That matches the two other Dependabot-aware paths in the same file: the `close-stale` job and the nix-npm-hash escape hatch both key on `pull_request.user.login`. A short comment above the guard documents why, so it does not regress back to `github.actor`.

Closes #1840

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] Find or simulate a Dependabot PR (templateless body), have a non-Dependabot actor edit its body, and confirm the PR Template Check job is skipped: no `missing-template` label, no warning comment, no failed check.
- [ ] Open or edit a normal (non-Dependabot) PR and confirm the check still runs and still flags a missing template.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the change is a GitHub Actions workflow `if` expression. It is not unit-testable in this repo's harness (no `act`/actionlint-condition runner). The regression guard is the documenting comment added above the guard; behavior is verified manually per the steps above.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)


**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design call (key on PR author, matching the rest of the file), reviewed the commit, and own the testing steps.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)
