### PR TITLE
fix(cockpit): queue image attachments instead of dropping them mid-turn

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -209,12 +209,15 @@ pruned in lockstep with it (and dropped when the session is deleted), so
 the event log stays lean. Replayed images are fetched lazily from
 `GET /api/sessions/{id}/cockpit/attachments/{attachment_id}`.
 
-Attachments require an idle, connected agent. Unlike text, they are not
-held in the offline prompt queue (which is stored locally in the
-browser); sending an attachment while the agent is mid-turn or
-disconnected surfaces an error rather than silently dropping it. Audio
-and embedded resources are sent and stored, but render as a labelled
-chip rather than an inline player or preview for now.
+Attachments queue alongside the prompt text. Sending one while the
+agent is mid-turn, disconnected, or restarting parks the message in the
+queue (the queued row shows a thumbnail / chip for each attachment) and
+the drain fires it once the session resumes, the same as a text-only
+follow-up. The bytes ride the queued row in memory only: they are kept
+out of the per-origin localStorage snapshot, so a full page reload drops
+any queued attachment row (you reattach and resend). Audio and embedded
+resources are sent and stored, but render as a labelled chip rather than
+an inline player or preview for now.
 
 ## Queued prompts (mid-turn + inactive session)
 
@@ -253,8 +256,12 @@ can't accept them yet. Two cases:
 Queued entries persist in the per-origin localStorage snapshot at
 `aoe:cockpit-state:v1:<sid>`, so a page reload (and closing then
 reopening the tab on the same origin) keeps them across the reconnect
-window. Server-side durability is not currently implemented; clearing
-site data wipes the queue.
+window. The one exception is queued rows that carry attachments: their
+base64 bytes are never written to the snapshot (they would blow the
+storage quota), and the whole row is dropped on reload rather than
+draining a text-only prompt with the image silently missing. Server-side
+durability is not currently implemented; clearing site data wipes the
+queue.
 
 **TUI cockpit.** The TUI cockpit view has the same client-side queue.
 Pressing `Enter` while a turn is active (or while the WebSocket is

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -26,6 +26,7 @@ import {
   Clock,
   Info,
   ListChecks,
+  Paperclip,
   RotateCcw,
   X,
 } from "lucide-react";
@@ -2320,6 +2321,30 @@ function QueuedPromptRow({
             >
               {rowExpanded ? "Show less" : "…"}
             </button>
+          )}
+          {prompt.attachments && prompt.attachments.length > 0 && (
+            <div className="mt-1 flex flex-wrap gap-1.5" data-testid="queued-attachments">
+              {prompt.attachments.map((att, i) => (
+                <span
+                  key={`${att.name ?? att.kind}-${i}`}
+                  className="flex items-center gap-1 rounded border border-sky-700/40 bg-sky-950/30 py-0.5 pl-0.5 pr-1.5 text-[10px] text-sky-200"
+                  title={att.name ?? att.kind}
+                >
+                  {att.kind === "image" ? (
+                    <img
+                      src={`data:${att.mimeType};base64,${att.dataB64}`}
+                      alt={att.name ?? "attachment"}
+                      className="h-5 w-5 rounded object-cover"
+                    />
+                  ) : (
+                    <Paperclip className="h-3 w-3" />
+                  )}
+                  <span className="max-w-[100px] truncate">
+                    {att.name ?? att.kind}
+                  </span>
+                </span>
+              ))}
+            </div>
           )}
         </div>
       )}

--- a/web/src/components/cockpit/QueuedPromptsStrip.test.tsx
+++ b/web/src/components/cockpit/QueuedPromptsStrip.test.tsx
@@ -108,6 +108,42 @@ describe("QueuedPromptsStrip clear-boundary divider (#1356)", () => {
   });
 });
 
