### PR TITLE
feat(cli): add --interactive session-name prompt to aoe add

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -143,6 +143,7 @@ Add a new session
 ###### **Options:**
 
 * `-t`, `--title <TITLE>` — Session title (defaults to folder name)
+* `-i`, `--interactive` — Prompt for the session name, mirroring the TUI `n` flow. Shows the generated default; press Enter to accept it. Ignored when --title is given. Requires an interactive terminal
 * `-g`, `--group <GROUP>` — Group path (defaults to parent folder)
 * `-c`, `--cmd <COMMAND>` — Command to run (e.g., 'claude' or any other supported agent)
 * `--tool <TOOL>` — Named built-in or configured custom agent to run

--- a/docs/cockpit/setup.md
+++ b/docs/cockpit/setup.md
@@ -114,11 +114,14 @@ tool's own binary; adapter-backed agents such as Claude keep using
 The web new-session wizard shows the resolved launch command read-only
 so you can confirm it before the session starts.
 
-Session naming differs by entry point. `aoe add` is non-interactive: it
-uses `--title` when given, otherwise the worktree branch name, otherwise
-a generated name; it never prompts. The TUI `n` flow and the web
-new-session wizard prompt for a name interactively. To name a session
-created from the CLI, pass `--title "<name>"`.
+Session naming differs by entry point. By default `aoe add` does not
+prompt for a name: it uses `--title` when given, otherwise the worktree
+branch name, otherwise a generated name. Pass `-i`/`--interactive` to get
+the same name prompt the TUI `n` flow and the web new-session wizard
+provide; it shows the generated default and pressing Enter accepts it.
+`--interactive` requires a terminal and is ignored when `--title` is
+given, so scripted and non-interactive `aoe add` calls keep auto-naming.
+To name a session non-interactively, pass `--title "<name>"`.
 
 ### Globally
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Args;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use crate::containers::{self, ContainerRuntimeInterface};
@@ -18,6 +19,12 @@ pub struct AddArgs {
     /// Session title (defaults to folder name)
     #[arg(short = 't', long)]
     title: Option<String>,
+
+    /// Prompt for the session name, mirroring the TUI `n` flow. Shows the
+    /// generated default; press Enter to accept it. Ignored when --title
+    /// is given. Requires an interactive terminal.
+    #[arg(short = 'i', long)]
+    interactive: bool,
 
     /// Group path (defaults to parent folder)
     #[arg(short = 'g', long)]
@@ -138,6 +145,13 @@ pub struct AddArgs {
 
 #[tracing::instrument(target = "cli.add", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
+    // Fail fast before any filesystem side effects: --interactive must
+    // have a real terminal to read the name from, otherwise the prompt
+    // would block on EOF or a PTY harness would hang.
+    if args.interactive && !std::io::stdin().is_terminal() {
+        bail!("--interactive requires a terminal; pass --title for non-interactive naming");
+    }
+
     // Scratch sessions have no project path; the scratch directory is
     // provisioned below once we know the instance id. Reject an
     // explicitly-passed path loudly so `aoe add /some/repo --scratch` does
@@ -346,7 +360,10 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         None
     };
 
-    // Generate title: use provided title, or branch name for worktree sessions, or random civ
+    // Generate title: use provided title, or branch name for worktree sessions, or random civ.
+    // With --interactive (and no --title), prompt for the name TUI-style,
+    // prefilling the generated default. The chosen title, whatever its
+    // source, runs through the same duplicate (title + path) check.
     let final_title = if let Some(title) = &args.title {
         let trimmed_title = title.trim();
         if is_duplicate_session(&instances, trimmed_title, path.to_str().unwrap_or("")) {
@@ -364,12 +381,22 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             return Ok(());
         }
         trimmed_title.to_string()
-    } else if let Some(ref branch) = args.worktree_branch {
-        let branch_title = branch.trim().to_string();
-        if is_duplicate_session(&instances, &branch_title, path.to_str().unwrap_or("")) {
+    } else {
+        let default_title = if let Some(ref branch) = args.worktree_branch {
+            branch.trim().to_string()
+        } else {
+            let existing_titles: Vec<&str> = instances.iter().map(|i| i.title.as_str()).collect();
+            civilizations::generate_random_title(&existing_titles)
+        };
+        let chosen_title = if args.interactive {
+            prompt_session_title(&default_title)?
+        } else {
+            default_title
+        };
+        if is_duplicate_session(&instances, &chosen_title, path.to_str().unwrap_or("")) {
             println!(
                 "Session already exists with same title and path: {}",
-                branch_title
+                chosen_title
             );
             cleanup_partial_session(
                 &path,
@@ -380,10 +407,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             );
             return Ok(());
         }
-        branch_title
-    } else {
-        let existing_titles: Vec<&str> = instances.iter().map(|i| i.title.as_str()).collect();
-        civilizations::generate_random_title(&existing_titles)
+        chosen_title
     };
 
     let mut instance = Instance::new(&final_title, path.to_str().unwrap_or(""));
@@ -890,6 +914,30 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Prompt for a session title on stderr, mirroring the TUI `n` flow's
+/// "auto-generates if empty" field. Empty input or EOF keeps
+/// `default_title`; a non-empty line is trimmed and used. Only reached in
+/// `--interactive` mode, which already verified stdin is a terminal.
+fn prompt_session_title(default_title: &str) -> Result<String> {
+    use std::io::Write;
+
+    eprint!("Session name [{}]: ", default_title);
+    std::io::stderr().flush()?;
+
+    let mut input = String::new();
+    let read = std::io::stdin().read_line(&mut input)?;
+    if read == 0 {
+        return Ok(default_title.to_string());
+    }
+
+    let trimmed = input.trim();
+    Ok(if trimmed.is_empty() {
+        default_title.to_string()
+    } else {
+        trimmed.to_string()
+    })
 }
 
 fn cleanup_partial_session(

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -69,6 +69,86 @@ fn test_cli_add_next_steps_uses_aoe_binary_name() {
     );
 }
 
+/// #1909: `aoe add --interactive` must fail loudly when stdin is not a
+/// terminal instead of hanging on the name prompt. `run_cli` runs the
+/// binary as a plain subprocess with no controlling TTY, which is the
+/// non-interactive case the guard protects.
+#[test]
+#[serial]
+fn test_cli_add_interactive_requires_tty() {
+    let h = TuiTestHarness::new("cli_add_interactive_no_tty");
+    let project = h.project_path();
+
+    let output = h.run_cli(&["add", project.to_str().unwrap(), "-i"]);
+    assert!(
+        !output.status.success(),
+        "aoe add -i without a TTY should fail, not hang or succeed"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("requires a terminal"),
+        "expected the --interactive TTY guard message.\nstderr: {}",
+        stderr
+    );
+
+    // The guard runs before any persistence, so no session row is written.
+    let sessions_path =
+        crate::harness::app_dir_in(h.home_path()).join("profiles/default/sessions.json");
+    assert!(
+        !sessions_path.exists(),
+        "the TTY guard must bail before writing sessions.json"
+    );
+}
+
+/// #1909: `aoe add --interactive` should prompt for a session name like
+/// the TUI `n` flow. Driven through a tmux pane so stdin is a real
+/// terminal; the typed name must become the session title.
+#[test]
+#[serial]
+fn test_cli_add_interactive_prompts_for_name() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("cli_add_interactive_prompt");
+    let project = h.project_path();
+    let project_arg = project.to_str().unwrap().to_string();
+
+    h.spawn(&["add", &project_arg, "-i"]);
+    h.wait_for("Session name [");
+    h.type_text("InteractivePrompted");
+    h.send_keys("Enter");
+
+    // The add command exits as soon as it persists, tearing down the tmux
+    // pane, so the screen goes blank. Poll the on-disk session store
+    // instead of waiting on screen output.
+    let sessions_path =
+        crate::harness::app_dir_in(h.home_path()).join("profiles/default/sessions.json");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let landed = loop {
+        let found = std::fs::read_to_string(&sessions_path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+            .map(|j| {
+                j.as_array().is_some_and(|sessions| {
+                    sessions
+                        .iter()
+                        .any(|s| s["title"].as_str() == Some("InteractivePrompted"))
+                })
+            })
+            .unwrap_or(false);
+        if found {
+            break true;
+        }
+        if std::time::Instant::now() >= deadline {
+            break false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    };
+    assert!(
+        landed,
+        "interactive prompt should persist a session titled InteractivePrompted"
+    );
+}
+
 #[test]
 #[serial]
 fn test_cli_add_invalid_path() {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The TUI `n` flow prompts for a session name, but the `aoe add` CLI used to launch cockpit sessions never did: with `--title` omitted it silently generated a random civilization name. Running `aoe add . --cmd opencode --cockpit` in a terminal therefore gave no naming prompt, the parity gap reported in #1909.

This adds an opt-in `-i`/`--interactive` flag to `aoe add`. When set and `--title` is absent, it prompts `Session name [<default>]:` on stderr with the generated default prefilled (worktree branch name when `--worktree`, otherwise a random civ name); pressing Enter accepts the default, and a typed name flows through the same duplicate (title + path) check as every other naming path. The flag bails early when stdin is not a terminal, so a pipe or a PTY harness cannot hang on the read, and the default behavior of `aoe add` is byte-for-byte unchanged, keeping it scriptable.

Design note: an opt-in flag is deliberate rather than prompting by default. A default-on prompt would be a backward-compatibility break for scripts, backgrounded `aoe add &` (SIGTTIN), and PTY-allocating CI harnesses; `--title` remains the declarative naming path. The docs paragraph that previously claimed `aoe add` "never prompts" (already untrue for the hook-trust prompt) is rewritten to describe the new flag.

Closes #1909

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] In a terminal, run `aoe add . --cmd opencode --cockpit -i` and confirm it prompts `Session name [<default>]:`; type a name and confirm the created session uses it.
- [ ] Run the same command again, press Enter at the prompt, and confirm the session is created with the shown default name.
- [ ] Run `aoe add . -t my-name` (no `-i`) and confirm no prompt appears and the title is `my-name`.
- [ ] Run `aoe add .` with no flags and confirm the previous silent auto-naming behavior is unchanged.
- [ ] Pipe input, e.g. `echo "" | aoe add . -i`, and confirm it errors with "requires a terminal" instead of hanging.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (opt-in flag over default-on prompt), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds an opt-in interactive mode to the `aoe add` CLI command that prompts users to confirm or override the generated session name, bringing parity with the TUI's existing name prompt behavior. When the `--interactive` flag is used and no explicit `--title` is provided, users are prompted on stderr to confirm or change the session name before the session is created.

## What Changed

**Core Changes:**
- Added `-i`/`--interactive` flag to the `aoe add` command
- Implemented TTY validation to prevent hanging in non-interactive environments (pipes, harnesses)
- Created a new prompt function that presents the generated default session name, accepts user input, and validates against duplicates
- Simplified the title generation flow by unifying default and user-chosen name handling

**Documentation Updates:**
- Updated `docs/cli/reference.md` to document the new `--interactive` option
- Updated `docs/cockpit/setup.md` to clarify that `aoe add` is non-interactive by default and explain how `-i` enables the TUI-style prompt
- Added guidance for non-interactive naming via `--title`

**Testing:**
- Added two comprehensive e2e tests covering the interactive prompt behavior and TTY validation

## Key Benefits

- **Workflow consistency**: CLI behavior now matches the TUI's session naming experience
- **User-friendly**: Allows users to confirm generated names or provide custom ones without needing `--title` upfront
- **Safe by default**: The `--interactive` flag is opt-in; existing scripts and automation are unaffected
- **Terminal-aware**: Early validation prevents the command from hanging in non-TTY environments

## Technical Highlights

- New `AddArgs.interactive: bool` field to track the flag
- New `prompt_session_title()` helper that handles user input, EOF handling, and default acceptance
- TTY validation occurs before any filesystem operations
- Existing duplicate detection and validation logic remains unchanged and applies to user-provided names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->