### PR TITLE
fix(web): handle CRLF line endings in diffPair

### DIFF
--- a/web/src/lib/diffPair.test.ts
+++ b/web/src/lib/diffPair.test.ts
@@ -93,3 +93,31 @@ describe("diffPair hunk shape", () => {
     });
   });
 });
+
+describe("diffPair CRLF line endings", () => {
+  it("strips the carriage return from identical CRLF content", () => {
+    const r = diffPair("a\r\nb\r\nc", "a\r\nb\r\nc");
+    expect(r.hunk.lines).toEqual([
+      { type: "equal", old_line_num: 1, new_line_num: 1, content: "a" },
+      { type: "equal", old_line_num: 2, new_line_num: 2, content: "b" },
+      { type: "equal", old_line_num: 3, new_line_num: 3, content: "c" },
+    ]);
+  });
+
+  it("strips the carriage return from changed CRLF content", () => {
+    const r = diffPair("a\r\nb\r\nc", "a\r\nB\r\nc");
+    expect(r.hunk.lines).toEqual([
+      { type: "equal", old_line_num: 1, new_line_num: 1, content: "a" },
+      { type: "delete", old_line_num: 2, new_line_num: null, content: "b" },
+      { type: "add", old_line_num: null, new_line_num: 2, content: "B" },
+      { type: "equal", old_line_num: 3, new_line_num: 3, content: "c" },
+    ]);
+  });
+
+  it("leaves no stray carriage returns in any line content", () => {
+    const r = diffPair("x\r\ny\r\nz", "x\r\ny2\r\nz");
+    for (const line of r.hunk.lines) {
+      expect(line.content).not.toContain("\r");
+    }
+  });
+});

--- a/web/src/lib/diffPair.ts
+++ b/web/src/lib/diffPair.ts
@@ -23,9 +23,10 @@ function withTrailingNewline(s: string): string {
 }
 
 /** `parseDiffFromFile` keeps the trailing newline on every line but
- *  the file's last; drop it so `content` is the bare line text. */
+ *  the file's last; drop it (and a preceding `\r` from CRLF input) so
+ *  `content` is the bare line text. */
 function stripNewline(s: string): string {
-  return s.endsWith("\n") ? s.slice(0, -1) : s;
+  return s.replace(/\r?\n$/, "");
 }
 
 /** Run a line-level diff over the pair and emit a `RichDiffHunk`
@@ -58,7 +59,7 @@ export function diffPair(oldText: string, newText: string): DiffPairResult {
   if (oldNormalized === newNormalized) {
     // Identical content yields no hunks; surface every line as `equal`
     // so the renderer still shows the snippet.
-    for (const content of stripNewline(oldNormalized).split("\n")) {
+    for (const content of stripNewline(oldNormalized).split(/\r?\n/)) {
       lines.push({
         type: "equal",
         old_line_num: oldNum++,


### PR DESCRIPTION
## Description

`stripNewline` in `web/src/lib/diffPair.ts` only stripped a trailing `\n`, leaving a bare `\r` in `RichDiffLine.content` for CRLF input, and the identical-content path split on `\n` rather than `/\r?\n/`. Both left stray carriage returns in the rendered diff (`web/src/components/diff/DiffLine.tsx`).

Fix:
- `stripNewline` now uses `s.replace(/\r?\n$/, "")` so it drops an optional preceding `\r`.
- The identical-content split changed from `split("\n")` to `split(/\r?\n/)`.

Fixes #1808.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A — no visual change; bug was stray `\r` characters)

## Test Coverage Analysis

Wrote failing Vitest cases first (TDD), then applied the fix. Added a `diffPair CRLF line endings` block in `web/src/lib/diffPair.test.ts` covering identical CRLF content, changed CRLF content, and a guard that no line content contains `\r`. All 15 tests pass; `prettier --check` and `tsc --noEmit` clean.

**Web dashboard / cockpit (Playwright user story)**
- [x] Skipped a test, because: this is a pure-logic fix in a lib helper; it is covered by the Vitest unit tests added here. `validate-coverage-matrix.mjs` passes with no matrix change required.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** AI wrote the failing tests and the fix; outputs were reviewed.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a bug in the diff rendering logic that caused Windows-style line endings (CRLF) to leave stray carriage return characters (`\r`) visible in diff output. The fix ensures that both Unix (`\n`) and Windows (`\r\n`) line endings are properly normalized during diff processing.

## What Changed

**Files Modified:**
- `web/src/lib/diffPair.ts` — Updated line-ending handling in two key functions
- `web/src/lib/diffPair.test.ts` — Added test coverage for CRLF scenarios

**Simple Summary:**
- The `stripNewline` function now removes both trailing newline characters and any preceding carriage returns that appear together
- The line-splitting logic now recognizes both Unix and Windows line endings when breaking content into individual lines
- Added comprehensive test suite to verify that CRLF inputs are handled correctly and no stray carriage returns remain in the output

## Technical Details

**Changes to `diffPair.ts`:**
- `stripNewline()` now uses regex pattern `/\r?\n$/` instead of string slicing, properly removing Windows line endings (`\r\n`) or Unix line endings (`\n`)
- Identical-content path now splits on `/\r?\n/` regex instead of hardcoded `"\n"` string literal, ensuring CRLF content is tokenized correctly

**Changes to `diffPair.test.ts`:**
- New test suite validates identical CRLF content produces correct hunk lines with clean content (no `\r` characters)
- Tests verify CRLF differences generate expected diff shapes while properly normalizing line content
- Guard assertion ensures no emitted hunk line content includes stray `\r` characters

## Benefits
- **Cross-platform compatibility:** Diffs now render correctly regardless of whether the source uses Windows or Unix line endings
- **Bug fix:** Eliminates a pre-existing issue that affected file diffs from Windows-based repositories
- **No API changes:** The fix is entirely internal—exported functions maintain backward compatibility
- **Well-tested:** Comprehensive test coverage validates the fix works for multiple CRLF scenarios (identical content, changed content, and carriage return guard checks)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->