### PR TITLE
feat(telemetry): add mutually-exclusive session substrate census

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -19,6 +19,14 @@ closed, versioned schema (see `src/telemetry/events.rs`):
   stream of actions:
   - how many sessions exist and how many are running / idle / errored,
   - how many use a sandbox, the cockpit, or yolo mode,
+  - a per-substrate census: each session is classified into exactly one of
+    `local` / `worktree` / `workspace` / `sandbox` / `scratch` (a closed
+    five-way vocabulary), so the counts partition the session total and answer
+    "of N sessions, how many are worktree vs local vs sandbox vs ...". All five
+    keys are always present. This is orthogonal to the sandbox count above: a
+    sandboxed worktree counts as `worktree` here yet still in the sandbox count,
+    so the `sandbox` bucket means "sandboxed and not also one of the others",
+    not "all sandboxed sessions",
   - a per-agent and per-model-family count (e.g. `{claude: 3, codex: 1}`),
   - how many sessions were created since the last snapshot, a trend counter so
     short-lived sessions that start and end between two snapshots are still
@@ -125,6 +133,7 @@ the install id and does all sending.
 
 **Schema contract.** The wire format is the flat, closed schema in
 `src/telemetry/events.rs`, mirrored by the gateway. New fields must be counts,
-booleans, or short identifier-like strings (and the two allowlisted bucket
-maps); the gateway drops free text, paths, branch-name-like strings, and any
-nested object, so anything richer than a count or flag will not survive ingest.
+booleans, or short identifier-like strings (and the allowlisted bucket maps:
+per-agent, per-model-family, and per-substrate); the gateway drops free text,
+paths, branch-name-like strings, and any nested object, so anything richer than
+a count or flag will not survive ingest.

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -10,7 +10,10 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 /// Payload schema version. Bump on any breaking change to the field set.
-pub const SCHEMA_VERSION: u32 = 1;
+///
+/// v2 (#1886): added `sessions_by_substrate`, a mutually-exclusive
+/// per-substrate census of live sessions.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -78,6 +81,21 @@ pub struct UsageSnapshot {
     pub sessions_by_agent: BTreeMap<String, u32>,
     /// Coarse model family bucket -> session count.
     pub sessions_by_model_bucket: BTreeMap<String, u32>,
+    /// Primary, mutually-exclusive substrate bucket -> session count. Every
+    /// session lands in exactly one of a fixed, closed vocabulary
+    /// (`local` / `worktree` / `workspace` / `sandbox` / `scratch`), so the
+    /// values partition `session_total` and always sum to it. All five keys
+    /// are always present (pre-seeded to 0), so a dashboard never has to treat
+    /// a missing key as zero. Keys are hardcoded, never derived from a path,
+    /// repo name, or image string.
+    ///
+    /// This is orthogonal to `session_sandboxed`, which may overlap: a
+    /// sandboxed worktree counts as `worktree` here (the substrate precedence
+    /// puts worktree above sandbox) yet still increments `session_sandboxed`.
+    /// So the `sandbox` bucket means "sandboxed and not also scratch /
+    /// workspace / worktree", NOT "all sandboxed sessions"; use
+    /// `session_sandboxed` for the latter.
+    pub sessions_by_substrate: BTreeMap<String, u32>,
     /// Install-level feature adoption: allowlisted feature name -> active.
     /// Keyed by the fixed registry in [`super::features`]; lets new gated
     /// features be tracked by registering the flag, not by extending the

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -112,6 +112,46 @@ fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()
 }
 
