### PR TITLE
fix(cockpit): respect agent_command_override in aoe add --cmd gates

### DIFF
--- a/docs/guides/agent-override.md
+++ b/docs/guides/agent-override.md
@@ -41,6 +41,12 @@ Finally, an agent command override can also be used via the CLI using the `aoe a
 aoe add --cmd-override <CMD_OVERRIDE>
 ```
 
+A configured override also applies to plain `aoe add --cmd <agent>` (without `--cmd-override`): the agent name
+resolves through `agent_command_override` just as it does in the TUI. This means the override is honored consistently
+whether the session is started from the TUI, a tmux CLI session, or a `--cockpit` session. The on-PATH check that
+`aoe add` runs before creating the session verifies the resolved override binary, so a session works even when only the
+wrapper (for example `opencode-plannotator`) is installed and the bare agent binary (`opencode`) is not.
+
 ## Priority order
 
 As mentioned in the [Configuration Guide](configuration.md), `aoe` uses a layered configuration system. As such,

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -445,25 +445,28 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         // resolved command, not the built-in name, otherwise `--cmd opencode`
         // falsely bails when only the override binary (e.g.
         // opencode-plannotator) is installed. See #1910.
-        let resolved_override = config.session.resolve_tool_command(&tool_name);
-        if !resolved_override.is_empty() {
-            let bin = resolved_override.split_whitespace().next().unwrap_or("");
-            if !bin.is_empty() && !crate::cli::cockpit::command_present(bin) {
-                bail!(
-                    "'{}' (from session.agent_command_override) is not installed or not on $PATH.\n\
-                     See all supported agents: aoe agents",
-                    bin
-                );
+        match override_launch_binary(&tool_name, &config.session) {
+            Some(bin) => {
+                if !crate::cli::cockpit::command_present(&bin) {
+                    bail!(
+                        "'{}' (from session.agent_command_override) is not installed or not on $PATH.\n\
+                         See all supported agents: aoe agents",
+                        bin
+                    );
+                }
             }
-        } else if let Some(agent_def) = crate::agents::get_agent(&tool_name) {
-            if !crate::tmux::is_agent_available(agent_def) {
-                bail!(
-                    "'{}' is not installed or not on $PATH.\n\
-                     Install with: {}\n\
-                     See all supported agents: aoe agents",
-                    agent_def.binary,
-                    agent_def.install_hint
-                );
+            None => {
+                if let Some(agent_def) = crate::agents::get_agent(&tool_name) {
+                    if !crate::tmux::is_agent_available(agent_def) {
+                        bail!(
+                            "'{}' is not installed or not on $PATH.\n\
+                             Install with: {}\n\
+                             See all supported agents: aoe agents",
+                            agent_def.binary,
+                            agent_def.install_hint
+                        );
+                    }
+                }
             }
         }
         instance.tool = tool_name;
@@ -1066,6 +1069,22 @@ fn detect_tool(cmd: &str) -> Result<String> {
         })
 }
 
+/// The binary `aoe add` must verify is on PATH for a `--cmd <tool>`
+/// selection when `session.agent_command_override` (or `custom_agents`)
+/// remaps the built-in to a different command. Returns the resolved
+/// command's first word, or `None` when no override applies (the caller
+/// then falls back to the built-in agent's own detection). See #1910.
+fn override_launch_binary(
+    tool: &str,
+    session: &crate::session::config::SessionConfig,
+) -> Option<String> {
+    session
+        .resolve_tool_command(tool)
+        .split_whitespace()
+        .next()
+        .map(str::to_string)
+}
+
 enum NamedToolSelection {
     Custom(String),
     BuiltIn(String),
@@ -1171,9 +1190,43 @@ fn resolve_sandbox_image(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_sandbox_image;
+    use super::{override_launch_binary, resolve_sandbox_image};
+    use crate::session::config::SessionConfig;
 
     const HARDCODED: &str = "ghcr.io/agent-of-empires/aoe-sandbox:latest";
+
+    #[test]
+    fn override_launch_binary_uses_command_override() {
+        let mut session = SessionConfig::default();
+        session
+            .agent_command_override
+            .insert("opencode".to_string(), "opencode-plannotator".to_string());
+        // The gate must verify the override binary, not the built-in
+        // `opencode`, so `--cmd opencode` works when only the wrapper is
+        // installed. See #1910.
+        assert_eq!(
+            override_launch_binary("opencode", &session).as_deref(),
+            Some("opencode-plannotator")
+        );
+    }
+
+    #[test]
+    fn override_launch_binary_takes_first_word_of_multiword_override() {
+        let mut session = SessionConfig::default();
+        session
+            .agent_command_override
+            .insert("opencode".to_string(), "ocp run sp".to_string());
+        assert_eq!(
+            override_launch_binary("opencode", &session).as_deref(),
+            Some("ocp")
+        );
+    }
+
+    #[test]
+    fn override_launch_binary_none_without_override() {
+        let session = SessionConfig::default();
+        assert_eq!(override_launch_binary("opencode", &session), None);
+    }
 
     #[test]
     fn flag_overrides_everything() {

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -439,8 +439,23 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         instance.tool = selection.name().to_string();
     } else if let Some(cmd) = &args.command {
         let tool_name = detect_tool(cmd)?;
-        // Verify the agent binary is actually on PATH before creating the session
-        if let Some(agent_def) = crate::agents::get_agent(&tool_name) {
+        // Verify the binary that will actually launch is on PATH before
+        // creating the session. A configured session.agent_command_override
+        // (or custom_agents) entry replaces the built-in binary, so check the
+        // resolved command, not the built-in name, otherwise `--cmd opencode`
+        // falsely bails when only the override binary (e.g.
+        // opencode-plannotator) is installed. See #1910.
+        let resolved_override = config.session.resolve_tool_command(&tool_name);
+        if !resolved_override.is_empty() {
+            let bin = resolved_override.split_whitespace().next().unwrap_or("");
+            if !bin.is_empty() && !crate::cli::cockpit::command_present(bin) {
+                bail!(
+                    "'{}' (from session.agent_command_override) is not installed or not on $PATH.\n\
+                     See all supported agents: aoe agents",
+                    bin
+                );
+            }
+        } else if let Some(agent_def) = crate::agents::get_agent(&tool_name) {
             if !crate::tmux::is_agent_available(agent_def) {
                 bail!(
                     "'{}' is not installed or not on $PATH.\n\
@@ -597,17 +612,36 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             // agent's configured ACP command, then verify the binary is on
             // PATH. A missing adapter is a hard error at add-time rather
             // than a silent 404 on the first prompt.
-            let spec = match registry.get(&agent_name) {
-                Some(spec) => spec.clone(),
+            let (mut spec, spec_from_registry) = match registry.get(&agent_name) {
+                Some(spec) => (spec.clone(), true),
                 None => match config.session.agent_cockpit_cmd.get(&agent_name) {
-                    Some(cmd) => crate::cockpit::AgentSpec::from_cockpit_cmd(&agent_name, cmd)
-                        .map_err(|e| anyhow::anyhow!(e))?,
+                    Some(cmd) => (
+                        crate::cockpit::AgentSpec::from_cockpit_cmd(&agent_name, cmd)
+                            .map_err(|e| anyhow::anyhow!(e))?,
+                        false,
+                    ),
                     None => bail!(
                         "cockpit agent `{agent_name}` is not in the registry.\n\
                          Run `aoe cockpit doctor` to see configured agents."
                     ),
                 },
             };
+            // Overlay session.agent_command_override the same way the cockpit
+            // spawn path does, so the precondition checks the binary that will
+            // actually launch (e.g. opencode-plannotator), not the bare
+            // registry binary. Without this, a user who installed only the
+            // override binary gets a false "not installed" bail. See #1910.
+            if let Some(ovr) = crate::server::cockpit_reconciler::command_override_for_spawn(
+                &instance.tool,
+                &instance.command,
+            ) {
+                crate::cockpit::supervisor::apply_agent_command_override(
+                    &agent_name,
+                    spec_from_registry,
+                    &ovr,
+                    &mut spec,
+                )?;
+            }
             if !crate::cli::cockpit::command_present(&spec.command) {
                 let hint = crate::cockpit::install_hints::install_hint_for(&spec.command)
                     .unwrap_or("install via your package manager and re-run");

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -447,7 +447,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         // opencode-plannotator) is installed. See #1910.
         match override_launch_binary(&tool_name, &config.session) {
             Some(bin) => {
-                if !crate::cli::cockpit::command_present(&bin) {
+                // Use the same detection as tmux (login-shell PATH fallback
+                // included) so an override binary visible only after shell
+                // init isn't rejected here while the non-override path accepts
+                // it. See #1910.
+                if !crate::tmux::is_binary_on_path(&bin) {
                     bail!(
                         "'{}' (from session.agent_command_override) is not installed or not on $PATH.\n\
                          See all supported agents: aoe agents",
@@ -1074,15 +1078,16 @@ fn detect_tool(cmd: &str) -> Result<String> {
 /// remaps the built-in to a different command. Returns the resolved
 /// command's first word, or `None` when no override applies (the caller
 /// then falls back to the built-in agent's own detection). See #1910.
+///
+/// Parsed with `shell_words` so a quoted path (e.g.
+/// `"/opt/My Wrapper/opencode" --mode plan`) yields the real binary, matching
+/// how `apply_agent_command_override` splits the command at spawn time.
 fn override_launch_binary(
     tool: &str,
     session: &crate::session::config::SessionConfig,
 ) -> Option<String> {
-    session
-        .resolve_tool_command(tool)
-        .split_whitespace()
-        .next()
-        .map(str::to_string)
+    let command = session.resolve_tool_command(tool);
+    shell_words::split(&command).ok()?.into_iter().next()
 }
 
 enum NamedToolSelection {
@@ -1219,6 +1224,21 @@ mod tests {
         assert_eq!(
             override_launch_binary("opencode", &session).as_deref(),
             Some("ocp")
+        );
+    }
+
+    #[test]
+    fn override_launch_binary_honors_quoted_path() {
+        let mut session = SessionConfig::default();
+        session.agent_command_override.insert(
+            "opencode".to_string(),
+            "\"/opt/My Wrapper/opencode\" --mode plan".to_string(),
+        );
+        // shell_words keeps the quoted path intact instead of splitting on
+        // the space, so preflight checks the real binary.
+        assert_eq!(
+            override_launch_binary("opencode", &session).as_deref(),
+            Some("/opt/My Wrapper/opencode")
         );
     }
 

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -487,7 +487,7 @@ fn command_matches_binary(command: &str, binary: &str) -> bool {
 /// `spec.command`, any remaining words are prepended to `spec.args`, so
 /// the registry's ACP args (e.g. `acp`) are preserved
 /// (`opencode-plannotator` → `opencode-plannotator acp`). See #1766.
-fn apply_agent_command_override(
+pub(crate) fn apply_agent_command_override(
     selected_agent: &str,
     spec_from_registry: bool,
     ovr: &AgentCommandOverride,

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -324,27 +324,37 @@ pub fn is_tmux_available() -> bool {
     Command::new("tmux").arg("-V").output().is_ok()
 }
 
+/// True when `binary` resolves on the user's PATH. An absolute or relative
+/// path is checked for existence; a bare name is looked up with `which`,
+/// falling back to a login shell so version-manager PATHs (NVM, etc.) are
+/// loaded. Shared by `is_agent_available` and the `aoe add` override
+/// availability check so both honor the same detection. See #1910.
+pub(crate) fn is_binary_on_path(binary: &str) -> bool {
+    if binary.contains('/') || binary.contains('\\') {
+        return std::path::Path::new(binary).exists();
+    }
+    // First try direct `which` (fast path).
+    let direct = Command::new("which")
+        .arg(binary)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if direct {
+        return true;
+    }
+    // Fall back to a login shell so version-manager PATHs (NVM, etc.) are loaded.
+    let shell = crate::session::user_shell();
+    Command::new(&shell)
+        .args(["-lc", &format!("which {}", shell_words::quote(binary))])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 pub(crate) fn is_agent_available(agent: &crate::agents::AgentDef) -> bool {
     use crate::agents::DetectionMethod;
     match &agent.detection {
-        DetectionMethod::Which(binary) => {
-            // First try direct `which` (fast path).
-            let direct = Command::new("which")
-                .arg(binary)
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false);
-            if direct {
-                return true;
-            }
-            // Fall back to a login shell so version-manager PATHs (NVM, etc.) are loaded.
-            let shell = crate::session::user_shell();
-            Command::new(&shell)
-                .args(["-lc", &format!("which {}", binary)])
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false)
-        }
+        DetectionMethod::Which(binary) => is_binary_on_path(binary),
         DetectionMethod::RunWithArg(binary, arg) => {
             if Command::new(binary)
                 .arg(arg)

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -258,6 +258,62 @@ agent_command_override = {{ claude = "my-custom-claude" }}
 
 #[test]
 #[serial]
+fn test_cli_add_cmd_respects_command_override_for_availability() {
+    // `qwen` is a built-in agent whose binary is not installed in CI. The
+    // override remaps it to a wrapper that we shim on PATH. Pre-fix, the
+    // `--cmd` availability check ran `which qwen` and bailed because the
+    // bare binary was absent; post-fix it verifies the override binary
+    // (`qwen-plannotator`) that will actually launch. See #1910.
+    let mut h = TuiTestHarness::new("cli_add_cmd_override_avail");
+    h.install_path_command("qwen-plannotator");
+    let project = h.project_path();
+
+    let config_dir = crate::harness::app_dir_in(h.home_path());
+    let config_content = format!(
+        r#"[updates]
+update_check_mode = "off"
+
+[app_state]
+has_seen_welcome = true
+last_seen_version = "{}"
+
+[session]
+agent_command_override = {{ qwen = "qwen-plannotator" }}
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).expect("write config.toml");
+
+    let add_output = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "QwenOverride",
+        "--cmd",
+        "qwen",
+    ]);
+    assert!(
+        add_output.status.success(),
+        "aoe add --cmd qwen should succeed when the override binary is on PATH: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session = &sessions[0];
+    assert_eq!(
+        session["tool"].as_str().unwrap_or(""),
+        "qwen",
+        "tool should resolve to the built-in qwen"
+    );
+    assert_eq!(
+        session["command"].as_str().unwrap_or(""),
+        "qwen-plannotator",
+        "command should resolve through session.agent_command_override"
+    );
+}
+
+#[test]
+#[serial]
 fn test_cli_add_cli_flags_override_config() {
     let h = TuiTestHarness::new("cli_add_flags_override");
     let project = h.project_path();

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -363,6 +363,25 @@ last_seen_version = "{}"
         self.set_env("AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS", "60000");
     }
 
+    /// Install a no-op executable named `name` on the CLI PATH so a
+    /// presence check (`which` / PATH scan) finds it. Used to stand in for
+    /// an agent wrapper binary (e.g. an `agent_command_override` target)
+    /// without installing the real tool. Returns the dir prepended to PATH.
+    pub fn install_path_command(&mut self, name: &str) -> PathBuf {
+        let bin = self.home_dir.path().join("path-bin");
+        std::fs::create_dir_all(&bin).expect("create path-bin dir");
+        let path = bin.join(name);
+        std::fs::write(&path, "#!/bin/sh\nexit 0\n").expect("write path command");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod path command");
+        }
+        self.extra_path_dirs.push(bin.clone());
+        bin
+    }
+
     /// Make `Drop` tear down cockpit workers and the serve daemon.
     pub fn stop_daemon_on_drop(&mut self) {
         self.stop_daemon_on_drop = true;


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`aoe add --cmd <agent>` resolves `session.agent_command_override` onto the session's launch command, and #1831 made the cockpit spawn path honor it at runtime. But two add-time guards still checked the un-overridden built-in binary, so `--cmd` did not fully respect the override:

- The `--cmd` availability check ran `is_agent_available` against the built-in binary (for example `opencode`), so `aoe add --cmd opencode` falsely bailed with "opencode is not installed" when only the override binary (`opencode-plannotator`) was on `$PATH`.
- The cockpit ACP precondition ran `command_present` on the registry spec command, not the override-resolved one, so the same false bail (or a check against a binary that isn't the one launched) could happen for `--cockpit` sessions.

This resolves the override in both gates. The availability check now verifies the override binary's first word; the cockpit precondition overlays the override onto the resolved `AgentSpec` via the shared `apply_agent_command_override` (now `pub(crate)`) before checking `$PATH`. Adapter-backed agents like Claude (`claude-agent-acp`) stay gated out by the same binary-match rule, so they keep using `session.agent_cockpit_cmd`. The result is that the override behaves the same whether a session is started from the TUI, a tmux CLI session, or a `--cockpit` session.

The binary-selection logic is extracted to a small pure helper (`override_launch_binary`) and unit-tested, plus a deterministic e2e drives the full `aoe add --cmd <agent>` round-trip: with `agent_command_override` mapping the uninstalled built-in `qwen` to a shimmed wrapper, `aoe add --cmd qwen` now succeeds and persists the wrapper as the launch command. That e2e fails on the pre-fix tree (bails with "qwen is not installed").

Closes #1910

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Add `[session.agent_command_override]` with `opencode = "opencode-plannotator"` (or any wrapper binary you have) to `config.toml`, ensure only the wrapper is on `$PATH` (not bare `opencode`), run `aoe add . --cmd opencode --cockpit`, and confirm it succeeds instead of bailing "opencode is not installed".
- [ ] With the same override, run `aoe add . --cmd opencode` (no `--cockpit`) and confirm the persisted session command is `opencode-plannotator` (`aoe list` / sessions.json).
- [ ] Remove the override, keep only bare `opencode` installed, and confirm `aoe add . --cmd opencode --cockpit` still works (no regression).
- [ ] Confirm a Claude cockpit session still launches via the `claude-agent-acp` adapter (the override gate skips adapter-backed agents).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/` (`test_cli_add_cmd_respects_command_override_for_availability`), plus unit tests on `override_launch_binary`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and verified the fix with a reproduce-then-fix e2e (red on the pre-fix tree, green after).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed (high-level)

- Fixed a bug so aoe add --cmd <tool> now respects session.agent_command_override at add-time.
- Ensures add-time checks (availability and cockpit precondition) validate the override-resolved launch command instead of the un-overridden built-in binary.
- Made small API visibility change to reuse existing override logic across cockpit code.
- Added tests and a test helper to reliably simulate binaries on PATH.
- Updated docs to explain that aoe add --cmd applies and validates command overrides.

## What moved / added / removed

- Added: override_launch_binary helper (pure, unit-tested) that picks the effective launch binary from an agent override.
- Added: is_binary_on_path helper to centralize "binary on PATH" checks.
- Added: e2e test test_cli_add_cmd_respects_command_override_for_availability.
- Added: tests/e2e harness method install_path_command to place shim executables on PATH for tests.
- Changed: src/cockpit/supervisor.rs — apply_agent_command_override made pub(crate).
- Changed: aoe add flow in src/cli/add.rs to use override-resolved binaries for preflight checks.
- Changed: cockpit adapter/spec checks now overlay agent_command_override before validating adapter presence.
- No public API surface removed; mostly internal refactors and test additions.
- Docs updated: docs/guides/agent-override.md clarifies behavior for aoe add --cmd.

## Benefits

- Consistency between CLI add-time behavior and TUI/runtime: overrides are treated the same everywhere.
- Prevents false failures when only an override/wrapper binary is installed.
- Sessions persist the correct override-resolved launch command, improving reliability and predictability.
- Test coverage reduces risk of regression.

## Technical details (concise)

- Two add-time gates previously used the un-overridden binary: (1) availability/is_agent_available and (2) cockpit ACP precondition/command_present. Both now resolve and use the override command’s first word (via override_launch_binary) for PATH checks.
- Adapter-backed agents remain gated by existing binary-match rules and continue to use session.agent_cockpit_cmd.
- is_binary_on_path centralizes PATH detection, including direct path checks and a login-shell fallback.
- apply_agent_command_override visibility widened to pub(crate) for reuse; no signature changes.
- New deterministic e2e test reproduces the original failure and verifies that mapping an uninstalled built-in to a shim wrapper allows aoe add --cmd <tool> to succeed and persist the wrapper command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->