### PR TITLE
fix(telemetry): correct create counter, send-failure handling, and aggregation accuracy

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -20,12 +20,16 @@ closed, versioned schema (see `src/telemetry/events.rs`):
   - how many sessions exist and how many are running / idle / errored,
   - how many use a sandbox, the cockpit, or yolo mode,
   - a per-agent and per-model-family count (e.g. `{claude: 3, codex: 1}`),
+  - how many sessions were created since the last snapshot, a trend counter so
+    short-lived sessions that start and end between two snapshots are still
+    counted (populated by `aoe serve`; the TUI reports `0`),
   - which opt-in features are turned on (see "Feature flags" below),
   - whether the web dashboard / cockpit was opened since the last snapshot.
 
 In practice that is a handful of small (well under 1 KB) requests per active
-install per day, with no retries and no offline buffering, so a flaky network
-drops events rather than building a backlog.
+install per day. There is no offline buffering, so a flaky network drops events
+rather than building a backlog; the only retry is coarse (see "Failure
+isolation" below).
 
 Every agent and model string passes through a sanitizer
 (`src/telemetry/sanitize.rs`) that coerces it to a fixed allowlist: a custom
@@ -41,6 +45,11 @@ driven by a registry in `src/telemetry/features.rs`: tracking a newly gated
 feature is one entry there (name + how to read it from config), not a schema
 change. The key set is fixed and the values are booleans, so a flag can never
 carry a path or name, and the gateway forwards only this allowlisted shape.
+
+The values reflect the **global** config (the install default), not any single
+profile's effective config. It is an install-level default-adoption signal;
+since sessions can run under arbitrary profiles whose overrides are not folded
+in here, per-session usage is reported separately by the session counts above.
 
 ## What is never sent
 
@@ -80,9 +89,25 @@ state explicitly rather than silently ignoring it.
 
 ## Failure isolation
 
-Sends are fire-and-forget with a hard ~2s timeout and every error is swallowed
+Sends are best-effort with a hard ~2s timeout and every error is swallowed
 (logged only at `debug`, `target: "telemetry"`). Telemetry never blocks, stalls
-on exit, or crashes the tool. There is no retry, no offline buffering.
+on exit, or crashes the tool. There is no offline buffering.
+
+A send counts as delivered only on a confirmed `2xx`: a transport error or a
+non-success HTTP status (for example a rejected key or a schema rejection at the
+gateway) is treated as a failure, not a silent success. Signals are not consumed
+until delivery is confirmed, so a failed send does not silently drop them:
+
+- the CLI `process_start` daily slot is claimed only on a confirmed send, so a
+  failed send leaves it open for the next invocation to retry (bounded to once
+  per hour so a down endpoint cannot make every `aoe` invocation re-send);
+- the serve `web_seen` / `cockpit_seen` flags and the session-create counter are
+  cleared only after a confirmed snapshot send, so a failed snapshot keeps them
+  for the next one instead of losing that window's signal.
+
+This is coarse, last-write retry, not a durable queue: periodic snapshots are
+still point-in-time, and a snapshot identical to the last confirmed one is
+deduped rather than re-sent.
 
 ## Backend
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2129,6 +2129,13 @@ pub async fn create_session(
             instances.push(instance);
             drop(instances);
 
+            // Count the create for the opt-in telemetry trend counter. Bounded
+            // accumulator, read-and-decremented by the snapshot loop; no-op for
+            // opted-out installs (the snapshot is never built / sent).
+            state
+                .telemetry_session_creates
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
             #[cfg(feature = "serve")]
             if let Some((
                 id,

--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -105,8 +105,12 @@ pub async fn post_telemetry_seen(
         Err(rej) => return rej.into_response(),
     };
     match req.surface.as_str() {
-        "web" => state.telemetry_web_seen.store(true, Ordering::Relaxed),
-        "cockpit" => state.telemetry_cockpit_seen.store(true, Ordering::Relaxed),
+        "web" => {
+            state.telemetry_web_seen.fetch_add(1, Ordering::Relaxed);
+        }
+        "cockpit" => {
+            state.telemetry_cockpit_seen.fetch_add(1, Ordering::Relaxed);
+        }
         other => {
             return (
                 StatusCode::BAD_REQUEST,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -331,13 +331,16 @@ pub struct AppState {
     /// checks this to suppress notifications when someone is actively using
     /// the web dashboard (on any device).
     pub last_web_activity: std::sync::atomic::AtomicI64,
-    /// Set when a browser reports the web dashboard / cockpit web UI was
-    /// opened, so the next opt-in telemetry snapshot can carry `web_seen` /
-    /// `cockpit_seen`. Reset after each snapshot. The browser never posts to
-    /// the telemetry backend; it pings the local daemon (`POST
-    /// /api/telemetry/seen`), which folds the flag into its own snapshot.
-    pub telemetry_web_seen: std::sync::atomic::AtomicBool,
-    pub telemetry_cockpit_seen: std::sync::atomic::AtomicBool,
+    /// Counts browser reports that the web dashboard / cockpit web UI was opened,
+    /// so the next opt-in telemetry snapshot can carry `web_seen` / `cockpit_seen`
+    /// (the wire field is the boolean `count > 0`). A monotonic counter rather than
+    /// a flag so the snapshot loop can decrement by exactly what it reported (like
+    /// the create counter): an open that lands during an in-flight send is then
+    /// preserved for the next snapshot instead of being cleared away. The browser
+    /// never posts to the telemetry backend; it pings the local daemon (`POST
+    /// /api/telemetry/seen`), which folds the count into its own snapshot.
+    pub telemetry_web_seen: std::sync::atomic::AtomicU32,
+    pub telemetry_cockpit_seen: std::sync::atomic::AtomicU32,
     /// Sessions created since the last opt-in telemetry snapshot. Feeds the
     /// `session_creates_since_last_snapshot` trend counter so short-lived sessions
     /// that start and end between two snapshots are still counted. Decremented (by
@@ -622,8 +625,8 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         push_enabled,
         web_config: config.web.clone(),
         last_web_activity: std::sync::atomic::AtomicI64::new(0),
-        telemetry_web_seen: std::sync::atomic::AtomicBool::new(false),
-        telemetry_cockpit_seen: std::sync::atomic::AtomicBool::new(false),
+        telemetry_web_seen: std::sync::atomic::AtomicU32::new(0),
+        telemetry_cockpit_seen: std::sync::atomic::AtomicU32::new(0),
         telemetry_session_creates: std::sync::atomic::AtomicU32::new(0),
         telemetry_last_reported: std::sync::Mutex::new(None),
         shutdown: CancellationToken::new(),
@@ -1683,16 +1686,16 @@ fn spawn_telemetry_loop(state: Arc<AppState>) {
 /// only after the send is confirmed. The clear is deferred (rather than reset at
 /// build time) so a failed send retains the signals for the next snapshot.
 struct ReportedServeSignals {
-    web_seen: bool,
-    cockpit_seen: bool,
+    web_seen: u32,
+    cockpit_seen: u32,
     session_creates: u32,
 }
 
 /// Build a serve `usage_snapshot` from the live session list, folding in the
-/// `web_seen` / `cockpit_seen` flags and the session-create trend counter
-/// *without resetting them*. The reported values are stashed in `AppState` so
-/// [`clear_reported_serve_signals`] can clear them once the send is confirmed.
-/// Returns `None` when telemetry is not opted in.
+/// `web_seen` / `cockpit_seen` open counts and the session-create trend counter
+/// *without resetting them*. The reported counts are stashed in `AppState` so
+/// [`clear_reported_serve_signals`] can subtract exactly what was reported once
+/// the send is confirmed. Returns `None` when telemetry is not opted in.
 async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::UsageSnapshot> {
     use std::sync::atomic::Ordering;
     let web_seen = state.telemetry_web_seen.load(Ordering::Relaxed);
@@ -1702,8 +1705,8 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
     let snapshot = crate::telemetry::build_usage_snapshot(
         crate::telemetry::Surface::Serve,
         &instances,
-        web_seen,
-        cockpit_seen,
+        web_seen > 0,
+        cockpit_seen > 0,
         session_creates,
     )?;
     *state.telemetry_last_reported.lock().unwrap() = Some(ReportedServeSignals {
@@ -1718,31 +1721,28 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
 /// confirmed (`SendOutcome::Sent`). On `Deduped` the prior confirmed send
 /// already cleared them; on `Failed` they are retained so the next snapshot
 /// re-reports them. The create counter is decremented by exactly the reported
-/// value (not reset to 0) so creates that arrived during the in-flight send are
-/// preserved; the `seen` flags are reset to false, with any open that landed
-/// during the send re-arming the flag on the next snapshot.
+/// value (not reset to 0). All three signals (the two `seen` open counts and the
+/// create counter) are decremented by exactly what was reported, so an open or a
+/// create that landed during the in-flight send survives into the next snapshot
+/// instead of being cleared away.
 fn clear_reported_serve_signals(state: &AppState, outcome: crate::telemetry::SendOutcome) {
-    use std::sync::atomic::Ordering;
     let Some(reported) = state.telemetry_last_reported.lock().unwrap().take() else {
         return;
     };
     if outcome != crate::telemetry::SendOutcome::Sent {
         return;
     }
-    if reported.web_seen {
-        state.telemetry_web_seen.store(false, Ordering::Relaxed);
-    }
-    if reported.cockpit_seen {
-        state.telemetry_cockpit_seen.store(false, Ordering::Relaxed);
-    }
-    decrement_reported_creates(&state.telemetry_session_creates, reported.session_creates);
+    decrement_reported_count(&state.telemetry_web_seen, reported.web_seen);
+    decrement_reported_count(&state.telemetry_cockpit_seen, reported.cockpit_seen);
+    decrement_reported_count(&state.telemetry_session_creates, reported.session_creates);
 }
 
-/// Decrement the create counter by exactly `reported`, never by more. Using
-/// `fetch_sub(reported)` rather than `swap(0)` preserves any creates that landed
-/// between the snapshot build and the confirmed send, so they roll into the next
-/// snapshot instead of being dropped. A no-op when nothing was reported.
-fn decrement_reported_creates(counter: &std::sync::atomic::AtomicU32, reported: u32) {
+/// Decrement a reported telemetry counter by exactly `reported`, never by more.
+/// Using `fetch_sub(reported)` rather than `swap(0)` preserves any increments
+/// (a create, or a web/cockpit open) that landed between the snapshot build and
+/// the confirmed send, so they roll into the next snapshot instead of being
+/// dropped. A no-op when nothing was reported.
+fn decrement_reported_count(counter: &std::sync::atomic::AtomicU32, reported: u32) {
     if reported > 0 {
         counter.fetch_sub(reported, std::sync::atomic::Ordering::Relaxed);
     }
@@ -2718,31 +2718,32 @@ pub(crate) fn derive_cockpit_status(event: &crate::cockpit::Event) -> Option<Sta
 mod tests {
     use super::*;
 
-    // #1874: a confirmed snapshot clears the create counter by exactly the value
-    // it reported, so creates that arrive during the in-flight send survive into
-    // the next snapshot instead of being reset away.
+    // #1874 / #1875: a confirmed snapshot clears a reported telemetry counter
+    // (the create counter and the web/cockpit open counts all share this path)
+    // by exactly the value it reported, so an increment that arrives during the
+    // in-flight send survives into the next snapshot instead of being reset away.
     #[test]
-    fn create_counter_decrement_preserves_concurrent_creates() {
+    fn reported_count_decrement_preserves_concurrent_increments() {
         use std::sync::atomic::{AtomicU32, Ordering};
         let counter = AtomicU32::new(5);
-        // The snapshot reported the 5 creates seen at build time.
+        // The snapshot reported the 5 increments seen at build time.
         let reported = counter.load(Ordering::Relaxed);
-        // A create lands while the snapshot is in flight.
+        // One more lands while the snapshot is in flight.
         counter.fetch_add(1, Ordering::Relaxed);
         // The confirmed send clears only what it reported.
-        decrement_reported_creates(&counter, reported);
+        decrement_reported_count(&counter, reported);
         assert_eq!(
             counter.load(Ordering::Relaxed),
             1,
-            "the create that arrived during the send must be retained"
+            "the increment that arrived during the send must be retained"
         );
     }
 
     #[test]
-    fn create_counter_decrement_is_noop_for_zero() {
+    fn reported_count_decrement_is_noop_for_zero() {
         use std::sync::atomic::{AtomicU32, Ordering};
         let counter = AtomicU32::new(3);
-        decrement_reported_creates(&counter, 0);
+        decrement_reported_count(&counter, 0);
         assert_eq!(counter.load(Ordering::Relaxed), 3);
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -338,6 +338,17 @@ pub struct AppState {
     /// /api/telemetry/seen`), which folds the flag into its own snapshot.
     pub telemetry_web_seen: std::sync::atomic::AtomicBool,
     pub telemetry_cockpit_seen: std::sync::atomic::AtomicBool,
+    /// Sessions created since the last opt-in telemetry snapshot. Feeds the
+    /// `session_creates_since_last_snapshot` trend counter so short-lived sessions
+    /// that start and end between two snapshots are still counted. Decremented (by
+    /// the value reported) only after a confirmed send, so a failed send retains
+    /// the count for the next snapshot instead of silently dropping it.
+    pub telemetry_session_creates: std::sync::atomic::AtomicU32,
+    /// What the most recent serve snapshot reported, held until its send is
+    /// confirmed so the originating signals (`web_seen` / `cockpit_seen` / the
+    /// create counter) are cleared only on success. The telemetry loop is the
+    /// sole reader/writer, so it never overlaps an in-flight build.
+    telemetry_last_reported: std::sync::Mutex<Option<ReportedServeSignals>>,
     /// Resolved when the daemon receives SIGINT/SIGTERM/SIGHUP. Long-lived
     /// handlers (cockpit WS, terminal WS) clone this and `select!` on
     /// `cancelled()` so they exit promptly instead of holding axum's
@@ -613,6 +624,8 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         last_web_activity: std::sync::atomic::AtomicI64::new(0),
         telemetry_web_seen: std::sync::atomic::AtomicBool::new(false),
         telemetry_cockpit_seen: std::sync::atomic::AtomicBool::new(false),
+        telemetry_session_creates: std::sync::atomic::AtomicU32::new(0),
+        telemetry_last_reported: std::sync::Mutex::new(None),
         shutdown: CancellationToken::new(),
     });
 
@@ -1642,13 +1655,23 @@ fn spawn_telemetry_loop(state: Arc<AppState>) {
                     // 12h ticks would otherwise emit the initial first-tick
                     // snapshot and an identical shutdown snapshot seconds apart.
                     if let Some(snapshot) = build_serve_snapshot(&state).await {
-                        crate::telemetry::flush_snapshot_if_changed(snapshot).await;
+                        let outcome = crate::telemetry::flush_snapshot_if_changed(snapshot).await;
+                        clear_reported_serve_signals(&state, outcome);
                     }
                     break;
                 }
                 _ = interval.tick() => {
                     if let Some(snapshot) = build_serve_snapshot(&state).await {
-                        crate::telemetry::spawn_snapshot(snapshot);
+                        // Awaited (not detached) so the reported signals are
+                        // cleared only after a confirmed send. A failed send
+                        // retains web_seen / cockpit_seen / the create counter
+                        // for the next snapshot instead of dropping them.
+                        let outcome = if crate::telemetry::send_snapshot(snapshot).await {
+                            crate::telemetry::SendOutcome::Sent
+                        } else {
+                            crate::telemetry::SendOutcome::Failed
+                        };
+                        clear_reported_serve_signals(&state, outcome);
                     }
                 }
             }
@@ -1656,22 +1679,73 @@ fn spawn_telemetry_loop(state: Arc<AppState>) {
     });
 }
 
-/// Build a serve `usage_snapshot` from the live session list, folding in (and
-/// resetting) the `web_seen` / `cockpit_seen` flags reported by browsers. The
-/// session-create trend counter is left at 0 for v1. Returns `None` when
-/// telemetry is not opted in.
+/// What a serve snapshot reported, so the originating signals can be cleared
+/// only after the send is confirmed. The clear is deferred (rather than reset at
+/// build time) so a failed send retains the signals for the next snapshot.
+struct ReportedServeSignals {
+    web_seen: bool,
+    cockpit_seen: bool,
+    session_creates: u32,
+}
+
+/// Build a serve `usage_snapshot` from the live session list, folding in the
+/// `web_seen` / `cockpit_seen` flags and the session-create trend counter
+/// *without resetting them*. The reported values are stashed in `AppState` so
+/// [`clear_reported_serve_signals`] can clear them once the send is confirmed.
+/// Returns `None` when telemetry is not opted in.
 async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::UsageSnapshot> {
     use std::sync::atomic::Ordering;
-    let web_seen = state.telemetry_web_seen.swap(false, Ordering::Relaxed);
-    let cockpit_seen = state.telemetry_cockpit_seen.swap(false, Ordering::Relaxed);
+    let web_seen = state.telemetry_web_seen.load(Ordering::Relaxed);
+    let cockpit_seen = state.telemetry_cockpit_seen.load(Ordering::Relaxed);
+    let session_creates = state.telemetry_session_creates.load(Ordering::Relaxed);
     let instances = state.instances.read().await.clone();
-    crate::telemetry::build_usage_snapshot(
+    let snapshot = crate::telemetry::build_usage_snapshot(
         crate::telemetry::Surface::Serve,
         &instances,
         web_seen,
         cockpit_seen,
-        0,
-    )
+        session_creates,
+    )?;
+    *state.telemetry_last_reported.lock().unwrap() = Some(ReportedServeSignals {
+        web_seen,
+        cockpit_seen,
+        session_creates,
+    });
+    Some(snapshot)
+}
+
+/// Clear the signals a serve snapshot reported, but only when the send was
+/// confirmed (`SendOutcome::Sent`). On `Deduped` the prior confirmed send
+/// already cleared them; on `Failed` they are retained so the next snapshot
+/// re-reports them. The create counter is decremented by exactly the reported
+/// value (not reset to 0) so creates that arrived during the in-flight send are
+/// preserved; the `seen` flags are reset to false, with any open that landed
+/// during the send re-arming the flag on the next snapshot.
+fn clear_reported_serve_signals(state: &AppState, outcome: crate::telemetry::SendOutcome) {
+    use std::sync::atomic::Ordering;
+    let Some(reported) = state.telemetry_last_reported.lock().unwrap().take() else {
+        return;
+    };
+    if outcome != crate::telemetry::SendOutcome::Sent {
+        return;
+    }
+    if reported.web_seen {
+        state.telemetry_web_seen.store(false, Ordering::Relaxed);
+    }
+    if reported.cockpit_seen {
+        state.telemetry_cockpit_seen.store(false, Ordering::Relaxed);
+    }
+    decrement_reported_creates(&state.telemetry_session_creates, reported.session_creates);
+}
+
+/// Decrement the create counter by exactly `reported`, never by more. Using
+/// `fetch_sub(reported)` rather than `swap(0)` preserves any creates that landed
+/// between the snapshot build and the confirmed send, so they roll into the next
+/// snapshot instead of being dropped. A no-op when nothing was reported.
+fn decrement_reported_creates(counter: &std::sync::atomic::AtomicU32, reported: u32) {
+    if reported > 0 {
+        counter.fetch_sub(reported, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 /// Background task that periodically refreshes session statuses. On each
@@ -2643,6 +2717,34 @@ pub(crate) fn derive_cockpit_status(event: &crate::cockpit::Event) -> Option<Sta
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #1874: a confirmed snapshot clears the create counter by exactly the value
+    // it reported, so creates that arrive during the in-flight send survive into
+    // the next snapshot instead of being reset away.
+    #[test]
+    fn create_counter_decrement_preserves_concurrent_creates() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let counter = AtomicU32::new(5);
+        // The snapshot reported the 5 creates seen at build time.
+        let reported = counter.load(Ordering::Relaxed);
+        // A create lands while the snapshot is in flight.
+        counter.fetch_add(1, Ordering::Relaxed);
+        // The confirmed send clears only what it reported.
+        decrement_reported_creates(&counter, reported);
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            1,
+            "the create that arrived during the send must be retained"
+        );
+    }
+
+    #[test]
+    fn create_counter_decrement_is_noop_for_zero() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let counter = AtomicU32::new(3);
+        decrement_reported_creates(&counter, 0);
+        assert_eq!(counter.load(Ordering::Relaxed), 3);
+    }
 
     #[cfg(feature = "serve")]
     #[test]

--- a/src/telemetry/features.rs
+++ b/src/telemetry/features.rs
@@ -16,9 +16,14 @@ use crate::session::config::UpdateCheckMode;
 use crate::session::Config;
 
 /// Install-level feature adoption: allowlisted feature name -> whether it is
-/// turned on for this install. Built from config so it reflects what the user
-/// opted into, independent of per-session counts (which the snapshot reports
-/// separately).
+/// turned on in the **global** config for this install.
+///
+/// This is deliberately the global, pre-profile-merge config, not a profile's
+/// effective config: it answers "what does this install default to", which is a
+/// stable install-level adoption signal. Because sessions can run under arbitrary
+/// profiles whose overrides are not reflected here, this is not per-session usage;
+/// per-session adoption is reported separately by the snapshot's session counts
+/// (`session_sandboxed`, `session_yolo`, ...). Documented in `docs/telemetry.md`.
 pub fn active_features(config: &Config) -> BTreeMap<String, bool> {
     let mut features = BTreeMap::new();
     features.insert("worktree".to_string(), config.worktree.enabled);

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -145,6 +145,8 @@ pub fn build_usage_snapshot(
         return None;
     }
     let install_id = state::ensure_install_id()?;
+    // Global, pre-profile-merge config on purpose: `features` is an install-level
+    // default-adoption signal, not per-session usage. See `features::active_features`.
     let features = features::active_features(&crate::session::Config::load_or_warn());
 
     let mut sessions_by_agent: BTreeMap<String, u32> = BTreeMap::new();

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -27,7 +27,7 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 pub use events::{ProcessStart, Surface, UsageSnapshot, SCHEMA_VERSION};
-pub use state::{claim_cli_process_start_slot, install_id, reset_install_id};
+pub use state::{cli_process_start_due, install_id, record_cli_process_start, reset_install_id};
 
 use crate::session::Instance;
 
@@ -57,6 +57,11 @@ const TELEMETRY_KEY: &str = "7bc5a4e45ce861662b9690a7105da988";
 /// still answers "did this install run the CLI today" without a POST per
 /// command.
 const CLI_PROCESS_START_MIN_GAP: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Retry backoff after a *failed* CLI `process_start` send. While the daily slot
+/// stays open (a failed send never claims it), this bounds re-attempts to once
+/// per hour so a down endpoint can't make every `aoe` invocation re-send.
+const CLI_PROCESS_START_RETRY_GAP: Duration = Duration::from_secs(60 * 60);
 
 /// True when `DO_NOT_TRACK` is set to an affirmative value. This is the
 /// absolute override: it wins over `config.telemetry.enabled`.
@@ -216,10 +221,14 @@ pub fn build_usage_snapshot(
     })
 }
 
-/// POST a serialized event to the endpoint. Every error is swallowed and
-/// logged at `debug` only. Bounded by both a short connect timeout and the
-/// overall [`SEND_TIMEOUT`] so a down endpoint can never delay the caller.
-async fn post<T: serde::Serialize>(event: &T) {
+/// POST a serialized event to the endpoint. Returns `true` only on a *confirmed*
+/// delivery: a transport-level `Ok` whose HTTP status is a 2xx. A transport error
+/// OR a non-success status (4xx/5xx, e.g. a rejected `X-Telemetry-Key` or a
+/// schema rejection at the gateway) returns `false` so callers can defer
+/// consuming a signal until delivery is actually confirmed. Every error is
+/// swallowed and logged at `debug` only. Bounded by both a short connect timeout
+/// and the overall [`SEND_TIMEOUT`] so a down endpoint can never delay the caller.
+async fn post<T: serde::Serialize>(event: &T) -> bool {
     let endpoint = endpoint();
     let client = match reqwest::Client::builder()
         .user_agent(concat!("agent-of-empires/", env!("CARGO_PKG_VERSION")))
@@ -230,7 +239,7 @@ async fn post<T: serde::Serialize>(event: &T) {
         Ok(c) => c,
         Err(e) => {
             tracing::debug!(target: "telemetry", "failed to build client: {e}");
-            return;
+            return false;
         }
     };
     match client
@@ -240,8 +249,16 @@ async fn post<T: serde::Serialize>(event: &T) {
         .send()
         .await
     {
-        Ok(resp) => tracing::debug!(target: "telemetry", status = %resp.status(), "telemetry sent"),
-        Err(e) => tracing::debug!(target: "telemetry", "telemetry send failed: {e}"),
+        Ok(resp) => {
+            let status = resp.status();
+            let ok = status.is_success();
+            tracing::debug!(target: "telemetry", status = %status, ok, "telemetry send completed");
+            ok
+        }
+        Err(e) => {
+            tracing::debug!(target: "telemetry", "telemetry send failed: {e}");
+            false
+        }
     }
 }
 
@@ -249,28 +266,44 @@ async fn post<T: serde::Serialize>(event: &T) {
 /// returns immediately and never blocks the caller.
 pub fn spawn_process_start(surface: Surface) {
     if let Some(event) = build_process_start(surface) {
-        tokio::spawn(async move { post(&event).await });
+        tokio::spawn(async move {
+            post(&event).await;
+        });
     }
 }
 
 /// Emit a `process_start`, awaiting delivery with a hard timeout so the event
-/// has a chance to flush before the process exits. Bounded by the connect and
-/// send timeouts, so a dead endpoint can never hang the caller; a no-op for the
+/// has a chance to flush before the process exits. Returns whether delivery was
+/// *confirmed* (a 2xx), so a throttled caller can defer claiming its slot until
+/// the send actually succeeds. Bounded by the connect and send timeouts, so a
+/// dead endpoint can never hang the caller; a no-op (returns `false`) for the
 /// common default-off (not opted in) case.
-pub async fn flush_process_start(surface: Surface) {
-    if let Some(event) = build_process_start(surface) {
-        let _ = tokio::time::timeout(SEND_TIMEOUT, post(&event)).await;
-    }
+pub async fn flush_process_start(surface: Surface) -> bool {
+    let Some(event) = build_process_start(surface) else {
+        return false;
+    };
+    matches!(
+        tokio::time::timeout(SEND_TIMEOUT, post(&event)).await,
+        Ok(true)
+    )
 }
 
 /// CLI entrypoint for `process_start`: same as [`flush_process_start`] for the
 /// `cli` surface, but throttled to at most once per install per day so a user
-/// scripting `aoe` in a loop can't flood the endpoint. The throttle stamp is
-/// only claimed when opted in, so default-off users never touch disk.
+/// scripting `aoe` in a loop can't flood the endpoint. The daily slot is claimed
+/// only after the send is *confirmed*, so a failed send leaves it open for the
+/// next invocation to retry (bounded by [`CLI_PROCESS_START_RETRY_GAP`] so a down
+/// endpoint can't make every invocation re-send). Nothing touches disk unless
+/// opted in and a send is actually due.
 pub async fn flush_cli_process_start() {
-    if is_opted_in() && state::claim_cli_process_start_slot(CLI_PROCESS_START_MIN_GAP) {
-        flush_process_start(Surface::Cli).await;
+    if !is_opted_in() {
+        return;
     }
+    if !cli_process_start_due(CLI_PROCESS_START_MIN_GAP, CLI_PROCESS_START_RETRY_GAP) {
+        return;
+    }
+    let confirmed = flush_process_start(Surface::Cli).await;
+    record_cli_process_start(confirmed);
 }
 
 /// Fingerprint of the last `usage_snapshot` whose send we initiated this
@@ -305,43 +338,75 @@ fn record_snapshot_fp(snapshot: &UsageSnapshot) {
     }
 }
 
-/// True (and records the new fingerprint) when `snapshot` differs from the last
-/// one we initiated a send for this process; false when it is identical. A
-/// poisoned lock fails open: sending is the safe default.
-fn snapshot_is_new(snapshot: &UsageSnapshot) -> bool {
+/// True when `snapshot` is identical (ignoring `sent_at`) to the last one whose
+/// send we *confirmed* this process. Pure peek, no mutation: the fingerprint is
+/// recorded by [`send_snapshot`] only after a confirmed send, so a failed send
+/// never poisons the dedup cache into dropping a later identical retry. A
+/// poisoned lock reports "not a duplicate", so sending is the safe default.
+fn snapshot_matches_last(snapshot: &UsageSnapshot) -> bool {
     let fp = snapshot_fingerprint(snapshot);
     match LAST_SNAPSHOT_FP.lock() {
-        Ok(mut last) => {
-            let is_new = *last != Some(fp);
-            if is_new {
-                *last = Some(fp);
-            }
-            is_new
-        }
-        Err(_) => true,
+        Ok(last) => *last == Some(fp),
+        Err(_) => false,
     }
 }
 
-/// Send a pre-built usage snapshot, detached. Caller builds via
-/// [`build_usage_snapshot`] (returns `None` when not opted in). Records the
-/// fingerprint so a redundant exit snapshot can be suppressed.
+/// Outcome of a snapshot flush, so a caller can decide whether to consume the
+/// state the snapshot reported (e.g. reset `web_seen` / a create counter).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendOutcome {
+    /// Delivery was confirmed (a 2xx). Safe to consume the reported state.
+    Sent,
+    /// Skipped because identical to the last confirmed send. The prior send
+    /// already consumed the reported state; consume nothing again.
+    Deduped,
+    /// The send failed. Retain the reported state so the next snapshot retries.
+    Failed,
+}
+
+/// Send a pre-built usage snapshot, awaiting delivery with a hard timeout.
+/// Records the dedup fingerprint *only on a confirmed send*, so a failed send
+/// never suppresses a later identical retry. Returns whether delivery was
+/// confirmed. Caller builds via [`build_usage_snapshot`] (returns `None` when
+/// not opted in).
+pub async fn send_snapshot(snapshot: UsageSnapshot) -> bool {
+    let confirmed = matches!(
+        tokio::time::timeout(SEND_TIMEOUT, post(&snapshot)).await,
+        Ok(true)
+    );
+    if confirmed {
+        record_snapshot_fp(&snapshot);
+    }
+    confirmed
+}
+
+/// Send a pre-built usage snapshot, detached. Returns immediately and never
+/// blocks the caller; the fingerprint is recorded inside the spawned task only
+/// on a confirmed send.
 pub fn spawn_snapshot(snapshot: UsageSnapshot) {
-    record_snapshot_fp(&snapshot);
-    tokio::spawn(async move { post(&snapshot).await });
+    tokio::spawn(async move {
+        send_snapshot(snapshot).await;
+    });
 }
 
 /// Send the best-effort snapshot on graceful exit, awaiting delivery with a
 /// hard timeout so the final snapshot can flush without risking a hang, but
 /// skipping the send when the snapshot is identical (ignoring `sent_at`) to the
-/// last one already emitted this run. A boot (or periodic) snapshot followed by
-/// a quit with unchanged session state would otherwise post the same counts
-/// twice within seconds; a snapshot that actually changed still flushes.
-pub async fn flush_snapshot_if_changed(snapshot: UsageSnapshot) {
-    if !snapshot_is_new(&snapshot) {
-        tracing::debug!(target: "telemetry", "exit snapshot unchanged since last emit; skipping duplicate");
-        return;
+/// last one already confirmed this run. A boot (or periodic) snapshot followed
+/// by a quit with unchanged session state would otherwise post the same counts
+/// twice within seconds; a snapshot that actually changed still flushes. The
+/// returned [`SendOutcome`] lets the caller consume reported state only when the
+/// send was actually confirmed.
+pub async fn flush_snapshot_if_changed(snapshot: UsageSnapshot) -> SendOutcome {
+    if snapshot_matches_last(&snapshot) {
+        tracing::debug!(target: "telemetry", "exit snapshot unchanged since last confirmed emit; skipping duplicate");
+        return SendOutcome::Deduped;
     }
-    let _ = tokio::time::timeout(SEND_TIMEOUT, post(&snapshot)).await;
+    if send_snapshot(snapshot).await {
+        SendOutcome::Sent
+    } else {
+        SendOutcome::Failed
+    }
 }
 
 #[cfg(test)]
@@ -417,7 +482,8 @@ mod tests {
     fn exit_snapshot_dedups_against_boot_but_resends_on_change() {
         *LAST_SNAPSHOT_FP.lock().unwrap() = None;
 
-        // Boot emit records the fingerprint (this is what spawn_snapshot does).
+        // A confirmed boot send records the fingerprint (this is what
+        // `send_snapshot` does on success).
         let boot = sample_snapshot();
         record_snapshot_fp(&boot);
 
@@ -427,25 +493,47 @@ mod tests {
         let mut exit = sample_snapshot();
         exit.sent_at = "2026-06-02T19:00:47Z".to_string();
         assert!(
-            !snapshot_is_new(&exit),
+            snapshot_matches_last(&exit),
             "an unchanged exit snapshot must dedupe against the boot snapshot"
         );
 
-        // A snapshot whose counts actually changed is new and would be sent,
-        // and then becomes the new baseline.
+        // A snapshot whose counts actually changed is not a duplicate, so it
+        // would be sent; a confirmed send then makes it the new baseline.
         let mut changed = sample_snapshot();
         changed.session_total = 8;
         assert!(
-            snapshot_is_new(&changed),
+            !snapshot_matches_last(&changed),
             "a changed snapshot must still be emitted"
         );
+        record_snapshot_fp(&changed);
         let mut changed_again = changed.clone();
         changed_again.sent_at = "2026-06-02T19:05:00Z".to_string();
         assert!(
-            !snapshot_is_new(&changed_again),
+            snapshot_matches_last(&changed_again),
             "repeating the latest snapshot dedups against it"
         );
 
+        *LAST_SNAPSHOT_FP.lock().unwrap() = None;
+    }
+
+    // The fingerprint is recorded only by `send_snapshot` on a confirmed send,
+    // never by `snapshot_matches_last` (a pure peek). So checking a snapshot
+    // without a confirmed send must not poison the dedup cache: a failed boot
+    // send leaves the next identical snapshot eligible to retry, instead of
+    // being silently dropped as a "duplicate" of something never delivered.
+    #[test]
+    #[serial]
+    fn peek_does_not_record_fingerprint() {
+        *LAST_SNAPSHOT_FP.lock().unwrap() = None;
+        let snap = sample_snapshot();
+        assert!(
+            !snapshot_matches_last(&snap),
+            "first peek must not match an empty cache"
+        );
+        assert!(
+            !snapshot_matches_last(&snap),
+            "peeking must not record the fingerprint, so it still does not match"
+        );
         *LAST_SNAPSHOT_FP.lock().unwrap() = None;
     }
 }

--- a/src/telemetry/sanitize.rs
+++ b/src/telemetry/sanitize.rs
@@ -31,6 +31,30 @@ pub fn agent_bucket(agent: &str) -> String {
     "custom".to_string()
 }
 
+/// How a family needle is matched against a model string.
+#[derive(Clone, Copy)]
+enum Needle {
+    /// Plain substring. Safe for distinctive needles long enough not to collide
+    /// (`claude`, `gpt`, `gemini`, ...).
+    Substr(&'static str),
+    /// Whole-token match: the needle must equal a token of the model string when
+    /// split on non-alphanumeric boundaries. Required for the 2-char OpenAI
+    /// tokens (`o1` / `o3` / `o4`) so `o3-mini` buckets as openai but `kilo3` or
+    /// `macro1` do not. `o3` is a token of `o3-mini` but not of `kilo3`.
+    Token(&'static str),
+}
+
+impl Needle {
+    fn matches(self, lower: &str) -> bool {
+        match self {
+            Needle::Substr(n) => lower.contains(n),
+            Needle::Token(n) => lower
+                .split(|c: char| !c.is_ascii_alphanumeric())
+                .any(|tok| tok == n),
+        }
+    }
+}
+
 /// Coarse family bucket for a model string. Never emits the raw value; maps
 /// to a small fixed vocabulary so an internal/custom model name can't leak.
 ///
@@ -40,18 +64,37 @@ pub fn model_bucket(model: Option<&str>) -> &'static str {
         return "unset";
     };
     let lower = model.to_ascii_lowercase();
-    const FAMILIES: &[(&str, &[&str])] = &[
-        ("claude", &["claude", "sonnet", "opus", "haiku"]),
-        ("openai", &["gpt", "openai", "codex", "o1", "o3", "o4"]),
-        ("gemini", &["gemini"]),
-        ("qwen", &["qwen"]),
-        ("grok", &["grok"]),
-        ("llama", &["llama"]),
-        ("mistral", &["mistral", "mixtral"]),
-        ("deepseek", &["deepseek"]),
+    use Needle::{Substr, Token};
+    const FAMILIES: &[(&str, &[Needle])] = &[
+        (
+            "claude",
+            &[
+                Substr("claude"),
+                Substr("sonnet"),
+                Substr("opus"),
+                Substr("haiku"),
+            ],
+        ),
+        (
+            "openai",
+            &[
+                Substr("gpt"),
+                Substr("openai"),
+                Substr("codex"),
+                Token("o1"),
+                Token("o3"),
+                Token("o4"),
+            ],
+        ),
+        ("gemini", &[Substr("gemini")]),
+        ("qwen", &[Substr("qwen")]),
+        ("grok", &[Substr("grok")]),
+        ("llama", &[Substr("llama")]),
+        ("mistral", &[Substr("mistral"), Substr("mixtral")]),
+        ("deepseek", &[Substr("deepseek")]),
     ];
     for (family, needles) in FAMILIES {
-        if needles.iter().any(|n| lower.contains(n)) {
+        if needles.iter().any(|n| n.matches(&lower)) {
             return family;
         }
     }
@@ -96,5 +139,46 @@ mod tests {
         assert_eq!(model_bucket(Some("   ")), "unset");
         // An internal/unknown model name must collapse to "other", not leak.
         assert_eq!(model_bucket(Some("acme-internal-v2")), "other");
+    }
+
+    // #1876: the short OpenAI tokens o1/o3/o4 are matched on a boundary, not as a
+    // bare substring, so a name that merely contains those two chars adjacent
+    // does not over-count as openai.
+    #[test]
+    fn short_openai_tokens_do_not_false_positive() {
+        for name in [
+            "kilo3",
+            "macro1-7b",
+            "kilo3-experimental",
+            "halo4",
+            "mono1x",
+        ] {
+            assert_eq!(
+                model_bucket(Some(name)),
+                "other",
+                "`{name}` must not bucket as openai"
+            );
+        }
+    }
+
+    #[test]
+    fn real_openai_models_still_bucket() {
+        for name in [
+            "o1",
+            "o1-mini",
+            "o1-preview",
+            "o3",
+            "o3-mini",
+            "o4-mini",
+            "gpt-5",
+            "gpt-4o",
+            "codex",
+        ] {
+            assert_eq!(
+                model_bucket(Some(name)),
+                "openai",
+                "`{name}` must bucket as openai"
+            );
+        }
     }
 }

--- a/src/telemetry/state.rs
+++ b/src/telemetry/state.rs
@@ -17,11 +17,17 @@ use crate::session::get_app_dir;
 struct TelemetryState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     install_id: Option<String>,
-    /// Last time a CLI `process_start` was emitted, used to throttle the one
-    /// unbounded event source to at most once per install per day. Long-lived
-    /// surfaces (TUI / serve) emit once per launch and need no throttle.
+    /// Last time a CLI `process_start` was *confirmed delivered*, used to throttle
+    /// the one unbounded event source to at most once per install per day. Long-lived
+    /// surfaces (TUI / serve) emit once per launch and need no throttle. Only stamped
+    /// on a successful send, so a failed send leaves the daily slot open for retry.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     last_cli_process_start: Option<DateTime<Utc>>,
+    /// Last time a CLI `process_start` send was *attempted* (success or failure).
+    /// Bounds retries: while the daily slot is open after a failed send, this stops
+    /// every `aoe` invocation from re-attempting against a down endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_cli_process_start_attempt: Option<DateTime<Utc>>,
 }
 
 fn state_path() -> Result<PathBuf> {
@@ -97,28 +103,37 @@ pub fn reset_install_id() -> Option<String> {
     ensure_install_id()
 }
 
-/// Claim the once-per-`min_gap` CLI `process_start` slot. Returns `true` and
-/// stamps "now" when the last emission is older than `min_gap` (or never),
-/// `false` otherwise. This bounds the only unbounded telemetry source: a user
-/// scripting `aoe` in a loop emits at most one CLI `process_start` per window
-/// instead of one per invocation. Caller is responsible for the opt-in gate.
-pub fn claim_cli_process_start_slot(min_gap: Duration) -> bool {
+/// Whether a CLI `process_start` send is due. Due when the last *confirmed*
+/// send is older than `success_gap` (or never) AND the last *attempt* is older
+/// than `retry_gap` (or never). `success_gap` is the real once-per-day throttle
+/// that bounds the only unbounded telemetry source; `retry_gap` bounds how often
+/// a failed send is retried so a down endpoint can't turn every `aoe` invocation
+/// into a fresh attempt. Caller is responsible for the opt-in gate. Read-only:
+/// the stamps are written by [`record_cli_process_start`] after the send.
+pub fn cli_process_start_due(success_gap: Duration, retry_gap: Duration) -> bool {
+    let state = load_state();
+    let now = Utc::now();
+    // A stamp is "fresh" when its positive elapsed is still inside the gap. A
+    // negative elapsed (clock skew) counts as not fresh, so the send is allowed.
+    let fresh = |stamp: Option<DateTime<Utc>>, gap: Duration| match stamp {
+        Some(last) => matches!((now - last).to_std(), Ok(elapsed) if elapsed < gap),
+        None => false,
+    };
+    !fresh(state.last_cli_process_start, success_gap)
+        && !fresh(state.last_cli_process_start_attempt, retry_gap)
+}
+
+/// Record a CLI `process_start` send. Always stamps the attempt (so `retry_gap`
+/// bounds retries); stamps the confirmed-delivery slot only when `success`, so a
+/// failed send leaves the daily slot open for the next invocation to retry.
+pub fn record_cli_process_start(success: bool) {
     let mut state = load_state();
     let now = Utc::now();
-    if let Some(last) = state.last_cli_process_start {
-        // A positive elapsed shorter than the window means "too soon". A
-        // negative elapsed (clock skew) falls through and is allowed.
-        if let Ok(elapsed) = (now - last).to_std() {
-            if elapsed < min_gap {
-                return false;
-            }
-        }
+    state.last_cli_process_start_attempt = Some(now);
+    if success {
+        state.last_cli_process_start = Some(now);
     }
-    state.last_cli_process_start = Some(now);
     if let Err(e) = save_state(&state) {
-        // Persisting the stamp failed; allow this send rather than dropping it,
-        // and try again to persist next time.
         tracing::debug!(target: "telemetry", "failed to persist cli throttle stamp: {e}");
     }
-    true
 }

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -124,6 +124,25 @@ fn snapshot_buckets_are_sanitized() {
     }
 }
 
+/// User story (#1874): the create-trend counter carries a real value. When N
+/// sessions were created during the window, the snapshot reports
+/// `session_creates_since_last_snapshot == N`; with none created it reports 0.
+#[test]
+#[serial]
+fn snapshot_carries_session_create_count() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let none = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 0)
+        .expect("snapshot built when opted in");
+    assert_eq!(none.session_creates_since_last_snapshot, 0);
+
+    let some = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 7)
+        .expect("snapshot built when opted in");
+    assert_eq!(some.session_creates_since_last_snapshot, 7);
+}
+
 /// The CLI `process_start` is throttled to once per install per day so a user
 /// scripting `aoe` in a loop can't flood the endpoint: a send is due first, then
 /// not due once a confirmed send claims the daily slot.

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -125,8 +125,8 @@ fn snapshot_buckets_are_sanitized() {
 }
 
 /// The CLI `process_start` is throttled to once per install per day so a user
-/// scripting `aoe` in a loop can't flood the endpoint: the first claim in a
-/// window succeeds, the next is denied.
+/// scripting `aoe` in a loop can't flood the endpoint: a send is due first, then
+/// not due once a confirmed send claims the daily slot.
 #[test]
 #[serial]
 fn cli_process_start_throttled_to_once_per_window() {
@@ -135,18 +135,52 @@ fn cli_process_start_throttled_to_once_per_window() {
     telemetry::apply_opt_in_change(true);
 
     let day = std::time::Duration::from_secs(24 * 60 * 60);
+    let hour = std::time::Duration::from_secs(60 * 60);
     assert!(
-        telemetry::claim_cli_process_start_slot(day),
-        "first claim in the window should be granted"
+        telemetry::cli_process_start_due(day, hour),
+        "first send in the window should be due"
     );
+    // A confirmed send claims the daily slot.
+    telemetry::record_cli_process_start(true);
     assert!(
-        !telemetry::claim_cli_process_start_slot(day),
-        "second claim within the window should be denied"
+        !telemetry::cli_process_start_due(day, hour),
+        "within the day, no further send is due after a confirmed send"
     );
-    // A zero-length window always re-grants (the stamp is always older).
-    assert!(telemetry::claim_cli_process_start_slot(
+    // Zero gaps always re-grant (every stamp is always older than zero).
+    assert!(telemetry::cli_process_start_due(
+        std::time::Duration::ZERO,
         std::time::Duration::ZERO
     ));
+}
+
+/// User story (#1875): when a CLI `process_start` send fails, the daily throttle
+/// slot is NOT consumed, so the next invocation retries instead of losing the
+/// whole day to one transient failure. The retry gap still bounds how often the
+/// failed send is re-attempted.
+#[test]
+#[serial]
+fn failed_cli_process_start_leaves_daily_slot_open() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let day = std::time::Duration::from_secs(24 * 60 * 60);
+    let hour = std::time::Duration::from_secs(60 * 60);
+
+    // Simulate a failed send: it stamps the attempt but never claims the slot.
+    telemetry::record_cli_process_start(false);
+
+    // The retry gap blocks an immediate re-attempt against a still-down endpoint.
+    assert!(
+        !telemetry::cli_process_start_due(day, hour),
+        "retry gap must block an immediate re-attempt after a failed send"
+    );
+    // But the daily slot is still open: once the retry gap elapses, a send is due
+    // again, unlike the old behaviour that lost the whole day on one failure.
+    assert!(
+        telemetry::cli_process_start_due(day, std::time::Duration::ZERO),
+        "a failed send must leave the daily slot open for retry"
+    );
 }
 
 /// An unreachable / slow endpoint must never block the CLI: `flush_process_start`


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Three linked telemetry data-correctness fixes, all follow-ups to the opt-in telemetry in #1863. Each made a shipped wire field carry wrong or no signal; this PR makes them truthful.

**#1874 - create-trend counter was always 0.** `usage_snapshot.session_creates_since_last_snapshot` was a wire field that every producer passed a literal `0` for, so it carried no signal (and #1870's design rests on it). `aoe serve` now keeps a process-local create counter, incremented in the `create_session` handler, and the snapshot reports it. Per the issue's open question this is serve-only for now (the TUI is short-lived and #1870 frames it as "almost entirely a serve win"); the TUI counter is tracked as a follow-up in #1897.

**#1875 - signals silently lost on send failure.** Sends were fire-and-forget and treated any transport `Ok` (including a 4xx/5xx rejection at the gateway) as success, while consuming local state before the POST was confirmed. A failed send permanently dropped that window's `web_seen` / `cockpit_seen` and the day's CLI `process_start`. Now `post()` returns whether delivery was confirmed (transport `Ok` and a 2xx), and state is consumed only on a confirmed send: the CLI daily slot is claimed only on success (failed sends retry, bounded to once per hour), and the serve seen-flags plus the new create counter are cleared only after a confirmed snapshot. The same fix corrects an adjacent bug surfaced in review: the dedup fingerprint was recorded before the send, so a failed boot send could poison the cache into dropping a later identical retry.

**#1876 - aggregation accuracy.** `model_bucket` matched the 2-char OpenAI tokens `o1`/`o3`/`o4` as bare substrings, so names like `kilo3` or `macro1` over-counted as `openai`; they now require a whole-token boundary match while distinctive needles stay substring matches. The `features` map is documented as the global install default (pre-profile-merge), an install-level adoption signal, rather than being silently misread as per-session usage.

Closes #1874
Closes #1875
Closes #1876

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Point `AOE_TELEMETRY_ENDPOINT` at a local sink, opt in, and run `aoe serve`; create a session via the dashboard and confirm the next `usage_snapshot` reports `session_creates_since_last_snapshot` > 0, then `0` again on the following snapshot.
- [ ] With the local sink returning a 5xx, opt in and run `aoe <subcommand>` twice within a day; confirm the second invocation still attempts a CLI `process_start` (the daily slot was not consumed by the failed send).
- [ ] With the local sink up again, confirm the daily CLI `process_start` slot is then claimed and a same-day re-run does not re-send.
- [ ] Open the web dashboard against a failing sink; confirm `web_seen` stays set and is reported again on the next snapshot rather than being lost.
- [ ] Confirm a model name like `kilo3` buckets as `other` and `o3-mini` buckets as `openai` in the emitted snapshot.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Skipped a test, because: the changes are backend telemetry only (no TUI rendering or CLI subcommand behavior change). Regression coverage lives in Rust unit/integration tests: `tests/telemetry.rs` (create count carried, failed send leaves the CLI slot open), `src/server/mod.rs` (create-counter decrement preserves concurrent creates), and `src/telemetry/sanitize.rs` (model-bucket false-positive table).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (with a multi-model `/debate` consult), and implementation drafted by Claude under my direction. I made the design calls (serve-only counter, keep-global features semantic), reviewed each commit, and own the test steps above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Telemetry Correctness Fixes

## What changed (high-level)
This PR implements three linked fixes that make telemetry data more accurate and resilient:

- Session create counter: serve now tracks sessions created since the last telemetry snapshot and reports/reset that count (TUI still reports 0 for now).
- Send semantics and retry behavior: telemetry is only finalized/consumed after confirmed delivery (HTTP 2xx). Failed sends no longer permanently drop signals; CLI daily process_start claims are only recorded after success and retries are bounded.
- Model bucketing and feature semantics: short OpenAI tokens (o1/o3/o4) are matched only at whole-token boundaries to avoid false positives; the `features` map is documented/treated as the install-wide default (pre-profile-merge), not per-session active-profile values.

Also includes documentation updates and tests for all three areas.

## Benefits
- More reliable telemetry (prevents silent loss on send failures).
- Accurate session-create counts in serve snapshots.
- Fewer false positives in model attribution.
- Clearer semantics for feature reporting and better-controlled retry/backoff behavior.

## Notable code-level changes
- serve: added a process-local atomic counter for session creates and converted seen flags to monotonic AtomicU32 counters; introduced telemetry_last_reported to defer clearing until confirmed sends.
- telemetry sending: post/send now returns delivery outcome; new SendOutcome enum (Sent, Deduped, Failed); dedup fingerprints and state mutations are recorded only after confirmed sends.
- CLI throttle state: replaced single claim API with cli_process_start_due(success_gap, retry_gap) and record_cli_process_start(success) to separate "is due" checks from "record result" and bound retry behavior.
- sanitization: introduced a Needle matcher supporting substring and whole-token matches; model_bucket uses token matches for short OpenAI tokens.
- tests & docs: updated telemetry docs and added tests covering session counts, send-failure behavior and retry semantics, and model bucketing edge cases.

## Potential follow-ups / considerations
- TUI session-create counter tracked separately (`#1897`); consider consolidating serve/TUI reporting for consistency.
- Review backoff parameters and observability for repeated send failures to ensure visibility without excessive retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->