### PR TITLE
fix(cockpit): recover end-of-turn wedge on background work and explain cockpit cancel

### DIFF
--- a/docs/cockpit/troubleshooting.md
+++ b/docs/cockpit/troubleshooting.md
@@ -390,14 +390,30 @@ each and lifts the effective grace to `OFF_PROTOCOL_WORK_GRACE_FLOOR`
   ID:` (either signal alone is enough; defense in depth so a single
   SDK string drift can't reintroduce the false-positive class).
 
-The off-protocol branch takes precedence over the cost-seen fast path
-(a cost-populated UsageUpdate mid-wait could be intermediate billing
-telemetry rather than turn termination). The grace stays finite by
-design so a real adapter wedge during off-protocol work still
-recovers, just slower. The async-agent path is a bandaid until
-upstream `agentclientprotocol/claude-agent-acp#336` forwards the
-SDK's `task_notification` / `task_started` system messages as proper
-ACP SessionUpdates.
+The off-protocol branch takes precedence over the cost-seen fast path,
+with one carve-out by kind (#1858):
+
+- `Bash run_in_background` (`BackgroundCommand`) is fire-and-forget: the
+  agent launches it and moves on, so it legitimately outlives the turn.
+  Once a cost-populated `UsageUpdate` arrives (the end-of-turn marker;
+  mid-turn usages carry `cost: null`), the background-command
+  suppression is dropped so a turn that streamed its final usage but
+  never sent the `PromptResponse` recovers on the fast grace instead of
+  hanging out the 30-minute floor. The clear is self-correcting: if the
+  turn continues, the next progress / tool event re-arms suppression on
+  the next backgrounded launch.
+- `Agent isAsync` (`AsyncAgent`) blocks the turn: the agent idles
+  waiting for the sub-agent and resumes in-band, and the genuine waits
+  emit `cost: null` usages (so the cost-populated marker does not arrive
+  mid-wait). Its floor is left intact, so the #1360 false-fire fix is
+  preserved.
+
+The grace stays finite by design so a real adapter wedge during
+off-protocol work still recovers, just slower. The async-agent path is
+a bandaid until upstream
+`agentclientprotocol/claude-agent-acp#336` forwards the SDK's
+`task_notification` / `task_started` system messages as proper ACP
+SessionUpdates.
 
 **Scheduled wakeup suppression (#1401):** when the agent calls the
 Claude SDK `ScheduleWakeup` tool with `delaySeconds: N`, the daemon

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -794,8 +794,25 @@ async fn cancel(session: &str) -> Result<()> {
     let endpoint = require_daemon().await?;
     let client = HttpClient::new(endpoint)?;
     client.cancel(session).await.map_err(map_http)?;
-    println!("cancel sent");
+    println!(
+        "{}",
+        cancel_confirmation_message(crate::cockpit::acp_client::CANCEL_ESCALATION_GRACE.as_secs())
+    );
     Ok(())
+}
+
+/// Honest confirmation for `aoe cockpit cancel`. The daemon only arms
+/// the auto-restart escalation when a prompt is in flight; for an idle
+/// session the cancel is a no-op notification, and the CLI cannot tell
+/// which from the 202 it gets back. Spell both out so the operator does
+/// not read a bare "cancel sent" as "nothing happened" and reach for
+/// `aoe cockpit restart` before the escalation has a chance to fire. See
+/// #1858.
+fn cancel_confirmation_message(escalation_grace_secs: u64) -> String {
+    format!(
+        "cancel sent. If a prompt is in flight and the agent does not stop within ~{escalation_grace_secs}s, \
+the worker is restarted automatically and the transcript is preserved. If the session is idle, this is a no-op."
+    )
 }
 
 async fn switch_agent(session: &str, target: &str, model: Option<&str>) -> Result<()> {
@@ -918,5 +935,27 @@ mod tests {
         );
         // Legacy record (field absent on disk): placeholder, always stale.
         assert_eq!(render_build_cell("", true), "<legacy> (stale)");
+    }
+
+    /// #1858: `aoe cockpit cancel` must explain the conditional
+    /// auto-restart escalation and the idle no-op, not print a bare
+    /// "cancel sent" that reads as "nothing happened".
+    #[test]
+    fn cancel_confirmation_message_states_escalation_and_no_op() {
+        let msg = cancel_confirmation_message(
+            crate::cockpit::acp_client::CANCEL_ESCALATION_GRACE.as_secs(),
+        );
+        assert!(
+            msg.contains("10s"),
+            "must surface the escalation grace: {msg}"
+        );
+        assert!(
+            msg.contains("restarted automatically"),
+            "must mention the auto-restart escalation: {msg}"
+        );
+        assert!(
+            msg.contains("no-op"),
+            "must spell out the idle no-op case: {msg}"
+        );
     }
 }

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -378,7 +378,7 @@ const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from
 /// against the adapter ignoring the signal, not against socket /
 /// stdout / process-level wedges that prevent the PromptResponse from
 /// reaching the daemon at all. See #1196.
-const CANCEL_ESCALATION_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+pub(crate) const CANCEL_ESCALATION_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Vendor-agnostic silent-orphan grace fallback used when no config
 /// value is available. Mirrors `CockpitConfig::silent_orphan_grace_secs`

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -683,6 +683,25 @@ impl SilentOrphanWatchdog {
             }
             LifecycleSignal::TerminalUsage => {
                 self.cost_seen = true;
+                // A cost-resolved UsageUpdate is the end-of-turn marker
+                // (mid-turn usages carry `cost: null`, see #1360). A
+                // backgrounded command is fire-and-forget: the agent
+                // launches it and moves on, so it legitimately outlives
+                // the turn and its suppression is moot once the turn
+                // ends. Drop it here, otherwise `effective_grace` keeps
+                // the 30-minute floor and a turn that streamed its final
+                // usage but never returned the PromptResponse hangs for
+                // half an hour instead of recovering on the fast grace
+                // (#1858). Self-correcting: if the turn somehow
+                // continues, the next Progress / ToolStarted /
+                // ToolCompleted clears `cost_seen` and the next
+                // backgrounded tool re-arms suppression. An AsyncAgent
+                // await blocks the turn (the agent idles waiting and
+                // resumes in-band), so its floor is left intact to
+                // preserve the #1360 fix.
+                if self.off_protocol_work_seen == Some(OffProtocolWorkKind::BackgroundCommand) {
+                    self.off_protocol_work_seen = None;
+                }
             }
             LifecycleSignal::WakeupPending { at } => {
                 self.saw_first_progress = true;
@@ -5537,7 +5556,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn watchdog_background_command_lifts_grace_above_fast_grace() {
+    async fn watchdog_terminal_usage_clears_background_command_suppression() {
+        // Regression for #1858. A backgrounded command lifts the grace to
+        // the 30-minute off-protocol floor mid-turn (so a legit `cmd &`
+        // is not killed), but a backgrounded command is fire-and-forget
+        // and outlives the turn. Once the cost-resolved UsageUpdate
+        // (TerminalUsage, the end-of-turn marker) arrives, the floor must
+        // drop so a turn that streamed its final usage but never returned
+        // the PromptResponse recovers on the fast grace instead of
+        // hanging for 30 minutes.
         let cfg = watchdog_test_cfg();
         let t0 = tokio::time::Instant::now();
         let wall = chrono::Utc::now();
@@ -5564,19 +5591,76 @@ mod tests {
             wall,
             cfg,
         );
+        // Before the terminal usage the floor holds: 60s in must not fire.
+        assert!(!w.should_fire(t0 + std::time::Duration::from_secs(60), cfg));
         w.apply_signal(
             LifecycleSignal::TerminalUsage,
             t0 + std::time::Duration::from_secs(3),
             wall,
             cfg,
         );
-        // 60s after last progress: well past fast grace (20s) and past
-        // base grace (120s)? No. Past fast but inside base. Off-protocol
-        // floor lifts grace to 30 min so we must NOT fire here.
+        // TerminalUsage cleared the background-command suppression.
+        assert!(w.off_protocol_work_seen().is_none());
+        // Now the fast grace (20s) applies, measured from the last
+        // progress at t0+2s. Inside the window: no fire.
+        assert!(!w.should_fire(t0 + std::time::Duration::from_secs(10), cfg));
+        // Past the fast grace (elapsed 23s > 20s): the wedge recovers
+        // instead of waiting out the 30-minute floor.
+        assert!(w.should_fire(t0 + std::time::Duration::from_secs(25), cfg));
+    }
+
+    #[tokio::test]
+    async fn watchdog_terminal_usage_then_background_command_rearms_floor() {
+        // Self-correction: TerminalUsage clearing background suppression
+        // must not be permanent. If activity resumes after the terminal
+        // usage (cost_seen flips false on Progress) and a new backgrounded
+        // command completes, the off-protocol floor re-arms.
+        let cfg = watchdog_test_cfg();
+        let t0 = tokio::time::Instant::now();
+        let wall = chrono::Utc::now();
+        let mut w = SilentOrphanWatchdog::new();
+        w.apply_signal(LifecycleSignal::Progress, t0, wall, cfg);
+        w.apply_signal(
+            LifecycleSignal::ToolCompleted {
+                id: "tc-bg-a".into(),
+                succeeded: true,
+                off_protocol_work: Some(OffProtocolWorkKind::BackgroundCommand),
+            },
+            t0 + std::time::Duration::from_secs(1),
+            wall,
+            cfg,
+        );
+        w.apply_signal(
+            LifecycleSignal::TerminalUsage,
+            t0 + std::time::Duration::from_secs(2),
+            wall,
+            cfg,
+        );
+        assert!(w.off_protocol_work_seen().is_none());
+        // Turn continues: more progress, then another backgrounded tool.
+        w.apply_signal(
+            LifecycleSignal::Progress,
+            t0 + std::time::Duration::from_secs(3),
+            wall,
+            cfg,
+        );
+        w.apply_signal(
+            LifecycleSignal::ToolCompleted {
+                id: "tc-bg-b".into(),
+                succeeded: true,
+                off_protocol_work: Some(OffProtocolWorkKind::BackgroundCommand),
+            },
+            t0 + std::time::Duration::from_secs(4),
+            wall,
+            cfg,
+        );
+        assert_eq!(
+            w.off_protocol_work_seen(),
+            Some(OffProtocolWorkKind::BackgroundCommand),
+            "a fresh backgrounded command after terminal usage must re-arm the floor",
+        );
+        // Floor is back: must not fire well past the fast grace.
         assert!(!w.should_fire(t0 + std::time::Duration::from_secs(60), cfg));
-        assert!(!w.should_fire(t0 + std::time::Duration::from_secs(60 * 25), cfg));
-        // Past the 30-min floor: watchdog finally recovers.
-        assert!(w.should_fire(t0 + std::time::Duration::from_secs(60 * 35), cfg));
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two cockpit fixes for the end-of-turn wedge in #1858.

**Watchdog precedence (the actual hang).** The silent-orphan watchdog lifts the grace to a 30-minute off-protocol floor when a backgrounded tool runs mid-turn, so a legitimate `cmd &` is not killed. The bug: that floor outlived the end of the turn. When a long turn (for example `/aoe-implement` running background `cargo build` / `cargo test`) finished, the cost-resolved `UsageUpdate` arrived but the adapter never returned the `PromptResponse`; `effective_grace` kept the 30-minute floor instead of the 20s fast grace, so the session looked permanently wedged and needed a manual `aoe cockpit restart`. A backgrounded command is fire-and-forget and legitimately outlives the turn, so once the end-of-turn marker (cost-populated `UsageUpdate`; mid-turn usages carry `cost: null`) arrives its suppression is moot. We now clear `off_protocol_work_seen` for the `BackgroundCommand` kind in the `TerminalUsage` arm, so the wedge recovers on the fast grace. The clear is self-correcting: continued activity re-arms suppression on the next backgrounded launch. The `AsyncAgent` floor is deliberately left intact (that await blocks the turn in-band and its genuine waits emit `cost: null`, so the cost marker does not arrive mid-wait), which preserves the #1360 false-fire fix.

**CLI cancel honesty.** `aoe cockpit cancel` printed a bare "cancel sent", which reads as "nothing happened". An operator who cancels a wedged turn, sees no immediate change, and reaches for `aoe cockpit restart` can beat the daemon's 10s cancel-escalation that would have auto-restarted the worker anyway. The command now prints the conditional behavior: if a prompt is in flight and the agent ignores cancel within the escalation grace, the worker is restarted automatically with the transcript preserved; if the session is idle, the cancel is a no-op. The grace seconds are read from `CANCEL_ESCALATION_GRACE` so the message cannot drift from the daemon.

Proposal C from the issue (logs observability: `aoe cockpit logs` surfacing the daemon-side watchdog/cancel breadcrumbs that currently only land in `debug.log`) is split into #1864 with the tee-at-subscriber approach as the recommended design, since it touches the tracing subscriber and deserves its own review.

The watchdog design (clear-the-flag vs reorder-precedence vs new floor, and the `wakeup_suppress_until` interaction) was worked through with a 3-model `/debate`; the kind-specific clear was chosen over a blanket clear after the #1360 evidence showed async waits emit `cost: null`, so the cost marker is a reliable end-of-turn signal and the `AsyncAgent` floor should stay.

Closes #1858

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe cockpit cancel <session>` and confirm the output explains the conditional auto-restart escalation (within ~10s, transcript preserved) and the idle no-op, instead of a bare "cancel sent".
- [ ] On a long cockpit turn that backgrounds a command (for example an `/aoe-implement` style run), if the turn ever wedges at end-of-turn (final message streamed, spinner stuck), confirm the session self-recovers within roughly 30s (20s fast grace plus the 10s cancel-escalation) instead of hanging for 30 minutes.
- [ ] Run `cargo test --features serve --lib watchdog` and confirm the `SilentOrphanWatchdog` suite passes, including `watchdog_terminal_usage_clears_background_command_suppression` and the preserved `watchdog_async_agent_lifts_grace_above_fast_grace`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the watchdog fix is covered by reproduce-then-fix `SilentOrphanWatchdog` unit tests (red on the pre-fix tree), and the `aoe cockpit cancel` message is covered by a deterministic unit test (`cancel_confirmation_message_states_escalation_and_no_op`). A live e2e for cancel would need to deterministically wedge a turn, which is flaky.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the 3-model design debate, and implementation were drafted by Claude under my direction. I made the design calls (kind-specific clear over blanket clear, splitting logs into #1864), reviewed each commit, and confirmed the red-then-green test direction.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes two issues in the cockpit system related to session management and user communication:

## What Changed

**1. Session Recovery from Backgrounded Tasks**
- When a tool runs in the background during a turn, the system was keeping suppression rules that prevented fast recovery even after the turn ended
- The fix clears this suppression when a turn definitively ends (when cost information arrives), allowing sessions to recover within ~30 seconds instead of getting stuck for up to 30 minutes
- Background commands (`Bash`) now properly reset their suppression state, while async agent executions continue to preserve their suppression to maintain compatibility with previous fixes

**2. Improved Cancel Command Feedback**
- The `aoe cockpit cancel` command previously showed a simple "cancel sent" message
- Now it provides a clear explanation of what will actually happen:
  - If a prompt is in flight and the agent ignores cancel, the worker will auto-restart with transcript preserved
  - If the session is idle, cancel is a no-op
- The message dynamically includes the configured escalation grace timeout value

**3. Documentation Clarification**
- Updated troubleshooting documentation to explicitly explain how off-protocol work suppression interacts with turn completion
- Clarifies the different behaviors for background commands vs. async agent executions

## Technical Changes

| File | Changes |
|------|---------|
| `src/cockpit/acp_client.rs` | Made `CANCEL_ESCALATION_GRACE` accessible to other modules; added logic to clear off-protocol suppression for `BackgroundCommand` when `TerminalUsage` (end-of-turn marker) arrives; expanded unit tests for watchdog behavior |
| `src/cli/cockpit.rs` | Added `cancel_confirmation_message()` helper function; enhanced cancel command output with escalation grace and behavior explanation; added unit test for message generation |
| `docs/cockpit/troubleshooting.md` | Expanded explanation of silent-orphan watchdog behavior (+24/-8 lines) |

## Benefits

- **Better Session Reliability**: Sessions no longer get unexpectedly wedged when background commands run during turns
- **Improved User Experience**: Users receive clear, actionable feedback about what cancel operations will do
- **Transparency**: Documentation now explicitly covers the different behavior paths in the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->