+/// The fixed, closed substrate vocabulary, in precedence order. A session is
+/// classified into exactly one of these by [`substrate_bucket`]; the snapshot
+/// pre-seeds all five so the census is always complete.
+const SUBSTRATES: [&str; 5] = ["scratch", "workspace", "worktree", "sandbox", "local"];
+
+/// Classify a session into its single primary substrate bucket.
+///
+/// Mutually exclusive by fixed precedence: `scratch` > `workspace` >
+/// `worktree` > `sandbox` > `local`. `scratch` is invariant-exclusive with
+/// worktree/workspace, so a session carrying both is an upstream state bug; we
+/// log it at `debug` and bucket by precedence rather than panic, because
+/// telemetry must never crash the tool. A sandbox can legitimately co-occur
+/// with a worktree, so it sits below worktree and the orthogonal
+/// `session_sandboxed` count carries the "has sandbox at all" signal.
+fn substrate_bucket(inst: &Instance) -> &'static str {
+    let has_worktree = inst.worktree_info.is_some();
+    let has_workspace = inst.workspace_info.is_some();
+    if inst.scratch {
+        if has_worktree || has_workspace {
+            tracing::debug!(
+                target: "telemetry",
+                has_worktree,
+                has_workspace,
+                "scratch session also carries worktree/workspace info; bucketing as scratch by precedence"
+            );
+        }
+        return "scratch";
+    }
+    if has_workspace {
+        return "workspace";
+    }
+    if has_worktree {
+        return "worktree";
+    }
+    if inst.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
+        return "sandbox";
+    }
+    "local"
+}
+
 /// Build a `process_start` event, or `None` when telemetry is not opted in
 /// (or `DO_NOT_TRACK` suppresses id generation).
 pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
