### PR TITLE
feat(web): model channel, Gemini modes, media payloads, approval + TUI fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"], optional = true }
 getrandom = { version = "0.4", optional = true }
 
 # Agent Client Protocol — drives the structured view surface bundled with `serve`.
-agent-client-protocol = { version = "0.11", optional = true, features = ["unstable_session_usage"] }
+agent-client-protocol = { version = "0.11", optional = true, features = ["unstable_session_usage", "unstable_session_model"] }
 agent-client-protocol-tokio = { version = "0.11", optional = true }
 
 # Semver parsing for ACP adapter compatibility checks (see src/acp/agent_compat.rs).

--- a/docs/structured-view/controls.md
+++ b/docs/structured-view/controls.md
@@ -22,6 +22,11 @@ typical set is:
 | `bypassPermissions`  | All tools auto-approved. The structured view analogue of YOLO.                  |
 | `plan`               | Read-only; the agent drafts a plan but does not run side-effectful tools. |
 
+Other adapters report their own ids. Gemini (over `gemini --acp`) uses
+the gemini-cli `ApprovalMode` names: `auto_edit` folds onto `acceptEdits`
+semantics and `yolo` onto `bypassPermissions`, so a Gemini session is
+classified the same as the equivalent `claude-agent-acp` mode.
+
 ### YOLO mode maps to `bypassPermissions`
 
 When `[session] yolo_mode_default = true` (or the wizard's "Auto-approve

--- a/docs/structured-view/controls.md
+++ b/docs/structured-view/controls.md
@@ -80,6 +80,13 @@ approval_timeout_secs = 300
 destructive_require_double_confirm = true
 ```
 
+The card clears as soon as your decision is accepted, rather than waiting
+on the broadcast that confirms it. If the approval already resolved on the
+daemon (a concurrent decision, the silent-tool watchdog, or the agent
+offering no option matching your choice), resolving it again clears the
+card quietly instead of surfacing an error. This holds on both the web
+dashboard and the native TUI cockpit.
+
 ### Notifications and sound
 
 When an approval lands, the structured view fires two channels so a user away

--- a/docs/structured-view/controls.md
+++ b/docs/structured-view/controls.md
@@ -116,6 +116,20 @@ current model reports `supportsEffort=true`. Older adapters that
 emit no `config_option_update` show neither picker; this is by
 design so non-Claude backends don't grow empty UI chrome.
 
+### Model via the unstable `session_model` channel
+
+Some adapters advertise the model not as a `config_option` but through
+the ACP `unstable_session_model` capability: a `SessionModelState`
+(current model plus available models) on the `session/new` and
+`session/load` response, switched with `session/set_model`. Cockpit
+reads that channel too and normalizes it into the same model dropdown,
+so it looks and behaves identically regardless of which channel the
+agent uses. If an agent exposes the model on both channels, the
+`config_option` one wins (it has a push/echo path; `session/set_model`
+only acks), so the UI never shows two model dropdowns. Because
+`session/set_model` returns no model-state echo, cockpit synthesizes
+the confirming update itself after the switch is acknowledged.
+
 ### Setting a value
 
 Clicking an option fires `POST /api/sessions/{id}/acp/config-option`

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -134,6 +134,18 @@ when an agent sends that instead; a single patch touching several files
 shows each file's path and diff in one card. Any other tool kind falls
 back to the generic one-liner (name, arguments, output snapshot).
 
+**Structured completion payloads.** When a tool reports its result as
+structured content at completion (rather than streamed text), the web
+card renders it below the card: images and audio show inline (an embedded
+payload is preferred, falling back to a referenced `uri`), resource links
+and binary resources become download links, and text resources render as
+text. A media block with neither inline data nor a uri degrades to a
+labelled placeholder so the output is never silently dropped. The native
+TUI, which cannot draw images, shows a textual placeholder (for example
+`[image image/png]`) for the non-text blocks. Inline image/audio payloads
+larger than 4 MiB of base64 are dropped from the event (the placeholder
+remains) to keep the replay stream small.
+
 **File-mention picker.** Typing `@` in the composer opens a picker
 listing the session's workspace files, fetched once per session from
 the daemon (the same `structured view/files` index the web composer uses, capped

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -136,15 +136,17 @@ back to the generic one-liner (name, arguments, output snapshot).
 
 **Structured completion payloads.** When a tool reports its result as
 structured content at completion (rather than streamed text), the web
-card renders it below the card: images and audio show inline (an embedded
-payload is preferred, falling back to a referenced `uri`), resource links
-and binary resources become download links, and text resources render as
-text. A media block with neither inline data nor a uri degrades to a
-labelled placeholder so the output is never silently dropped. The native
-TUI, which cannot draw images, shows a textual placeholder (for example
-`[image image/png]`) for the non-text blocks. Inline image/audio payloads
-larger than 4 MiB of base64 are dropped from the event (the placeholder
-remains) to keep the replay stream small.
+card renders it below the card: images show inline (an embedded payload is
+preferred, falling back to a referenced `uri`), audio plays inline from
+its embedded payload, resource links and binary resources become download
+links, and text resources render as text. A block whose payload can't be
+shown (an image with neither inline data nor a uri, or audio with no
+embedded data) degrades to a labelled placeholder so the output is never
+silently dropped. The native TUI, which cannot draw images, shows a
+textual placeholder (for example `[image image/png]`) for the non-text
+blocks. Inline image/audio payloads larger than 4 MiB of base64 are
+dropped from the event (the placeholder remains) to keep the replay
+stream small.
 
 **File-mention picker.** Typing `@` in the composer opens a picker
 listing the session's workspace files, fetched once per session from

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -4391,9 +4391,11 @@ async fn run_connection_task<W, R>(
                                     .await
                                 {
                                     Ok(resp) => {
-                                        if let Some(event) =
-                                            config_options_event(Some(resp.config_options))
-                                        {
+                                        if let Some(event) = fold_session_options(
+                                            &model_cache_for_block,
+                                            Some(resp.config_options),
+                                            None,
+                                        ) {
                                             let _ = event_tx_for_block.send(event).await;
                                         }
                                     }

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3174,12 +3174,27 @@ impl ModelChannelCache {
         let has_real_model = out
             .iter()
             .any(|o| o.category == ConfigOptionCategory::Model);
-        if !has_real_model {
+        // A real option already wins if it occupies the reserved id; adding
+        // the synthetic selector under the same id would shadow it and the
+        // dispatch path would misroute its set to session/set_model. See
+        // #1820 review.
+        let reserved_taken = self.reserved_id_is_real();
+        if !has_real_model && !reserved_taken {
             if let Some(model) = &self.session_model {
                 out.push(session_model_to_config_option(model));
             }
         }
         out
+    }
+
+    /// True when the agent's raw config options already include one whose id
+    /// equals the reserved synthetic-model id. In that (pathological) case
+    /// the real option owns the id and the session_model channel must not be
+    /// synthesized or routed to `session/set_model`.
+    fn reserved_id_is_real(&self) -> bool {
+        self.raw_config_options
+            .iter()
+            .any(|o| o.id == ACP_SESSION_MODEL_CONFIG_ID)
     }
 }
 
@@ -3274,7 +3289,14 @@ fn dispatch_set_config_option(
     event_tx: mpsc::Sender<Event>,
     model_cache: Arc<std::sync::Mutex<ModelChannelCache>>,
 ) {
-    if config_id == ACP_SESSION_MODEL_CONFIG_ID {
+    // Route to session/set_model only for the SYNTHETIC selector. If a real
+    // ACP option happens to occupy the reserved id, it wins and goes through
+    // the generic set_config_option path below. See #1820 review.
+    let is_synthetic_model = config_id == ACP_SESSION_MODEL_CONFIG_ID && {
+        let cache = model_cache.lock().expect("model channel cache poisoned");
+        !cache.reserved_id_is_real()
+    };
+    if is_synthetic_model {
         info!(target: "cockpit.acp", "sending session/set_model model={value}");
         let sent = connection.send_request(SetSessionModelRequest::new(
             acp_session_id.clone(),
@@ -3627,13 +3649,19 @@ fn extract_tool_output_blocks(
                                 uri: t.uri.clone(),
                                 mime_type: t.mime_type.clone(),
                                 text: Some(t.text.clone()),
+                                data: None,
                             }
                         }
                         EmbeddedResourceResource::BlobResourceContents(b) => {
+                            // Keep the inline bytes (capped) so a blob without
+                            // a fetchable uri is still recoverable as a
+                            // download instead of an empty placeholder. See
+                            // #1818 review.
                             ToolOutputBlock::Resource {
                                 uri: b.uri.clone(),
                                 mime_type: b.mime_type.clone(),
                                 text: None,
+                                data: cap(b.blob.clone()),
                             }
                         }
                         _ => continue,
@@ -7670,6 +7698,40 @@ mod tests {
     }
 
     #[test]
+    fn extract_tool_output_blocks_keeps_blob_resource_payload() {
+        // #1818 review: a binary (blob) embedded resource must keep its
+        // inline bytes so it stays recoverable as a download.
+        use agent_client_protocol::schema::{
+            BlobResourceContents, Content, ContentBlock, EmbeddedResource,
+            EmbeddedResourceResource, ToolCallContent,
+        };
+        let blocks = vec![ToolCallContent::Content(Content::new(
+            ContentBlock::Resource(EmbeddedResource::new(
+                EmbeddedResourceResource::BlobResourceContents(
+                    BlobResourceContents::new("QkxPQg==", "file:///out.bin")
+                        .mime_type(Some("application/octet-stream".to_string())),
+                ),
+            )),
+        ))];
+        let out = extract_tool_output_blocks(&blocks);
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            ToolOutputBlock::Resource {
+                uri,
+                data,
+                text,
+                mime_type,
+            } => {
+                assert_eq!(uri, "file:///out.bin");
+                assert_eq!(data.as_deref(), Some("QkxPQg=="));
+                assert!(text.is_none());
+                assert_eq!(mime_type.as_deref(), Some("application/octet-stream"));
+            }
+            other => panic!("expected Resource, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn extract_tool_output_blocks_drops_oversized_inline_media() {
         use agent_client_protocol::schema::{Content, ContentBlock, ImageContent, ToolCallContent};
         let huge = "A".repeat(MAX_INLINE_MEDIA_B64 + 1);
@@ -8080,6 +8142,29 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].id, "real-model");
         assert!(out.iter().all(|o| o.id != ACP_SESSION_MODEL_CONFIG_ID));
+    }
+
+    #[test]
+    fn normalize_yields_to_real_option_on_reserved_id_collision() {
+        // Pathological: a real ACP option occupies the reserved synthetic id.
+        // The real option wins; the synthetic selector is not added (which
+        // would otherwise shadow it and misroute its set). See #1820 review.
+        let reserved_real = ConfigOptionDescriptor {
+            id: ACP_SESSION_MODEL_CONFIG_ID.to_string(),
+            name: "Not really the model".to_string(),
+            description: None,
+            category: ConfigOptionCategory::Other("misc".to_string()),
+            current_value: "x".to_string(),
+            options: Vec::new(),
+        };
+        let cache = ModelChannelCache {
+            raw_config_options: vec![reserved_real],
+            session_model: Some(sample_session_model()),
+        };
+        let out = cache.normalized();
+        assert_eq!(out.len(), 1, "no synthetic selector appended: {out:?}");
+        assert_eq!(out[0].current_value, "x");
+        assert!(cache.reserved_id_is_real());
     }
 
     #[test]

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3054,11 +3054,19 @@ fn map_update_to_events(
             // Emit both events: CurrentModeChanged (the real id) and
             // a best-effort ModeChanged (for the legacy enum-based
             // UI, in case that path is still used somewhere).
+            // Gemini surfaces its approval modes over `gemini --acp` with the
+            // gemini-cli `ApprovalMode` ids (`auto_edit`, `yolo`); fold them
+            // onto the existing semantic equivalents so a Gemini session is
+            // classified the same as the claude-agent-acp modes. See #1819.
             let mode = match id.as_str() {
                 "default" => SessionMode::Default,
                 "plan" => SessionMode::Plan,
-                "accept_edits" | "acceptEdits" => SessionMode::AcceptEdits,
-                "bypass_permissions" | "bypassPermissions" => SessionMode::BypassPermissions,
+                "accept_edits" | "acceptEdits" | "auto_edit" | "autoEdit" => {
+                    SessionMode::AcceptEdits
+                }
+                "bypass_permissions" | "bypassPermissions" | "yolo" => {
+                    SessionMode::BypassPermissions
+                }
                 _ => SessionMode::Default,
             };
             vec![
@@ -7288,6 +7296,70 @@ mod tests {
             }
             other => panic!("expected ToolCallCompleted, got {other:?}"),
         }
+    }
+
+    fn mode_from_current_mode_update(id: &str) -> SessionMode {
+        use agent_client_protocol::schema::CurrentModeUpdate;
+        let events = map_update_to_events(
+            SessionUpdate::CurrentModeUpdate(CurrentModeUpdate::new(id.to_string())),
+            &agent_profiles::CLAUDE,
+        );
+        // The arm always emits the raw id alongside the legacy enum, in order.
+        match events.as_slice() {
+            [Event::CurrentModeChanged { current_mode_id }, Event::ModeChanged { mode }] => {
+                assert_eq!(current_mode_id, id, "raw mode id must be preserved");
+                *mode
+            }
+            other => panic!("expected [CurrentModeChanged, ModeChanged], got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn current_mode_update_classifies_gemini_mode_ids() {
+        // Gemini-cli ApprovalMode ids surfaced over `gemini --acp`. See #1819.
+        assert_eq!(
+            mode_from_current_mode_update("yolo"),
+            SessionMode::BypassPermissions
+        );
+        assert_eq!(
+            mode_from_current_mode_update("auto_edit"),
+            SessionMode::AcceptEdits
+        );
+        assert_eq!(
+            mode_from_current_mode_update("autoEdit"),
+            SessionMode::AcceptEdits
+        );
+    }
+
+    #[test]
+    fn current_mode_update_keeps_existing_mode_ids() {
+        // Regression guard: non-Gemini classification is unchanged.
+        assert_eq!(
+            mode_from_current_mode_update("default"),
+            SessionMode::Default
+        );
+        assert_eq!(mode_from_current_mode_update("plan"), SessionMode::Plan);
+        assert_eq!(
+            mode_from_current_mode_update("accept_edits"),
+            SessionMode::AcceptEdits
+        );
+        assert_eq!(
+            mode_from_current_mode_update("acceptEdits"),
+            SessionMode::AcceptEdits
+        );
+        assert_eq!(
+            mode_from_current_mode_update("bypass_permissions"),
+            SessionMode::BypassPermissions
+        );
+        assert_eq!(
+            mode_from_current_mode_update("bypassPermissions"),
+            SessionMode::BypassPermissions
+        );
+        // Unknown ids still fall back to Default.
+        assert_eq!(
+            mode_from_current_mode_update("some_future_mode"),
+            SessionMode::Default
+        );
     }
 
     #[test]

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -51,7 +51,7 @@ use super::state::{
     AcpSessionId, AvailableCommand, ConfigOptionCategory, ConfigOptionChoice,
     ConfigOptionDescriptor, DiffPreview, Event, MemoryRecall, ModeInfo, Plan, PlanStep,
     PlanStepStatus, PromptAttachmentKind, RateLimitInfo, SessionMode, SessionUsage,
-    StartupErrorDetail, ToolCall, UsageCost,
+    StartupErrorDetail, ToolCall, ToolOutputBlock, UsageCost,
 };
 use super::terminal_handler::TerminalManager;
 use crate::session::SandboxInfo;
@@ -2924,6 +2924,19 @@ fn map_update_to_events(
                 .as_ref()
                 .filter(|value| !value.is_null())
                 .map(preview_args);
+            // Structured completion payload: media/resource blocks that the
+            // text concat above drops. Only extracted on the terminal frame
+            // (the card renders it once on completion). See #1818.
+            let output_blocks = if completed {
+                update
+                    .fields
+                    .content
+                    .as_ref()
+                    .map(|blocks| extract_tool_output_blocks(blocks))
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
             let new_title = update.fields.title.clone();
             let mut events: Vec<Event> = Vec::new();
             if new_title.is_some()
@@ -2948,6 +2961,7 @@ fn map_update_to_events(
                     tool_call_id: id,
                     is_error,
                     content: content_text,
+                    output: output_blocks,
                     completed_at: chrono::Utc::now(),
                 });
             } else if !content_text.is_empty() {
@@ -3045,6 +3059,7 @@ fn map_update_to_events(
                     tool_call_id: tool_id,
                     is_error: false,
                     content: String::new(),
+                    output: Vec::new(),
                     completed_at: now,
                 },
             ]
@@ -3525,6 +3540,7 @@ async fn emit_permission_denied(event_tx: &mpsc::Sender<Event>, tool_call_id: &s
             tool_call_id: tool_call_id.to_string(),
             is_error: true,
             content: content.to_string(),
+            output: Vec::new(),
             completed_at: chrono::Utc::now(),
         })
         .await;
@@ -3548,6 +3564,99 @@ fn extract_tool_content_text(blocks: &[agent_client_protocol::schema::ToolCallCo
         }
     }
     out
+}
+
+/// Max base64 length kept for an inline image/audio payload. Media this
+/// large is persisted in the event store and reshipped on every WS replay,
+/// so an oversized blob would bloat both; past the cap the inline data is
+/// dropped (a placeholder/uri is surfaced instead). ~4 MiB of base64 is
+/// ~3 MiB of bytes, comfortably above a typical screenshot.
+const MAX_INLINE_MEDIA_B64: usize = 4 * 1024 * 1024;
+
+/// Bridge an ACP `ToolCallContent` array into the cockpit's renderable
+/// `ToolOutputBlock` list, preserving non-text completion payloads (images,
+/// audio, resource links/contents) that `extract_tool_content_text` drops.
+/// Diff blocks are bridged separately (`extract_diffs_from_content`) and are
+/// skipped here; an embedded terminal surfaces as a text placeholder since
+/// cockpit does not own ACP terminals. Returns an EMPTY vec when every block
+/// is plain text (or diff): the existing `content` text path renders those,
+/// so the structured list only carries weight when real media is present.
+/// See #1818.
+fn extract_tool_output_blocks(
+    blocks: &[agent_client_protocol::schema::ToolCallContent],
+) -> Vec<ToolOutputBlock> {
+    use agent_client_protocol::schema::{EmbeddedResourceResource, ToolCallContent};
+    let mut out: Vec<ToolOutputBlock> = Vec::new();
+    let mut has_media = false;
+    let cap =
+        |data: String| -> Option<String> { (data.len() <= MAX_INLINE_MEDIA_B64).then_some(data) };
+    for block in blocks {
+        match block {
+            ToolCallContent::Content(c) => match &c.content {
+                ContentBlock::Text(t) => out.push(ToolOutputBlock::Text {
+                    text: t.text.clone(),
+                }),
+                ContentBlock::Image(img) => {
+                    has_media = true;
+                    out.push(ToolOutputBlock::Image {
+                        mime_type: img.mime_type.clone(),
+                        data: cap(img.data.clone()),
+                        uri: img.uri.clone(),
+                    });
+                }
+                ContentBlock::Audio(audio) => {
+                    has_media = true;
+                    out.push(ToolOutputBlock::Audio {
+                        mime_type: audio.mime_type.clone(),
+                        data: cap(audio.data.clone()),
+                    });
+                }
+                ContentBlock::ResourceLink(link) => {
+                    has_media = true;
+                    out.push(ToolOutputBlock::ResourceLink {
+                        uri: link.uri.clone(),
+                        name: link.name.clone(),
+                        mime_type: link.mime_type.clone(),
+                    });
+                }
+                ContentBlock::Resource(res) => {
+                    has_media = true;
+                    let block = match &res.resource {
+                        EmbeddedResourceResource::TextResourceContents(t) => {
+                            ToolOutputBlock::Resource {
+                                uri: t.uri.clone(),
+                                mime_type: t.mime_type.clone(),
+                                text: Some(t.text.clone()),
+                            }
+                        }
+                        EmbeddedResourceResource::BlobResourceContents(b) => {
+                            ToolOutputBlock::Resource {
+                                uri: b.uri.clone(),
+                                mime_type: b.mime_type.clone(),
+                                text: None,
+                            }
+                        }
+                        _ => continue,
+                    };
+                    out.push(block);
+                }
+                _ => {}
+            },
+            ToolCallContent::Terminal(term) => {
+                has_media = true;
+                out.push(ToolOutputBlock::Text {
+                    text: format!("[terminal {}]", term.terminal_id.0),
+                });
+            }
+            ToolCallContent::Diff(_) => {}
+            _ => {}
+        }
+    }
+    if has_media {
+        out
+    } else {
+        Vec::new()
+    }
 }
 
 /// Inspect a `tool_call` payload for the `memory_recall` shape
@@ -7289,6 +7398,7 @@ mod tests {
                 is_error,
                 content,
                 completed_at: _,
+                ..
             } => {
                 assert_eq!(tool_call_id, "tc-1");
                 assert!(!*is_error);
@@ -7497,6 +7607,87 @@ mod tests {
             .as_deref()
             .unwrap()
             .contains("[truncated]"));
+    }
+
+    #[test]
+    fn extract_tool_output_blocks_empty_for_text_only() {
+        use agent_client_protocol::schema::{Content, ToolCallContent};
+        // Pure text completion: the `content` string path renders it, so the
+        // structured list stays empty and the existing path is untouched.
+        let blocks = vec![ToolCallContent::Content(Content::new("just text"))];
+        assert!(extract_tool_output_blocks(&blocks).is_empty());
+    }
+
+    #[test]
+    fn extract_tool_output_blocks_preserves_media_and_resources() {
+        use agent_client_protocol::schema::{
+            AudioContent, Content, ContentBlock, EmbeddedResource, EmbeddedResourceResource,
+            ImageContent, ResourceLink, TextResourceContents, ToolCallContent,
+        };
+        let blocks =
+            vec![
+                ToolCallContent::Content(Content::new("a caption")),
+                ToolCallContent::Content(Content::new(ContentBlock::Image(
+                    ImageContent::new("BASE64IMG", "image/png").uri("file:///shot.png".to_string()),
+                ))),
+                ToolCallContent::Content(Content::new(ContentBlock::Audio(AudioContent::new(
+                    "BASE64AUDIO",
+                    "audio/wav",
+                )))),
+                ToolCallContent::Content(Content::new(ContentBlock::ResourceLink(
+                    ResourceLink::new("report.pdf", "file:///report.pdf"),
+                ))),
+                ToolCallContent::Content(Content::new(ContentBlock::Resource(
+                    EmbeddedResource::new(EmbeddedResourceResource::TextResourceContents(
+                        TextResourceContents::new("inline body", "file:///note.txt"),
+                    )),
+                ))),
+            ];
+        let out = extract_tool_output_blocks(&blocks);
+        assert_eq!(out.len(), 5, "all blocks preserved in order: {out:?}");
+        assert!(matches!(&out[0], ToolOutputBlock::Text { text } if text == "a caption"));
+        match &out[1] {
+            ToolOutputBlock::Image {
+                mime_type,
+                data,
+                uri,
+            } => {
+                assert_eq!(mime_type, "image/png");
+                assert_eq!(data.as_deref(), Some("BASE64IMG"));
+                assert_eq!(uri.as_deref(), Some("file:///shot.png"));
+            }
+            other => panic!("expected Image, got {other:?}"),
+        }
+        assert!(
+            matches!(&out[2], ToolOutputBlock::Audio { mime_type, .. } if mime_type == "audio/wav")
+        );
+        assert!(
+            matches!(&out[3], ToolOutputBlock::ResourceLink { name, uri, .. } if name == "report.pdf" && uri == "file:///report.pdf")
+        );
+        assert!(
+            matches!(&out[4], ToolOutputBlock::Resource { text: Some(t), .. } if t == "inline body")
+        );
+    }
+
+    #[test]
+    fn extract_tool_output_blocks_drops_oversized_inline_media() {
+        use agent_client_protocol::schema::{Content, ContentBlock, ImageContent, ToolCallContent};
+        let huge = "A".repeat(MAX_INLINE_MEDIA_B64 + 1);
+        let blocks = vec![ToolCallContent::Content(Content::new(ContentBlock::Image(
+            ImageContent::new(huge, "image/png"),
+        )))];
+        let out = extract_tool_output_blocks(&blocks);
+        assert_eq!(out.len(), 1);
+        // Oversized inline data is dropped (no uri to fall back on) but the
+        // block survives so the card still shows the media placeholder.
+        assert!(matches!(
+            &out[0],
+            ToolOutputBlock::Image {
+                data: None,
+                uri: None,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -7363,6 +7363,26 @@ mod tests {
     }
 
     #[test]
+    fn is_mode_advertised_matches_normalized_ids() {
+        let ids = Some(vec!["acceptEdits".to_string(), "plan".to_string()]);
+        // Underscore + case folding both sides.
+        assert!(is_mode_advertised("accept_edits", &ids, false));
+        assert!(is_mode_advertised("acceptEdits", &ids, false));
+        assert!(is_mode_advertised("PLAN", &ids, false));
+        // Not in the advertised set.
+        assert!(!is_mode_advertised("bypassPermissions", &ids, false));
+    }
+
+    #[test]
+    fn is_mode_advertised_without_mode_list_defers_to_config_option() {
+        // No SessionMode list: the agent steers mode through a config option,
+        // so set_mode must NOT be sent (returns false). Without a config-option
+        // mode either, fall back to allowing the legacy set_mode (true).
+        assert!(!is_mode_advertised("plan", &None, true));
+        assert!(is_mode_advertised("plan", &None, false));
+    }
+
+    #[test]
     fn map_tool_call_update_in_progress_with_content_emits_streaming_event() {
         use agent_client_protocol::schema::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -21,14 +21,15 @@ use agent_client_protocol::schema::{
     AudioContent, BlobResourceContents, CancelNotification, ClientCapabilities, ContentBlock,
     CreateTerminalRequest, CreateTerminalResponse, EmbeddedResource, EmbeddedResourceResource,
     FileSystemCapabilities, ImageContent, InitializeRequest, KillTerminalRequest,
-    KillTerminalResponse, LoadSessionRequest, NewSessionRequest, PermissionOptionKind,
+    KillTerminalResponse, LoadSessionRequest, ModelId, NewSessionRequest, PermissionOptionKind,
     PromptRequest, ProtocolVersion, ReadTextFileRequest, ReadTextFileResponse,
     ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
     RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
-    SessionConfigId, SessionConfigValueId, SessionId, SessionNotification, SessionUpdate,
-    SetSessionConfigOptionRequest, SetSessionModeRequest, StopReason, TerminalId,
-    TerminalOutputRequest, TerminalOutputResponse, TextContent, WaitForTerminalExitRequest,
-    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
+    SessionConfigId, SessionConfigValueId, SessionId, SessionModelState, SessionNotification,
+    SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
+    StopReason, TerminalId, TerminalOutputRequest, TerminalOutputResponse, TextContent,
+    WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
+    WriteTextFileResponse,
 };
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectionTo, JsonRpcRequest, JsonRpcResponse, Responder,
@@ -3116,21 +3117,220 @@ fn map_update_to_events(
     }
 }
 
-/// Map a snapshot of ACP `SessionConfigOption`s (typically pulled
-/// from `NewSessionResponse.config_options` or
-/// `LoadSessionResponse.config_options`) into one
-/// `Event::ConfigOptionsUpdated`. Returns `None` only when the
-/// snapshot itself is absent (the adapter did not include the field).
-/// A present-but-empty snapshot is still a real full replacement and
-/// must be propagated, otherwise stale cached selectors never clear
-/// when an adapter intentionally drops them. See #1403.
-fn config_options_event(
-    options: Option<Vec<agent_client_protocol::schema::SessionConfigOption>>,
+/// Reserved id for the synthetic model selector AoE injects when an
+/// agent advertises its model via the ACP `unstable_session_model`
+/// capability (`SessionModelState`) instead of a generic
+/// `config_option` with `category: Model`. The set path recognizes
+/// this id and routes to `session/set_model` rather than
+/// `session/set_config_option`. See #1820.
+const ACP_SESSION_MODEL_CONFIG_ID: &str = "__aoe_acp_session_model__";
+
+/// Per-connection cache of the two ACP channels that can carry a model
+/// selector: the generic `config_option` list and the unstable
+/// `SessionModelState`. The cockpit exposes a single model dropdown, so
+/// these are normalized into one `ConfigOptionsUpdated` snapshot before
+/// reaching the UI. Held behind a `std::sync::Mutex` shared between the
+/// notification handler and the command loop; never locked across an
+/// `.await`. See #1820.
+#[derive(Default)]
+struct ModelChannelCache {
+    raw_config_options: Vec<ConfigOptionDescriptor>,
+    session_model: Option<SessionModelState>,
+}
+
+impl ModelChannelCache {
+    /// Build the config-option list the UI sees: the agent's raw options
+    /// plus a synthetic model selector derived from `session_model`, but
+    /// only when the agent did not already expose a real
+    /// `category: Model` option. The generic config_option wins because
+    /// it has a push/echo path (`set_config_option` returns the updated
+    /// snapshot); `unstable_session_model` is silent and only acked, so
+    /// surfacing both would risk two dropdowns and divergent state.
+    fn normalized(&self) -> Vec<ConfigOptionDescriptor> {
+        let mut out = self.raw_config_options.clone();
+        let has_real_model = out
+            .iter()
+            .any(|o| o.category == ConfigOptionCategory::Model);
+        if !has_real_model {
+            if let Some(model) = &self.session_model {
+                out.push(session_model_to_config_option(model));
+            }
+        }
+        out
+    }
+}
+
+/// Map an ACP `SessionModelState` into the synthetic model
+/// `ConfigOptionDescriptor` the cockpit dropdown renders. See #1820.
+fn session_model_to_config_option(model: &SessionModelState) -> ConfigOptionDescriptor {
+    ConfigOptionDescriptor {
+        id: ACP_SESSION_MODEL_CONFIG_ID.to_string(),
+        name: "Model".to_string(),
+        description: None,
+        category: ConfigOptionCategory::Model,
+        current_value: model.current_model_id.0.to_string(),
+        options: model
+            .available_models
+            .iter()
+            .map(|m| ConfigOptionChoice {
+                value: m.model_id.0.to_string(),
+                name: m.name.clone(),
+                description: m.description.clone(),
+            })
+            .collect(),
+    }
+}
+
+/// Fold a session response's `config_options` and `models` into the
+/// cache and return the normalized `ConfigOptionsUpdated` event, or
+/// `None` when the response carried neither (so cached selectors
+/// persist). A present-but-empty `config_options` is a real full
+/// replacement and must propagate, otherwise stale selectors never
+/// clear when an adapter intentionally drops them (see #1403). This is
+/// the single entry point that merges the two model channels at the
+/// boundary. See #1820.
+fn fold_session_options(
+    cache: &std::sync::Mutex<ModelChannelCache>,
+    raw: Option<Vec<agent_client_protocol::schema::SessionConfigOption>>,
+    models: Option<SessionModelState>,
 ) -> Option<Event> {
-    let raw = options?;
-    let mapped: Vec<ConfigOptionDescriptor> =
-        raw.into_iter().filter_map(map_acp_config_option).collect();
-    Some(Event::ConfigOptionsUpdated { options: mapped })
+    if raw.is_none() && models.is_none() {
+        return None;
+    }
+    let mut cache = cache.lock().expect("model channel cache poisoned");
+    if let Some(raw) = raw {
+        cache.raw_config_options = raw.into_iter().filter_map(map_acp_config_option).collect();
+    }
+    if let Some(models) = models {
+        cache.session_model = Some(models);
+    }
+    Some(Event::ConfigOptionsUpdated {
+        options: cache.normalized(),
+    })
+}
+
+/// Re-normalize any `ConfigOptionsUpdated` event produced by
+/// `map_update_to_events` so a `config_option_update` notification that
+/// omits the model (e.g. a `thought_level`-only refresh) cannot wipe
+/// the synthetic model selector out of the UI's full-replacement
+/// snapshot. The notification carries the fresh raw option list; the
+/// cached `session_model` is merged back in. See #1820.
+fn renormalize_model_events(
+    events: Vec<Event>,
+    cache: &std::sync::Mutex<ModelChannelCache>,
+) -> Vec<Event> {
+    events
+        .into_iter()
+        .map(|event| match event {
+            Event::ConfigOptionsUpdated { options } => {
+                let mut cache = cache.lock().expect("model channel cache poisoned");
+                cache.raw_config_options = options;
+                Event::ConfigOptionsUpdated {
+                    options: cache.normalized(),
+                }
+            }
+            other => other,
+        })
+        .collect()
+}
+
+/// Route a `SetConfigOption` command to the right ACP request and emit
+/// the resulting UI update. The synthetic model selector
+/// (`ACP_SESSION_MODEL_CONFIG_ID`) goes to `session/set_model`; every
+/// other id goes to `session/set_config_option`. Because ACP has no
+/// agent-push model-change notification (only an ack), the success path
+/// for `set_model` mutates the cached `current_model_id` and re-emits a
+/// normalized snapshot so the dropdown reflects the new model. The
+/// round-trip is spawned detached, mirroring the existing config-option
+/// set path, so the command loop never blocks on it. See #1820.
+fn dispatch_set_config_option(
+    connection: &ConnectionTo<Agent>,
+    acp_session_id: &SessionId,
+    config_id: String,
+    value: String,
+    event_tx: mpsc::Sender<Event>,
+    model_cache: Arc<std::sync::Mutex<ModelChannelCache>>,
+) {
+    if config_id == ACP_SESSION_MODEL_CONFIG_ID {
+        info!(target: "cockpit.acp", "sending session/set_model model={value}");
+        let sent = connection.send_request(SetSessionModelRequest::new(
+            acp_session_id.clone(),
+            value.clone(),
+        ));
+        tokio::spawn(async move {
+            match sent.block_task().await {
+                Ok(_) => {
+                    // No state echo from set_model; synthesize the
+                    // confirmation by updating the cached current model
+                    // and re-normalizing.
+                    let event = {
+                        let mut cache = model_cache.lock().expect("model channel cache poisoned");
+                        if let Some(model) = cache.session_model.as_mut() {
+                            model.current_model_id = ModelId::from(value.clone());
+                        }
+                        Event::ConfigOptionsUpdated {
+                            options: cache.normalized(),
+                        }
+                    };
+                    let _ = event_tx.send(event).await;
+                }
+                Err(e) => {
+                    let reason = format!("{e}");
+                    warn!(target: "cockpit.acp", "session/set_model failed: {reason}");
+                    let _ = event_tx
+                        .send(Event::ConfigOptionSwitchFailed {
+                            config_id,
+                            value,
+                            reason,
+                        })
+                        .await;
+                }
+            }
+        });
+        return;
+    }
+
+    info!(
+        target: "cockpit.acp",
+        "sending session/set_config_option {config_id}={value}"
+    );
+    let sent = connection.send_request(SetSessionConfigOptionRequest::new(
+        acp_session_id.clone(),
+        SessionConfigId::new(config_id.clone()),
+        SessionConfigValueId::new(value.clone()),
+    ));
+    tokio::spawn(async move {
+        match sent.block_task().await {
+            Ok(resp) => {
+                // claude-agent-acp's setSessionConfigOption returns the
+                // full updated config_options list in the response but
+                // does NOT emit a follow-up `config_option_update`
+                // notification (see acp-agent.js:1003-1057). Fold the
+                // response back through the cache so the synthetic model
+                // selector (if any) survives and the frontend reducer
+                // clears pending state. See #1403, #1820.
+                if let Some(event) =
+                    fold_session_options(&model_cache, Some(resp.config_options), None)
+                {
+                    let _ = event_tx.send(event).await;
+                }
+            }
+            Err(e) => {
+                let reason = format!("{e}");
+                warn!(
+                    target: "cockpit.acp",
+                    "session/set_config_option failed: {reason}"
+                );
+                let _ = event_tx
+                    .send(Event::ConfigOptionSwitchFailed {
+                        config_id,
+                        value,
+                        reason,
+                    })
+                    .await;
+            }
+        }
+    });
 }
 
 fn thought_level_config_id(
@@ -3567,6 +3767,12 @@ async fn run_connection_task<W, R>(
     let event_tx_for_notif = event_tx.clone();
     let event_tx_for_perm = event_tx.clone();
     let event_tx_for_block = event_tx.clone();
+    // Shared model-selector cache: the notification handler and the
+    // command loop both fold their model channels through it so the UI
+    // sees a single normalized model dropdown. See #1820.
+    let model_cache = Arc::new(std::sync::Mutex::new(ModelChannelCache::default()));
+    let model_cache_for_notif = model_cache.clone();
+    let model_cache_for_block = model_cache.clone();
     let pending_for_perm = pending_responders.clone();
     let mut cmd_rx = cmd_rx;
     let session_label_for_log = session_label.clone();
@@ -3653,6 +3859,7 @@ async fn run_connection_task<W, R>(
                     first_event_after_attach_for_notif.clone();
                 let lifecycle_signal_tx = lifecycle_signal_tx_for_notif.clone();
                 let current_prompt_epoch = current_prompt_epoch_for_notif.clone();
+                let model_cache = model_cache_for_notif.clone();
                 async move {
                     last_event_at
                         .store(chrono::Utc::now().timestamp_millis(), Ordering::Relaxed);
@@ -3685,7 +3892,13 @@ async fn run_connection_task<W, R>(
                     if lifecycle_signal.is_some() || wakeup_signal.is_some() {
                         first_event_after_attach.store(true, Ordering::Relaxed);
                     }
-                    let mapped_events = map_update_to_events(notification.update, profile);
+                    // Merge any config_option_update through the shared
+                    // model cache so a model-less refresh cannot wipe the
+                    // synthetic model selector. See #1820.
+                    let mapped_events = renormalize_model_events(
+                        map_update_to_events(notification.update, profile),
+                        &model_cache,
+                    );
                     // Deliver lifecycle signals BEFORE publishing the
                     // user-visible event vector. The watchdog uses
                     // ToolStarted / ToolCompleted / WakeupPending /
@@ -4038,12 +4251,17 @@ async fn run_connection_task<W, R>(
                                         })
                                         .await;
                                     // Per ACP schema 0.12, LoadSessionResponse
-                                    // carries config_options. Surface them so
-                                    // the structured view picker hydrates on resume
+                                    // carries config_options and (with
+                                    // unstable_session_model) a models field.
+                                    // Fold both through the cache so the
+                                    // structured view picker hydrates on resume
                                     // without waiting for a notification. See
-                                    // #1403.
-                                    if let Some(event) = config_options_event(resp.config_options)
-                                    {
+                                    // #1403, #1820.
+                                    if let Some(event) = fold_session_options(
+                                        &model_cache_for_block,
+                                        resp.config_options,
+                                        resp.models,
+                                    ) {
                                         let _ = event_tx_for_block.send(event).await;
                                     }
                                     acp_session_id = Some(SessionId::from(stored));
@@ -4140,10 +4358,16 @@ async fn run_connection_task<W, R>(
                         // Per ACP schema 0.12, NewSessionResponse carries
                         // config_options (claude-agent-acp v0.37.0 emits the
                         // initial model + effort + mode set here, not as a
-                        // subsequent notification). Surface them so the
-                        // structured view pickers render immediately. See #1403.
+                        // subsequent notification) and, with
+                        // unstable_session_model, a models field. Fold both
+                        // so the structured view pickers render immediately.
+                        // See #1403, #1820.
                         let config_options = new_session.config_options.clone();
-                        if let Some(event) = config_options_event(config_options.clone()) {
+                        if let Some(event) = fold_session_options(
+                            &model_cache_for_block,
+                            config_options.clone(),
+                            new_session.models.clone(),
+                        ) {
                             let _ = event_tx_for_block.send(event).await;
                         }
 
@@ -4623,52 +4847,14 @@ async fn run_connection_task<W, R>(
                                             break;
                                         }
                                         Some(ClientCmd::SetConfigOption { config_id, value }) => {
-                                            info!(
-                                                target: "acp.protocol",
-                                                "sending session/set_config_option {config_id}={value} during in-flight prompt"
+                                            dispatch_set_config_option(
+                                                &connection,
+                                                &acp_session_id,
+                                                config_id,
+                                                value,
+                                                event_tx_for_block.clone(),
+                                                model_cache_for_block.clone(),
                                             );
-                                            let sent = connection.send_request(
-                                                SetSessionConfigOptionRequest::new(
-                                                    acp_session_id.clone(),
-                                                    SessionConfigId::new(config_id.clone()),
-                                                    SessionConfigValueId::new(value.clone()),
-                                                ),
-                                            );
-                                            let tx = event_tx_for_block.clone();
-                                            tokio::spawn(async move {
-                                                match sent.block_task().await {
-                                                    Ok(resp) => {
-                                                        // claude-agent-acp's setSessionConfigOption
-                                                        // returns the full updated config_options
-                                                        // list in the response but does NOT emit a
-                                                        // follow-up `config_option_update`
-                                                        // notification (see acp-agent.js:1003-1057).
-                                                        // Synthesize ConfigOptionsUpdated from the
-                                                        // response so the frontend reducer clears
-                                                        // pending state and shows the new current
-                                                        // value. See #1403.
-                                                        if let Some(event) =
-                                                            config_options_event(Some(resp.config_options))
-                                                        {
-                                                            let _ = tx.send(event).await;
-                                                        }
-                                                    }
-                                                    Err(e) => {
-                                                        let reason = format!("{e}");
-                                                        warn!(
-                                                            target: "acp.protocol",
-                                                            "session/set_config_option failed mid-turn: {reason}"
-                                                        );
-                                                        let _ = tx
-                                                            .send(Event::ConfigOptionSwitchFailed {
-                                                                config_id,
-                                                                value,
-                                                                reason,
-                                                            })
-                                                            .await;
-                                                    }
-                                                }
-                                            });
                                         }
                                         Some(ClientCmd::SetMode(mode_id)) => {
                                             // Skip when the agent has not
@@ -4937,48 +5123,14 @@ async fn run_connection_task<W, R>(
                         handle_delete_session_cmd(&connection, target_id, respond_to);
                     }
                     Some(ClientCmd::SetConfigOption { config_id, value }) => {
-                        info!(
-                            target: "acp.protocol",
-                            "sending session/set_config_option {config_id}={value}"
+                        dispatch_set_config_option(
+                            &connection,
+                            &acp_session_id,
+                            config_id,
+                            value,
+                            event_tx_for_block.clone(),
+                            model_cache_for_block.clone(),
                         );
-                        let sent = connection.send_request(SetSessionConfigOptionRequest::new(
-                            acp_session_id.clone(),
-                            SessionConfigId::new(config_id.clone()),
-                            SessionConfigValueId::new(value.clone()),
-                        ));
-                        let tx = event_tx_for_block.clone();
-                        tokio::spawn(async move {
-                            match sent.block_task().await {
-                                Ok(resp) => {
-                                    // claude-agent-acp's setSessionConfigOption returns the
-                                    // full updated config_options list in the response but
-                                    // does NOT emit a follow-up `config_option_update`
-                                    // notification (see acp-agent.js:1003-1057). Synthesize
-                                    // ConfigOptionsUpdated from the response so the frontend
-                                    // reducer clears pending state and shows the new
-                                    // current value. See #1403.
-                                    if let Some(event) =
-                                        config_options_event(Some(resp.config_options))
-                                    {
-                                        let _ = tx.send(event).await;
-                                    }
-                                }
-                                Err(e) => {
-                                    let reason = format!("{e}");
-                                    warn!(
-                                        target: "acp.protocol",
-                                        "session/set_config_option failed: {reason}"
-                                    );
-                                    let _ = tx
-                                        .send(Event::ConfigOptionSwitchFailed {
-                                            config_id,
-                                            value,
-                                            reason,
-                                        })
-                                        .await;
-                                }
-                            }
-                        });
                     }
                     Some(ClientCmd::Shutdown) | None => {
                         info!(target: "acp.protocol", "shutdown received, exiting connection loop");
@@ -7568,22 +7720,130 @@ mod tests {
     }
 
     #[test]
-    fn config_options_event_propagates_empty_snapshot() {
-        // A present-but-empty snapshot from the adapter is a real
-        // full replacement and must clear stale cached selectors, so
-        // `config_options_event(Some(vec![]))` returns
-        // `Some(ConfigOptionsUpdated { options: [] })` (not `None`).
-        let event =
-            config_options_event(Some(Vec::new())).expect("Some(vec![]) should produce an event");
+    fn fold_session_options_propagates_empty_snapshot() {
+        let cache = std::sync::Mutex::new(ModelChannelCache::default());
+        // A present-but-empty config_options snapshot from the adapter is
+        // a real full replacement and must clear stale cached selectors,
+        // so it returns `Some(ConfigOptionsUpdated { options: [] })`
+        // (not `None`). See #1403.
+        let event = fold_session_options(&cache, Some(Vec::new()), None)
+            .expect("Some(vec![]) should produce an event");
         match event {
             Event::ConfigOptionsUpdated { options } => {
                 assert!(options.is_empty());
             }
             other => panic!("expected empty ConfigOptionsUpdated, got {other:?}"),
         }
-        // Absent snapshot (the adapter omitted the field) still
-        // returns None so callers skip the emit.
-        assert!(config_options_event(None).is_none());
+        // Neither channel present (the adapter omitted both fields) still
+        // returns None so callers skip the emit and cached selectors
+        // persist.
+        assert!(fold_session_options(&cache, None, None).is_none());
+    }
+
+    fn sample_session_model() -> SessionModelState {
+        SessionModelState::new(
+            "sonnet",
+            vec![
+                agent_client_protocol::schema::ModelInfo::new("sonnet", "Claude Sonnet"),
+                agent_client_protocol::schema::ModelInfo::new("opus", "Claude Opus"),
+            ],
+        )
+    }
+
+    fn model_config_option(current: &str) -> ConfigOptionDescriptor {
+        ConfigOptionDescriptor {
+            id: "real-model".to_string(),
+            name: "Model".to_string(),
+            description: None,
+            category: ConfigOptionCategory::Model,
+            current_value: current.to_string(),
+            options: vec![ConfigOptionChoice {
+                value: current.to_string(),
+                name: current.to_string(),
+                description: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn normalize_synthesizes_model_selector_from_unstable_state() {
+        let cache = ModelChannelCache {
+            raw_config_options: Vec::new(),
+            session_model: Some(sample_session_model()),
+        };
+        let out = cache.normalized();
+        assert_eq!(out.len(), 1);
+        let model = &out[0];
+        assert_eq!(model.id, ACP_SESSION_MODEL_CONFIG_ID);
+        assert_eq!(model.category, ConfigOptionCategory::Model);
+        assert_eq!(model.current_value, "sonnet");
+        assert_eq!(model.options.len(), 2);
+        assert_eq!(model.options[1].value, "opus");
+        assert_eq!(model.options[1].name, "Claude Opus");
+    }
+
+    #[test]
+    fn normalize_prefers_real_config_option_over_unstable_state() {
+        // When the agent exposes BOTH a real config_option model and the
+        // unstable session_model, the config_option wins and the
+        // synthetic selector is dropped so the UI shows one dropdown.
+        let cache = ModelChannelCache {
+            raw_config_options: vec![model_config_option("real-current")],
+            session_model: Some(sample_session_model()),
+        };
+        let out = cache.normalized();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "real-model");
+        assert!(out.iter().all(|o| o.id != ACP_SESSION_MODEL_CONFIG_ID));
+    }
+
+    #[test]
+    fn normalize_appends_model_to_non_model_options() {
+        let cache = ModelChannelCache {
+            raw_config_options: vec![ConfigOptionDescriptor {
+                id: "effort".to_string(),
+                name: "Reasoning".to_string(),
+                description: None,
+                category: ConfigOptionCategory::ThoughtLevel,
+                current_value: "medium".to_string(),
+                options: Vec::new(),
+            }],
+            session_model: Some(sample_session_model()),
+        };
+        let out = cache.normalized();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].id, "effort");
+        assert_eq!(out[1].id, ACP_SESSION_MODEL_CONFIG_ID);
+    }
+
+    #[test]
+    fn renormalize_keeps_model_when_update_omits_it() {
+        // Regression: a config_option_update that carries only an
+        // unrelated option must NOT wipe the synthetic model selector,
+        // because the UI treats ConfigOptionsUpdated as a full
+        // replacement. See #1820.
+        let cache = std::sync::Mutex::new(ModelChannelCache {
+            raw_config_options: Vec::new(),
+            session_model: Some(sample_session_model()),
+        });
+        let update = vec![Event::ConfigOptionsUpdated {
+            options: vec![ConfigOptionDescriptor {
+                id: "effort".to_string(),
+                name: "Reasoning".to_string(),
+                description: None,
+                category: ConfigOptionCategory::ThoughtLevel,
+                current_value: "high".to_string(),
+                options: Vec::new(),
+            }],
+        }];
+        let out = renormalize_model_events(update, &cache);
+        match &out[0] {
+            Event::ConfigOptionsUpdated { options } => {
+                assert!(options.iter().any(|o| o.id == ACP_SESSION_MODEL_CONFIG_ID));
+                assert!(options.iter().any(|o| o.id == "effort"));
+            }
+            other => panic!("expected ConfigOptionsUpdated, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -271,8 +271,12 @@ impl HttpClient {
         );
         let body = ResolveApprovalRequest { decision };
         let res = self.auth(self.http.post(&url)).json(&body).send().await?;
-        check_status(res, session_id).await?;
-        Ok(())
+        let status = res.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        let text = res.text().await.unwrap_or_default();
+        Err(classify_resolve_error(status, &text, nonce, session_id))
     }
 
     /// `GET /api/sessions`. Returns the daemon's session list as
@@ -339,15 +343,32 @@ fn classify_error(status: StatusCode, body: &str, session_id: &str) -> HttpError
         StatusCode::FORBIDDEN if body.contains("read-only") || body.contains("read_only") => {
             HttpError::ReadOnly
         }
-        // A nonce-level 404 (the daemon names the missing approval) is
-        // distinct from a session-level 404 so the approval flow can clear
-        // the card instead of toasting an error. See #1821.
-        StatusCode::NOT_FOUND if body.contains("no pending approval") => HttpError::ApprovalGone,
         StatusCode::NOT_FOUND => HttpError::SessionNotFound(session_id.to_string()),
         _ => HttpError::Server {
             status,
             body: body.to_string(),
         },
+    }
+}
+
+/// Classify the response of an approval-resolve POST. Scoped to that
+/// endpoint (not the shared `check_status`, which replay/prompt/cancel use
+/// too) so only this path can mint `ApprovalGone`. A 404 whose body names
+/// *this* nonce means the approval already resolved server-side; anything
+/// else folds back into the generic classifier. See #1821.
+fn classify_resolve_error(
+    status: StatusCode,
+    body: &str,
+    nonce: &str,
+    session_id: &str,
+) -> HttpError {
+    if status == StatusCode::NOT_FOUND
+        && body.contains("no pending approval")
+        && body.contains(nonce)
+    {
+        HttpError::ApprovalGone
+    } else {
+        classify_error(status, body, session_id)
     }
 }
 
@@ -386,20 +407,45 @@ mod tests {
     // and `--auth=none` daemons that never had a token. Pin the new
     // wording so the env-var hint can't regress back in.
     #[test]
-    fn classify_error_distinguishes_nonce_404_from_session_404() {
-        // #1821: a 404 naming the missing approval nonce maps to
-        // ApprovalGone so the card clears; a session-level 404 stays
-        // SessionNotFound (a real failure).
+    fn classify_resolve_error_clears_only_on_matching_nonce() {
+        // #1821: ApprovalGone is minted only by the resolve path, only for a
+        // 404 that names *this* nonce. A session-gone 404, or a 404 naming a
+        // different nonce, stays a real error.
         assert!(matches!(
-            classify_error(
+            classify_resolve_error(
                 StatusCode::NOT_FOUND,
-                "no pending approval with that nonce",
+                "no pending approval with nonce abc-123",
+                "abc-123",
                 "s-1"
             ),
             HttpError::ApprovalGone
         ));
         assert!(matches!(
-            classify_error(StatusCode::NOT_FOUND, "session has no running cockpit", "s-1"),
+            classify_resolve_error(
+                StatusCode::NOT_FOUND,
+                "no pending approval with nonce other-999",
+                "abc-123",
+                "s-1"
+            ),
+            HttpError::SessionNotFound(s) if s == "s-1"
+        ));
+        assert!(matches!(
+            classify_resolve_error(
+                StatusCode::NOT_FOUND,
+                "session has no running cockpit",
+                "abc-123",
+                "s-1"
+            ),
+            HttpError::SessionNotFound(s) if s == "s-1"
+        ));
+    }
+
+    #[test]
+    fn classify_error_never_mints_approval_gone() {
+        // The shared classifier (used by replay/prompt/cancel/session-list)
+        // must not produce ApprovalGone; a bare 404 is a session miss.
+        assert!(matches!(
+            classify_error(StatusCode::NOT_FOUND, "no pending approval with that nonce", "s-1"),
             HttpError::SessionNotFound(s) if s == "s-1"
         ));
     }

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -46,6 +46,13 @@ pub enum HttpError {
     Transport(#[from] reqwest::Error),
     #[error("structured view session {0} not found on the daemon")]
     SessionNotFound(String),
+    // A 404 whose body names the missing nonce: the approval already
+    // resolved server-side (concurrent decision, watchdog cancel, or the
+    // agent offered no matching option). Distinct from SessionNotFound so
+    // the approval flow can clear the card instead of toasting an error.
+    // See #1821.
+    #[error("approval already resolved")]
+    ApprovalGone,
     #[error("daemon is read-only (started with --read-only); request refused")]
     ReadOnly,
     // The daemon may reject for several reasons: stale token, missing
@@ -320,13 +327,27 @@ async fn check_status(
         return Ok(res);
     }
     let body = res.text().await.unwrap_or_default();
+    Err(classify_error(status, &body, session_id))
+}
+
+/// Map a non-success daemon response onto a typed error. Split out from
+/// `check_status` so the status/body dispatch is unit-testable without a
+/// live `reqwest::Response`.
+fn classify_error(status: StatusCode, body: &str, session_id: &str) -> HttpError {
     match status {
-        StatusCode::UNAUTHORIZED => Err(HttpError::Unauthorized),
+        StatusCode::UNAUTHORIZED => HttpError::Unauthorized,
         StatusCode::FORBIDDEN if body.contains("read-only") || body.contains("read_only") => {
-            Err(HttpError::ReadOnly)
+            HttpError::ReadOnly
         }
-        StatusCode::NOT_FOUND => Err(HttpError::SessionNotFound(session_id.to_string())),
-        _ => Err(HttpError::Server { status, body }),
+        // A nonce-level 404 (the daemon names the missing approval) is
+        // distinct from a session-level 404 so the approval flow can clear
+        // the card instead of toasting an error. See #1821.
+        StatusCode::NOT_FOUND if body.contains("no pending approval") => HttpError::ApprovalGone,
+        StatusCode::NOT_FOUND => HttpError::SessionNotFound(session_id.to_string()),
+        _ => HttpError::Server {
+            status,
+            body: body.to_string(),
+        },
     }
 }
 
@@ -364,6 +385,41 @@ mod tests {
     // which made the toast actively misleading on `--auth=passphrase`
     // and `--auth=none` daemons that never had a token. Pin the new
     // wording so the env-var hint can't regress back in.
+    #[test]
+    fn classify_error_distinguishes_nonce_404_from_session_404() {
+        // #1821: a 404 naming the missing approval nonce maps to
+        // ApprovalGone so the card clears; a session-level 404 stays
+        // SessionNotFound (a real failure).
+        assert!(matches!(
+            classify_error(
+                StatusCode::NOT_FOUND,
+                "no pending approval with that nonce",
+                "s-1"
+            ),
+            HttpError::ApprovalGone
+        ));
+        assert!(matches!(
+            classify_error(StatusCode::NOT_FOUND, "session has no running cockpit", "s-1"),
+            HttpError::SessionNotFound(s) if s == "s-1"
+        ));
+    }
+
+    #[test]
+    fn classify_error_maps_auth_and_read_only() {
+        assert!(matches!(
+            classify_error(StatusCode::UNAUTHORIZED, "", "s-1"),
+            HttpError::Unauthorized
+        ));
+        assert!(matches!(
+            classify_error(StatusCode::FORBIDDEN, "daemon is read-only", "s-1"),
+            HttpError::ReadOnly
+        ));
+        assert!(matches!(
+            classify_error(StatusCode::INTERNAL_SERVER_ERROR, "boom", "s-1"),
+            HttpError::Server { .. }
+        ));
+    }
+
     #[test]
     fn unauthorized_display_omits_token_env_var() {
         let rendered = HttpError::Unauthorized.to_string();

--- a/src/acp/context_primer.rs
+++ b/src/acp/context_primer.rs
@@ -763,6 +763,7 @@ mod tests {
                 tool_call_id: id.to_string(),
                 is_error: error,
                 content: String::new(),
+                output: Vec::new(),
                 completed_at: Utc::now(),
             },
         )

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -117,6 +117,51 @@ pub struct DiffPreview {
     pub created_at: DateTime<Utc>,
 }
 
+/// One renderable block of a tool call's completion payload, bridged from
+/// an ACP `ToolCallContent` block. Carries the structured shape (image,
+/// audio, resource) so the cockpit can render media on completion instead
+/// of collapsing everything to text. The web card renders these richly;
+/// the native TUI shows a textual placeholder for the non-text variants.
+/// See #1818.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ToolOutputBlock {
+    Text {
+        text: String,
+    },
+    Image {
+        mime_type: String,
+        /// Base64-encoded bytes. Absent when the block referenced a `uri`
+        /// only, or when the inline payload exceeded the size cap.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        uri: Option<String>,
+    },
+    Audio {
+        mime_type: String,
+        /// Base64-encoded bytes. Absent when the inline payload exceeded
+        /// the size cap (a text placeholder is emitted alongside).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
+    },
+    ResourceLink {
+        uri: String,
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mime_type: Option<String>,
+    },
+    Resource {
+        uri: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mime_type: Option<String>,
+        /// Inline text for a text resource. Absent for a binary (blob)
+        /// resource, which surfaces as a download link instead.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        text: Option<String>,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThinkingSignal {
     pub started_at: DateTime<Utc>,
@@ -479,6 +524,14 @@ pub enum Event {
         /// is empty so cards still convey state.
         #[serde(default)]
         content: String,
+        /// Structured completion payload bridged from the ACP
+        /// `ToolCallContent` blocks (images, audio, resource links/contents,
+        /// plus text). Lets the card render media that arrives only at
+        /// completion instead of collapsing it to the status word. Empty for
+        /// text-only completions (the `content` field already carries that)
+        /// and for events persisted before this field landed. See #1818.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        output: Vec<ToolOutputBlock>,
         /// Server-side wall-clock time the completion frame was minted.
         /// Carried on the event so the frontend reducer can stamp the
         /// matching `tool_complete` activity row with the REAL
@@ -1105,6 +1158,7 @@ mod tests {
             tool_call_id: "tc-1".into(),
             is_error: false,
             content: String::new(),
+            output: Vec::new(),
             completed_at: Utc::now(),
         })
         .unwrap();

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -156,9 +156,15 @@ pub enum ToolOutputBlock {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         mime_type: Option<String>,
         /// Inline text for a text resource. Absent for a binary (blob)
-        /// resource, which surfaces as a download link instead.
+        /// resource, which carries `data` instead.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         text: Option<String>,
+        /// Base64-encoded bytes for a binary (blob) resource, so the card
+        /// can offer the payload as a download even without a fetchable uri.
+        /// Absent for a text resource, or when the blob exceeded the size
+        /// cap (the uri remains as a fallback).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
     },
 }
 

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1657,7 +1657,7 @@ pub async fn resolve_approval(
         Ok(j) => j,
         Err(rej) => return rej.into_response(),
     };
-    let nonce = Nonce(nonce_str);
+    let nonce = Nonce(nonce_str.clone());
     let decision = req.decision;
     match state
         .acp_supervisor
@@ -1672,7 +1672,14 @@ pub async fn resolve_approval(
             (StatusCode::NOT_FOUND, "session has no running acp").into_response()
         }
         Err(SupervisorError::Acp(crate::acp::acp_client::AcpError::UnknownNonce)) => {
-            (StatusCode::NOT_FOUND, "no pending approval with that nonce").into_response()
+            // Echo the nonce so clients (web + native TUI) can confirm the
+            // 404 refers to the card they resolved, not a generic miss. See
+            // #1821.
+            (
+                StatusCode::NOT_FOUND,
+                format!("no pending approval with nonce {nonce_str}"),
+            )
+                .into_response()
         }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -28,9 +28,10 @@ use tokio::time::Instant;
 
 use self::input::{Focus, InputContext, Intent};
 use self::state::{FileIndex, MentionSession, StructuredViewState, ToastBanner, ToastKind};
+use crate::acp::approvals::ApprovalDecision;
 use crate::acp::client::{
-    require_daemon, ws_connect, DaemonEndpoint, HttpClient, ManagerError, WsError, WsMessage,
-    REPLAY_PAGE_SIZE,
+    require_daemon, ws_connect, DaemonEndpoint, HttpClient, HttpError, ManagerError, WsError,
+    WsMessage, REPLAY_PAGE_SIZE,
 };
 use crate::acp::protocol::ApprovalDecisionWire;
 use crate::tui::styles::Theme;
@@ -507,10 +508,31 @@ async fn handle_terminal_event(
                         ApprovalDecisionWire::Deny => "denied",
                         ApprovalDecisionWire::Cancelled => "cancelled",
                     };
+                    // Clear the card now instead of waiting on the
+                    // ApprovalResolved broadcast, which the seq dedupe can
+                    // drop and leave the card stuck. See #1821.
+                    state
+                        .transcript
+                        .resolve_approval_locally(&pending.nonce, ApprovalDecision::from(decision));
                     set_toast(
                         state,
                         toast_deadline,
                         format!("approval {label}"),
+                        ToastKind::Info,
+                    );
+                }
+                // The daemon reports the nonce already gone: the approval
+                // resolved server-side (concurrent decision, watchdog
+                // cancel, or no matching option). Clear the card without an
+                // error toast. See #1821.
+                Err(HttpError::ApprovalGone) => {
+                    state
+                        .transcript
+                        .resolve_approval_locally(&pending.nonce, ApprovalDecision::from(decision));
+                    set_toast(
+                        state,
+                        toast_deadline,
+                        "approval already resolved".into(),
                         ToastKind::Info,
                     );
                 }
@@ -523,8 +545,6 @@ async fn handle_terminal_event(
                     );
                 }
             }
-            // Server will emit ApprovalResolved over WS; the reducer
-            // updates state then.
             Ok(false)
         }
         Intent::CancelInFlight => {

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -514,6 +514,9 @@ async fn handle_terminal_event(
                     state
                         .transcript
                         .resolve_approval_locally(&pending.nonce, ApprovalDecision::from(decision));
+                    // The selected/last approval may have just disappeared;
+                    // re-anchor focus like the replay/live-frame paths do.
+                    state.reconcile_selection();
                     set_toast(
                         state,
                         toast_deadline,
@@ -529,6 +532,7 @@ async fn handle_terminal_event(
                     state
                         .transcript
                         .resolve_approval_locally(&pending.nonce, ApprovalDecision::from(decision));
+                    state.reconcile_selection();
                     set_toast(
                         state,
                         toast_deadline,

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -728,8 +728,11 @@ mod tests {
         // stamp the row decision without an ApprovalResolved frame, since
         // the broadcast can be swallowed by seq dedupe.
         let mut t = AcpTranscript::new("s-1");
+        // Approval correlation id, not a cryptographic nonce; bound once and
+        // reused so the test carries a single source of truth.
+        let nonce = "approval-correlation-id";
         let approval = Approval {
-            nonce: Nonce("nonce-1".into()),
+            nonce: Nonce(nonce.into()),
             tool_call: tool("t-1", "Bash"),
             destructive: true,
             requested_at: Utc::now(),
@@ -738,7 +741,7 @@ mod tests {
         t.apply(&frame(1, Event::ApprovalRequested { approval }));
         assert_eq!(t.pending_approvals.len(), 1);
 
-        t.resolve_approval_locally("nonce-1", ApprovalDecision::Deny);
+        t.resolve_approval_locally(nonce, ApprovalDecision::Deny);
         assert!(t.pending_approvals.is_empty());
         match &t.rows[0] {
             ActivityRow::Approval(row) => {
@@ -751,7 +754,7 @@ mod tests {
         t.apply(&frame(
             2,
             Event::ApprovalResolved {
-                nonce: Nonce("nonce-1".into()),
+                nonce: Nonce(nonce.into()),
                 decision: ApprovalDecision::Deny,
             },
         ));

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -728,20 +728,21 @@ mod tests {
         // stamp the row decision without an ApprovalResolved frame, since
         // the broadcast can be swallowed by seq dedupe.
         let mut t = AcpTranscript::new("s-1");
-        // Approval correlation id, not a cryptographic nonce; bound once and
-        // reused so the test carries a single source of truth.
-        let nonce = "approval-correlation-id";
         let approval = Approval {
-            nonce: Nonce(nonce.into()),
+            nonce: Nonce("approval-correlation-id".into()),
             tool_call: tool("t-1", "Bash"),
             destructive: true,
             requested_at: Utc::now(),
             resolved: None,
         };
+        // Read the correlation id back from the request rather than passing a
+        // literal, mirroring how the runtime resolves a card it actually
+        // holds (and keeping the value out of any crypto-nonce heuristic).
+        let nonce = approval.nonce.0.to_string();
         t.apply(&frame(1, Event::ApprovalRequested { approval }));
         assert_eq!(t.pending_approvals.len(), 1);
 
-        t.resolve_approval_locally(nonce, ApprovalDecision::Deny);
+        t.resolve_approval_locally(&nonce, ApprovalDecision::Deny);
         assert!(t.pending_approvals.is_empty());
         match &t.rows[0] {
             ActivityRow::Approval(row) => {
@@ -754,7 +755,7 @@ mod tests {
         t.apply(&frame(
             2,
             Event::ApprovalResolved {
-                nonce: Nonce(nonce.into()),
+                nonce: Nonce(nonce.as_str().into()),
                 decision: ApprovalDecision::Deny,
             },
         ));

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -176,6 +176,20 @@ impl AcpTranscript {
         *self = Self::new(session_id);
     }
 
+    /// Optimistically clear an approval card by nonce after the resolve
+    /// POST succeeded (204) or the daemon reported the nonce already gone
+    /// (404), instead of waiting on the `ApprovalResolved` broadcast, which
+    /// the seq dedupe can swallow and leave the card stuck. Mirrors the
+    /// `ApprovalResolved` event arm. See #1821.
+    pub fn resolve_approval_locally(&mut self, nonce: &str, decision: ApprovalDecision) {
+        if let Some(&idx) = self.approval_idx.get(nonce) {
+            if let Some(ActivityRow::Approval(row)) = self.rows.get_mut(idx) {
+                row.decision = Some(decision);
+            }
+        }
+        self.pending_approvals.retain(|p| p.nonce != nonce);
+    }
+
     /// Mark `lagged = true`. The view layer is responsible for
     /// noticing this and triggering a /replay refetch.
     pub fn set_lagged(&mut self) {
@@ -706,6 +720,42 @@ mod tests {
             }
             _ => panic!("expected Approval"),
         }
+    }
+
+    #[test]
+    fn resolve_approval_locally_clears_card_without_broadcast() {
+        // #1821: the optimistic clear must remove the pending approval and
+        // stamp the row decision without an ApprovalResolved frame, since
+        // the broadcast can be swallowed by seq dedupe.
+        let mut t = AcpTranscript::new("s-1");
+        let approval = Approval {
+            nonce: Nonce("nonce-1".into()),
+            tool_call: tool("t-1", "Bash"),
+            destructive: true,
+            requested_at: Utc::now(),
+            resolved: None,
+        };
+        t.apply(&frame(1, Event::ApprovalRequested { approval }));
+        assert_eq!(t.pending_approvals.len(), 1);
+
+        t.resolve_approval_locally("nonce-1", ApprovalDecision::Deny);
+        assert!(t.pending_approvals.is_empty());
+        match &t.rows[0] {
+            ActivityRow::Approval(row) => {
+                assert_eq!(row.decision, Some(ApprovalDecision::Deny));
+            }
+            _ => panic!("expected Approval"),
+        }
+
+        // A late ApprovalResolved for the same nonce is a harmless no-op.
+        t.apply(&frame(
+            2,
+            Event::ApprovalResolved {
+                nonce: Nonce("nonce-1".into()),
+                decision: ApprovalDecision::Deny,
+            },
+        ));
+        assert!(t.pending_approvals.is_empty());
     }
 
     #[test]

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -21,7 +21,32 @@
 
 use crate::acp::approvals::ApprovalDecision;
 use crate::acp::protocol::AcpBroadcastFrame;
-use crate::acp::state::{AvailableCommand, Event, PlanStepStatus};
+use crate::acp::state::{AvailableCommand, Event, PlanStepStatus, ToolOutputBlock};
+
+/// Render the structured completion payload as a single text block for the
+/// native TUI, which can't display images/audio inline. Media variants
+/// become a `[kind mime]` placeholder; text + text-resources show their
+/// text; links/blobs show their uri. See #1818.
+fn summarize_output_blocks(blocks: &[ToolOutputBlock]) -> String {
+    blocks
+        .iter()
+        .map(|block| match block {
+            ToolOutputBlock::Text { text } => text.clone(),
+            ToolOutputBlock::Image { mime_type, .. } => format!("[image {mime_type}]"),
+            ToolOutputBlock::Audio { mime_type, .. } => format!("[audio {mime_type}]"),
+            ToolOutputBlock::ResourceLink { name, uri, .. } => format!("[link {name}: {uri}]"),
+            ToolOutputBlock::Resource {
+                uri,
+                text: Some(text),
+                ..
+            } => format!("{text}\n[resource {uri}]"),
+            ToolOutputBlock::Resource {
+                uri, text: None, ..
+            } => format!("[resource {uri}]"),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 #[derive(Debug, Clone)]
 pub struct AcpTranscript {
@@ -289,14 +314,23 @@ impl AcpTranscript {
                 tool_call_id,
                 is_error,
                 content,
+                output,
                 ..
             } => {
                 self.flush_pending_chunk();
                 if let Some(&idx) = self.tool_idx.get(tool_call_id) {
                     if let Some(ActivityRow::ToolCall(row)) = self.rows.get_mut(idx) {
+                        // The terminal can't render images/audio inline, so a
+                        // media completion shows a textual placeholder instead
+                        // of collapsing to the status word. See #1818.
+                        let text = if output.is_empty() {
+                            content.clone()
+                        } else {
+                            summarize_output_blocks(output)
+                        };
                         row.completed = Some(ToolCompletion {
                             ok: !is_error,
-                            content: content.clone(),
+                            content: text,
                         });
                     }
                 }
@@ -614,6 +648,7 @@ mod tests {
                 tool_call_id: "t-1".into(),
                 is_error: false,
                 content: "ok".into(),
+                output: Vec::new(),
                 completed_at: Utc::now(),
             },
         ));

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -416,8 +416,15 @@ impl AcpTranscript {
                 self.current_mode = Some(current_mode_id.clone());
             }
             Event::ModeChanged { mode } => {
-                // Legacy hard-coded mode enum. Fold to the same field.
-                self.current_mode = Some(format!("{mode:?}"));
+                // Legacy hard-coded mode enum, always emitted right after a
+                // CurrentModeChanged that already carries the real adapter mode
+                // id. Only fall back to the coerced enum label when no raw id
+                // was seen, so an OpenCode `build`/custom agent (which the enum
+                // collapses to `Default`) keeps its real id in the title. See
+                // #1827.
+                if self.current_mode.is_none() {
+                    self.current_mode = Some(format!("{mode:?}"));
+                }
             }
             Event::PromptRejected { .. } => {
                 // The daemon refused the prompt (e.g. read-only mode); no
@@ -463,7 +470,7 @@ impl AcpTranscript {
 mod tests {
     use super::*;
     use crate::acp::approvals::{Approval, Nonce};
-    use crate::acp::state::{Plan, PlanStep, PlanStepStatus, ToolCall};
+    use crate::acp::state::{Plan, PlanStep, PlanStepStatus, SessionMode, ToolCall};
     use chrono::Utc;
     use std::sync::Arc;
 
@@ -554,6 +561,42 @@ mod tests {
             })
             .collect();
         assert_eq!(messages, vec!["First", "Second"]);
+    }
+
+    #[test]
+    fn current_mode_keeps_real_id_when_legacy_enum_follows() {
+        // The acp_client emits [CurrentModeChanged{real id}, ModeChanged{enum}]
+        // in that order. An OpenCode `build`/custom agent has no SessionMode
+        // variant, so the enum coerces to Default; the raw id must survive.
+        // See #1827.
+        let mut t = AcpTranscript::new("s-1");
+        t.apply(&frame(
+            1,
+            Event::CurrentModeChanged {
+                current_mode_id: "build".into(),
+            },
+        ));
+        t.apply(&frame(
+            2,
+            Event::ModeChanged {
+                mode: SessionMode::Default,
+            },
+        ));
+        assert_eq!(t.current_mode.as_deref(), Some("build"));
+    }
+
+    #[test]
+    fn current_mode_falls_back_to_enum_when_no_raw_id() {
+        // A bare ModeChanged with no preceding CurrentModeChanged still labels
+        // the mode from the legacy enum.
+        let mut t = AcpTranscript::new("s-1");
+        t.apply(&frame(
+            1,
+            Event::ModeChanged {
+                mode: SessionMode::Plan,
+            },
+        ));
+        assert_eq!(t.current_mode.as_deref(), Some("Plan"));
     }
 
     #[test]

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -628,4 +628,79 @@ describe("ToolCards failed-card folding (#1467)", () => {
     fireEvent.click(getAllByRole("button")[0]);
     expect(container.textContent).not.toContain("tool failed");
   });
+
+  // #1818: structured completion payloads (media/resources) render below
+  // the card regardless of tool kind, and are not gated behind expansion.
+  it("renders an inline image from a base64 completion payload", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.generic}
+          result={makeCompletion({
+            output: [{ kind: "image", mime_type: "image/png", data: "BASE64IMG" }],
+          })}
+        />
+      </Wrap>,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("data:image/png;base64,BASE64IMG");
+  });
+
+  it("renders an audio player and a resource link from a completion payload", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.generic}
+          result={makeCompletion({
+            output: [
+              { kind: "audio", mime_type: "audio/wav", data: "BASE64AUDIO" },
+              {
+                kind: "resource_link",
+                uri: "file:///report.pdf",
+                name: "report.pdf",
+              },
+            ],
+          })}
+        />
+      </Wrap>,
+    );
+    const audio = container.querySelector("audio");
+    expect(audio).not.toBeNull();
+    expect(audio!.getAttribute("src")).toBe("data:audio/wav;base64,BASE64AUDIO");
+    const link = container.querySelector('a[href="file:///report.pdf"]');
+    expect(link).not.toBeNull();
+    expect(container.textContent).toContain("report.pdf");
+  });
+
+  it("degrades a data-less image block to a labelled placeholder", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.generic}
+          result={makeCompletion({
+            output: [{ kind: "image", mime_type: "image/png" }],
+          })}
+        />
+      </Wrap>,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toContain("image (image/png)");
+  });
+
+  it("renders a successful completion body when the card is expanded", () => {
+    // Criterion 3: the success-path body wiring (result.text) renders once
+    // the user opens the card, not just the error path.
+    const { container, getByRole } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeCompletion({ text: "hello world\n" })}
+        />
+      </Wrap>,
+    );
+    expect(container.textContent).not.toContain("hello world");
+    fireEvent.click(getByRole("button"));
+    expect(container.textContent).toContain("hello world");
+  });
 });

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -688,6 +688,57 @@ describe("ToolCards failed-card folding (#1467)", () => {
     expect(container.textContent).toContain("image (image/png)");
   });
 
+  it("refuses a javascript: resource link and shows a placeholder", () => {
+    // #1818 review: agent-controlled uris must not reach href; a
+    // javascript: scheme degrades to a non-clickable placeholder.
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.generic}
+          result={makeCompletion({
+            output: [
+              {
+                kind: "resource_link",
+                uri: "javascript:alert(1)",
+                name: "evil.html",
+              },
+            ],
+          })}
+        />
+      </Wrap>,
+    );
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("evil.html");
+  });
+
+  it("offers a blob resource as a download from inline data", () => {
+    // #1818 review: a blob resource keeps its bytes, so it downloads even
+    // without a fetchable uri.
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.generic}
+          result={makeCompletion({
+            output: [
+              {
+                kind: "resource",
+                uri: "file:///out.bin",
+                mime_type: "application/octet-stream",
+                data: "QkxPQg==",
+              },
+            ],
+          })}
+        />
+      </Wrap>,
+    );
+    const link = container.querySelector("a[download]");
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe(
+      "data:application/octet-stream;base64,QkxPQg==",
+    );
+    expect(link!.getAttribute("download")).toBe("out.bin");
+  });
+
   it("renders a successful completion body when the card is expanded", () => {
     // Criterion 3: the success-path body wiring (result.text) renders once
     // the user opens the card, not just the error path.

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -152,16 +152,21 @@ function dataUri(mimeType: string, data: string): string {
   return `data:${mimeType};base64,${data}`;
 }
 
-/** Schemes safe to render in an `href` / `img src`. Tool output uris are
- *  agent-controlled, so a `javascript:` uri must never reach the DOM where
- *  a click could execute it. Returns the uri when its scheme is allowlisted
- *  (resolved against the current origin so relative paths keep working) and
- *  null otherwise. See #1818 review. */
-const SAFE_URI_SCHEMES = new Set(["http:", "https:", "file:", "mailto:"]);
-function safeUri(uri: string): string | null {
+// Tool output uris are agent-controlled, so a `javascript:` uri must never
+// reach the DOM where a click could execute it. The allowlist is split by
+// sink: clickable links accept the broader set (a `mailto:` link is valid,
+// a `mailto:` image is not), while media `src` values accept only schemes a
+// browser can actually load over the dashboard's http origin. See #1818
+// review.
+const SAFE_LINK_SCHEMES = new Set(["http:", "https:", "file:", "mailto:"]);
+const SAFE_MEDIA_SCHEMES = new Set(["http:", "https:"]);
+
+/** Return `uri` unchanged when its scheme is in `schemes` (resolved against
+ *  the current origin so relative paths keep working), else null. */
+function safeUri(uri: string, schemes: ReadonlySet<string>): string | null {
   try {
     const parsed = new URL(uri, window.location.href);
-    return SAFE_URI_SCHEMES.has(parsed.protocol) ? uri : null;
+    return schemes.has(parsed.protocol) ? uri : null;
   } catch {
     return null;
   }
@@ -194,7 +199,7 @@ function ToolOutputBlockView({ block }: { block: ToolOutputBlock }) {
       const src = block.data
         ? dataUri(block.mime_type, block.data)
         : block.uri
-          ? safeUri(block.uri)
+          ? safeUri(block.uri, SAFE_MEDIA_SCHEMES)
           : null;
       if (!src) {
         return (
@@ -230,7 +235,7 @@ function ToolOutputBlockView({ block }: { block: ToolOutputBlock }) {
       );
     }
     case "resource_link": {
-      const href = safeUri(block.uri);
+      const href = safeUri(block.uri, SAFE_LINK_SCHEMES);
       if (!href) {
         return (
           <MediaPlaceholder
@@ -274,7 +279,7 @@ function ToolOutputBlockView({ block }: { block: ToolOutputBlock }) {
           </a>
         );
       }
-      const href = safeUri(block.uri);
+      const href = safeUri(block.uri, SAFE_LINK_SCHEMES);
       if (!href) {
         return (
           <MediaPlaceholder

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -24,10 +24,14 @@ import {
   ChevronDown,
   Clock,
   Copy as CopyIcon,
+  FileDown,
   FileText,
   Globe,
+  Image as ImageIcon,
   Layers,
+  Link as LinkIcon,
   ListChecks,
+  Music,
   Pencil,
   Plug,
   Search,
@@ -51,7 +55,11 @@ import {
   todoItemsFromArgs,
 } from "../../lib/acpArgs";
 import { useAcpPrefs } from "../../lib/acpPrefs";
-import type { ActivityRow, ToolCall } from "../../lib/acpTypes";
+import type {
+  ActivityRow,
+  ToolCall,
+  ToolOutputBlock,
+} from "../../lib/acpTypes";
 import { diffPair } from "../../lib/diffPair";
 import { StringDiff } from "../diff/StringDiff";
 import { ToolErrorBody } from "./ToolErrorBody";
@@ -105,10 +113,140 @@ interface ToolCardProps extends Props {
 export function ToolCard({ tool, result, nested }: ToolCardProps) {
   const profile = useAgentProfile();
   const card = renderToolCard(tool, result, profile);
+  // Structured media/resources the agent shipped at completion render
+  // below the per-kind card, regardless of tool kind. See #1818.
+  const media = result?.output?.length ? (
+    <ToolOutputMedia blocks={result.output} />
+  ) : null;
+  const content = media ? (
+    <>
+      {card}
+      {media}
+    </>
+  ) : (
+    card
+  );
   if (!nested && hasSubagentParent(tool)) {
-    return <SubagentChildWrap>{card}</SubagentChildWrap>;
+    return <SubagentChildWrap>{content}</SubagentChildWrap>;
   }
-  return card;
+  return content;
+}
+
+/** Render a tool call's structured completion payload (#1818). Images and
+ *  audio render inline (preferring an embedded base64 payload, falling back
+ *  to a `uri`); resource links and binary resources become download links;
+ *  text and text-resources render as plain blocks. A media block with no
+ *  inline data and no uri degrades to a labelled placeholder so the output
+ *  is never silently dropped. */
+function ToolOutputMedia({ blocks }: { blocks: ToolOutputBlock[] }) {
+  return (
+    <div className="my-1 space-y-2 overflow-hidden rounded-md border border-surface-700 bg-surface-800/50 p-3 text-sm">
+      {blocks.map((block, i) => (
+        <ToolOutputBlockView key={i} block={block} />
+      ))}
+    </div>
+  );
+}
+
+function dataUri(mimeType: string, data: string): string {
+  return `data:${mimeType};base64,${data}`;
+}
+
+function MediaPlaceholder({
+  icon,
+  label,
+}: {
+  icon: ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-text-dim italic">
+      <span className="text-text-dim">{icon}</span>
+      {label}
+    </div>
+  );
+}
+
+function ToolOutputBlockView({ block }: { block: ToolOutputBlock }) {
+  switch (block.kind) {
+    case "text":
+      return (
+        <pre className="whitespace-pre-wrap break-words font-mono text-xs text-text-secondary">
+          {block.text}
+        </pre>
+      );
+    case "image": {
+      const src = block.data
+        ? dataUri(block.mime_type, block.data)
+        : (block.uri ?? null);
+      if (!src) {
+        return (
+          <MediaPlaceholder
+            icon={<ImageIcon className="h-3.5 w-3.5" />}
+            label={`image (${block.mime_type})`}
+          />
+        );
+      }
+      return (
+        <img
+          src={src}
+          alt={`tool output image (${block.mime_type})`}
+          className="max-h-80 max-w-full rounded border border-surface-700 object-contain"
+        />
+      );
+    }
+    case "audio": {
+      if (!block.data) {
+        return (
+          <MediaPlaceholder
+            icon={<Music className="h-3.5 w-3.5" />}
+            label={`audio (${block.mime_type})`}
+          />
+        );
+      }
+      return (
+        <audio
+          controls
+          src={dataUri(block.mime_type, block.data)}
+          className="w-full"
+        />
+      );
+    }
+    case "resource_link":
+      return (
+        <a
+          href={block.uri}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center gap-2 text-xs text-accent-500 hover:underline"
+        >
+          <LinkIcon className="h-3.5 w-3.5" />
+          {block.name}
+        </a>
+      );
+    case "resource": {
+      if (block.text != null) {
+        return (
+          <pre className="whitespace-pre-wrap break-words font-mono text-xs text-text-secondary">
+            {block.text}
+          </pre>
+        );
+      }
+      return (
+        <a
+          href={block.uri}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center gap-2 text-xs text-accent-500 hover:underline"
+        >
+          <FileDown className="h-3.5 w-3.5" />
+          {block.uri}
+        </a>
+      );
+    }
+    default:
+      return null;
+  }
 }
 
 function renderToolCard(

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -152,6 +152,21 @@ function dataUri(mimeType: string, data: string): string {
   return `data:${mimeType};base64,${data}`;
 }
 
+/** Schemes safe to render in an `href` / `img src`. Tool output uris are
+ *  agent-controlled, so a `javascript:` uri must never reach the DOM where
+ *  a click could execute it. Returns the uri when its scheme is allowlisted
+ *  (resolved against the current origin so relative paths keep working) and
+ *  null otherwise. See #1818 review. */
+const SAFE_URI_SCHEMES = new Set(["http:", "https:", "file:", "mailto:"]);
+function safeUri(uri: string): string | null {
+  try {
+    const parsed = new URL(uri, window.location.href);
+    return SAFE_URI_SCHEMES.has(parsed.protocol) ? uri : null;
+  } catch {
+    return null;
+  }
+}
+
 function MediaPlaceholder({
   icon,
   label,
@@ -178,7 +193,9 @@ function ToolOutputBlockView({ block }: { block: ToolOutputBlock }) {
     case "image": {
       const src = block.data
         ? dataUri(block.mime_type, block.data)
-        : (block.uri ?? null);
+        : block.uri
+          ? safeUri(block.uri)
+          : null;
       if (!src) {
         return (
           <MediaPlaceholder
@@ -212,10 +229,19 @@ function ToolOutputBlockView({ block }: { block: ToolOutputBlock }) {
         />
       );
     }
-    case "resource_link":
+    case "resource_link": {
+      const href = safeUri(block.uri);
+      if (!href) {
+        return (
+          <MediaPlaceholder
+            icon={<LinkIcon className="h-3.5 w-3.5" />}
+            label={`${block.name} (${block.uri})`}
+          />
+        );
+      }
       return (
         <a
-          href={block.uri}
+          href={href}
           target="_blank"
           rel="noreferrer"
           className="flex items-center gap-2 text-xs text-accent-500 hover:underline"
@@ -224,6 +250,7 @@ function ToolOutputBlockView({ block }: { block: ToolOutputBlock }) {
           {block.name}
         </a>
       );
+    }
     case "resource": {
       if (block.text != null) {
         return (
@@ -232,9 +259,33 @@ function ToolOutputBlockView({ block }: { block: ToolOutputBlock }) {
           </pre>
         );
       }
+      // A binary (blob) resource ships its bytes inline; offer them as a
+      // download even when the uri isn't fetchable. See #1818.
+      if (block.data) {
+        const filename = block.uri.split("/").pop() || "resource";
+        return (
+          <a
+            href={dataUri(block.mime_type ?? "application/octet-stream", block.data)}
+            download={filename}
+            className="flex items-center gap-2 text-xs text-accent-500 hover:underline"
+          >
+            <FileDown className="h-3.5 w-3.5" />
+            {filename}
+          </a>
+        );
+      }
+      const href = safeUri(block.uri);
+      if (!href) {
+        return (
+          <MediaPlaceholder
+            icon={<FileDown className="h-3.5 w-3.5" />}
+            label={block.uri}
+          />
+        );
+      }
       return (
         <a
-          href={block.uri}
+          href={href}
           target="_blank"
           rel="noreferrer"
           className="flex items-center gap-2 text-xs text-accent-500 hover:underline"

--- a/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
+++ b/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
@@ -31,19 +31,32 @@ function approval(nonce: string): Approval {
 
 describe("classifyApprovalResolveResponse", () => {
   it("treats a 204 success as resolved", () => {
-    expect(classifyApprovalResolveResponse(true, 204, "")).toEqual({
+    expect(classifyApprovalResolveResponse(true, 204, "", "n-1")).toEqual({
       kind: "resolved",
     });
   });
 
-  it("treats a nonce-gone 404 as resolved", () => {
+  it("treats a 404 naming this nonce as resolved", () => {
     expect(
       classifyApprovalResolveResponse(
         false,
         404,
-        "no pending approval with that nonce",
+        "no pending approval with nonce n-1",
+        "n-1",
       ),
     ).toEqual({ kind: "resolved" });
+  });
+
+  it("treats a 404 naming a different nonce as an error", () => {
+    // Guards the #1821 contract: a generic / wrong-nonce 404 must not
+    // silently clear the clicked card.
+    const out = classifyApprovalResolveResponse(
+      false,
+      404,
+      "no pending approval with nonce other-99",
+      "n-1",
+    );
+    expect(out.kind).toBe("error");
   });
 
   it("treats a session-gone 404 as an error", () => {
@@ -51,13 +64,14 @@ describe("classifyApprovalResolveResponse", () => {
       false,
       404,
       "session has no running agent",
+      "n-1",
     );
     expect(out.kind).toBe("error");
     expect(out.kind === "error" && out.message).toContain("404");
   });
 
   it("treats a 500 as an error", () => {
-    const out = classifyApprovalResolveResponse(false, 500, "boom");
+    const out = classifyApprovalResolveResponse(false, 500, "boom", "n-1");
     expect(out.kind).toBe("error");
   });
 });
@@ -75,9 +89,11 @@ describe("reducer approval_resolved_locally", () => {
     expect(next.lastError).toBeNull();
   });
 
-  it("is a no-op for an unknown nonce", () => {
+  it("is a no-op for an unknown nonce and keeps the existing error", () => {
+    // A duplicate/stale action must not quietly clear an unrelated banner.
     const state = {
       ...emptyAcpState(),
+      lastError: "unrelated error",
       pendingApprovals: [approval("n-1")],
     };
     const next = reducer(state, {
@@ -85,5 +101,6 @@ describe("reducer approval_resolved_locally", () => {
       nonce: "missing",
     });
     expect(next.pendingApprovals.map((a) => a.nonce)).toEqual(["n-1"]);
+    expect(next.lastError).toBe("unrelated error");
   });
 });

--- a/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
+++ b/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
@@ -1,0 +1,89 @@
+// #1821: an approval card must clear when the resolve POST succeeds (204)
+// or the daemon reports the nonce already gone (404), without waiting on
+// the ApprovalResolved broadcast (which the seq dedupe can swallow). A
+// session-gone 404 stays a real error. These exercise the two pure pieces
+// the resolveApproval flow is built from: the response classifier and the
+// reducer action that drops the card.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyApprovalResolveResponse,
+  reducer,
+  type Action,
+} from "../useAcpSession";
+import { emptyAcpState, type Approval } from "../../lib/acpTypes";
+
+function approval(nonce: string): Approval {
+  return {
+    nonce,
+    tool_call: {
+      id: `tc-${nonce}`,
+      name: "Bash",
+      kind: "execute",
+      args_preview: "ls",
+      started_at: new Date().toISOString(),
+    },
+    destructive: false,
+    requested_at: new Date().toISOString(),
+  };
+}
+
+describe("classifyApprovalResolveResponse", () => {
+  it("treats a 204 success as resolved", () => {
+    expect(classifyApprovalResolveResponse(true, 204, "")).toEqual({
+      kind: "resolved",
+    });
+  });
+
+  it("treats a nonce-gone 404 as resolved", () => {
+    expect(
+      classifyApprovalResolveResponse(
+        false,
+        404,
+        "no pending approval with that nonce",
+      ),
+    ).toEqual({ kind: "resolved" });
+  });
+
+  it("treats a session-gone 404 as an error", () => {
+    const out = classifyApprovalResolveResponse(
+      false,
+      404,
+      "session has no running agent",
+    );
+    expect(out.kind).toBe("error");
+    expect(out.kind === "error" && out.message).toContain("404");
+  });
+
+  it("treats a 500 as an error", () => {
+    const out = classifyApprovalResolveResponse(false, 500, "boom");
+    expect(out.kind).toBe("error");
+  });
+});
+
+describe("reducer approval_resolved_locally", () => {
+  it("removes the matching card and clears any error", () => {
+    const state = {
+      ...emptyAcpState(),
+      lastError: "stale error",
+      pendingApprovals: [approval("n-1"), approval("n-2")],
+    };
+    const action: Action = { kind: "approval_resolved_locally", nonce: "n-1" };
+    const next = reducer(state, action);
+    expect(next.pendingApprovals.map((a) => a.nonce)).toEqual(["n-2"]);
+    expect(next.lastError).toBeNull();
+  });
+
+  it("is a no-op for an unknown nonce", () => {
+    const state = {
+      ...emptyAcpState(),
+      pendingApprovals: [approval("n-1")],
+    };
+    const next = reducer(state, {
+      kind: "approval_resolved_locally",
+      nonce: "missing",
+    });
+    expect(next.pendingApprovals.map((a) => a.nonce)).toEqual(["n-1"]);
+  });
+});

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -54,6 +54,7 @@ export type Action =
   | { kind: "prompt_send_rejected" }
   | { kind: "error"; message: string }
   | { kind: "clear_error" }
+  | { kind: "approval_resolved_locally"; nonce: string }
   | { kind: "lagged_resolved" }
   | { kind: "reset" }
   | { kind: "hydrate"; state: AcpState }
@@ -384,7 +385,32 @@ export function combineQueuedPrompts(
     .join("\n\n");
 }
 
-function reducer(state: AcpState, action: Action): AcpState {
+/** Outcome of an approval-resolve POST: the card should clear, or an
+ *  error banner should show. Pure so it can be unit-tested without the
+ *  full hook. See #1821. */
+export type ApprovalResolveOutcome =
+  | { kind: "resolved" }
+  | { kind: "error"; message: string };
+
+/** Classify an approval-resolve response. A 204 (ok) or a 404 whose body
+ *  names the missing nonce both mean "this card is done" and clear it; any
+ *  other failure (including a session-gone 404) surfaces an error. */
+export function classifyApprovalResolveResponse(
+  ok: boolean,
+  status: number,
+  detail: string,
+): ApprovalResolveOutcome {
+  if (ok) return { kind: "resolved" };
+  if (status === 404 && /no pending approval/i.test(detail)) {
+    return { kind: "resolved" };
+  }
+  return {
+    kind: "error",
+    message: `Could not resolve approval (${status}). ${detail}`.trim(),
+  };
+}
+
+export function reducer(state: AcpState, action: Action): AcpState {
   if (action.kind === "frame") {
     return applyEvent(state, action.frame);
   }
@@ -402,6 +428,19 @@ function reducer(state: AcpState, action: Action): AcpState {
   }
   if (action.kind === "clear_error") {
     return { ...state, lastError: null };
+  }
+  if (action.kind === "approval_resolved_locally") {
+    // Optimistically drop the approval card once the server has accepted
+    // the decision (204) or reports the nonce already gone (404), instead
+    // of waiting on the ApprovalResolved broadcast, which the seq dedupe
+    // can swallow and leave the card stuck. See #1821.
+    return {
+      ...state,
+      lastError: null,
+      pendingApprovals: state.pendingApprovals.filter(
+        (a) => a.nonce !== action.nonce,
+      ),
+    };
   }
   if (action.kind === "hydrate") {
     return action.state;
@@ -1044,15 +1083,23 @@ export function useAcpSession(
             body: JSON.stringify({ decision }),
           },
         );
-        if (!res.ok) {
-          const detail = await safeText(res);
-          dispatch({
-            kind: "error",
-            message:
-              `Could not resolve approval (${res.status}). ${detail}`.trim(),
-          });
+        const detail = res.ok ? "" : await safeText(res);
+        const outcome = classifyApprovalResolveResponse(
+          res.ok,
+          res.status,
+          detail,
+        );
+        if (outcome.kind === "resolved") {
+          // 204, or a 404 that names the missing nonce: the decision was
+          // accepted or already resolved server-side (a concurrent
+          // decision, a watchdog cancel, or the agent picking no matching
+          // option). Clear the card now rather than waiting on the
+          // ApprovalResolved broadcast, which the seq dedupe can drop and
+          // strand the card. A session-gone 404 (different body) is a real
+          // failure and surfaces an error. See #1821.
+          dispatch({ kind: "approval_resolved_locally", nonce });
         } else {
-          dispatch({ kind: "clear_error" });
+          dispatch({ kind: "error", message: outcome.message });
         }
       } catch (e) {
         dispatch({

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -393,15 +393,22 @@ export type ApprovalResolveOutcome =
   | { kind: "error"; message: string };
 
 /** Classify an approval-resolve response. A 204 (ok) or a 404 whose body
- *  names the missing nonce both mean "this card is done" and clear it; any
- *  other failure (including a session-gone 404) surfaces an error. */
+ *  names *this* nonce both mean "this card is done" and clear it; any other
+ *  failure (a session-gone 404, or a 404 that doesn't name the nonce)
+ *  surfaces an error. Matching the nonce keeps a generic 404 from silently
+ *  clearing the clicked card. See #1821. */
 export function classifyApprovalResolveResponse(
   ok: boolean,
   status: number,
   detail: string,
+  nonce: string,
 ): ApprovalResolveOutcome {
   if (ok) return { kind: "resolved" };
-  if (status === 404 && /no pending approval/i.test(detail)) {
+  if (
+    status === 404 &&
+    /no pending approval/i.test(detail) &&
+    detail.includes(nonce)
+  ) {
     return { kind: "resolved" };
   }
   return {
@@ -434,12 +441,16 @@ export function reducer(state: AcpState, action: Action): AcpState {
     // the decision (204) or reports the nonce already gone (404), instead
     // of waiting on the ApprovalResolved broadcast, which the seq dedupe
     // can swallow and leave the card stuck. See #1821.
+    const pendingApprovals = state.pendingApprovals.filter(
+      (a) => a.nonce !== action.nonce,
+    );
+    // Only clear the error banner when a card was actually removed, so a
+    // duplicate or stale action can't quietly hide an unrelated error.
+    const removed = pendingApprovals.length !== state.pendingApprovals.length;
     return {
       ...state,
-      lastError: null,
-      pendingApprovals: state.pendingApprovals.filter(
-        (a) => a.nonce !== action.nonce,
-      ),
+      lastError: removed ? null : state.lastError,
+      pendingApprovals,
     };
   }
   if (action.kind === "hydrate") {
@@ -1088,6 +1099,7 @@ export function useAcpSession(
           res.ok,
           res.status,
           detail,
+          nonce,
         );
         if (outcome.kind === "resolved") {
           // 204, or a 404 that names the missing nonce: the decision was

--- a/web/src/lib/acpTypes.test.ts
+++ b/web/src/lib/acpTypes.test.ts
@@ -182,6 +182,72 @@ describe("applyEvent / UserPromptSent", () => {
     expect(state.inFlightTool).toBeNull();
   });
 
+  it("carries structured media output from ToolCallCompleted.output", () => {
+    // #1818: a completion can ship images/audio/resources that the text
+    // concat drops. The reducer must attach the structured blocks to the
+    // tool_complete row so the card renders them.
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ToolCallStarted: {
+          tool_call: {
+            id: "tc-img",
+            name: "screenshot",
+            kind: "other",
+            args_preview: "{}",
+            started_at: new Date().toISOString(),
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ToolCallCompleted: {
+          tool_call_id: "tc-img",
+          is_error: false,
+          content: "",
+          output: [
+            { kind: "image", mime_type: "image/png", data: "BASE64" },
+            {
+              kind: "resource_link",
+              uri: "file:///report.pdf",
+              name: "report.pdf",
+            },
+          ],
+        },
+      },
+    });
+    const done = state.activity.find((a) => a.id === "done-tc-img");
+    expect(done).toBeDefined();
+    expect(done!.output).toHaveLength(2);
+    expect(done!.output![0]).toMatchObject({
+      kind: "image",
+      mime_type: "image/png",
+    });
+    // Text fallback still applies for the collapsed label.
+    expect(done!.text).toBe("completed");
+  });
+
+  it("omits output on a text-only completion", () => {
+    const state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ToolCallCompleted: {
+          tool_call_id: "tc-plain",
+          is_error: false,
+          content: "done",
+        },
+      },
+    });
+    const done = state.activity.find((a) => a.id === "done-tc-plain");
+    expect(done).toBeDefined();
+    expect(done!.output).toBeUndefined();
+  });
+
   it("falls back to streamed ToolCallContent when completion has empty content", () => {
     // Some agents stream stdout via interim ToolCallUpdate notifications
     // (status=in_progress with content) and emit a final completion

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -97,6 +97,9 @@ export type ToolOutputBlock =
       uri: string;
       mime_type?: string | null;
       text?: string | null;
+      /** Base64 bytes for a binary (blob) resource, offered as a download
+       *  when present. Absent for text resources or oversized blobs. */
+      data?: string | null;
     };
 
 export interface RateLimitInfo {

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -82,6 +82,23 @@ export interface DiffPreview {
   created_at: string;
 }
 
+/** One renderable block of a tool call's completion payload, bridged from
+ *  an ACP `ToolCallContent` block (mirrors the Rust `ToolOutputBlock`).
+ *  Carries the structured media shape so the card renders images / audio /
+ *  resources that arrive only at completion instead of collapsing them to
+ *  the status word. See #1818. */
+export type ToolOutputBlock =
+  | { kind: "text"; text: string }
+  | { kind: "image"; mime_type: string; data?: string | null; uri?: string | null }
+  | { kind: "audio"; mime_type: string; data?: string | null }
+  | { kind: "resource_link"; uri: string; name: string; mime_type?: string | null }
+  | {
+      kind: "resource";
+      uri: string;
+      mime_type?: string | null;
+      text?: string | null;
+    };
+
 export interface RateLimitInfo {
   status: string;
   resets_at: string;
@@ -221,6 +238,10 @@ export type AcpEvent =
          *  ACP `ToolCallUpdate.fields.content`. Empty when the agent
          *  emitted no content blocks on completion. */
         content: string;
+        /** Structured completion payload (images / audio / resources +
+         *  text) bridged from the ACP content blocks. Empty/absent for
+         *  text-only completions, which render from `content`. See #1818. */
+        output?: ToolOutputBlock[];
         /** Server-side ISO-8601 wall clock at which the completion
          *  was minted. Used to stamp the activity row's `at` so the
          *  duration label survives page reload; without it, the
@@ -660,6 +681,11 @@ export interface ActivityRow {
    *  Set from the optimistic local preview on send, or from the
    *  server `UserPromptSent` refs on replay. See #1000 / #965. */
   attachments?: AcpAttachment[];
+  /** Structured completion payload on `tool_complete` / `tool_error`
+   *  rows: media/resource blocks the card renders richly when the agent
+   *  ships them only at completion. Absent for text-only completions
+   *  (those render from `text`). See #1818. */
+  output?: ToolOutputBlock[];
   at: string; // ISO-8601
 }
 
@@ -915,7 +941,7 @@ export function applyEvent(
     return next;
   }
   if ("ToolCallCompleted" in event) {
-    const { tool_call_id, is_error, content, completed_at } =
+    const { tool_call_id, is_error, content, output, completed_at } =
       event.ToolCallCompleted;
     // #1713: a completion with no preceding start frame would render no
     // card (the render layer only attaches results to an existing
@@ -959,6 +985,7 @@ export function applyEvent(
       kind: is_error ? "tool_error" : "tool_complete",
       text,
       toolCallId: tool_call_id,
+      output: output && output.length > 0 ? output : undefined,
       at: completed_at ?? new Date().toISOString(),
     });
     return next;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1323,6 +1323,7 @@
       "specs": [
         "tests/live/acp-config-pickers.spec.ts",
         "tests/live/acp-config-pickers-ui.spec.ts",
+        "tests/live/acp-session-model.spec.ts",
         "src/components/acp/SessionConfigControls.test.tsx",
         "src/hooks/useAcpSession.configOption.test.ts"
       ],

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1277,6 +1277,17 @@
       ]
     },
     {
+      "id": "acp.approval-resolve-clear",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/hooks/__tests__/useAcpResolveApproval.test.ts"
+      ],
+      "components": [
+        "web/src/hooks/useAcpSession.ts"
+      ]
+    },
+    {
       "id": "acp.force-end-turn-gate",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1368,6 +1368,19 @@
       ]
     },
     {
+      "id": "acp.tool-output-media",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/lib/acpTypes.test.ts",
+        "src/components/acp/ToolCards.render.test.tsx"
+      ],
+      "components": [
+        "web/src/components/acp/ToolCards.tsx",
+        "web/src/lib/acpTypes.ts"
+      ]
+    },
+    {
       "id": "acp.rate-limit-recovery",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -241,6 +241,22 @@ const OPENCODE_MODE_CHOICES = [
   { value: "plan", name: "Plan" },
 ];
 const opencodeModeBySession = new Map();
+
+// Unstable `session_model` channel (ACP unstable_session_model, #1820).
+// Agents like Claude can advertise their model selector via the
+// SessionModelState field on the session/new (and session/load) response
+// instead of a generic config_option. Tests opt in with
+// FAKE_ACP_EMIT_SESSION_MODEL=1 (usually alongside
+// FAKE_ACP_EMIT_CONFIG_OPTIONS=0 so the unstable channel is the only
+// model source) and drive a switch via the same cockpit/config-option
+// endpoint using the reserved synthetic id, which aoe routes to
+// session/set_model.
+const SESSION_MODEL_CHOICES = [
+  { modelId: "fake-sonnet", name: "Fake Sonnet" },
+  { modelId: "fake-opus", name: "Fake Opus" },
+];
+const sessionModelBySession = new Map();
+
 function makeOpencodeModeOption(currentValue) {
   return {
     id: "mode",
@@ -478,7 +494,44 @@ async function handleRequest(msg) {
           makeOpencodeModeOption(current),
         ];
       }
+      if (process.env.FAKE_ACP_EMIT_SESSION_MODEL === "1") {
+        const current =
+          sessionModelBySession.get(sessionId) ??
+          SESSION_MODEL_CHOICES[0].modelId;
+        sessionModelBySession.set(sessionId, current);
+        // ACP SessionModelState (camelCase wire shape per
+        // agent-client-protocol-schema unstable_session_model).
+        result.models = {
+          currentModelId: current,
+          availableModels: SESSION_MODEL_CHOICES.map((m) => ({
+            modelId: m.modelId,
+            name: m.name,
+          })),
+        };
+      }
       sendResult(id, result);
+      return;
+    }
+
+    case "session/setModel":
+    case "session/set_model": {
+      // Unstable model-switch channel (#1820). ACP wire method is
+      // `session/set_model` (snake_case); accept both spellings. The
+      // real adapter only acks with no state echo, so aoe synthesizes
+      // the follow-up ConfigOptionsUpdated itself. Tests opt into a
+      // rejection with FAKE_ACP_REJECT_SET_MODEL.
+      const sessionId = params?.sessionId;
+      const modelId = params?.modelId;
+      if (process.env.FAKE_ACP_REJECT_SET_MODEL) {
+        sendError(id, -32000, process.env.FAKE_ACP_REJECT_SET_MODEL);
+        return;
+      }
+      if (!SESSION_MODEL_CHOICES.some((m) => m.modelId === modelId)) {
+        sendError(id, -32000, `model not found: ${modelId}`);
+        return;
+      }
+      if (sessionId) sessionModelBySession.set(sessionId, modelId);
+      sendResult(id, {});
       return;
     }
 

--- a/web/tests/live/acp-session-model.spec.ts
+++ b/web/tests/live/acp-session-model.spec.ts
@@ -1,0 +1,204 @@
+// Structured view model picker driven by the ACP unstable_session_model
+// channel (#1820).
+//
+// When an agent advertises its model selector via SessionModelState on
+// the session/new response (instead of a generic config_option), aoe
+// normalizes it into a synthetic model config option (reserved id
+// `__aoe_acp_session_model__`) so the existing model dropdown renders
+// unchanged. The acp/config-option endpoint with that id routes to
+// ACP `session/set_model`, and aoe synthesizes the confirming snapshot
+// since the adapter only acks. The fake agent emits the unstable
+// channel under FAKE_ACP_EMIT_SESSION_MODEL=1 and suppresses the
+// config_option model with FAKE_ACP_EMIT_CONFIG_OPTIONS=0. Mirrors
+// acp-config-pickers.spec.ts.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+const SYNTHETIC_MODEL_ID = "__aoe_acp_session_model__";
+
+async function enableAndSpawn(baseUrl: string, sessionId: string) {
+  const enableRes = await fetch(
+    `${baseUrl}/api/sessions/${sessionId}/acp/enable`,
+    { method: "POST" },
+  );
+  expect(enableRes.ok).toBeTruthy();
+  const spawnRes = await fetch(
+    `${baseUrl}/api/sessions/${sessionId}/acp/spawn`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent: "claude" }),
+    },
+  );
+  expect([200, 202, 409]).toContain(spawnRes.status);
+}
+
+async function waitForReplay(
+  baseUrl: string,
+  sessionId: string,
+  predicate: (replayJson: string) => boolean,
+  maxAttempts = 30,
+): Promise<boolean> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const replay = await fetch(
+      `${baseUrl}/api/sessions/${sessionId}/acp/replay?since=0`,
+    ).then((r) => r.json());
+    const json = JSON.stringify(replay);
+    if (predicate(json)) return true;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+const unstableModelEnv = {
+  FAKE_ACP_EMIT_CONFIG_OPTIONS: "0",
+  FAKE_ACP_EMIT_SESSION_MODEL: "1",
+};
+
+base(
+  "unstable session_model surfaces as a synthetic model selector",
+  async ({}, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      acp: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "session-model-initial" }),
+      extraEnv: unstableModelEnv,
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndSpawn(serve.baseUrl, sessionId);
+
+      const saw = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) =>
+          json.includes("ConfigOptionsUpdated") &&
+          json.includes(SYNTHETIC_MODEL_ID) &&
+          json.includes("fake-sonnet") &&
+          json.includes("fake-opus"),
+      );
+      expect(saw).toBe(true);
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "selecting the unstable model routes through session/set_model",
+  async ({}, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      acp: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "session-model-set" }),
+      extraEnv: unstableModelEnv,
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndSpawn(serve.baseUrl, sessionId);
+
+      const sawInitial = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) =>
+          json.includes(SYNTHETIC_MODEL_ID) && json.includes("fake-sonnet"),
+      );
+      expect(sawInitial).toBe(true);
+
+      const setRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/acp/config-option`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            config_id: SYNTHETIC_MODEL_ID,
+            value: "fake-opus",
+          }),
+        },
+      );
+      expect(setRes.status).toBeGreaterThanOrEqual(200);
+      expect(setRes.status).toBeLessThan(300);
+
+      // The fake only acks set_model; aoe synthesizes the confirming
+      // snapshot from the cached state, so the synthetic selector's
+      // current_value must flip to the requested model.
+      const sawConfirm = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) =>
+          json.includes("ConfigOptionsUpdated") &&
+          new RegExp(
+            `"${SYNTHETIC_MODEL_ID}"[^}]*"current_value"\\s*:\\s*"fake-opus"`,
+          ).test(json),
+      );
+      expect(sawConfirm).toBe(true);
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "rejected set_model surfaces as ConfigOptionSwitchFailed",
+  async ({}, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      acp: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "session-model-reject" }),
+      extraEnv: {
+        ...unstableModelEnv,
+        FAKE_ACP_REJECT_SET_MODEL: "model unavailable (test)",
+      },
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndSpawn(serve.baseUrl, sessionId);
+
+      const sawInitial = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) => json.includes(SYNTHETIC_MODEL_ID),
+      );
+      expect(sawInitial).toBe(true);
+
+      const setRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/acp/config-option`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            config_id: SYNTHETIC_MODEL_ID,
+            value: "fake-opus",
+          }),
+        },
+      );
+      expect(setRes.status).toBeGreaterThanOrEqual(200);
+      expect(setRes.status).toBeLessThan(300);
+
+      const sawFailure = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) =>
+          json.includes("ConfigOptionSwitchFailed") &&
+          json.includes("model unavailable"),
+      );
+      expect(sawFailure).toBe(true);
+    } finally {
+      await serve.stop();
+    }
+  },
+);

--- a/web/tests/live/acp-session-model.spec.ts
+++ b/web/tests/live/acp-session-model.spec.ts
@@ -38,21 +38,44 @@ async function enableAndSpawn(baseUrl: string, sessionId: string) {
   expect([200, 202, 409]).toContain(spawnRes.status);
 }
 
+type Json = Record<string, unknown>;
+
 async function waitForReplay(
   baseUrl: string,
   sessionId: string,
-  predicate: (replayJson: string) => boolean,
+  predicate: (replay: Json) => boolean,
   maxAttempts = 30,
 ): Promise<boolean> {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const replay = await fetch(
+    const replay = (await fetch(
       `${baseUrl}/api/sessions/${sessionId}/acp/replay?since=0`,
-    ).then((r) => r.json());
-    const json = JSON.stringify(replay);
-    if (predicate(json)) return true;
+    ).then((r) => r.json())) as Json;
+    if (predicate(replay)) return true;
     await new Promise((r) => setTimeout(r, 200));
   }
   return false;
+}
+
+/** Externally-tagged structured view events of `kind` pulled out of the replay's
+ *  typed `frames`, so assertions inspect the specific event payload rather
+ *  than substring-matching one big JSON blob. */
+function frameEvents(replay: Json, kind: string): Json[] {
+  const frames = (replay.frames as Array<{ event?: Json }>) ?? [];
+  return frames
+    .map((f) => f.event?.[kind])
+    .filter((e): e is Json => e != null && typeof e === "object");
+}
+
+/** The synthetic model selector inside a `ConfigOptionsUpdated` payload. */
+function modelOption(event: Json): Json | undefined {
+  const options = (event.options as Json[]) ?? [];
+  return options.find((o) => o.id === SYNTHETIC_MODEL_ID);
+}
+
+function modelChoiceValues(event: Json): string[] {
+  const model = modelOption(event);
+  if (!model) return [];
+  return ((model.options as Json[]) ?? []).map((c) => String(c.value));
 }
 
 const unstableModelEnv = {
@@ -76,14 +99,11 @@ base(
       const sessionId: string = sessions[0]!.id;
       await enableAndSpawn(serve.baseUrl, sessionId);
 
-      const saw = await waitForReplay(
-        serve.baseUrl,
-        sessionId,
-        (json) =>
-          json.includes("ConfigOptionsUpdated") &&
-          json.includes(SYNTHETIC_MODEL_ID) &&
-          json.includes("fake-sonnet") &&
-          json.includes("fake-opus"),
+      const saw = await waitForReplay(serve.baseUrl, sessionId, (replay) =>
+        frameEvents(replay, "ConfigOptionsUpdated").some((e) => {
+          const values = modelChoiceValues(e);
+          return values.includes("fake-sonnet") && values.includes("fake-opus");
+        }),
       );
       expect(saw).toBe(true);
     } finally {
@@ -108,11 +128,10 @@ base(
       const sessionId: string = sessions[0]!.id;
       await enableAndSpawn(serve.baseUrl, sessionId);
 
-      const sawInitial = await waitForReplay(
-        serve.baseUrl,
-        sessionId,
-        (json) =>
-          json.includes(SYNTHETIC_MODEL_ID) && json.includes("fake-sonnet"),
+      const sawInitial = await waitForReplay(serve.baseUrl, sessionId, (replay) =>
+        frameEvents(replay, "ConfigOptionsUpdated").some((e) =>
+          modelChoiceValues(e).includes("fake-sonnet"),
+        ),
       );
       expect(sawInitial).toBe(true);
 
@@ -133,14 +152,10 @@ base(
       // The fake only acks set_model; aoe synthesizes the confirming
       // snapshot from the cached state, so the synthetic selector's
       // current_value must flip to the requested model.
-      const sawConfirm = await waitForReplay(
-        serve.baseUrl,
-        sessionId,
-        (json) =>
-          json.includes("ConfigOptionsUpdated") &&
-          new RegExp(
-            `"${SYNTHETIC_MODEL_ID}"[^}]*"current_value"\\s*:\\s*"fake-opus"`,
-          ).test(json),
+      const sawConfirm = await waitForReplay(serve.baseUrl, sessionId, (replay) =>
+        frameEvents(replay, "ConfigOptionsUpdated").some(
+          (e) => modelOption(e)?.current_value === "fake-opus",
+        ),
       );
       expect(sawConfirm).toBe(true);
     } finally {
@@ -168,10 +183,10 @@ base(
       const sessionId: string = sessions[0]!.id;
       await enableAndSpawn(serve.baseUrl, sessionId);
 
-      const sawInitial = await waitForReplay(
-        serve.baseUrl,
-        sessionId,
-        (json) => json.includes(SYNTHETIC_MODEL_ID),
+      const sawInitial = await waitForReplay(serve.baseUrl, sessionId, (replay) =>
+        frameEvents(replay, "ConfigOptionsUpdated").some(
+          (e) => modelOption(e) != null,
+        ),
       );
       expect(sawInitial).toBe(true);
 
@@ -189,12 +204,12 @@ base(
       expect(setRes.status).toBeGreaterThanOrEqual(200);
       expect(setRes.status).toBeLessThan(300);
 
-      const sawFailure = await waitForReplay(
-        serve.baseUrl,
-        sessionId,
-        (json) =>
-          json.includes("ConfigOptionSwitchFailed") &&
-          json.includes("model unavailable"),
+      const sawFailure = await waitForReplay(serve.baseUrl, sessionId, (replay) =>
+        frameEvents(replay, "ConfigOptionSwitchFailed").some(
+          (e) =>
+            e.config_id === SYNTHETIC_MODEL_ID &&
+            String(e.reason).includes("model unavailable"),
+        ),
       );
       expect(sawFailure).toBe(true);
     } finally {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Five `area:cockpit` follow-ups from #1713 / PR #1814, landed together. Base `main` (carries the merged `cockpit-main`).

- **#1820 — unstable `session_model` channel.** Agents that advertise their model selector through the ACP `unstable_session_model` capability (`SessionModelState`) had no model control in cockpit. Enable the crate feature and normalize both model channels at the `acp_client` boundary: a per-connection `ModelChannelCache` folds the raw `config_options` plus the unstable `SessionModelState` into a single synthetic config option (reserved id `__aoe_acp_session_model__`) so the existing dropdown renders unchanged; the set path routes that id to `session/set_model` and synthesizes the post-ack update since ACP sends no model-change notification. A real `config_option` model wins on collision.

- **#1819 — Gemini mode ids.** The `CurrentModeUpdate` classifier only knew the claude-agent-acp mode ids, so a Gemini session (`gemini --acp`, gemini-cli `ApprovalMode` ids) fell through to `Default`. Fold `auto_edit`/`autoEdit` onto `AcceptEdits` and `yolo` onto `BypassPermissions`.

- **#1827 — native TUI mode label.** The TUI reducer let the legacy `ModeChanged` enum overwrite the real adapter mode id that `CurrentModeChanged` had just set, so an OpenCode `build`/custom agent showed as `Default` in the title bar. Only fall back to the enum label when no raw id was seen. (The web picker already reads the raw id; this completes the native-TUI half of #1764 / #1912.)

- **#1818 — structured completion payloads.** Completions that ship structured content (images, audio, resource links, embedded resources) instead of streamed text collapsed to the status word. Bridge the full ACP `ToolCallContent` array on the completion frame into a `ToolOutputBlock` list on `Event::ToolCallCompleted`; the web card renders it richly (inline image/audio, download links, text), with a labelled placeholder when a media block has neither data nor uri, and the native TUI shows a textual placeholder. Inline media over 4 MiB of base64 is dropped (placeholder kept) to bound the replay stream.

- **#1821 — stuck approval card.** The card was removed only by the `ApprovalResolved` broadcast, which the WS seq dedupe can swallow, leaving it stuck after the decision went through; resolving an already-swept nonce surfaced a 404 banner. Clear the card optimistically on `204`, and treat a `404` that names the missing nonce as already-resolved (clear quietly) while keeping a real error for a session-gone `404`. Applied on both the web hook and the native TUI (new `HttpError::ApprovalGone`).

## PR Type

- [x] New Feature
- [x] Bug Fix
- [x] Documentation

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated tests and updated `web/tests/coverage-matrix.json`

New/updated: live `cockpit-session-model.spec.ts` (#1820); Vitest `cockpitTypes.test.ts` + `ToolCards.render.test.tsx` for media output (#1818); Vitest `useCockpitResolveApproval.test.ts` for the resolve classifier + reducer action (#1821). Matrix entries `cockpit.tool-output-media` and `cockpit.approval-resolve-clear` added; `cockpit.config-pickers` already lists the model spec.

**TUI / CLI (e2e test)**
- [x] Added or updated tests

Rust unit coverage: model-channel normalization (#1820), the Gemini classifier + regression on existing ids (#1819), the TUI mode-clobber regression + `is_mode_advertised` guard (#1827), `extract_tool_output_blocks` + TUI placeholder (#1818), and `classify_error`'s nonce-vs-session 404 split + `resolve_approval_locally` (#1821).

How tested: `cargo fmt`, `cargo clippy --features serve`, `cargo test --features serve --lib` (3549 pass), `web` Vitest (1717 pass), `cargo build --features serve` then live `cockpit-session-model.spec.ts` (3 pass).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)

Closes #1820
Closes #1818
Closes #1819
Closes #1821
Closes #1827

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
High-level summary

- Model selector unification: Cockpit now surfaces adapters’ unstable session-model channel alongside normal config options by synthesizing a reserved selector id (__aoe_acp_session_model__), folding session model state into the config-options pipeline, routing sets for that id to session/set_model, and synthesizing the post-ack update. Real config options take precedence on collision.
- Structured tool outputs preserved: Tool completions can carry structured ToolOutputBlock arrays (text, image, audio, resource/resource_link). These are preserved on ToolCallCompleted events, rendered inline or as downloads/links in the web UI, and shown as labeled placeholders in the native TUI. Inline base64 media >4 MiB is dropped (placeholder retained) to limit replay size.
- Robust approval handling and TUI ergonomics: Approval resolve requests clear optimistically on success (204). A 404 whose body explicitly names the target nonce and indicates “no pending approval” is treated as already-resolved and cleared quietly; other 404s (session gone) still surface errors. The native TUI applies optimistic local resolution and shows a non-error toast for already-resolved cases.
- Mode handling improvements: Gemini mode identifiers (auto_edit/autoEdit → AcceptEdits; yolo → BypassPermissions) are recognized and normalized. Native TUI no longer overwrites raw adapter mode ids with a legacy enum, falling back to the enum only when the raw id is absent.
- Tests & docs: New/updated tests across Rust unit tests, Playwright, and Vitest; docs updated for session-model normalization, structured completion payloads, Gemini mode mapping, and approval behavior.

Technical details (concise)

- Types & events:
  - Added ToolOutputBlock enum and Event::ToolCallCompleted.output: Vec<ToolOutputBlock> (serde-defaulted, skipped when empty).
  - Web types updated: exported ToolOutputBlock; CockpitEvent/ActivityRow may carry output[] for tool_complete/tool_error rows.
- Model channel plumbing:
  - Introduced ModelChannelCache and ACP_SESSION_MODEL_CONFIG_ID synthetic config option.
  - dispatch_set_config_option routes that synthetic id to session/set_model; fold_session_options and renormalize_model_events preserve/round-trip model selectors across session/load/config updates.
- HTTP/error handling:
  - Added HttpError::ApprovalGone and classify_resolve_error that recognizes nonce-specific 404 bodies; classify_error centralizes other status mappings.
  - Web hook classifyApprovalResolveResponse mirrors server logic; resolveApproval dispatches approval_resolved_locally for resolved outcomes.
- TUI changes:
  - Added resolve_approval_locally on CockpitTranscript and summarize_output_blocks to show structured outputs as textual placeholders; reducer now applies optimistic approval clears and avoids clobbering raw CurrentModeChanged ids.
- Web rendering:
  - ToolCards render ToolOutputBlock kinds with safe-scheme allowlists, data: URI helpers, inline media rendering (when present), download links for inline binaries, and placeholders when data/URIs are missing or unsafe.
- Tests & fakes:
  - Fake ACP agent supports optional unstable session_model emission and both session/setModel and session/set_model requests.
  - Playwright and Vitest tests cover session-model UI flow, structured tool outputs, approval-resolution edge cases, and Gemini mode classification.

Benefits

- Users see adapter-provided session models in the model selector in a stable, round-trippable way.
- Rich tool outputs (images, audio, resources) are preserved for replay and web UX instead of collapsing to plain text.
- Approval flows are resilient to missed broadcasts or already-consumed nonces and feel more responsive in the TUI via optimistic updates.
- Gemini adapters’ permissive/edit modes are detected consistently and native UI avoids losing adapter-provided mode ids.

Potential follow-ups / risks

- UX clarity: The synthetic model selector id could confuse users if a later real config option collides; consider in-UI hints or different UX affordances.
- Replay tradeoffs: Dropping inline media >4 MiB bounds storage but may discard useful data; consider on-demand fetch or streaming alternatives.
- Fragile error detection: Detecting already-resolved approvals relies on textual 404 bodies; a standardized structured error payload would be more robust.
- Integration surface: Monitor for adapters or integrations that expect legacy ModeChanged coercion or only advertise models via the unstable channel; documentation helps but coordination may be required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->