### PR TITLE
fix(telemetry): dedup the exit usage_snapshot against the boot one

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1638,8 +1638,11 @@ fn spawn_telemetry_loop(state: Arc<AppState>) {
         loop {
             tokio::select! {
                 _ = state.shutdown.cancelled() => {
+                    // Deduped: a serve process that starts and stops between
+                    // 12h ticks would otherwise emit the initial first-tick
+                    // snapshot and an identical shutdown snapshot seconds apart.
                     if let Some(snapshot) = build_serve_snapshot(&state).await {
-                        crate::telemetry::flush_snapshot(snapshot).await;
+                        crate::telemetry::flush_snapshot_if_changed(snapshot).await;
                     }
                     break;
                 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -330,16 +330,9 @@ pub fn spawn_snapshot(snapshot: UsageSnapshot) {
     tokio::spawn(async move { post(&snapshot).await });
 }
 
-/// Send a usage snapshot and await delivery with a hard timeout. Used on
-/// graceful shutdown so the final snapshot has a chance to flush without
-/// risking a hang. Records the fingerprint.
-pub async fn flush_snapshot(snapshot: UsageSnapshot) {
-    record_snapshot_fp(&snapshot);
-    let _ = tokio::time::timeout(SEND_TIMEOUT, post(&snapshot)).await;
-}
-
-/// Like [`flush_snapshot`], for the best-effort snapshot on graceful exit, but
-/// skips the send when the snapshot is identical (ignoring `sent_at`) to the
+/// Send the best-effort snapshot on graceful exit, awaiting delivery with a
+/// hard timeout so the final snapshot can flush without risking a hang, but
+/// skipping the send when the snapshot is identical (ignoring `sent_at`) to the
 /// last one already emitted this run. A boot (or periodic) snapshot followed by
 /// a quit with unchanged session state would otherwise post the same counts
 /// twice within seconds; a snapshot that actually changed still flushes.

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -273,16 +273,81 @@ pub async fn flush_cli_process_start() {
     }
 }
 
+/// Fingerprint of the last `usage_snapshot` whose send we initiated this
+/// process. Lets [`flush_snapshot_if_changed`] drop a redundant exit snapshot
+/// that would otherwise repeat the boot (or last periodic) snapshot verbatim
+/// within seconds. Process-local on purpose: a fresh launch starts empty, which
+/// is correct because `process_start` already carries the per-launch signal, so
+/// the snapshot only needs to report state and identical state is not worth
+/// re-sending back to back.
+static LAST_SNAPSHOT_FP: std::sync::Mutex<Option<u64>> = std::sync::Mutex::new(None);
+
+/// Content fingerprint of a snapshot, excluding the volatile `sent_at` stamp.
+/// Everything else is included: `install_id` is stable per install, so two
+/// snapshots with the same counts hash equal. Used only for in-process dedup,
+/// never sent anywhere.
+fn snapshot_fingerprint(snapshot: &UsageSnapshot) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut probe = snapshot.clone();
+    probe.sent_at = String::new();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    serde_json::to_string(&probe)
+        .unwrap_or_default()
+        .hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Record that we just initiated a send for `snapshot`, so a later
+/// [`flush_snapshot_if_changed`] can tell whether anything changed since.
+fn record_snapshot_fp(snapshot: &UsageSnapshot) {
+    if let Ok(mut last) = LAST_SNAPSHOT_FP.lock() {
+        *last = Some(snapshot_fingerprint(snapshot));
+    }
+}
+
+/// True (and records the new fingerprint) when `snapshot` differs from the last
+/// one we initiated a send for this process; false when it is identical. A
+/// poisoned lock fails open: sending is the safe default.
+fn snapshot_is_new(snapshot: &UsageSnapshot) -> bool {
+    let fp = snapshot_fingerprint(snapshot);
+    match LAST_SNAPSHOT_FP.lock() {
+        Ok(mut last) => {
+            let is_new = *last != Some(fp);
+            if is_new {
+                *last = Some(fp);
+            }
+            is_new
+        }
+        Err(_) => true,
+    }
+}
+
 /// Send a pre-built usage snapshot, detached. Caller builds via
-/// [`build_usage_snapshot`] (returns `None` when not opted in).
+/// [`build_usage_snapshot`] (returns `None` when not opted in). Records the
+/// fingerprint so a redundant exit snapshot can be suppressed.
 pub fn spawn_snapshot(snapshot: UsageSnapshot) {
+    record_snapshot_fp(&snapshot);
     tokio::spawn(async move { post(&snapshot).await });
 }
 
 /// Send a usage snapshot and await delivery with a hard timeout. Used on
 /// graceful shutdown so the final snapshot has a chance to flush without
-/// risking a hang.
+/// risking a hang. Records the fingerprint.
 pub async fn flush_snapshot(snapshot: UsageSnapshot) {
+    record_snapshot_fp(&snapshot);
+    let _ = tokio::time::timeout(SEND_TIMEOUT, post(&snapshot)).await;
+}
+
+/// Like [`flush_snapshot`], for the best-effort snapshot on graceful exit, but
+/// skips the send when the snapshot is identical (ignoring `sent_at`) to the
+/// last one already emitted this run. A boot (or periodic) snapshot followed by
+/// a quit with unchanged session state would otherwise post the same counts
+/// twice within seconds; a snapshot that actually changed still flushes.
+pub async fn flush_snapshot_if_changed(snapshot: UsageSnapshot) {
+    if !snapshot_is_new(&snapshot) {
+        tracing::debug!(target: "telemetry", "exit snapshot unchanged since last emit; skipping duplicate");
+        return;
+    }
     let _ = tokio::time::timeout(SEND_TIMEOUT, post(&snapshot)).await;
 }
 
@@ -322,5 +387,72 @@ mod tests {
         unsafe { std::env::set_var("AOE_TELEMETRY_ENDPOINT", " https://x/y ") };
         assert_eq!(endpoint(), "https://x/y");
         unsafe { std::env::remove_var("AOE_TELEMETRY_ENDPOINT") };
+    }
+
+    fn sample_snapshot() -> UsageSnapshot {
+        UsageSnapshot {
+            schema: SCHEMA_VERSION,
+            event: "usage_snapshot",
+            install_id: "00000000-0000-0000-0000-000000000000".to_string(),
+            sent_at: "2026-06-02T19:00:45Z".to_string(),
+            surface: Surface::Tui,
+            aoe_version: "0.0.0".to_string(),
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            session_total: 7,
+            session_running: 1,
+            session_idle: 6,
+            session_error: 0,
+            session_cockpit: 0,
+            session_sandboxed: 2,
+            session_yolo: 0,
+            sessions_by_agent: BTreeMap::new(),
+            sessions_by_model_bucket: BTreeMap::new(),
+            features: BTreeMap::new(),
+            web_seen: false,
+            cockpit_seen: false,
+            session_creates_since_last_snapshot: 0,
+        }
+    }
+
+    // Regression for the duplicate `usage_snapshot` seen in dogfooding: the TUI
+    // (and serve) emit a snapshot at boot and another on graceful exit, so a
+    // launch-then-quit with unchanged sessions posted the identical payload
+    // twice within seconds. The exit path now dedups against the last emit.
+    #[test]
+    #[serial]
+    fn exit_snapshot_dedups_against_boot_but_resends_on_change() {
+        *LAST_SNAPSHOT_FP.lock().unwrap() = None;
+
+        // Boot emit records the fingerprint (this is what spawn_snapshot does).
+        let boot = sample_snapshot();
+        record_snapshot_fp(&boot);
+
+        // Quit right after, sessions unchanged: same content, newer stamp.
+        // The only difference is `sent_at`, which the fingerprint excludes, so
+        // the exit snapshot is recognised as a duplicate and not re-sent.
+        let mut exit = sample_snapshot();
+        exit.sent_at = "2026-06-02T19:00:47Z".to_string();
+        assert!(
+            !snapshot_is_new(&exit),
+            "an unchanged exit snapshot must dedupe against the boot snapshot"
+        );
+
+        // A snapshot whose counts actually changed is new and would be sent,
+        // and then becomes the new baseline.
+        let mut changed = sample_snapshot();
+        changed.session_total = 8;
+        assert!(
+            snapshot_is_new(&changed),
+            "a changed snapshot must still be emitted"
+        );
+        let mut changed_again = changed.clone();
+        changed_again.sent_at = "2026-06-02T19:05:00Z".to_string();
+        assert!(
+            !snapshot_is_new(&changed_again),
+            "repeating the latest snapshot dedups against it"
+        );
+
+        *LAST_SNAPSHOT_FP.lock().unwrap() = None;
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1303,9 +1303,11 @@ impl App {
         }
 
         // Best-effort final snapshot on graceful exit, bounded so a dead
-        // endpoint can't delay quit.
+        // endpoint can't delay quit. Deduped against the boot/periodic snapshot
+        // so a launch-then-quit with unchanged sessions doesn't post the same
+        // counts twice within seconds.
         if let Some(snapshot) = self.build_telemetry_snapshot() {
-            crate::telemetry::flush_snapshot(snapshot).await;
+            crate::telemetry::flush_snapshot_if_changed(snapshot).await;
         }
 
         Ok(())


### PR DESCRIPTION
> _Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Follow-up to #1863. The first real dogfooding data showed duplicate `usage_snapshot` events: a single TUI session produced two identical snapshots (same `surface=tui`, same `session_total`, etc.) a couple of seconds apart.

Root cause: the TUI and `aoe serve` each emit a `usage_snapshot` at boot and another on graceful exit. When session state did not change between the two, the payloads are identical (only `sent_at` differs), so a launch-then-quit (or a quit-then-relaunch, where one process's exit snapshot and the next process's boot snapshot land back to back) shows up as a duplicate.

I reproduced it with `scripts/telemetry_sink.py` pointed at a throwaway local sink:

- TUI launch then quit emitted two identical `usage_snapshot`s about 6s apart.
- `aoe serve` start then stop did the same: its 12h `tokio::time::interval` fires an immediate first tick (the boot snapshot), then the shutdown flush repeats it.

Fix: track a content fingerprint of the last snapshot whose send we initiated this process (everything except the volatile `sent_at`), and have the graceful-exit path (`flush_snapshot_if_changed`) skip the send when it matches the last one. Boot and periodic snapshots always send and refresh the fingerprint, so the cadence is now "one at start, one per 12h interval, and at most one on exit, and the exit one only when state actually changed." It is process-local on purpose: `process_start` already carries the per-launch signal, so re-sending identical state back to back adds nothing.

After the fix, both repros emit a single `usage_snapshot` per run, and a snapshot whose counts genuinely changed still flushes on exit.

### On the `process_start` "cli + tui" pairing

The handoff that prompted this PR also flagged `process_start` emitting both a `cli` and a surface event per launch. I checked this against the code and a sink reproduction and it does not happen: launching the bare TUI emits only `surface=tui` (a bare `aoe` is the clap `None` arm, so `cli_oneshot` is false), and `aoe serve` emits only `surface=serve`. A plain `aoe ls` emits a single `surface=cli`, throttled to once per day. The `cli` and `tui` events seen 21s apart in the data were two separate invocations, not one launch double-counting, so no change was needed there.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none: `docs/telemetry.md` already describes the "on start, then periodic, plus a final flush" cadence; this only removes a redundant send)
- [x] For UI changes: N/A (no UI change)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a full-binary e2e, because: the dedup decision is covered deterministically by an in-module unit test (`exit_snapshot_dedups_against_boot_but_resends_on_change` in `src/telemetry/mod.rs`), and end-to-end behavior was verified by hand against the local sink for both the TUI and serve. A full-binary e2e asserting send counts would need a live HTTP sink and would add flakiness without covering anything the unit test plus the manual sink run do not.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Diagnosed by reproducing the emit paths against the local sink, then fixed via back-and-forth with @njbrake. The decision to dedup the exit snapshot (rather than drop the boot or persist across processes) is his.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR prevents duplicate telemetry `usage_snapshot` events by adding process-local deduplication so identical snapshots emitted at boot and on graceful exit are not sent twice. Boot and periodic snapshots still always send; exit snapshots are skipped only when their content (excluding the volatile timestamp) matches the last sent snapshot.

### Changes Made

What was added
- A process-local fingerprinting mechanism in the telemetry module that computes a content hash of a UsageSnapshot (clearing `sent_at`) and records the last sent fingerprint.
- `flush_snapshot_if_changed(snapshot)` that checks the fingerprint and skips sending when unchanged.
- A unit test (exit_snapshot_dedups_against_boot_but_resends_on_change) validating deduplication and that changed snapshots still send.

What was changed
- TUI exit path and server shutdown telemetry now call `flush_snapshot_if_changed(...)` instead of always sending on exit.
- `spawn_snapshot` now records the fingerprint when initiating a send.

What was removed
- A now-dead public function `flush_snapshot` was removed after behavior was consolidated into `flush_snapshot_if_changed`.

### Technical notes (brief)
- Fingerprints are computed by cloning the snapshot, clearing `sent_at`, serializing to JSON, and hashing the result; deduplication state is process-local and in-memory.
- Boot and periodic snapshots refresh the fingerprint so later exit deduping compares against the most recently sent snapshot.
- No public API signature changes; scope is limited to telemetry sending behavior.

### Benefits
- Reduces redundant telemetry events (cleaner analytics).
- Keeps metrics accurate by avoiding duplicate counts from identical boot/exit snapshots.
- Preserves correctness: exit snapshots still flush when counts or other content change.
- Low-risk, backward-compatible change with unit-test coverage and manual verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->