### PR TITLE
fix(ci): fix weekly release-PR schedule drops and template-check false positive

### DIFF
--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,6 +1,6 @@
 name: Open Release PR
 
-# Weekly release-staging PR (#1140). Runs every Wednesday at 09:00 UTC,
+# Weekly release-staging PR (#1140). Runs every Wednesday at 08:17 UTC,
 # computes the next-patch version from the latest `v*` tag, bumps
 # `Cargo.toml` + `Cargo.lock`, and opens a PR labeled `release-staging`
 # with a plain newest-first commit list in the body. Merging that PR
@@ -20,9 +20,12 @@ name: Open Release PR
 
 on:
   schedule:
-    # Every Wednesday at 09:00 UTC. Cron strings are interpreted in UTC
+    # Every Wednesday at 08:17 UTC. Cron strings are interpreted in UTC
     # regardless of repo timezone, so this stays stable across DST shifts.
-    - cron: '0 9 * * 3'
+    # The off-hour minute (:17, not :00) avoids GitHub's top-of-hour
+    # scheduled-run congestion, which was dropping or heavily delaying
+    # the previous 09:00 trigger.
+    - cron: '17 8 * * 3'
   workflow_dispatch:
     inputs:
       bump:

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -56,7 +56,18 @@ jobs:
               body.includes('<!-- nix-npm-hash:') &&
               body.includes('## Checklist');
 
-            const hasChecklist = hasAllTemplateSections || isNixNpmHashBotPr;
+            // Escape hatch for the weekly release-staging PR
+            // (`.github/workflows/open-release-pr.yml`), whose body is a
+            // version bump plus changelog, not the contributor template.
+            // It carries a `<!-- release-version: -->` marker; gate on
+            // actor login = github-actions[bot] so a human PR cannot opt
+            // out by pasting the marker into its body.
+            const isReleaseStagingBotPr =
+              actor === 'github-actions[bot]' &&
+              body.includes('<!-- release-version:');
+
+            const hasChecklist =
+              hasAllTemplateSections || isNixNpmHashBotPr || isReleaseStagingBotPr;
 
             const prNumber = context.payload.pull_request.number;
             const labelName = 'missing-template';
@@ -168,6 +179,15 @@ jobs:
               // Skip Dependabot PRs
               if (pr.user?.login === 'dependabot[bot]') {
                 console.log(`Skipping Dependabot PR #${pr.number}`);
+                continue;
+              }
+
+              // Skip the weekly release-staging PR; its body is exempt
+              // from the template check above, so it should never be
+              // closed for missing it.
+              if (pr.user?.login === 'github-actions[bot]' &&
+                  (pr.body || '').includes('<!-- release-version:')) {
+                console.log(`Skipping release-staging PR #${pr.number}`);
                 continue;
               }
 


### PR DESCRIPTION
## Description

Two fixes to the weekly release-staging automation (`open-release-pr.yml`).

**1. Cron moved off top-of-hour.** The trigger was `0 9 * * 3` (09:00 UTC Wednesday). GitHub's scheduled-run queue is most congested at the top of the hour, so it was being heavily delayed or dropped:

- 2026-05-27: fired at 10:23 UTC (84 min late).
- 2026-06-03: no run record at all (dropped under load); the daily `PR Template Check` cron'd at `0 0` likewise slipped to 04:08 UTC the same day, confirming top-of-hour congestion rather than a config or token fault.

Moved to `17 8 * * 3` (08:17 UTC Wednesday): still morning UTC, off-hour minute that sidesteps the `:00` congestion window.

**2. Release-staging PR exempted from the template check.** The release PR body is a version bump plus changelog, not the contributor template, so `pr-template-check.yml` was labeling it `missing-template` and queuing it for 24h auto-close. Added a `<!-- release-version: -->` marker escape hatch to both the template check and the stale-close sweep, gated on `github-actions[bot]` author (same shape as the existing nix-npm-hash exemption, so a human PR cannot opt out by pasting the marker).

No workflow-body behavior change beyond the trigger time and the new exemption.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:** Investigated the missed schedule and the template-check false positive, then wrote both fixes.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR moves the weekly release-staging PR workflow off the top-of-hour to avoid GitHub Actions scheduler congestion and adds exemptions so the generated release PRs aren't flagged or auto-closed by the template-check workflow.

## What changed (high-level)
- Updated the scheduled trigger for the weekly "Open Release PR" workflow from 09:00 UTC Wednesday to 08:17 UTC Wednesday (moves run to an off-minute).
- Updated comments/headers in the workflow to reflect the new cron and note UTC/off-minute rationale.
- Expanded the PR template-check workflow to exempt automation-generated release PRs authored by github-actions[bot] when the PR body contains a release-version marker, and to skip stale-close for those PRs.

## Benefits
- Reduces likelihood of scheduled runs being delayed or dropped by avoiding top-of-hour scheduler congestion.
- Prevents the automated template enforcement and stale-close jobs from falsely marking or closing the weekly release-staging PR.
- Keeps the release process reliable while preserving existing workflow logic.

## Technical notes
- Workflow changes are limited to triggers, comments, and matching logic; no core workflow job logic was altered.
- open-release-pr.yml: cron changed from `0 9 * * 3` → `17 8 * * 3`.
- pr-template-check.yml: template presence guard and stale-close skip expanded to detect `github-actions[bot]` PRs containing a `<!-- release-version:` marker.
- Lines changed across both files: small footprint (+/− as indicated in PR metadata).

## Evidence motivating the change
- Observed late and missing runs: 2026-05-27 ran 84 minutes late; 2026-06-03 had no run recorded. A separate daily cron also slipped the same day, consistent with top-of-hour congestion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->