### PR TITLE
feat(telemetry): census of pinned/snoozed/archived sessions in usage_snapshot

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -19,6 +19,9 @@ closed, versioned schema (see `src/telemetry/events.rs`):
   stream of actions:
   - how many sessions exist and how many are running / idle / errored,
   - how many use a sandbox, the cockpit, or yolo mode,
+  - how many sessions are currently pinned, snoozed, or archived (a
+    point-in-time count of the session-organization states, not how often
+    those actions were taken),
   - a per-agent and per-model-family count (e.g. `{claude: 3, codex: 1}`),
   - how many sessions were created since the last snapshot, a trend counter so
     short-lived sessions that start and end between two snapshots are still

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -9,8 +9,10 @@ use std::collections::BTreeMap;
 
 use serde::Serialize;
 
-/// Payload schema version. Bump on any breaking change to the field set.
-pub const SCHEMA_VERSION: u32 = 1;
+/// Payload schema version. Bump whenever the wire payload shape changes
+/// (a new field, a removed field, a renamed field, or a type change); this is
+/// a closed, auditable schema, so the version identifies the exact shape.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -73,6 +75,16 @@ pub struct UsageSnapshot {
     pub session_cockpit: u32,
     pub session_sandboxed: u32,
     pub session_yolo: u32,
