### PR TITLE
fix(web): stop diff comments writing empty localStorage keys and sweep orphans

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import { useResolvedTheme } from "./hooks/useResolvedTheme";
 import { useWebSettings } from "./hooks/useWebSettings";
 import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useDiffComments } from "./hooks/useDiffComments";
+import { sweepOrphanComments } from "./components/diff/comments/storage";
 import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialog";
 import { useCommandActions } from "./hooks/useCommandActions";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
@@ -234,6 +235,17 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     if (!sessionsLoaded) return;
     sweptDraftsRef.current = true;
     sweepOrphanDrafts(new Set(sessions.map((s) => s.id)));
+  }, [sessionsLoaded, sessions]);
+
+  // Same once-on-mount sweep for diff-comments keys (#1842). Clears keys for
+  // deleted sessions and retroactively removes empty keys written before the
+  // empty-removal fix. Mirrors the draft sweep above.
+  const sweptCommentsRef = useRef(false);
+  useEffect(() => {
+    if (sweptCommentsRef.current) return;
+    if (!sessionsLoaded) return;
+    sweptCommentsRef.current = true;
+    sweepOrphanComments(new Set(sessions.map((s) => s.id)));
   }, [sessionsLoaded, sessions]);
 
   const [sidebarSortMode, setSidebarSortMode] = useSidebarSortMode();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,7 +18,10 @@ import { useResolvedTheme } from "./hooks/useResolvedTheme";
 import { useWebSettings } from "./hooks/useWebSettings";
 import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useDiffComments } from "./hooks/useDiffComments";
-import { sweepOrphanComments } from "./components/diff/comments/storage";
+import {
+  clearStoredComments,
+  sweepOrphanComments,
+} from "./components/diff/comments/storage";
 import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialog";
 import { useCommandActions } from "./hooks/useCommandActions";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
@@ -555,6 +558,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     // localStorage key doesn't linger (#1358). Cross-tab / cross-device
     // deletes go through the startup sweep instead.
     clearDraft(sessionId);
+    // Same hygiene for persisted diff-comments storage (#1842); cross-tab /
+    // cross-device deletes still fall to the startup sweep.
+    clearStoredComments(sessionId);
 
     // Server returns `messages` from `perform_deletion` when there's something
     // user-facing to report (e.g. "Scratch directory kept at: <path>" when

--- a/web/src/components/diff/comments/storage.sweep.test.ts
+++ b/web/src/components/diff/comments/storage.sweep.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+//
+// sweepOrphanComments iterates window.localStorage, so it needs a real DOM
+// storage (jsdom) rather than the node-env fake used by storage.test.ts.
+// Mirrors the sweepOrphanDrafts coverage in cockpitDrafts.test.ts (#1842).
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  EMPTY_STORAGE,
+  saveComments,
+  storageKey,
+  sweepOrphanComments,
+} from "./storage";
+import type { DiffComment } from "./types";
+
+function mkComment(overrides: Partial<DiffComment> = {}): DiffComment {
+  return {
+    id: "c1",
+    filePath: "src/foo.rs",
+    side: "new",
+    startLine: 5,
+    endLine: 5,
+    body: "review",
+    capturedSnippet: "snippet",
+    createdAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("sweepOrphanComments", () => {
+  it("removes keys for sessions not in the active set", () => {
+    saveComments("active", { ...EMPTY_STORAGE, comments: [mkComment({})] });
+    saveComments("orphan", { ...EMPTY_STORAGE, comments: [mkComment({})] });
+    sweepOrphanComments(new Set(["active"]));
+    expect(window.localStorage.getItem(storageKey("active"))).not.toBeNull();
+    expect(window.localStorage.getItem(storageKey("orphan"))).toBeNull();
+  });
+
+  it("leaves unrelated keys untouched", () => {
+    window.localStorage.setItem("cockpit:draft:foo", "keep me");
+    saveComments("orphan", { ...EMPTY_STORAGE, comments: [mkComment({})] });
+    sweepOrphanComments(new Set());
+    expect(window.localStorage.getItem("cockpit:draft:foo")).toBe("keep me");
+    expect(window.localStorage.getItem(storageKey("orphan"))).toBeNull();
+  });
+
+  it("is a no-op when every key is active", () => {
+    saveComments("a", { ...EMPTY_STORAGE, comments: [mkComment({})] });
+    saveComments("b", { ...EMPTY_STORAGE, comments: [mkComment({})] });
+    sweepOrphanComments(new Set(["a", "b"]));
+    expect(window.localStorage.getItem(storageKey("a"))).not.toBeNull();
+    expect(window.localStorage.getItem(storageKey("b"))).not.toBeNull();
+  });
+});

--- a/web/src/components/diff/comments/storage.test.ts
+++ b/web/src/components/diff/comments/storage.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  clearStoredComments,
   EMPTY_STORAGE,
   isEmptyState,
   loadComments,
@@ -206,6 +207,23 @@ describe("storage", () => {
       saveComments("sess-1", { ...EMPTY_STORAGE, comments: [mkComment({})] });
       expect(data.has(storageKey("sess-1"))).toBe(true);
       expect(loadComments("sess-1").comments).toHaveLength(1);
+    });
+  });
+
+  describe("clearStoredComments", () => {
+    it("removes the key for a single session", () => {
+      const data = installFakeLocalStorage();
+      saveComments("sess-1", { ...EMPTY_STORAGE, comments: [mkComment({})] });
+      saveComments("sess-2", { ...EMPTY_STORAGE, comments: [mkComment({})] });
+      clearStoredComments("sess-1");
+      expect(data.has(storageKey("sess-1"))).toBe(false);
+      expect(data.has(storageKey("sess-2"))).toBe(true);
+    });
+
+    it("is a no-op for a session with no stored comments", () => {
+      const data = installFakeLocalStorage();
+      expect(() => clearStoredComments("absent")).not.toThrow();
+      expect(data.has(storageKey("absent"))).toBe(false);
     });
   });
 });

