### PR TITLE
fix(cockpit): skip session/set_mode for modes the agent has not advertised

### DIFF
--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -3490,6 +3490,31 @@ fn truncate_for_log(s: &str, max_bytes: usize) -> String {
     out
 }
 
+/// Whether the agent advertised the given mode ID in its session modes
+/// or config-option mode category.
+///
+/// Returns `false` (skip) when:
+/// - `available_mode_ids` is `Some` and the normalized mode_id is not in the list, or
+/// - `available_mode_ids` is `None` and the agent uses config-option modes
+///   (session/set_mode won't work for arbitrary mode IDs).
+///
+/// Returns `true` (allow) only when there is no mode information at all
+/// (e.g. the test shim, which handles all set_mode requests).
+fn is_mode_advertised(
+    mode_id: &str,
+    available_mode_ids: &Option<Vec<String>>,
+    has_config_option_mode: bool,
+) -> bool {
+    match available_mode_ids {
+        Some(ids) => {
+            let normalized = mode_id.replace('_', "").to_lowercase();
+            ids.iter()
+                .any(|id| id.replace('_', "").to_lowercase() == normalized)
+        }
+        None => !has_config_option_mode,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_connection_task<W, R>(
     transport: ByteStreams<W, R>,
@@ -3860,6 +3885,16 @@ async fn run_connection_task<W, R>(
                 "initialize handshake complete"
             );
 
+            // Track the mode channels the agent advertised so we can skip
+            // session/set_mode requests for modes the agent doesn't support.
+            // When new_session.modes is present, only those IDs are valid.
+            // When config-options have a Mode category, the agent uses
+            // session/set_config_option for modes instead of session/set_mode.
+            // If neither is present (e.g. test shim), allow all set_mode
+            // requests through.
+            let mut available_mode_ids: Option<Vec<String>> = None;
+            let mut has_config_option_mode: bool = false;
+
             let acp_session_id: SessionId = match mode {
                 ConnectMode::Resume {
                     acp_session_id: stored,
@@ -3939,6 +3974,32 @@ async fn run_connection_task<W, R>(
                                         stored_id = %stored,
                                         "session/load succeeded; suppressing post-load history replay"
                                     );
+                                    // Capture available mode info from the
+                                    // load response before consuming resp.
+                                    let modes = resp.modes.as_ref().map(|m| {
+                                        m.available_modes
+                                            .iter()
+                                            .map(|mode| mode.id.0.to_string())
+                                            .collect::<Vec<_>>()
+                                    });
+                                    if modes.is_some() {
+                                        available_mode_ids = modes;
+                                    }
+                                    if resp
+                                        .config_options
+                                        .as_ref()
+                                        .is_some_and(|opts| {
+                                            opts.iter().any(|o| {
+                                                o.category
+                                                    == Some(
+                                                        agent_client_protocol::schema::
+                                                            SessionConfigOptionCategory::Mode,
+                                                    )
+                                            })
+                                        })
+                                    {
+                                        has_config_option_mode = true;
+                                    }
                                     // Emit AcpSessionAssigned even on resume so the
                                     // frontend reducer can clear any sticky
                                     // `startupError` / `lastError` from a prior crash
@@ -3999,6 +4060,34 @@ async fn run_connection_task<W, R>(
                             new_id = %id.0,
                             "session/new succeeded, captured acp_session_id"
                         );
+
+                        // Capture available mode IDs and config-option mode
+                        // category so the SetMode handlers below can skip
+                        // modes the agent has not advertised.
+                        if let Some(modes) = &new_session.modes {
+                            available_mode_ids = Some(
+                                modes
+                                    .available_modes
+                                    .iter()
+                                    .map(|m| m.id.0.to_string())
+                                    .collect(),
+                            );
+                        }
+                        if new_session
+                            .config_options
+                            .as_ref()
+                            .is_some_and(|opts| {
+                                opts.iter().any(|o| {
+                                    o.category
+                                        == Some(
+                                            agent_client_protocol::schema::
+                                                SessionConfigOptionCategory::Mode,
+                                        )
+                                })
+                            })
+                        {
+                            has_config_option_mode = true;
+                        }
 
                         // Surface the agent-advertised modes (if any) so the UI
                         // can render the actual modes the agent supports rather
@@ -4515,6 +4604,20 @@ async fn run_connection_task<W, R>(
                                             });
                                         }
                                         Some(ClientCmd::SetMode(mode_id)) => {
+                                            // Skip when the agent has not
+                                            // advertised this mode (see the
+                                            // mode-tracking comments above).
+                                            if !is_mode_advertised(
+                                                &mode_id,
+                                                &available_mode_ids,
+                                                has_config_option_mode,
+                                            ) {
+                                                debug!(
+                                                    target: "cockpit.acp",
+                                                    "skipping session/set_mode mode={mode_id}: not advertised (mid-turn)"
+                                                );
+                                                continue;
+                                            }
                                             info!(
                                                 target: "cockpit.acp",
                                                 "sending session/set_mode mode={mode_id} during in-flight prompt"
@@ -4720,6 +4823,19 @@ async fn run_connection_task<W, R>(
                             .send_notification(CancelNotification::new(acp_session_id.clone()));
                     }
                     Some(ClientCmd::SetMode(mode_id)) => {
+                        // Skip when the agent has not advertised this mode
+                        // (see the mode-tracking comments above).
+                        if !is_mode_advertised(
+                            &mode_id,
+                            &available_mode_ids,
+                            has_config_option_mode,
+                        ) {
+                            debug!(
+                                target: "cockpit.acp",
+                                "skipping session/set_mode mode={mode_id}: not advertised"
+                            );
+                            continue;
+                        }
                         info!(target: "cockpit.acp", "sending session/set_mode mode={mode_id}");
                         // Detached, same shape as the mid-turn path: don't
                         // freeze the cmd_rx loop on the round-trip.


### PR DESCRIPTION
## Description

The post-spawn `set_mode("bypassPermissions")` call in the cockpit supervisor was always failing with a "mode not found" banner for agents that don't advertise that mode. OpenCode uses the config-option mode channel (build/plan) rather than ACP session modes, so every cockpit session with `yolo=true` showed a `ModeSwitchFailed` banner.

Added a guard in the connection task's SetMode handlers that checks whether the agent advertised the requested mode either through `new_session.modes` or through the config-option mode category. When neither channel advertises the mode, silently skip the request instead of emitting `ModeSwitchFailed`.

**Before:** Every opencode cockpit session with YOLO on showed a red banner: "Mode bypassPermissions is not available."  
**After:** The banner is gone. YOLO mode works for agents that advertise bypass support (claude-agent-acp with ALLOW_BYPASS) and is silently skipped for agents that don't (opencode, and any future agent using config-option modes).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (opencode/big-pickle)

**Any Additional AI Details you'd like to share:** The complete `/aoe-implement` skill workflow was used: issue investigation, plan with three proposals, user-approved plan with tweak, implementation with server-side guard, pre-PR validation (3458 tests pass, clippy clean, cargo fmt clean), and PR creation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

Closes #1906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Added intelligent mode-checking logic to the cockpit supervisor's connection task to prevent attempting to switch modes that agents don't advertise.

### High-Level Summary

The PR fixes a persistent issue where cockpit sessions with `yolo_mode=true` would show a "mode not found" error banner when connecting to agents that don't support the `bypassPermissions` mode. This affected agents like OpenCode, which expose their modes through a different mechanism (config-option categories like `build`/`plan`) rather than through standard session modes.

**What was added:**
- A mode-checking helper function that validates whether a requested mode is actually advertised by the agent
- State tracking during the initial handshake to record which modes the agent supports and how it exposes them (either via session modes list or config-option category)
- Guards at two SetMode request points (mid-turn and no-prompt) that skip sending mode-switch requests for modes the agent doesn't advertise

**The benefit:** Sessions now proceed silently in default mode when a requested mode isn't available, instead of generating a failed mode-switch error. Agents that do advertise modes continue to work as before.

---

## Technical Details

### Implementation

A new helper function `is_mode_advertised()` checks three conditions:
1. If the agent advertises a `modes` list, it normalizes and compares the requested mode against it (handling underscore/case variations)
2. If the agent doesn't have a modes list but does advertise a config-option `Mode` category, the request is skipped (since that agent uses config-options for mode selection)
3. If neither exists (e.g., test shim), the request is allowed through

The connection task now maintains two state variables initialized after the ACP handshake:
- `available_mode_ids`: populated from either `LoadSessionResponse.modes` or `NewSessionResponse.modes`
- `has_config_option_mode`: set when `config_options` contains a `Mode` category

Both SetMode command paths (in-flight prompt and detached command) check mode availability before issuing a `SetSessionModeRequest`. Skipped requests are logged at debug level instead of warning level.

### Code Coverage

- Added 116 lines of code (guards, helper function, and mode-tracking logic)
- No public API changes
- No alterations to exported entities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->