### PR TITLE
fix(cockpit): render opencode todo updates

### DIFF
--- a/docs/cockpit/interface.md
+++ b/docs/cockpit/interface.md
@@ -294,19 +294,20 @@ single collapsible cards:
   with no agent text between them (for example Read, Read, Grep, Read
   during investigation) collapses into one "actions" card. Expand it to
   see each call as its normal per-tool card.
-- **Consecutive TodoWrite updates.** When the agent fires three or more
-  `TodoWrite` calls back-to-back, the per-call snapshots fold into one
-  todo card titled "updated N times". Collapsed, the card shows the
-  latest list (the only snapshot whose pending/in-progress/done mix is
-  current), so you see what the agent is working on without expanding.
-  Expand it to inspect each individual update in order and audit how the
-  plan evolved during the turn.
+- **Consecutive TodoWrite updates.** When Claude fires three or more
+  `TodoWrite` calls back-to-back, or OpenCode sends three or more
+  `todowrite` updates with a structured `todos` payload, the per-call
+  snapshots fold into one todo card titled "updated N times". Collapsed,
+  the card shows the latest list (the only snapshot whose
+  pending/in-progress/done mix is current), so you see what the agent is
+  working on without expanding. Expand it to inspect each individual
+  update in order and audit how the plan evolved during the turn.
 
 Folding only fires when every call in the run is the same shape. A
-TodoWrite sandwiched between real tool work (Read, Edit) stays inline as
-its own card rather than being hidden inside a group, so a status update
-between actions is never buried. Two-in-a-row stays inline as well; the
-fold threshold is three.
+TodoWrite or `todowrite` update sandwiched between real tool work (Read,
+Edit) stays inline as its own card rather than being hidden inside a
+group, so a status update between actions is never buried. Two-in-a-row
+stays inline as well; the fold threshold is three.
 
 Automatic grouping needs an unbroken run, so a phase where the agent
 narrates between each action (common right after a plan is approved)

--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -36,11 +36,11 @@ agent's profile opts in, or is currently claude-only.
 | Usage / context-window display | ✓ | depends | ✓ | ✓ | depends |
 | MCP tool grouping | ✓ | claimed* | claimed* | claimed* | claimed* |
 | `/clear` boundary divider | `/clear` | `/new` | `/new` | none | none |
-| TodoWrite card | ✓ | no | ✓ | no | no |
-| Skill card | ✓ | no | no | no | no |
-| ExitPlanMode synthesis | ✓ | no | no | no | no |
-| ScheduleWakeup (`/loop`) | ✓ | no | no | no | no |
-| Subagent indentation | ✓ | no | unverified | no | no |
+| TodoWrite card | ✓ | — | — | — | — |
+| Skill card | ✓ | — | — | — | — |
+| ExitPlanMode synthesis | ✓ | — | — | — | — |
+| ScheduleWakeup (`/loop`) | ✓ | — | — | — | — |
+| Subagent indentation | ✓ | — | unverified | — | — |
 | Session resume across `aoe serve` restart | ✓ | depends | ✓ | depends | depends |
 
 \* All profiles default to the `mcp__` prefix. If your agent uses a
@@ -49,12 +49,10 @@ different MCP naming scheme, file an issue or PR adjusting the profile's
 
 ### Notes on the matrix
 
-- **TodoWrite cards** are enabled for agents whose profile has verified a
-  structured todo payload. Claude emits TodoWrite-compatible payloads;
-  OpenCode emits `todowrite` tool updates with `rawInput.todos`, which the
-  cockpit renders through the same card. Skill / ExitPlanMode /
-  ScheduleWakeup remain Claude-only today, so those cards stay quiet on
-  other agents.
+- **TodoWrite / Skill / ExitPlanMode / ScheduleWakeup** are claude-only
+  tools today, so the cards stay quiet on other agents. The cockpit
+  doesn't fire those cards based on coincidental tool names; gating
+  happens in the agent profile.
 - **`/clear`** is detected server-side by matching the user's prompt
   against the profile's `clearAliases`. Claude uses `/clear`; codex and
   opencode use `/new`. Gemini has no slash command verified as a

--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -36,11 +36,11 @@ agent's profile opts in, or is currently claude-only.
 | Usage / context-window display | ✓ | depends | ✓ | ✓ | depends |
 | MCP tool grouping | ✓ | claimed* | claimed* | claimed* | claimed* |
 | `/clear` boundary divider | `/clear` | `/new` | `/new` | none | none |
