### PR TITLE
feat: add anonymous opt-in usage telemetry

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -60,6 +60,11 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe theme list`↴](#aoe-theme-list)
 * [`aoe theme export`↴](#aoe-theme-export)
 * [`aoe theme dir`↴](#aoe-theme-dir)
+* [`aoe telemetry`↴](#aoe-telemetry)
+* [`aoe telemetry status`↴](#aoe-telemetry-status)
+* [`aoe telemetry enable`↴](#aoe-telemetry-enable)
+* [`aoe telemetry disable`↴](#aoe-telemetry-disable)
+* [`aoe telemetry reset-id`↴](#aoe-telemetry-reset-id)
 * [`aoe serve`↴](#aoe-serve)
 * [`aoe url`↴](#aoe-url)
 * [`aoe cockpit`↴](#aoe-cockpit)
@@ -109,6 +114,7 @@ Run without arguments to launch the TUI dashboard.
 * `tmux` — tmux integration utilities
 * `sounds` — Manage sound effects for agent state transitions
 * `theme` — Manage color themes (list, export, customize)
+* `telemetry` — Manage anonymous opt-in usage telemetry
 * `serve` — Start a web dashboard for remote session access
 * `url` — Print the current dashboard URL of a running `aoe serve` daemon
 * `cockpit` — Cockpit (ACP-based native agent rendering) management
@@ -913,6 +919,53 @@ Export a built-in theme as a TOML file for customization
 Show the custom themes directory path
 
 **Usage:** `aoe theme dir`
+
+
+
+## `aoe telemetry`
+
+Manage anonymous opt-in usage telemetry
+
+**Usage:** `aoe telemetry <COMMAND>`
+
+###### **Subcommands:**
+
+* `status` — Show the current telemetry opt-in state and install id
+* `enable` — Opt in to anonymous usage telemetry
+* `disable` — Opt out of telemetry (deletes the local install id)
+* `reset-id` — Generate a fresh anonymous install id (only while opted in)
+
+
+
+## `aoe telemetry status`
+
+Show the current telemetry opt-in state and install id
+
+**Usage:** `aoe telemetry status`
+
+
+
+## `aoe telemetry enable`
+
+Opt in to anonymous usage telemetry
+
+**Usage:** `aoe telemetry enable`
+
+
+
+## `aoe telemetry disable`
+
+Opt out of telemetry (deletes the local install id)
+
+**Usage:** `aoe telemetry disable`
+
+
+
+## `aoe telemetry reset-id`
+
+Generate a fresh anonymous install id (only while opted in)
+
+**Usage:** `aoe telemetry reset-id`
 
 
 

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -28,6 +28,7 @@ Only a small set of sub-targets is enumerated in the settings dropdown (see `KNO
 | `serve` | `aoe serve` daemonize/foreground startup, PID/URL file IO, tunnel up/down, signal-driven shutdown. |
 | `hooks` | Agent hook integration (Claude/Settl/Hermes/Kiro) install/uninstall, hook status file lifecycle, user-configured status hook command failures, and attached status hook watcher failures. |
 | `sound` | Notification sound asset download/install and per-event playback. |
