### PR TITLE
feat: publish aoe skill to the Hermes Agent Skills Hub

### DIFF
--- a/contrib/hermes-skill/SKILL.md
+++ b/contrib/hermes-skill/SKILL.md
@@ -1,39 +1,43 @@
 ---
 name: aoe
-description: Manage AI coding agent sessions via Agent of Empires (aoe)
+description: Use when launching, monitoring, or controlling AI coding agents (Claude Code, Codex, OpenCode, etc.) in tmux via Agent of Empires (aoe). Covers creating sessions, capturing agent output, running parallel worktree agents, and organizing work into groups and profiles. Prefer aoe over raw tmux for agent management.
+version: 1.0.0
+author: njbrake (Agent of Empires)
+license: MIT
 metadata:
-  openclaw:
-    requires:
-      bins:
-        - aoe
-        - tmux
-    homepage: https://github.com/agent-of-empires/agent-of-empires
+  hermes:
+    tags: [coding-agents, tmux, orchestration, sessions, worktrees, automation]
+    related_skills: [subagent-driven-development]
 ---
 
-# Agent of Empires (aoe) Skill
+# Agent of Empires (aoe)
 
-Use `aoe` to create, manage, and monitor AI coding agent sessions (Claude Code, Codex, OpenCode, etc.) in tmux. Prefer `aoe` over raw `tmux` commands for agent management.
+## Overview
 
-## When to use this skill
+`aoe` creates, manages, and monitors AI coding agent sessions (Claude Code, Codex, OpenCode, and others) inside tmux. Each session is an agent process with an ID, title, tool, project path, and live status. Use `aoe` instead of raw `tmux` commands whenever the work is about coding agents: it tracks status, captures output, manages git worktrees for parallel branches, and organizes sessions into groups and profiles.
 
-- Launching one or more AI coding agents on project directories
-- Monitoring agent progress (waiting vs running vs idle)
-- Capturing agent output for review
-- Organizing agents into groups or profiles
-- Setting up parallel worktree-based development
+## When to Use
 
-Do NOT use this skill for general tmux window/pane management unrelated to coding agents.
+- Launching one or more AI coding agents on project directories.
+- Monitoring agent progress (waiting vs running vs idle).
+- Capturing agent output for review.
+- Organizing agents into groups or profiles.
+- Setting up parallel worktree-based development.
 
-## Core concepts
+**Don't use for:** general tmux window/pane management unrelated to coding agents.
 
-- **Session**: An agent process running in a tmux session. Each session has an ID, title, tool (e.g. `claude`), and project path.
+## Requirements
+
+The `aoe` and `tmux` binaries must be on `PATH`, and commands run through a shell. Install aoe from https://github.com/agent-of-empires/agent-of-empires.
+
+## Core Concepts
+
+- **Session**: An agent process running in a tmux session. Each has an ID, title, tool (e.g. `claude`), and project path.
 - **Group**: A named folder for organizing sessions (supports nesting with `/`, e.g. `backend/api`).
 - **Profile**: A separate workspace with its own sessions and config. Use `-p <name>` globally or set `AGENT_OF_EMPIRES_PROFILE`.
 - **Status**: One of `running`, `waiting`, `idle`, `stopped`, `error`, `starting`, `unknown`.
 
-## Command reference
-
-### Adding sessions
+## Adding Sessions
 
 ```bash
 # Add a session for the current directory
@@ -58,20 +62,15 @@ aoe add . -t "sub task" -P <parent-id>
 aoe add . -t "yolo" -y -l
 ```
 
-### Listing sessions
+## Listing Sessions
 
 ```bash
-# Human-readable list
-aoe list
-
-# JSON output for parsing
-aoe list --json
-
-# List across all profiles
-aoe list --all
+aoe list              # human-readable
+aoe list --json       # JSON for parsing
+aoe list --all        # across all profiles
 ```
 
-**JSON output shape** (`aoe list --json`):
+**JSON shape** (`aoe list --json`):
 ```json
 [
   {
@@ -88,9 +87,9 @@ aoe list --all
 ]
 ```
 
-`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `list --json` does not include live status; use `aoe status --json` or `aoe session capture --json` for that.
+`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `list --json` does not include live status: use `aoe status --json` or `aoe session capture --json` for that.
 
