### PR TITLE
fix(cockpit): clear dormant resume_intent on cockpit_enable

### DIFF
--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1217,6 +1217,18 @@ pub struct SubstrateSwitchResponse {
     pub cockpit_mode: bool,
 }
 
+/// Apply the atomic mutation contract for the cockpit-enable toggle to
+/// an [`crate::session::Instance`] slot: flip `cockpit_mode` to `true`
+/// and reset any dormant `resume_intent` written by the CLI
+/// `set-session-id`. Both fields must be touched together so the
+/// in-memory state, on-disk state (single `Storage::update` flock),
+/// and the local clone used to spawn the cockpit worker stay coherent.
+/// See #1745.
+fn apply_cockpit_enable_fields_to_slot(slot: &mut crate::session::Instance) {
+    slot.cockpit_mode = true;
+    slot.resume_intent = crate::session::ResumeIntent::Default;
+}
+
 /// Switch a tmux-mode session to cockpit. Idempotent: a session that
 /// is already cockpit-mode returns 200 with no work done.
 ///
@@ -1286,21 +1298,27 @@ pub async fn cockpit_enable(
     if let Err(e) = instance.kill() {
         tracing::warn!(target: "cockpit.switch", session = %id, "kill tmux failed: {e}");
     }
-    instance.cockpit_mode = true;
+    apply_cockpit_enable_fields_to_slot(&mut instance);
 
     // Persist before spawning so a crash mid-swap leaves us in the
     // declared end state, not a half-broken intermediate.
     //
     // The on-disk and in-memory updates mutate ONLY the cockpit-specific
-    // field (`cockpit_mode = true`). Wholesale replacement with a
-    // pre-lock snapshot would clobber concurrent writes to other
-    // fields (status, last_accessed, agent_session_id) made by the
-    // status poll loop or other handlers between the snapshot and the
-    // lock acquisition.
+    // fields (`cockpit_mode = true`, `resume_intent = Default`).
+    // Wholesale replacement with a pre-lock snapshot would clobber
+    // concurrent writes to other fields (status, last_accessed,
+    // agent_session_id) made by the status poll loop or other handlers
+    // between the snapshot and the lock acquisition.
+    //
+    // Clearing `resume_intent` here closes the dormant-intent gap: the
+    // CLI `set-session-id` writes `Use(sid)` to disk, then the user
+    // toggles cockpit on; without this reset, a future `cockpit_disable`
+    // would reload the stale `Use(sid)` and the next non-cockpit launch
+    // would honor a session id the user no longer expects. See #1745.
     {
         let mut instances = state.instances.write().await;
         if let Some(slot) = instances.iter_mut().find(|i| i.id == id) {
-            slot.cockpit_mode = true;
+            apply_cockpit_enable_fields_to_slot(slot);
         }
     }
     let id_for_save = id.clone();
@@ -1309,7 +1327,7 @@ pub async fn cockpit_enable(
         let storage = crate::session::Storage::new(&profile_for_save)?;
         storage.update(|all, _groups| {
             if let Some(slot) = all.iter_mut().find(|i| i.id == id_for_save) {
-                slot.cockpit_mode = true;
+                apply_cockpit_enable_fields_to_slot(slot);
             }
             Ok(())
         })?;
@@ -1967,5 +1985,29 @@ mod tests {
         let (files, truncated) = list_files(dir.path(), 3).unwrap();
         assert!(truncated);
         assert_eq!(files, vec!["f0.rs", "f1.rs", "f2.rs"]);
+    }
+
+    #[test]
+    fn cockpit_enable_clears_dormant_use_resume_intent() {
+        let mut inst = crate::session::Instance::new("test", "/tmp");
+        inst.cockpit_mode = false;
+        inst.resume_intent = crate::session::ResumeIntent::Use("pinned-sid".to_string());
+
+        super::apply_cockpit_enable_fields_to_slot(&mut inst);
+
+        assert!(inst.cockpit_mode);
+        assert_eq!(inst.resume_intent, crate::session::ResumeIntent::Default);
+    }
+
+    #[test]
+    fn cockpit_enable_clears_dormant_cleared_resume_intent() {
+        let mut inst = crate::session::Instance::new("test", "/tmp");
+        inst.cockpit_mode = false;
+        inst.resume_intent = crate::session::ResumeIntent::Cleared;
+
+        super::apply_cockpit_enable_fields_to_slot(&mut inst);
+
+        assert!(inst.cockpit_mode);
+        assert_eq!(inst.resume_intent, crate::session::ResumeIntent::Default);
     }
 }

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -1217,18 +1217,6 @@ pub struct SubstrateSwitchResponse {
     pub cockpit_mode: bool,
 }
 
-/// Apply the atomic mutation contract for the cockpit-enable toggle to
-/// an [`crate::session::Instance`] slot: flip `cockpit_mode` to `true`
-/// and reset any dormant `resume_intent` written by the CLI
-/// `set-session-id`. Both fields must be touched together so the
-/// in-memory state, on-disk state (single `Storage::update` flock),
-/// and the local clone used to spawn the cockpit worker stay coherent.
-/// See #1745.
-fn apply_cockpit_enable_fields_to_slot(slot: &mut crate::session::Instance) {
-    slot.cockpit_mode = true;
-    slot.resume_intent = crate::session::ResumeIntent::Default;
-}
-
 /// Switch a tmux-mode session to cockpit. Idempotent: a session that
 /// is already cockpit-mode returns 200 with no work done.
 ///
@@ -1298,7 +1286,8 @@ pub async fn cockpit_enable(
     if let Err(e) = instance.kill() {
         tracing::warn!(target: "cockpit.switch", session = %id, "kill tmux failed: {e}");
     }
-    apply_cockpit_enable_fields_to_slot(&mut instance);
+    instance.cockpit_mode = true;
+    instance.resume_intent = crate::session::ResumeIntent::Default;
 
     // Persist before spawning so a crash mid-swap leaves us in the
     // declared end state, not a half-broken intermediate.
@@ -1318,7 +1307,8 @@ pub async fn cockpit_enable(
     {
         let mut instances = state.instances.write().await;
         if let Some(slot) = instances.iter_mut().find(|i| i.id == id) {
-            apply_cockpit_enable_fields_to_slot(slot);
+            slot.cockpit_mode = true;
+            slot.resume_intent = crate::session::ResumeIntent::Default;
         }
     }
     let id_for_save = id.clone();
@@ -1327,7 +1317,8 @@ pub async fn cockpit_enable(
         let storage = crate::session::Storage::new(&profile_for_save)?;
         storage.update(|all, _groups| {
             if let Some(slot) = all.iter_mut().find(|i| i.id == id_for_save) {
-                apply_cockpit_enable_fields_to_slot(slot);
+                slot.cockpit_mode = true;
+                slot.resume_intent = crate::session::ResumeIntent::Default;
             }
             Ok(())
         })?;
@@ -1985,29 +1976,5 @@ mod tests {
         let (files, truncated) = list_files(dir.path(), 3).unwrap();
         assert!(truncated);
         assert_eq!(files, vec!["f0.rs", "f1.rs", "f2.rs"]);
-    }
-
-    #[test]
-    fn cockpit_enable_clears_dormant_use_resume_intent() {
-        let mut inst = crate::session::Instance::new("test", "/tmp");
-        inst.cockpit_mode = false;
-        inst.resume_intent = crate::session::ResumeIntent::Use("pinned-sid".to_string());
-
-        super::apply_cockpit_enable_fields_to_slot(&mut inst);
-
-        assert!(inst.cockpit_mode);
-        assert_eq!(inst.resume_intent, crate::session::ResumeIntent::Default);
-    }
-
-    #[test]
-    fn cockpit_enable_clears_dormant_cleared_resume_intent() {
-        let mut inst = crate::session::Instance::new("test", "/tmp");
-        inst.cockpit_mode = false;
-        inst.resume_intent = crate::session::ResumeIntent::Cleared;
-
-        super::apply_cockpit_enable_fields_to_slot(&mut inst);
-
-        assert!(inst.cockpit_mode);
-        assert_eq!(inst.resume_intent, crate::session::ResumeIntent::Default);
     }
 }


### PR DESCRIPTION
## Description

Fix #1745. The CLI `set-session-id` writes `resume_intent = Use(sid)` to disk so the next non-cockpit launch resumes from a pinned session id. If the user subsequently enables cockpit on the same session, the prior write is left untouched: a future `cockpit_disable` reloads the stale `Use(sid)`, and the first non-cockpit launch then honors a session id the user has moved past, triggering a ~2 s probe on a sid that nothing is going to answer.

`cockpit_enable` now resets `resume_intent` to `Default` atomically with `cockpit_mode = true` at all three mutation sites (the local `instance` clone used to spawn the worker, the in-memory `state.instances` write under the `RwLock`, and the on-disk write inside the single `Storage::update` flock). The disk and `state.instances` stay coherent without a reload. The shape mirrors the multi-field atomic toggle precedent already established by `cockpit_disable`, which inlines `cockpit_mode = false` together with `cockpit_acp_session_id = None` at the same three sites.

### Root cause

The clear-on-enable was omitted, not rejected. The `cockpit_enable` comment block has historically described the persistence step as mutating "ONLY the cockpit-specific field (`cockpit_mode = true`)", and that invariant was never revisited when `resume_intent` landed as a user-settable field that the launch path reads unconditionally. The forward-looking guard at `set-session-id` (refuses to mutate `resume_intent` on a cockpit-mode session) was added; the reverse direction (clearing `resume_intent` when entering cockpit mode) was missed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No UI surface is touched. The fix is daemon-side only.

### How tested

- `cargo fmt --all -- --check`: clean.
- `cargo build --features serve`: clean.
- `cargo test --features serve --lib`: 3455/3455 pass, 0 regressions.
- Companion forward-guard regression check: `cli::session::cockpit_reject_tests::set_session_id_rejects_cockpit_mode_session` still green.
- All 9 `session::instance::tests::resume_fallback::*` tests still green; the `Default` semantics on the post-toggle non-cockpit launch path is exercised by `resume_intent_default_uses_observed`.
- `cargo clippy --features serve -- -D warnings` fails on `src/cockpit/event_store.rs:988` (`clippy::manual_repeat_n`), pre-existing on `upstream/main` from commit `05bada3d0` and untouched by this PR. Verified by stashing the changes and re-running clippy on a clean main.

### History

The branch contains two commits that the maintainer can squash-merge:

1. `c86dba6a fix(cockpit): clear dormant resume_intent on cockpit_enable` - initial fix routed through a `apply_cockpit_enable_fields_to_slot` helper plus 2 unit tests.
2. `1715c7be fix(cockpit): inline resume_intent reset, drop helper` - self-review revert: the helper created an asymmetry with `cockpit_disable` (which inlines its analogous atomic write), and the helper-only tests would not have caught the actual regression class (a removed helper invocation at one of the 3 sites). The final shape inlines the reset to match `cockpit_disable` and treats the toggle contract as a code-review-time invariant, the same way `cockpit_disable`'s atomic write is treated today.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The fix is purely server-side state management: the cockpit-enable HTTP response shape is unchanged, no new endpoints, no new payload fields, no UI affordance. The bug surface is the `resume_intent` field on disk, which is daemon-internal and never exposed to the dashboard.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: matches `cockpit_disable`'s shape, which has no handler-level test for its analogous atomic write today. The toggle contract is a code-review-time invariant: all three sites in `cockpit_enable` flip `cockpit_mode` and reset `resume_intent` together; the call site comment + `#1745` reference document the contract for future maintainers. A handler-level integration test would require scaffolding the full `AppState` (cockpit supervisor, broadcast channels, login manager, rate limiter, ...), which is a larger change than the fix itself and is out of scope for a P2 fix that mirrors an existing untested precedent.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 4.7 via OpenCode (Sisyphus agent), with one Explore-agent dispatch for the targeted codebase audit (Storage::update closure, `ResumeIntent` variants/serde, `Instance.resume_intent` semantics, existing test patterns, all read sites, prior precedent search), followed by a 5-agent self-review (goal verification, QA via cargo execution, code quality, security, context mining) that surfaced the helper-asymmetry concern and motivated the second commit.

**Any Additional AI Details you'd like to share:**

The first commit took the helper-extraction path to enable RED→GREEN unit tests without `AppState` scaffolding. The 5-agent self-review correctly flagged the asymmetry with `cockpit_disable` and the tautological-test issue (the helper-only tests assert the helper's body, which would not catch a regression where a future patch removes one of the three callsites). The second commit reverts the helper and matches `cockpit_disable`'s shape exactly, accepting the "no handler-level test" tradeoff documented above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

What changed
- cockpit_enable now clears any existing resume_intent (sets it to ResumeIntent::Default) whenever a session is switched into cockpit mode.
- The reset is performed atomically alongside setting cockpit_mode = true inside the same Storage::update flock, and the in-memory state and local spawn-clone are updated to match.
- The previously introduced helper that centralized this behavior was removed; the resume_intent reset is inlined at each cockpit_enable mutation site (matching cockpit_disable’s pattern).
- Small code delta: approx +14 / -5 lines. No public API changes.

Problem fixed
- Prevents a dormant CLI-written resume_intent = Use(sid) on disk from surviving when a session is enabled for cockpit, which could later cause an unexpected resume probe after cockpit_disable.

Benefits
- Disk and in-memory session state remain coherent without requiring a reload.
- Avoids surprising resume behavior and startup probes for users who previously pinned sessions via CLI.
- Atomic update under a single flock removes race/coherency window between cockpit_mode and resume_intent writes.
- Tests and formatting/build checks pass; change is daemon-side only.

Technical notes (concise)
- Files changed: src/server/api/cockpit.rs.
- Behavior: inside each cockpit_enable mutation site, set cockpit_mode = true and resume_intent = ResumeIntent::Default in the same Storage::update closure; mirror the same reset into state.instances and the local clone used to spawn the cockpit worker.
- Tests that previously targeted the helper were dropped after inlining; test suite (cargo test --features serve), fmt and clippy pass locally. AI-assisted audit/implementation is disclosed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->