+| `telemetry` | Anonymous opt-in usage telemetry: install-id persistence, opt-in/opt-out transitions, and send outcomes (all at `debug`). The `aoe serve` consent route emits under `http.api.telemetry`. |
 | `log.runtime` | Filter swaps (REST + runner file-watch). |
 
 ## Levels

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,78 @@
+# Telemetry
+
+Agent of Empires can send **anonymous, opt-in** usage telemetry so the
+maintainers can answer basic product questions (how many installs are active,
+how many sessions people keep open, which agents/models/platforms matter, TUI
+vs web). It is designed to be conservative: **off by default**, no PII, no
+content, and it honors `DO_NOT_TRACK`.
+
+## What is sent
+
+Only when you opt in, and only aggregate counts. Two event kinds, both with a
+closed, versioned schema (see `src/telemetry/events.rs`):
+
+- **`process_start`** on boot: surface (`cli` / `tui` / `serve`), aoe version,
+  OS, and CPU arch.
+- **`usage_snapshot`** from the TUI and `aoe serve`, on start and roughly
+  hourly: counts of sessions by status, how many are sandboxed / cockpit /
+  yolo, counts bucketed by agent and by model family, and whether the web
+  dashboard / cockpit was opened.
+
+Every agent and model string passes through a sanitizer
+(`src/telemetry/sanitize.rs`) that coerces it to a fixed allowlist: a custom
+agent command becomes `custom`, an unrecognized model becomes `other`. **Raw
+commands, file paths, titles, branch names, group paths, and prompts are never
+sent.**
+
+## What is never sent
+
+Prompts, file or project paths, session titles, branch names, group paths,
+custom command lines, model strings, hostnames, usernames, or anything derived
+from them. The install id is a random UUID generated locally on opt-in; it is
+never derived from hostname, username, MAC, or filesystem.
+
+## Anonymous install id
+
+Counting distinct installs needs a stable id. On opt-in, aoe generates a random
+`uuid::Uuid::new_v4()` and stores it in `<app_dir>/telemetry.json` (owner-only).
+It is kept **out of `config.toml`** on purpose, since people routinely paste
+their config into bug reports. Opting out deletes the file; `aoe telemetry
+reset-id` rotates it.
+
+## Controlling it
+
+Telemetry is **off by default**. Turn it on or off in any surface:
+
+- **CLI**: `aoe telemetry status | enable | disable | reset-id`
+- **TUI**: Settings → System → Telemetry
+- **Web dashboard**: Settings → Telemetry, or the one-time consent prompt shown
+  on first load
+
+New users also see a telemetry pane in the first-run walkthrough; users who
+finished the walkthrough before telemetry existed get a one-time opt-in popup.
+
+### `DO_NOT_TRACK`
+
+If the `DO_NOT_TRACK` environment variable is set to `1` / `true` / `yes`,
+telemetry is suppressed absolutely: nothing is sent and no install id is
+generated, regardless of the config flag. Every surface shows this suppressed
+state explicitly rather than silently ignoring it.
+
+## Failure isolation
+
+Sends are fire-and-forget with a hard ~2s timeout and every error is swallowed
+(logged only at `debug`, `target: "telemetry"`). Telemetry never blocks, stalls
+on exit, or crashes the tool. There is no retry, no offline buffering.
+
+## Backend
+
+The client is **backend-neutral**. The send endpoint is read from the
+`AOE_TELEMETRY_ENDPOINT` environment variable; there is no hardcoded server.
+With no endpoint configured, nothing is ever sent even when opted in. The web
+dashboard never posts to the telemetry backend directly (that would leak the
+browser's IP and User-Agent); it reports local state to `aoe serve`, which owns
+the install id and does all sending.
+
+The collection service lives in a separate repository and is wired in by
+pointing `AOE_TELEMETRY_ENDPOINT` at it; until then opting in is a no-op beyond
+generating the local install id.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -12,11 +12,16 @@ Only when you opt in, and only aggregate counts. Two event kinds, both with a
 closed, versioned schema (see `src/telemetry/events.rs`):
 
 - **`process_start`** on boot: surface (`cli` / `tui` / `serve`), aoe version,
-  OS, and CPU arch.
-- **`usage_snapshot`** from the TUI and `aoe serve`, on start and roughly
-  hourly: counts of sessions by status, how many are sandboxed / cockpit /
+  OS, and CPU arch. The `cli` surface is throttled to at most once per install
+  per day, so scripting `aoe` in a loop never floods the endpoint.
+- **`usage_snapshot`** from the TUI and `aoe serve`, on start and then every
+  ~12 hours: counts of sessions by status, how many are sandboxed / cockpit /
   yolo, counts bucketed by agent and by model family, and whether the web
   dashboard / cockpit was opened.
+
+In practice that is a handful of small (well under 1 KB) requests per active
+install per day, with no retries and no offline buffering, so a flaky network
+drops events rather than building a backlog.
 
 Every agent and model string passes through a sanitizer
 (`src/telemetry/sanitize.rs`) that coerces it to a fixed allowlist: a custom

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -42,7 +42,9 @@ Counting distinct installs needs a stable id. On opt-in, aoe generates a random
 `uuid::Uuid::new_v4()` and stores it in `<app_dir>/telemetry.json` (owner-only).
 It is kept **out of `config.toml`** on purpose, since people routinely paste
 their config into bug reports. Opting out deletes the file; `aoe telemetry
-reset-id` rotates it.
+reset-id` rotates it. Resetting mints a brand-new id, so that install then
+counts as a new one in the aggregate distinct-install and retention numbers;
+only reset if you actually want to disassociate from prior counts.
 
 ## Controlling it
 
@@ -71,13 +73,20 @@ on exit, or crashes the tool. There is no retry, no offline buffering.
 
 ## Backend
 
-The client is **backend-neutral**. The send endpoint is read from the
-`AOE_TELEMETRY_ENDPOINT` environment variable; there is no hardcoded server.
-With no endpoint configured, nothing is ever sent even when opted in. The web
-dashboard never posts to the telemetry backend directly (that would leak the
+Opted-in events go to the collection gateway at
+`https://telemetry.agent-of-empires.com/v1/ingest`. The gateway validates the
+envelope and re-sanitizes every field as a defense-in-depth backstop, then
+folds the payload into aggregate counts. `AOE_TELEMETRY_ENDPOINT` overrides the
+target (point it at a local sink to see exactly what is sent). A compiled-in
+`X-Telemetry-Key` header lets the gateway drop unkeyed drive-by traffic; it is
+visible in the source, so it is noise-shedding, not authentication.
+
+The web dashboard never posts to the gateway directly (that would leak the
 browser's IP and User-Agent); it reports local state to `aoe serve`, which owns
 the install id and does all sending.
 
-The collection service lives in a separate repository and is wired in by
-pointing `AOE_TELEMETRY_ENDPOINT` at it; until then opting in is a no-op beyond
-generating the local install id.
+**Schema contract.** The wire format is the flat, closed schema in
+`src/telemetry/events.rs`, mirrored by the gateway. New fields must be counts,
+booleans, or short identifier-like strings (and the two allowlisted bucket
+maps); the gateway drops free text, paths, branch-name-like strings, and any
+nested object, so anything richer than a count or flag will not survive ingest.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -15,9 +15,13 @@ closed, versioned schema (see `src/telemetry/events.rs`):
   OS, and CPU arch. The `cli` surface is throttled to at most once per install
   per day, so scripting `aoe` in a loop never floods the endpoint.
 - **`usage_snapshot`** from the TUI and `aoe serve`, on start and then every
-  ~12 hours: counts of sessions by status, how many are sandboxed / cockpit /
-  yolo, counts bucketed by agent and by model family, and whether the web
-  dashboard / cockpit was opened.
+  ~12 hours. It is a point-in-time summary of the current install, never a
+  stream of actions:
+  - how many sessions exist and how many are running / idle / errored,
+  - how many use a sandbox, the cockpit, or yolo mode,
+  - a per-agent and per-model-family count (e.g. `{claude: 3, codex: 1}`),
+  - which opt-in features are turned on (see "Feature flags" below),
+  - whether the web dashboard / cockpit was opened since the last snapshot.
 
 In practice that is a handful of small (well under 1 KB) requests per active
 install per day, with no retries and no offline buffering, so a flaky network
@@ -28,6 +32,15 @@ Every agent and model string passes through a sanitizer
 agent command becomes `custom`, an unrecognized model becomes `other`. **Raw
 commands, file paths, titles, branch names, group paths, and prompts are never
 sent.**
+
+### Feature flags
+
+The snapshot includes a small `features` map (allowlisted feature name ->
+on/off) so we can see which opt-in features installs actually turn on. It is
+driven by a registry in `src/telemetry/features.rs`: tracking a newly gated
+feature is one entry there (name + how to read it from config), not a schema
+change. The key set is fixed and the values are booleans, so a flag can never
+carry a path or name, and the gateway forwards only this allowlisted shape.
 
 ## What is never sent
 

--- a/scripts/telemetry_sink.py
+++ b/scripts/telemetry_sink.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Local telemetry sink for trying out aoe's opt-in usage telemetry.
+
+A throwaway HTTP server that accepts the telemetry POSTs aoe sends and
+pretty-prints each payload to stdout. Use it to watch what the client emits
+without standing up the real collection backend.
+
+Usage:
+    python3 scripts/telemetry_sink.py            # listens on 127.0.0.1:8899
+    python3 scripts/telemetry_sink.py --port 9000
+
+Then, in another shell, point aoe at it and opt in:
+    export AOE_TELEMETRY_ENDPOINT=http://127.0.0.1:8899/ingest
+    aoe telemetry enable
+    aoe                  # TUI emits process_start + usage_snapshot
+    # or: aoe serve      # daemon emits a serve snapshot on boot and hourly
+
+Stdlib only, no dependencies. Ctrl-C to stop. Always replies 200 OK.
+"""
+
+import argparse
+import datetime
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("content-length", 0))
+        raw = self.rfile.read(length) if length else b""
+        stamp = datetime.datetime.now().strftime("%H:%M:%S")
+        try:
+            parsed = json.loads(raw)
+            body = json.dumps(parsed, indent=2, sort_keys=True)
+            event = parsed.get("event", "?") if isinstance(parsed, dict) else "?"
+        except (ValueError, UnicodeDecodeError):
+            body = raw.decode("utf-8", "replace")
+            event = "?"
+        ua = self.headers.get("user-agent", "")
+        # flush each line: stdout is block-buffered when piped to a file, and
+        # this server is meant to be watched live.
+        print(f"\n[{stamp}] POST {self.path}  event={event}  ({ua})", flush=True)
+        print(body, flush=True)
+        self.send_response(200)
+        self.send_header("content-length", "0")
+        self.end_headers()
+
+    # Silence the default per-request access log; the handler prints its own.
+    def log_message(self, *_args):
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8899)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    endpoint = f"http://{args.host}:{args.port}/ingest"
+    print(f"telemetry sink listening on {args.host}:{args.port}")
+    print(f"  export AOE_TELEMETRY_ENDPOINT={endpoint}")
+    print("  (Ctrl-C to stop)")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopping")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -25,6 +25,7 @@ use super::serve::ServeArgs;
 use super::session::SessionCommands;
 use super::sounds::SoundsCommands;
 use super::status::StatusArgs;
+use super::telemetry::TelemetryCommands;
 use super::theme::ThemeCommands;
 use super::tmux::TmuxCommands;
 use super::uninstall::UninstallArgs;
@@ -142,6 +143,12 @@ pub enum Commands {
     Theme {
         #[command(subcommand)]
         command: ThemeCommands,
+    },
+
+    /// Manage anonymous opt-in usage telemetry
+    Telemetry {
+        #[command(subcommand)]
+        command: TelemetryCommands,
     },
 
     /// Start a web dashboard for remote session access

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,6 +22,7 @@ pub mod serve;
 pub mod session;
 pub mod sounds;
 pub mod status;
+pub mod telemetry;
 pub mod theme;
 pub mod tmux;
 pub mod uninstall;

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -48,9 +48,13 @@ fn run_status() -> Result<()> {
         println!("Telemetry: disabled (default)");
     }
 
-    match endpoint {
-        Some(ep) => println!("  endpoint: {ep}"),
-        None => println!("  endpoint: (none configured; nothing is sent)"),
+    let overridden = std::env::var("AOE_TELEMETRY_ENDPOINT")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false);
+    if overridden {
+        println!("  endpoint: {endpoint}  (overridden via AOE_TELEMETRY_ENDPOINT)");
+    } else {
+        println!("  endpoint: {endpoint}  (default)");
     }
     Ok(())
 }
@@ -74,6 +78,12 @@ fn run_set_enabled(enabled: bool) -> Result<()> {
                 println!("  anonymous install id: {id}");
             }
         }
+    } else if crate::telemetry::install_id().is_some() {
+        // apply_opt_in_change only logs delete failures, so confirm rather
+        // than assume the file is gone.
+        println!(
+            "Telemetry disabled, but the local install id could not be removed; see the debug log."
+        );
     } else {
         println!("Telemetry disabled. The local install id has been deleted.");
     }
@@ -92,7 +102,13 @@ fn run_reset_id() -> Result<()> {
         return Ok(());
     }
     match crate::telemetry::reset_install_id() {
-        Some(id) => println!("Generated a fresh anonymous install id: {id}"),
+        Some(id) => {
+            println!("Generated a fresh anonymous install id: {id}");
+            println!(
+                "Note: the old id is gone, so this install now counts as a new one in \
+                 aggregate stats (distinct-install and retention counts)."
+            );
+        }
         None => println!("Could not generate a new install id."),
     }
     Ok(())

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -1,0 +1,99 @@
+//! `aoe telemetry` subcommands: inspect and control anonymous opt-in usage
+//! telemetry from the CLI.
+
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::session::{save_config, Config};
+
+#[derive(Subcommand)]
+pub enum TelemetryCommands {
+    /// Show the current telemetry opt-in state and install id
+    Status,
+    /// Opt in to anonymous usage telemetry
+    Enable,
+    /// Opt out of telemetry (deletes the local install id)
+    Disable,
+    /// Generate a fresh anonymous install id (only while opted in)
+    ResetId,
+}
+
+#[tracing::instrument(target = "cli.session", skip_all)]
+pub fn run(command: TelemetryCommands) -> Result<()> {
+    match command {
+        TelemetryCommands::Status => run_status(),
+        TelemetryCommands::Enable => run_set_enabled(true),
+        TelemetryCommands::Disable => run_set_enabled(false),
+        TelemetryCommands::ResetId => run_reset_id(),
+    }
+}
+
+fn run_status() -> Result<()> {
+    let enabled = Config::load_or_warn().telemetry.enabled;
+    let dnt = crate::telemetry::do_not_track();
+    let id = crate::telemetry::install_id();
+    let endpoint = crate::telemetry::endpoint();
+
+    if dnt {
+        println!("Telemetry: suppressed by DO_NOT_TRACK");
+        println!("  DO_NOT_TRACK is set, so nothing is sent and no install id is generated,");
+        println!("  regardless of the config setting (config enabled = {enabled}).");
+    } else if enabled {
+        println!("Telemetry: enabled (opt-in)");
+        match id {
+            Some(id) => println!("  install id: {id}"),
+            None => println!("  install id: (not yet generated)"),
+        }
+    } else {
+        println!("Telemetry: disabled (default)");
+    }
+
+    match endpoint {
+        Some(ep) => println!("  endpoint: {ep}"),
+        None => println!("  endpoint: (none configured; nothing is sent)"),
+    }
+    Ok(())
+}
+
+fn run_set_enabled(enabled: bool) -> Result<()> {
+    let mut config = Config::load_or_warn();
+    config.telemetry.enabled = enabled;
+    config.app_state.has_responded_to_telemetry = true;
+    save_config(&config)?;
+    crate::telemetry::apply_opt_in_change(enabled);
+
+    if enabled {
+        if crate::telemetry::do_not_track() {
+            println!(
+                "Telemetry enabled in config, but DO_NOT_TRACK is set, so nothing is sent \
+                 and no install id is generated."
+            );
+        } else {
+            println!("Telemetry enabled. Thank you for helping improve aoe.");
+            if let Some(id) = crate::telemetry::install_id() {
+                println!("  anonymous install id: {id}");
+            }
+        }
+    } else {
+        println!("Telemetry disabled. The local install id has been deleted.");
+    }
+    Ok(())
+}
+
+fn run_reset_id() -> Result<()> {
+    if !Config::load_or_warn().telemetry.enabled {
+        println!(
+            "Telemetry is disabled; nothing to reset. Enable it first with `aoe telemetry enable`."
+        );
+        return Ok(());
+    }
+    if crate::telemetry::do_not_track() {
+        println!("DO_NOT_TRACK is set; no install id is generated, so there is nothing to reset.");
+        return Ok(());
+    }
+    match crate::telemetry::reset_install_id() {
+        Some(id) => println!("Generated a fresh anonymous install id: {id}"),
+        None => println!("Could not generate a new install id."),
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod session;
 pub mod sound;
 mod status_hooks;
 pub mod task_util;
+pub mod telemetry;
 pub mod terminal;
 pub mod tmux;
 pub mod tui;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -146,6 +146,7 @@ pub const DEFAULT_TARGET_ROOTS: &[&str] = &[
     "serve",
     "hooks",
     "sound",
+    "telemetry",
 ];
 
 /// Sub-targets users can tune individually from the settings UI.

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,7 @@ async fn main() -> Result<()> {
                 ThemeCommands::Dir => cli::theme::run_dir(),
             };
         }
+        Some(Commands::Telemetry { command }) => return cli::telemetry::run(command),
         Some(Commands::Uninstall(args)) => return cli::uninstall::run(args).await,
         Some(Commands::Update(args)) => return cli::update::run(args).await,
         _ => {}
@@ -265,7 +266,19 @@ async fn main() -> Result<()> {
         migrations::run_migrations()?;
     }
 
-    match cli.command {
+    // Whether this invocation is a short-lived CLI command. The long-running
+    // surfaces (TUI, serve) emit their own `process_start` with the correct
+    // surface and run their own snapshot loop, so they're excluded here.
+    #[cfg(feature = "serve")]
+    let cli_oneshot = cli.command.is_some()
+        && !matches!(
+            cli.command,
+            Some(Commands::Serve(_)) | Some(Commands::CockpitRunner(_))
+        );
+    #[cfg(not(feature = "serve"))]
+    let cli_oneshot = cli.command.is_some();
+
+    let result = match cli.command {
         Some(Commands::Add(args)) => cli::add::run(&profile, *args).await,
         Some(Commands::List(args)) => cli::list::run(&profile, args).await,
         Some(Commands::Remove(args)) => cli::remove::run(&profile, args).await,
@@ -302,5 +315,16 @@ async fn main() -> Result<()> {
             tui::run(&profile, combined).await
         }
         _ => unreachable!(),
+    };
+
+    // Emit `process_start` for a short-lived CLI command AFTER it runs, so the
+    // command's own output isn't delayed. Awaited with a hard timeout so a
+    // dead endpoint can't hang exit; a no-op unless the user opted in and an
+    // endpoint is configured, so default-off users pay nothing.
+    if cli_oneshot {
+        agent_of_empires::telemetry::flush_process_start(agent_of_empires::telemetry::Surface::Cli)
+            .await;
     }
+
+    result
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,12 +318,11 @@ async fn main() -> Result<()> {
     };
 
     // Emit `process_start` for a short-lived CLI command AFTER it runs, so the
-    // command's own output isn't delayed. Awaited with a hard timeout so a
-    // dead endpoint can't hang exit; a no-op unless the user opted in and an
-    // endpoint is configured, so default-off users pay nothing.
+    // command's own output isn't delayed. Throttled to once per install per
+    // day and awaited with a hard timeout so a dead endpoint can't hang exit;
+    // a no-op unless the user opted in, so default-off users pay nothing.
     if cli_oneshot {
-        agent_of_empires::telemetry::flush_process_start(agent_of_empires::telemetry::Surface::Cli)
-            .await;
+        agent_of_empires::telemetry::flush_cli_process_start().await;
     }
 
     result

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -308,6 +308,11 @@ mod tests {
                 include_str!("../push.rs"),
                 &["subscribe", "unsubscribe", "test"],
             ),
+            (
+                "api/telemetry.rs",
+                include_str!("telemetry.rs"),
+                &["set_telemetry_consent", "post_telemetry_seen"],
+            ),
         ];
 
         let guard_patterns: &[&str] = &[

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -19,6 +19,7 @@ mod log_level;
 mod projects;
 mod sessions;
 mod system;
+mod telemetry;
 
 #[cfg(feature = "serve")]
 pub use cockpit::{
@@ -48,6 +49,7 @@ pub use system::{
     list_sounds, list_themes, rename_profile, serve_sound_file, update_profile_settings,
     update_settings,
 };
+pub use telemetry::{get_telemetry_status, post_telemetry_seen, set_telemetry_consent};
 
 const SHELL_METACHARACTERS: &[char] = &[
     ';', '&', '|', '$', '`', '(', ')', '{', '}', '<', '>', '\n', '\r', '\\', '"', '\'', '!', '#',

--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -85,12 +85,21 @@ pub struct SeenRequest {
 }
 
 /// Record that the web dashboard / cockpit web UI was opened. Folded into the
-/// daemon's next opt-in snapshot. A no-op (still 200) when telemetry is off so
-/// the client need not branch on consent state.
+/// daemon's next opt-in snapshot. Returns 204 on success; the client need not
+/// branch on consent state (the daemon only sends the flag when opted in).
 pub async fn post_telemetry_seen(
     State(state): State<Arc<AppState>>,
     body: Result<Json<SeenRequest>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
     let Json(req) = match body {
         Ok(b) => b,
         Err(rej) => return rej.into_response(),

--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -1,0 +1,110 @@
+//! Telemetry consent endpoints.
+//!
+//! The browser never posts to the telemetry backend (that would leak its IP /
+//! User-Agent and create a second identity surface). Instead it manages the
+//! opt-in state through the local daemon, which owns the install id and does
+//! all sending. `seen` lets the web UI report that the dashboard / cockpit was
+//! opened so the daemon's next snapshot can carry `web_seen` / `cockpit_seen`.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+
+use super::AppState;
+
+#[derive(Serialize)]
+pub struct TelemetryStatus {
+    /// `config.telemetry.enabled`.
+    enabled: bool,
+    /// Whether the user has answered the opt-in prompt (drives whether the
+    /// web consent modal should show).
+    responded: bool,
+    /// `DO_NOT_TRACK` is set; the toggle is forced off and nothing is sent.
+    do_not_track: bool,
+}
+
+fn current_status() -> TelemetryStatus {
+    let config = crate::session::Config::load_or_warn();
+    TelemetryStatus {
+        enabled: config.telemetry.enabled,
+        responded: config.app_state.has_responded_to_telemetry,
+        do_not_track: crate::telemetry::do_not_track(),
+    }
+}
+
+pub async fn get_telemetry_status() -> impl IntoResponse {
+    (StatusCode::OK, Json(current_status())).into_response()
+}
+
+#[derive(Deserialize)]
+pub struct ConsentRequest {
+    enabled: bool,
+}
+
+pub async fn set_telemetry_consent(
+    State(state): State<Arc<AppState>>,
+    body: Result<Json<ConsentRequest>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    let Json(req) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+
+    let mut config = crate::session::Config::load_or_warn();
+    config.telemetry.enabled = req.enabled;
+    config.app_state.has_responded_to_telemetry = true;
+    if let Err(e) = crate::session::save_config(&config) {
+        tracing::error!(target: "http.api.telemetry", "failed to save telemetry consent: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "save_failed", "message": "Failed to save telemetry setting"})),
+        )
+            .into_response();
+    }
+    // Reconcile the install id (no-op under DO_NOT_TRACK). The daemon, not the
+    // browser, owns the id.
+    crate::telemetry::apply_opt_in_change(req.enabled);
+    (StatusCode::OK, Json(current_status())).into_response()
+}
+
+#[derive(Deserialize)]
+pub struct SeenRequest {
+    /// `"web"` or `"cockpit"`.
+    surface: String,
+}
+
+/// Record that the web dashboard / cockpit web UI was opened. Folded into the
+/// daemon's next opt-in snapshot. A no-op (still 200) when telemetry is off so
+/// the client need not branch on consent state.
+pub async fn post_telemetry_seen(
+    State(state): State<Arc<AppState>>,
+    body: Result<Json<SeenRequest>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    let Json(req) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+    match req.surface.as_str() {
+        "web" => state.telemetry_web_seen.store(true, Ordering::Relaxed),
+        "cockpit" => state.telemetry_cockpit_seen.store(true, Ordering::Relaxed),
+        other => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "bad_surface", "message": format!("unknown surface '{other}'")})),
+            )
+                .into_response();
+        }
+    }
+    StatusCode::NO_CONTENT.into_response()
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -331,6 +331,13 @@ pub struct AppState {
     /// checks this to suppress notifications when someone is actively using
     /// the web dashboard (on any device).
     pub last_web_activity: std::sync::atomic::AtomicI64,
+    /// Set when a browser reports the web dashboard / cockpit web UI was
+    /// opened, so the next opt-in telemetry snapshot can carry `web_seen` /
+    /// `cockpit_seen`. Reset after each snapshot. The browser never posts to
+    /// the telemetry backend; it pings the local daemon (`POST
+    /// /api/telemetry/seen`), which folds the flag into its own snapshot.
+    pub telemetry_web_seen: std::sync::atomic::AtomicBool,
+    pub telemetry_cockpit_seen: std::sync::atomic::AtomicBool,
     /// Resolved when the daemon receives SIGINT/SIGTERM/SIGHUP. Long-lived
     /// handlers (cockpit WS, terminal WS) clone this and `select!` on
     /// `cancelled()` so they exit promptly instead of holding axum's
@@ -604,8 +611,15 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         push_enabled,
         web_config: config.web.clone(),
         last_web_activity: std::sync::atomic::AtomicI64::new(0),
+        telemetry_web_seen: std::sync::atomic::AtomicBool::new(false),
+        telemetry_cockpit_seen: std::sync::atomic::AtomicBool::new(false),
         shutdown: CancellationToken::new(),
     });
+
+    // Telemetry (opt-in, no-op otherwise): announce the serve surface on boot
+    // and refresh an aggregate snapshot periodically. Detached; errors are
+    // swallowed.
+    spawn_telemetry_loop(state.clone());
 
     let app = build_router(state.clone());
 
@@ -1180,6 +1194,11 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(api::get_log_level).patch(api::patch_log_level),
         )
         .route("/api/client-log", post(api::post_client_log))
+        // Telemetry consent (browser manages opt-in via the daemon; it never
+        // posts to the telemetry backend directly).
+        .route("/api/telemetry/status", get(api::get_telemetry_status))
+        .route("/api/telemetry/consent", post(api::set_telemetry_consent))
+        .route("/api/telemetry/seen", post(api::post_telemetry_seen))
         // Terminal WebSockets
         .route("/sessions/{id}/ws", get(ws::terminal_ws))
         .route("/sessions/{id}/terminal/ws", get(ws::paired_terminal_ws))
@@ -1605,6 +1624,51 @@ fn merge_runtime_fields(prior: Instance, mut fresh: Instance) -> Instance {
     fresh.session_id_poller = prior.session_id_poller;
     fresh.retroactive_capture_excludes = prior.retroactive_capture_excludes;
     fresh
+}
+
+/// Background task: emit an opt-in telemetry `process_start` for the serve
+/// surface, then a `usage_snapshot` immediately and every hour, plus a final
+/// one on graceful shutdown. All sends are best-effort and swallow errors;
+/// nothing leaves the box unless the user opted in and an endpoint is
+/// configured.
+fn spawn_telemetry_loop(state: Arc<AppState>) {
+    crate::telemetry::spawn_process_start(crate::telemetry::Surface::Serve);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60 * 60));
+        loop {
+            tokio::select! {
+                _ = state.shutdown.cancelled() => {
+                    if let Some(snapshot) = build_serve_snapshot(&state).await {
+                        crate::telemetry::flush_snapshot(snapshot).await;
+                    }
+                    break;
+                }
+                _ = interval.tick() => {
+                    if let Some(snapshot) = build_serve_snapshot(&state).await {
+                        crate::telemetry::spawn_snapshot(snapshot);
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Build a serve `usage_snapshot` from the live session list, folding in (and
+/// resetting) the `web_seen` / `cockpit_seen` flags reported by browsers. The
+/// session-create trend counter is left at 0 for v1. Returns `None` when
+/// telemetry is not opted in.
+async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::UsageSnapshot> {
+    use std::sync::atomic::Ordering;
+    let web_seen = state.telemetry_web_seen.swap(false, Ordering::Relaxed);
+    let cockpit_seen = state.telemetry_cockpit_seen.swap(false, Ordering::Relaxed);
+    let instances = state.instances.read().await.clone();
+    crate::telemetry::build_usage_snapshot(
+        crate::telemetry::Surface::Serve,
+        &instances,
+        web_seen,
+        cockpit_seen,
+        0,
+    )
 }
 
 /// Background task that periodically refreshes session statuses. On each

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1627,14 +1627,14 @@ fn merge_runtime_fields(prior: Instance, mut fresh: Instance) -> Instance {
 }
 
 /// Background task: emit an opt-in telemetry `process_start` for the serve
-/// surface, then a `usage_snapshot` immediately and every hour, plus a final
-/// one on graceful shutdown. All sends are best-effort and swallow errors;
-/// nothing leaves the box unless the user opted in and an endpoint is
+/// surface, then a `usage_snapshot` immediately and every 12 hours, plus a
+/// final one on graceful shutdown. All sends are best-effort and swallow
+/// errors; nothing leaves the box unless the user opted in and an endpoint is
 /// configured.
 fn spawn_telemetry_loop(state: Arc<AppState>) {
     crate::telemetry::spawn_process_start(crate::telemetry::Surface::Serve);
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60 * 60));
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(12 * 60 * 60));
         loop {
             tokio::select! {
                 _ = state.shutdown.cancelled() => {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
     pub updates: UpdatesConfig,
 
     #[serde(default)]
+    pub telemetry: TelemetryConfig,
+
+    #[serde(default)]
     pub worktree: WorktreeConfig,
 
     #[serde(default)]
@@ -506,6 +509,13 @@ pub struct AppStateConfig {
     /// users hide it with `i` when they want the full pane for live output.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub show_preview_info: Option<bool>,
+
+    /// True once the user has answered the telemetry opt-in prompt (in any
+    /// surface, either by enabling or declining). Gates the one-time
+    /// standalone consent popup shown to users who completed the walkthrough
+    /// before telemetry existed, so it appears once and never again.
+    #[serde(default)]
+    pub has_responded_to_telemetry: bool,
 
     #[serde(default)]
     pub has_seen_custom_instruction_warning: bool,
@@ -1139,6 +1149,21 @@ fn default_web_poll_interval_minutes() -> u64 {
     60
 }
 
+/// Anonymous, opt-in usage telemetry. Off by default; mirrors the privacy
+/// posture of [`UpdatesConfig`] (the only other outbound call in the tool).
+///
+/// The single `enabled` flag is the consent boundary the user controls in
+/// every settings surface. The anonymous install id lives in a dedicated
+/// `telemetry.json` (NOT here), so pasting `config.toml` into a bug report
+/// can never leak it. `DO_NOT_TRACK` overrides this flag at runtime and
+/// suppresses both sending and id generation regardless of its value.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TelemetryConfig {
+    /// User opted in to anonymous usage telemetry. Defaults to `false`.
+    #[serde(default)]
+    pub enabled: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorktreeConfig {
     #[serde(default)]
@@ -1555,6 +1580,10 @@ pub fn effective_profile(profile: &str) -> String {
 
 pub fn get_update_settings() -> UpdatesConfig {
     Config::load_or_warn().updates
+}
+
+pub fn get_telemetry_settings() -> TelemetryConfig {
+    Config::load_or_warn().telemetry
 }
 
 #[cfg(test)]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -23,10 +23,11 @@ pub use crate::sound::{SoundConfig, SoundConfigOverride};
 pub use crate::status_hooks::{StatusHookConfig, StatusHookConfigOverride};
 pub(crate) use capture::is_valid_session_id;
 pub use config::{
-    get_update_settings, load_config, save_config, validate_snooze_duration, ClickAction, Config,
-    ContainerRuntimeName, DefaultTerminalMode, GroupByMode, NewSessionAttachMode, RowTagMode,
-    SandboxConfig, SessionConfig, ThemeConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode,
-    UpdatesConfig, VolumeIgnoresStrategy, WorktreeConfig,
+    get_telemetry_settings, get_update_settings, load_config, save_config,
+    validate_snooze_duration, ClickAction, Config, ContainerRuntimeName, DefaultTerminalMode,
+    GroupByMode, NewSessionAttachMode, RowTagMode, SandboxConfig, SessionConfig, TelemetryConfig,
+    ThemeConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode, UpdatesConfig,
+    VolumeIgnoresStrategy, WorktreeConfig,
 };
 pub(crate) use environment::user_shell;
 pub use environment::{validate_env_entries, validate_env_entry};

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -50,8 +50,8 @@ pub struct ProcessStart {
     pub arch: String,
 }
 
-/// Emitted by long-running surfaces (TUI, `aoe serve`) on start, then
-/// periodically, and best-effort on graceful shutdown. Carries current
+/// Emitted by long-running surfaces (TUI, `aoe serve`) on start, then every
+/// ~12 hours, and best-effort on graceful shutdown. Carries current
 /// aggregate state, never a per-action stream. Every string-valued bucket
 /// has already passed through [`super::sanitize`].
 #[derive(Debug, Clone, Serialize)]

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -78,6 +78,11 @@ pub struct UsageSnapshot {
     pub sessions_by_agent: BTreeMap<String, u32>,
     /// Coarse model family bucket -> session count.
     pub sessions_by_model_bucket: BTreeMap<String, u32>,
+    /// Install-level feature adoption: allowlisted feature name -> active.
+    /// Keyed by the fixed registry in [`super::features`]; lets new gated
+    /// features be tracked by registering the flag, not by extending the
+    /// schema. See `telemetry::features`.
+    pub features: BTreeMap<String, bool>,
 
     /// The web dashboard was opened at least once since the last snapshot.
     pub web_seen: bool,

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -1,0 +1,90 @@
+//! Closed, versioned telemetry event schema.
+//!
+//! Both event kinds are plain serializable structs with a fixed set of
+//! fields, so the entire wire payload is auditable from this file. There is
+//! no open-ended map of arbitrary keys. Adding a field is a deliberate,
+//! reviewable change; bump [`SCHEMA_VERSION`] when the shape changes.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+/// Payload schema version. Bump on any breaking change to the field set.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Which surface emitted the event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Surface {
+    /// A short-lived `aoe <subcommand>` invocation.
+    Cli,
+    /// The interactive terminal UI.
+    Tui,
+    /// The `aoe serve` daemon (web dashboard / cockpit host).
+    Serve,
+}
+
+impl Surface {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Surface::Cli => "cli",
+            Surface::Tui => "tui",
+            Surface::Serve => "serve",
+        }
+    }
+}
+
+/// Emitted once on boot. Captures short-lived invocations that a periodic
+/// snapshot would miss. Carries no session details.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProcessStart {
+    pub schema: u32,
+    /// Always `"process_start"`.
+    pub event: &'static str,
+    pub install_id: String,
+    /// RFC 3339 UTC timestamp.
+    pub sent_at: String,
+    pub surface: Surface,
+    pub aoe_version: String,
+    pub os: String,
+    pub arch: String,
+}
+
+/// Emitted by long-running surfaces (TUI, `aoe serve`) on start, then
+/// periodically, and best-effort on graceful shutdown. Carries current
+/// aggregate state, never a per-action stream. Every string-valued bucket
+/// has already passed through [`super::sanitize`].
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageSnapshot {
+    pub schema: u32,
+    /// Always `"usage_snapshot"`.
+    pub event: &'static str,
+    pub install_id: String,
+    pub sent_at: String,
+    pub surface: Surface,
+    pub aoe_version: String,
+    pub os: String,
+    pub arch: String,
+
+    pub session_total: u32,
+    pub session_running: u32,
+    pub session_idle: u32,
+    pub session_error: u32,
+    pub session_cockpit: u32,
+    pub session_sandboxed: u32,
+    pub session_yolo: u32,
+
+    /// Allowlisted agent bucket -> session count.
+    pub sessions_by_agent: BTreeMap<String, u32>,
+    /// Coarse model family bucket -> session count.
+    pub sessions_by_model_bucket: BTreeMap<String, u32>,
+
+    /// The web dashboard was opened at least once since the last snapshot.
+    pub web_seen: bool,
+    /// The cockpit web UI was opened at least once since the last snapshot.
+    pub cockpit_seen: bool,
+
+    /// Sessions created since the previous snapshot (a trend counter, not a
+    /// per-session event stream).
+    pub session_creates_since_last_snapshot: u32,
+}

--- a/src/telemetry/features.rs
+++ b/src/telemetry/features.rs
@@ -1,0 +1,52 @@
+//! Registry of opt-in features whose adoption telemetry reports.
+//!
+//! This is the single, auditable place that decides which feature flags are
+//! tracked. The result is a map keyed by a **fixed set of short feature
+//! names** (the allowlist), so it can never carry a path, name, or other
+//! free-form value, and the gateway forwards it as allowlisted short-id ->
+//! bool while dropping anything else.
+//!
+//! Tracking a newly gated feature is one entry here: add its name and how to
+//! detect it from [`Config`]. For example, an `openshell` feature behind a
+//! config flag would be `m.insert("openshell".into(), config.openshell.enabled)`.
+
+use std::collections::BTreeMap;
+
+use crate::session::config::UpdateCheckMode;
+use crate::session::Config;
+
+/// Install-level feature adoption: allowlisted feature name -> whether it is
+/// turned on for this install. Built from config so it reflects what the user
+/// opted into, independent of per-session counts (which the snapshot reports
+/// separately).
+pub fn active_features(config: &Config) -> BTreeMap<String, bool> {
+    let mut features = BTreeMap::new();
+    features.insert("worktree".to_string(), config.worktree.enabled);
+    features.insert("sandbox".to_string(), config.sandbox.enabled_by_default);
+    features.insert("cockpit".to_string(), config.cockpit.enabled);
+    features.insert(
+        "auto_update".to_string(),
+        matches!(config.updates.update_check_mode, UpdateCheckMode::Auto),
+    );
+    features
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reports_allowlisted_flags_from_config() {
+        let mut config = Config::default();
+        config.worktree.enabled = true;
+        config.updates.update_check_mode = UpdateCheckMode::Auto;
+
+        let features = active_features(&config);
+        assert_eq!(features.get("worktree"), Some(&true));
+        assert_eq!(features.get("auto_update"), Some(&true));
+        // Defaults stay false, but the keys are always present so the gateway
+        // sees a stable, fixed key set.
+        assert_eq!(features.get("sandbox"), Some(&false));
+        assert_eq!(features.get("cockpit"), Some(&false));
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -19,6 +19,7 @@
 //!   names, and prompts are never emitted.
 
 pub mod events;
+pub mod features;
 pub mod sanitize;
 mod state;
 
@@ -139,6 +140,7 @@ pub fn build_usage_snapshot(
         return None;
     }
     let install_id = state::ensure_install_id()?;
+    let features = features::active_features(&crate::session::Config::load_or_warn());
 
     let mut sessions_by_agent: BTreeMap<String, u32> = BTreeMap::new();
     let mut sessions_by_model_bucket: BTreeMap<String, u32> = BTreeMap::new();
@@ -207,6 +209,7 @@ pub fn build_usage_snapshot(
         session_yolo: yolo,
         sessions_by_agent,
         sessions_by_model_bucket,
+        features,
         web_seen,
         cockpit_seen,
         session_creates_since_last_snapshot,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -5,14 +5,15 @@
 //!   [`crate::session::TelemetryConfig::enabled`] in any settings surface.
 //! - **`DO_NOT_TRACK` is absolute.** When set (`1` / `true` / `yes`), it
 //!   suppresses both sending and install-id generation regardless of config.
-//! - **Backend-neutral.** The send endpoint is resolved from
-//!   `AOE_TELEMETRY_ENDPOINT`; there is no hardcoded server. With no endpoint
-//!   configured, nothing is ever sent (the collection infra lives in a
-//!   separate private repo). The opt-in state and install id still work, so
-//!   the consent surfaces and tests are exercised without a live backend.
-//! - **Fire-and-forget.** Sends run detached with a hard timeout and swallow
-//!   every error (logged only at `debug`, `target: "telemetry"`). Telemetry
-//!   must never slow, stall, or crash the tool.
+//! - **Endpoint.** Opted-in sends go to the collection gateway at
+//!   [`DEFAULT_ENDPOINT`] (which validates and re-sanitizes as a backstop);
+//!   `AOE_TELEMETRY_ENDPOINT` overrides it, e.g. to point at a local sink. A
+//!   compiled-in [`TELEMETRY_KEY`] is sent as `X-Telemetry-Key` so the gateway
+//!   can shed drive-by noise (it is visible in source, so not real auth).
+//! - **Fire-and-forget.** Sends run detached with a hard timeout (plus a short
+//!   connect timeout so a down endpoint fails fast) and swallow every error
+//!   (logged only at `debug`, `target: "telemetry"`). Telemetry must never
+//!   slow, stall, or crash the tool.
 //! - **Sanitized.** No content ever leaves [`sanitize`]: agent/model strings
 //!   are coerced to a closed allowlist; raw commands, paths, titles, branch
 //!   names, and prompts are never emitted.
@@ -34,6 +35,22 @@ use crate::session::Instance;
 /// the CLI's exit or a daemon tick beyond this.
 const SEND_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Connect timeout for the send. Much shorter than [`SEND_TIMEOUT`] so a
+/// black-holed or slow-DNS endpoint fails in well under a second rather than
+/// costing a CLI run the full send budget.
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Default collection gateway. Overridable via `AOE_TELEMETRY_ENDPOINT` (handy
+/// for pointing at a local sink to inspect what is sent). The gateway
+/// validates the envelope and re-sanitizes every field as a defense-in-depth
+/// backstop. Nothing reaches it unless the user has opted in.
+const DEFAULT_ENDPOINT: &str = "https://telemetry.agent-of-empires.com/v1/ingest";
+
+/// Static key sent as `X-Telemetry-Key`. NOT authentication: it is visible in
+/// this source, so it only lets the gateway drop unkeyed drive-by traffic. The
+/// gateway must be configured to require this exact value.
+const TELEMETRY_KEY: &str = "7bc5a4e45ce861662b9690a7105da988";
+
 /// CLI `process_start` is the only unbounded event source (one per `aoe`
 /// invocation), so it is throttled to at most once per install per day. That
 /// still answers "did this install run the CLI today" without a POST per
@@ -52,13 +69,15 @@ pub fn do_not_track() -> bool {
     }
 }
 
-/// The configured send endpoint, if any. Resolved from `AOE_TELEMETRY_ENDPOINT`.
-/// Empty/whitespace is treated as unset.
-pub fn endpoint() -> Option<String> {
-    std::env::var("AOE_TELEMETRY_ENDPOINT")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+/// The send endpoint. `AOE_TELEMETRY_ENDPOINT` overrides when set to a
+/// non-empty value; otherwise the compiled-in [`DEFAULT_ENDPOINT`] is used.
+/// Always returns a target, so the opt-in gate (not a missing endpoint) is
+/// what decides whether anything is sent.
+pub fn endpoint() -> String {
+    match std::env::var("AOE_TELEMETRY_ENDPOINT") {
+        Ok(v) if !v.trim().is_empty() => v.trim().to_string(),
+        _ => DEFAULT_ENDPOINT.to_string(),
+    }
 }
 
 /// Consent state, ignoring whether a backend is wired. True when the user has
@@ -194,15 +213,14 @@ pub fn build_usage_snapshot(
     })
 }
 
-/// POST a serialized event to the configured endpoint. No-op when no endpoint
-/// is configured. Every error is swallowed and logged at `debug` only.
+/// POST a serialized event to the endpoint. Every error is swallowed and
+/// logged at `debug` only. Bounded by both a short connect timeout and the
+/// overall [`SEND_TIMEOUT`] so a down endpoint can never delay the caller.
 async fn post<T: serde::Serialize>(event: &T) {
-    let Some(endpoint) = endpoint() else {
-        tracing::debug!(target: "telemetry", "no AOE_TELEMETRY_ENDPOINT configured; not sending");
-        return;
-    };
+    let endpoint = endpoint();
     let client = match reqwest::Client::builder()
         .user_agent(concat!("agent-of-empires/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(CONNECT_TIMEOUT)
         .timeout(SEND_TIMEOUT)
         .build()
     {
@@ -212,7 +230,13 @@ async fn post<T: serde::Serialize>(event: &T) {
             return;
         }
     };
-    match client.post(&endpoint).json(event).send().await {
+    match client
+        .post(&endpoint)
+        .header("X-Telemetry-Key", TELEMETRY_KEY)
+        .json(event)
+        .send()
+        .await
+    {
         Ok(resp) => tracing::debug!(target: "telemetry", status = %resp.status(), "telemetry sent"),
         Err(e) => tracing::debug!(target: "telemetry", "telemetry send failed: {e}"),
     }
@@ -227,9 +251,9 @@ pub fn spawn_process_start(surface: Surface) {
 }
 
 /// Emit a `process_start`, awaiting delivery with a hard timeout so the event
-/// has a chance to flush before the process exits. Bounded by [`SEND_TIMEOUT`],
-/// so a dead endpoint can never hang the caller; a no-op for the common
-/// default-off / no-endpoint case.
+/// has a chance to flush before the process exits. Bounded by the connect and
+/// send timeouts, so a dead endpoint can never hang the caller; a no-op for the
+/// common default-off (not opted in) case.
 pub async fn flush_process_start(surface: Surface) {
     if let Some(event) = build_process_start(surface) {
         let _ = tokio::time::timeout(SEND_TIMEOUT, post(&event)).await;
@@ -262,14 +286,15 @@ pub async fn flush_snapshot(snapshot: UsageSnapshot) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
-    /// Guards mutation of `DO_NOT_TRACK` / `AOE_TELEMETRY_ENDPOINT` across
-    /// tests in this module, which otherwise race on the shared process env.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
+    // `#[serial]` (the default global group) serializes these env-mutating
+    // tests against every other telemetry test that reads `DO_NOT_TRACK` /
+    // `AOE_TELEMETRY_ENDPOINT`, including the consent-dialog tests in another
+    // module, so none of them race on the shared process env.
     #[test]
+    #[serial]
     fn do_not_track_recognises_affirmative_values() {
-        let _g = ENV_LOCK.lock().unwrap();
         for v in ["1", "true", "TRUE", "yes", "Yes"] {
             unsafe { std::env::set_var("DO_NOT_TRACK", v) };
             assert!(do_not_track(), "{v} should suppress");
@@ -283,14 +308,16 @@ mod tests {
     }
 
     #[test]
-    fn endpoint_unset_is_none() {
-        let _g = ENV_LOCK.lock().unwrap();
+    #[serial]
+    fn endpoint_falls_back_to_default_and_env_overrides() {
+        // Unset or blank => the compiled-in default gateway.
         unsafe { std::env::remove_var("AOE_TELEMETRY_ENDPOINT") };
-        assert_eq!(endpoint(), None);
+        assert_eq!(endpoint(), DEFAULT_ENDPOINT);
         unsafe { std::env::set_var("AOE_TELEMETRY_ENDPOINT", "   ") };
-        assert_eq!(endpoint(), None);
-        unsafe { std::env::set_var("AOE_TELEMETRY_ENDPOINT", "https://x/y") };
-        assert_eq!(endpoint().as_deref(), Some("https://x/y"));
+        assert_eq!(endpoint(), DEFAULT_ENDPOINT);
+        // A non-empty value overrides (trimmed).
+        unsafe { std::env::set_var("AOE_TELEMETRY_ENDPOINT", " https://x/y ") };
+        assert_eq!(endpoint(), "https://x/y");
         unsafe { std::env::remove_var("AOE_TELEMETRY_ENDPOINT") };
     }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -25,7 +25,7 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 pub use events::{ProcessStart, Surface, UsageSnapshot, SCHEMA_VERSION};
-pub use state::{install_id, reset_install_id};
+pub use state::{claim_cli_process_start_slot, install_id, reset_install_id};
 
 use crate::session::Instance;
 
@@ -33,6 +33,12 @@ use crate::session::Instance;
 /// the outer flush bound use it, so a dead or slow endpoint can never delay
 /// the CLI's exit or a daemon tick beyond this.
 const SEND_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// CLI `process_start` is the only unbounded event source (one per `aoe`
+/// invocation), so it is throttled to at most once per install per day. That
+/// still answers "did this install run the CLI today" without a POST per
+/// command.
+const CLI_PROCESS_START_MIN_GAP: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// True when `DO_NOT_TRACK` is set to an affirmative value. This is the
 /// absolute override: it wins over `config.telemetry.enabled`.
@@ -220,13 +226,23 @@ pub fn spawn_process_start(surface: Surface) {
     }
 }
 
-/// Emit a `process_start` for a short-lived CLI invocation, awaiting delivery
-/// with a hard timeout so the event has a chance to flush before the process
-/// exits. Bounded by [`SEND_TIMEOUT`], so a dead endpoint can never hang the
-/// CLI; a no-op for the common default-off / no-endpoint case.
+/// Emit a `process_start`, awaiting delivery with a hard timeout so the event
+/// has a chance to flush before the process exits. Bounded by [`SEND_TIMEOUT`],
+/// so a dead endpoint can never hang the caller; a no-op for the common
+/// default-off / no-endpoint case.
 pub async fn flush_process_start(surface: Surface) {
     if let Some(event) = build_process_start(surface) {
         let _ = tokio::time::timeout(SEND_TIMEOUT, post(&event)).await;
+    }
+}
+
+/// CLI entrypoint for `process_start`: same as [`flush_process_start`] for the
+/// `cli` surface, but throttled to at most once per install per day so a user
+/// scripting `aoe` in a loop can't flood the endpoint. The throttle stamp is
+/// only claimed when opted in, so default-off users never touch disk.
+pub async fn flush_cli_process_start() {
+    if is_opted_in() && state::claim_cli_process_start_slot(CLI_PROCESS_START_MIN_GAP) {
+        flush_process_start(Surface::Cli).await;
     }
 }
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,0 +1,280 @@
+//! Anonymous, opt-in usage telemetry.
+//!
+//! Design constraints (see issue #1762):
+//! - **Off by default.** Nothing is sent unless the user opts in via
+//!   [`crate::session::TelemetryConfig::enabled`] in any settings surface.
+//! - **`DO_NOT_TRACK` is absolute.** When set (`1` / `true` / `yes`), it
+//!   suppresses both sending and install-id generation regardless of config.
+//! - **Backend-neutral.** The send endpoint is resolved from
+//!   `AOE_TELEMETRY_ENDPOINT`; there is no hardcoded server. With no endpoint
+//!   configured, nothing is ever sent (the collection infra lives in a
+//!   separate private repo). The opt-in state and install id still work, so
+//!   the consent surfaces and tests are exercised without a live backend.
+//! - **Fire-and-forget.** Sends run detached with a hard timeout and swallow
+//!   every error (logged only at `debug`, `target: "telemetry"`). Telemetry
+//!   must never slow, stall, or crash the tool.
+//! - **Sanitized.** No content ever leaves [`sanitize`]: agent/model strings
+//!   are coerced to a closed allowlist; raw commands, paths, titles, branch
+//!   names, and prompts are never emitted.
+
+pub mod events;
+pub mod sanitize;
+mod state;
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+pub use events::{ProcessStart, Surface, UsageSnapshot, SCHEMA_VERSION};
+pub use state::{install_id, reset_install_id};
+
+use crate::session::Instance;
+
+/// Hard cap on any single telemetry send. Both the reqwest client timeout and
+/// the outer flush bound use it, so a dead or slow endpoint can never delay
+/// the CLI's exit or a daemon tick beyond this.
+const SEND_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// True when `DO_NOT_TRACK` is set to an affirmative value. This is the
+/// absolute override: it wins over `config.telemetry.enabled`.
+pub fn do_not_track() -> bool {
+    match std::env::var("DO_NOT_TRACK") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            matches!(v.as_str(), "1" | "true" | "yes")
+        }
+        Err(_) => false,
+    }
+}
+
+/// The configured send endpoint, if any. Resolved from `AOE_TELEMETRY_ENDPOINT`.
+/// Empty/whitespace is treated as unset.
+pub fn endpoint() -> Option<String> {
+    std::env::var("AOE_TELEMETRY_ENDPOINT")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Consent state, ignoring whether a backend is wired. True when the user has
+/// opted in and `DO_NOT_TRACK` is not suppressing. Drives id generation and
+/// whether events are built at all.
+pub fn is_opted_in() -> bool {
+    crate::session::get_telemetry_settings().enabled && !do_not_track()
+}
+
+/// Apply an opt-in/opt-out transition's side effect on the install id. The
+/// caller is responsible for persisting `config.telemetry.enabled`; this only
+/// manages `telemetry.json`. Enabling (when not suppressed) generates the id;
+/// disabling deletes it. Centralised so every surface (CLI, TUI, web, consent
+/// prompts) behaves identically.
+pub fn apply_opt_in_change(enabled: bool) {
+    if enabled {
+        if !do_not_track() {
+            let _ = state::ensure_install_id();
+        }
+    } else if let Err(e) = state::delete_install_id() {
+        tracing::debug!(target: "telemetry", "failed to delete install id on opt-out: {e}");
+    }
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// Build a `process_start` event, or `None` when telemetry is not opted in
+/// (or `DO_NOT_TRACK` suppresses id generation).
+pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
+    if !is_opted_in() {
+        return None;
+    }
+    let install_id = state::ensure_install_id()?;
+    Some(ProcessStart {
+        schema: SCHEMA_VERSION,
+        event: "process_start",
+        install_id,
+        sent_at: now_rfc3339(),
+        surface,
+        aoe_version: env!("CARGO_PKG_VERSION").to_string(),
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+    })
+}
+
+/// Build a `usage_snapshot` from the current sessions, or `None` when not
+/// opted in. All agent/model strings pass through [`sanitize`]; raw values
+/// never reach the payload.
+pub fn build_usage_snapshot(
+    surface: Surface,
+    instances: &[Instance],
+    web_seen: bool,
+    cockpit_seen: bool,
+    session_creates_since_last_snapshot: u32,
+) -> Option<UsageSnapshot> {
+    if !is_opted_in() {
+        return None;
+    }
+    let install_id = state::ensure_install_id()?;
+
+    let mut sessions_by_agent: BTreeMap<String, u32> = BTreeMap::new();
+    let mut sessions_by_model_bucket: BTreeMap<String, u32> = BTreeMap::new();
+    let (mut running, mut idle, mut error, mut cockpit, mut sandboxed, mut yolo) =
+        (0u32, 0u32, 0u32, 0u32, 0u32, 0u32);
+
+    for inst in instances {
+        match inst.status {
+            crate::session::Status::Running => running += 1,
+            crate::session::Status::Idle => idle += 1,
+            crate::session::Status::Error => error += 1,
+            _ => {}
+        }
+        // Cockpit fields only exist in `serve` builds; treat them as absent
+        // otherwise so the snapshot logic stays surface-agnostic.
+        #[cfg(feature = "serve")]
+        let is_cockpit = inst.cockpit_mode;
+        #[cfg(not(feature = "serve"))]
+        let is_cockpit = false;
+        if is_cockpit {
+            cockpit += 1;
+        }
+        if inst.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
+            sandboxed += 1;
+        }
+        if inst.yolo_mode {
+            yolo += 1;
+        }
+
+        // Prefer the canonical detection name; fall back to the raw tool
+        // string. Either way it is coerced to an allowlisted bucket.
+        let agent_src = if inst.detect_as.trim().is_empty() {
+            inst.tool.as_str()
+        } else {
+            inst.detect_as.as_str()
+        };
+        *sessions_by_agent
+            .entry(sanitize::agent_bucket(agent_src))
+            .or_insert(0) += 1;
+
+        #[cfg(feature = "serve")]
+        let model = inst.cockpit_model.as_deref();
+        #[cfg(not(feature = "serve"))]
+        let model: Option<&str> = None;
+        let bucket = sanitize::model_bucket(model);
+        *sessions_by_model_bucket
+            .entry(bucket.to_string())
+            .or_insert(0) += 1;
+    }
+
+    Some(UsageSnapshot {
+        schema: SCHEMA_VERSION,
+        event: "usage_snapshot",
+        install_id,
+        sent_at: now_rfc3339(),
+        surface,
+        aoe_version: env!("CARGO_PKG_VERSION").to_string(),
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        session_total: instances.len() as u32,
+        session_running: running,
+        session_idle: idle,
+        session_error: error,
+        session_cockpit: cockpit,
+        session_sandboxed: sandboxed,
+        session_yolo: yolo,
+        sessions_by_agent,
+        sessions_by_model_bucket,
+        web_seen,
+        cockpit_seen,
+        session_creates_since_last_snapshot,
+    })
+}
+
+/// POST a serialized event to the configured endpoint. No-op when no endpoint
+/// is configured. Every error is swallowed and logged at `debug` only.
+async fn post<T: serde::Serialize>(event: &T) {
+    let Some(endpoint) = endpoint() else {
+        tracing::debug!(target: "telemetry", "no AOE_TELEMETRY_ENDPOINT configured; not sending");
+        return;
+    };
+    let client = match reqwest::Client::builder()
+        .user_agent(concat!("agent-of-empires/", env!("CARGO_PKG_VERSION")))
+        .timeout(SEND_TIMEOUT)
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!(target: "telemetry", "failed to build client: {e}");
+            return;
+        }
+    };
+    match client.post(&endpoint).json(event).send().await {
+        Ok(resp) => tracing::debug!(target: "telemetry", status = %resp.status(), "telemetry sent"),
+        Err(e) => tracing::debug!(target: "telemetry", "telemetry send failed: {e}"),
+    }
+}
+
+/// Emit a `process_start` for a long-running surface (TUI / serve). Detached:
+/// returns immediately and never blocks the caller.
+pub fn spawn_process_start(surface: Surface) {
+    if let Some(event) = build_process_start(surface) {
+        tokio::spawn(async move { post(&event).await });
+    }
+}
+
+/// Emit a `process_start` for a short-lived CLI invocation, awaiting delivery
+/// with a hard timeout so the event has a chance to flush before the process
+/// exits. Bounded by [`SEND_TIMEOUT`], so a dead endpoint can never hang the
+/// CLI; a no-op for the common default-off / no-endpoint case.
+pub async fn flush_process_start(surface: Surface) {
+    if let Some(event) = build_process_start(surface) {
+        let _ = tokio::time::timeout(SEND_TIMEOUT, post(&event)).await;
+    }
+}
+
+/// Send a pre-built usage snapshot, detached. Caller builds via
+/// [`build_usage_snapshot`] (returns `None` when not opted in).
+pub fn spawn_snapshot(snapshot: UsageSnapshot) {
+    tokio::spawn(async move { post(&snapshot).await });
+}
+
+/// Send a usage snapshot and await delivery with a hard timeout. Used on
+/// graceful shutdown so the final snapshot has a chance to flush without
+/// risking a hang.
+pub async fn flush_snapshot(snapshot: UsageSnapshot) {
+    let _ = tokio::time::timeout(SEND_TIMEOUT, post(&snapshot)).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards mutation of `DO_NOT_TRACK` / `AOE_TELEMETRY_ENDPOINT` across
+    /// tests in this module, which otherwise race on the shared process env.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn do_not_track_recognises_affirmative_values() {
+        let _g = ENV_LOCK.lock().unwrap();
+        for v in ["1", "true", "TRUE", "yes", "Yes"] {
+            unsafe { std::env::set_var("DO_NOT_TRACK", v) };
+            assert!(do_not_track(), "{v} should suppress");
+        }
+        for v in ["0", "false", "no", ""] {
+            unsafe { std::env::set_var("DO_NOT_TRACK", v) };
+            assert!(!do_not_track(), "{v} should not suppress");
+        }
+        unsafe { std::env::remove_var("DO_NOT_TRACK") };
+        assert!(!do_not_track());
+    }
+
+    #[test]
+    fn endpoint_unset_is_none() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("AOE_TELEMETRY_ENDPOINT") };
+        assert_eq!(endpoint(), None);
+        unsafe { std::env::set_var("AOE_TELEMETRY_ENDPOINT", "   ") };
+        assert_eq!(endpoint(), None);
+        unsafe { std::env::set_var("AOE_TELEMETRY_ENDPOINT", "https://x/y") };
+        assert_eq!(endpoint().as_deref(), Some("https://x/y"));
+        unsafe { std::env::remove_var("AOE_TELEMETRY_ENDPOINT") };
+    }
+}

--- a/src/telemetry/sanitize.rs
+++ b/src/telemetry/sanitize.rs
@@ -1,0 +1,100 @@
+//! The single privacy boundary for telemetry.
+//!
+//! Every free-form string that could carry user content (agent command,
+//! model name) is coerced here against a closed allowlist before it can
+//! reach a payload. Raw values never leave this module: an agent that is
+//! not a recognised built-in becomes `"custom"`, and a model string that
+//! matches no known family becomes a coarse bucket (`"other"` / `"unset"`).
+//!
+//! The agent allowlist is derived from [`crate::agents::AGENTS`] rather than
+//! hardcoded, so adding a built-in agent keeps the sanitizer in sync without
+//! a second edit. Anything outside that set collapses to `"custom"`.
+
+/// Bucket for an agent identifier (`tool` / `detect_as`).
+///
+/// Returns the canonical built-in name when the input matches a known agent
+/// (case-insensitive, by canonical name or alias); otherwise `"custom"`. An
+/// empty input is treated as unknown and returns `"custom"`.
+pub fn agent_bucket(agent: &str) -> String {
+    let trimmed = agent.trim();
+    if trimmed.is_empty() {
+        return "custom".to_string();
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    for def in crate::agents::AGENTS {
+        if def.name.eq_ignore_ascii_case(&lower)
+            || def.aliases.iter().any(|a| a.eq_ignore_ascii_case(&lower))
+        {
+            return def.name.to_string();
+        }
+    }
+    "custom".to_string()
+}
+
+/// Coarse family bucket for a model string. Never emits the raw value; maps
+/// to a small fixed vocabulary so an internal/custom model name can't leak.
+///
+/// `None` or empty → `"unset"`. A string matching no known family → `"other"`.
+pub fn model_bucket(model: Option<&str>) -> &'static str {
+    let Some(model) = model.map(str::trim).filter(|s| !s.is_empty()) else {
+        return "unset";
+    };
+    let lower = model.to_ascii_lowercase();
+    const FAMILIES: &[(&str, &[&str])] = &[
+        ("claude", &["claude", "sonnet", "opus", "haiku"]),
+        ("openai", &["gpt", "openai", "codex", "o1", "o3", "o4"]),
+        ("gemini", &["gemini"]),
+        ("qwen", &["qwen"]),
+        ("grok", &["grok"]),
+        ("llama", &["llama"]),
+        ("mistral", &["mistral", "mixtral"]),
+        ("deepseek", &["deepseek"]),
+    ];
+    for (family, needles) in FAMILIES {
+        if needles.iter().any(|n| lower.contains(n)) {
+            return family;
+        }
+    }
+    "other"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_agents_keep_canonical_name() {
+        assert_eq!(agent_bucket("claude"), "claude");
+        assert_eq!(agent_bucket("CLAUDE"), "claude");
+        assert_eq!(agent_bucket("codex"), "codex");
+        assert_eq!(agent_bucket("gemini"), "gemini");
+        assert_eq!(agent_bucket("opencode"), "opencode");
+    }
+
+    #[test]
+    fn unknown_agent_collapses_to_custom() {
+        // A custom command or an internal wrapper must never surface verbatim.
+        assert_eq!(agent_bucket("/usr/local/bin/my-secret-agent"), "custom");
+        assert_eq!(agent_bucket("acme-internal-llm"), "custom");
+        assert_eq!(agent_bucket(""), "custom");
+        assert_eq!(agent_bucket("   "), "custom");
+    }
+
+    #[test]
+    fn model_buckets_map_to_families() {
+        assert_eq!(model_bucket(Some("claude-opus-4-8")), "claude");
+        assert_eq!(model_bucket(Some("gpt-5")), "openai");
+        assert_eq!(model_bucket(Some("o3-mini")), "openai");
+        assert_eq!(model_bucket(Some("gemini-2.5-pro")), "gemini");
+        assert_eq!(model_bucket(Some("qwen3-coder")), "qwen");
+    }
+
+    #[test]
+    fn model_bucket_unset_and_other() {
+        assert_eq!(model_bucket(None), "unset");
+        assert_eq!(model_bucket(Some("")), "unset");
+        assert_eq!(model_bucket(Some("   ")), "unset");
+        // An internal/unknown model name must collapse to "other", not leak.
+        assert_eq!(model_bucket(Some("acme-internal-v2")), "other");
+    }
+}

--- a/src/telemetry/state.rs
+++ b/src/telemetry/state.rs
@@ -91,7 +91,9 @@ pub fn delete_install_id() -> Result<()> {
 /// `aoe telemetry reset-id`. Returns the new id, or `None` if suppressed by
 /// `DO_NOT_TRACK`.
 pub fn reset_install_id() -> Option<String> {
-    let _ = delete_install_id();
+    if let Err(e) = delete_install_id() {
+        tracing::debug!(target: "telemetry", "failed to delete install id during reset: {e}");
+    }
     ensure_install_id()
 }
 

--- a/src/telemetry/state.rs
+++ b/src/telemetry/state.rs
@@ -6,8 +6,10 @@
 //! counts. The file is created only on opt-in and deleted on opt-out.
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::session::get_app_dir;
 
@@ -15,6 +17,11 @@ use crate::session::get_app_dir;
 struct TelemetryState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     install_id: Option<String>,
+    /// Last time a CLI `process_start` was emitted, used to throttle the one
+    /// unbounded event source to at most once per install per day. Long-lived
+    /// surfaces (TUI / serve) emit once per launch and need no throttle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_cli_process_start: Option<DateTime<Utc>>,
 }
 
 fn state_path() -> Result<PathBuf> {
@@ -86,4 +93,30 @@ pub fn delete_install_id() -> Result<()> {
 pub fn reset_install_id() -> Option<String> {
     let _ = delete_install_id();
     ensure_install_id()
+}
+
+/// Claim the once-per-`min_gap` CLI `process_start` slot. Returns `true` and
+/// stamps "now" when the last emission is older than `min_gap` (or never),
+/// `false` otherwise. This bounds the only unbounded telemetry source: a user
+/// scripting `aoe` in a loop emits at most one CLI `process_start` per window
+/// instead of one per invocation. Caller is responsible for the opt-in gate.
+pub fn claim_cli_process_start_slot(min_gap: Duration) -> bool {
+    let mut state = load_state();
+    let now = Utc::now();
+    if let Some(last) = state.last_cli_process_start {
+        // A positive elapsed shorter than the window means "too soon". A
+        // negative elapsed (clock skew) falls through and is allowed.
+        if let Ok(elapsed) = (now - last).to_std() {
+            if elapsed < min_gap {
+                return false;
+            }
+        }
+    }
+    state.last_cli_process_start = Some(now);
+    if let Err(e) = save_state(&state) {
+        // Persisting the stamp failed; allow this send rather than dropping it,
+        // and try again to persist next time.
+        tracing::debug!(target: "telemetry", "failed to persist cli throttle stamp: {e}");
+    }
+    true
 }

--- a/src/telemetry/state.rs
+++ b/src/telemetry/state.rs
@@ -1,0 +1,89 @@
+//! Persistence of the anonymous install id.
+//!
+//! Stored in a dedicated `<app_dir>/telemetry.json`, deliberately separate
+//! from `config.toml`: users routinely paste their config into bug reports,
+//! and the id leaking there would both expose it and corrupt distinct-install
+//! counts. The file is created only on opt-in and deleted on opt-out.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::session::get_app_dir;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct TelemetryState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    install_id: Option<String>,
+}
+
+fn state_path() -> Result<PathBuf> {
+    Ok(get_app_dir()?.join("telemetry.json"))
+}
+
+fn load_state() -> TelemetryState {
+    let Ok(path) = state_path() else {
+        return TelemetryState::default();
+    };
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return TelemetryState::default();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+fn save_state(state: &TelemetryState) -> Result<()> {
+    let path = state_path()?;
+    let content = serde_json::to_string_pretty(state)?;
+    crate::session::atomic_write(&path, content.as_bytes())?;
+    // The id is mildly sensitive (it's the distinct-install key); keep the
+    // file owner-only, matching the `aoe serve` runtime files.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+/// The current install id, if one has been generated. Read-only: never
+/// generates. Returns `None` when telemetry was never opted into.
+pub fn install_id() -> Option<String> {
+    load_state().install_id.filter(|s| !s.trim().is_empty())
+}
+
+/// Return the existing install id, generating and persisting a fresh random
+/// UUID v4 if none exists. Honors `DO_NOT_TRACK`: when set, never generates
+/// or persists an id and returns `None`.
+pub fn ensure_install_id() -> Option<String> {
+    if super::do_not_track() {
+        return None;
+    }
+    let mut state = load_state();
+    if let Some(id) = state.install_id.as_ref().filter(|s| !s.trim().is_empty()) {
+        return Some(id.clone());
+    }
+    let id = uuid::Uuid::new_v4().to_string();
+    state.install_id = Some(id.clone());
+    if let Err(e) = save_state(&state) {
+        tracing::debug!(target: "telemetry", "failed to persist install id: {e}");
+        return None;
+    }
+    Some(id)
+}
+
+/// Delete the install id (and its file) on opt-out. Idempotent.
+pub fn delete_install_id() -> Result<()> {
+    let path = state_path()?;
+    if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+/// Delete the current id and generate a fresh one. Used by
+/// `aoe telemetry reset-id`. Returns the new id, or `None` if suppressed by
+/// `DO_NOT_TRACK`.
+pub fn reset_install_id() -> Option<String> {
+    let _ = delete_install_id();
+    ensure_install_id()
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -572,7 +572,7 @@ impl App {
         // Telemetry (opt-in, no-op otherwise): announce this surface on boot,
         // send an initial snapshot, then refresh it periodically and once more
         // on graceful exit. All sends are detached and swallow errors.
-        const TELEMETRY_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(60 * 60);
+        const TELEMETRY_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(12 * 60 * 60);
         crate::telemetry::spawn_process_start(crate::telemetry::Surface::Tui);
         self.emit_telemetry_snapshot();
         let mut last_telemetry_snapshot = std::time::Instant::now();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -232,6 +232,15 @@ impl App {
             home.show_changelog(config.app_state.last_seen_version.clone());
             config.app_state.last_seen_version = Some(current_version);
             save_config(&config)?;
+        } else if !config.app_state.has_responded_to_telemetry {
+            // Existing users who finished the walkthrough before telemetry
+            // existed get a one-time opt-in popup. Gated behind the changelog
+            // branch above (mutually exclusive in this if/else chain), so it
+            // never co-renders with the changelog; and because it is a modal
+            // dialog, the version update modal (opened only by an explicit
+            // keypress) can't open on top of it while it is up. No save here:
+            // the dialog's response handler persists the answer.
+            home.show_telemetry_consent();
         }
 
         let dismissed_update_version = config.app_state.dismissed_update_version.clone();
@@ -427,6 +436,7 @@ impl App {
         // before the intro walkthrough.
         self.home.intro_dialog = None;
         self.home.changelog_dialog = None;
+        self.home.telemetry_consent_dialog = None;
         tracing::info!(target: "tui.dialog", dialog = "warning", "opening warning dialog");
         self.home.info_dialog =
             Some(crate::tui::dialogs::InfoDialog::new("Warning", message).with_size(WIDTH, height));
@@ -558,6 +568,14 @@ impl App {
         // so other TUIs can count this instance.
         crate::session::write_tui_heartbeat();
         self.home.active_tui_count = crate::session::count_active_tuis(PRESENCE_FRESH_WINDOW);
+
+        // Telemetry (opt-in, no-op otherwise): announce this surface on boot,
+        // send an initial snapshot, then refresh it periodically and once more
+        // on graceful exit. All sends are detached and swallow errors.
+        const TELEMETRY_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(60 * 60);
+        crate::telemetry::spawn_process_start(crate::telemetry::Surface::Tui);
+        self.emit_telemetry_snapshot();
+        let mut last_telemetry_snapshot = std::time::Instant::now();
 
         loop {
             // Force full redraw if needed (e.g., after returning from tmux).
@@ -695,6 +713,12 @@ impl App {
                                                             // Click consumed by the context menu
                                                             // (item dispatched, kept open, or
                                                             // dismissed on outside-click).
+                                                        } else if self.home.handle_dialog_click(mouse.column, mouse.row) {
+                                                            // A modal (e.g. the telemetry consent
+                                                            // popup) swallowed the click. Mirrors the
+                                                            // non-burst path so dialog buttons are
+                                                            // clickable even when a mouse event lands
+                                                            // right after a paste/dictation burst.
                                                         } else if hit_list {
                                                             let action = self.home.handle_click(mouse.column, mouse.row);
                                                             if action.is_none() {
@@ -1143,6 +1167,11 @@ impl App {
                 last_heartbeat = std::time::Instant::now();
             }
 
+            if last_telemetry_snapshot.elapsed() >= TELEMETRY_SNAPSHOT_INTERVAL {
+                last_telemetry_snapshot = std::time::Instant::now();
+                self.emit_telemetry_snapshot();
+            }
+
             if last_presence_refresh.elapsed() >= PRESENCE_REFRESH_INTERVAL {
                 last_presence_refresh = std::time::Instant::now();
                 let count = crate::session::count_active_tuis(PRESENCE_FRESH_WINDOW);
@@ -1259,7 +1288,34 @@ impl App {
             tracing::error!(target: "tui.input", "Failed to save on quit: {}", e);
         }
 
+        // Best-effort final snapshot on graceful exit, bounded so a dead
+        // endpoint can't delay quit.
+        if let Some(snapshot) = self.build_telemetry_snapshot() {
+            crate::telemetry::flush_snapshot(snapshot).await;
+        }
+
         Ok(())
+    }
+
+    /// Build a `usage_snapshot` from the current session list, or `None` when
+    /// telemetry is not opted in. The TUI never hosts the web dashboard, so
+    /// `web_seen` / `cockpit_seen` are false and the create-trend counter is
+    /// left at 0 (the `aoe serve` daemon is the surface that tracks those).
+    fn build_telemetry_snapshot(&self) -> Option<crate::telemetry::UsageSnapshot> {
+        crate::telemetry::build_usage_snapshot(
+            crate::telemetry::Surface::Tui,
+            self.home.instances(),
+            false,
+            false,
+            0,
+        )
+    }
+
+    /// Build and send a snapshot, detached. No-op when not opted in.
+    fn emit_telemetry_snapshot(&self) {
+        if let Some(snapshot) = self.build_telemetry_snapshot() {
+            crate::telemetry::spawn_snapshot(snapshot);
+        }
     }
 
     fn render(&mut self, frame: &mut Frame) {

--- a/src/tui/dialogs/intro.rs
+++ b/src/tui/dialogs/intro.rs
@@ -27,11 +27,17 @@ use crate::tui::styles::{available_themes, Theme};
 pub struct IntroOutcome {
     pub final_theme: Option<String>,
     pub final_attach_mode: Option<NewSessionAttachMode>,
+    /// `Some(true)` if the user opted in to telemetry on the Telemetry page,
+    /// `Some(false)` if they declined, `None` if they skipped before reaching
+    /// it. The caller writes `config.telemetry.enabled` and marks the opt-in
+    /// prompt answered only when this is `Some`.
+    pub telemetry_opt_in: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Page {
     Welcome,
+    Telemetry,
     FirstSession,
     AttachMode,
     ThemePicker,
@@ -51,6 +57,7 @@ impl Page {
     fn all() -> &'static [Page] {
         &[
             Page::Welcome,
+            Page::Telemetry,
             Page::FirstSession,
             Page::AttachMode,
             Page::ThemePicker,
@@ -107,6 +114,18 @@ pub struct IntroDialog {
     /// Index into `attach_mode_areas` (0 = LiveSend, 1 = Tmux) for the
     /// option the mouse is currently hovering on the AttachMode page.
     hovered_attach_idx: Option<usize>,
+
+    /// True when the user has chosen to opt in to telemetry on the Telemetry
+    /// page. Defaults to `false`: telemetry is off unless explicitly enabled.
+    telemetry_opt_in: bool,
+    /// True once the user has visited the Telemetry page; the choice is only
+    /// persisted (and the opt-in prompt only marked answered) when they did.
+    telemetry_visited: bool,
+    /// Hit-test rects for the two Telemetry options (0 = enable, 1 = decline).
+    telemetry_option_areas: [Rect; 2],
+    /// Index into `telemetry_option_areas` for the option under the mouse on
+    /// the Telemetry page.
+    hovered_telemetry_idx: Option<usize>,
 }
 
 impl IntroDialog {
@@ -134,6 +153,10 @@ impl IntroDialog {
             hovered_button: None,
             hovered_theme_row: None,
             hovered_attach_idx: None,
+            telemetry_opt_in: false,
+            telemetry_visited: false,
+            telemetry_option_areas: [Rect::default(), Rect::default()],
+            hovered_telemetry_idx: None,
         }
     }
 
@@ -175,6 +198,9 @@ impl IntroDialog {
             }
             Page::AttachMode => {
                 self.attach_mode_visited = true;
+            }
+            Page::Telemetry => {
+                self.telemetry_visited = true;
             }
             _ => {}
         }
@@ -218,6 +244,11 @@ impl IntroDialog {
             } else {
                 None
             },
+            telemetry_opt_in: if self.telemetry_visited {
+                Some(self.telemetry_opt_in)
+            } else {
+                None
+            },
         }
     }
 
@@ -232,6 +263,17 @@ impl IntroDialog {
             NewSessionAttachMode::LiveSend => NewSessionAttachMode::Tmux,
             NewSessionAttachMode::Tmux => NewSessionAttachMode::LiveSend,
         };
+    }
+
+    /// Flip the telemetry opt-in choice. A no-op when `DO_NOT_TRACK` forces
+    /// telemetry off, so the displayed choice can't drift from what will
+    /// actually happen.
+    fn toggle_telemetry(&mut self) {
+        if crate::telemetry::do_not_track() {
+            self.telemetry_opt_in = false;
+            return;
+        }
+        self.telemetry_opt_in = !self.telemetry_opt_in;
     }
 
     fn move_theme_cursor(&mut self, delta: isize) {
@@ -267,6 +309,18 @@ impl IntroDialog {
             match key.code {
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     self.toggle_attach_mode();
+                    return DialogResult::Continue;
+                }
+                _ => {}
+            }
+        }
+
+        // Telemetry page captures up/down/j/k to flip the opt-in choice,
+        // mirroring the attach-mode page.
+        if self.current_page() == Page::Telemetry {
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    self.toggle_telemetry();
                     return DialogResult::Continue;
                 }
                 _ => {}
@@ -316,12 +370,21 @@ impl IntroDialog {
         } else {
             None
         };
+        let new_telemetry = if self.current_page() == Page::Telemetry {
+            self.telemetry_option_areas
+                .iter()
+                .position(|a| a.contains(pos))
+        } else {
+            None
+        };
         let changed = self.hovered_button != new_button
             || self.hovered_theme_row != new_theme
-            || self.hovered_attach_idx != new_attach;
+            || self.hovered_attach_idx != new_attach
+            || self.hovered_telemetry_idx != new_telemetry;
         self.hovered_button = new_button;
         self.hovered_theme_row = new_theme;
         self.hovered_attach_idx = new_attach;
+        self.hovered_telemetry_idx = new_telemetry;
         changed
     }
 
@@ -332,6 +395,7 @@ impl IntroDialog {
     fn clear_page_hover(&mut self) {
         self.hovered_theme_row = None;
         self.hovered_attach_idx = None;
+        self.hovered_telemetry_idx = None;
     }
 
     /// Route a left-click. Returns `Some(result)` when the click hit a known
@@ -369,6 +433,15 @@ impl IntroDialog {
                 }
             }
         }
+        if self.current_page() == Page::Telemetry {
+            for (idx, area) in self.telemetry_option_areas.iter().enumerate() {
+                if area.contains(pos) {
+                    // Index 0 = enable, 1 = decline. DO_NOT_TRACK forces off.
+                    self.telemetry_opt_in = idx == 0 && !crate::telemetry::do_not_track();
+                    return Some(DialogResult::Continue);
+                }
+            }
+        }
         None
     }
 
@@ -399,6 +472,7 @@ impl IntroDialog {
 
         match self.current_page() {
             Page::Welcome => self.render_welcome(frame, chunks[0], theme),
+            Page::Telemetry => self.render_telemetry(frame, chunks[0], theme),
             Page::FirstSession => self.render_first_session(frame, chunks[0], theme),
             Page::AttachMode => self.render_attach_mode(frame, chunks[0], theme),
             Page::ThemePicker => self.render_theme_picker(frame, chunks[0], theme),
@@ -470,6 +544,112 @@ impl IntroDialog {
         ];
         let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
         frame.render_widget(paragraph, area);
+    }
+
+    fn render_telemetry(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let dnt = crate::telemetry::do_not_track();
+
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(7),
+                Constraint::Length(2),
+                Constraint::Length(2),
+                Constraint::Min(0),
+                Constraint::Length(1),
+            ])
+            .split(area);
+
+        let intro = Paragraph::new(vec![
+            Line::from(Span::styled(
+                "Help improve aoe with anonymous usage telemetry?",
+                Style::default().fg(theme.title).bold(),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "It shows us how aoe is actually used, so we can prioritize the",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(Span::styled(
+                "features that matter most. Off by default; when on, aoe sends",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(Span::styled(
+                "anonymous counts only: sessions, agents/models, version, and OS.",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(Span::styled(
+                "Never prompts, paths, names, branches, or commands.",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(Span::styled(
+                "Change it any time under Settings, or with `aoe telemetry`.",
+                Style::default().fg(theme.dimmed),
+            )),
+        ])
+        .wrap(Wrap { trim: false });
+        frame.render_widget(intro, layout[0]);
+
+        if dnt {
+            // DO_NOT_TRACK is an absolute override; make the suppressed state
+            // explicit rather than silently ignoring the toggle.
+            self.telemetry_option_areas = [Rect::default(), Rect::default()];
+            let note = Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "DO_NOT_TRACK is set in your environment.",
+                    Style::default().fg(theme.accent).bold(),
+                )),
+                Line::from(Span::styled(
+                    "Telemetry stays off and no install id is generated, whatever you pick.",
+                    Style::default().fg(theme.text),
+                )),
+            ])
+            .wrap(Wrap { trim: false });
+            frame.render_widget(note, layout[1]);
+            let hint = Paragraph::new(Span::styled(
+                "Enter to continue",
+                Style::default().fg(theme.hint).italic(),
+            ));
+            frame.render_widget(hint, layout[4]);
+            return;
+        }
+
+        let options = [
+            (true, "Enable anonymous telemetry"),
+            (false, "No thanks  (default)"),
+        ];
+        for (slot_idx, slot) in [layout[1], layout[2]].iter().enumerate() {
+            let (value, label) = options[slot_idx];
+            let is_selected = self.telemetry_opt_in == value;
+            let is_hovered = self.hovered_telemetry_idx == Some(slot_idx);
+            self.telemetry_option_areas[slot_idx] = *slot;
+            let marker = if is_selected { "▶ " } else { "  " };
+            let mut style = if is_selected {
+                Style::default().fg(theme.accent).bold()
+            } else {
+                Style::default().fg(theme.text)
+            };
+            if is_hovered {
+                style = style.bg(theme.selection);
+            }
+            let line = Line::from(vec![
+                Span::styled(marker.to_string(), style),
+                Span::styled(label.to_string(), style),
+            ]);
+            let para = Paragraph::new(line);
+            let para = if is_hovered {
+                para.style(Style::default().bg(theme.selection))
+            } else {
+                para
+            };
+            frame.render_widget(para, *slot);
+        }
+
+        let hint = Paragraph::new(Span::styled(
+            "↑/↓ to choose  •  Enter to confirm",
+            Style::default().fg(theme.hint).italic(),
+        ));
+        frame.render_widget(hint, layout[4]);
     }
 
     fn render_first_session(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -877,7 +1057,14 @@ mod tests {
     #[test]
     fn enter_advances_through_pages_to_finish() {
         let mut dialog = IntroDialog::new("default");
-        // Welcome -> FirstSession
+        // Welcome -> Telemetry (marks telemetry_visited)
+        assert!(matches!(
+            dialog.handle_key(key(KeyCode::Enter)),
+            DialogResult::Continue
+        ));
+        assert_eq!(dialog.current_page(), Page::Telemetry);
+        assert!(dialog.telemetry_visited);
+        // Telemetry -> FirstSession
         assert!(matches!(
             dialog.handle_key(key(KeyCode::Enter)),
             DialogResult::Continue
@@ -929,7 +1116,9 @@ mod tests {
     #[test]
     fn esc_reverts_preview_when_theme_was_visited() {
         let mut dialog = IntroDialog::new("default");
-        // Walk to theme page (Welcome -> FirstSession -> AttachMode -> Theme).
+        // Walk to theme page (Welcome -> Telemetry -> FirstSession ->
+        // AttachMode -> Theme).
+        dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
@@ -952,6 +1141,8 @@ mod tests {
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
+        dialog.handle_key(key(KeyCode::Enter));
+        assert_eq!(dialog.current_page(), Page::ThemePicker);
         // Entering the theme page itself queues a preview of the cursor's
         // current theme; drain it so we can isolate the arrow-key effect.
         let _ = dialog.take_pending_preview();
@@ -966,10 +1157,13 @@ mod tests {
     #[test]
     fn submit_outcome_carries_final_theme_when_user_picks_a_new_one() {
         let mut dialog = IntroDialog::new("default");
-        // Walk through Welcome -> FirstSession -> AttachMode -> ThemePicker.
+        // Walk to ThemePicker (Welcome -> Telemetry -> FirstSession ->
+        // AttachMode -> ThemePicker).
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
+        dialog.handle_key(key(KeyCode::Enter));
+        assert_eq!(dialog.current_page(), Page::ThemePicker);
         // Move the cursor so the pick differs from the original "default";
         // outcome() suppresses identity picks to avoid an unnecessary
         // SetTheme dispatch + screen clear on close.
@@ -995,7 +1189,7 @@ mod tests {
         // Walk through all pages without touching the cursor: it stays on
         // "default", which equals the original; outcome() should report
         // None so the close path skips a needless SetTheme dispatch.
-        for _ in 0..5 {
+        for _ in 0..6 {
             let _ = dialog.handle_key(key(KeyCode::Enter));
         }
         let outcome = dialog.outcome();
@@ -1017,6 +1211,7 @@ mod tests {
         let mut dialog = IntroDialog::new("default");
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
+        dialog.handle_key(key(KeyCode::Enter));
         assert_eq!(dialog.current_page(), Page::AttachMode);
         assert_eq!(dialog.attach_mode_cursor, NewSessionAttachMode::LiveSend);
         dialog.handle_key(key(KeyCode::Down));
@@ -1033,7 +1228,7 @@ mod tests {
         // who flips this for "clickable buttons" should make a
         // conscious choice rather than regressing the copy flow.
         let mut dialog = IntroDialog::new("default");
-        for _ in 0..5 {
+        for _ in 0..6 {
             assert!(dialog.wants_text_selection());
             dialog.handle_key(key(KeyCode::Right));
         }
@@ -1050,6 +1245,7 @@ mod tests {
             width: 10,
             height: 4,
         };
+        dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
         assert_eq!(dialog.current_page(), Page::AttachMode);
@@ -1085,6 +1281,7 @@ mod tests {
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
+        dialog.handle_key(key(KeyCode::Enter));
         assert_eq!(dialog.current_page(), Page::ThemePicker);
         assert!(dialog.handle_hover(5, 0));
         assert_eq!(dialog.hovered_theme_row, Some(0));
@@ -1106,6 +1303,8 @@ mod tests {
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
+        dialog.handle_key(key(KeyCode::Enter));
+        assert_eq!(dialog.current_page(), Page::ThemePicker);
         let _ = dialog.handle_hover(5, 0);
         assert!(dialog.hovered_theme_row.is_some());
         // Advancing to Done clears the per-page hover; if it leaked, the
@@ -1121,6 +1320,7 @@ mod tests {
         // Walk to AttachMode, toggle to Tmux, then walk to the end.
         dialog.handle_key(key(KeyCode::Enter));
         dialog.handle_key(key(KeyCode::Enter));
+        dialog.handle_key(key(KeyCode::Enter));
         assert_eq!(dialog.current_page(), Page::AttachMode);
         dialog.handle_key(key(KeyCode::Down));
         assert_eq!(dialog.attach_mode_cursor, NewSessionAttachMode::Tmux);
@@ -1129,6 +1329,52 @@ mod tests {
         }
         let outcome = dialog.outcome();
         assert_eq!(outcome.final_attach_mode, Some(NewSessionAttachMode::Tmux));
+    }
+
+    #[test]
+    fn telemetry_toggle_switches_choice() {
+        let mut dialog = IntroDialog::new("default");
+        // Welcome -> Telemetry.
+        dialog.handle_key(key(KeyCode::Enter));
+        assert_eq!(dialog.current_page(), Page::Telemetry);
+        // Default is opt-out; toggle on, then back off.
+        assert!(!dialog.telemetry_opt_in);
+        dialog.handle_key(key(KeyCode::Down));
+        assert!(dialog.telemetry_opt_in);
+        dialog.handle_key(key(KeyCode::Up));
+        assert!(!dialog.telemetry_opt_in);
+    }
+
+    #[test]
+    fn outcome_carries_telemetry_opt_in_when_user_enables_it() {
+        let mut dialog = IntroDialog::new("default");
+        dialog.handle_key(key(KeyCode::Enter)); // -> Telemetry
+        dialog.handle_key(key(KeyCode::Down)); // opt in
+        for _ in 0..5 {
+            let _ = dialog.handle_key(key(KeyCode::Enter));
+        }
+        let outcome = dialog.outcome();
+        assert_eq!(outcome.telemetry_opt_in, Some(true));
+    }
+
+    #[test]
+    fn outcome_carries_telemetry_decline_when_left_default() {
+        let mut dialog = IntroDialog::new("default");
+        // Walk the whole wizard without touching the telemetry choice.
+        for _ in 0..6 {
+            let _ = dialog.handle_key(key(KeyCode::Enter));
+        }
+        let outcome = dialog.outcome();
+        // Visited the page but left it on the default: an explicit decline.
+        assert_eq!(outcome.telemetry_opt_in, Some(false));
+    }
+
+    #[test]
+    fn outcome_omits_telemetry_when_skipped_before_the_page() {
+        let mut dialog = IntroDialog::new("default");
+        // Skip on the Welcome page, before reaching Telemetry.
+        let _ = dialog.handle_key(key(KeyCode::Esc));
+        assert_eq!(dialog.outcome().telemetry_opt_in, None);
     }
 
     #[test]

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -24,6 +24,7 @@ mod send_message;
 mod serve;
 mod snooze_duration;
 mod sort_picker;
+mod telemetry_consent;
 mod tool_picker;
 mod update_confirm;
 
@@ -54,6 +55,7 @@ pub use send_message::SendMessageDialog;
 pub use serve::{ServeAction, ServeView};
 pub use snooze_duration::SnoozeDurationDialog;
 pub use sort_picker::SortPickerDialog;
+pub use telemetry_consent::TelemetryConsentDialog;
 pub use tool_picker::ToolPickerDialog;
 pub use update_confirm::UpdateConfirmDialog;
 

--- a/src/tui/dialogs/telemetry_consent.rs
+++ b/src/tui/dialogs/telemetry_consent.rs
@@ -1,0 +1,363 @@
+//! Standalone telemetry opt-in popup.
+//!
+//! Shown once to users who completed the first-run walkthrough before
+//! telemetry existed (the walkthrough itself carries the prompt as its second
+//! pane for new users). `Submit(true)` opts in, `Submit(false)` / `Cancel`
+//! declines; the caller marks the prompt answered in either case so it never
+//! re-appears. Startup gating ensures it never renders on top of the changelog
+//! or the version update modal.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::Position;
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+
+use super::DialogResult;
+use crate::tui::styles::Theme;
+
+#[derive(Default)]
+pub struct TelemetryConsentDialog {
+    /// Focused option: `Some(true)` = Enable, `Some(false)` = Decline,
+    /// `None` = nothing focused yet. There is no default focus on purpose:
+    /// a reflexive Enter does nothing until the user makes an explicit
+    /// left/right choice, so the prompt can't be dismissed without reading.
+    selected: Option<bool>,
+    enable_button_area: Rect,
+    decline_button_area: Rect,
+    /// Which button the mouse is over (0 = Enable, 1 = Decline). Visual only.
+    hovered: Option<usize>,
+}
+
+impl TelemetryConsentDialog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<bool> {
+        match key.code {
+            // Esc is the standard cancel; treat it as a decline.
+            KeyCode::Esc => DialogResult::Submit(false),
+            // Enter only confirms once a side has been chosen; with no focus
+            // it is a no-op so the user can't blow past the prompt.
+            KeyCode::Enter | KeyCode::Char(' ') => match self.selected {
+                Some(choice) => DialogResult::Submit(choice),
+                None => DialogResult::Continue,
+            },
+            KeyCode::Left | KeyCode::Char('h') => {
+                self.selected = Some(true);
+                DialogResult::Continue
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                self.selected = Some(false);
+                DialogResult::Continue
+            }
+            KeyCode::Tab => {
+                self.selected = Some(!self.selected.unwrap_or(false));
+                DialogResult::Continue
+            }
+            _ => DialogResult::Continue,
+        }
+    }
+
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<bool>> {
+        let pos = Position::from((col, row));
+        if self.enable_button_area.contains(pos) {
+            return Some(DialogResult::Submit(true));
+        }
+        if self.decline_button_area.contains(pos) {
+            return Some(DialogResult::Submit(false));
+        }
+        None
+    }
+
+    /// Update the hover highlight. Returns true when it changed (so the caller
+    /// can skip redrawing on every pixel of mouse drift).
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let pos = Position::from((col, row));
+        let new = if self.enable_button_area.contains(pos) {
+            Some(0)
+        } else if self.decline_button_area.contains(pos) {
+            Some(1)
+        } else {
+            None
+        };
+        let changed = self.hovered != new;
+        self.hovered = new;
+        changed
+    }
+
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let dnt = crate::telemetry::do_not_track();
+        let dialog_area = super::centered_rect(area, 76, if dnt { 13 } else { 17 });
+        frame.render_widget(Clear, dialog_area);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .title(" Usage telemetry ")
+            .title_style(Style::default().fg(theme.accent).bold());
+        let inner = block.inner(dialog_area);
+        frame.render_widget(block, dialog_area);
+
+        if dnt {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .margin(1)
+                .constraints([Constraint::Min(1), Constraint::Length(1)])
+                .split(inner);
+            self.render_dnt(frame, chunks[0], chunks[1], theme);
+            return;
+        }
+
+        // body (top) · [Enable] [Not now] · "change any time" hint (bottom).
+        // The hint sits under the buttons so the action is what the eye lands
+        // on, not the fine print.
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints([
+                Constraint::Min(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+            ])
+            .split(inner);
+
+        let body = Paragraph::new(vec![
+            Line::from(Span::styled(
+                "Help improve aoe with anonymous usage telemetry?",
+                Style::default().fg(theme.title).bold(),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "It shows us how aoe is actually used, so we can prioritize the",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(Span::styled(
+                "features that matter most. Off by default.",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "When on, aoe sends anonymous counts only: sessions, agents and",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(Span::styled(
+                "models, your aoe version, and OS. Never prompts, paths, names,",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(Span::styled(
+                "branch names, or commands.",
+                Style::default().fg(theme.text),
+            )),
+        ])
+        .wrap(Wrap { trim: false });
+        frame.render_widget(body, chunks[0]);
+
+        // chunks[1] is a one-row gap between the body and the buttons.
+        self.render_buttons(frame, chunks[2], theme);
+
+        // No default focus: tell the user how to choose so a bare Enter (which
+        // is intentionally inert here) isn't a dead end.
+        let keys = Paragraph::new(Span::styled(
+            "←/→ or Tab to choose, then Enter to confirm",
+            Style::default().fg(theme.hint).italic(),
+        ))
+        .alignment(Alignment::Center);
+        frame.render_widget(keys, chunks[3]);
+
+        let hint = Paragraph::new(Span::styled(
+            "Change it any time under Settings, or with `aoe telemetry`.",
+            Style::default().fg(theme.dimmed),
+        ))
+        .alignment(Alignment::Center);
+        frame.render_widget(hint, chunks[4]);
+    }
+
+    fn render_dnt(&mut self, frame: &mut Frame, body_area: Rect, footer: Rect, theme: &Theme) {
+        // DO_NOT_TRACK forces telemetry off; surface that rather than offering
+        // a toggle that would do nothing.
+        self.enable_button_area = Rect::default();
+        self.decline_button_area = Rect::default();
+        let body = Paragraph::new(vec![
+            Line::from(Span::styled(
+                "DO_NOT_TRACK is set in your environment.",
+                Style::default().fg(theme.accent).bold(),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Telemetry stays off and no install id is generated. You can",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(Span::styled(
+                "unset DO_NOT_TRACK and opt in under Settings if you change",
+                Style::default().fg(theme.text),
+            )),
+            Line::from(Span::styled("your mind.", Style::default().fg(theme.text))),
+        ])
+        .wrap(Wrap { trim: false });
+        frame.render_widget(body, body_area);
+        let hint = Paragraph::new(Span::styled(
+            "Press Enter or Esc to dismiss",
+            Style::default().fg(theme.hint).italic(),
+        ))
+        .alignment(Alignment::Center);
+        frame.render_widget(hint, footer);
+    }
+
+    fn render_buttons(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let enable_label = "[Enable]";
+        let decline_label = "[Not now]";
+        let gap = "    ";
+        let row_width = (enable_label.len() + gap.len() + decline_label.len()) as u16;
+
+        // A side lights up in its active color when it's the keyboard-focused
+        // choice OR the mouse is hovering it; otherwise it stays dimmed. With
+        // no choice and no hover, both are dimmed so nothing reads as
+        // preselected. Hover drives the highlight only (like the other
+        // dialogs), so a click is what commits, not a stray mouse drift.
+        let enable_active = self.selected == Some(true) || self.hovered == Some(0);
+        let decline_active = self.selected == Some(false) || self.hovered == Some(1);
+        let enable_style = if enable_active {
+            Style::default().fg(theme.accent).bold()
+        } else {
+            Style::default().fg(theme.dimmed)
+        };
+        let decline_style = if decline_active {
+            Style::default().fg(theme.running).bold()
+        } else {
+            Style::default().fg(theme.dimmed)
+        };
+        let line = Line::from(vec![
+            Span::styled(enable_label, enable_style),
+            Span::raw(gap),
+            Span::styled(decline_label, decline_style),
+        ]);
+        frame.render_widget(Paragraph::new(line).alignment(Alignment::Center), area);
+
+        if area.width < row_width || area.height == 0 {
+            self.enable_button_area = Rect::default();
+            self.decline_button_area = Rect::default();
+            return;
+        }
+        let left_pad = (area.width - row_width) / 2;
+        let enable_x = area.x + left_pad;
+        let decline_x = enable_x + (enable_label.len() + gap.len()) as u16;
+        self.enable_button_area = Rect::new(enable_x, area.y, enable_label.len() as u16, 1);
+        self.decline_button_area = Rect::new(decline_x, area.y, decline_label.len() as u16, 1);
+
+        if let Some(idx) = self.hovered {
+            let rect = if idx == 0 {
+                self.enable_button_area
+            } else {
+                self.decline_button_area
+            };
+            crate::tui::components::hover::paint_hover_bg(frame, rect, theme.selection);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    fn k(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn click_after_render_submits_the_hit_button() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+        let theme = crate::tui::styles::load_theme("default");
+        let mut term = Terminal::new(TestBackend::new(100, 30)).unwrap();
+        let mut d = TelemetryConsentDialog::new();
+        term.draw(|f| d.render(f, f.area(), &theme)).unwrap();
+        // Clicking the rendered [Enable] / [Not now] glyphs commits directly.
+        let enable = d.enable_button_area;
+        let decline = d.decline_button_area;
+        assert!(matches!(
+            d.handle_click(enable.x, enable.y),
+            Some(DialogResult::Submit(true))
+        ));
+        assert!(matches!(
+            d.handle_click(decline.x, decline.y),
+            Some(DialogResult::Submit(false))
+        ));
+    }
+
+    #[test]
+    fn no_default_focus() {
+        assert_eq!(TelemetryConsentDialog::new().selected, None);
+    }
+
+    #[test]
+    fn enter_with_no_focus_is_inert() {
+        // The whole point of no default focus: a reflexive Enter must not
+        // dismiss the prompt until the user has chosen a side.
+        let mut d = TelemetryConsentDialog::new();
+        assert!(matches!(
+            d.handle_key(k(KeyCode::Enter)),
+            DialogResult::Continue
+        ));
+        assert!(matches!(
+            d.handle_key(k(KeyCode::Char(' '))),
+            DialogResult::Continue
+        ));
+    }
+
+    #[test]
+    fn tab_focuses_then_enter_confirms() {
+        let mut d = TelemetryConsentDialog::new();
+        // Tab from no focus lands on Enable; a second Tab flips to Decline.
+        assert!(matches!(
+            d.handle_key(k(KeyCode::Tab)),
+            DialogResult::Continue
+        ));
+        assert_eq!(d.selected, Some(true));
+        assert!(matches!(
+            d.handle_key(k(KeyCode::Tab)),
+            DialogResult::Continue
+        ));
+        assert_eq!(d.selected, Some(false));
+    }
+
+    #[test]
+    fn esc_declines() {
+        assert!(matches!(
+            TelemetryConsentDialog::new().handle_key(k(KeyCode::Esc)),
+            DialogResult::Submit(false)
+        ));
+    }
+
+    #[test]
+    fn left_focuses_enable_then_enter_opts_in() {
+        let mut d = TelemetryConsentDialog::new();
+        assert!(matches!(
+            d.handle_key(k(KeyCode::Left)),
+            DialogResult::Continue
+        ));
+        assert_eq!(d.selected, Some(true));
+        assert!(matches!(
+            d.handle_key(k(KeyCode::Enter)),
+            DialogResult::Submit(true)
+        ));
+    }
+
+    #[test]
+    fn right_focuses_decline_then_enter_declines() {
+        let mut d = TelemetryConsentDialog::new();
+        assert!(matches!(
+            d.handle_key(k(KeyCode::Right)),
+            DialogResult::Continue
+        ));
+        assert_eq!(d.selected, Some(false));
+        assert!(matches!(
+            d.handle_key(k(KeyCode::Enter)),
+            DialogResult::Submit(false)
+        ));
+    }
+}

--- a/src/tui/dialogs/telemetry_consent.rs
+++ b/src/tui/dialogs/telemetry_consent.rs
@@ -37,10 +37,13 @@ impl TelemetryConsentDialog {
         match key.code {
             // Esc is the standard cancel; treat it as a decline.
             KeyCode::Esc => DialogResult::Submit(false),
-            // Enter only confirms once a side has been chosen; with no focus
-            // it is a no-op so the user can't blow past the prompt.
+            // Enter confirms a chosen side. With no choice it is a no-op so the
+            // user can't blow past the prompt, EXCEPT under DO_NOT_TRACK, where
+            // the dialog shows no buttons and explicitly says "Press Enter or
+            // Esc to dismiss", so Enter must dismiss (as a decline).
             KeyCode::Enter | KeyCode::Char(' ') => match self.selected {
                 Some(choice) => DialogResult::Submit(choice),
+                None if crate::telemetry::do_not_track() => DialogResult::Submit(false),
                 None => DialogResult::Continue,
             },
             KeyCode::Left | KeyCode::Char('h') => {
@@ -263,6 +266,7 @@ impl TelemetryConsentDialog {
 mod tests {
     use super::*;
     use crossterm::event::KeyModifiers;
+    use serial_test::serial;
 
     fn k(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -294,10 +298,14 @@ mod tests {
         assert_eq!(TelemetryConsentDialog::new().selected, None);
     }
 
+    // `#[serial]` because `handle_key` reads the `DO_NOT_TRACK` env var, which
+    // other telemetry tests mutate; serializing keeps it deterministic.
     #[test]
+    #[serial]
     fn enter_with_no_focus_is_inert() {
         // The whole point of no default focus: a reflexive Enter must not
         // dismiss the prompt until the user has chosen a side.
+        unsafe { std::env::remove_var("DO_NOT_TRACK") };
         let mut d = TelemetryConsentDialog::new();
         assert!(matches!(
             d.handle_key(k(KeyCode::Enter)),
@@ -307,6 +315,18 @@ mod tests {
             d.handle_key(k(KeyCode::Char(' '))),
             DialogResult::Continue
         ));
+    }
+
+    #[test]
+    #[serial]
+    fn enter_dismisses_under_do_not_track() {
+        // Under DO_NOT_TRACK the popup shows no buttons and says "Press Enter
+        // or Esc to dismiss", so Enter with no selection must decline-dismiss.
+        unsafe { std::env::set_var("DO_NOT_TRACK", "1") };
+        let mut d = TelemetryConsentDialog::new();
+        let result = d.handle_key(k(KeyCode::Enter));
+        unsafe { std::env::remove_var("DO_NOT_TRACK") };
+        assert!(matches!(result, DialogResult::Submit(false)));
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -36,7 +36,10 @@ const DOUBLE_CLICK_THRESHOLD: std::time::Duration = std::time::Duration::from_mi
 /// logged and swallowed: the intro should never block startup on a config
 /// write hiccup.
 fn apply_intro_outcome(outcome: &IntroOutcome) {
-    if outcome.final_theme.is_none() && outcome.final_attach_mode.is_none() {
+    if outcome.final_theme.is_none()
+        && outcome.final_attach_mode.is_none()
+        && outcome.telemetry_opt_in.is_none()
+    {
         return;
     }
     let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) else {
@@ -50,9 +53,34 @@ fn apply_intro_outcome(outcome: &IntroOutcome) {
         config.session.new_session_attach_mode = mode;
         config.session.default_attach_mode = mode;
     }
+    if let Some(opt_in) = outcome.telemetry_opt_in {
+        config.telemetry.enabled = opt_in;
+        config.app_state.has_responded_to_telemetry = true;
+    }
     if let Err(e) = save_config(&config) {
         tracing::warn!(target: "tui.input", "Failed to persist intro outcome: {e}");
     }
+    // Sync the install id with the saved opt-in choice (no-op under
+    // DO_NOT_TRACK). Done after save so telemetry.json matches config.
+    if let Some(opt_in) = outcome.telemetry_opt_in {
+        crate::telemetry::apply_opt_in_change(opt_in);
+    }
+}
+
+/// Persist the user's answer to the standalone telemetry consent popup.
+/// Sets the opt-in flag, marks the prompt answered so it never re-appears,
+/// and reconciles the install id (no-op under `DO_NOT_TRACK`).
+fn persist_telemetry_consent(opt_in: bool) {
+    let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) else {
+        tracing::warn!(target: "tui.input", "telemetry consent: load_config failed; not persisting");
+        return;
+    };
+    config.telemetry.enabled = opt_in;
+    config.app_state.has_responded_to_telemetry = true;
+    if let Err(e) = save_config(&config) {
+        tracing::warn!(target: "tui.input", "Failed to persist telemetry consent: {e}");
+    }
+    crate::telemetry::apply_opt_in_change(opt_in);
 }
 
 /// xterm bracketed-paste start sequence: `ESC [ 2 0 0 ~`. An agent that
@@ -790,6 +818,20 @@ impl HomeView {
             }
             return true;
         }
+        if let Some(dialog) = &self.telemetry_consent_dialog {
+            if let Some(result) = dialog.handle_click(col, row) {
+                let opt_in = match result {
+                    DialogResult::Submit(opt_in) => Some(opt_in),
+                    DialogResult::Cancel => Some(false),
+                    DialogResult::Continue => None,
+                };
+                if let Some(opt_in) = opt_in {
+                    self.telemetry_consent_dialog = None;
+                    persist_telemetry_consent(opt_in);
+                }
+            }
+            return true;
+        }
         if let Some(dialog) = &self.snooze_duration_dialog {
             if let Some(DialogResult::Submit(minutes)) = dialog.handle_click(col, row) {
                 self.snooze_duration_dialog = None;
@@ -1215,6 +1257,23 @@ impl HomeView {
                 DialogResult::Continue => {}
                 DialogResult::Cancel | DialogResult::Submit(_) => {
                     self.changelog_dialog = None;
+                }
+            }
+            return None;
+        }
+
+        if let Some(dialog) = &mut self.telemetry_consent_dialog {
+            match dialog.handle_key(key) {
+                DialogResult::Continue => {}
+                DialogResult::Submit(opt_in) => {
+                    self.telemetry_consent_dialog = None;
+                    persist_telemetry_consent(opt_in);
+                }
+                // Cancel can't be produced by this dialog (Esc maps to a
+                // decline), but treat it as a decline for completeness.
+                DialogResult::Cancel => {
+                    self.telemetry_consent_dialog = None;
+                    persist_telemetry_consent(false);
                 }
             }
             return None;
@@ -3293,6 +3352,9 @@ impl HomeView {
             overlay_changed |= dialog.handle_hover(col, row);
         }
         if let Some(dialog) = &mut self.update_confirm_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.telemetry_consent_dialog {
             overlay_changed |= dialog.handle_hover(col, row);
         }
         if let Some(dialog) = &mut self.snooze_duration_dialog {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -432,6 +432,10 @@ pub struct HomeView {
     #[cfg(feature = "serve")]
     pub(super) serve_view: Option<ServeView>,
     pub(super) update_confirm_dialog: Option<UpdateConfirmDialog>,
+    /// One-time opt-in popup for users who finished the walkthrough before
+    /// telemetry existed. Startup gating keeps it from rendering over the
+    /// changelog or the version update modal.
+    pub(super) telemetry_consent_dialog: Option<super::dialogs::TelemetryConsentDialog>,
     pub(super) send_message_dialog: Option<super::dialogs::SendMessageDialog>,
     /// Session to receive the message from the send dialog
     pub(super) pending_send_session: Option<String>,
@@ -874,6 +878,7 @@ impl HomeView {
             #[cfg(feature = "serve")]
             serve_view: None,
             update_confirm_dialog: None,
+            telemetry_consent_dialog: None,
             send_message_dialog: None,
             pending_send_session: None,
             pending_send_target: live_send::LiveSendTarget::Agent,
@@ -2371,6 +2376,7 @@ impl HomeView {
             || self.tool_picker_dialog.is_some()
             || self.send_message_dialog.is_some()
             || self.update_confirm_dialog.is_some()
+            || self.telemetry_consent_dialog.is_some()
             || serve_open
             || self.settings_view.is_some()
             || self.diff_view.is_some()
@@ -2406,6 +2412,7 @@ impl HomeView {
             || self.tool_picker_dialog.is_some()
             || self.send_message_dialog.is_some()
             || self.update_confirm_dialog.is_some()
+            || self.telemetry_consent_dialog.is_some()
             || serve_open
             || self.settings_view.is_some()
             || self.diff_view.is_some()
@@ -2536,6 +2543,11 @@ impl HomeView {
             "opening",
         );
         self.changelog_dialog = Some(ChangelogDialog::new(from_version));
+    }
+
+    pub fn show_telemetry_consent(&mut self) {
+        tracing::info!(target: "tui.dialog", dialog = "telemetry_consent", "opening");
+        self.telemetry_consent_dialog = Some(super::dialogs::TelemetryConsentDialog::new());
     }
 
     pub fn instances(&self) -> &[Instance] {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -834,6 +834,7 @@ impl HomeView {
             || self.intro_dialog.is_some()
             || self.no_agents_dialog.is_some()
             || self.changelog_dialog.is_some()
+            || self.telemetry_consent_dialog.is_some()
             || self.info_dialog.is_some()
             || self.profile_picker_dialog.is_some()
             || self.group_picker_dialog.is_some()

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -601,6 +601,7 @@ impl HomeView {
             intro_dialog,
             no_agents_dialog,
             changelog_dialog,
+            telemetry_consent_dialog,
             info_dialog,
             snooze_duration_dialog,
             profile_picker_dialog,

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -17,6 +17,7 @@ use super::SettingsScope;
 pub enum SettingsCategory {
     Theme,
     Updates,
+    Telemetry,
     Worktree,
     Sandbox,
     Tmux,
@@ -37,6 +38,7 @@ impl SettingsCategory {
         match self {
             Self::Theme => "Theme",
             Self::Updates => "Updates",
+            Self::Telemetry => "Telemetry",
             Self::Worktree => "Worktree",
             Self::Sandbox => "Sandbox",
             Self::Tmux => "Tmux",
@@ -68,6 +70,8 @@ pub enum FieldKey {
     CheckIntervalHours,
     NotifyInCli,
     WebPollIntervalMinutes,
+    // Telemetry
+    TelemetryEnabled,
     // Worktree
     WorktreeEnabled,
     PathTemplate,
@@ -376,6 +380,7 @@ pub fn build_fields_for_category(
     match category {
         SettingsCategory::Theme => build_theme_fields(scope, global, profile),
         SettingsCategory::Updates => build_updates_fields(scope, global, profile),
+        SettingsCategory::Telemetry => build_telemetry_fields(global),
         SettingsCategory::Worktree => build_worktree_fields(scope, global, profile),
         SettingsCategory::Sandbox => build_sandbox_fields(scope, global, profile),
         SettingsCategory::Tmux => build_tmux_fields(scope, global, profile),
@@ -1106,6 +1111,29 @@ fn build_updates_fields(
             ),
         },
     ]
+}
+
+/// Telemetry is a single install-level consent toggle, so it is global-only
+/// (no profile override) and mirrors the `build_logging_fields` shape. When
+/// `DO_NOT_TRACK` is set the description calls out that nothing is sent
+/// regardless of the toggle, so the suppressed state is never silent.
+fn build_telemetry_fields(global: &Config) -> Vec<SettingField> {
+    let description = if crate::telemetry::do_not_track() {
+        "Anonymous, opt-in usage telemetry. DO_NOT_TRACK is set, so nothing is sent and no \
+         install id is generated regardless of this toggle. Off by default; never sends content."
+    } else {
+        "Anonymous, opt-in usage telemetry (counts of sessions, agents, version, OS). Off by \
+         default. Never sends prompts, paths, names, or commands. Honors DO_NOT_TRACK."
+    };
+    vec![SettingField {
+        key: FieldKey::TelemetryEnabled,
+        label: "Enable usage telemetry",
+        description,
+        value: FieldValue::Bool(global.telemetry.enabled),
+        category: SettingsCategory::Telemetry,
+        has_override: false,
+        inherited_display: None,
+    }]
 }
 
 fn build_worktree_fields(
@@ -2687,6 +2715,8 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::WebPollIntervalMinutes, FieldValue::Number(v)) => {
             config.updates.web_poll_interval_minutes = *v
         }
+        // Telemetry
+        (FieldKey::TelemetryEnabled, FieldValue::Bool(v)) => config.telemetry.enabled = *v,
         // Worktree
         (FieldKey::WorktreeEnabled, FieldValue::Bool(v)) => config.worktree.enabled = *v,
         (FieldKey::PathTemplate, FieldValue::Text(v)) => config.worktree.path_template = v.clone(),

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -1092,6 +1092,7 @@ impl SettingsView {
             | FieldKey::LoggingMaxSizeMib
             | FieldKey::LoggingKeepCount
             | FieldKey::LoggingShowSpans
+            | FieldKey::TelemetryEnabled
             | FieldKey::SessionIdPollerMaxThreads => {}
             FieldKey::HostEnvironment => {
                 config.environment = None;

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -525,6 +525,13 @@ impl SettingsView {
 
         match self.scope {
             SettingsScope::Global => {
+                // Saving the Telemetry page counts as answering the opt-in
+                // prompt even if the toggle was left untouched, so the one-time
+                // standalone popup doesn't reappear for someone who reviewed it
+                // here and chose to leave it off.
+                if self.current_category() == SettingsCategory::Telemetry {
+                    self.global_config.app_state.has_responded_to_telemetry = true;
+                }
                 save_config(&self.global_config)?;
                 self.resolved_base =
                     merge_configs(self.global_config.clone(), &self.profile_config);

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -304,6 +304,11 @@ impl SettingsView {
 
         push_section(&mut rows, "System");
         push_tab(&mut rows, SettingsCategory::Updates);
+        // Telemetry is an install-level consent toggle, not a per-profile or
+        // per-repo setting, so it only appears under the Global scope.
+        if scope == SettingsScope::Global {
+            push_tab(&mut rows, SettingsCategory::Telemetry);
+        }
         push_tab(&mut rows, SettingsCategory::Logging);
 
         rows
@@ -476,6 +481,7 @@ impl SettingsView {
         }
 
         let field = &self.fields[field_index];
+        let field_key = field.key;
 
         match self.scope {
             SettingsScope::Global | SettingsScope::Profile => {
@@ -485,6 +491,12 @@ impl SettingsView {
                     &mut self.global_config,
                     &mut self.profile_config,
                 );
+                // Editing the telemetry toggle counts as responding to the
+                // opt-in prompt, so the one-time standalone consent popup
+                // never re-appears for a user who already made a choice here.
+                if field_key == FieldKey::TelemetryEnabled {
+                    self.global_config.app_state.has_responded_to_telemetry = true;
+                }
             }
             SettingsScope::Repo => {
                 // Use Profile logic but against resolved_base and repo_as_profile
@@ -530,6 +542,10 @@ impl SettingsView {
                 crate::session::poller::set_session_id_poller_max_threads(
                     self.global_config.session.session_id_poller_max_threads,
                 );
+                // Reconcile the on-disk install id with the saved opt-in
+                // state: generate one when enabled, delete it on opt-out.
+                // Idempotent, so running it on every global save is safe.
+                crate::telemetry::apply_opt_in_change(self.global_config.telemetry.enabled);
             }
             SettingsScope::Profile => {
                 save_profile_config(&self.profile, &self.profile_config)?;

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -240,6 +240,10 @@ impl TuiTestHarness {
         }
 
         // Pre-seed config.toml to skip the welcome dialog and update checks.
+        // `has_responded_to_telemetry` is set so the one-time telemetry consent
+        // popup (gated on that flag alone in `App::new`) never renders over the
+        // TUI and swallows input in the general e2e tests; the telemetry consent
+        // surfaces are covered directly by their own unit and integration tests.
         // On Linux the app uses $XDG_CONFIG_HOME/agent-of-empires[-dev]/ (set
         // below), on macOS it uses $HOME/.agent-of-empires[-dev]/. The `-dev`
         // suffix kicks in on debug builds, which is what `cargo test` produces.
@@ -251,6 +255,7 @@ update_check_mode = "off"
 
 [app_state]
 has_seen_welcome = true
+has_responded_to_telemetry = true
 last_seen_version = "{}"
 "#,
             env!("CARGO_PKG_VERSION")

--- a/tests/e2e/intro.rs
+++ b/tests/e2e/intro.rs
@@ -37,7 +37,7 @@ fn intro_walkthrough_appears_on_first_run() {
 
     // Title bar uses the literal string from IntroDialog::render.
     h.wait_for("Welcome to Agent of Empires");
-    h.assert_screen_contains("(1/5)");
+    h.assert_screen_contains("(1/6)");
     h.assert_screen_contains("[Skip]");
     h.assert_screen_contains("[Next");
 }
@@ -51,24 +51,27 @@ fn intro_advances_through_pages_with_enter() {
     force_first_run(&h);
     h.spawn_tui();
 
-    h.wait_for("(1/5)");
+    h.wait_for("(1/6)");
     h.send_keys("Enter");
-    h.wait_for("(2/5)");
+    h.wait_for("(2/6)");
+    h.assert_screen_contains("Help improve aoe with anonymous usage telemetry?");
+    h.send_keys("Enter");
+    h.wait_for("(3/6)");
     h.assert_screen_contains("Start your first session");
     h.send_keys("Enter");
-    h.wait_for("(3/5)");
+    h.wait_for("(4/6)");
     h.assert_screen_contains("How do you want to drive your sessions?");
     h.send_keys("Enter");
-    h.wait_for("(4/5)");
+    h.wait_for("(5/6)");
     h.assert_screen_contains("Pick a theme");
     h.send_keys("Enter");
-    h.wait_for("(5/5)");
+    h.wait_for("(6/6)");
     h.assert_screen_contains("You're all set");
     h.send_keys("Enter");
     // Intro dismissed: list view marker should appear and the dialog title
     // should be gone.
     h.wait_for("No sessions yet");
-    h.wait_for_absent("(5/5)", Duration::from_secs(3));
+    h.wait_for_absent("(6/6)", Duration::from_secs(3));
 }
 
 #[test]
@@ -80,7 +83,7 @@ fn intro_esc_skips_without_changing_theme() {
     force_first_run(&h);
     h.spawn_tui();
 
-    h.wait_for("(1/5)");
+    h.wait_for("(1/6)");
     h.send_keys("Escape");
     h.wait_for("No sessions yet");
 
@@ -111,18 +114,20 @@ fn intro_theme_pick_persists_to_config() {
     force_first_run(&h);
     h.spawn_tui();
 
-    h.wait_for("(1/5)");
-    h.send_keys("Enter"); // -> page 2 (first session)
-    h.wait_for("(2/5)");
-    h.send_keys("Enter"); // -> page 3 (attach mode, pre-selects LiveSend)
-    h.wait_for("(3/5)");
-    h.send_keys("Enter"); // -> page 4 (theme picker)
-    h.wait_for("(4/5)");
+    h.wait_for("(1/6)");
+    h.send_keys("Enter"); // -> page 2 (telemetry)
+    h.wait_for("(2/6)");
+    h.send_keys("Enter"); // -> page 3 (first session)
+    h.wait_for("(3/6)");
+    h.send_keys("Enter"); // -> page 4 (attach mode, pre-selects LiveSend)
+    h.wait_for("(4/6)");
+    h.send_keys("Enter"); // -> page 5 (theme picker)
+    h.wait_for("(5/6)");
     // BUILTIN_THEMES (src/tui/styles/mod.rs) is ordered `default, empire, ...`
     // so a single Down from the default-seeded cursor lands on `empire`.
     h.send_keys("Down");
-    h.send_keys("Enter"); // -> page 5 (done)
-    h.wait_for("(5/5)");
+    h.send_keys("Enter"); // -> page 6 (done)
+    h.wait_for("(6/6)");
     h.send_keys("Enter"); // submit
 
     h.wait_for("No sessions yet");
@@ -153,17 +158,19 @@ fn intro_lets_user_choose_tmux_attach() {
     force_first_run(&h);
     h.spawn_tui();
 
-    h.wait_for("(1/5)");
+    h.wait_for("(1/6)");
+    h.send_keys("Enter"); // -> telemetry
+    h.wait_for("(2/6)");
     h.send_keys("Enter"); // -> first session
-    h.wait_for("(2/5)");
+    h.wait_for("(3/6)");
     h.send_keys("Enter"); // -> attach mode
-    h.wait_for("(3/5)");
+    h.wait_for("(4/6)");
     // Pre-selected LiveSend; flip to Tmux.
     h.send_keys("Down");
     h.send_keys("Enter"); // -> theme
-    h.wait_for("(4/5)");
+    h.wait_for("(5/6)");
     h.send_keys("Enter"); // -> done
-    h.wait_for("(5/5)");
+    h.wait_for("(6/6)");
     h.send_keys("Enter"); // submit
 
     h.wait_for("No sessions yet");

--- a/tests/e2e/new_session.rs
+++ b/tests/e2e/new_session.rs
@@ -238,6 +238,7 @@ update_check_mode = "off"
 
 [app_state]
 has_seen_welcome = true
+has_responded_to_telemetry = true
 last_seen_version = "{version}"
 has_acknowledged_agent_hooks = true
 "#,
@@ -395,6 +396,7 @@ update_check_mode = "off"
 
 [app_state]
 has_seen_welcome = true
+has_responded_to_telemetry = true
 last_seen_version = "{version}"
 has_acknowledged_agent_hooks = true
 

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -115,6 +115,31 @@ fn snapshot_buckets_are_sanitized() {
     assert_eq!(snapshot.session_total, 2);
 }
 
+/// The CLI `process_start` is throttled to once per install per day so a user
+/// scripting `aoe` in a loop can't flood the endpoint: the first claim in a
+/// window succeeds, the next is denied.
+#[test]
+#[serial]
+fn cli_process_start_throttled_to_once_per_window() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let day = std::time::Duration::from_secs(24 * 60 * 60);
+    assert!(
+        telemetry::claim_cli_process_start_slot(day),
+        "first claim in the window should be granted"
+    );
+    assert!(
+        !telemetry::claim_cli_process_start_slot(day),
+        "second claim within the window should be denied"
+    );
+    // A zero-length window always re-grants (the stamp is always older).
+    assert!(telemetry::claim_cli_process_start_slot(
+        std::time::Duration::ZERO
+    ));
+}
+
 /// An unreachable / slow endpoint must never block the CLI: `flush_process_start`
 /// is bounded and returns well within the timeout even when the endpoint
 /// black-holes the connection.

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -1,0 +1,141 @@
+//! Integration tests for the opt-in telemetry user stories (issue #1762).
+//!
+//! These mutate process-global env (`HOME` / `XDG_CONFIG_HOME` to redirect the
+//! app dir, plus `DO_NOT_TRACK` / `AOE_TELEMETRY_ENDPOINT`), so every test is
+//! `#[serial]`. Each test points the app dir at a fresh `TempDir`, so no real
+//! user state is touched.
+
+use agent_of_empires::session::{save_config, Config, Instance};
+use agent_of_empires::telemetry::{self, Surface};
+use serial_test::serial;
+
+/// Redirect the app dir at a temp location and clear the telemetry-related env
+/// vars. Returns the guard; keep it alive for the test's duration.
+fn isolate() -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    unsafe {
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+        std::env::remove_var("DO_NOT_TRACK");
+        std::env::remove_var("AOE_TELEMETRY_ENDPOINT");
+    }
+    tmp
+}
+
+fn set_enabled(enabled: bool) {
+    let mut config = Config::load_or_warn();
+    config.telemetry.enabled = enabled;
+    save_config(&config).expect("save config");
+}
+
+/// Default-off must hold: a fresh install reports no opt-in, no install id,
+/// and builds no events.
+#[test]
+#[serial]
+fn default_off_emits_nothing() {
+    let _tmp = isolate();
+    assert!(!telemetry::is_opted_in());
+    assert_eq!(telemetry::install_id(), None);
+    assert!(telemetry::build_process_start(Surface::Cli).is_none());
+    assert!(telemetry::build_usage_snapshot(Surface::Tui, &[], false, false, 0).is_none());
+}
+
+/// Opting in generates an install id and lets events build; opting back out
+/// deletes the id.
+#[test]
+#[serial]
+fn opt_in_round_trips_and_opt_out_deletes_id() {
+    let _tmp = isolate();
+
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+    assert!(telemetry::is_opted_in());
+    let id = telemetry::install_id().expect("id generated on opt-in");
+    assert!(!id.is_empty());
+
+    let event = telemetry::build_process_start(Surface::Tui).expect("event built when opted in");
+    assert_eq!(event.surface, Surface::Tui);
+    assert_eq!(event.event, "process_start");
+    assert_eq!(event.install_id, id);
+
+    // Opt back out: id deleted, events stop building.
+    set_enabled(false);
+    telemetry::apply_opt_in_change(false);
+    assert!(!telemetry::is_opted_in());
+    assert_eq!(telemetry::install_id(), None);
+    assert!(telemetry::build_process_start(Surface::Tui).is_none());
+}
+
+/// `DO_NOT_TRACK` is absolute: even with the config flag on, nothing is opted
+/// in, no install id is generated, and no events build.
+#[test]
+#[serial]
+fn do_not_track_suppresses_send_and_id() {
+    let _tmp = isolate();
+    set_enabled(true);
+    unsafe { std::env::set_var("DO_NOT_TRACK", "1") };
+
+    assert!(telemetry::do_not_track());
+    assert!(!telemetry::is_opted_in());
+    // apply_opt_in_change must NOT generate an id while suppressed.
+    telemetry::apply_opt_in_change(true);
+    assert_eq!(telemetry::install_id(), None);
+    assert!(telemetry::build_process_start(Surface::Cli).is_none());
+
+    unsafe { std::env::remove_var("DO_NOT_TRACK") };
+}
+
+/// The snapshot payload carries only allowlisted buckets: a custom agent
+/// command and a custom model collapse to `custom` / `other`, never the raw
+/// strings.
+#[test]
+#[serial]
+fn snapshot_buckets_are_sanitized() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let mut custom = Instance::new("secret-session", "/home/me/secret-project");
+    custom.tool = "/usr/local/bin/my-internal-agent".to_string();
+    custom.detect_as = String::new();
+    let claude = Instance::new("c", "/p");
+
+    let snapshot =
+        telemetry::build_usage_snapshot(Surface::Tui, &[custom, claude], false, false, 0)
+            .expect("snapshot built when opted in");
+
+    let serialized = serde_json::to_string(&snapshot).expect("serialize");
+    // The raw custom command / project path must never appear in the payload.
+    assert!(!serialized.contains("my-internal-agent"));
+    assert!(!serialized.contains("secret-project"));
+    assert!(!serialized.contains("secret-session"));
+
+    assert_eq!(snapshot.sessions_by_agent.get("custom"), Some(&1));
+    assert_eq!(snapshot.sessions_by_agent.get("claude"), Some(&1));
+    assert_eq!(snapshot.session_total, 2);
+}
+
+/// An unreachable / slow endpoint must never block the CLI: `flush_process_start`
+/// is bounded and returns well within the timeout even when the endpoint
+/// black-holes the connection.
+#[test]
+#[serial]
+fn unreachable_endpoint_never_blocks() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+    // 127.0.0.1:9 (discard) with nothing listening: connection refused fast,
+    // but the bound is what guarantees we never hang regardless.
+    unsafe { std::env::set_var("AOE_TELEMETRY_ENDPOINT", "http://127.0.0.1:9/ingest") };
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let start = std::time::Instant::now();
+    rt.block_on(telemetry::flush_process_start(Surface::Cli));
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "flush_process_start blocked for {elapsed:?}; must be bounded"
+    );
+
+    unsafe { std::env::remove_var("AOE_TELEMETRY_ENDPOINT") };
+}

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -113,6 +113,15 @@ fn snapshot_buckets_are_sanitized() {
     assert_eq!(snapshot.sessions_by_agent.get("custom"), Some(&1));
     assert_eq!(snapshot.sessions_by_agent.get("claude"), Some(&1));
     assert_eq!(snapshot.session_total, 2);
+
+    // The feature-adoption map is present with its fixed allowlisted keys
+    // (values reflect config; all false under a default config).
+    for key in ["worktree", "sandbox", "cockpit", "auto_update"] {
+        assert!(
+            snapshot.features.contains_key(key),
+            "features map missing allowlisted key `{key}`"
+        );
+    }
 }
 
 /// The CLI `process_start` is throttled to once per install per day so a user

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,9 @@ import {
   deleteSession,
   fetchAbout,
   fetchSettings,
+  fetchTelemetryStatus,
+  setTelemetryConsent,
+  reportTelemetrySeen,
   isDebugBuild,
   updateWorkspaceOrdering,
 } from "./lib/api";
@@ -82,6 +85,7 @@ import {
   resetTokenExpired,
 } from "./lib/fetchInterceptor";
 import { AboutModal } from "./components/AboutModal";
+import { TelemetryConsentModal } from "./components/TelemetryConsentModal";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
 import { DisconnectBanner } from "./components/DisconnectBanner";
 import { ElevationPrompt } from "./components/ElevationPrompt";
@@ -313,6 +317,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [showHelp, setShowHelp] = useState(false);
   const [showPalette, setShowPalette] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
+  const [telemetryConsentNeeded, setTelemetryConsentNeeded] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(
     () => window.innerWidth >= 768,
   );
@@ -496,6 +501,33 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   useEffect(() => {
     refreshServerAbout();
   }, [refreshServerAbout]);
+
+  // Telemetry: once authenticated and on a writable server, report that the
+  // web dashboard was opened (folded into the daemon's next opt-in snapshot)
+  // and, if the user has not yet answered the opt-in prompt, show the consent
+  // modal. The browser never posts to the telemetry backend; it only talks to
+  // the local daemon. Read-only servers can't persist a choice, so skip.
+  useEffect(() => {
+    // AppContent only renders past the login gate, so reaching here means the
+    // session is usable. Read-only servers can't persist a choice, so skip.
+    if (!serverAboutLoaded || serverAbout?.read_only) return;
+    reportTelemetrySeen("web");
+    let active = true;
+    void fetchTelemetryStatus().then((status) => {
+      if (!active || !status) return;
+      if (!status.responded && !status.do_not_track) {
+        setTelemetryConsentNeeded(true);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [serverAboutLoaded, serverAbout?.read_only]);
+
+  const handleTelemetryConsent = useCallback((enabled: boolean) => {
+    setTelemetryConsentNeeded(false);
+    void setTelemetryConsent(enabled);
+  }, []);
 
   const deletingWorkspace = deletingWorkspaceId
     ? workspaces.find((w) => w.id === deletingWorkspaceId)
@@ -1137,6 +1169,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
 
       {showAbout && <AboutModal onClose={() => setShowAbout(false)} />}
+      {telemetryConsentNeeded && (
+        <TelemetryConsentModal onChoose={handleTelemetryConsent} />
+      )}
 
       {deletingSession && (
         <DeleteSessionDialog

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -246,7 +246,7 @@ export function SettingsView({
   );
 
   const renderTabContent = () => {
-    if (!settings && activeTab !== "notifications" && activeTab !== "terminal" && activeTab !== "security" && activeTab !== "devices" && activeTab !== "cockpit") {
+    if (!settings && activeTab !== "notifications" && activeTab !== "terminal" && activeTab !== "security" && activeTab !== "devices" && activeTab !== "cockpit" && activeTab !== "telemetry") {
       return <div className="text-sm text-text-dim">Loading settings...</div>;
     }
 

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -25,6 +25,7 @@ import { ThemeSettings } from "./settings/ThemeSettings";
 import { DiffSettings } from "./settings/DiffSettings";
 import { SoundSettings } from "./settings/SoundSettings";
 import { UpdateSettings } from "./settings/UpdateSettings";
+import { TelemetrySettings } from "./settings/TelemetrySettings";
 import { TmuxSettings } from "./settings/TmuxSettings";
 import { LoggingSettings } from "./settings/LoggingSettings";
 import { SettingsHeader } from "./settings/SettingsHeader";
@@ -38,6 +39,7 @@ type TabId =
   | "sound"
   | "tmux"
   | "updates"
+  | "telemetry"
   | "notifications"
   | "terminal"
   | "security"
@@ -79,6 +81,7 @@ export function buildSidebar(): SidebarItem[] {
     { kind: "tab", id: "devices", label: "Devices" },
     { kind: "divider", label: "System" },
     { kind: "tab", id: "updates", label: "Updates" },
+    { kind: "tab", id: "telemetry", label: "Telemetry" },
     { kind: "tab", id: "logging", label: "Logging" },
   ];
 }
@@ -100,6 +103,7 @@ const ALL_TAB_IDS = new Set<TabId>([
   "sound",
   "tmux",
   "updates",
+  "telemetry",
   "notifications",
   "terminal",
   "security",
@@ -469,6 +473,8 @@ export function SettingsView({
         return <TmuxSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
       case "updates":
         return <UpdateSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
+      case "telemetry":
+        return <TelemetrySettings />;
       case "logging":
         return <LoggingSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
 

--- a/web/src/components/TelemetryConsentModal.tsx
+++ b/web/src/components/TelemetryConsentModal.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from "react";
+
+interface Props {
+  /// Called with the user's choice. The parent persists it via the consent
+  /// endpoint and hides the modal.
+  onChoose: (enabled: boolean) => void;
+}
+
+/// One-time opt-in prompt for the web dashboard, mirroring the TUI walkthrough
+/// pane and standalone popup. Shown on first load when the user has not yet
+/// answered and DO_NOT_TRACK is not set. Declining ("Not now") still records a
+/// response so it does not re-appear every visit.
+export function TelemetryConsentModal({ onChoose }: Props) {
+  const declineRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    // Default focus on decline so a stray Enter never silently opts in.
+    declineRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="telemetry-modal-title"
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in"
+    >
+      <div
+        className="bg-surface-800 border border-surface-700/50 rounded-lg w-[460px] max-w-[90vw] shadow-2xl animate-slide-up"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-5 py-4 border-b border-surface-700">
+          <h2
+            id="telemetry-modal-title"
+            className="text-sm font-semibold text-text-bright"
+          >
+            Help improve aoe?
+          </h2>
+        </div>
+
+        <div className="p-5 space-y-3 text-sm text-text-secondary">
+          <p>
+            Turning it on shows us how aoe is actually used, so we can
+            prioritize the features that matter most. It is off by default and
+            sends anonymous counts only: number of sessions, which agents and
+            model families, your aoe version, and OS.
+          </p>
+          <p className="text-text-dim">
+            It never sends prompts, file paths, names, branch names, or
+            commands. You can change this any time under Settings &rarr;
+            Telemetry.
+          </p>
+        </div>
+
+        <div className="px-5 py-4 border-t border-surface-700 flex justify-end gap-2">
+          <button
+            ref={declineRef}
+            onClick={() => onChoose(false)}
+            className="px-4 py-2 rounded-md border border-surface-700/50 text-sm text-text-secondary hover:bg-surface-850 hover:text-text-primary transition-colors cursor-pointer"
+          >
+            Not now
+          </button>
+          <button
+            onClick={() => onChoose(true)}
+            className="px-4 py-2 rounded-md bg-brand-600 text-sm text-white hover:bg-brand-500 transition-colors cursor-pointer"
+          >
+            Enable telemetry
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/TelemetryConsentModal.tsx
+++ b/web/src/components/TelemetryConsentModal.tsx
@@ -56,13 +56,13 @@ export function TelemetryConsentModal({ onChoose }: Props) {
           <button
             ref={declineRef}
             onClick={() => onChoose(false)}
-            className="px-4 py-2 rounded-md border border-surface-700/50 text-sm text-text-secondary hover:bg-surface-850 hover:text-text-primary transition-colors cursor-pointer"
+            className="h-8 px-3 rounded-md border border-surface-700/50 text-sm text-text-secondary hover:bg-surface-850 hover:text-text-primary transition-colors duration-150 cursor-pointer"
           >
             Not now
           </button>
           <button
             onClick={() => onChoose(true)}
-            className="px-4 py-2 rounded-md bg-brand-600 text-sm text-white hover:bg-brand-500 transition-colors cursor-pointer"
+            className="h-8 px-3 rounded-md bg-brand-600 text-sm text-white hover:bg-brand-500 transition-colors duration-150 cursor-pointer"
           >
             Enable telemetry
           </button>

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -38,6 +38,7 @@ describe("buildSidebar", () => {
       { kind: "tab", id: "devices", label: "Devices" },
       { kind: "divider", label: "System" },
       { kind: "tab", id: "updates", label: "Updates" },
+      { kind: "tab", id: "telemetry", label: "Telemetry" },
       { kind: "tab", id: "logging", label: "Logging" },
     ]);
   });

--- a/web/src/components/__tests__/TelemetryConsentModal.test.tsx
+++ b/web/src/components/__tests__/TelemetryConsentModal.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+//
+// Contract test for the first-load telemetry consent modal: each button
+// reports the user's choice through onChoose so the parent can persist it.
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+
+import { TelemetryConsentModal } from "../TelemetryConsentModal";
+
+describe("TelemetryConsentModal", () => {
+  it("Enable telemetry reports opt-in", () => {
+    const onChoose = vi.fn();
+    const { getByText } = render(<TelemetryConsentModal onChoose={onChoose} />);
+    fireEvent.click(getByText("Enable telemetry"));
+    expect(onChoose).toHaveBeenCalledWith(true);
+  });
+
+  it("Not now reports decline", () => {
+    const onChoose = vi.fn();
+    const { getByText } = render(<TelemetryConsentModal onChoose={onChoose} />);
+    fireEvent.click(getByText("Not now"));
+    expect(onChoose).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/src/components/settings/LoggingSettings.tsx
+++ b/web/src/components/settings/LoggingSettings.tsx
@@ -38,6 +38,8 @@ const KNOWN_TARGETS: { value: string; group: string }[] = [
   { value: "containers.runtime", group: "Containers" },
   { value: "git.command", group: "Git" },
   { value: "web.client", group: "Web" },
+  { value: "telemetry", group: "Telemetry" },
+  { value: "http.api.telemetry", group: "Telemetry" },
   { value: "log.runtime", group: "Meta" },
 ];
 

--- a/web/src/components/settings/TelemetrySettings.tsx
+++ b/web/src/components/settings/TelemetrySettings.tsx
@@ -17,9 +17,15 @@ export function TelemetrySettings() {
 
   useEffect(() => {
     let active = true;
-    void fetchTelemetryStatus().then((s) => {
-      if (active) setStatus(s);
-    });
+    void (async () => {
+      try {
+        const s = await fetchTelemetryStatus();
+        if (active) setStatus(s);
+      } catch {
+        // fetchTelemetryStatus already swallows network errors and returns
+        // null, but guard here too so a throw can never leave the panel blank.
+      }
+    })();
     return () => {
       active = false;
     };
@@ -27,9 +33,13 @@ export function TelemetrySettings() {
 
   const onToggle = async (enabled: boolean) => {
     setSaving(true);
-    const next = await setTelemetryConsent(enabled);
-    if (next) setStatus(next);
-    setSaving(false);
+    try {
+      const next = await setTelemetryConsent(enabled);
+      if (next) setStatus(next);
+    } finally {
+      // Always clear the saving flag so the toggle can't get stuck disabled.
+      setSaving(false);
+    }
   };
 
   const dnt = status?.do_not_track ?? false;

--- a/web/src/components/settings/TelemetrySettings.tsx
+++ b/web/src/components/settings/TelemetrySettings.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+
+import {
+  fetchTelemetryStatus,
+  setTelemetryConsent,
+  type TelemetryStatus,
+} from "../../lib/api";
+import { ToggleField } from "./FormFields";
+
+/// Telemetry opt-in toggle. Unlike the other settings panels this does not go
+/// through the generic settings PATCH: the daemon owns the anonymous install
+/// id (the browser never posts to the telemetry backend), so the toggle calls
+/// the dedicated consent endpoint, which also generates / deletes the id.
+export function TelemetrySettings() {
+  const [status, setStatus] = useState<TelemetryStatus | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void fetchTelemetryStatus().then((s) => {
+      if (active) setStatus(s);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const onToggle = async (enabled: boolean) => {
+    setSaving(true);
+    const next = await setTelemetryConsent(enabled);
+    if (next) setStatus(next);
+    setSaving(false);
+  };
+
+  const dnt = status?.do_not_track ?? false;
+  const enabled = status?.enabled ?? false;
+
+  return (
+    <div className="space-y-4">
+      <ToggleField
+        label="Enable usage telemetry"
+        description="Anonymous, opt-in usage telemetry: counts of sessions, agents/models, your aoe version, and OS. Off by default. Never sends prompts, paths, names, branches, or commands. Honors DO_NOT_TRACK."
+        checked={enabled && !dnt}
+        onChange={(v) => {
+          if (!dnt && !saving) void onToggle(v);
+        }}
+      />
+      {dnt && (
+        <p className="text-xs text-text-dim">
+          DO_NOT_TRACK is set in the server environment, so telemetry stays off
+          and no install id is generated regardless of this toggle.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/__tests__/TelemetrySettings.test.tsx
+++ b/web/src/components/settings/__tests__/TelemetrySettings.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+//
+// Contract test for the TelemetrySettings panel. Unlike the other settings
+// panels it talks to the dedicated telemetry endpoints directly (the daemon
+// owns the install id; the browser never posts to the telemetry backend), so
+// this mocks the api module and asserts the toggle calls setTelemetryConsent
+// with the right value, and that DO_NOT_TRACK forces the toggle off.
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+
+import type { TelemetryStatus } from "../../../lib/api";
+
+const fetchTelemetryStatus = vi.fn<[], Promise<TelemetryStatus | null>>();
+const setTelemetryConsent =
+  vi.fn<[boolean], Promise<TelemetryStatus | null>>();
+
+vi.mock("../../../lib/api", () => ({
+  fetchTelemetryStatus: () => fetchTelemetryStatus(),
+  setTelemetryConsent: (enabled: boolean) => setTelemetryConsent(enabled),
+}));
+
+// Imported after the mock is registered.
+import { TelemetrySettings } from "../TelemetrySettings";
+
+function status(overrides: Partial<TelemetryStatus> = {}): TelemetryStatus {
+  return { enabled: false, responded: true, do_not_track: false, ...overrides };
+}
+
+beforeEach(() => {
+  fetchTelemetryStatus.mockReset();
+  setTelemetryConsent.mockReset();
+  setTelemetryConsent.mockResolvedValue(status({ enabled: true }));
+});
+
+describe("TelemetrySettings contract", () => {
+  it("toggling on calls setTelemetryConsent(true)", async () => {
+    fetchTelemetryStatus.mockResolvedValue(status({ enabled: false }));
+    const { container } = render(<TelemetrySettings />);
+    await waitFor(() => fetchTelemetryStatus.mock.calls.length > 0);
+
+    const toggle = container.querySelector(
+      "button[role=switch]",
+    ) as HTMLButtonElement;
+    fireEvent.click(toggle);
+    expect(setTelemetryConsent).toHaveBeenCalledWith(true);
+  });
+
+  it("toggling off calls setTelemetryConsent(false)", async () => {
+    fetchTelemetryStatus.mockResolvedValue(status({ enabled: true }));
+    const { container } = render(<TelemetrySettings />);
+    await waitFor(() => {
+      const t = container.querySelector(
+        "button[role=switch]",
+      ) as HTMLButtonElement | null;
+      return t?.getAttribute("aria-checked") === "true";
+    });
+
+    const toggle = container.querySelector(
+      "button[role=switch]",
+    ) as HTMLButtonElement;
+    fireEvent.click(toggle);
+    expect(setTelemetryConsent).toHaveBeenCalledWith(false);
+  });
+
+  it("DO_NOT_TRACK forces the toggle off and shows a note; clicking is a no-op", async () => {
+    fetchTelemetryStatus.mockResolvedValue(
+      status({ enabled: true, do_not_track: true }),
+    );
+    const { container, findByText } = render(<TelemetrySettings />);
+    await findByText(/DO_NOT_TRACK is set/i);
+
+    const toggle = container.querySelector(
+      "button[role=switch]",
+    ) as HTMLButtonElement;
+    // Forced off despite enabled=true in config.
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(toggle);
+    expect(setTelemetryConsent).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/settings/__tests__/TelemetrySettings.test.tsx
+++ b/web/src/components/settings/__tests__/TelemetrySettings.test.tsx
@@ -37,7 +37,9 @@ describe("TelemetrySettings contract", () => {
   it("toggling on calls setTelemetryConsent(true)", async () => {
     fetchTelemetryStatus.mockResolvedValue(status({ enabled: false }));
     const { container } = render(<TelemetrySettings />);
-    await waitFor(() => fetchTelemetryStatus.mock.calls.length > 0);
+    await waitFor(() => {
+      expect(fetchTelemetryStatus).toHaveBeenCalled();
+    });
 
     const toggle = container.querySelector(
       "button[role=switch]",
@@ -53,7 +55,7 @@ describe("TelemetrySettings contract", () => {
       const t = container.querySelector(
         "button[role=switch]",
       ) as HTMLButtonElement | null;
-      return t?.getAttribute("aria-checked") === "true";
+      expect(t?.getAttribute("aria-checked")).toBe("true");
     });
 
     const toggle = container.querySelector(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -348,6 +348,45 @@ export function fetchAbout(): Promise<ServerAbout | null> {
   return fetchJson<ServerAbout>("/api/about");
 }
 
+export interface TelemetryStatus {
+  enabled: boolean;
+  responded: boolean;
+  do_not_track: boolean;
+}
+
+export function fetchTelemetryStatus(): Promise<TelemetryStatus | null> {
+  return fetchJson<TelemetryStatus>("/api/telemetry/status");
+}
+
+/// Set the opt-in state. The daemon owns the anonymous install id; the
+/// browser never posts to the telemetry backend itself. Returns the updated
+/// status, or null on failure.
+export async function setTelemetryConsent(
+  enabled: boolean,
+): Promise<TelemetryStatus | null> {
+  try {
+    const res = await fetch("/api/telemetry/consent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled }),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+/// Tell the daemon the web dashboard or cockpit UI was opened, so its next
+/// opt-in snapshot can carry web_seen / cockpit_seen. Best-effort.
+export function reportTelemetrySeen(surface: "web" | "cockpit"): void {
+  void fetch("/api/telemetry/seen", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ surface }),
+  }).catch(() => {});
+}
+
 /** Runtime helper around `ServerAbout.build_flavor`. See #1055. */
 export function isDebugBuild(about: ServerAbout | null | undefined): boolean {
   if (!about) return false;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -150,6 +150,19 @@
       ]
     },
     {
+      "id": "settings.telemetry-consent",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/settings/__tests__/TelemetrySettings.test.tsx",
+        "src/components/__tests__/TelemetryConsentModal.test.tsx"
+      ],
+      "components": [
+        "web/src/components/settings/TelemetrySettings.tsx",
+        "web/src/components/TelemetryConsentModal.tsx"
+      ]
+    },
+    {
       "id": "settings.theme-persistence-passphrase",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -515,6 +515,15 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     // under contention and triggering an optimistic-update revert).
     // Override via process env if a future investigation needs it.
     AOE_LOG_LEVEL: process.env.AOE_LOG_LEVEL ?? "info",
+    // Suppress the first-load telemetry consent modal. Every live spec boots
+    // a fresh HOME where `has_responded_to_telemetry` is false, so the modal
+    // (`telemetry-modal-title`, a z-50 full-screen backdrop) would otherwise
+    // intercept pointer events and time out every `click`. `DO_NOT_TRACK`
+    // makes `/api/telemetry/status` report `do_not_track: true`, which App.tsx
+    // treats as "never auto-show the modal". The consent flow itself is
+    // covered by the Vitest + RTL contract tests, not the live suite. A future
+    // live spec that exercises the modal can unset this in its own env.
+    DO_NOT_TRACK: process.env.DO_NOT_TRACK ?? "1",
   };
 
   if (authMode === "token") {

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -314,6 +314,13 @@ const PAGES = [
     description:
       "REST endpoints for driving Agent of Empires sessions from external orchestrators.",
   },
+  {
+    source: "docs/telemetry.md",
+    dest: "docs/telemetry.md",
+    title: "Telemetry",
+    description:
+      "How Agent of Empires' anonymous, opt-in usage telemetry works: what is and isn't collected, the DO_NOT_TRACK override, and how to enable or disable it.",
+  },
 ];
 
 // Every known docs path → website URL, used for link rewriting.
@@ -341,6 +348,7 @@ const URL_MAP = {
   "docs/cockpit/persistence.md": "/docs/cockpit/persistence/",
   "docs/cockpit/troubleshooting.md": "/docs/cockpit/troubleshooting/",
   "docs/api.md": "/docs/api/",
+  "docs/telemetry.md": "/docs/telemetry/",
   // Guides
   "docs/guides/shell-completions.md": "/guides/shell-completions/",
   "docs/guides/diff-view.md": "/guides/diff-view/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -67,6 +67,7 @@ export const docsNav: NavSection[] = [
     items: [
       { title: "CLI Reference", href: "/docs/cli/reference/" },
       { title: "HTTP API Reference", href: "/docs/api/" },
+      { title: "Telemetry", href: "/docs/telemetry/" },
       { title: "GitHub Integration", href: "/docs/github-integration/" },
       { title: "Configuration", href: "/docs/guides/configuration/" },
     ],


### PR DESCRIPTION
> _Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Implements the opt-in usage telemetry client from #1762, so we can see how aoe is actually used in the wild and prioritize the features that matter most.

The posture is deliberately conservative: off by default, no PII, no content, honors `DO_NOT_TRACK`. It is client side only. Opted-in sends go to a compiled-in default endpoint (`https://telemetry.agent-of-empires.com/v1/ingest`), which `AOE_TELEMETRY_ENDPOINT` overrides (handy for pointing at a local sink to inspect what is sent). A compiled-in `X-Telemetry-Key` is sent so the gateway can shed unkeyed drive-by traffic; it is visible in source, so it is not real auth. The collection gateway lives in a separate private repo and re-sanitizes every field as a defense-in-depth backstop. Until that gateway is live, an opted-in client's sends fail closed (bounded timeout, every error swallowed), so nothing is lost and nothing blocks; the consent surfaces and install-id lifecycle are fully exercisable locally for review.

**What it sends** (opt-in only, aggregate counts via a closed, versioned schema in `src/telemetry/events.rs`):
- `process_start` on boot: surface (cli / tui / serve), aoe version, os, arch.
- `usage_snapshot` from the TUI and `aoe serve` (on start, then hourly): session counts by status, sandboxed / cockpit / yolo counts, counts bucketed by agent and by model family, and `web_seen` / `cockpit_seen`.

A central sanitizer (`src/telemetry/sanitize.rs`) is the single privacy boundary: agent and model strings are coerced to a fixed allowlist (`custom` / `other`); raw commands, paths, titles, branch names, group paths, and prompts are never emitted. The anonymous install id is a random UUID stored in `telemetry.json` (kept out of `config.toml` so it cannot leak via a pasted config), deleted on opt-out, rotatable with `aoe telemetry reset-id`.

**Consent surfaces, across all three frontends:**
- TUI walkthrough: a telemetry pane as the second intro step for new users.
- TUI: a one-time standalone popup for users who finished the walkthrough before telemetry existed. It is gated so it never renders over the changelog or the version update modal, and it has no default focus so a reflexive Enter cannot dismiss it without a deliberate choice. Buttons are keyboard and mouse driven (hover highlights, click commits).
- CLI: `aoe telemetry status | enable | disable | reset-id`.
- Web: a Settings telemetry toggle plus a first-load consent modal. The browser never posts to the telemetry backend; it manages opt-in and the seen flags through the daemon, which owns the install id.

`DO_NOT_TRACK` is an absolute override: it suppresses both sending and id generation regardless of config, and every surface shows the suppressed state rather than ignoring it silently. Sends are fire and forget with a hard 2s timeout and swallow all errors, so telemetry never blocks, stalls on exit, or crashes the tool.

The standalone TUI popup:

```
╭ Usage telemetry ─────────────────────────────────────────────────────────╮
│ Help improve aoe with anonymous usage telemetry?                         │
│                                                                          │
│ It shows us how aoe is actually used, so we can prioritize the           │
│ features that matter most. Off by default.                               │
│                                                                          │
│ When on, aoe sends anonymous counts only: sessions, agents and           │
│ models, your aoe version, and OS. Never prompts, paths, names,           │
│ branch names, or commands.                                               │
│                                                                          │
│                           [Enable]    [Not now]                          │
│             ←/→ or Tab to choose, then Enter to confirm                  │
│        Change it any time under Settings, or with `aoe telemetry`.       │
╰──────────────────────────────────────────────────────────────────────────╯
```

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (ASCII render of the TUI popup above; web modal mirrors the same copy)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a spec and updated `web/tests/coverage-matrix.json` (Vitest + RTL contract tests for `TelemetrySettings` and `TelemetryConsentModal`, the right layer for request payload and modal-choice permutations per the matrix mandate; matrix entry `settings.telemetry-consent` added)

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the consent dialogs, sanitizer, opt-in gate, install-id lifecycle, and "unreachable endpoint never blocks" guarantee are covered deterministically by in-module unit tests plus a Rust integration suite (`tests/telemetry.rs`); a full-binary tmux e2e would add flakiness without covering anything those do not.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implemented via back-and-forth with @njbrake. The design decisions (opt-in, aggregate-only, DO_NOT_TRACK, install-id placement, consent UX) are his; Claude wrote the code and prose.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a privacy-first, opt-in anonymous telemetry system spanning CLI, TUI, server, and web, plus documentation, tests, and a local test sink script.

What changed (high-level)
- New telemetry subsystem: event schema, builders, send/flush APIs, sanitization, persisted anonymous install id (telemetry.json), and state/throttling.
- Two events: process_start (boot) and usage_snapshot (periodic aggregate).
- Opt-in controls on all surfaces:
  - CLI: aoe telemetry status | enable | disable | reset-id
  - TUI: onboarding telemetry page + one-time gated popup
  - Web: first-load consent modal + Telemetry settings tab (browser notifies daemon; daemon controls sending)
  - Server: GET /api/telemetry/status, POST /api/telemetry/consent, POST /api/telemetry/seen
- Strong privacy posture:
  - Telemetry is opt-in by default; DO_NOT_TRACK suppresses install-id generation and sending.
  - Central sanitizer buckets agents/models; raw commands, paths, prompts, titles, branches, group paths, and other free text are never emitted.
  - Anonymous install id kept out of config.toml, deleted on opt-out, and rotatable via reset-id.
- Delivery & ops:
  - Endpoint read from AOE_TELEMETRY_ENDPOINT with a DEFAULT_ENDPOINT fallback; sends are fire-and-forget with bounded timeouts and errors swallowed.
  - Optional compiled-in X-Telemetry-Key header support to let a gateway drop unauthenticated traffic.
- Lifecycle & throttling:
  - CLI process_start throttled to at most once per install per day.
  - usage_snapshot emitted by TUI and server on start and periodically (12-hour), with best-effort final flush on shutdown.
  - Web/cockpit surface “seen” flags reported to daemon and included once per snapshot.
- Tests, docs, tools:
  - Rust unit & integration tests, web Vitest/RTL tests, docs/telemetry.md, CLI docs updates, and scripts/telemetry_sink.py for local testing.

Benefits
- Preserves user privacy through opt-in default, DO_NOT_TRACK respect, aggressive sanitization, and install-id management.
- Consistent consent UX across CLI, TUI, web, and server.
- Low operational risk: bounded timeouts, fire-and-forget sends, throttling, coarse snapshots, and gateway-friendly schema reduce impact and noise.
- Gateway-aligned design: allowlisted fields, short identifiers, and optional key header make downstream validation and rate-limiting easier.

Concise technical summary
- Wire schema/events: src/telemetry/events.rs (SCHEMA_VERSION, ProcessStart, UsageSnapshot).
- Sanitization: src/telemetry/sanitize.rs (agent_bucket, model_bucket).
- Persisted state & throttling: src/telemetry/state.rs (telemetry.json, install_id, last_cli_process_start).
- Core telemetry logic: src/telemetry/mod.rs (opt-in checks, endpoint(), post with timeouts, X-Telemetry-Key, spawn/flush helpers, flush_cli_process_start).
- Feature registry: src/telemetry/features.rs (allowlisted features map).
- Integrations: CLI subcommand, TUI onboarding/dialogs and snapshot hooks, server API/routes and AppState seen flags, web consent modal and settings UI, web client API helpers.
- Tests & docs: tests/telemetry.rs, web component tests, docs/telemetry.md, scripts/telemetry_sink.py.

Areas for review / next steps
- Keep DEFAULT_ENDPOINT disabled by default until the gateway is live and rollout is planned.
- Finalize X-Telemetry-Key ops (distribution, rotation, server expectations).
- Confirm and tune short connect timeout (suggest ~500ms) in addition to total send timeout to avoid stalled sends.
- Consider exposing snapshot interval and throttling knobs for operators/testing while keeping privacy-safe defaults.
- Continue gateway-side re-sanitization and contract pinning; restrict future fields to scalars/booleans/short identifier-like strings and allowlisted maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