-### Session lifecycle
+## Session Lifecycle
 
 ```bash
 aoe session start <id-or-title>
@@ -99,10 +98,10 @@ aoe session restart <id-or-title>
 aoe session attach <id-or-title>   # interactive attach
 ```
 
-### Inspecting sessions
+## Inspecting Sessions
 
 ```bash
-# Show session metadata
+# Session metadata
 aoe session show <id-or-title> --json
 
 # Capture tmux pane content (key for monitoring)
@@ -115,7 +114,7 @@ aoe status --json
 aoe status -q   # just the waiting count (for scripting)
 ```
 
-**JSON output shape** (`aoe session capture --json`):
+**JSON shape** (`aoe session capture --json`):
 ```json
 {
   "id": "a1b2c3d4-...",
@@ -127,7 +126,7 @@ aoe status -q   # just the waiting count (for scripting)
 }
 ```
 
-**JSON output shape** (`aoe session show --json`):
+**JSON shape** (`aoe session show --json`):
 ```json
 {
   "id": "a1b2c3d4-...",
@@ -141,7 +140,9 @@ aoe status -q   # just the waiting count (for scripting)
 }
 ```
 
-**JSON output shape** (`aoe status --json`):
+`parent_session_id` is included only for sub-sessions.
+
+**JSON shape** (`aoe status --json`):
 ```json
 {
   "waiting": 1,
@@ -155,7 +156,7 @@ aoe status -q   # just the waiting count (for scripting)
 
 ### Auto-detection (inside a tmux pane)
 
-When called from within an aoe-managed tmux session, identifier can be omitted:
+When called from within an aoe-managed tmux session, the identifier can be omitted:
 
 ```bash
 aoe session show          # auto-detects current session
@@ -163,7 +164,7 @@ aoe session capture       # auto-detects current session
 aoe session current --json
 ```
 
-### Renaming and organizing
+## Renaming and Organizing
 
 ```bash
 aoe session rename <id> -t "new title"
@@ -175,17 +176,17 @@ aoe group list --json
 aoe group delete mygroup --force
 ```
 
-### Profiles
+## Profiles
 
 ```bash
 aoe profile list
 aoe profile create staging
 aoe profile delete staging
 aoe profile default staging   # set default
-aoe -p staging list            # use inline
+aoe -p staging list           # use inline
 ```
 
-### Worktrees
+## Worktrees
 
 ```bash
 aoe worktree list
@@ -193,14 +194,14 @@ aoe worktree info <id-or-title>
 aoe worktree cleanup -f
 ```
 
-### Removing sessions
+## Removing Sessions
 
 ```bash
 aoe remove <id-or-title>
 aoe remove <id-or-title> --delete-worktree --force
 ```
 
-## Workflow patterns
+## Workflow Patterns
 
 ### Single agent
 
@@ -221,7 +222,7 @@ aoe status --json   # check all at once
 
 ### Monitoring loop
 
-Poll all sessions until none are running:
+Poll all sessions until none are running or waiting:
 
 ```bash
 while true; do