-| TodoWrite card | ✓ | — | — | — | — |
-| Skill card | ✓ | — | — | — | — |
-| ExitPlanMode synthesis | ✓ | — | — | — | — |
-| ScheduleWakeup (`/loop`) | ✓ | — | — | — | — |
-| Subagent indentation | ✓ | — | unverified | — | — |
+| TodoWrite card | ✓ | no | ✓ | no | no |
+| Skill card | ✓ | no | no | no | no |
+| ExitPlanMode synthesis | ✓ | no | no | no | no |
+| ScheduleWakeup (`/loop`) | ✓ | no | no | no | no |
+| Subagent indentation | ✓ | no | unverified | no | no |
 | Session resume across `aoe serve` restart | ✓ | depends | ✓ | depends | depends |
 
 \* All profiles default to the `mcp__` prefix. If your agent uses a
@@ -49,10 +49,12 @@ different MCP naming scheme, file an issue or PR adjusting the profile's
 
 ### Notes on the matrix
 
-- **TodoWrite / Skill / ExitPlanMode / ScheduleWakeup** are claude-only
-  tools today, so the cards stay quiet on other agents. The cockpit
-  doesn't fire those cards based on coincidental tool names; gating
-  happens in the agent profile.
+- **TodoWrite cards** are enabled for agents whose profile has verified a
+  structured todo payload. Claude emits TodoWrite-compatible payloads;
+  OpenCode emits `todowrite` tool updates with `rawInput.todos`, which the
+  cockpit renders through the same card. Skill / ExitPlanMode /
+  ScheduleWakeup remain Claude-only today, so those cards stay quiet on
+  other agents.
 - **`/clear`** is detected server-side by matching the user's prompt
   against the profile's `clearAliases`. Claude uses `/clear`; codex and
   opencode use `/new`. Gemini has no slash command verified as a

--- a/web/src/components/cockpit/CockpitRuntime.test.ts
+++ b/web/src/components/cockpit/CockpitRuntime.test.ts
@@ -181,6 +181,29 @@ describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
     ).toEqual(["td1", "td2", "td3"]);
   });
 
