### PR TITLE
fix(session): gate RECOVERY_HOOK_TIMEOUT_FLOOR to debug builds

### DIFF
--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -265,6 +265,7 @@ pub const RECOVERY_HOOK_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Lower bound on `AOE_RECOVERY_HOOK_TIMEOUT_MS` so a misconfigured test
 /// cannot race fork+exec and trip the timeout before the child spawns.
+#[cfg(debug_assertions)]
 const RECOVERY_HOOK_TIMEOUT_FLOOR: Duration = Duration::from_millis(50);
 
 /// Resolve the recovery hook timeout. Release builds always return


### PR DESCRIPTION
## Description

`cargo build --profile dev-release` (and `--release`) emit a `dead_code` warning:

```
warning: constant `RECOVERY_HOOK_TIMEOUT_FLOOR` is never used
   --> src/session/recovery.rs:268:7
```

The constant's only reader is the `#[cfg(debug_assertions)]` branch of `recovery_hook_timeout()`. Optimized profiles disable `debug_assertions`, so the constant has no readers there and trips `dead_code`. This gates the definition with the same `#[cfg(debug_assertions)]` so its presence tracks its sole use. No `#[allow(dead_code)]` (forbidden by repo guidelines), and the intra-doc link in the function's doc comment still resolves.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Verified by building under both configs: `cargo build` (debug, constant used) and `cargo build --features serve --profile dev-release` (optimized, warning gone). `cargo doc` under `dev-release` confirms no broken intra-doc link for the constant.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Diagnosis and one-line fix drafted by Claude via back-and-forth with @njbrake; reasoning and decision are his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

A single conditional compilation attribute (`#[cfg(debug_assertions)]`) was added to the `RECOVERY_HOOK_TIMEOUT_FLOOR` constant definition in `src/session/recovery.rs`. The constant now only exists in debug builds, matching where it's actually used.

## The Problem & Solution

The `RECOVERY_HOOK_TIMEOUT_FLOOR` constant is only referenced inside a debug-only code block (used by `recovery_hook_timeout()` to clamp minimum timeout values during testing). When building with optimized profiles like `--release` or `--profile dev-release`, debug assertions are disabled, leaving the constant entirely unused and triggering a compiler dead code warning.

By conditionally compiling the constant definition itself with `#[cfg(debug_assertions)]`, the constant no longer exists in release builds, eliminating the warning. No logic was changed, and the intra-doc link in the function's documentation comment still resolves correctly.

## Benefits

- **Cleaner builds**: Removes dead code warnings from optimized/release builds without needing suppression pragmas
- **Semantic clarity**: The constant's presence now directly matches its sole usage context (debug builds only)
- **No documentation issues**: Verified that `cargo doc` still works correctly with no broken links
- **Minimal change**: Single-line addition with no impact on runtime behavior, control flow, or public APIs

## Technical Details

The fix uses Rust's `#[cfg(debug_assertions)]` conditional compilation attribute, which activates only when the `debug_assertions` config option is enabled (standard in debug builds, disabled in release/optimized profiles). This is a compile-time gating mechanism that ensures the constant is only compiled where it's needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->