### PR TITLE
fix: preserve inherited sandbox env resolution

### DIFF
--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -161,6 +161,10 @@ pub struct NewSessionDialog {
     /// Extra environment entries (session-specific).
     /// `KEY` = pass through, `KEY=VALUE` = set explicitly.
     pub(super) extra_env: Vec<String>,
+    /// True after the user edits the sandbox env list in this dialog.
+    /// Inherited config is shown for review, but is not submitted as a
+    /// per-session override unless this flips.
+    pub(super) extra_env_overridden: bool,
     /// Whether the env list is expanded (editing mode)
     pub(super) env_list_expanded: bool,
     /// Currently selected index in the env list
@@ -464,6 +468,7 @@ impl NewSessionDialog {
             yolo_mode,
             yolo_mode_default: yolo_mode,
             extra_env,
+            extra_env_overridden: false,
             env_list_expanded: false,
             env_selected_index: 0,
             env_editing_input: None,
@@ -496,6 +501,9 @@ impl NewSessionDialog {
     /// Pre-fill the path field (e.g. from a selected session).
     pub fn set_path(&mut self, path: String) {
         self.path = Input::new(path);
+        if !self.extra_env_overridden {
+            self.reload_config_defaults();
+        }
     }
 
     /// Pre-fill the group field (e.g. from a selected session or group).
@@ -587,6 +595,27 @@ impl NewSessionDialog {
         self.available_profiles.len() > 1
     }
 
+    fn resolve_config_for_path(&self, profile: &str) -> crate::session::Config {
+        let path = self.path.value().trim();
+        if path.is_empty() {
+            resolve_config_or_warn(profile)
+        } else {
+            crate::session::repo_config::resolve_config_with_repo_or_warn(
+                profile,
+                std::path::Path::new(path),
+            )
+        }
+    }
+
+    fn refresh_inherited_sandbox_settings(&mut self) {
+        if !self.sandbox_enabled || self.extra_env_overridden {
+            return;
+        }
+        let config = self.resolve_config_for_path(&self.profile);
+        self.extra_env = config.sandbox.environment.clone();
+        self.inherited_settings = build_inherited_settings(&config.sandbox);
+    }
+
     /// Whether the currently selected tool is always in YOLO mode (no opt-in needed).
     fn selected_tool_always_yolo(&self) -> bool {
         let tool_name = &self.available_tools[self.tool_index];
@@ -628,7 +657,7 @@ impl NewSessionDialog {
     fn reload_config_defaults(&mut self) {
         let profile = self.selected_profile().to_string();
         self.profile = profile.clone();
-        let config = resolve_config_or_warn(&profile);
+        let config = self.resolve_config_for_path(&profile);
 
         // Reset tool index
         self.tool_index = if let Some(ref default_tool) = config.session.default_tool {
@@ -659,6 +688,7 @@ impl NewSessionDialog {
             self.extra_env.clear();
             self.inherited_settings.clear();
         }
+        self.extra_env_overridden = false;
 
         // Reset extra args and command override for new default tool
         let selected_tool = self
@@ -735,6 +765,7 @@ impl NewSessionDialog {
             yolo_mode: false,
             yolo_mode_default: false,
             extra_env: Vec::new(),
+            extra_env_overridden: false,
             env_list_expanded: false,
             env_selected_index: 0,
             env_editing_input: None,
@@ -804,6 +835,7 @@ impl NewSessionDialog {
             yolo_mode: false,
             yolo_mode_default: false,
             extra_env: Vec::new(),
+            extra_env_overridden: false,
             env_list_expanded: false,
             env_selected_index: 0,
             env_editing_input: None,
@@ -1076,11 +1108,13 @@ impl NewSessionDialog {
         } else if self.focused_field == sandbox_field {
             self.sandbox_enabled = !self.sandbox_enabled;
             if self.sandbox_enabled {
-                let config = resolve_config_or_warn(&self.profile);
+                let config = self.resolve_config_for_path(&self.profile);
                 self.extra_env = config.sandbox.environment.clone();
                 self.inherited_settings = build_inherited_settings(&config.sandbox);
+                self.extra_env_overridden = false;
             } else {
                 self.extra_env.clear();
+                self.extra_env_overridden = false;
                 self.env_list_expanded = false;
                 self.env_editing_input = None;
                 self.inherited_settings.clear();
@@ -1252,6 +1286,7 @@ impl NewSessionDialog {
                 return DialogResult::Continue;
             }
             if self.focused_field == sandbox_field && self.sandbox_enabled {
+                self.refresh_inherited_sandbox_settings();
                 self.sandbox_config_mode = true;
                 self.sandbox_focused_field = 0;
                 return DialogResult::Continue;
@@ -1395,11 +1430,13 @@ impl NewSessionDialog {
             {
                 self.sandbox_enabled = !self.sandbox_enabled;
                 if self.sandbox_enabled {
-                    let config = resolve_config_or_warn(&self.profile);
+                    let config = self.resolve_config_for_path(&self.profile);
                     self.extra_env = config.sandbox.environment.clone();
                     self.inherited_settings = build_inherited_settings(&config.sandbox);
+                    self.extra_env_overridden = false;
                 } else {
                     self.extra_env.clear();
+                    self.extra_env_overridden = false;
                     self.env_list_expanded = false;
                     self.env_editing_input = None;
                     self.inherited_settings.clear();
@@ -1716,6 +1753,7 @@ impl NewSessionDialog {
 
         // Validate the current entry if the list changed
         if self.extra_env != snapshot {
+            self.extra_env_overridden = true;
             self.error_message = self
                 .extra_env
                 .get(self.env_selected_index)
@@ -1960,7 +1998,7 @@ impl NewSessionDialog {
             sandbox: self.sandbox_enabled,
             sandbox_image: self.sandbox_image.value().trim().to_string(),
             yolo_mode: self.yolo_mode || self.selected_tool_always_yolo(),
-            extra_env: if self.sandbox_enabled {
+            extra_env: if self.sandbox_enabled && self.extra_env_overridden {
                 self.extra_env.clone()
             } else {
                 Vec::new()

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1154,6 +1154,243 @@ fn test_profile_included_in_submit() {
     }
 }
 
+#[test]
+#[serial_test::serial]
+fn test_profile_switch_reloads_sandbox_env_without_session_override() {
+    let temp_home = tempfile::tempdir().expect("temp home");
+    let old_home = std::env::var_os("HOME");
+    let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    std::env::set_var("HOME", temp_home.path());
+    #[cfg(target_os = "linux")]
+    std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+    std::env::set_var("OLD_THING", "1");
+    std::env::set_var("NEW_THING", "2");
+
+    let app_dir = crate::session::get_app_dir().expect("app dir");
+    let profiles_dir = app_dir.join("profiles");
+    fs::create_dir_all(profiles_dir.join("default")).expect("default profile");
+    fs::create_dir_all(profiles_dir.join("aoe")).expect("aoe profile");
+    fs::write(
+        app_dir.join("config.toml"),
+        r#"
+default_profile = "default"
+
+[sandbox]
+enabled_by_default = true
+environment = ["THING=$OLD_THING"]
+"#,
+    )
+    .expect("global config");
+    fs::write(
+        profiles_dir.join("aoe").join("config.toml"),
+        r#"
+[sandbox]
+environment = ["THING=$NEW_THING"]
+"#,
+    )
+    .expect("profile config");
+
+    let mut dialog = single_tool_dialog();
+    dialog.available_profiles = vec!["default".to_string(), "aoe".to_string()];
+    dialog.profile_descriptions = vec![None, None];
+    dialog.profile_index = 0;
+    dialog.docker_available = true;
+    dialog.reload_config_defaults();
+    assert_eq!(dialog.extra_env, vec!["THING=$OLD_THING".to_string()]);
+
+    dialog.focused_field = 0;
+    dialog.handle_key(key(KeyCode::Right));
+
+    assert_eq!(dialog.selected_profile(), "aoe");
+    assert!(dialog.sandbox_enabled);
+    assert_eq!(dialog.extra_env, vec!["THING=$NEW_THING".to_string()]);
+    assert!(!dialog.extra_env_overridden);
+
+    match dialog.build_submit_result() {
+        DialogResult::Submit(data) => {
+            assert_eq!(data.profile, "aoe");
+            assert!(
+                data.extra_env.is_empty(),
+                "inherited sandbox env must not become a session override"
+            );
+        }
+        _ => panic!("Expected Submit"),
+    }
+
+    std::env::remove_var("OLD_THING");
+    std::env::remove_var("NEW_THING");
+    match old_home {
+        Some(v) => std::env::set_var("HOME", v),
+        None => std::env::remove_var("HOME"),
+    }
+    match old_xdg {
+        Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+        None => std::env::remove_var("XDG_CONFIG_HOME"),
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn test_set_path_reloads_repo_sandbox_env_without_session_override() {
+    let temp_home = tempfile::tempdir().expect("temp home");
+    let old_home = std::env::var_os("HOME");
+    let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    std::env::set_var("HOME", temp_home.path());
+    #[cfg(target_os = "linux")]
+    std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+    let app_dir = crate::session::get_app_dir().expect("app dir");
+    let profiles_dir = app_dir.join("profiles");
+    fs::create_dir_all(profiles_dir.join("default")).expect("default profile");
+    fs::write(
+        app_dir.join("config.toml"),
+        r#"
+default_profile = "default"
+
+[sandbox]
+enabled_by_default = true
+environment = ["THING=$OLD_THING"]
+"#,
+    )
+    .expect("global config");
+
+    let repo = tempfile::tempdir().expect("repo dir");
+    fs::create_dir_all(repo.path().join(".agent-of-empires")).expect("repo config dir");
+    fs::write(
+        repo.path().join(".agent-of-empires/config.toml"),
+        r#"
+[sandbox]
+environment = ["THING=$REPO_THING"]
+"#,
+    )
+    .expect("repo config");
+
+    let mut dialog = single_tool_dialog();
+    dialog.docker_available = true;
+    dialog.reload_config_defaults();
+    assert_eq!(dialog.extra_env, vec!["THING=$OLD_THING".to_string()]);
+
+    dialog.set_path(repo.path().to_string_lossy().to_string());
+
+    assert_eq!(dialog.extra_env, vec!["THING=$REPO_THING".to_string()]);
+    assert!(!dialog.extra_env_overridden);
+    match dialog.build_submit_result() {
+        DialogResult::Submit(data) => {
+            assert!(
+                data.extra_env.is_empty(),
+                "repo-inherited sandbox env must not become a session override"
+            );
+        }
+        _ => panic!("Expected Submit"),
+    }
+
+    match old_home {
+        Some(v) => std::env::set_var("HOME", v),
+        None => std::env::remove_var("HOME"),
+    }
+    match old_xdg {
+        Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+        None => std::env::remove_var("XDG_CONFIG_HOME"),
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn test_sandbox_config_refreshes_typed_path_repo_env_without_session_override() {
+    let temp_home = tempfile::tempdir().expect("temp home");
+    let old_home = std::env::var_os("HOME");
+    let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    std::env::set_var("HOME", temp_home.path());
+    #[cfg(target_os = "linux")]
+    std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+    let app_dir = crate::session::get_app_dir().expect("app dir");
+    let profiles_dir = app_dir.join("profiles");
+    fs::create_dir_all(profiles_dir.join("default")).expect("default profile");
+    fs::write(
+        app_dir.join("config.toml"),
+        r#"
+default_profile = "default"
+
+[sandbox]
+enabled_by_default = true
+environment = ["THING=$OLD_THING"]
+"#,
+    )
+    .expect("global config");
+
+    let repo = tempfile::tempdir().expect("repo dir");
+    fs::create_dir_all(repo.path().join(".agent-of-empires")).expect("repo config dir");
+    fs::write(
+        repo.path().join(".agent-of-empires/config.toml"),
+        r#"
+[sandbox]
+environment = ["THING=$REPO_THING"]
+"#,
+    )
+    .expect("repo config");
+
+    let mut dialog = single_tool_dialog();
+    dialog.docker_available = true;
+    dialog.reload_config_defaults();
+    assert_eq!(dialog.extra_env, vec!["THING=$OLD_THING".to_string()]);
+
+    dialog.path = Input::new(repo.path().to_string_lossy().to_string());
+    dialog.focused_field = 4;
+    let result = dialog.handle_key(ctrl_key(KeyCode::Char('p')));
+
+    assert!(matches!(result, DialogResult::Continue));
+    assert!(dialog.sandbox_config_mode);
+    assert_eq!(dialog.extra_env, vec!["THING=$REPO_THING".to_string()]);
+    assert!(!dialog.extra_env_overridden);
+    match dialog.build_submit_result() {
+        DialogResult::Submit(data) => {
+            assert!(
+                data.extra_env.is_empty(),
+                "repo-inherited sandbox env must not become a session override"
+            );
+        }
+        _ => panic!("Expected Submit"),
+    }
+
+    match old_home {
+        Some(v) => std::env::set_var("HOME", v),
+        None => std::env::remove_var("HOME"),
+    }
+    match old_xdg {
+        Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+        None => std::env::remove_var("XDG_CONFIG_HOME"),
+    }
+}
+
+#[test]
+fn test_env_list_edit_submits_session_override() {
+    let mut dialog = single_tool_dialog();
+    dialog.docker_available = true;
+    dialog.sandbox_enabled = true;
+    dialog.extra_env = vec!["THING=$NEW_THING".to_string()];
+    dialog.env_list_expanded = true;
+    dialog.sandbox_config_mode = true;
+    dialog.sandbox_focused_field = 1;
+
+    dialog.handle_env_list_key(key(KeyCode::Char('a')));
+    for ch in "EXTRA=1".chars() {
+        dialog.handle_env_list_key(key(KeyCode::Char(ch)));
+    }
+    dialog.handle_env_list_key(key(KeyCode::Enter));
+
+    assert!(dialog.extra_env_overridden);
+    match dialog.build_submit_result() {
+        DialogResult::Submit(data) => {
+            assert_eq!(
+                data.extra_env,
+                vec!["THING=$NEW_THING".to_string(), "EXTRA=1".to_string()]
+            );
+        }
+        _ => panic!("Expected Submit"),
+    }
+}
+
 // --- Sandbox config mode tests ---
 
 #[test]


### PR DESCRIPTION
## Description
Fixes a TUI new-session edge case where inherited sandbox env settings could be submitted as a per-session override. This showed up when using Shift+N from an existing session/worktree: the dialog was created, then its path/profile context was prefilled, but the env list could still behave like a frozen override.

This keeps inherited sandbox env visible in the dialog, refreshes it when the profile/path context changes, and only submits `extra_env` when the user actually edits the env list.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A, no visual change)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: added focused TUI dialog unit regressions for inherited sandbox env, profile switching, path prefill, and manual path refresh. No tmux/container lifecycle behavior changed.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Codex (GPT-5)

**Any Additional AI Details you'd like to share:** Used to investigate the TUI session creation path, implement the fix, and run verification commands.

- [x] I am an AI Agent filling out this form (check box if true)

## Testing

- `cargo fmt`
- `cargo test tui::dialogs::new_session::tests --lib`
- `cargo test session::environment::tests --lib`
- `cargo test --lib`
- `cargo clippy --lib -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a bug in the TUI session creation dialog where inherited sandbox environment settings could inadvertently be submitted as per-session overrides when creating a new session from an existing session (using Shift+N). The fix ensures that inherited sandbox environment settings remain properly inherited unless the user explicitly edits them.

## What Changed

**Main changes in `src/tui/dialogs/new_session/mod.rs`:**
- Added a new tracking flag (`extra_env_overridden`) to detect when a user manually edits the sandbox environment list
- Modified the config reload logic to preserve inherited sandbox environment settings unless the flag indicates the user has made changes
- Updated the profile and path switching logic to refresh inherited sandbox settings when context changes (but only if the user hasn't manually overridden them)
- Modified the submission payload to only include custom environment variables when the user has explicitly overridden the defaults

**New test coverage in `src/tui/dialogs/new_session/tests.rs`:**
- Added 4 integration-style tests that verify inherited sandbox environment behavior when:
  - Switching between profiles
  - Changing the typed path
  - Editing sandbox environment entries
  - Submitting the dialog with and without overrides

## Benefits

- **Prevents unintended overrides**: Users can now create sessions from existing sessions without accidentally converting inherited environment settings into per-session overrides
- **Preserves user intent**: The dialog maintains a clear separation between inherited settings and custom edits
- **Improved configuration management**: Environment settings flow correctly from global/profile configuration to the session layer without unwanted promotion to overrides
- **Better test coverage**: New tests ensure the fix works across different user interaction paths (profile switching, path changes, env editing)

## Technical Details

The implementation tracks the override state with a boolean flag that:
- Initializes to `false` when the dialog opens or profile/path context changes
- Becomes `true` only when the user actively edits the environment list
- Controls whether config defaults are auto-refreshed (only refresh when `false`)
- Determines what gets submitted in the final payload (only submit custom env when `true`)

The refresh of inherited sandbox settings is triggered in three key scenarios: when opening the sandbox overlay (Ctrl+P), when toggling sandbox on, and when changing profile/path context—but only if the user hasn't already made manual edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->