### PR TITLE
fix(web): activate cockpit_seen telemetry signal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -533,8 +533,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // both the desktop and mobile cockpit mounts, so this single effect covers
   // both layouts. Same guard as the `"web"` ping above: skip until
   // `serverAbout` loads, skip read-only servers (which can't persist). The
-  // backend flag is an idempotent AtomicBool, so re-fires on session switch
-  // are harmless. See #1882.
+  // backend folds repeated pings into a monotonic open-count (reported as the
+  // boolean `cockpit_seen` and decremented by exactly what each snapshot
+  // reported), so re-fires on session switch are harmless. See #1882.
   useEffect(() => {
     if (!serverAboutLoaded || serverAbout?.read_only) return;
     if (!activeSession?.cockpit_mode) return;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -528,6 +528,19 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     };
   }, [serverAboutLoaded, serverAbout?.read_only]);
 
+  // Telemetry: report that the cockpit web UI was opened, folded into the
+  // daemon's next opt-in snapshot as `cockpit_seen`. `activeSession` drives
+  // both the desktop and mobile cockpit mounts, so this single effect covers
+  // both layouts. Same guard as the `"web"` ping above: skip until
+  // `serverAbout` loads, skip read-only servers (which can't persist). The
+  // backend flag is an idempotent AtomicBool, so re-fires on session switch
+  // are harmless. See #1882.
+  useEffect(() => {
+    if (!serverAboutLoaded || serverAbout?.read_only) return;
+    if (!activeSession?.cockpit_mode) return;
+    reportTelemetrySeen("cockpit");
+  }, [serverAboutLoaded, serverAbout?.read_only, activeSession?.cockpit_mode]);
+
   const handleTelemetryConsent = useCallback((enabled: boolean) => {
     setTelemetryConsentNeeded(false);
     void setTelemetryConsent(enabled);

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -163,6 +163,17 @@
       ]
     },
     {
+      "id": "telemetry.cockpit-seen",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-telemetry-seen.spec.ts"
+      ],
+      "components": [
+        "web/src/App.tsx"
+      ]
+    },
+    {
       "id": "settings.theme-persistence-passphrase",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/cockpit-telemetry-seen.spec.ts
+++ b/web/tests/live/cockpit-telemetry-seen.spec.ts
@@ -1,0 +1,99 @@
+// cockpit_seen telemetry activation (#1882).
+//
+// The backend path for `cockpit_seen` shipped with #1863 (endpoint,
+// AtomicBool, snapshot swap-on-read) and the `reportTelemetrySeen` helper
+// accepts `surface: "cockpit"`, but no frontend caller ever passed
+// `"cockpit"`, so the flag was always false. These specs pin the activated
+// behavior: opening a cockpit session fires the cockpit seen-ping, and a
+// read-only server short-circuits the shared guard so no ping is sent.
+
+import { test, expect } from "../helpers/liveTest";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+import { enableCockpitAndWait, waitForCockpitView } from "../helpers/cockpit";
+
+/** Capture every `POST /api/telemetry/seen` body the browser sends, parsed
+ *  into `{ surface }`. Attach before `page.goto` so the on-load `"web"`
+ *  ping and the cockpit ping are both observed. */
+function captureSeenPings(
+  page: import("@playwright/test").Page,
+): Array<{ surface?: string }> {
+  const pings: Array<{ surface?: string }> = [];
+  page.on("request", (req) => {
+    if (
+      req.method() === "POST" &&
+      req.url().includes("/api/telemetry/seen")
+    ) {
+      const body = req.postData();
+      if (!body) return;
+      try {
+        pings.push(JSON.parse(body));
+      } catch {
+        // Ignore unparseable bodies; the assertions only care about the
+        // well-formed `{ surface }` posts the helper emits.
+      }
+    }
+  });
+  return pings;
+}
+
+test("opening a cockpit session fires the cockpit seen-ping", async ({
+  page,
+}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "cockpit-seen-ping" }),
+  });
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const sessionId: string = sessions[0]!.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    const pings = captureSeenPings(page);
+    await page.goto(`${serve.baseUrl}/session/${sessionId}`);
+    await waitForCockpitView(page);
+
+    // The cockpit mount fires `reportTelemetrySeen("cockpit")`. Pre-fix no
+    // caller passed `"cockpit"`, so this poll timed out (the bug).
+    await expect
+      .poll(() => pings.some((p) => p.surface === "cockpit"), {
+        timeout: 10_000,
+      })
+      .toBe(true);
+
+    // The on-load `"web"` ping still fires too; the cockpit ping is
+    // additive, not a replacement.
+    expect(pings.some((p) => p.surface === "web")).toBe(true);
+  } finally {
+    await serve.stop();
+  }
+});
+
+test("a read-only server sends no telemetry seen-ping", async ({
+  serveReadOnly,
+  page,
+}) => {
+  // The seen-ping effects (both `"web"` and `"cockpit"`) share the same
+  // guard: skip on read-only servers, which can't persist a snapshot. The
+  // backend also rejects `POST /api/telemetry/seen` with 403 in read-only,
+  // but the frontend should never get that far.
+  const pings = captureSeenPings(page);
+
+  const aboutPromise = page.waitForResponse(
+    (r) => r.url().endsWith("/api/about") && r.status() === 200,
+    { timeout: 10_000 },
+  );
+  await page.goto(serveReadOnly.baseUrl);
+  await aboutPromise;
+  // Settle so React commits the read-only serverAbout state and any effect
+  // that was going to fire would have fired.
+  await page.waitForTimeout(500);
+
+  expect(pings).toHaveLength(0);
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The `cockpit_seen` opt-in usage telemetry signal shipped dead. The full backend path exists (the `/api/telemetry/seen` endpoint, the `telemetry_cockpit_seen` `AtomicBool`, the snapshot field, and swap-on-read), and the `reportTelemetrySeen` helper already accepts `surface: "cockpit"`, but no frontend caller ever passed `"cockpit"`. Only the `"web"` ping fired, on app load, so `cockpit_seen` was always false in every snapshot and we had zero data on cockpit adoption among opted-in users.

This activates the existing signal with one guarded effect in `AppContent`, mirroring the `"web"` ping. The effect is keyed on `activeSession.cockpit_mode`; since `activeSession` drives both the desktop and the mobile cockpit mounts, one effect covers both layouts with the same guard (skip until `serverAbout` loads, skip read-only servers). The backend flag is an idempotent `AtomicBool`, so re-fires on session switch are harmless.

The issue suggested wiring this into `CockpitRuntime.tsx`, but that component receives no `serverAbout`/`read_only` and would need prop threading for the guard. Placing the effect in `AppContent` next to the `"web"` ping keeps the guard logic in one place and covers mobile and desktop without threading.

`docs/telemetry.md` already states "whether the web dashboard / cockpit was opened since the last snapshot", so this brings runtime behavior in line with the docs; no doc change needed.

Closes #1882

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe serve` (writable, not read-only) and open the dashboard in a browser with devtools Network open.
- [ ] Open a cockpit-mode session; observe a `POST /api/telemetry/seen` with body `{"surface":"cockpit"}` fire (a `{"surface":"web"}` ping also fires on initial load).
- [ ] Opt in to telemetry, open the cockpit, then trigger / wait for the next usage snapshot and confirm it carries `cockpit_seen = true`.
- [ ] Run `aoe serve --read-only` and open the dashboard; confirm no `POST /api/telemetry/seen` request is sent at all.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (call-site choice, test layer) and reviewed each commit. The new live spec was proven to fail on the pre-fix tree and pass after.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR activates the dormant cockpit_seen telemetry signal by adding a guarded effect in AppContent that reports reportTelemetrySeen("cockpit") when a cockpit session opens. The backend already supported this signal; the frontend previously never sent it.

Added:
- A telemetry useEffect in AppContent keyed on activeSession?.cockpit_mode that fires when the cockpit UI becomes active (waits for serverAbout, skips read-only servers).
- A Playwright live test (web/tests/live/cockpit-telemetry-seen.spec.ts) that verifies a POST /api/telemetry/seen with {"surface":"cockpit"} is sent for writable servers and suppressed for read-only servers.
- A coverage-matrix entry linking the new live test to web/src/App.tsx.

No removals or relocations.

## Benefits

- Restores cockpit usage telemetry, improving product observability.
- Honors existing consent/read-only guards and backend idempotency, avoiding duplicate or unwanted pings.
- Covered by live tests to prevent regressions.

## Technical Details

- Implementation: new useEffect in AppContent that:
  - Depends on activeSession?.cockpit_mode,
  - Waits for serverAboutLoaded,
  - Skips servers where serverAbout?.read_only is true,
  - Calls reportTelemetrySeen("cockpit") (backend AtomicBool ensures idempotence).
- Tests: captureSeenPings helper intercepts POST /api/telemetry/seen and asserts presence/absence of { surface: "cockpit" } for writable vs read-only servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->