@@ -151,6 +191,11 @@ pub fn build_usage_snapshot(
 
     let mut sessions_by_agent: BTreeMap<String, u32> = BTreeMap::new();
     let mut sessions_by_model_bucket: BTreeMap<String, u32> = BTreeMap::new();
+    // Pre-seed every substrate to 0 so the census is always complete: a
+    // dashboard never has to coalesce a missing key, and the values always
+    // sum to `session_total`.
+    let mut sessions_by_substrate: BTreeMap<String, u32> =
+        SUBSTRATES.iter().map(|s| (s.to_string(), 0)).collect();
     let (mut running, mut idle, mut error, mut cockpit, mut sandboxed, mut yolo) =
         (0u32, 0u32, 0u32, 0u32, 0u32, 0u32);
 
@@ -176,6 +221,12 @@ pub fn build_usage_snapshot(
         if inst.yolo_mode {
             yolo += 1;
         }
+
+        // Mutually-exclusive primary substrate; orthogonal to the sandbox count
+        // above (a sandboxed worktree buckets as `worktree` here).
+        *sessions_by_substrate
+            .entry(substrate_bucket(inst).to_string())
+            .or_insert(0) += 1;
 
         // Prefer the canonical detection name; fall back to the raw tool
         // string. Either way it is coerced to an allowlisted bucket.
@@ -216,6 +267,7 @@ pub fn build_usage_snapshot(
         session_yolo: yolo,
         sessions_by_agent,
         sessions_by_model_bucket,
+        sessions_by_substrate,
         features,
         web_seen,
         cockpit_seen,
@@ -468,6 +520,7 @@ mod tests {
             session_yolo: 0,
             sessions_by_agent: BTreeMap::new(),
             sessions_by_model_bucket: BTreeMap::new(),
+            sessions_by_substrate: BTreeMap::new(),
             features: BTreeMap::new(),
             web_seen: false,
             cockpit_seen: false,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -523,7 +523,7 @@ mod tests {
             session_yolo: 0,
             sessions_by_agent: BTreeMap::new(),
             sessions_by_model_bucket: BTreeMap::new(),
-            sessions_by_substrate: BTreeMap::new(),
+            sessions_by_substrate: SUBSTRATES.iter().map(|s| (s.to_string(), 0)).collect(),
             features: BTreeMap::new(),
             web_seen: false,
             cockpit_seen: false,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -223,10 +223,13 @@ pub fn build_usage_snapshot(
         }
 
         // Mutually-exclusive primary substrate; orthogonal to the sandbox count
-        // above (a sandboxed worktree buckets as `worktree` here).
+        // above (a sandboxed worktree buckets as `worktree` here). The map is
+        // pre-seeded with the closed vocabulary, so increment the existing key
+        // rather than inserting: any drift in `substrate_bucket` then fails
+        // loudly instead of silently broadening the payload.
         *sessions_by_substrate
-            .entry(substrate_bucket(inst).to_string())
-            .or_insert(0) += 1;
+            .get_mut(substrate_bucket(inst))
+            .expect("SUBSTRATES must contain every substrate bucket") += 1;
 
         // Prefer the canonical detection name; fall back to the raw tool
         // string. Either way it is coerced to an allowlisted bucket.

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -5,8 +5,11 @@
 //! `#[serial]`. Each test points the app dir at a fresh `TempDir`, so no real
 //! user state is touched.
 
-use agent_of_empires::session::{save_config, Config, Instance};
+use agent_of_empires::session::{
+    save_config, Config, Instance, SandboxInfo, WorkspaceInfo, WorktreeInfo,
+};
 use agent_of_empires::telemetry::{self, Surface};
+use chrono::Utc;
 use serial_test::serial;
 
 /// Redirect the app dir at a temp location and clear the telemetry-related env
@@ -122,6 +125,143 @@ fn snapshot_buckets_are_sanitized() {
             "features map missing allowlisted key `{key}`"
         );
     }
+}
+
+/// The fixed, closed substrate vocabulary (#1886). The snapshot must never
+/// emit a key outside this set.
+const SUBSTRATE_VOCAB: [&str; 5] = ["local", "worktree", "workspace", "sandbox", "scratch"];
+
+fn with_worktree(mut inst: Instance) -> Instance {
+    inst.worktree_info = Some(WorktreeInfo {
+        branch: "feature/x".to_string(),
+        main_repo_path: "/repo".to_string(),
+        managed_by_aoe: true,
+        created_at: Utc::now(),
+        base_branch: None,
+    });
+    inst
+}
+
+fn with_workspace(mut inst: Instance) -> Instance {
+    inst.workspace_info = Some(WorkspaceInfo {
+        branch: "feature/x".to_string(),
+        workspace_dir: "/ws".to_string(),
+        repos: Vec::new(),
+        created_at: Utc::now(),
+        cleanup_on_delete: true,
+    });
+    inst
+}
+
+fn with_sandbox(mut inst: Instance, enabled: bool) -> Instance {
+    inst.sandbox_info = Some(SandboxInfo {
+        enabled,
+        container_id: None,
+        image: "secret-internal-image:latest".to_string(),
+        container_name: "aoe_secret_container".to_string(),
+        extra_env: None,
+        custom_instruction: None,
+    });
+    inst
+}
+
+/// User story (#1886): a maintainer with one local, one worktree, and one
+/// sandboxed session sees one count in each of the matching substrate buckets.
+#[test]
+#[serial]
+fn substrate_census_counts_each_bucket() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let local = Instance::new("a", "/p");
+    let worktree = with_worktree(Instance::new("b", "/p"));
+    let sandbox = with_sandbox(Instance::new("c", "/p"), true);
+
+    let snapshot =
+        telemetry::build_usage_snapshot(Surface::Tui, &[local, worktree, sandbox], false, false, 0)
+            .expect("snapshot built when opted in");
+
+    assert_eq!(snapshot.sessions_by_substrate.get("local"), Some(&1));
+    assert_eq!(snapshot.sessions_by_substrate.get("worktree"), Some(&1));
+    assert_eq!(snapshot.sessions_by_substrate.get("sandbox"), Some(&1));
+    // Untouched buckets are still present (pre-seeded) and zero.
+    assert_eq!(snapshot.sessions_by_substrate.get("workspace"), Some(&0));
+    assert_eq!(snapshot.sessions_by_substrate.get("scratch"), Some(&0));
+}
+
+/// User story (#1886): a session that is both scratch and (somehow) carries
+/// worktree info is classified into exactly one bucket by the documented
+/// precedence (scratch wins), never double-counted. The substrate buckets
+/// always partition `session_total`, so they sum to it.
+#[test]
+#[serial]
+fn substrate_buckets_are_mutually_exclusive_and_sum_to_total() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    // Impossible-but-defensive combo: scratch AND worktree set. Precedence puts
+    // it in `scratch`, and it is counted exactly once.
+    let mut conflicted = with_worktree(Instance::new("a", "/p"));
+    conflicted.scratch = true;
+    // A sandboxed worktree buckets as `worktree` (sandbox sits below worktree),
+    // yet still increments the orthogonal `session_sandboxed` count.
+    let sandboxed_worktree = with_sandbox(with_worktree(Instance::new("b", "/p")), true);
+    let workspace = with_workspace(Instance::new("c", "/p"));
+    let local = Instance::new("d", "/p");
+
+    let instances = [conflicted, sandboxed_worktree, workspace, local];
+    let total = instances.len() as u32;
+    let snapshot = telemetry::build_usage_snapshot(Surface::Tui, &instances, false, false, 0)
+        .expect("snapshot built when opted in");
+
+    let sum: u32 = snapshot.sessions_by_substrate.values().sum();
+    assert_eq!(
+        sum, total,
+        "substrate buckets must partition session_total exactly once each"
+    );
+    assert_eq!(snapshot.session_total, total);
+    assert_eq!(snapshot.sessions_by_substrate.get("scratch"), Some(&1));
+    assert_eq!(snapshot.sessions_by_substrate.get("worktree"), Some(&1));
+    assert_eq!(snapshot.sessions_by_substrate.get("workspace"), Some(&1));
+    assert_eq!(snapshot.sessions_by_substrate.get("local"), Some(&1));
+    assert_eq!(snapshot.sessions_by_substrate.get("sandbox"), Some(&0));
+    // The substrate map is orthogonal to the sandbox count: the sandboxed
+    // worktree is bucketed as worktree but still tallied as sandboxed.
+    assert_eq!(snapshot.session_sandboxed, 1);
+}
+
+/// Privacy: the substrate map keys are only the allowlisted closed vocabulary,
+/// never a path, repo name, branch, or sandbox image string (#1886).
+#[test]
+#[serial]
+fn substrate_keys_are_only_allowlisted_vocab() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let instances = [
+        with_sandbox(
+            with_worktree(Instance::new("a", "/home/me/secret-project")),
+            true,
+        ),
+        with_workspace(Instance::new("b", "/home/me/secret-workspace")),
+    ];
+    let snapshot = telemetry::build_usage_snapshot(Surface::Serve, &instances, false, false, 0)
+        .expect("snapshot built when opted in");
+
+    for key in snapshot.sessions_by_substrate.keys() {
+        assert!(
+            SUBSTRATE_VOCAB.contains(&key.as_str()),
+            "substrate key `{key}` is outside the closed vocabulary"
+        );
+    }
+    // And the raw image/path strings must not leak into the serialized payload.
+    let serialized = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(!serialized.contains("secret-project"));
+    assert!(!serialized.contains("secret-workspace"));
+    assert!(!serialized.contains("secret-internal-image"));
 }
 
 /// User story (#1874): the create-trend counter carries a real value. When N


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The usage snapshot could not say how people actually run sessions. It tracked only the non-exclusive `session_sandboxed` / `session_cockpit` counts, so worktree, workspace, scratch, and plain-local sessions were invisible and there was no mutually-exclusive substrate breakdown.