@@ -247,6 +248,16 @@ for id in $(aoe list --json | jq -r '.[].id'); do
 done
 ```
 
-### Group operations via TUI
+## Common Pitfalls
 
-Groups are primarily managed through the `aoe` TUI (run `aoe` with no arguments). The TUI supports bulk start/stop/restart on groups. Use CLI commands above for scripted workflows.
+1. **Expecting `aoe list --json` to carry live status.** It does not. The fields are static session metadata (`path`, `group`, `tool`, `command`, etc.). For status, call `aoe status --json` or `aoe session capture --json`.
+2. **Using raw `tmux` to start or stop agents.** That bypasses aoe's tracking; the session's status and metadata go stale. Always use `aoe session start/stop/restart`.
+3. **Forgetting `-l`/`--launch`.** `aoe add` creates a session but does not start it unless you pass `-l`.
+4. **Running across the wrong profile.** Sessions are profile-scoped; use `-p <name>` or set `AGENT_OF_EMPIRES_PROFILE` when scripting, and `aoe list --all` to see everything.
+
+## Verification Checklist
+
+- [ ] `aoe` and `tmux` are on `PATH`.
+- [ ] `aoe add` was followed by a launch (`-l`) or an explicit `aoe session start`.
+- [ ] JSON parsing reads `path`/`group` (not `project_path`/`group_path`) and gets status from `aoe status`/`aoe session capture`, not `aoe list`.
+- [ ] Scripted polling exits when both `running` and `waiting` reach 0.

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -66,6 +66,20 @@ gh workflow run prepare-release.yml -f version=1.7.2
 
 This bypasses the staging PR. `prepare-release.yml` regenerates `CHANGELOG.md` from git-cliff and folds it into the same `chore: bump version` commit; `release.yml` builds the binaries and creates the GitHub Release with the per-version body that git-cliff emits via `--current --strip header`.
 
+## Skill hubs
+
+`aoe` ships a coding-agent management skill to two skill hubs. The skill sources live in `contrib/`, and `cargo xtask check-skill` (run in CI) validates that both reference real CLI commands and follow each hub's frontmatter rules.
+
+- **ClawHub** (`contrib/openclaw-skill/`): published automatically by the `publish-clawhub` job in `release.yml` on every release, using `CLAWHUB_TOKEN`. ClawHub is a registry, so each release idempotently pushes the new version. The frontmatter must not carry a top-level `version:` field; ClawHub's `_meta.json` and the `--version` flag are the source of truth.
+
+- **Hermes Agent Skills Hub** (`contrib/hermes-skill/`): published manually. Unlike ClawHub, the Hermes hub is GitHub-PR-based: `hermes skills publish` forks the hub repo, commits the skill snapshot, and opens a PR for a maintainer to merge. There is no auto-sync, so the in-repo copy is the source of truth and the hub copy drifts until you re-publish. The frontmatter must carry a top-level `version:` field. To publish (or push an update), bump the `version:` in `contrib/hermes-skill/SKILL.md`, then run:
+
+  ```bash
+  hermes skills publish contrib/hermes-skill --to github --repo NousResearch/hermes-agent
+  ```
+
+  This requires the `hermes` CLI and a GitHub token with fork permissions (`GITHUB_TOKEN` in `~/.hermes/.env` or `gh auth login`). Re-run it whenever the skill changes meaningfully; cadence is "on change," not "every release."
+
 ## Versioning
 
 We follow semver, but the autopick is patch. Maintainer adjusts when:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -198,45 +198,121 @@ fn collect_subcommand_paths(cmd: &clap::Command, prefix: &str, out: &mut BTreeSe
     }
 }
 
+/// How the skill's published version is sourced, which determines whether a
+/// top-level `version:` field is allowed in the frontmatter.
+enum VersionRule {
+    /// clawhub manages the version via `_meta.json` and the release workflow's
+    /// `--version` flag, so a static `version:` field would go stale: forbid it.
+    Forbidden,
+    /// The Hermes Skills Hub requires a top-level `version:` field: require it.
+    Required,
+}
+
 fn check_skill() {
-    let skill_path = Path::new("contrib/openclaw-skill/SKILL.md");
-    if !skill_path.exists() {
-        eprintln!("Skill file not found: {}", skill_path.display());
-        std::process::exit(1);
-    }
+    let skills = [
+        ("contrib/openclaw-skill/SKILL.md", VersionRule::Forbidden),
+        ("contrib/hermes-skill/SKILL.md", VersionRule::Required),
+    ];
 
-    let content = fs::read_to_string(skill_path).expect("Failed to read SKILL.md");
-
-    let mut has_error = false;
-
-    // The skill's published version is managed by clawhub via _meta.json and
-    // the release workflow's `--version` flag. A static `version:` in the
-    // frontmatter goes stale on every release, so disallow it.
-    if let Some((frontmatter, _)) = content
-        .strip_prefix("---\n")
-        .and_then(|s| s.split_once("\n---"))
-    {
-        for line in frontmatter.lines() {
-            if line.starts_with("version:") {
-                eprintln!(
-                    "ERROR: SKILL.md frontmatter must not contain a top-level `version:` field; \
-                     clawhub's _meta.json is the source of truth"
-                );
-                has_error = true;
-                break;
-            }
-        }
-    }
-
-    // Build the clap command tree
+    // Build the clap command tree once; shared across every skill file.
     let cli_cmd = agent_of_empires::cli::Cli::command();
     let mut cli_commands: BTreeSet<String> = BTreeSet::new();
     collect_subcommand_paths(&cli_cmd, "", &mut cli_commands);
 
+    let mut has_error = false;
+    let mut referenced: BTreeSet<String> = BTreeSet::new();
+
+    for (path_str, version_rule) in &skills {
+        let skill_path = Path::new(path_str);
+        if !skill_path.exists() {
+            eprintln!("Skill file not found: {}", skill_path.display());
+            has_error = true;
+            continue;
+        }
+
+        let content = fs::read_to_string(skill_path).expect("Failed to read SKILL.md");
+
+        if check_skill_file(
+            path_str,
+            &content,
+            version_rule,
+            &cli_commands,
+            &mut referenced,
+        ) {
+            has_error = true;
+        }
+    }
+
+    // Advisory: CLI commands not referenced in any skill file.
+    let mut missing_from_skill = Vec::new();
+    for cli_cmd in &cli_commands {
+        let mentioned = referenced.iter().any(|s| {
+            s == cli_cmd
+                || cli_cmd.starts_with(&format!("{} ", s))
+                || s.starts_with(&format!("{} ", cli_cmd))
+        });
+        if !mentioned {
+            missing_from_skill.push(cli_cmd.clone());
+        }
+    }
+
+    if !missing_from_skill.is_empty() {
+        println!("Advisory: CLI commands not referenced in any skill file:");
+        for cmd in &missing_from_skill {
+            println!("  aoe {}", cmd);
+        }
+    }
+
+    if has_error {
+        std::process::exit(1);
+    }
+
+    println!("Skill check passed.");
+}
+
+/// Validate one skill file's frontmatter version rule and command references.
+/// Referenced commands are accumulated into `referenced` for the shared
+/// advisory. Returns `true` if an error was found.
+fn check_skill_file(
+    path_str: &str,
+    content: &str,
+    version_rule: &VersionRule,
+    cli_commands: &BTreeSet<String>,
+    referenced: &mut BTreeSet<String>,
+) -> bool {
+    let mut has_error = false;
+
+    let has_version = content
+        .strip_prefix("---\n")
+        .and_then(|s| s.split_once("\n---"))
+        .is_some_and(|(frontmatter, _)| {
+            frontmatter.lines().any(|line| line.starts_with("version:"))
+        });
+
+    match version_rule {
+        VersionRule::Forbidden if has_version => {
+            eprintln!(
+                "ERROR: {} frontmatter must not contain a top-level `version:` field; \
+                 clawhub's _meta.json is the source of truth",
+                path_str
+            );
+            has_error = true;
+        }
+        VersionRule::Required if !has_version => {
+            eprintln!(
+                "ERROR: {} frontmatter must contain a top-level `version:` field; \
+                 the Hermes Skills Hub requires it",
+                path_str
+            );
+            has_error = true;
+        }
+        _ => {}
+    }
+
     // Extract `aoe <words>` patterns and match longest valid subcommand path
     let re = regex::Regex::new(r"aoe\s+([a-z][a-z0-9 -]*)").unwrap();
     let mut skill_commands: BTreeSet<String> = BTreeSet::new();
-    for cap in re.captures_iter(&content) {
+    for cap in re.captures_iter(content) {
         let raw = cap[1].trim();
         let words: Vec<&str> = raw
             .split_whitespace()
@@ -281,37 +357,14 @@ fn check_skill() {
                 .any(|c| c.starts_with(&format!("{} ", skill_cmd)));
             if !is_prefix {
                 eprintln!(
-                    "ERROR: Skill references command 'aoe {}' which does not exist in CLI",
-                    skill_cmd
+                    "ERROR: {} references command 'aoe {}' which does not exist in CLI",
+                    path_str, skill_cmd
                 );
                 has_error = true;
             }
         }
     }
 
-    // Advisory: CLI commands not mentioned in skill
-    let mut missing_from_skill = Vec::new();
-    for cli_cmd in &cli_commands {
-        let mentioned = skill_commands.iter().any(|s| {
-            s == cli_cmd
-                || cli_cmd.starts_with(&format!("{} ", s))
-                || s.starts_with(&format!("{} ", cli_cmd))
-        });
-        if !mentioned {
-            missing_from_skill.push(cli_cmd.clone());
-        }
-    }
-
-    if !missing_from_skill.is_empty() {
-        println!("Advisory: CLI commands not referenced in skill file:");
-        for cmd in &missing_from_skill {
-            println!("  aoe {}", cmd);
-        }
-    }
-
-    if has_error {
-        std::process::exit(1);
-    }
-
-    println!("Skill check passed.");
+    referenced.extend(skill_commands);
+    has_error
 }


### PR DESCRIPTION
## Description

Publishes the `aoe` coding-agent management skill to the [Hermes Agent Skills Hub](https://hermes-agent.nousresearch.com/docs/developer-guide/creating-skills), mirroring what we already do for OpenClaw/ClawHub.

- **New `contrib/hermes-skill/SKILL.md`** in the Hermes skill format: a required top-level `version:` field, `author`, `license`, `metadata.hermes.{tags, related_skills}`, a "Use when ..." description, and the peer structure Hermes skills follow (Overview / When to Use / body / Common Pitfalls / Verification Checklist). The content is adapted from the OpenClaw skill with corrected JSON shapes.
- **Documents the publish flow** in `docs/development/releases.md`. Unlike ClawHub (a registry pushed idempotently on every release), the Hermes hub is GitHub-PR-based: `hermes skills publish` forks the hub repo and opens a PR, so the in-repo copy is the source of truth and updates land as re-publish PRs (cadence is "on change", not "every release").
- **Extends `cargo xtask check-skill`** to validate both skill files, applying the opposite version rule to each (forbidden for ClawHub since its `_meta.json` owns the version; required for Hermes) while sharing the CLI-command-reference validation.
- **Fixes two stale JSON shapes in the OpenClaw skill** that the command-reference check could not catch:
  - `aoe list --json` documented `project_path`/`group_path` and a nonexistent `status` field; the real fields are `path`/`group`, and `list` carries no live status.
  - `aoe status --json` documented a nonexistent `sessions` array and omitted the real `error` count.

Fixes #1855

## PR Type

- [x] New Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The validation surface here is `cargo xtask check-skill`, which is exercised in CI (Skill Check job) and now covers both skill files, including the per-file version rule (verified locally that both the forbidden and required cases fire).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude researched the Hermes skill format and publish mechanism (reading `NousResearch/hermes-agent`'s `hermes_cli/skills_hub.py` and the authoring skill), drafted the skill file and xtask changes, and found the OpenClaw JSON-shape bugs by diffing the documented shapes against the actual `SessionJson`/`StatusJson`/`CaptureOutput`/`SessionDetails` serializers. njbrake directed the scope and decisions.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR publishes the `aoe` coding-agent management skill to the Hermes Agent Skills Hub and updates related tooling and documentation.

**Files added:**
- `contrib/hermes-skill/SKILL.md` — New Hermes-compatible skill file documenting the aoe tool, including use cases, requirements, core concepts, command examples, workflows, common pitfalls, and a verification checklist

**Files updated:**
- `contrib/openclaw-skill/SKILL.md` — Fixed outdated JSON output schemas for `aoe list --json` and `aoe status --json` commands to reflect actual API responses
- `docs/development/releases.md` — Added documentation of the Hermes publish flow, explaining how aoe distributes skills to both ClawHub and Hermes, including differences in publishing cadence and mechanics
- `xtask/src/main.rs` — Refactored the `check-skill` validation command to handle both OpenClaw and Hermes skill files with their different requirements (e.g., version field handling)

## High-Level Summary

This PR enables the aoe tool to reach users through the Hermes Agent Skills Hub by creating a companion skill definition and updating the validation infrastructure. It also corrects stale documentation in the existing OpenClaw skill file and clarifies the publishing workflow for future maintainers. The validation tooling is now flexible enough to support both hub formats simultaneously while enforcing format-specific rules.

## Benefits

- **Expanded reach**: aoe is now published to Hermes, making it available to a broader audience of AI agents and developers
- **Consistent documentation**: Both hub platforms now have accurate, up-to-date skill documentation
- **Maintainability**: The shared validation logic reduces duplication and ensures both skill files remain valid
- **Future-proof**: The refactored `check-skill` command scales to additional hub formats without major rework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->