+
+    /// Sessions currently pinned, snoozed (future `snoozed_until`), or
+    /// archived at snapshot time. Point-in-time state prevalence, not action
+    /// counts; the three are mutually exclusive per the session triage
+    /// invariant, so they sum to at most `session_total`. Set through a shared
+    /// mutator layer, so this census covers both the web and TUI surfaces with
+    /// no per-surface wiring.
+    pub session_pinned: u32,
+    pub session_snoozed: u32,
+    pub session_archived: u32,
 
     /// Allowlisted agent bucket -> session count.
     pub sessions_by_agent: BTreeMap<String, u32>,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -183,14 +183,27 @@ fn aggregate_instances(instances: &[Instance]) -> InstanceMetrics {
         // exclusive per the triage invariant enforced in the session apply /
         // merge path (see `Instance::archive`/`snooze`/`pin` and the merge
         // reconciliation), so independent checks never double-count a
-        // well-formed session.
-        if inst.is_pinned() {
+        // well-formed session. The debug assert makes a future mutator or
+        // merge regression fail fast instead of silently skewing the census
+        // (sum of the three counts exceeding `session_total`).
+        let is_pinned = inst.is_pinned();
+        let is_snoozed = inst.is_snoozed();
+        let is_archived = inst.is_archived();
+        debug_assert!(
+            [is_pinned, is_snoozed, is_archived]
+                .into_iter()
+                .filter(|state| *state)
+                .count()
+                <= 1,
+            "session triage states must be mutually exclusive"
+        );
+        if is_pinned {
             pinned += 1;
         }
-        if inst.is_snoozed() {
+        if is_snoozed {
             snoozed += 1;
         }
-        if inst.is_archived() {
+        if is_archived {
             archived += 1;
         }
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -579,11 +579,13 @@ mod tests {
     // and carry no session id, name, path, or timestamp (issue #1892, story 3).
     #[test]
     fn triage_counts_are_plain_integers() {
-        fn assert_u32(_: u32) {}
-        let snap = sample_snapshot();
-        assert_u32(snap.session_pinned);
-        assert_u32(snap.session_snoozed);
-        assert_u32(snap.session_archived);
+        // Assert the wire format, not just the Rust type: a future serde
+        // attribute or wrapper that serialized these as strings or null would
+        // regress the telemetry contract while a `u32`-only check still passed.
+        let json = serde_json::to_value(sample_snapshot()).unwrap();
+        assert!(json["session_pinned"].is_u64());
+        assert!(json["session_snoozed"].is_u64());
+        assert!(json["session_archived"].is_u64());
     }
 
     // An opted-out install records nothing: `build_usage_snapshot` returns

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -131,6 +131,104 @@ pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
     })
 }
 
+/// Pure per-session aggregation, split out of [`build_usage_snapshot`] so the
+/// counting logic is unit-testable without the opt-in / install-id / config
+/// global state the snapshot builder pulls in.
+struct InstanceMetrics {
+    total: u32,
+    running: u32,
+    idle: u32,
+    error: u32,
+    cockpit: u32,
+    sandboxed: u32,
+    yolo: u32,
+    pinned: u32,
+    snoozed: u32,
+    archived: u32,
+    by_agent: BTreeMap<String, u32>,
+    by_model_bucket: BTreeMap<String, u32>,
+}
+
+fn aggregate_instances(instances: &[Instance]) -> InstanceMetrics {
+    let mut by_agent: BTreeMap<String, u32> = BTreeMap::new();
+    let mut by_model_bucket: BTreeMap<String, u32> = BTreeMap::new();
+    let (mut running, mut idle, mut error, mut cockpit, mut sandboxed, mut yolo) =
+        (0u32, 0u32, 0u32, 0u32, 0u32, 0u32);
+    let (mut pinned, mut snoozed, mut archived) = (0u32, 0u32, 0u32);
+
+    for inst in instances {
+        match inst.status {
+            crate::session::Status::Running => running += 1,
+            crate::session::Status::Idle => idle += 1,
+            crate::session::Status::Error => error += 1,
+            _ => {}
+        }
+        // Cockpit fields only exist in `serve` builds; treat them as absent
+        // otherwise so the aggregation stays surface-agnostic.
+        #[cfg(feature = "serve")]
+        let is_cockpit = inst.cockpit_mode;
+        #[cfg(not(feature = "serve"))]
+        let is_cockpit = false;
+        if is_cockpit {
+            cockpit += 1;
+        }
+        if inst.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
+            sandboxed += 1;
+        }
+        if inst.yolo_mode {
+            yolo += 1;
+        }
+
+        // Point-in-time session-triage census. The three states are mutually
+        // exclusive per the triage invariant enforced in the session apply /
+        // merge path (see `Instance::archive`/`snooze`/`pin` and the merge
+        // reconciliation), so independent checks never double-count a
+        // well-formed session.
+        if inst.is_pinned() {
+            pinned += 1;
+        }
+        if inst.is_snoozed() {
+            snoozed += 1;
+        }
+        if inst.is_archived() {
+            archived += 1;
+        }
+
+        // Prefer the canonical detection name; fall back to the raw tool
+        // string. Either way it is coerced to an allowlisted bucket.
+        let agent_src = if inst.detect_as.trim().is_empty() {
+            inst.tool.as_str()
+        } else {
+            inst.detect_as.as_str()
+        };
+        *by_agent
+            .entry(sanitize::agent_bucket(agent_src))
+            .or_insert(0) += 1;
+
+        #[cfg(feature = "serve")]
+        let model = inst.cockpit_model.as_deref();
+        #[cfg(not(feature = "serve"))]
+        let model: Option<&str> = None;
+        let bucket = sanitize::model_bucket(model);
+        *by_model_bucket.entry(bucket.to_string()).or_insert(0) += 1;
+    }
+
+    InstanceMetrics {
+        total: instances.len() as u32,
+        running,
+        idle,
+        error,
+        cockpit,
+        sandboxed,
+        yolo,
+        pinned,
+        snoozed,
+        archived,
+        by_agent,
+        by_model_bucket,
+    }
+}
+
 /// Build a `usage_snapshot` from the current sessions, or `None` when not
 /// opted in. All agent/model strings pass through [`sanitize`]; raw values
 /// never reach the payload.
@@ -149,54 +247,7 @@ pub fn build_usage_snapshot(
     // default-adoption signal, not per-session usage. See `features::active_features`.
     let features = features::active_features(&crate::session::Config::load_or_warn());
 
-    let mut sessions_by_agent: BTreeMap<String, u32> = BTreeMap::new();
-    let mut sessions_by_model_bucket: BTreeMap<String, u32> = BTreeMap::new();
-    let (mut running, mut idle, mut error, mut cockpit, mut sandboxed, mut yolo) =
-        (0u32, 0u32, 0u32, 0u32, 0u32, 0u32);
-
-    for inst in instances {
-        match inst.status {
-            crate::session::Status::Running => running += 1,
-            crate::session::Status::Idle => idle += 1,
-            crate::session::Status::Error => error += 1,
-            _ => {}
-        }
-        // Cockpit fields only exist in `serve` builds; treat them as absent
-        // otherwise so the snapshot logic stays surface-agnostic.
-        #[cfg(feature = "serve")]
-        let is_cockpit = inst.cockpit_mode;
-        #[cfg(not(feature = "serve"))]
-        let is_cockpit = false;
-        if is_cockpit {
-            cockpit += 1;
-        }
-        if inst.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
-            sandboxed += 1;
-        }
-        if inst.yolo_mode {
-            yolo += 1;
-        }
-
-        // Prefer the canonical detection name; fall back to the raw tool
-        // string. Either way it is coerced to an allowlisted bucket.
-        let agent_src = if inst.detect_as.trim().is_empty() {
-            inst.tool.as_str()
-        } else {
-            inst.detect_as.as_str()
-        };
-        *sessions_by_agent
-            .entry(sanitize::agent_bucket(agent_src))
-            .or_insert(0) += 1;
-
-        #[cfg(feature = "serve")]
-        let model = inst.cockpit_model.as_deref();
-        #[cfg(not(feature = "serve"))]
-        let model: Option<&str> = None;
-        let bucket = sanitize::model_bucket(model);
-        *sessions_by_model_bucket
-            .entry(bucket.to_string())
-            .or_insert(0) += 1;
-    }
+    let metrics = aggregate_instances(instances);
 
     Some(UsageSnapshot {
         schema: SCHEMA_VERSION,
@@ -207,15 +258,18 @@ pub fn build_usage_snapshot(
         aoe_version: env!("CARGO_PKG_VERSION").to_string(),
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
-        session_total: instances.len() as u32,
-        session_running: running,
-        session_idle: idle,
-        session_error: error,
-        session_cockpit: cockpit,
-        session_sandboxed: sandboxed,
-        session_yolo: yolo,
-        sessions_by_agent,
-        sessions_by_model_bucket,
+        session_total: metrics.total,
+        session_running: metrics.running,
+        session_idle: metrics.idle,
+        session_error: metrics.error,
+        session_cockpit: metrics.cockpit,
+        session_sandboxed: metrics.sandboxed,
+        session_yolo: metrics.yolo,
+        session_pinned: metrics.pinned,
+        session_snoozed: metrics.snoozed,
+        session_archived: metrics.archived,
+        sessions_by_agent: metrics.by_agent,
+        sessions_by_model_bucket: metrics.by_model_bucket,
         features,
         web_seen,
         cockpit_seen,
@@ -466,6 +520,9 @@ mod tests {
             session_cockpit: 0,
             session_sandboxed: 2,
             session_yolo: 0,
+            session_pinned: 0,
+            session_snoozed: 0,
+            session_archived: 0,
             sessions_by_agent: BTreeMap::new(),
             sessions_by_model_bucket: BTreeMap::new(),
             features: BTreeMap::new(),
@@ -473,6 +530,76 @@ mod tests {
             cockpit_seen: false,
             session_creates_since_last_snapshot: 0,
         }
+    }
+
+    use crate::session::Instance;
+
+    // A maintainer with two pinned sessions and one snoozed session must see
+    // `session_pinned = 2` and `session_snoozed = 1` (issue #1892, story 1).
+    #[test]
+    fn aggregate_counts_each_triage_state() {
+        let mut pinned_a = Instance::new("pin-a", "/tmp/a");
+        pinned_a.pin();
+        let mut pinned_b = Instance::new("pin-b", "/tmp/b");
+        pinned_b.pin();
+        let mut snoozed = Instance::new("snooze", "/tmp/c");
+        snoozed.snooze(60);
+        let mut archived = Instance::new("arch", "/tmp/d");
+        archived.archive();
+        let untouched = Instance::new("plain", "/tmp/e");
+
+        let m = aggregate_instances(&[pinned_a, pinned_b, snoozed, archived, untouched]);
+
+        assert_eq!(m.pinned, 2, "two pinned sessions");
+        assert_eq!(m.snoozed, 1, "one currently snoozed session");
+        assert_eq!(m.archived, 1, "one archived session");
+        assert_eq!(m.total, 5);
+    }
+
+    // A snooze whose window has elapsed must not be counted, matching
+    // `Instance::is_snoozed()` semantics (issue #1892, story 2).
+    #[test]
+    fn expired_snooze_is_not_counted() {
+        let mut expired = Instance::new("expired", "/tmp/x");
+        // A snooze that ended an hour ago: `snoozed_until` is set but in the past.
+        expired.snoozed_until = Some(chrono::Utc::now() - chrono::Duration::hours(1));
+        assert!(
+            !expired.is_snoozed(),
+            "precondition: expired snooze reads false"
+        );
+
+        let m = aggregate_instances(&[expired]);
+        assert_eq!(
+            m.snoozed, 0,
+            "an elapsed snooze must not increment session_snoozed"
+        );
+    }
+
+    // The triage census emits only integer counts; the fields are plain `u32`
+    // and carry no session id, name, path, or timestamp (issue #1892, story 3).
+    #[test]
+    fn triage_counts_are_plain_integers() {
+        fn assert_u32(_: u32) {}
+        let snap = sample_snapshot();
+        assert_u32(snap.session_pinned);
+        assert_u32(snap.session_snoozed);
+        assert_u32(snap.session_archived);
+    }
+
+    // An opted-out install records nothing: `build_usage_snapshot` returns
+    // `None` regardless of session state (issue #1892, story 4). `DO_NOT_TRACK`
+    // is the absolute, config-independent suppressor.
+    #[test]
+    #[serial]
+    fn opted_out_build_returns_none() {
+        unsafe { std::env::set_var("DO_NOT_TRACK", "1") };
+        let mut pinned = Instance::new("pin", "/tmp/p");
+        pinned.pin();
+        assert!(
+            build_usage_snapshot(Surface::Tui, &[pinned], false, false, 0).is_none(),
+            "opted-out install must not build a snapshot"
+        );
+        unsafe { std::env::remove_var("DO_NOT_TRACK") };
     }
 
     // Regression for the duplicate `usage_snapshot` seen in dogfooding: the TUI


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

We had no signal on whether people use the session-organization actions (snooze, archive, pin). These are the primary "keep my session list manageable" tools, exposed in both the web dashboard and the native TUI, yet telemetry said nothing about them, so we could not tell if they were load-bearing features or dead weight.

This adds three coarse, point-in-time counts to the opt-in `usage_snapshot`: `session_pinned`, `session_snoozed`, and `session_archived`. All three are persisted attributes on the session `Instance`, set through a shared mutator layer that both surfaces funnel into, so a census over the existing per-session loop covers web and TUI with zero per-surface wiring. The counts are point-in-time (how many sessions sit in each state at snapshot time); they are not action-frequency counters.

Implementation notes:
- The per-session aggregation loop in `build_usage_snapshot` is extracted into a pure `aggregate_instances(&[Instance]) -> InstanceMetrics`, so the counting is unit-testable without the opt-in / install-id / config global state the builder pulls in. The builder becomes a thin mapper.
- The three states are mutually exclusive per the session triage invariant enforced in the apply/merge path (`Instance::archive`/`snooze`/`pin` clear the siblings, and the merge reconciliation enforces a single active triage state, which the web sidebar comparator depends on), so independent counting never double-counts a well-formed session.
- `SCHEMA_VERSION` is bumped 1 -> 2: this is a closed, auditable schema whose version identifies the exact wire shape, so any field addition bumps it. Verified the `aoe-telemetry` gateway accepts the extra fields (`extra="allow"`, no schema-version gate, ints clamped and forwarded to PostHog which auto-registers properties), so this lands entirely client-side with no gateway changes.
- Verified the open question from the issue: archived sessions ARE present in the `instances` slice both callers pass (TUI `home.instances()` and serve `load_all_instances()` both originate from unfiltered `storage.load()`), so `session_archived` is non-zero.

Closes #1892

## How to test

- [ ] Opt in to telemetry, point `AOE_TELEMETRY_ENDPOINT` at a local sink, pin two sessions and snooze one, then trigger a snapshot and confirm the payload reports `session_pinned = 2` and `session_snoozed = 1`.
- [ ] Snooze a session, let the snooze window elapse, trigger a snapshot, and confirm the session is no longer counted in `session_snoozed`.
- [ ] Archive a session, trigger a snapshot, and confirm `session_archived` increments (and the session is not also counted as pinned or snoozed).
- [ ] With telemetry opted out (or `DO_NOT_TRACK=1`), pin/snooze/archive sessions and confirm no snapshot is built or sent.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: the change is pure telemetry derivation; the four mandated user stories are covered by Rust unit tests on `aggregate_instances` and the opted-out path in `src/telemetry/mod.rs`.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)


**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (census over action-frequency, schema bump, independent counting) and reviewed each commit.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary of Changes

Overview: Adds point-in-time telemetry counts for session organization (pinned, snoozed, archived) and extracts session-aggregation into a pure, testable helper.

What changed, moved, added
- Added three u32 counters to the usage_snapshot telemetry: session_pinned, session_snoozed, session_archived.
- Bumped telemetry schema version to accommodate the new fields.
- Extracted the per-session aggregation loop from build_usage_snapshot into a pure aggregate_instances(&[Instance]) -> InstanceMetrics and introduced the InstanceMetrics type.
- Updated build_usage_snapshot to use aggregate_instances and map its results into UsageSnapshot.
- Added unit tests for aggregate_instances (including snooze-expiry behavior), a serialization test ensuring the triage fields are emitted as JSON numbers, and an opted-out integration test.
- Updated docs to clarify these counts reflect current state distribution (point-in-time), not action frequency.
- Added a debug_assert in aggregation to catch violations of the triage mutual-exclusion invariant during debug/tests.

Benefits
- Improves observability of session-organization features across surfaces without per-surface wiring.
- Preserves privacy by emitting only integer counts (no per-user identifiers or action details).
- Improves testability and code clarity by isolating aggregation logic.
- Fast-fail debug-time invariant helps detect mutator/merge regressions early.

Technical details (concise)
- Counts derive from persisted Instance fields: pinned_at.is_some(), snoozed_until > now, archived_at.is_some().
- Triage states are treated as mutually exclusive by mutator/merge logic; aggregation includes a debug_assert to enforce this in debug builds.
- Tests verify snooze expiry handling, that archived sessions can be counted, and that the wire format preserves numeric types for the new fields.
- No public API signatures were changed beyond the UsageSnapshot wire schema version and added telemetry fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->