### PR TITLE
fix(cockpit): self-terminate orphaned runners so dead-daemon agents stop leaking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,10 @@ serve = [
 
 [dev-dependencies]
 serial_test = "3.4"
+# Integration tests are separate crates and don't inherit the normal
+# `serde_json` dependency; the cockpit-runner orphan test parses a worker
+# registry record to mutate its pid structurally.
+serde_json = "1.0"
 cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt"] }
 # Test-only axum dep, used by the update e2e fixture server that serves
 # a fake release tarball. The runtime code uses reqwest, not axum.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ serve = [
 [dev-dependencies]
 serial_test = "3.4"
 # Integration tests are separate crates and don't inherit the normal
-# `serde_json` dependency; the cockpit-runner orphan test parses a worker
+# `serde_json` dependency; the acp-runner orphan test parses a worker
 # registry record to mutate its pid structurally.
 serde_json = "1.0"
 cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt"] }

--- a/docs/structured-view/persistence.md
+++ b/docs/structured-view/persistence.md
@@ -52,6 +52,20 @@ Practical implications:
   restarts and e2e runs (#1689). A runner that is hard-killed with
   `SIGKILL` (which cannot run its own cleanup) can still leak; prefer
   the verbs above over `kill -9`.
+- **Self-termination when abandoned.** The reapers above all run inside a
+  live daemon, so a daemon that dies WITHOUT killing its runners (a crash,
+  a `SIGKILL`, or an ephemeral test `$HOME` that gets deleted) would
+  otherwise orphan the runner plus its agent tree forever. Each runner
+  carries a watchdog that polls its own registry record and self-destructs
+  (terminating its whole process group) when it observes that it has been
+  abandoned: the record file vanished, the record was taken over by a
+  newer runner, or it has been detached with no daemon attached for longer
+  than a 48h retention window. The 48h window is generous enough to cover
+  an overnight or weekend `aoe serve --stop`, and the clock resets on every
+  reattach, so an intentionally stopped session stays reattachable. A
+  pending `aoe cockpit restart` is exempt (the runner sees the restart
+  marker and waits). This is a backstop; the explicit verbs above are
+  still the fast path. See #1921.
 - During the detach window (between `aoe serve --stop` and the next
   `aoe serve`), the runner buffers up to 256 agent → daemon
   notification lines so per-stream chunks emitted while the daemon was

--- a/docs/structured-view/persistence.md
+++ b/docs/structured-view/persistence.md
@@ -57,7 +57,8 @@ Practical implications:
   a `SIGKILL`, or an ephemeral test `$HOME` that gets deleted) would
   otherwise orphan the runner plus its agent tree forever. Each runner
   carries a watchdog that polls its own registry record and self-destructs
-  (terminating its whole process group) when it observes that it has been
+  (terminating its whole process group when it is the group leader, which
+  it normally is via `setsid`) when it observes that it has been
   abandoned: the record file vanished, the record was taken over by a
   newer runner, or it has been detached with no daemon attached for longer
   than a 48h retention window. The 48h window is generous enough to cover

--- a/docs/structured-view/persistence.md
+++ b/docs/structured-view/persistence.md
@@ -64,7 +64,7 @@ Practical implications:
   than a 48h retention window. The 48h window is generous enough to cover
   an overnight or weekend `aoe serve --stop`, and the clock resets on every
   reattach, so an intentionally stopped session stays reattachable. A
-  pending `aoe cockpit restart` is exempt (the runner sees the restart
+  pending `aoe acp restart` is exempt (the runner sees the restart
   marker and waits). This is a backstop; the explicit verbs above are
   still the fast path. See #1921.
 - During the detach window (between `aoe serve --stop` and the next

--- a/src/acp/runner.rs
+++ b/src/acp/runner.rs
@@ -45,8 +45,9 @@
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Context, Result};
 use clap::Args;
@@ -57,7 +58,71 @@ use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
-use super::worker_registry::{self, WorkerRecord};
+use super::worker_registry::{self, RunnerRecordState, WorkerRecord};
+
+/// How often the abandonment watchdog inspects its own registry record.
+const WATCHDOG_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Resolve the watchdog poll interval. Tests shrink it via
+/// `AOE_ACP_WATCHDOG_POLL_MS` so an orphan dies in well under a second
+/// instead of tens of seconds; production always uses
+/// [`WATCHDOG_POLL_INTERVAL`]. Mirrors the
+/// `AOE_ACP_RUNNER_SOCKET_TIMEOUT_MS` test knob.
+fn watchdog_poll_interval() -> Duration {
+    std::env::var("AOE_ACP_WATCHDOG_POLL_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|ms| *ms > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(WATCHDOG_POLL_INTERVAL)
+}
+
+/// Consecutive `Missing` polls before the watchdog treats the record as
+/// gone for good. Debounced so a daemon-side delete+respawn (supersede) or
+/// an atomic-rename window can't trigger a false self-destruct on a single
+/// observation. The first poll only fires after `WATCHDOG_POLL_INTERVAL`,
+/// which doubles as a startup grace so the initial record write isn't
+/// raced.
+const WATCHDOG_MISSING_THRESHOLD: u32 = 2;
+
+/// Bounded retention for a detached runner. While no daemon is attached,
+/// the runner keeps the agent alive so a fresh `aoe serve` can reattach
+/// mid-turn (this is the whole point of the shim outliving the daemon).
+/// But a daemon that crashes/SIGKILLs in a persistent `$HOME` and never
+/// restarts would otherwise leave the runner + agent alive forever, with
+/// no daemon left to reap them. After this long with no attachment, the
+/// runner self-terminates. Generous enough to cover an overnight or
+/// weekend daemon stop; the clock resets on every reattach. See #1921.
+const DETACHED_RETENTION: Duration = Duration::from_secs(48 * 60 * 60);
+
+/// Sentinel in [`DetachedSince`] meaning "a daemon is currently attached",
+/// so the detached-retention clock is not running.
+const ATTACHED: u64 = 0;
+
+/// Shared unix-epoch-seconds marker for when the runner last went
+/// detached, or [`ATTACHED`] while a daemon is connected. Written by the
+/// accept loop on connect/disconnect, read by the watchdog.
+type DetachedSince = AtomicU64;
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Why the runner is tearing down. Drives whether teardown deletes the
+/// registry entry: a superseded runner must NOT delete, since the files
+/// now belong to the fresh runner that replaced it.
+#[derive(Debug, Clone, Copy)]
+enum WatchdogShutdown {
+    /// Our registry record vanished (HOME deleted, or daemon `delete`d it).
+    RecordMissing,
+    /// A fresh runner superseded us; the on-disk files are now theirs.
+    Superseded,
+    /// Detached past [`DETACHED_RETENTION`] with no daemon reattaching.
+    DetachedRetentionExpired,
+}
 
 /// Cap on agent → daemon notification lines stored while detached.
 /// Each entry is at most one ndjson line (a few KB). Past this, oldest
@@ -236,8 +301,36 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
     let shutdown_signal = wait_for_shutdown();
 
     let session_id = args.session_id.clone();
+
+    // Abandonment watchdog: a daemon that dies without explicitly killing
+    // its runners (crash, SIGKILL, or an ephemeral test `$HOME` that gets
+    // deleted) would otherwise leave this runner + agent + grandchildren
+    // alive forever, since every other reaper runs inside a live daemon in
+    // the same `$HOME`. The watchdog gives the runner a self-destruct path.
+    // It polls the registry record via a non-creating read of a path
+    // captured now (while the dir exists), so it never resurrects a deleted
+    // `$HOME`. `detached_since` starts "detached" (no daemon yet) and is
+    // flipped by the accept loop. See #1921.
+    let detached_since: Arc<DetachedSince> = Arc::new(AtomicU64::new(now_secs()));
+    let watchdog_task = {
+        let record_path = worker_registry::record_path(&args.session_id)?;
+        let restart_marker = worker_registry::restart_marker_path(&args.session_id)?;
+        let (watchdog_tx, watchdog_rx) = tokio::sync::oneshot::channel::<WatchdogShutdown>();
+        let handle = tokio::spawn(run_watchdog(
+            record_path,
+            restart_marker,
+            our_pid,
+            Arc::clone(&detached_since),
+            session_id.clone(),
+            watchdog_tx,
+        ));
+        (handle, watchdog_rx)
+    };
+    let (watchdog_handle, mut watchdog_rx) = watchdog_task;
+
     let accept_session_id = session_id.clone();
     let accept_shared = Arc::clone(&shared);
+    let accept_detached = Arc::clone(&detached_since);
     let accept_loop = async move {
         loop {
             match listener.accept().await {
@@ -248,6 +341,7 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
                         "daemon connected"
                     );
                     worker_registry::mark_attached(&accept_session_id);
+                    accept_detached.store(ATTACHED, Ordering::Relaxed);
                     handle_connection(
                         stream,
                         Arc::clone(&accept_shared),
@@ -261,6 +355,7 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
                         "daemon disconnected; runner stays alive"
                     );
                     worker_registry::mark_detached(&accept_session_id);
+                    accept_detached.store(now_secs(), Ordering::Relaxed);
                 }
                 Err(e) => {
                     warn!(target: "acp.runner", "accept error: {e}");
@@ -270,8 +365,8 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
         }
     };
 
-    // Wait for: agent exit, signal, or accept loop death (latter is
-    // unreachable but kept for symmetry).
+    // Wait for: agent exit, signal, watchdog self-destruct, or accept loop
+    // death (last is unreachable but kept for symmetry).
     tokio::select! {
         status = agent_child.wait() => {
             match status {
@@ -297,14 +392,164 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
             let _ = agent_child.start_kill();
             let _ = agent_child.wait().await;
         }
+        reason = &mut watchdog_rx => {
+            if let Ok(reason) = reason {
+                self_terminate_agent_tree(reason, &session_id, our_pid, &mut agent_child).await;
+            }
+        }
         _ = accept_loop => {
             warn!(target: "acp.runner", session = %session_id, "accept loop exited unexpectedly");
         }
     }
 
+    watchdog_handle.abort();
     agent_stdout_task.abort();
     worker_registry::delete(&session_id).ok();
     Ok(())
+}
+
+/// Poll this runner's own registry record and signal the main loop to
+/// self-destruct when it observes that the runner has been abandoned.
+/// Sends at most one [`WatchdogShutdown`] and returns; the main `select!`
+/// owns the actual teardown so there is exactly one killer (no double-fire
+/// with the signal/agent-exit paths, which simply cancel this task). See
+/// #1921.
+async fn run_watchdog(
+    record_path: PathBuf,
+    restart_marker: PathBuf,
+    own_pid: u32,
+    detached_since: Arc<DetachedSince>,
+    session_id: String,
+    tx: tokio::sync::oneshot::Sender<WatchdogShutdown>,
+) {
+    let mut missing = 0u32;
+    let poll_interval = watchdog_poll_interval();
+    loop {
+        // Sleep first: the initial delay doubles as a startup grace so the
+        // record write at boot isn't raced.
+        tokio::time::sleep(poll_interval).await;
+
+        // Detached-retention backstop for the persistent-`$HOME`
+        // crash-no-restart case, where the record survives but no daemon
+        // is left to reap us.
+        let since = detached_since.load(Ordering::Relaxed);
+        if since != ATTACHED && now_secs().saturating_sub(since) >= DETACHED_RETENTION.as_secs() {
+            warn!(
+                target: "acp.runner",
+                session = %session_id,
+                "detached past retention with no daemon; self-terminating"
+            );
+            let _ = tx.send(WatchdogShutdown::DetachedRetentionExpired);
+            return;
+        }
+
+        match worker_registry::inspect_record_for_runner(&record_path, own_pid) {
+            // Still ours, or a transient read hiccup we shouldn't act on.
+            RunnerRecordState::Matches | RunnerRecordState::Unreadable => missing = 0,
+            RunnerRecordState::Superseded => {
+                warn!(
+                    target: "acp.runner",
+                    session = %session_id,
+                    "registry record now owned by a different pid; superseded, self-terminating"
+                );
+                let _ = tx.send(WatchdogShutdown::Superseded);
+                return;
+            }
+            RunnerRecordState::Missing => {
+                // `aoe acp restart` deletes the record right before it
+                // SIGTERMs us; the marker tells us not to race that to a
+                // hard self-destruct.
+                if restart_marker.exists() {
+                    missing = 0;
+                    continue;
+                }
+                missing += 1;
+                if missing >= WATCHDOG_MISSING_THRESHOLD {
+                    warn!(
+                        target: "acp.runner",
+                        session = %session_id,
+                        "registry record gone; abandoned, self-terminating"
+                    );
+                    let _ = tx.send(WatchdogShutdown::RecordMissing);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Tear down the agent process tree after the watchdog flags abandonment.
+/// Politely SIGTERMs the agent, waits briefly, then SIGKILLs the whole
+/// process group (runner + node wrapper + `claude` grandchild) so nothing
+/// is left orphaned under PID 1.
+#[cfg(unix)]
+async fn self_terminate_agent_tree(
+    reason: WatchdogShutdown,
+    session_id: &str,
+    own_pid: u32,
+    agent_child: &mut Child,
+) {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::{getpgrp, getpid, Pid};
+
+    info!(
+        target: "acp.runner",
+        session = %session_id,
+        ?reason,
+        "runner abandoned; terminating agent tree"
+    );
+
+    // A superseded runner must NOT delete the registry/socket: those files
+    // now belong to the fresh runner that replaced us, and deleting them
+    // would make the new runner's own watchdog see "missing" and cascade.
+    // Every other reason means we still own them (or they're already gone),
+    // so cleanup is safe and clears a stale socket that would confuse
+    // attach.
+    if !matches!(reason, WatchdogShutdown::Superseded) {
+        worker_registry::delete(session_id).ok();
+    }
+
+    // Polite SIGTERM to the agent (node) so a cooperative adapter can
+    // flush; the group SIGKILL below is the guarantee.
+    if let Some(agent_pid) = agent_child.id() {
+        let _ = kill(Pid::from_raw(agent_pid as i32), Signal::SIGTERM);
+    }
+    let _ = tokio::time::timeout(Duration::from_secs(2), agent_child.wait()).await;
+
+    // Final hammer. The runner is its own process-group leader via setsid,
+    // so SIGKILLing the group reaps the node wrapper and its `claude`
+    // grandchild together. It also kills the runner itself, which is
+    // exactly the intent: nothing is left to clean up after this. Guard on
+    // actually being the group leader so a failed setsid can't make us
+    // SIGKILL the daemon's inherited group.
+    if getpgrp() == getpid() {
+        worker_registry::kill_runner_group(own_pid);
+    } else {
+        // setsid failed; we share another group. Never group-kill it. Kill
+        // just the direct child and fall through to a normal runner exit.
+        let _ = agent_child.start_kill();
+        let _ = agent_child.wait().await;
+    }
+}
+
+#[cfg(not(unix))]
+async fn self_terminate_agent_tree(
+    reason: WatchdogShutdown,
+    session_id: &str,
+    _own_pid: u32,
+    agent_child: &mut Child,
+) {
+    info!(
+        target: "acp.runner",
+        session = %session_id,
+        ?reason,
+        "runner abandoned; terminating agent"
+    );
+    if !matches!(reason, WatchdogShutdown::Superseded) {
+        worker_registry::delete(session_id).ok();
+    }
+    let _ = agent_child.start_kill();
+    let _ = agent_child.wait().await;
 }
 
 /// State the accept loop and the agent-stdout fanout share. The active

--- a/src/acp/runner.rs
+++ b/src/acp/runner.rs
@@ -365,6 +365,10 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
         }
     };
 
+    // Set when teardown must leave the registry/socket in place because a
+    // newer runner now owns them (the superseded case).
+    let mut preserve_registry = false;
+
     // Wait for: agent exit, signal, watchdog self-destruct, or accept loop
     // death (last is unreachable but kept for symmetry).
     tokio::select! {
@@ -394,6 +398,14 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
         }
         reason = &mut watchdog_rx => {
             if let Ok(reason) = reason {
+                // A superseded runner must not delete the registry/socket:
+                // they belong to the fresh runner that replaced it. The
+                // group-leader teardown SIGKILLs itself and never returns
+                // here, but the non-leader fallback (and the non-unix path)
+                // do return, so guard the post-loop delete below too.
+                if matches!(reason, WatchdogShutdown::Superseded) {
+                    preserve_registry = true;
+                }
                 self_terminate_agent_tree(reason, &session_id, our_pid, &mut agent_child).await;
             }
         }
@@ -404,7 +416,9 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
 
     watchdog_handle.abort();
     agent_stdout_task.abort();
-    worker_registry::delete(&session_id).ok();
+    if !preserve_registry {
+        worker_registry::delete(&session_id).ok();
+    }
     Ok(())
 }
 

--- a/src/acp/worker_registry.rs
+++ b/src/acp/worker_registry.rs
@@ -487,6 +487,58 @@ pub fn terminate(session_id: &str) {
     delete(session_id).ok();
 }
 
+/// Reap a runner process group with SIGKILL escalation: SIGTERM the group,
+/// wait `grace` for it to exit, then SIGKILL the group. A bare SIGTERM can
+/// leave a node/`claude` grandchild that ignores it alive under PID 1, so
+/// the escalation is what actually guarantees the tree dies. `killpg`
+/// ignores ESRCH, so the SIGKILL on an already-empty group is a no-op.
+/// Used by the boot reconciler's orphan sweep. See #1921.
+#[cfg(unix)]
+pub async fn reap_group_escalating(pid: u32, grace: std::time::Duration) {
+    terminate_runner_group(pid);
+    tokio::time::sleep(grace).await;
+    kill_runner_group(pid);
+}
+
+/// What this runner's own registry record looks like from its watchdog's
+/// point of view. Computed from a non-creating read of a path captured at
+/// startup; see [`inspect_record_for_runner`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerRecordState {
+    /// Record present and its `pid` matches ours: we are still the owner.
+    Matches,
+    /// Record file is gone (HOME deleted, or a daemon `delete`d it).
+    Missing,
+    /// Record present but owned by a different pid: a fresh runner has
+    /// superseded us (delete + respawn). We must exit without touching the
+    /// files, which now belong to the new owner.
+    Superseded,
+    /// Read or parse failed for a reason other than absence. Treated as
+    /// non-fatal (transient FS hiccup) by the watchdog.
+    Unreadable,
+}
+
+/// Inspect this runner's registry record WITHOUT creating the workers dir.
+///
+/// The watchdog cannot use [`load`], because `load` -> `record_path` ->
+/// `workers_dir` calls `create_dir_all`, which would recreate the very
+/// directory whose deletion is the watchdog's primary self-destruct signal
+/// (and resurrect a temp `$HOME` a test just removed). The caller captures
+/// the concrete `<session_id>.json` path once at startup, while the dir
+/// still exists, and polls it here. See #1921.
+pub fn inspect_record_for_runner(record_path: &Path, own_pid: u32) -> RunnerRecordState {
+    let bytes = match std::fs::read(record_path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return RunnerRecordState::Missing,
+        Err(_) => return RunnerRecordState::Unreadable,
+    };
+    match serde_json::from_slice::<WorkerRecord>(&bytes) {
+        Ok(rec) if rec.pid == own_pid => RunnerRecordState::Matches,
+        Ok(_) => RunnerRecordState::Superseded,
+        Err(_) => RunnerRecordState::Unreadable,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1200,12 +1200,17 @@ async fn sweep_orphan_workers(state: &Arc<AppState>, live: &HashSet<&String>) {
             pid = record.pid,
             "sweeping orphan worker (no matching session on disk)"
         );
+        // Group-kill with SIGKILL escalation, not a single-pid SIGTERM: the
+        // orphan's node wrapper and `claude` grandchild share the runner's
+        // process group, and a bare SIGTERM to just the leader pid can
+        // leave them alive under PID 1 (part of the leak this fixes). The
+        // escalation runs detached so one stubborn orphan can't stall the
+        // sweep for the grace window. See #1921.
         #[cfg(unix)]
-        if crate::acp::worker_registry::is_pid_alive(record.pid) {
-            use nix::sys::signal::{kill, Signal};
-            use nix::unistd::Pid;
-            let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGTERM);
-        }
+        tokio::spawn(crate::acp::worker_registry::reap_group_escalating(
+            record.pid,
+            std::time::Duration::from_secs(2),
+        ));
         crate::acp::worker_registry::delete(&record.session_id).ok();
     }
 }

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1205,7 +1205,11 @@ async fn sweep_orphan_workers(state: &Arc<AppState>, live: &HashSet<&String>) {
         // process group, and a bare SIGTERM to just the leader pid can
         // leave them alive under PID 1 (part of the leak this fixes). The
         // escalation runs detached so one stubborn orphan can't stall the
-        // sweep for the grace window. See #1921.
+        // sweep for the grace window. If the daemon exits within the 2s
+        // grace the spawned task is dropped before its SIGKILL fires, so a
+        // grandchild that ignored the SIGTERM survives with only that
+        // signal; the next daemon boot re-sweeps it, so this is acceptable.
+        // See #1921.
         #[cfg(unix)]
         tokio::spawn(crate::acp::worker_registry::reap_group_escalating(
             record.pid,

--- a/tests/acp_runner_orphan.rs
+++ b/tests/acp_runner_orphan.rs
@@ -1,4 +1,4 @@
-//! Regression tests for #1921: an abandoned `aoe __cockpit-runner` must
+//! Regression tests for #1921: an abandoned `aoe __acp-runner` must
 //! self-terminate instead of leaking forever, and a superseded runner must
 //! exit WITHOUT deleting the replacement runner's files.
 //!
@@ -57,14 +57,14 @@ impl Drop for Scratch {
 /// Spawn a runner with `cat` as the fake agent and wait until it has
 /// written its registry record. Returns the child and the record path.
 fn spawn_runner_and_wait_for_record(home: &Path, xdg: &Path, session_id: &str) -> (Child, PathBuf) {
-    let workers = app_dir(home, xdg).join("cockpit-workers");
+    let workers = app_dir(home, xdg).join("acp-workers");
     let socket = workers.join(format!("{session_id}.sock"));
     let record = workers.join(format!("{session_id}.json"));
 
     let bin = env!("CARGO_BIN_EXE_aoe");
     let mut child = Command::new(bin)
         .args([
-            "__cockpit-runner",
+            "__acp-runner",
             "--socket",
             socket.to_str().unwrap(),
             "--session-id",
@@ -79,9 +79,9 @@ fn spawn_runner_and_wait_for_record(home: &Path, xdg: &Path, session_id: &str) -
         .env("HOME", home)
         .env("XDG_CONFIG_HOME", xdg)
         // Shrink the watchdog poll so an orphan dies in well under a second.
-        .env("AOE_COCKPIT_WATCHDOG_POLL_MS", "150")
+        .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
         .spawn()
-        .expect("spawn cockpit runner");
+        .expect("spawn acp runner");
 
     let deadline = Instant::now() + Duration::from_secs(10);
     while !record.exists() {

--- a/tests/cockpit_runner_orphan.rs
+++ b/tests/cockpit_runner_orphan.rs
@@ -115,6 +115,50 @@ fn assert_exits_within(child: &mut Child, secs: u64, what: &str) {
     }
 }
 
+/// PID of the runner's direct child (the fake `cat` agent), via `pgrep -P`.
+fn agent_pid_of(runner_pid: u32) -> u32 {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let out = Command::new("pgrep")
+            .args(["-P", &runner_pid.to_string()])
+            .output()
+            .expect("run pgrep");
+        if let Some(pid) = String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .next()
+            .and_then(|l| l.trim().parse::<u32>().ok())
+        {
+            return pid;
+        }
+        if Instant::now() > deadline {
+            panic!("fake agent (cat) child of runner {runner_pid} never appeared");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// `kill -0`: success means the pid is still alive.
+fn pid_alive(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Assert the agent pid is gone within `secs`. The leak this PR fixes is
+/// specifically the agent surviving its runner, so the test must prove the
+/// agent dies, not just the runner.
+fn assert_pid_gone_within(pid: u32, secs: u64, what: &str) {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    while pid_alive(pid) {
+        if Instant::now() > deadline {
+            panic!("{what}");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
 #[test]
 fn orphaned_runner_self_terminates_when_record_deleted() {
     if cfg!(not(unix)) {
@@ -124,6 +168,7 @@ fn orphaned_runner_self_terminates_when_record_deleted() {
     let scratch = Scratch::new("a");
     let (home, xdg) = (scratch.0.clone(), scratch.0.clone());
     let (mut child, record) = spawn_runner_and_wait_for_record(&home, &xdg, "s1921");
+    let agent_pid = agent_pid_of(child.id());
 
     // It must stay alive while the record exists (the whole point of the
     // shim outliving a detached daemon).
@@ -142,6 +187,13 @@ fn orphaned_runner_self_terminates_when_record_deleted() {
         15,
         "orphaned runner did not self-terminate within 15s of its record being deleted",
     );
+    // The agent subprocess, not just the runner, must die: the agent
+    // surviving its runner is the exact leak this PR fixes.
+    assert_pid_gone_within(
+        agent_pid,
+        5,
+        "fake agent survived the runner's self-termination (the leak this PR fixes)",
+    );
 }
 
 #[test]
@@ -153,23 +205,28 @@ fn superseded_runner_exits_without_deleting_replacement_record() {
     let scratch = Scratch::new("b");
     let (home, xdg) = (scratch.0.clone(), scratch.0.clone());
     let (mut child, record) = spawn_runner_and_wait_for_record(&home, &xdg, "s1922");
+    let agent_pid = agent_pid_of(child.id());
 
     // Simulate a fresh runner taking over: rewrite the record so its `pid`
-    // is no longer ours. The watchdog must read this as "superseded" and
-    // exit, but MUST leave the (replacement's) record file in place.
+    // is no longer ours. Parse + mutate structurally so the test doesn't
+    // break on a harmless serializer format change. The watchdog must read
+    // this as "superseded" and exit, but MUST leave the (replacement's)
+    // record file in place.
+    let mut rec: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&record).unwrap()).unwrap();
     let runner_pid = child.id();
-    let content = std::fs::read_to_string(&record).unwrap();
-    let replaced = content.replace(
-        &format!("\"pid\": {runner_pid}"),
-        &format!("\"pid\": {}", runner_pid.wrapping_add(1_000_000)),
-    );
-    assert_ne!(replaced, content, "expected to rewrite the record's pid");
-    std::fs::write(&record, &replaced).unwrap();
+    rec["pid"] = serde_json::json!(runner_pid.wrapping_add(1_000_000));
+    std::fs::write(&record, serde_json::to_vec(&rec).unwrap()).unwrap();
 
     assert_exits_within(
         &mut child,
         15,
         "superseded runner did not self-terminate within 15s of its record being taken over",
+    );
+    assert_pid_gone_within(
+        agent_pid,
+        5,
+        "fake agent survived the superseded runner's self-termination",
     );
 
     // The replacement runner's record must survive the superseded runner's

--- a/tests/cockpit_runner_orphan.rs
+++ b/tests/cockpit_runner_orphan.rs
@@ -1,21 +1,22 @@
-//! Regression test for #1921: an abandoned `aoe __cockpit-runner` must
-//! self-terminate instead of leaking forever.
+//! Regression tests for #1921: an abandoned `aoe __cockpit-runner` must
+//! self-terminate instead of leaking forever, and a superseded runner must
+//! exit WITHOUT deleting the replacement runner's files.
 //!
 //! Before the fix, the runner's main loop only exited on agent-child exit
 //! or SIGTERM/SIGINT, so a runner whose daemon vanished (crash, SIGKILL, or
 //! a deleted `$HOME`) stayed alive indefinitely, holding its agent
 //! subprocess open. The watchdog added in #1921 polls the runner's own
-//! registry record and self-destructs when it disappears.
+//! registry record and self-destructs when it disappears or is taken over.
 //!
-//! This spawns a real runner with `cat` as a trivial long-lived fake agent
-//! (it blocks reading stdin, which the runner keeps open), waits for the
-//! registry record, deletes it, and asserts the runner exits. The runner is
+//! These spawn a real runner with `cat` as a trivial long-lived fake agent
+//! (it blocks reading stdin, which the runner keeps open). The runner is
 //! spawned WITHOUT `setsid` here (only the daemon sets that up in
 //! production), so it takes the non-group-leader fallback teardown path,
-//! which is safe under the test's own process group.
+//! which is safe under the test's own process group, and is exactly the
+//! path where the superseded-delete bug lived.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
 /// App data dir for the debug binary, which uses the `-dev` namespace.
@@ -30,17 +31,18 @@ fn app_dir(home: &Path, xdg: &Path) -> PathBuf {
 /// Unique scratch dir; removed on drop. Rooted under `/tmp` (not the
 /// system temp dir, which is a long `/var/folders/...` path on macOS) and
 /// kept short so the worker unix socket path stays under the macOS
-/// `SUN_LEN` (~104 byte) limit. Same constraint the live/e2e harnesses hit.
+/// `SUN_LEN` (~104 byte) limit. The `label` keeps concurrently-running
+/// tests in the same binary from sharing (and racing to delete) a dir.
 struct Scratch(PathBuf);
 
 impl Scratch {
-    fn new() -> Self {
+    fn new(label: &str) -> Self {
         let base = if cfg!(unix) {
             PathBuf::from("/tmp")
         } else {
             std::env::temp_dir()
         };
-        let dir = base.join(format!("ao{}", std::process::id()));
+        let dir = base.join(format!("ao{}{label}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         Scratch(dir)
     }
@@ -52,20 +54,10 @@ impl Drop for Scratch {
     }
 }
 
-#[test]
-fn orphaned_runner_self_terminates_when_record_deleted() {
-    // The watchdog teardown is unix process-group based.
-    if cfg!(not(unix)) {
-        return;
-    }
-
-    let scratch = Scratch::new();
-    // HOME == XDG == the scratch root, kept short for the socket-path limit.
-    let home = scratch.0.clone();
-    let xdg = scratch.0.clone();
-
-    let workers = app_dir(&home, &xdg).join("cockpit-workers");
-    let session_id = "s1921";
+/// Spawn a runner with `cat` as the fake agent and wait until it has
+/// written its registry record. Returns the child and the record path.
+fn spawn_runner_and_wait_for_record(home: &Path, xdg: &Path, session_id: &str) -> (Child, PathBuf) {
+    let workers = app_dir(home, xdg).join("cockpit-workers");
     let socket = workers.join(format!("{session_id}.sock"));
     let record = workers.join(format!("{session_id}.json"));
 
@@ -84,14 +76,13 @@ fn orphaned_runner_self_terminates_when_record_deleted() {
             "--",
             "cat",
         ])
-        .env("HOME", &home)
-        .env("XDG_CONFIG_HOME", &xdg)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", xdg)
         // Shrink the watchdog poll so an orphan dies in well under a second.
         .env("AOE_COCKPIT_WATCHDOG_POLL_MS", "150")
         .spawn()
         .expect("spawn cockpit runner");
 
-    // Wait for the runner to write its registry record.
     let deadline = Instant::now() + Duration::from_secs(10);
     while !record.exists() {
         if let Ok(Some(status)) = child.try_wait() {
@@ -106,6 +97,33 @@ fn orphaned_runner_self_terminates_when_record_deleted() {
         }
         std::thread::sleep(Duration::from_millis(50));
     }
+    (child, record)
+}
+
+/// Wait for `child` to exit within `secs`, killing + panicking otherwise.
+fn assert_exits_within(child: &mut Child, secs: u64, what: &str) {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            return;
+        }
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("{what}");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[test]
+fn orphaned_runner_self_terminates_when_record_deleted() {
+    if cfg!(not(unix)) {
+        return;
+    }
+
+    let scratch = Scratch::new("a");
+    let (home, xdg) = (scratch.0.clone(), scratch.0.clone());
+    let (mut child, record) = spawn_runner_and_wait_for_record(&home, &xdg, "s1921");
 
     // It must stay alive while the record exists (the whole point of the
     // shim outliving a detached daemon).
@@ -119,17 +137,46 @@ fn orphaned_runner_self_terminates_when_record_deleted() {
     // `delete` would.
     std::fs::remove_file(&record).unwrap();
 
-    // The watchdog (150ms poll, 2-miss debounce) should fire and the runner
-    // should exit well within this margin.
-    let deadline = Instant::now() + Duration::from_secs(15);
-    loop {
-        if child.try_wait().unwrap().is_some() {
-            return; // self-terminated: pass
-        }
-        if Instant::now() > deadline {
-            let _ = child.kill();
-            panic!("orphaned runner did not self-terminate within 15s of its record being deleted");
-        }
-        std::thread::sleep(Duration::from_millis(100));
+    assert_exits_within(
+        &mut child,
+        15,
+        "orphaned runner did not self-terminate within 15s of its record being deleted",
+    );
+}
+
+#[test]
+fn superseded_runner_exits_without_deleting_replacement_record() {
+    if cfg!(not(unix)) {
+        return;
     }
+
+    let scratch = Scratch::new("b");
+    let (home, xdg) = (scratch.0.clone(), scratch.0.clone());
+    let (mut child, record) = spawn_runner_and_wait_for_record(&home, &xdg, "s1922");
+
+    // Simulate a fresh runner taking over: rewrite the record so its `pid`
+    // is no longer ours. The watchdog must read this as "superseded" and
+    // exit, but MUST leave the (replacement's) record file in place.
+    let runner_pid = child.id();
+    let content = std::fs::read_to_string(&record).unwrap();
+    let replaced = content.replace(
+        &format!("\"pid\": {runner_pid}"),
+        &format!("\"pid\": {}", runner_pid.wrapping_add(1_000_000)),
+    );
+    assert_ne!(replaced, content, "expected to rewrite the record's pid");
+    std::fs::write(&record, &replaced).unwrap();
+
+    assert_exits_within(
+        &mut child,
+        15,
+        "superseded runner did not self-terminate within 15s of its record being taken over",
+    );
+
+    // The replacement runner's record must survive the superseded runner's
+    // exit; deleting it here would cascade (the new runner would then see
+    // its own record vanish and self-destruct too).
+    assert!(
+        record.exists(),
+        "superseded runner deleted the replacement runner's registry record"
+    );
 }

--- a/tests/cockpit_runner_orphan.rs
+++ b/tests/cockpit_runner_orphan.rs
@@ -1,0 +1,135 @@
+//! Regression test for #1921: an abandoned `aoe __cockpit-runner` must
+//! self-terminate instead of leaking forever.
+//!
+//! Before the fix, the runner's main loop only exited on agent-child exit
+//! or SIGTERM/SIGINT, so a runner whose daemon vanished (crash, SIGKILL, or
+//! a deleted `$HOME`) stayed alive indefinitely, holding its agent
+//! subprocess open. The watchdog added in #1921 polls the runner's own
+//! registry record and self-destructs when it disappears.
+//!
+//! This spawns a real runner with `cat` as a trivial long-lived fake agent
+//! (it blocks reading stdin, which the runner keeps open), waits for the
+//! registry record, deletes it, and asserts the runner exits. The runner is
+//! spawned WITHOUT `setsid` here (only the daemon sets that up in
+//! production), so it takes the non-group-leader fallback teardown path,
+//! which is safe under the test's own process group.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+/// App data dir for the debug binary, which uses the `-dev` namespace.
+fn app_dir(home: &Path, xdg: &Path) -> PathBuf {
+    if cfg!(target_os = "linux") {
+        xdg.join("agent-of-empires-dev")
+    } else {
+        home.join(".agent-of-empires-dev")
+    }
+}
+
+/// Unique scratch dir; removed on drop. Rooted under `/tmp` (not the
+/// system temp dir, which is a long `/var/folders/...` path on macOS) and
+/// kept short so the worker unix socket path stays under the macOS
+/// `SUN_LEN` (~104 byte) limit. Same constraint the live/e2e harnesses hit.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new() -> Self {
+        let base = if cfg!(unix) {
+            PathBuf::from("/tmp")
+        } else {
+            std::env::temp_dir()
+        };
+        let dir = base.join(format!("ao{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        Scratch(dir)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn orphaned_runner_self_terminates_when_record_deleted() {
+    // The watchdog teardown is unix process-group based.
+    if cfg!(not(unix)) {
+        return;
+    }
+
+    let scratch = Scratch::new();
+    // HOME == XDG == the scratch root, kept short for the socket-path limit.
+    let home = scratch.0.clone();
+    let xdg = scratch.0.clone();
+
+    let workers = app_dir(&home, &xdg).join("cockpit-workers");
+    let session_id = "s1921";
+    let socket = workers.join(format!("{session_id}.sock"));
+    let record = workers.join(format!("{session_id}.json"));
+
+    let bin = env!("CARGO_BIN_EXE_aoe");
+    let mut child = Command::new(bin)
+        .args([
+            "__cockpit-runner",
+            "--socket",
+            socket.to_str().unwrap(),
+            "--session-id",
+            session_id,
+            "--agent-name",
+            "fake-agent",
+            "--cwd",
+            home.to_str().unwrap(),
+            "--",
+            "cat",
+        ])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &xdg)
+        // Shrink the watchdog poll so an orphan dies in well under a second.
+        .env("AOE_COCKPIT_WATCHDOG_POLL_MS", "150")
+        .spawn()
+        .expect("spawn cockpit runner");
+
+    // Wait for the runner to write its registry record.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !record.exists() {
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!("runner exited before writing its registry record: {status}");
+        }
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!(
+                "runner never wrote its registry record at {}",
+                record.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // It must stay alive while the record exists (the whole point of the
+    // shim outliving a detached daemon).
+    std::thread::sleep(Duration::from_millis(500));
+    assert!(
+        child.try_wait().unwrap().is_none(),
+        "runner exited while its registry record still existed"
+    );
+
+    // Abandon it: delete the record, as a deleted `$HOME` or a daemon-side
+    // `delete` would.
+    std::fs::remove_file(&record).unwrap();
+
+    // The watchdog (150ms poll, 2-miss debounce) should fire and the runner
+    // should exit well within this margin.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            return; // self-terminated: pass
+        }
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("orphaned runner did not self-terminate within 15s of its record being deleted");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -265,10 +265,10 @@ export function appDirFor(home: string, xdg: string, binaryPath: string): string
 }
 
 /**
- * Last-resort teardown: group-kill any `aoe __cockpit-runner` still
+ * Last-resort teardown: group-kill any `aoe __acp-runner` still
  * recorded in the worker registry by reading its pid straight off disk.
  *
- * `aoe cockpit stop --all` only works while the daemon is alive; if the
+ * `aoe acp stop --all` only works while the daemon is alive; if the
  * daemon already crashed or was SIGKILLed, its runners (and their node +
  * `claude` descendants) are orphaned and would leak forever once the temp
  * HOME is deleted. Each runner is its own process-group leader (spawned via
@@ -277,7 +277,7 @@ export function appDirFor(home: string, xdg: string, binaryPath: string): string
  */
 async function killOrphanRunners(appDir: string): Promise<void> {
   const { readdirSync, readFileSync } = await import("node:fs");
-  const workersDir = join(appDir, "cockpit-workers");
+  const workersDir = join(appDir, "acp-workers");
   let entries: string[];
   try {
     entries = readdirSync(workersDir);
@@ -712,13 +712,13 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     },
     async stop() {
       try {
-        // Terminate cockpit workers BEFORE killing the daemon and deleting
-        // the temp HOME. `cockpit stop --all` makes the still-live daemon
-        // group-kill every per-session `aoe __cockpit-runner` (and its node
+        // Terminate acp workers BEFORE killing the daemon and deleting
+        // the temp HOME. `acp stop --all` makes the still-live daemon
+        // group-kill every per-session `aoe __acp-runner` (and its node
         // + claude descendants). Without it they outlive the daemon, the
         // HOME is then wiped, and the orphaned tree leaks forever. See
         // #1921.
-        spawnSync(aoeBinary, ["cockpit", "stop", "--all"], {
+        spawnSync(aoeBinary, ["acp", "stop", "--all"], {
           env: seedEnv,
           stdio: "ignore",
           timeout: 10_000,

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -265,6 +265,50 @@ export function appDirFor(home: string, xdg: string, binaryPath: string): string
 }
 
 /**
+ * Last-resort teardown: group-kill any `aoe __cockpit-runner` still
+ * recorded in the worker registry by reading its pid straight off disk.
+ *
+ * `aoe cockpit stop --all` only works while the daemon is alive; if the
+ * daemon already crashed or was SIGKILLed, its runners (and their node +
+ * `claude` descendants) are orphaned and would leak forever once the temp
+ * HOME is deleted. Each runner is its own process-group leader (spawned via
+ * setsid), so `process.kill(-pid, "SIGKILL")` reaps the whole tree. Runs
+ * before the HOME is wiped. See #1921.
+ */
+async function killOrphanRunners(appDir: string): Promise<void> {
+  const { readdirSync, readFileSync } = await import("node:fs");
+  const workersDir = join(appDir, "cockpit-workers");
+  let entries: string[];
+  try {
+    entries = readdirSync(workersDir);
+  } catch {
+    return; // no workers dir; nothing to reap
+  }
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    let pid: unknown;
+    try {
+      pid = JSON.parse(readFileSync(join(workersDir, name), "utf8"))?.pid;
+    } catch {
+      continue; // unparseable record; skip
+    }
+    if (typeof pid !== "number" || pid <= 1) continue;
+    // Negative pid targets the process group (runner + node + claude); the
+    // positive pid is a belt-and-suspenders for a non-leader runner.
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      // group already gone
+    }
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // leader already gone
+    }
+  }
+}
+
+/**
  * Wait for `serve.token` to appear in the daemon's app dir, then read
  * it. The daemon writes the token early in startup, so by the time
  * `waitForServer` resolves it is on disk; the loop is a small safety
@@ -668,8 +712,24 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     },
     async stop() {
       try {
+        // Terminate cockpit workers BEFORE killing the daemon and deleting
+        // the temp HOME. `cockpit stop --all` makes the still-live daemon
+        // group-kill every per-session `aoe __cockpit-runner` (and its node
+        // + claude descendants). Without it they outlive the daemon, the
+        // HOME is then wiped, and the orphaned tree leaks forever. See
+        // #1921.
+        spawnSync(aoeBinary, ["cockpit", "stop", "--all"], {
+          env: seedEnv,
+          stdio: "ignore",
+          timeout: 10_000,
+        });
         if (proc) await killProc(proc);
       } finally {
+        // Direct fallback for a daemon that was already dead/wedged (so the
+        // RPC above was a no-op): group-kill any runner still recorded in
+        // the registry, reading its pid off disk. Runs before rmSync so we
+        // never orphan a tree by deleting its HOME out from under it.
+        await killOrphanRunners(appDirFor(home, xdg, aoeBinary));
         // Best-effort: kill any tmux server bound to the isolated socket
         // before deleting the dir. Structured view specs leave tmux child
         // processes around that hold open file descriptors and trip


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Per-session `aoe __cockpit-runner` shims are designed to outlive their daemon so a fresh `aoe serve` can reattach mid-turn. The downside: the runner only exited on agent-child exit or SIGTERM/SIGINT, so a daemon that went away WITHOUT explicitly killing its runners (a crash, a `SIGKILL`, or an ephemeral test `$HOME` that gets deleted) orphaned the runner plus its `node` ACP wrapper and `claude` grandchild forever. Every existing reaper (`aoe cockpit stop --all`, per-session stop, the boot reconciler sweep, idle-reap) runs inside a live daemon in the same `$HOME`, so none can reap orphans of a dead daemon. On a dev box running the suite this accumulated into hundreds of leaked processes.

This adds a self-termination backstop and closes the two amplifiers:

1. **Runner watchdog** (`src/cockpit/runner.rs`, `src/cockpit/worker_registry.rs`). The runner polls its own registry record via a non-creating read of a path captured at startup (`load()` would recreate the very directory whose deletion is the signal). It self-destructs when the record vanishes (2-poll debounce, `.restart`-marker exempt), when a newer runner supersedes it (pid mismatch), or when detached past a 48h retention window with no daemon attached. Teardown politely SIGTERMs the agent then SIGKILLs the whole process group, guarded on actually being the group leader so a failed `setsid` can never signal the daemon's group. The 48h window covers an overnight or weekend `aoe serve --stop` and resets on every reattach, so intentionally stopped sessions stay reattachable.

2. **Live test harness** (`web/tests/helpers/aoeServe.ts`). `stop()` now runs `aoe cockpit stop --all` against the test `$HOME` before killing the daemon, and falls back to reading each runner's pid from the registry and group-killing it directly if the daemon already died. This is the dominant real-world leak source.

3. **Reconciler orphan sweep** (`src/server/cockpit_reconciler.rs`). Switched from a single-pid `SIGTERM` (which can orphan the node/claude grandchildren) to an escalating group kill (SIGTERM, grace, SIGKILL).

The e2e harness (`tests/e2e/harness.rs`) already group-kills via `cockpit stop --all` on teardown, so it needed no change.

Closes #1921

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start `aoe serve`, enable cockpit, create a session (confirm one `aoe __cockpit-runner` + one `claude-agent-acp` in `ps`).
- [ ] `kill -9` the daemon (not `aoe serve --stop`). Confirm the runner + agent are still alive (expected: they outlive the daemon).
- [ ] Delete the worker registry file `~/.agent-of-empires/cockpit-workers/<session>.json`. Within ~30s, confirm the runner and its `node`/`claude` descendants have all exited (`ps` shows none).
- [ ] Separately: `aoe serve --stop` then `aoe serve` again with a live session, confirm the session reattaches and is NOT killed (the 48h window must not touch an intentionally stopped session).
- [ ] Run the regression test: `cargo test --features serve --test cockpit_runner_orphan` (passes; fails on `main`).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (the only web change is the live test harness teardown helper)

**TUI / CLI (e2e test)**
- [x] Added a regression test under `tests/cockpit_runner_orphan.rs` (spawns a real runner, deletes its record, asserts the process tree self-terminates; red on `main`, green here)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, design (consulted via a multi-model debate), and implementation drafted by Claude under my direction. I made the design calls (registry-vanished + 48h detached-retention triggers, group-kill teardown, no new config field) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR prevents orphaned cockpit runner processes and their agent subtrees from leaking when their daemon dies by adding a runner-side self-termination watchdog, making reconciler cleanup escalate to group kills, and hardening test harness teardown and docs. Key changes:

- Runner watchdog: each `aoe __cockpit-runner` polls its registry record (non-creating read) and self-terminates when the record is deleted, a newer runner supersedes it (PID mismatch), or it remains detached for 48 hours. A 2-poll debounce and exemption for `.restart` avoid false positives. Teardown SIGTERMs the agent and escalates to killing the process group only when the runner is the group leader.
- Reconciler cleanup: orphan sweep now schedules an escalating group reap (SIGTERM → grace → SIGKILL) for runner process groups rather than sending SIGTERM to a single PID.
- Test harness and CI: Playwright test helper runs `aoe cockpit stop --all` during teardown and falls back to reading registry runner PIDs and group-killing them to prevent leaks; e2e harness already group-kills. Adds Unix-only regression tests asserting runner + agent subtree exit when registry records are removed.
- Docs: documents the watchdog behavior and 48-hour retention semantics.

Benefits: eliminates persistent orphaned processes, ensures full subtree cleanup, reduces manual/system-level cleanup burden, and improves test/environment reliability. Closes `#1921`.

## Technical Details (concise)

- src/cockpit/runner.rs
  - Adds abandonment watchdog using an AtomicU64 attach/detach timestamp and polling of the runner registry record + restart marker.
  - Debounces deletion detection (2 polls) and respects `.restart`.
  - On watchdog trigger: conditionally delete registry/socket (unless superseded), SIGTERM the agent, wait briefly, then escalate to process-group SIGKILL on Unix if group leader; non-Unix kills children. Watchdog reports a distinct termination reason.

- src/cockpit/worker_registry.rs
  - Adds RunnerRecordState { Matches, Missing, Superseded, Unreadable } and inspect_record_for_runner(record_path, own_pid) for non-creating reads.
  - Adds pub async fn reap_group_escalating(pid, grace) to perform SIGTERM → wait → SIGKILL on a process group (Unix-gated).

- src/server/cockpit_reconciler.rs
  - Replaces single-PID SIGTERM with tokio::spawn(worker_registry::reap_group_escalating(record.pid, 2s)) and continues to delete the registry entry.

- tests/cockpit_runner_orphan.rs
  - Adds Unix-only regression tests that spawn a real runner with a fake long-lived agent, remove or mutate the registry record (deletion/supersession), and assert the runner and agent exit within time bounds.

- web/tests/helpers/aoeServe.ts
  - ServeHandle.stop() now attempts `aoe cockpit stop --all` first, then kills the daemon, then runs killOrphanRunners which reads cockpit-workers/*.json and group-kills leftover runner PIDs before removing the test HOME.

- Cargo.toml
  - Adds serde_json dev-dependency to support integration test parsing.

## Potential follow-ups

- Make the 48-hour detached retention and watchdog poll/grace values configurable (env/config).
- Add structured telemetry/logging for watchdog-triggered teardowns for diagnostics.
- Consider a test-only hook to shorten watchdog intervals without env hacks to speed CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->