+describe("QueuedPromptRow attachment indicator (#1833)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const withImage: QueuedPrompt = {
+    id: "img",
+    text: "look at this",
+    queuedAt: "2026-05-21T00:00:00.000Z",
+    attachments: [
+      {
+        kind: "image",
+        mimeType: "image/png",
+        dataB64: "aA==",
+        name: "shot.png",
+      },
+    ],
+  };
+
+  it("renders a thumbnail for an image attachment on a queued row", () => {
+    const { getByTestId, getByAltText } = renderWithProfile("claude", [
+      withImage,
+    ]);
+    expect(getByTestId("queued-attachments")).toBeTruthy();
+    const img = getByAltText("shot.png") as HTMLImageElement;
+    expect(img.src).toContain("data:image/png;base64,aA==");
+  });
+
+  it("renders no attachment strip for a text-only queued row", () => {
+    const { queryByTestId } = renderWithProfile("claude", [
+      mk("a", "plain text"),
+    ]);
+    expect(queryByTestId("queued-attachments")).toBeNull();
+  });
+});
+
 describe("QueuedPromptRow expanded-state bounds (#1642)", () => {
   afterEach(() => {
     cleanup();

--- a/web/src/hooks/useCockpit.eviction.test.ts
+++ b/web/src/hooks/useCockpit.eviction.test.ts
@@ -188,3 +188,58 @@ describe("cockpit cache eviction (#1345)", () => {
     expect(window.localStorage.getItem(`${DRAFT_KEY_PREFIX}sess-a`)).toBe("draft");
   });
 });
+
+describe("persistState strips attachment-bearing queued rows (#1833)", () => {
+  it("drops queued rows that carry attachments and writes no base64 bytes", () => {
+    const state = {
+      ...emptyCockpitState(),
+      queuedPrompts: [
+        { id: "q1", text: "plain text", queuedAt: "2026-01-01T00:00:00.000Z" },
+        {
+          id: "q2",
+          text: "with image",
+          queuedAt: "2026-01-01T00:00:01.000Z",
+          attachments: [
+            {
+              kind: "image" as const,
+              mimeType: "image/png",
+              dataB64: "QUJDREVG",
+              name: "shot.png",
+            },
+          ],
+        },
+      ],
+    };
+
+    persistState("sess-strip", state);
+
+    const raw = window.localStorage.getItem(`${STORAGE_KEY_PREFIX}sess-strip`);
+    expect(raw).not.toBeNull();
+    // The base64 payload must never reach localStorage (quota invariant).
+    expect(raw).not.toContain("QUJDREVG");
+
+    const parsed = JSON.parse(raw!) as {
+      state: { queuedPrompts: Array<{ id: string; attachments?: unknown }> };
+    };
+    // Only the text-only row survives persistence; the attachment row is
+    // dropped entirely so reload never drains a degraded prompt.
+    expect(parsed.state.queuedPrompts).toHaveLength(1);
+    expect(parsed.state.queuedPrompts[0]?.id).toBe("q1");
+  });
+
+  it("leaves a fully text-only queue untouched (no needless clone)", () => {
+    const state = {
+      ...emptyCockpitState(),
+      queuedPrompts: [
+        { id: "q1", text: "a", queuedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    };
+    persistState("sess-textonly", state);
+    const raw = window.localStorage.getItem(`${STORAGE_KEY_PREFIX}sess-textonly`);
+    const parsed = JSON.parse(raw!) as {
+      state: { queuedPrompts: Array<{ id: string }> };
+    };
+    expect(parsed.state.queuedPrompts).toHaveLength(1);
+    expect(parsed.state.queuedPrompts[0]?.id).toBe("q1");
+  });
+});

--- a/web/src/hooks/useCockpit.queue.test.ts
+++ b/web/src/hooks/useCockpit.queue.test.ts
@@ -46,6 +46,32 @@ describe("cockpitHookReducer / queue actions", () => {
     }
   });
 
+  it("enqueue_prompt carries attachments onto the queued row (#1833)", () => {
+    const s1 = cockpitHookReducer(emptyCockpitState(), {
+      kind: "enqueue_prompt",
+      text: "with image",
+      attachments: [
+        { kind: "image", mimeType: "image/png", dataB64: "aA==", name: "x.png" },
+      ],
+    });
+    expect(s1.queuedPrompts[0]?.attachments).toHaveLength(1);
+    expect(s1.queuedPrompts[0]?.attachments?.[0]?.name).toBe("x.png");
+  });
+
+  it("enqueue_prompt omits the attachments key for a text-only send", () => {
+    const s1 = cockpitHookReducer(emptyCockpitState(), {
+      kind: "enqueue_prompt",
+      text: "text only",
+    });
+    expect(s1.queuedPrompts[0]?.attachments).toBeUndefined();
+    const s2 = cockpitHookReducer(emptyCockpitState(), {
+      kind: "enqueue_prompt",
+      text: "empty list",
+      attachments: [],
+    });
+    expect(s2.queuedPrompts[0]?.attachments).toBeUndefined();
+  });
+
   it("dequeue_prompt removes the matching entry by id", () => {
     const s1 = cockpitHookReducer(emptyCockpitState(), {
       kind: "enqueue_prompt",
@@ -201,6 +227,13 @@ describe("combineQueuedPrompts (combined drain mode)", () => {
 
   it("returns a single entry unchanged for a one-item queue", () => {
     expect(combineQueuedPrompts([mk("a", "only one")])).toBe("only one");
+  });
+
+  it("skips empty (attachment-only) entries so no stray blank lines appear (#1833)", () => {
+    expect(combineQueuedPrompts([mk("a", "before"), mk("b", ""), mk("c", "after")])).toBe(
+      "before\n\nafter",
+    );
+    expect(combineQueuedPrompts([mk("a", ""), mk("b", "")])).toBe("");
   });
 });
 
@@ -559,10 +592,11 @@ describe("useCockpit drain race (#1144)", () => {
     );
   });
 
-  it("keeps the error banner on a worker_not_ready 503 for an attachment send (#1748)", async () => {
-    // Attachments cannot be re-queued (the local queue is text-only), so a
-    // worker_not_ready 503 for an attachment send has no retry path. The
-    // banner must show rather than being suppressed as transient.
+  it("re-queues an attachment send without an error banner on a worker_not_ready 503 (#1833)", async () => {
+    // The local queue now carries attachments in memory, so a
+    // worker_not_ready 503 for an attachment send has a retry path: park
+    // it (image included) and suppress the banner, exactly like a
+    // text-only send. The drain re-fires it once the worker comes online.
     const { result } = renderHook(() => useCockpit("sess-idle-attach", "absent"));
     await flushAsync();
     const ws = sockets[0]!;
@@ -597,9 +631,139 @@ describe("useCockpit drain race (#1144)", () => {
     });
     await flushAsync();
 
-    expect(result.current.state.lastError ?? "").toContain(
-      "Could not send prompt (503)",
+    expect(result.current.state.lastError ?? "").not.toContain(
+      "Could not send prompt",
     );
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+    expect(result.current.state.queuedPrompts[0]?.text).toBe("wake me up");
+    expect(result.current.state.queuedPrompts[0]?.attachments).toHaveLength(1);
+    expect(result.current.state.queuedPrompts[0]?.attachments?.[0]?.name).toBe(
+      "shot.png",
+    );
+  });
+
+  it("queues an attachment send mid-turn instead of dropping it (#1833)", async () => {
+    // The bug: sending an image while the agent is still producing the
+    // previous turn surfaced an error and the composer cleared the image,
+    // losing it. It must queue like text and drain on Stopped.
+    const { result } = renderHook(() => useCockpit("sess-attach-midturn"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+
+    // Kick a turn so turnActive flips on.
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-attach-midturn",
+          seq: 1,
+          event: { UserPromptSent: { text: "kicker" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.turnActive).toBe(true);
+
+    // Send an image while the turn is active.
+    await act(async () => {
+      await result.current.sendPrompt("look at this", [
+        {
+          kind: "image",
+          mimeType: "image/png",
+          dataB64: "aA==",
+          name: "shot.png",
+        },
+      ]);
+    });
+    await flushAsync();
+
+    // No POST yet, no error banner, and the image is parked on the queue.
+    expect(promptPostCount).toBe(0);
+    expect(result.current.state.lastError ?? "").not.toContain(
+      "Could not send prompt",
+    );
+    expect(result.current.state.lastError ?? "").not.toContain("Attachments");
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+    expect(result.current.state.queuedPrompts[0]?.attachments).toHaveLength(1);
+
+    // End the turn: the drain fires and the POST carries the attachment.
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-attach-midturn",
+          seq: 2,
+          event: { Stopped: { reason: "prompt_complete" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(1);
+    const sent = JSON.parse(promptPostBodies[0]!) as {
+      text: string;
+      attachments: Array<{ name?: string; data: string }>;
+    };
+    expect(sent.text).toBe("look at this");
+    expect(sent.attachments).toHaveLength(1);
+    expect(sent.attachments[0]?.name).toBe("shot.png");
+    expect(sent.attachments[0]?.data).toBe("aA==");
+    expect(result.current.state.queuedPrompts).toEqual([]);
+  });
+
+  it("combined-mode drain merges attachments from every queued row into one POST (#1833)", async () => {
+    const { result } = renderHook(() => useCockpit("sess-attach-combined"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-attach-combined",
+          seq: 1,
+          event: { UserPromptSent: { text: "kicker" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+
+    act(() => {
+      void result.current.sendPrompt("first", [
+        { kind: "image", mimeType: "image/png", dataB64: "aA==", name: "a.png" },
+      ]);
+    });
+    act(() => {
+      void result.current.sendPrompt("second", [
+        { kind: "image", mimeType: "image/png", dataB64: "bB==", name: "b.png" },
+      ]);
+    });
+    await flushAsync();
+    expect(result.current.state.queuedPrompts).toHaveLength(2);
+
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-attach-combined",
+          seq: 2,
+          event: { Stopped: { reason: "prompt_complete" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+
+    expect(promptPostCount).toBe(1);
+    const sent = JSON.parse(promptPostBodies[0]!) as {
+      text: string;
+      attachments: Array<{ name?: string }>;
+    };
+    expect(sent.text).toBe("first\n\nsecond");
+    expect(sent.attachments.map((a) => a.name)).toEqual(["a.png", "b.png"]);
     expect(result.current.state.queuedPrompts).toEqual([]);
   });
 

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -53,7 +53,11 @@ export type Action =
   | { kind: "lagged_resolved" }
   | { kind: "reset" }
   | { kind: "hydrate"; state: CockpitState }
-  | { kind: "enqueue_prompt"; text: string }
+  | {
+      kind: "enqueue_prompt";
+      text: string;
+      attachments?: PromptAttachmentInput[];
+    }
   | { kind: "dequeue_prompt"; id: string }
   | { kind: "dequeue_prompts_by_id"; ids: string[] }
   | { kind: "edit_queued_prompt"; id: string; text: string }
@@ -147,9 +151,27 @@ function evictOldestPersistedCockpitState(currentKey: string): boolean {
   }
 }
 
+/** Project the in-memory reducer state into the shape written to
+ *  localStorage. Queued prompts that carry attachments are dropped
+ *  entirely: their base64 bytes would blow the per-origin quota, and
+ *  persisting the text alone would silently drain a degraded prompt on
+ *  reload (e.g. "fix this screenshot:" with no screenshot). The full
+ *  row stays in the in-memory `stateCache`, so it survives a component
+ *  remount but not a hard page reload. See #1833 / #1000. */
+function toPersistedState(state: CockpitState): CockpitState {
+  if (!state.queuedPrompts.some((q) => q.attachments?.length)) return state;
+  return {
+    ...state,
+    queuedPrompts: state.queuedPrompts.filter((q) => !q.attachments?.length),
+  };
+}
+
 function persistState(sessionId: string, state: CockpitState): void {
   const key = storageKey(sessionId);
-  const body = JSON.stringify({ savedAt: Date.now(), state } satisfies PersistedEntry);
+  const body = JSON.stringify({
+    savedAt: Date.now(),
+    state: toPersistedState(state),
+  } satisfies PersistedEntry);
   if (safeSetItem(key, body)) {
     setQueueCount(sessionId, state.queuedPrompts.length);
     setRateLimit(sessionId, state.rateLimit);
@@ -350,7 +372,12 @@ export function cockpitHookReducer(
 export function combineQueuedPrompts(
   queue: ReadonlyArray<QueuedPrompt>,
 ): string {
-  return queue.map((q) => q.text).join("\n\n");
+  // Skip empty entries: an attachment-only queued prompt carries no
+  // text, and gluing its "" in would leave stray blank-line separators.
+  return queue
+    .map((q) => q.text)
+    .filter((t) => t.length > 0)
+    .join("\n\n");
 }
 
 function reducer(state: CockpitState, action: Action): CockpitState {
@@ -432,6 +459,9 @@ function reducer(state: CockpitState, action: Action): CockpitState {
       id: `q-${Date.now()}-${state.queuedPrompts.length}`,
       text: action.text,
       queuedAt: new Date().toISOString(),
+      ...(action.attachments && action.attachments.length > 0
+        ? { attachments: action.attachments }
+        : {}),
     };
     return { ...state, queuedPrompts: state.queuedPrompts.concat(entry) };
   }
@@ -1131,14 +1161,11 @@ export function useCockpit(
           // is NOT this case: it needs operator action, so it keeps its
           // banner. See #1748.
           //
-          // Only suppress for text-only sends: the local queue does not
-          // carry attachments, so an attachment send that hits this 503 has
-          // no retry path. Keep its banner so the user knows to resend
-          // rather than seeing a silent optimistic bubble. See #1748.
+          // Attachments are now re-queued on this transient (the queue
+          // carries them in memory; see sendPrompt + the drain effect), so
+          // suppress the banner for attachment sends too. See #1833.
           const workerNotReady =
-            res.status === 503 &&
-            detail.startsWith("worker_not_ready") &&
-            (!attachments || attachments.length === 0);
+            res.status === 503 && detail.startsWith("worker_not_ready");
           if (rejected) {
             dispatch({ kind: "prompt_send_rejected" });
           }
@@ -1221,36 +1248,23 @@ export function useCockpit(
         ? blockedAsideFromWorker
         : blockedAsideFromWorker || workerNotRunning;
       if (shouldEnqueue) {
-        // The local prompt queue is text-only (persisted to
-        // localStorage, where megabytes of base64 would blow the
-        // quota). Attachments must go through the immediate POST, so
-        // surface why rather than silently dropping them. The composer
-        // keeps the text + attachments so the user can resend once the
-        // agent is idle. See #1000 / #965.
-        if (attachments && attachments.length > 0) {
-          dispatch({
-            kind: "error",
-            message:
-              "Attachments can only be sent while the agent is idle and connected. Your message was not sent; try again in a moment.",
-          });
-          return;
-        }
-        dispatch({ kind: "enqueue_prompt", text });
+        // Park the prompt (with any attachments) so the drain effect
+        // fires it once the agent is idle and connected, instead of
+        // dropping the image. The attachment bytes ride the queued row
+        // in memory only; `persistState` keeps them out of localStorage
+        // (and drops the whole row on reload) so the quota invariant
+        // holds. See #1833 / #1000.
+        dispatch({ kind: "enqueue_prompt", text, attachments });
         return;
       }
       const result = await dispatchPromptNow(text, attachments);
       // Idle-dormant direct send: the worker was respawning and did not
       // come online within send_prompt's wait window, so the POST returned
-      // a retryable typed 503. Park the prompt instead of dropping it; the
-      // drain effect re-fires it once AcpSessionAssigned brings the worker
-      // online (text-only, since the queue does not carry attachments).
-      // See #1748.
-      if (
-        result === "retryable_failure" &&
-        state.workerIdleStopped &&
-        (!attachments || attachments.length === 0)
-      ) {
-        dispatch({ kind: "enqueue_prompt", text });
+      // a retryable typed 503. Park the prompt (with its attachments)
+      // instead of dropping it; the drain effect re-fires it once
+      // AcpSessionAssigned brings the worker online. See #1748 / #1833.
+      if (result === "retryable_failure" && state.workerIdleStopped) {
+        dispatch({ kind: "enqueue_prompt", text, attachments });
       }
     },
     [
@@ -1337,8 +1351,16 @@ export function useCockpit(
       }
       const snapshot = queue.slice(0, batchEnd);
       const combined = combineQueuedPrompts(snapshot);
+      // Merge every attachment in the sub-batch into the one combined
+      // POST. If that overflows the server's per-prompt cap the POST
+      // 4xx-rejects and the batch retires via the non-retryable path
+      // below, same as any other rejected combined send. See #1833.
+      const combinedAttachments = snapshot.flatMap((q) => q.attachments ?? []);
       const sentIds = snapshot.map((q) => q.id);
-      void dispatchPromptNow(combined)
+      void dispatchPromptNow(
+        combined,
+        combinedAttachments.length > 0 ? combinedAttachments : undefined,
+      )
         .then((result) => {
           // Retire on success and on non-retryable rejection; only a
           // transient failure keeps the batch queued for the next retry.
@@ -1352,7 +1374,7 @@ export function useCockpit(
     } else {
       const head = state.queuedPrompts[0]!;
       const headId = head.id;
-      void dispatchPromptNow(head.text)
+      void dispatchPromptNow(head.text, head.attachments)
         .then((result) => {
           if (result !== "retryable_failure") {
             dispatch({ kind: "dequeue_prompt", id: headId });

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -617,6 +617,12 @@ export interface QueuedPrompt {
   /** ISO-8601 client wall clock at enqueue time. Displayed as a
    *  relative age in the strip. */
   queuedAt: string;
+  /** Attachments staged with this queued prompt. EPHEMERAL: these carry
+   *  raw base64 bytes, so `persistState` drops any queued row that has
+   *  them rather than writing megabytes into the per-origin localStorage
+   *  quota. They survive a component remount (the in-memory `stateCache`
+   *  keeps the full row) but not a full page reload. See #1833 / #1000. */
+  attachments?: PromptAttachmentInput[];
 }
 
 export interface ActivityRow {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the web dashboard cockpit, sending an image attachment while the agent's previous turn had not finished dismissed the image. Text in the same situation queues and drains when the agent goes idle; attachments did not. The root cause: `sendPrompt` dispatched an error banner and returned without queuing when attachments were present and the session was busy, while the composer synchronously cleared the staged image right after, so the file was wiped.

This change parks the prompt with its attachments on the local queue exactly like text. The drain effect fires it once the session is idle and connected: combined mode merges the sub-batch's attachments into the single POST, serial mode sends the head row's attachments.

The attachment bytes ride the in-memory reducer state only. `persistState` drops any attachment-bearing queued row from the localStorage snapshot, so the per-origin quota invariant (the reason the queue was text-only, refs #1000 / #965) still holds, and a hard page reload never drains a text-only prompt with the image silently missing. Now that attachments have a queue retry path, the `worker_not_ready` 503 banner suppression and the idle-dormant re-enqueue no longer special-case text-only sends. Queued rows that carry attachments render a thumbnail (or a paperclip chip for non-image kinds) so the user can see the image is parked, not lost.

Closes #1833

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a cockpit session in the web dashboard and send a prompt so the agent starts a turn.
- [ ] While the turn is still running, attach an image and hit Send. Confirm the image lands in the Queued strip with a thumbnail and no error banner appears.
- [ ] Wait for the agent to finish the turn. Confirm the queued prompt drains and the image appears in the sent message.
- [ ] Attach an image with no text mid-turn and confirm the attachment-only prompt queues and drains the same way.
- [ ] Queue two image prompts mid-turn (combined drain mode) and confirm both images arrive in the agent's next turn.
- [ ] Queue an image, then hard-reload the page. Confirm the attachment row is gone (bytes are not persisted) rather than draining a text-only prompt with the image missing.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the fix is client-side queue/state logic, not a backend round-trip (the server already accepts attachments). The regression tests are vitest hook-integration tests that drive the real `useCockpit` hook through WS frames + fetch and assert the queued attachment drains into a POST carrying the bytes, which is the canonical home for request-payload/logic permutations per AGENTS.md. The changed files (`useCockpit.ts`, `CockpitView.tsx`, `cockpitTypes.ts`) are already mapped by existing coverage-matrix entries (validator passes).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (with a multi-model design debate on the queue persistence approach), and implementation drafted by Claude under my direction. I made the design calls (drop attachment rows on reload rather than persisting base64 or draining degraded text) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

**Problem Being Fixed:**
When users attached and sent an image to the web dashboard while the AI agent was still processing a previous response, the image was lost instead of being queued for later delivery.

**Solution Implemented:**

The cockpit now properly queues image attachments alongside text prompts when the agent is busy or disconnected, preventing silent loss of attachments. Key changes include:

- **Queueing**: Prompts with attachments are now parked in the local queue (like text prompts) instead of being immediately rejected
- **Visual Feedback**: Queued attachments display as image thumbnails or paperclip icons so users see their attachment is queued
- **Draining**: When the session becomes idle and ready:
  - In combined mode: attachments from multiple queued prompts merge into a single POST
  - In serial mode: the oldest queued prompt's attachments are sent
- **Memory-Only Storage**: Attachment bytes are kept only in the browser's memory; localStorage snapshots exclude attachment-bearing prompts to preserve storage quota
- **Documentation**: Updated user-facing docs to describe the new attachment queueing behavior

**Files Changed:**
- Documentation updated with new queueing behavior details
- UI component enhanced to render queued attachment indicators
- Core queue/drain logic extended to handle attachments end-to-end
- Type definitions expanded to include attachments in queued prompts
- Comprehensive test coverage added for queueing, persistence, and rendering

## Benefits

- **User Experience**: Users no longer lose attachments when sending images during agent processing
- **Data Integrity**: Attachment data flows through the same reliable queue-and-drain system as text prompts
- **Storage Efficiency**: Keeps attachment bytes out of persistent localStorage, maintaining per-origin quota limits
- **Predictability**: Consistent handling of attachment sends across all session states (connected, disconnected, worker idle)

## Technical Details

The implementation extends `useCockpit`'s reducer to:
- Accept `attachments?: PromptAttachmentInput[]` in the `enqueue_prompt` action
- Filter empty-text queued entries to prevent stray separators
- Merge attachments during combined-mode drain
- Apply existing error banner suppression (worker_not_ready 503) uniformly to attachment sends
- Exclude attachment-carrying queued rows from `persistState` localStorage snapshots while preserving text-only queued prompts

The type system adds an optional `attachments` field to `QueuedPrompt` to track staged attachments as ephemeral in-memory data across component remounts until page reload.

Test coverage verifies reducer behavior, attachment persistence exclusion, UI rendering of thumbnails/chips, combined-mode merging of multi-row attachments, and retry behavior on transient errors.

Closes `#1833`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->