+  it("uses the generic group for todo-shaped runs when todos are disabled", () => {
+    const messages = activityToThreadMessages(
+      [
+        userRow("go"),
+        todoStart("td1", [{ content: "a", status: "pending" }]),
+        todoStart("td2", [{ content: "a", status: "in_progress" }]),
+        todoStart("td3", [{ content: "a", status: "completed" }]),
+      ],
+      false,
+      false,
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = assistant.content as Array<{
+      type: string;
+      toolName?: string;
+    }>;
+    const toolParts = parts.filter((p) => p.type === "tool-call");
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]!.toolName).toBe(TOOL_GROUP_NAME);
+    expect(toolParts[0]!.toolName).not.toBe(TODO_GROUP_NAME);
+  });
+
   it("leaves 2 consecutive TodoWrite snapshots inline (#1468)", () => {
     const messages = activityToThreadMessages(
       [

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -41,6 +41,7 @@ import type {
   PromptAttachmentInput,
   ToolCall,
 } from "../../lib/cockpitTypes";
+import { hasTodoItemsArgsText, parseJsonObject } from "../../lib/cockpitArgs";
 
 interface Props {
   sessionId: string;
@@ -527,20 +528,14 @@ class AssistantBuilder {
 }
 
 function isTodoWriteArgsText(argsText: string): boolean {
-  try {
-    const parsed = JSON.parse(argsText);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      const title = (parsed as Record<string, unknown>)._aoe_title;
-      if (typeof title === "string" && title.startsWith("Update TODOs")) {
-        return true;
-      }
-      const todos = (parsed as Record<string, unknown>).todos;
-      if (Array.isArray(todos)) return true;
+  const parsed = parseJsonObject(argsText);
+  if (parsed) {
+    const title = parsed._aoe_title;
+    if (typeof title === "string" && title.startsWith("Update TODOs")) {
+      return true;
     }
-  } catch {
-    // ignore
   }
-  return false;
+  return hasTodoItemsArgsText(argsText);
 }
 
 /** Synthetic toolName for a Claude sub-agent (Task) and its child tool

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -42,6 +42,7 @@ import type {
   ToolCall,
 } from "../../lib/cockpitTypes";
 import { hasTodoItemsArgsText, parseJsonObject } from "../../lib/cockpitArgs";
+import { useAgentProfile } from "../../lib/agentProfileContext";
 
 interface Props {
   sessionId: string;
@@ -123,6 +124,7 @@ export function CockpitRuntime({
   children,
 }: Props) {
   const cockpit = useCockpit(sessionId, cockpitWorkerState, archivedAt, snoozedUntil);
+  const agentProfile = useAgentProfile();
   // Staged attachments for the next prompt. A ref mirror keeps `onNew`
   // (recreated each render by useExternalStoreRuntime) reading the
   // latest value without going stale. See #1000 / #965.
@@ -145,8 +147,14 @@ export function CockpitRuntime({
         cockpit.state.activity,
         cockpit.state.turnActive,
         showClearedTurns,
+        agentProfile.capabilities.todos,
       ),
-    [cockpit.state.activity, cockpit.state.turnActive, showClearedTurns],
+    [
+      cockpit.state.activity,
+      cockpit.state.turnActive,
+      showClearedTurns,
+      agentProfile.capabilities.todos,
+    ],
   );
 
   const runtime = useExternalStoreRuntime<ThreadMessageLike>({
@@ -229,6 +237,7 @@ export function activityToThreadMessages(
   rows: readonly ActivityRow[],
   turnActive: boolean,
   showClearedTurns = false,
+  todosEnabled = true,
 ): ThreadMessageLike[] {
   // Fold pre-clear turns by default. When the user has run `/clear`,
   // earlier rows describe a conversation the model has forgotten; the
@@ -254,7 +263,7 @@ export function activityToThreadMessages(
 
   const flushAssistant = () => {
     if (!currentAssistant) return;
-    messages.push(currentAssistant.build());
+    messages.push(currentAssistant.build(todosEnabled));
     currentAssistant = null;
   };
 
@@ -509,9 +518,9 @@ class AssistantBuilder {
     }
   }
 
-  build(): ThreadMessageLike {
+  build(todosEnabled: boolean): ThreadMessageLike {
     const subagentCollapsed = collapseSubagents(this.parts);
-    const grouped = collapseToolRuns(subagentCollapsed);
+    const grouped = collapseToolRuns(subagentCollapsed, todosEnabled);
     return {
       id: this.id,
       role: "assistant",
@@ -527,7 +536,8 @@ class AssistantBuilder {
   }
 }
 
-function isTodoWriteArgsText(argsText: string): boolean {
+function isTodoWriteArgsText(argsText: string, todosEnabled: boolean): boolean {
+  if (!todosEnabled) return false;
   const parsed = parseJsonObject(argsText);
   if (parsed) {
     const title = parsed._aoe_title;
@@ -701,7 +711,10 @@ function buildGroupChildren(run: DraftPart[]): {
  *  underlying tool-call data is preserved verbatim inside the group's
  *  argsText payload so the renderer can expand back to the original
  *  per-tool cards on click. */
-function collapseToolRuns(parts: DraftPart[]): DraftPart[] {
+function collapseToolRuns(
+  parts: DraftPart[],
+  todosEnabled: boolean,
+): DraftPart[] {
   const out: DraftPart[] = [];
   let run: DraftPart[] = [];
   const flushRun = () => {
@@ -715,7 +728,7 @@ function collapseToolRuns(parts: DraftPart[]): DraftPart[] {
       // expand. TodoWrites are detected via the `_aoe_title` echo /
       // `todos` payload stashed in argsText.
       const isTodo = (p: DraftPart) =>
-        p.type === "tool-call" && isTodoWriteArgsText(p.argsText);
+        p.type === "tool-call" && isTodoWriteArgsText(p.argsText, todosEnabled);
       if (run.every(isTodo)) {
         const { childIds, children } = buildGroupChildren(run);
         out.push({

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -260,6 +260,34 @@ describe("ToolCards profile-gated dispatch (claude)", () => {
   });
 });
 
+describe("ToolCards profile-gated dispatch (opencode)", () => {
+  it("routes OpenCode todowrite payloads to the todos card", () => {
+    const { container } = render(
+      <Wrap toolKey="opencode">
+        <ToolCard
+          tool={makeToolCall({
+            id: "oc-todo-1",
+            name: "5 todos",
+            kind: "other",
+            args_preview: JSON.stringify({
+              todos: [
+                { content: "Check ACP schema", status: "completed" },
+                { content: "Render OpenCode todos", status: "in_progress" },
+              ],
+            }),
+          })}
+          result={undefined}
+        />
+      </Wrap>,
+    );
+
+    expect(container.textContent).toContain("todos");
+    expect(container.textContent).toContain("2 items");
+    expect(container.textContent).toContain("Check ACP schema");
+    expect(container.textContent).toContain("Render OpenCode todos");
+  });
+});
+
 describe("TodoGroupCard fold (#1468)", () => {
   function snapshot(id: string, content: string, status: string) {
     return {
@@ -277,6 +305,42 @@ describe("TodoGroupCard fold (#1468)", () => {
     snapshot("td1", "Step Alpha", "in_progress"),
     snapshot("td2", "Step Bravo", "in_progress"),
     snapshot("td3", "Step Charlie", "in_progress"),
+  ];
+
+  const opencodeItems = [
+    {
+      tool: makeToolCall({
+        id: "oc-td1",
+        name: "todowrite",
+        kind: "other",
+        args_preview: JSON.stringify({
+          todos: [{ content: "OpenCode Alpha", status: "pending" }],
+        }),
+      }),
+      result: makeCompletion({ id: "done-oc-td1", toolCallId: "oc-td1" }),
+    },
+    {
+      tool: makeToolCall({
+        id: "oc-td2",
+        name: "2 todos",
+        kind: "other",
+        args_preview: JSON.stringify({
+          todos: [{ content: "OpenCode Bravo", status: "in_progress" }],
+        }),
+      }),
+      result: makeCompletion({ id: "done-oc-td2", toolCallId: "oc-td2" }),
+    },
+    {
+      tool: makeToolCall({
+        id: "oc-td3",
+        name: "1 todos",
+        kind: "other",
+        args_preview: JSON.stringify({
+          todos: [{ content: "OpenCode Charlie", status: "completed" }],
+        }),
+      }),
+      result: makeCompletion({ id: "done-oc-td3", toolCallId: "oc-td3" }),
+    },
   ];
 
   it("shows the latest snapshot collapsed without expanding", () => {
@@ -357,6 +421,20 @@ describe("TodoGroupCard fold (#1468)", () => {
     // The header reads "stopped", not the misleading "done".
     expect(container.textContent).toContain("stopped");
     expect(container.textContent).not.toContain("done");
+  });
+
+  it("keeps OpenCode todowrite groups visible", () => {
+    const { container } = render(
+      <Wrap toolKey="opencode">
+        <TodoGroupCard items={opencodeItems} />
+      </Wrap>,
+    );
+
+    expect(container.textContent).toContain("todos");
+    expect(container.textContent).toContain("updated 3 times");
+    expect(container.textContent).toContain("OpenCode Charlie");
+    expect(container.textContent).not.toContain("OpenCode Alpha");
+    expect(container.textContent).not.toContain("OpenCode Bravo");
   });
 });
 

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -44,7 +44,12 @@ import {
 } from "../../lib/highlighter";
 import { useShikiTheme } from "../../hooks/useShikiTheme";
 import { hasAnsi, parseAnsi, type AnsiStyle } from "../../lib/ansi";
-import { parseJsonObject, pickFirst, pickStr } from "../../lib/cockpitArgs";
+import {
+  parseJsonObject,
+  pickFirst,
+  pickStr,
+  todoItemsFromArgs,
+} from "../../lib/cockpitArgs";
 import { useCockpitPrefs } from "../../lib/cockpitPrefs";
 import type { ActivityRow, ToolCall } from "../../lib/cockpitTypes";
 import { diffPair } from "../../lib/diffPair";
@@ -1026,37 +1031,22 @@ interface TodoItem {
   status: TodoStatus;
 }
 
-/** Heuristic for Claude's TodoWrite tool. The adapter ships it as a
- *  `kind: "think"` tool call with the joined todo list crammed into the
- *  title (`"Update TODOs: a, b, c"`) and the structured `{todos: [...]}`
- *  payload in raw_input. We detect via the title prefix and parse the
- *  args payload to render a proper checklist. See #1064. Profile-keyed
- *  so coincidental matches on other agents return early. */
+/** Heuristic for agent todo tools. Claude and OpenCode both carry the
+ *  current list in `args_preview.todos`, but their titles differ. The
+ *  profile opt-in is the safety gate; the structured todo payload is the
+ *  shared discriminator so grouping and rendering agree. See #1905. */
 function classifyTodoWrite(
   tool: ToolCall,
   profile: AgentProfile,
 ): { isTodoWrite: true; todos: TodoItem[] } | { isTodoWrite: false } {
-  const title = tool.name?.trim() ?? "";
-  const prefixes = profile.specialTitles.todoPrefixes;
-  const looksLikeTodo =
-    title === "TodoWrite" || prefixes.some((p) => title.startsWith(p));
-  if (!looksLikeTodo) return { isTodoWrite: false };
+  if (!profile.capabilities.todos) return { isTodoWrite: false };
   const args = parseJsonObject(tool.args_preview);
-  if (!args) return { isTodoWrite: false };
-  const raw = args.todos;
-  if (!Array.isArray(raw)) return { isTodoWrite: false };
-  const todos: TodoItem[] = [];
-  for (const entry of raw) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
-    const obj = entry as Record<string, unknown>;
-    const content = typeof obj.content === "string" ? obj.content : "";
-    if (!content) continue;
-    todos.push({
-      content,
-      status: normaliseTodoStatus(obj.status),
-    });
-  }
-  if (todos.length === 0) return { isTodoWrite: false };
+  const payload = todoItemsFromArgs(args);
+  if (payload.length === 0) return { isTodoWrite: false };
+  const todos = payload.map((entry) => ({
+    content: entry.content,
+    status: normaliseTodoStatus(entry.status),
+  }));
   return { isTodoWrite: true, todos };
 }
 

--- a/web/src/lib/agentProfiles.test.ts
+++ b/web/src/lib/agentProfiles.test.ts
@@ -32,14 +32,22 @@ describe("resolveAgentProfile", () => {
     expect(p.parentMetaNamespaces).toEqual(["claudeCode"]);
   });
 
-  it("codex / opencode / gemini disable claude-specific cards", () => {
-    for (const key of ["codex", "opencode", "gemini"] as const) {
+  it("codex / gemini disable claude-specific cards", () => {
+    for (const key of ["codex", "gemini"] as const) {
       const p = resolveAgentProfile(key);
       expect(p.capabilities.todos).toBe(false);
       expect(p.capabilities.skills).toBe(false);
       expect(p.capabilities.wakeup).toBe(false);
       expect(p.parentMetaNamespaces).toEqual([]);
     }
+  });
+
+  it("opencode supports todowrite cards but keeps other claude-specific cards disabled", () => {
+    const p = resolveAgentProfile("opencode");
+    expect(p.capabilities.todos).toBe(true);
+    expect(p.capabilities.skills).toBe(false);
+    expect(p.capabilities.wakeup).toBe(false);
+    expect(p.parentMetaNamespaces).toEqual([]);
   });
 
   it("codex aliases route shell / apply_patch / view_file to canonical cards", () => {

--- a/web/src/lib/agentProfiles.ts
+++ b/web/src/lib/agentProfiles.ts
@@ -1,7 +1,7 @@
 // Per-agent classifier profiles for the cockpit's frontend tool-card
 // dispatch. Mirrors src/cockpit/agent_profiles.rs (server-side gates);
 // this side covers the React presentation: which tool names map to
-// which cards, which claude-only cards (TodoWrite, Skill, Schedule)
+// which cards, which specialised cards (TodoWrite, Skill, Schedule)
 // should fire for this agent, which MCP prefixes to recognise.
 //
 // Profile data is conservative. Where the adapter's actual tool surface
@@ -25,13 +25,13 @@ export interface AgentProfile {
   /** Registry key, matches `AgentRegistry` on the server side
    *  (e.g. `claude`, `codex`, `opencode`, `gemini`). */
   key: string;
-  /** Capability gates for claude-specific specialised cards. When a
+  /** Capability gates for specialised cards. When a
    *  capability is `false`, the matching classifier short-circuits
    *  before consulting tool title heuristics, so coincidental tool
    *  names on other agents don't render a TodoCard / SkillCard /
    *  ScheduleCard. */
   capabilities: {
-    /** Claude's `TodoWrite` (kind=think, title=`"Update TODOs: ..."`). */
+    /** Agent todo tools, e.g. Claude `TodoWrite` or OpenCode `todowrite`. */
     todos: boolean;
     /** Claude's `Skill` (kind=other, title=`"Skill"`). */
     skills: boolean;
@@ -67,15 +67,12 @@ export interface AgentProfile {
    *  should route to that card when the wire `tool.kind` lands as
    *  `"other"` or doesn't otherwise indicate the right surface. */
   aliases: Partial<Record<CardKind, string[]>>;
-  /** Title equality checks for claude's specialised cards. The
+  /** Title equality checks for Claude's specialised cards. The
    *  current claude-agent-acp behavior threads the raw tool name
    *  through the `Other` arm of its title-rewriter; other agents that
    *  happen to emit the same name shouldn't fire the card unless
    *  their profile lists it too. */
   specialTitles: {
-    /** Prefixes matched against the wire `tool.name` for TodoWrite
-     *  classification (claude emits `"Update TODOs: ..."`). */
-    todoPrefixes: string[];
     /** Lowercased title values matched for the Skill card. */
     skillNames: string[];
     /** Exact title values matched for the Schedule cards. */
@@ -91,7 +88,6 @@ const CLAUDE: AgentProfile = {
   clearAliases: ["/clear"],
   aliases: {},
   specialTitles: {
-    todoPrefixes: ["Update TODOs"],
     skillNames: ["skill", "claude-skill"],
     scheduleNames: ["ScheduleWakeup", "CronCreate", "CronList", "CronDelete"],
   },
@@ -113,16 +109,12 @@ const CODEX: AgentProfile = {
     edit: ["apply_patch"],
     read: ["view_file", "read_file", "read"],
   },
-  specialTitles: {
-    todoPrefixes: [],
-    skillNames: [],
-    scheduleNames: [],
-  },
+  specialTitles: { skillNames: [], scheduleNames: [] },
 };
 
 const OPENCODE: AgentProfile = {
   key: "opencode",
-  capabilities: { todos: false, skills: false, wakeup: false, subagents: true, legacyModeFallback: false },
+  capabilities: { todos: true, skills: false, wakeup: false, subagents: true, legacyModeFallback: false },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
   clearAliases: ["/new"],
@@ -134,11 +126,7 @@ const OPENCODE: AgentProfile = {
     fetch: ["webfetch"],
     think: ["task"],
   },
-  specialTitles: {
-    todoPrefixes: [],
-    skillNames: [],
-    scheduleNames: [],
-  },
+  specialTitles: { skillNames: [], scheduleNames: [] },
 };
 
 const GEMINI: AgentProfile = {
@@ -154,11 +142,7 @@ const GEMINI: AgentProfile = {
     search: ["grep", "glob"],
     fetch: ["web_fetch"],
   },
-  specialTitles: {
-    todoPrefixes: [],
-    skillNames: [],
-    scheduleNames: [],
-  },
+  specialTitles: { skillNames: [], scheduleNames: [] },
 };
 
 const VIBE: AgentProfile = {
@@ -168,7 +152,7 @@ const VIBE: AgentProfile = {
   mcpPrefixes: ["mcp__"],
   clearAliases: [],
   aliases: {},
-  specialTitles: { todoPrefixes: [], skillNames: [], scheduleNames: [] },
+  specialTitles: { skillNames: [], scheduleNames: [] },
 };
 
 const PI: AgentProfile = {
@@ -178,7 +162,7 @@ const PI: AgentProfile = {
   mcpPrefixes: ["mcp__"],
   clearAliases: [],
   aliases: {},
-  specialTitles: { todoPrefixes: [], skillNames: [], scheduleNames: [] },
+  specialTitles: { skillNames: [], scheduleNames: [] },
 };
 
 const AOE_AGENT: AgentProfile = {
@@ -196,7 +180,7 @@ export const DEFAULT_AGENT_PROFILE: AgentProfile = {
   mcpPrefixes: ["mcp__"],
   clearAliases: [],
   aliases: {},
-  specialTitles: { todoPrefixes: [], skillNames: [], scheduleNames: [] },
+  specialTitles: { skillNames: [], scheduleNames: [] },
 };
 
 const PROFILES: Record<string, AgentProfile> = {

--- a/web/src/lib/cockpitArgs.test.ts
+++ b/web/src/lib/cockpitArgs.test.ts
@@ -7,10 +7,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   hasArgsBody,
+  hasTodoItemsArgsText,
   parseJsonObject,
   pickFirst,
   pickStr,
   previewFromArgs,
+  todoItemsFromArgs,
 } from "./cockpitArgs";
 
 describe("parseJsonObject", () => {
@@ -150,5 +152,46 @@ describe("hasArgsBody", () => {
   it("is true for non-blank non-object payloads, false when blank", () => {
     expect(hasArgsBody("raw text [truncated]")).toBe(true);
     expect(hasArgsBody("   ")).toBe(false);
+  });
+});
+
+describe("todoItemsFromArgs", () => {
+  it("returns todo items with non-blank content", () => {
+    expect(
+      todoItemsFromArgs({
+        todos: [
+          { content: " Check schema ", status: "completed" },
+          { content: "Render todos", status: "in_progress" },
+        ],
+      }),
+    ).toEqual([
+      { content: " Check schema ", status: "completed" },
+      { content: "Render todos", status: "in_progress" },
+    ]);
+  });
+
+  it("ignores whitespace-only todo content", () => {
+    expect(
+      todoItemsFromArgs({
+        todos: [
+          { content: "   ", status: "pending" },
+          { content: "\t", status: "in_progress" },
+          { content: "Keep me", status: "completed" },
+        ],
+      }),
+    ).toEqual([{ content: "Keep me", status: "completed" }]);
+  });
+
+  it("detects todo args only when at least one item has content", () => {
+    expect(
+      hasTodoItemsArgsText(
+        JSON.stringify({ todos: [{ content: "   ", status: "pending" }] }),
+      ),
+    ).toBe(false);
+    expect(
+      hasTodoItemsArgsText(
+        JSON.stringify({ todos: [{ content: "Real", status: "pending" }] }),
+      ),
+    ).toBe(true);
   });
 });

--- a/web/src/lib/cockpitArgs.ts
+++ b/web/src/lib/cockpitArgs.ts
@@ -85,7 +85,7 @@ export function todoItemsFromArgs(
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
     const obj = entry as Record<string, unknown>;
     const content = typeof obj.content === "string" ? obj.content : "";
-    if (!content) continue;
+    if (content.trim() === "") continue;
     todos.push({ content, status: obj.status });
   }
   return todos;

--- a/web/src/lib/cockpitArgs.ts
+++ b/web/src/lib/cockpitArgs.ts
@@ -69,3 +69,28 @@ export function hasArgsBody(argsPreview: string): boolean {
   if (!parsed) return argsPreview.trim().length > 0;
   return Object.keys(parsed).some((k) => !k.startsWith("_aoe_"));
 }
+
+export interface TodoPayloadItem {
+  content: string;
+  status: unknown;
+}
+
+export function todoItemsFromArgs(
+  args: Record<string, unknown> | null,
+): TodoPayloadItem[] {
+  const raw = args?.todos;
+  if (!Array.isArray(raw)) return [];
+  const todos: TodoPayloadItem[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const obj = entry as Record<string, unknown>;
+    const content = typeof obj.content === "string" ? obj.content : "";
+    if (!content) continue;
+    todos.push({ content, status: obj.status });
+  }
+  return todos;
+}
+
+export function hasTodoItemsArgsText(argsText: string): boolean {
+  return todoItemsFromArgs(parseJsonObject(argsText)).length > 0;
+}

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -351,6 +351,52 @@ describe("applyEvent / UserPromptSent", () => {
     expect(rowAfter?.tool?.diffs?.length).toBe(1);
   });
 
+  it("patches OpenCode todowrite args when ToolCallUpdated supplies todos later", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ToolCallStarted: {
+          tool_call: {
+            id: "tc-todos",
+            name: "todowrite",
+            kind: "other",
+            args_preview: "{}",
+            started_at: new Date().toISOString(),
+          },
+        },
+      },
+    });
+    const todos = JSON.stringify({
+      todos: [
+        {
+          content: "Render OpenCode todos",
+          priority: "high",
+          status: "in_progress",
+        },
+      ],
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ToolCallUpdated: {
+          tool_call_id: "tc-todos",
+          title: "1 todos",
+          args_preview: todos,
+        },
+      },
+    });
+
+    const startRow = state.activity.find(
+      (a) => a.kind === "tool_start" && a.toolCallId === "tc-todos",
+    );
+    expect(startRow?.tool?.name).toBe("1 todos");
+    expect(startRow?.tool?.args_preview).toBe(todos);
+    expect(state.inFlightTool?.name).toBe("1 todos");
+    expect(state.inFlightTool?.args_preview).toBe(todos);
+  });
+
   it("uses 'tool failed' when error event has no content", () => {
     const state = applyEvent(emptyCockpitState(), {
       session_id: "s-1",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1577,6 +1577,7 @@
       "kind": "vitest",
       "risk": "medium",
       "specs": [
+        "src/components/cockpit/CockpitRuntime.test.ts",
         "src/components/cockpit/ToolCards.render.test.tsx",
         "src/lib/agentProfiles.test.ts",
         "src/lib/cockpitTypes.test.ts"

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1573,6 +1573,23 @@
       ]
     },
     {
+      "id": "cockpit.opencode-todos",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/ToolCards.render.test.tsx",
+        "src/lib/agentProfiles.test.ts",
+        "src/lib/cockpitTypes.test.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/ToolCards.tsx",
+        "web/src/components/cockpit/CockpitRuntime.tsx",
+        "web/src/lib/agentProfiles.ts",
+        "web/src/lib/cockpitArgs.ts",
+        "web/src/lib/cockpitTypes.ts"
+      ]
+    },
+    {
       "id": "cockpit.context-primer-banner",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

OpenCode emits todo updates through regular ACP tool calls instead of a dedicated todo event. The dashboard already receives the structured `todos` payload in `args_preview`, but the cockpit card classifier treated OpenCode as not supporting todo cards, so those updates rendered as generic tool cards.

This changes the cockpit todo classifier to use a profile opt-in plus the structured `todos` payload as the discriminator. OpenCode is opted into todo cards, Claude keeps the same behavior, and other agents remain protected from accidental todo-card rendering. The grouping path now uses the same payload helper, so consecutive OpenCode `todowrite` updates fold into the existing todo group card.

Regression coverage now verifies OpenCode profile capabilities, late `ToolCallUpdated` payload patching, a single OpenCode todo card, and grouped OpenCode todo updates. The cockpit interface docs now describe OpenCode `todowrite` grouping alongside Claude `TodoWrite` grouping.

Closes #1905

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open an OpenCode cockpit session that emits a `todowrite` update and confirm the dashboard shows a todo card instead of a generic tool card.
- [ ] Trigger three consecutive OpenCode `todowrite` updates and confirm the dashboard folds them into one todo card titled "updated 3 times" showing the latest todo list.
- [ ] Trigger a non-todo OpenCode tool call and confirm it still renders through its normal tool card, not the todo card.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this is a deterministic cockpit tool-card classification and reducer regression covered by Vitest in `web/src/components/cockpit/ToolCards.render.test.tsx`, `web/src/lib/agentProfiles.test.ts`, and `web/src/lib/cockpitTypes.test.ts`; `web/tests/coverage-matrix.json` was updated

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

Claude via Claude Code and the agent-of-empires `/aoe-implement` workflow.

**Any Additional AI Details you'd like to share:**

Investigation, implementation, tests, docs, and validation were drafted by Claude under my direction. I made the design calls, including keeping rendering gated by the agent profile and treating the upstream OpenCode ACP behavior as valid structured tool input.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR lets OpenCode emit and update todo lists as dedicated todo cards in the Cockpit UI (same UX Claude already had) while keeping the behavior profile-gated and robust to late-patched payloads.

### What changed (high-level)
- OpenCode agent profile is opted into todo capability (capabilities.todos = true).
- Todo classification now requires an agent opt-in plus a structured `todos` array in tool.args_preview; title/prefix checks were de-emphasized.
- Shared helpers were added to parse/normalize todo payloads and to ensure grouping and rendering use the same predicate.
- Consecutive OpenCode `todowrite` updates fold into a single grouped todo card (shows latest snapshot and “updated N times”).
- Tool calls that receive their `todos` via a later ToolCallUpdated event are correctly reclassified on replay/reconnect.
- Tests and documentation were added/updated to cover OpenCode todo rendering, grouped updates, replay behavior, and profile changes.

### Benefits
- Consistent UX: OpenCode todos match Claude’s todo behavior.
- Safe rollout: feature only applies when an agent profile explicitly permits todos.
- Reliable: handles late/updated payloads so cards don’t disappear or collapse to empty.
- Maintainable: unified parsing/helpers reduce divergence between grouping and rendering.

---

## Technical details

Key additions
- New helpers in web/src/lib/cockpitArgs.ts:
  - TodoPayloadItem interface (content, optional status)
  - todoItemsFromArgs(args) to extract non-empty todo items
  - hasTodoItemsArgsText(argsText) to detect non-empty todos in args preview
- isTodoWrite / classification refactor:
  - ToolCards and CockpitRuntime now use the shared helper to decide todo classification.
  - Classification requires profile.capabilities.todos === true and a non-empty structured `todos` payload.
- Profile changes:
  - AgentProfile.specialTitles no longer contains todo-prefix matching; titles-based gating removed.
  - OPENCODE profile now has capabilities.todos = true.
- Grouping/rendering:
  - CockpitRuntime and ToolCards use the same todo predicate so grouped todo cards never collapse to empty and folding behavior is consistent (including “updated N times”).
  - Fold threshold behavior preserved (folding requires same-shaped consecutive calls).
- Replay handling:
  - Reducer/runtime updated so a ToolCallStarted with empty args, later patched by ToolCallUpdated with `todos`, becomes a todo card after replay/reconnect.
- Tests & docs:
  - New/updated Vitest and RTL tests for single OpenCode todo card, grouped TodoGroupCard behavior, and ToolCallStarted→ToolCallUpdated replay.
  - Agent profile tests adjusted to assert OpenCode todo capability.
  - Documentation updated (docs/cockpit/interface.md) to describe OpenCode `todowrite` grouping alongside Claude `TodoWrite`.
  - coverage-matrix.json updated to include the new test surface.

Files of note
- web/src/lib/cockpitArgs.ts (+ tests)
- web/src/components/cockpit/ToolCards.tsx (+ render tests)
- web/src/components/cockpit/CockpitRuntime.tsx (+ tests)
- web/src/lib/agentProfiles.ts (+ tests)
- docs/cockpit/interface.md
- web/src/lib/cockpitTypes.test.ts, web/tests/coverage-matrix.json
<!-- end of auto-generated comment: release notes by coderabbit.ai -->