### PR TITLE
feat(tui): focus title field for New from selection

### DIFF
--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -511,6 +511,12 @@ impl NewSessionDialog {
         self.group = Input::new(group);
     }
 
+    /// Move focus to the title field. Used by "new from selection", where the
+    /// path is pre-filled so the user lands directly on naming the session.
+    pub fn focus_title(&mut self) {
+        self.focused_field = self.title_field();
+    }
+
     #[cfg(test)]
     pub fn path_value(&self) -> &str {
         self.path.value()

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2118,13 +2118,19 @@ impl HomeView {
                 &current_profile,
                 profiles,
             );
+            let has_prefilled_path = prefill_path.is_some();
             if let Some(path) = prefill_path {
                 dialog.set_path(path);
             }
             if let Some(group) = prefill_group {
                 dialog.set_group(group);
             }
-            dialog.focus_title();
+            // Only skip to the title when the path was inherited from a
+            // session. In the group-only fallback the path is still the
+            // default cwd, so leaving focus there lets the user confirm it.
+            if has_prefilled_path {
+                dialog.focus_title();
+            }
             self.new_dialog = Some(dialog);
         }
     }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2124,6 +2124,7 @@ impl HomeView {
             if let Some(group) = prefill_group {
                 dialog.set_group(group);
             }
+            dialog.focus_title();
             self.new_dialog = Some(dialog);
         }
     }


### PR DESCRIPTION
## Description

When you press `N` (New from selection), the new-session dialog opens with the path and group already pre-filled from the selected session. This change moves the initial focus to the **title** field instead of leaving it on the first field (profile/path).

The rationale: the point of "New from selection" as i understand it is that essentially every field is drawn from an existing session, so the cursor should land on the one thing the user still needs to provide, the session name. Previously they had to tab past the pre-filled path (and profile) to reach it.

Implementation:
- Added `NewSessionDialog::focus_title()`, which sets the focused field to the title index (the helper already accounts for the optional profile picker shifting field positions).
- Called it in `open_new_from_selection()` after the path/group are pre-filled.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle (only the initial focus position within an existing dialog)

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves the "New from selection" workflow by moving initial keyboard focus to the title (session name) field when a new-session dialog is opened from an existing session and the session's path was prefilled. That makes duplicating a session faster because users can immediately type the new session name.

## What changed (high level)

- Added NewSessionDialog::focus_title() to jump focus to the title field.
- Updated the "New from selection" flow to call focus_title() only when the dialog actually inherited the selected session's path; if only the group was copied (path left as default), focus is not moved.

## Why this matters

- Reduces friction when duplicating sessions: title is usually the only thing users change.
- Avoids an unsafe focus jump when the path wasn't inherited (prevents accidentally creating a session in the wrong directory).

## Technical details

- New method: pub fn focus_title(&mut self) in NewSessionDialog (accounts for optional profile picker shifting field indices).
- HomeView::open_new_from_selection now computes has_prefilled_path and calls dialog.focus_title() only when true.
- Files modified: src/tui/dialogs/new_session/mod.rs, src/tui/home/input.rs.

## Benefits & possible follow-ups

- Benefit: smoother keyboard-first session duplication.
- Follow-ups: consider similar focus heuristics for other quick-create flows (e.g., "New from template") or expose a small integration test asserting focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->