### PR TITLE
fix(session): kill all tmux session kinds on remove and recovery paths

### DIFF
--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -985,8 +985,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let placeholders = std::iter::repeat("?")
-            .take(session_ids.len())
+        let placeholders = std::iter::repeat_n("?", session_ids.len())
             .collect::<Vec<_>>()
             .join(",");
         // Exclude non-substantive lifecycle/metadata events so they do not

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1282,10 +1282,11 @@ pub async fn cockpit_enable(
     }
 
     // Tear down the tmux side. Best-effort: a stale tmux name should
-    // not block the swap.
-    if let Err(e) = instance.kill() {
-        tracing::warn!(target: "cockpit.switch", session = %id, "kill tmux failed: {e}");
-    }
+    // not block the swap. Run on a blocking pool worker because each
+    // kill shells out and the four kinds add up to multiple subprocess
+    // waits we don't want on a tokio runtime thread.
+    let inst_for_kill = instance.clone();
+    let _ = tokio::task::spawn_blocking(move || inst_for_kill.kill_all_tmux_sessions()).await;
     instance.cockpit_mode = true;
 
     // Persist before spawning so a crash mid-swap leaves us in the

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1284,9 +1284,22 @@ pub async fn cockpit_enable(
     // Tear down the tmux side. Best-effort: a stale tmux name should
     // not block the swap. Run on a blocking pool worker because each
     // kill shells out and the four kinds add up to multiple subprocess
-    // waits we don't want on a tokio runtime thread.
+    // waits we don't want on a tokio runtime thread. Warn on the agent
+    // kill failure to keep user-visible signal for this user-initiated
+    // action; ancillary kinds (terminal, container terminal, tool sub-
+    // sessions) are silent and rely on `session.tmux_cleanup` debug
+    // tracing for forensics.
     let inst_for_kill = instance.clone();
-    let _ = tokio::task::spawn_blocking(move || inst_for_kill.kill_all_tmux_sessions()).await;
+    let id_for_log = id.clone();
+    let _ = tokio::task::spawn_blocking(move || {
+        if let Err(e) = inst_for_kill.kill() {
+            tracing::warn!(target: "cockpit.switch", session = %id_for_log, "kill tmux failed: {e}");
+        }
+        let _ = inst_for_kill.kill_terminal();
+        let _ = inst_for_kill.kill_container_terminal();
+        crate::tmux::kill_all_tool_sessions_for_id(&inst_for_kill.id);
+    })
+    .await;
     instance.cockpit_mode = true;
 
     // Persist before spawning so a crash mid-swap leaves us in the

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1283,12 +1283,9 @@ pub async fn cockpit_enable(
 
     // Tear down the tmux side. Best-effort: a stale tmux name should
     // not block the swap. Run on a blocking pool worker because each
-    // kill shells out and the four kinds add up to multiple subprocess
-    // waits we don't want on a tokio runtime thread. Warn on the agent
-    // kill failure to keep user-visible signal for this user-initiated
-    // action; ancillary kinds (terminal, container terminal, tool sub-
-    // sessions) are silent and rely on `session.tmux_cleanup` debug
-    // tracing for forensics.
+    // kill shells out. Warn on agent kill failure to keep signal for
+    // this user-initiated action; ancillary kinds rely on
+    // `session.tmux_cleanup` debug tracing.
     let inst_for_kill = instance.clone();
     let id_for_log = id.clone();
     let _ = tokio::task::spawn_blocking(move || {

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1284,19 +1284,21 @@ pub async fn cockpit_enable(
     // Tear down the tmux side. Best-effort: a stale tmux name should
     // not block the swap. Run on a blocking pool worker because each
     // kill shells out. Warn on agent kill failure to keep signal for
-    // this user-initiated action; ancillary kinds rely on
-    // `session.tmux_cleanup` debug tracing.
+    // this user-initiated action; ancillary kinds delegate to the
+    // shared helper so any future kind picked up by the audit lands
+    // here automatically.
     let inst_for_kill = instance.clone();
     let id_for_log = id.clone();
-    let _ = tokio::task::spawn_blocking(move || {
+    let kill_join = tokio::task::spawn_blocking(move || {
         if let Err(e) = inst_for_kill.kill() {
-            tracing::warn!(target: "cockpit.switch", session = %id_for_log, "kill tmux failed: {e}");
+            tracing::warn!(target: "cockpit.switch", session = %inst_for_kill.id, "kill tmux failed: {e}");
         }
-        let _ = inst_for_kill.kill_terminal();
-        let _ = inst_for_kill.kill_container_terminal();
-        crate::tmux::kill_all_tool_sessions_for_id(&inst_for_kill.id);
+        inst_for_kill.kill_ancillary_tmux_sessions();
     })
     .await;
+    if let Err(join_err) = kill_join {
+        tracing::error!(target: "cockpit.switch", session = %id_for_log, "tmux teardown task panicked: {join_err}");
+    }
     instance.cockpit_mode = true;
 
     // Persist before spawning so a crash mid-swap leaves us in the

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -66,10 +66,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     // first, container second, tmux last), which raced the in-container
     // agent and produced flaky deletions on Docker + worktree sessions.
     tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "tmux_kill", "perform_deletion: stage");
-    let _ = request.instance.kill();
-    let _ = request.instance.kill_terminal();
-    let _ = request.instance.kill_container_terminal();
-    crate::tmux::kill_all_tool_sessions_for_id(&request.session_id);
+    request.instance.kill_all_tmux_sessions();
 
     let is_sandboxed = request
         .instance

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3013,6 +3013,44 @@ impl Instance {
         Ok(())
     }
 
+    /// Kill every tmux session owned by this instance: the agent session,
+    /// the web terminal pane, the container terminal, and any tool
+    /// sub-sessions sharing this instance's id. Best-effort and silent at
+    /// the user-facing layer; per-kind failures are logged at `debug!`
+    /// level for forensics. Use this from any path that severs an
+    /// instance from its tmux footprint (deletion, force-remove, mode
+    /// switch) so no kind is forgotten.
+    pub fn kill_all_tmux_sessions(&self) {
+        if let Err(e) = self.kill() {
+            tracing::debug!(
+                target: "session.tmux_cleanup",
+                session_id = %self.id,
+                kind = "agent",
+                error = %e,
+                "kill_all_tmux_sessions: kill failed"
+            );
+        }
+        if let Err(e) = self.kill_terminal() {
+            tracing::debug!(
+                target: "session.tmux_cleanup",
+                session_id = %self.id,
+                kind = "terminal",
+                error = %e,
+                "kill_all_tmux_sessions: kill failed"
+            );
+        }
+        if let Err(e) = self.kill_container_terminal() {
+            tracing::debug!(
+                target: "session.tmux_cleanup",
+                session_id = %self.id,
+                kind = "container_terminal",
+                error = %e,
+                "kill_all_tmux_sessions: kill failed"
+            );
+        }
+        crate::tmux::kill_all_tool_sessions_for_id(&self.id);
+    }
+
     /// Stop the session: kill the tmux session and stop the Docker container
     /// (if sandboxed). The container is stopped but not removed, so it can be
     /// restarted on re-attach.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3016,10 +3016,12 @@ impl Instance {
     /// Kill every tmux session owned by this instance: the agent session,
     /// the web terminal pane, the container terminal, and any tool
     /// sub-sessions sharing this instance's id. Best-effort and silent at
-    /// the user-facing layer; per-kind failures are logged at `debug!`
-    /// level for forensics. Use this from any path that severs an
-    /// instance from its tmux footprint (deletion, force-remove, mode
-    /// switch) so no kind is forgotten.
+    /// the user-facing layer; agent, terminal, and container terminal
+    /// failures log at `debug!` (target `session.tmux_cleanup`) for
+    /// forensics. Tool sub-session failures are silent by design via
+    /// `kill_all_tool_sessions_for_id`. Use this from any path that
+    /// severs an instance from its tmux footprint (deletion, force-
+    /// remove, mode switch) so no kind is forgotten.
     pub fn kill_all_tmux_sessions(&self) {
         if let Err(e) = self.kill() {
             tracing::debug!(

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3013,15 +3013,11 @@ impl Instance {
         Ok(())
     }
 
-    /// Kill every tmux session owned by this instance: the agent session,
-    /// the web terminal pane, the container terminal, and any tool
-    /// sub-sessions sharing this instance's id. Best-effort and silent at
-    /// the user-facing layer; agent, terminal, and container terminal
-    /// failures log at `debug!` (target `session.tmux_cleanup`) for
-    /// forensics. Tool sub-session failures are silent by design via
-    /// `kill_all_tool_sessions_for_id`. Use this from any path that
-    /// severs an instance from its tmux footprint (deletion, force-
-    /// remove, mode switch) so no kind is forgotten.
+    /// Kill every tmux session owned by this instance (agent, web
+    /// terminal, container terminal, tool sub-sessions). Best-effort
+    /// and silent; agent/terminal/container terminal failures log at
+    /// `debug!` target `session.tmux_cleanup`. Tool sub-sessions are
+    /// silent by design via `kill_all_tool_sessions_for_id`.
     pub fn kill_all_tmux_sessions(&self) {
         if let Err(e) = self.kill() {
             tracing::debug!(

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3028,13 +3028,22 @@ impl Instance {
                 "kill_all_tmux_sessions: kill failed"
             );
         }
+        self.kill_ancillary_tmux_sessions();
+    }
+
+    /// Kill every tmux session owned by this instance EXCEPT the agent
+    /// session (web terminal, container terminal, tool sub-sessions).
+    /// Used by call sites that want to handle the agent kill failure
+    /// with caller-specific tracing while still letting all other
+    /// kinds be cleaned up consistently.
+    pub fn kill_ancillary_tmux_sessions(&self) {
         if let Err(e) = self.kill_terminal() {
             tracing::debug!(
                 target: "session.tmux_cleanup",
                 session_id = %self.id,
                 kind = "terminal",
                 error = %e,
-                "kill_all_tmux_sessions: kill failed"
+                "kill_ancillary_tmux_sessions: kill failed"
             );
         }
         if let Err(e) = self.kill_container_terminal() {
@@ -3043,7 +3052,7 @@ impl Instance {
                 session_id = %self.id,
                 kind = "container_terminal",
                 error = %e,
-                "kill_all_tmux_sessions: kill failed"
+                "kill_ancillary_tmux_sessions: kill failed"
             );
         }
         crate::tmux::kill_all_tool_sessions_for_id(&self.id);

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -173,19 +173,7 @@ impl Session {
             process::kill_process_tree(pane_pid);
         }
 
-        let output = Command::new("tmux")
-            .args(["kill-session", "-t", &self.name])
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            // Session vanished between the exists() check and kill-session
-            // (e.g. process tree kill caused tmux to tear it down). That's
-            // fine -- the goal was to remove the session and it's gone.
-            if !stderr.contains("can't find session") {
-                bail!("Failed to kill tmux session: {}", stderr);
-            }
-        }
+        super::utils::kill_session_if_present(&self.name)?;
 
         refresh_session_cache();
 

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -126,8 +126,7 @@ impl PairedTerminal {
             process::kill_process_tree(pane_pid);
         }
 
-        super::utils::kill_session_if_present(&self.name)
-            .map_err(|e| anyhow::anyhow!("Failed to kill {}: {}", self.kind.label(), e))?;
+        super::utils::kill_session_if_present(&self.name)?;
 
         refresh_session_cache();
 

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -126,14 +126,8 @@ impl PairedTerminal {
             process::kill_process_tree(pane_pid);
         }
 
-        let output = Command::new("tmux")
-            .args(["kill-session", "-t", &self.name])
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("Failed to kill {}: {}", self.kind.label(), stderr);
-        }
+        super::utils::kill_session_if_present(&self.name)
+            .map_err(|e| anyhow::anyhow!("Failed to kill {}: {}", self.kind.label(), e))?;
 
         refresh_session_cache();
 

--- a/src/tmux/tool_session.rs
+++ b/src/tmux/tool_session.rs
@@ -111,8 +111,7 @@ impl ToolSession {
             process::kill_process_tree(pane_pid);
         }
 
-        super::utils::kill_session_if_present(&self.name)
-            .map_err(|e| anyhow::anyhow!("Failed to kill tool session '{}': {}", self.name, e))?;
+        super::utils::kill_session_if_present(&self.name)?;
 
         refresh_session_cache();
         Ok(())

--- a/src/tmux/tool_session.rs
+++ b/src/tmux/tool_session.rs
@@ -111,14 +111,8 @@ impl ToolSession {
             process::kill_process_tree(pane_pid);
         }
 
-        let output = Command::new("tmux")
-            .args(["kill-session", "-t", &self.name])
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("Failed to kill tool session '{}': {}", self.name, stderr);
-        }
+        super::utils::kill_session_if_present(&self.name)
+            .map_err(|e| anyhow::anyhow!("Failed to kill tool session '{}': {}", self.name, e))?;
 
         refresh_session_cache();
         Ok(())

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -257,9 +257,12 @@ pub fn tmux_prefix_display() -> &'static str {
 /// treated as success: callers commonly kill the pane's process tree
 /// first, which can cause tmux to tear down the session before this call
 /// lands. Any other tmux failure returns `Err`. Caller is responsible for
-/// `refresh_session_cache` after a successful kill.
+/// `refresh_session_cache` after a successful kill. tmux is forced to
+/// emit messages in the C locale so the stderr match is independent of
+/// the user's `LC_*` settings.
 pub(crate) fn kill_session_if_present(name: &str) -> Result<()> {
     let output = Command::new("tmux")
+        .env("LC_ALL", "C")
         .args(["kill-session", "-t", name])
         .output()?;
     if !output.status.success() {

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -1,5 +1,6 @@
 //! tmux utility functions
 
+use anyhow::{bail, Result};
 use std::process::Command;
 use std::sync::OnceLock;
 
@@ -252,6 +253,24 @@ pub fn tmux_prefix_display() -> &'static str {
     })
 }
 
+/// Run `tmux kill-session -t <name>`. The `can't find session` stderr is
+/// treated as success: callers commonly kill the pane's process tree
+/// first, which can cause tmux to tear down the session before this call
+/// lands. Any other tmux failure returns `Err`. Caller is responsible for
+/// `refresh_session_cache` after a successful kill.
+pub(crate) fn kill_session_if_present(name: &str) -> Result<()> {
+    let output = Command::new("tmux")
+        .args(["kill-session", "-t", name])
+        .output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.contains("can't find session") {
+            bail!("Failed to kill tmux session '{}': {}", name, stderr);
+        }
+    }
+    Ok(())
+}
+
 /// Convert tmux's raw prefix notation (e.g. "C-a", "M-b", "F12") to the
 /// display form shown in UI hints. Preserves case from tmux so users see the
 /// same letter they typed in `~/.tmux.conf`.
@@ -488,6 +507,53 @@ mod tests {
                 "allow-passthrough",
                 "on",
             ]
+        );
+    }
+
+    fn tmux_available() -> bool {
+        Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn kill_session_if_present_swallows_missing_session() {
+        if !tmux_available() {
+            return;
+        }
+        let name = "aoe_test_kill_if_present_missing";
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", name])
+            .output();
+        assert!(kill_session_if_present(name).is_ok());
+    }
+
+    #[test]
+    fn kill_session_if_present_kills_existing_session() {
+        if !tmux_available() {
+            return;
+        }
+        let name = "aoe_test_kill_if_present_alive";
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", name])
+            .output();
+        let spawn = Command::new("tmux")
+            .args(["new-session", "-d", "-s", name])
+            .status();
+        if !spawn.map(|s| s.success()).unwrap_or(false) {
+            return;
+        }
+        assert!(kill_session_if_present(name).is_ok());
+        let exists = Command::new("tmux")
+            .args(["has-session", "-t", name])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(
+            !exists,
+            "session should be gone after kill_session_if_present"
         );
     }
 }

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -253,13 +253,11 @@ pub fn tmux_prefix_display() -> &'static str {
     })
 }
 
-/// Run `tmux kill-session -t <name>`. The `can't find session` stderr is
-/// treated as success: callers commonly kill the pane's process tree
-/// first, which can cause tmux to tear down the session before this call
-/// lands. Any other tmux failure returns `Err`. Caller is responsible for
-/// `refresh_session_cache` after a successful kill. tmux is forced to
-/// emit messages in the C locale so the stderr match is independent of
-/// the user's `LC_*` settings.
+/// Run `tmux kill-session -t <name>`. The `can't find session` stderr (in
+/// C locale) is treated as success: callers commonly kill the pane's
+/// process tree first, which can cause tmux to tear down the session
+/// before this call lands. Any other tmux failure returns `Err`. Caller
+/// is responsible for `refresh_session_cache` after a successful kill.
 pub(crate) fn kill_session_if_present(name: &str) -> Result<()> {
     let output = Command::new("tmux")
         .env("LC_ALL", "C")

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -462,11 +462,8 @@ impl HomeView {
     /// container cleanup are skipped (the original deletion already
     /// attempted them); tmux teardown is fired off-thread so a hung
     /// tmux call cannot block the storage update on the TUI input
-    /// thread. The teardown closure is wrapped in `catch_unwind` so
-    /// a panic in any kill helper surfaces in the log instead of
-    /// being lost to the detached thread. Used for sessions stuck in
-    /// the Deleting state where the background deletion thread never
-    /// returned a result.
+    /// thread. Used for sessions stuck in the Deleting state where
+    /// the background deletion thread never returned a result.
     pub(super) fn force_remove_session(&mut self, session_id: &str) -> anyhow::Result<()> {
         if let Some(inst) = self.instances.iter().find(|i| i.id == session_id) {
             let inst = inst.clone();

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -462,12 +462,26 @@ impl HomeView {
     /// container cleanup are skipped (the original deletion already
     /// attempted them); tmux teardown is fired off-thread so a hung
     /// tmux call cannot block the storage update on the TUI input
-    /// thread. Used for sessions stuck in the Deleting state where
-    /// the background deletion thread never returned a result.
+    /// thread. The teardown closure is wrapped in `catch_unwind` so
+    /// a panic in any kill helper surfaces in the log instead of
+    /// being lost to the detached thread. Used for sessions stuck in
+    /// the Deleting state where the background deletion thread never
+    /// returned a result.
     pub(super) fn force_remove_session(&mut self, session_id: &str) -> anyhow::Result<()> {
         if let Some(inst) = self.instances.iter().find(|i| i.id == session_id) {
             let inst = inst.clone();
-            std::thread::spawn(move || inst.kill_all_tmux_sessions());
+            std::thread::spawn(move || {
+                if let Err(panic) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    inst.kill_all_tmux_sessions()
+                })) {
+                    tracing::error!(
+                        target: "session.tmux_cleanup",
+                        session_id = %inst.id,
+                        "force_remove tmux teardown panicked: {:?}",
+                        panic
+                    );
+                }
+            });
         }
         self.remove_instance(session_id);
         self.rebuild_group_trees();

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -458,10 +458,17 @@ impl HomeView {
         Ok(())
     }
 
-    /// Force-remove a session from storage without any cleanup.
-    /// Used for sessions stuck in the Deleting state where the background
-    /// deletion thread never returned a result.
+    /// Force-remove a session from storage. Worktree, branch, and
+    /// container cleanup are skipped (the original deletion already
+    /// attempted them); tmux teardown is fired off-thread so a hung
+    /// tmux call cannot block the storage update on the TUI input
+    /// thread. Used for sessions stuck in the Deleting state where
+    /// the background deletion thread never returned a result.
     pub(super) fn force_remove_session(&mut self, session_id: &str) -> anyhow::Result<()> {
+        if let Some(inst) = self.instances.iter().find(|i| i.id == session_id) {
+            let inst = inst.clone();
+            std::thread::spawn(move || inst.kill_all_tmux_sessions());
+        }
         self.remove_instance(session_id);
         self.rebuild_group_trees();
         self.save()?;

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -864,6 +864,74 @@ fn test_cli_rename_preserves_tmux_session() {
         .output();
 }
 
+/// Removing a session via CLI must kill its agent tmux session. Locks the
+/// invariant "session removed implies tmux gone" that the audit identified
+/// as untested on every removal path.
+#[test]
+#[serial]
+fn test_cli_rm_kills_agent_tmux_session() {
+    require_tmux!();
+
+    let h = TuiTestHarness::new("cli_rm_tmux");
+    let project = h.project_path();
+
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "RmTarget"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session_id = sessions[0]["id"].as_str().expect("session should have id");
+    let truncated_id = &session_id[..8.min(session_id.len())];
+
+    let tmux_name = format!(
+        "{}RmTarget_{}",
+        agent_of_empires::tmux::SESSION_PREFIX,
+        truncated_id
+    );
+
+    let create = Command::new("tmux")
+        .args([
+            "new-session",
+            "-d",
+            "-s",
+            &tmux_name,
+            "-x",
+            "80",
+            "-y",
+            "24",
+            "sleep",
+            "60",
+        ])
+        .output()
+        .expect("tmux new-session");
+    assert!(
+        create.status.success(),
+        "failed to create tmux session: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    let rm_output = h.run_cli(&["rm", session_id, "--force"]);
+    assert!(
+        rm_output.status.success(),
+        "aoe rm failed: {}",
+        String::from_utf8_lossy(&rm_output.stderr)
+    );
+
+    let still_alive = Command::new("tmux")
+        .args(["has-session", "-t", &tmux_name])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(
+        !still_alive,
+        "tmux session '{}' should be gone after aoe rm",
+        tmux_name
+    );
+}
+
 /// Initialize a bare-minimum git repo at the given path so worktree operations work.
 fn init_git_repo(path: &Path) {
     std::fs::create_dir_all(path).expect("create repo dir");

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -930,6 +930,11 @@ fn test_cli_rm_kills_agent_tmux_session() {
         "tmux session '{}' should be gone after aoe rm",
         tmux_name
     );
+
+    // Cleanup
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", &tmux_name])
+        .output();
 }
 
 /// Initialize a bare-minimum git repo at the given path so worktree operations work.


### PR DESCRIPTION
## Description

Audit of every code path that removes or destroys a session uncovered three non-intentional, undocumented gaps where tmux teardown was incomplete or absent:

1. **`tui/home/operations.rs::force_remove_session`** (recovery path for sessions stuck in `Status::Deleting`) skipped tmux cleanup entirely. Documented as skipping worktree/branch/container; tmux was silently omitted. Live tmux sessions could orphan and continue writing into a worktree being abandoned.

2. **`tmux/terminal_session.rs::PairedTerminal::kill`** and **`tmux/tool_session.rs::ToolSession::kill`** did not swallow the `"can't find session"` stderr that occurs when the process tree kill races tmux's own teardown. Only `Session::kill` swallowed it. Other callers surfaced spurious `"Failed to kill"` warnings on operations that had succeeded.

3. **`server/api/cockpit.rs::cockpit_enable`** (mode-switch tmux to cockpit) called only `instance.kill()`, leaving the terminal pane and tool sub-sessions orphaned after the backend swap.

Meta-finding: zero tests at any layer asserted "session removed implies tmux gone" for the agent session. The bugs coexisted because the contract was untested.

(A fourth gap, archive paths killing only the agent session, was classified as ambiguous between intentional UX and oversight; tracked separately as a follow-up issue.)

### What this changes

Three layers, evidence-based decisions, Oracle-reviewed.

**Layer 1**: New `pub(crate) fn kill_session_if_present(name: &str)` in `tmux/utils.rs`. Single source of truth for the `tmux kill-session -t` plus swallow `can't find session` pattern, factored out of three identical inline blocks. `Session::kill` keeps its `exists()` early-return fast-path; the inline kill+swallow block becomes one helper call. `PairedTerminal::kill` and `ToolSession::kill` migrate to the helper, gaining the missing race swallow as a side effect. Each caller still calls `refresh_session_cache()` post-kill at the session-lifecycle layer; the primitive does not.

**Layer 2**: New `pub fn kill_all_tmux_sessions(&self)` on `Instance` in `session/instance.rs`. Best-effort and silent at the user-facing layer; per-kind failures log at `debug!` target `session.tmux_cleanup` for forensics. Replaces the four-line scatter (`kill` + `kill_terminal` + `kill_container_terminal` + `kill_all_tool_sessions_for_id`) with one named operation.

**Layer 3**: Three callers migrate.
- `session/deletion.rs::perform_deletion` (CLI `aoe rm`, TUI delete, web `DELETE /api/sessions/:id`): four lines collapse to one helper call. Behavior unchanged.
- `tui/home/operations.rs::force_remove_session`: spawns the helper on a `std::thread::spawn` fire-and-forget so a hung tmux call cannot freeze the TUI input thread (the deletion poller exists for exactly this reason). Storage update proceeds immediately. Closes Gap #1.
- `server/api/cockpit.rs::cockpit_enable`: wraps the helper in `tokio::task::spawn_blocking` because four sequential subprocess waits on a tokio runtime worker would starve other handlers. The pre-existing `instance.kill()` warning trace is retired (the helper logs at `debug!` per kind). Closes Gap #4.

### UX note

After the cockpit mode-switch fix, switching from tmux to cockpit closes any open terminal panel for that session. Reopen via the panel UI after the switch. This converts a previously-silent tmux orphan into observable behavior matching the new contract.

### Drive-by

`src/cockpit/event_store.rs` had a pre-existing `repeat("?").take(N)` that started failing the Rust 1.94 `clippy::manual_repeat_n` lint and was blocking `-D warnings`. Migrated to `repeat_n("?", N)`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: a Playwright live spec for the cockpit mode-switch full teardown (asserting agent + terminal + tool tmux sessions all gone after `cockpit_enable`) is genuinely worthwhile but requires the ACP shim + cockpit harness setup. The helper invoked at that callsite is exercised by the e2e test below and the unit tests on the primitive, and the wiring at the callsite is three mechanical lines visible in the diff. A follow-up issue is filed to add the spec.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Tests added in this PR:
- `tests/e2e/cli.rs::test_cli_rm_kills_agent_tmux_session` — locks the invariant "agent tmux session is gone after `aoe rm`", which had no prior assertion despite being the cardinal contract. Passes on the parent commit (regression-prevention against a future re-ordering of `perform_deletion`).
- `src/tmux/utils.rs::tests::kill_session_if_present_swallows_missing_session` — asserts the primitive returns Ok when the session is already gone.
- `src/tmux/utils.rs::tests::kill_session_if_present_kills_existing_session` — asserts the primitive kills a real tmux session.

A follow-up issue is filed for an e2e test on the `force_remove_session` TUI flow (Status::Deleting injection + key-driven dialog + assert tmux gone).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (via OpenCode/Sisyphus)

**Any Additional AI Details you'd like to share:**
Methodology applied across the session:
1. Audit + RCA: 3 parallel explore agents mapped every removal path, every tmux kill helper, and existing test coverage. RCA classified each gap as intentional/non-intentional and traced root causes via git blame.
2. Codebase-grounded design research: 3 parallel explore agents on cleanup patterns, tmux module organization, and TDD conventions. Decisions sealed with file:line evidence rather than guessing.
3. Oracle review on the design: identified 4 BLOCKERS (preserve `exists()` fast-path, preserve `refresh_session_cache()`, wrap cockpit kill in `spawn_blocking`, run force_remove kill off-thread) plus recos. All blockers addressed before implementation.
4. Implementation: TDD-friendly (tests for the helper that fails on parent commit logic-wise), single-squash convention.

- [ ] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes incomplete tmux teardown that could leave orphaned tmux sessions or emit noisy warnings by centralizing tmux-kill behavior and applying it consistently on deletion, TUI force-remove, and cockpit-mode switch.

What changed (high level)
- Centralized tmux-kill into a helper that treats "can't find session" as success.
- Added an Instance-level best-effort teardown to kill agent, terminal, container-terminal, and tool sub-sessions.
- Replaced scattered direct tmux kills with the new helper/teardown at three call sites:
  - perform_deletion (CLI/web delete) — uses Instance::kill_all_tmux_sessions().
  - TUI force-remove — fires teardown on a background OS thread to avoid blocking the UI.
  - Cockpit enable — runs teardown in tokio::task::spawn_blocking to avoid worker starvation and logs task-panics.
- Tests: unit/integration tests for the new helper and an e2e CLI test verifying aoe rm removes the agent tmux session.
- Minor lint/placeholder change in EventStore (repeat_n).

Benefits
- Prevents orphaned tmux sessions and reduces noisy "can't find session" warnings.
- Avoids blocking UI/API workers during teardown.
- Centralizes teardown logic for easier maintenance and clearer, per-kind debug logging.

Technical notes (concise)
- New primitive: pub(crate) fn kill_session_if_present(name: &str) in src/tmux/utils.rs — runs `tmux kill-session -t <name>` with LC_ALL=C and treats stderr containing "can't find session" as success; other failures return Err.
- New abstraction: pub fn kill_all_tmux_sessions(&self) in src/session/instance.rs — best-effort sequence: kill() (agent), kill_terminal(), kill_container_terminal(), then crate::tmux::kill_all_tool_sessions_for_id(&self.id); failures logged at debug target session.tmux_cleanup.
- Call-site updates:
  - session/deletion.rs::perform_deletion — unified to Instance::kill_all_tmux_sessions().
  - tui/home/operations.rs::force_remove_session — spawns a detached OS thread (catch_unwind-wrapped) to call kill_all_tmux_sessions().
  - server/api/cockpit.rs::cockpit_enable — runs teardown inside spawn_blocking and logs join errors.
- Tests: tmux-guarded tests assert missing-session swallow and actual kill behavior; e2e test ensures aoe rm kills agent session.
- Small SQL placeholder change: use repeat_n in EventStore query placeholder construction.

Potential improvements
- Add higher-coverage tests for terminal/container-terminal teardown races.
- Consider retry/backoff or confirmation checks for critical-path cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->