--- a/web/src/components/diff/comments/storage.test.ts
+++ b/web/src/components/diff/comments/storage.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { EMPTY_STORAGE, loadComments, saveComments, storageKey } from "./storage";
+import {
+  EMPTY_STORAGE,
+  isEmptyState,
+  loadComments,
+  saveComments,
+  storageKey,
+} from "./storage";
 import type { DiffComment, DiffCommentsStorageV1 } from "./types";
 
 // Vitest default env is node; install a minimal in-memory localStorage
@@ -139,12 +145,67 @@ describe("storage", () => {
     const spy = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
       throw new Error("QuotaExceeded");
     });
-    // Should not throw despite the failing setItem.
-    expect(() => saveComments("sess-1", EMPTY_STORAGE)).not.toThrow();
+    // Non-empty state still routes through setItem; should not throw despite
+    // the failing write.
+    expect(() =>
+      saveComments("sess-1", { ...EMPTY_STORAGE, comments: [mkComment({})] }),
+    ).not.toThrow();
     expect(spy).toHaveBeenCalled();
   });
 
   it("uses a deterministic, versioned key", () => {
     expect(storageKey("abc")).toBe("aoe:diff-comments:v1:abc");
+  });
+
+  describe("isEmptyState", () => {
+    it("is true for the empty envelope", () => {
+      expect(isEmptyState(EMPTY_STORAGE)).toBe(true);
+    });
+
+    it("ignores a non-default clearAfterSend toggle", () => {
+      expect(isEmptyState({ ...EMPTY_STORAGE, clearAfterSend: false })).toBe(
+        true,
+      );
+    });
+
+    it("is false with a comment", () => {
+      expect(
+        isEmptyState({ ...EMPTY_STORAGE, comments: [mkComment({})] }),
+      ).toBe(false);
+    });
+
+    it("is false with draft text", () => {
+      expect(isEmptyState({ ...EMPTY_STORAGE, introDraft: "hi" })).toBe(false);
+      expect(isEmptyState({ ...EMPTY_STORAGE, outroDraft: "bye" })).toBe(false);
+    });
+  });
+
+  describe("saveComments empty-removal", () => {
+    it("removes the key instead of writing an empty record", () => {
+      const data = installFakeLocalStorage();
+      saveComments("sess-1", EMPTY_STORAGE);
+      expect(data.has(storageKey("sess-1"))).toBe(false);
+    });
+
+    it("removes an existing key when state goes back to empty", () => {
+      const data = installFakeLocalStorage();
+      saveComments("sess-1", { ...EMPTY_STORAGE, comments: [mkComment({})] });
+      expect(data.has(storageKey("sess-1"))).toBe(true);
+      saveComments("sess-1", EMPTY_STORAGE);
+      expect(data.has(storageKey("sess-1"))).toBe(false);
+    });
+
+    it("treats a lone clearAfterSend toggle as empty and removes the key", () => {
+      const data = installFakeLocalStorage();
+      saveComments("sess-1", { ...EMPTY_STORAGE, clearAfterSend: false });
+      expect(data.has(storageKey("sess-1"))).toBe(false);
+    });
+
+    it("still persists non-empty state", () => {
+      const data = installFakeLocalStorage();
+      saveComments("sess-1", { ...EMPTY_STORAGE, comments: [mkComment({})] });
+      expect(data.has(storageKey("sess-1"))).toBe(true);
+      expect(loadComments("sess-1").comments).toHaveLength(1);
+    });
   });
 });