This adds `sessions_by_substrate` to the snapshot: a closed five-way census (`local` / `worktree` / `workspace` / `sandbox` / `scratch`) that classifies each live session into exactly one primary substrate by a fixed precedence (`scratch > workspace > worktree > sandbox > local`), derived in the existing per-session loop in `build_usage_snapshot`. All five keys are pre-seeded to 0 so the partition is always complete and the buckets always sum to `session_total`; a dashboard never has to coalesce a missing key.

The map is orthogonal to `session_sandboxed`, which is kept on purpose: a sandboxed worktree buckets as `worktree` yet still increments `session_sandboxed`, so the `sandbox` bucket means "sandboxed and not also one of the others", not "all sandboxed sessions". Keep `session_sandboxed` for the latter signal.

`scratch` is invariant-exclusive with worktree/workspace, so a session carrying both is an upstream state bug; it is logged at `debug` and bucketed by precedence rather than asserted, since telemetry must never crash the tool. The bucket keys are hardcoded, never derived from a path, repo name, branch, or image string, so the closed-vocabulary allowlist holds with no new sanitizer. `SCHEMA_VERSION` is bumped to 2.

No changes are needed in the `aoe-telemetry` gateway: it forwards generic `string -> number` count maps unchanged (pydantic `extra="allow"` plus the generic sanitizer, and there is already a passthrough test for exactly this map shape), and there is no schema-version check to reject. The change lands entirely client-side.