--- a/web/src/components/diff/comments/storage.ts
+++ b/web/src/components/diff/comments/storage.ts
@@ -1,10 +1,19 @@
-import { safeGetItem, safeSetItem } from "../../../lib/safeStorage";
+import {
+  safeGetItem,
+  safeRemoveItem,
+  safeSetItem,
+} from "../../../lib/safeStorage";
 import type { DiffComment, DiffCommentsStorageV1 } from "./types";
 
 const KEY_PREFIX = "aoe:diff-comments:v1:";
 
 export function storageKey(sessionId: string): string {
   return `${KEY_PREFIX}${sessionId}`;
+}
+
+function sessionIdFromKey(key: string): string | null {
+  if (!key.startsWith(KEY_PREFIX)) return null;
+  return key.slice(KEY_PREFIX.length);
 }
 
 export const EMPTY_STORAGE: DiffCommentsStorageV1 = {
@@ -44,11 +53,52 @@ export function loadComments(sessionId: string): DiffCommentsStorageV1 {
   }
 }
 
+/** An empty state carries no comments and no draft text. `clearAfterSend`
+ *  is ignored: it defaults to true and a lone non-default toggle on an
+ *  otherwise-empty session is inert until a comment exists (at which point
+ *  the state is no longer empty and persists). Treating it as empty matches
+ *  user intent (nothing to send) and the cockpit-drafts precedent (#1358). */
+export function isEmptyState(s: DiffCommentsStorageV1): boolean {
+  return s.comments.length === 0 && s.introDraft === "" && s.outroDraft === "";
+}
+
 export function saveComments(
   sessionId: string,
   state: DiffCommentsStorageV1,
 ): void {
+  // Remove the key for empty state rather than writing an empty record, so
+  // sessions the user never commented on don't accumulate junk keys. Both
+  // the write-through and the pagehide flush route through here, so this
+  // covers every write path at once. Mirrors setDraft's empty-removal (#1358).
+  if (isEmptyState(state)) {
+    safeRemoveItem(storageKey(sessionId));
+    return;
+  }
   safeSetItem(storageKey(sessionId), JSON.stringify(state));
+}
+
+// Remove every `aoe:diff-comments:v1:<id>` key whose session id is not in
+// the given active set. Run once on app mount to catch keys left behind by
+// session deletions in another tab or on another device, and to retroactively
+// clear empty keys written before the empty-removal fix landed. Mirrors
+// sweepOrphanDrafts (#1358).
+export function sweepOrphanComments(
+  activeSessionIds: ReadonlySet<string>,
+): void {
+  if (typeof window === "undefined") return;
+  const toRemove: string[] = [];
+  try {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (!k) continue;
+      const sid = sessionIdFromKey(k);
+      if (sid === null) continue;
+      if (!activeSessionIds.has(sid)) toRemove.push(k);
+    }
+    for (const k of toRemove) window.localStorage.removeItem(k);
+  } catch {
+    /* localStorage blocked; sweep is best-effort */
+  }
 }
 
 export function isWellFormed(c: unknown): c is DiffComment {

--- a/web/src/components/diff/comments/storage.ts
+++ b/web/src/components/diff/comments/storage.ts
@@ -77,6 +77,14 @@ export function saveComments(
   safeSetItem(storageKey(sessionId), JSON.stringify(state));
 }
 
+// Drop the persisted diff-comments for a single session id. Convenience
+// over saveComments(id, EMPTY_STORAGE); intended for session-delete paths
+// (mirrors clearDraft for cockpit composer drafts). Cross-tab / cross-device
+// deletes still fall to sweepOrphanComments on the next mount.
+export function clearStoredComments(sessionId: string): void {
+  safeRemoveItem(storageKey(sessionId));
+}
+
 // Remove every `aoe:diff-comments:v1:<id>` key whose session id is not in
 // the given active set. Run once on app mount to catch keys left behind by
 // session deletions in another tab or on another device, and to retroactively

--- a/web/src/hooks/useDiffComments.rtl.test.tsx
+++ b/web/src/hooks/useDiffComments.rtl.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+//
+// RTL coverage for the diff-comments empty-key fix (#1842). Renders the
+// real hook (debounce + pagehide flush included) and asserts the storage
+// hygiene contract that the storage-layer tests pin at the saveComments
+// boundary:
+//   - switching across sessions the user never commented on writes no key
+//   - a session with real, unsent comments survives a pagehide flush
+// Both fail on the pre-fix tree (empty state was written through, and the
+// pagehide flush wrote it again on every tab-away).
+
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDiffComments } from "./useDiffComments";
+import { storageKey } from "../components/diff/comments/storage";
+
+const DEBOUNCE_MS = 200;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useDiffComments storage hygiene (#1842)", () => {
+  it("writes no key when switching across never-commented sessions", () => {
+    const { rerender } = renderHook(
+      ({ id }: { id: string }) => useDiffComments(id),
+      { initialProps: { id: "sess-A" } },
+    );
+
+    act(() => {
+      rerender({ id: "sess-B" });
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    act(() => {
+      rerender({ id: "sess-C" });
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(window.localStorage.getItem(storageKey("sess-A"))).toBeNull();
+    expect(window.localStorage.getItem(storageKey("sess-B"))).toBeNull();
+    expect(window.localStorage.getItem(storageKey("sess-C"))).toBeNull();
+  });
+
+  it("does not persist an empty active session on pagehide / tab-away", () => {
+    renderHook(() => useDiffComments("sess-empty"));
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    expect(window.localStorage.getItem(storageKey("sess-empty"))).toBeNull();
+  });
+
+  it("keeps real comments intact across a pagehide flush", () => {
+    const { result } = renderHook(() => useDiffComments("sess-real"));
+
+    act(() => {
+      result.current.addComment({
+        filePath: "src/foo.rs",
+        side: "new",
+        startLine: 5,
+        endLine: 5,
+        body: "needs a guard here",
+        capturedSnippet: "let x = 1;",
+      });
+    });
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    const raw = window.localStorage.getItem(storageKey("sess-real"));
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!) as { comments: { body: string }[] };
+    expect(parsed.comments).toHaveLength(1);
+    expect(parsed.comments[0].body).toBe("needs a guard here");
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -969,6 +969,19 @@
       ]
     },
     {
+      "id": "diff-comments.storage-cleanup",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/diff/comments/storage.test.ts",
+        "src/components/diff/comments/storage.sweep.test.ts",
+        "src/hooks/useDiffComments.rtl.test.tsx"
+      ],
+      "components": [
+        "web/src/components/diff/comments/storage.ts"
+      ]
+    },
+    {
       "id": "right-panel.mobile-picker",
       "kind": "mocked-playwright",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The diff-comments feature wrote an `aoe:diff-comments:v1:<sessionId>` localStorage key for sessions the user never commented on, and never pruned them. Each held an empty payload (`{"version":1,"comments":[],"clearAfterSend":true,"introDraft":"","outroDraft":""}`). One junk key accumulated per cockpit session ever opened, and on mobile the `pagehide` flush re-persisted the active (often empty) session on every tab-away. This is the diff-comments analog of the cockpit-drafts bug fixed in #1358, which got the empty-skip and orphan-sweep treatment that diff comments never did.

Two layers, both addressed by reusing the #1358 shape:

1. **Empty-removal at the write boundary.** `saveComments` now removes the key when the state is empty (no comments, blank intro/outro drafts) instead of writing an empty record. Both the debounced write-through and the `pagehide` / `beforeunload` flush route through `saveComments`, so this closes every write path at once, including the session-switch trace that defeated the `initialMountRef` guard. `clearAfterSend` is treated as inert when deciding emptiness: with zero comments there is nothing to send, so a lone non-default toggle does not keep the key alive (it persists naturally once a comment exists).

2. **Orphan sweep on mount.** A new `sweepOrphanComments(activeSessionIds)` mirrors `sweepOrphanDrafts`, wired once on app mount next to the existing draft sweep and gated on `sessionsLoaded`. It clears keys left by sessions deleted in another tab or device, and retroactively removes empty keys already on affected users' machines on their next load.

No migration is needed: the sweep plus empty-removal clears existing junk without a formal version bump. No user-visible behavior changes; this is storage hygiene.

Closes #1842

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, open DevTools, Application > Local Storage. Click through several cockpit sessions you have never commented on. Confirm no `aoe:diff-comments:v1:<id>` key appears for any of them.
- [ ] Open a session, add a diff comment, then delete it so the panel is empty again. Confirm the session's `aoe:diff-comments:v1:<id>` key is removed, not left as an empty record.
- [ ] Add a real, unsent diff comment to a session, switch tabs (fires `pagehide`) and come back. Confirm the comment is still there and its key still holds the comment payload.
- [ ] Delete a session that had diff comments, then reload the dashboard. Confirm the orphaned `aoe:diff-comments:v1:<deletedId>` key is gone and only keys for active sessions remain.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The change is pure storage logic, so coverage is Vitest (the layer the issue recommends and the one AGENTS.md assigns to payload/logic permutations), not Playwright. Added a `diff-comments.storage-cleanup` entry to `web/tests/coverage-matrix.json` mapping `web/src/components/diff/comments/storage.ts`, backed by: `storage.test.ts` (`isEmptyState`, `saveComments` empty-removal), a jsdom-env `storage.sweep.test.ts` (`sweepOrphanComments`), and `useDiffComments.rtl.test.tsx` (renderHook: never-commented session switches write no key; real comments survive a `pagehide` flush). The empty-removal and pagehide cases were verified red on the pre-fix tree.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (treat a lone `clearAfterSend` toggle as empty, once-on-mount sweep), reviewed each commit, and confirmed the reproduce-then-fix tests go red on the pre-fix tree.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR fixes diff-comments creating and keeping empty localStorage entries and adds a one-time cleanup for orphaned keys.

- saveComments now deletes a session's storage key when the state is empty (no comments and no intro/outro drafts), so empty records are no longer persisted.
- All write paths (debounced writes, session switches, and pagehide/beforeunload flush) route through saveComments to enforce the empty-removal behavior consistently.
- A one-time sweepOrphanComments(activeSessionIds) runs on app mount (after sessionsLoaded) to remove keys for sessions that no longer exist and to clear previously-written empty/orphan keys.
- Deleting a session now immediately clears its stored diff-comments via clearStoredComments.
- Tests (Vitest + RTL/jsdom) added to cover empty-state detection, saveComments empty-removal, orphan sweep behavior, and useDiffComments storage interactions.

## Technical Summary

- Modified:
  - web/src/components/diff/comments/storage.ts
    - Added isEmptyState(state)
    - saveComments(sessionId, state) now removes the key when empty; otherwise writes JSON via safeSetItem
    - Added clearStoredComments(sessionId)
    - Added sweepOrphanComments(activeSessionIds) that scans localStorage keys with a key parser and removes orphans (guarded for window presence and errors)
  - web/src/App.tsx
    - Imports and invokes sweepOrphanComments once after sessionsLoaded; calls clearStoredComments on session delete
  - web/src/components/diff/comments/storage.test.ts
    - Adjusted tests to exercise non-empty write behavior

- New:
  - web/src/components/diff/comments/storage.sweep.test.ts (Vitest jsdom tests for sweepOrphanComments)
  - web/src/hooks/useDiffComments.rtl.test.tsx (RTL/jsdom tests ensuring no empty writes on session switch/pagehide and proper persistence of real comments)
  - web/tests/coverage-matrix.json (added coverage surface for storage-cleanup)

- Exports added/changed:
  - export isEmptyState(state)
  - export clearStoredComments(sessionId)
  - export sweepOrphanComments(activeSessionIds)
  - saveComments now conditionally removes keys (behavior change, same signature)

## Benefits

- Prevents accumulation of empty localStorage keys and reduces storage bloat (important for constrained environments like mobile).
- Cleans up orphaned keys created by deleted sessions or legacy runs.
- Ensures consistent, centralized storage hygiene across all write paths.
- No migration or version bump required; behavior retroactively cleans prior empty/orphan keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->