Closes #1886

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] Opt in to telemetry (`aoe telemetry enable`) and point at a local sink: `AOE_TELEMETRY_ENDPOINT=http://127.0.0.1:8000 python scripts/telemetry_sink.py` in one terminal.
- [ ] Create a mix of sessions: one plain-local, one git worktree, one sandboxed (`--sandbox`), and one scratch.
- [ ] Launch the TUI (or `aoe serve`) and observe the emitted `usage_snapshot`; confirm `sessions_by_substrate` carries all five keys with one count in each of `local`, `worktree`, `sandbox`, `scratch` and `0` for `workspace`.
- [ ] Confirm the substrate counts sum to `session_total`, and the sandboxed-worktree case (if you make one) buckets as `worktree` while `session_sandboxed` still counts it.
- [ ] Confirm the payload contains no path, repo name, branch, or image string in the substrate keys (only the five-word vocabulary), and that `schema` is `2`.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

This is a pure telemetry-payload derivation. It is covered by three new integration tests in `tests/telemetry.rs` mapping to the issue's user stories: per-bucket census counts, mutual-exclusion + sum-to-total under a co-occurring-flag combo, and the privacy assertion that keys stay within the closed vocabulary and no raw image/path leaks.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. The four design forks (keep `session_sandboxed`, silent-vs-logged precedence, workspace as its own bucket, sparse-vs-pre-seeded map) were pressure-tested via a multi-model debate; I made the calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR adds a mutually-exclusive substrate census to telemetry snapshots to report where live sessions run.

- Added a new telemetry field `sessions_by_substrate: BTreeMap<String,u32>` with a closed five-key vocabulary: local, worktree, workspace, sandbox, scratch.
- Each live session is classified into exactly one bucket using fixed precedence (scratch > workspace > worktree > sandbox > local); all five keys are pre-seeded to 0 so the map is always complete and values sum to `session_total`.
- The existing `session_sandboxed` field is retained and remains orthogonal: sandboxed worktrees still count as `worktree` while also incrementing `session_sandboxed`.
- Sessions with inconsistent flags (e.g., scratch + worktree) are logged at debug and bucketed by precedence rather than asserted, avoiding telemetry-caused failures.
- Enforced closed vocabulary by incrementing pre-seeded keys via `get_mut(...).expect(...)` so any drift fails loudly in dev/tests instead of silently broadening the payload.
- Bumped telemetry schema version to reflect the wire-shape change.
- Added three integration tests covering per-bucket counts, precedence/sum-to-total behavior, and privacy (closed-vocabulary).
- Documentation updated to clarify substrate semantics and allowed wire-format types.

Files changed (high-level):
- docs/telemetry.md — docs clarified (+12/-3)
- src/telemetry/events.rs — schema field added and SCHEMA_VERSION bumped (+20/-1)
- src/telemetry/mod.rs — substrate classification and census construction (+56/-0)
- tests/telemetry.rs — three integration tests and test helpers (+150/-1)

Review fixes applied:
- Substrate increments now use `get_mut(...).expect(...)` against pre-seeded keys.
- Test snapshot fixtures are pre-seeded with the five zero-filled substrate keys to match the new wire shape.

Technical details

- Closed vocabulary: Keys are hardcoded and contain no user/environment strings (paths, repo names, branches, image identifiers) to preserve sanitization/privacy guarantees.
- Precedence and exclusivity: Each session increments exactly one substrate bucket by precedence; buckets are pre-seeded so the map shape is stable and sums to `session_total`.
- Robustness: Inconsistent instance states are debug-logged and resolved deterministically by precedence; no runtime panics in production telemetry emission.
- Schema migration: Client-side schema version bump; the gateway forwards generic string→number maps unchanged (no server changes required).

Benefits

- Improves visibility into how sessions run across execution substrates.
- Maintains privacy through a closed vocabulary.
- Ensures data integrity with pre-seeded keys and strict increment semantics.
- Minimal operational impact—client-only change compatible with existing gateway behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->