### PR TITLE
feat(telemetry): replace bespoke seen signals with an allowlisted usage-signal registry

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -24,7 +24,8 @@ closed, versioned schema (see `src/telemetry/events.rs`):
     short-lived sessions that start and end between two snapshots are still
     counted (populated by `aoe serve`; the TUI reports `0`),
   - which opt-in features are turned on (see "Feature flags" below),
-  - whether the web dashboard / cockpit was opened since the last snapshot.
+  - which surfaces were opened since the last snapshot, as a `usage_seen` map
+    of allowlisted signal name to open-count (see "Usage signals" below).
 
 In practice that is a handful of small (well under 1 KB) requests per active
 install per day. There is no offline buffering, so a flaky network drops events
@@ -50,6 +51,18 @@ The values reflect the **global** config (the install default), not any single
 profile's effective config. It is an install-level default-adoption signal;
 since sessions can run under arbitrary profiles whose overrides are not folded
 in here, per-session usage is reported separately by the session counts above.
+
+### Usage signals
+
+The snapshot also includes a `usage_seen` map (allowlisted signal name ->
+open-count) so we can see which surfaces installs actually use within a window,
+for example `{web: 3, cockpit: 1}`. It is driven by a registry in
+`src/telemetry/usage_signals.rs`: instrumenting a new surface is one entry there
+(its short name), not a schema change. The key set is fixed and the values are
+counts, so a signal can never carry a path or free text, and the gateway
+forwards only this allowlisted shape. The web dashboard reports an open by
+pinging `POST /api/telemetry/seen`; an unregistered name is rejected. The TUI
+never hosts the web surfaces, so it reports the map zeroed.
 
 ## What is never sent
 
@@ -101,9 +114,10 @@ until delivery is confirmed, so a failed send does not silently drop them:
 - the CLI `process_start` daily slot is claimed only on a confirmed send, so a
   failed send leaves it open for the next invocation to retry (bounded to once
   per hour so a down endpoint cannot make every `aoe` invocation re-send);
-- the serve `web_seen` / `cockpit_seen` flags and the session-create counter are
-  cleared only after a confirmed snapshot send, so a failed snapshot keeps them
-  for the next one instead of losing that window's signal.
+- the serve `usage_seen` open counts and the session-create counter are cleared
+  only after a confirmed snapshot send, decremented by exactly what was reported,
+  so a failed snapshot keeps them for the next one instead of losing that
+  window's signal.
 
 This is coarse, last-write retry, not a durable queue: periodic snapshots are
 still point-in-time, and a snapshot identical to the last confirmed one is

--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -4,9 +4,8 @@
 //! User-Agent and create a second identity surface). Instead it manages the
 //! opt-in state through the local daemon, which owns the install id and does
 //! all sending. `seen` lets the web UI report that the dashboard / cockpit was
-//! opened so the daemon's next snapshot can carry `web_seen` / `cockpit_seen`.
+//! opened so the daemon's next snapshot can carry the `usage_seen` map.
 
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
@@ -104,20 +103,14 @@ pub async fn post_telemetry_seen(
         Ok(b) => b,
         Err(rej) => return rej.into_response(),
     };
-    match req.surface.as_str() {
-        "web" => {
-            state.telemetry_web_seen.fetch_add(1, Ordering::Relaxed);
-        }
-        "cockpit" => {
-            state.telemetry_cockpit_seen.fetch_add(1, Ordering::Relaxed);
-        }
-        other => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "bad_surface", "message": format!("unknown surface '{other}'")})),
-            )
-                .into_response();
-        }
+    // Validate the surface against the allowlisted registry; an off-list name
+    // is rejected and never creates a counter, so it can never reach a snapshot.
+    if !state.telemetry_usage_seen.record(&req.surface) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "bad_surface", "message": format!("unknown surface '{}'", req.surface)})),
+        )
+            .into_response();
     }
     StatusCode::NO_CONTENT.into_response()
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -331,16 +331,16 @@ pub struct AppState {
     /// checks this to suppress notifications when someone is actively using
     /// the web dashboard (on any device).
     pub last_web_activity: std::sync::atomic::AtomicI64,
-    /// Counts browser reports that the web dashboard / cockpit web UI was opened,
-    /// so the next opt-in telemetry snapshot can carry `web_seen` / `cockpit_seen`
-    /// (the wire field is the boolean `count > 0`). A monotonic counter rather than
-    /// a flag so the snapshot loop can decrement by exactly what it reported (like
-    /// the create counter): an open that lands during an in-flight send is then
-    /// preserved for the next snapshot instead of being cleared away. The browser
-    /// never posts to the telemetry backend; it pings the local daemon (`POST
-    /// /api/telemetry/seen`), which folds the count into its own snapshot.
-    pub telemetry_web_seen: std::sync::atomic::AtomicU32,
-    pub telemetry_cockpit_seen: std::sync::atomic::AtomicU32,
+    /// Allowlisted usage-signal counters: per-signal counts of browser reports
+    /// that a surface (web dashboard / cockpit web UI) was opened, so the next
+    /// opt-in telemetry snapshot can carry the `usage_seen` map. Monotonic
+    /// counters rather than flags so the snapshot loop can decrement by exactly
+    /// what it reported (like the create counter): an open that lands during an
+    /// in-flight send is preserved for the next snapshot instead of being cleared
+    /// away. The browser never posts to the telemetry backend; it pings the local
+    /// daemon (`POST /api/telemetry/seen`), which folds the count in here.
+    /// Instrumenting a new surface is one entry in `telemetry::usage_signals`.
+    pub telemetry_usage_seen: crate::telemetry::usage_signals::UsageSeenCounters,
     /// Sessions created since the last opt-in telemetry snapshot. Feeds the
     /// `session_creates_since_last_snapshot` trend counter so short-lived sessions
     /// that start and end between two snapshots are still counted. Decremented (by
@@ -348,7 +348,7 @@ pub struct AppState {
     /// the count for the next snapshot instead of silently dropping it.
     pub telemetry_session_creates: std::sync::atomic::AtomicU32,
     /// What the most recent serve snapshot reported, held until its send is
-    /// confirmed so the originating signals (`web_seen` / `cockpit_seen` / the
+    /// confirmed so the originating signals (the `usage_seen` counts and the
     /// create counter) are cleared only on success. The telemetry loop is the
     /// sole reader/writer, so it never overlaps an in-flight build.
     telemetry_last_reported: std::sync::Mutex<Option<ReportedServeSignals>>,
@@ -625,8 +625,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         push_enabled,
         web_config: config.web.clone(),
         last_web_activity: std::sync::atomic::AtomicI64::new(0),
-        telemetry_web_seen: std::sync::atomic::AtomicU32::new(0),
-        telemetry_cockpit_seen: std::sync::atomic::AtomicU32::new(0),
+        telemetry_usage_seen: crate::telemetry::usage_signals::UsageSeenCounters::new(),
         telemetry_session_creates: std::sync::atomic::AtomicU32::new(0),
         telemetry_last_reported: std::sync::Mutex::new(None),
         shutdown: CancellationToken::new(),
@@ -1677,7 +1676,7 @@ fn spawn_telemetry_loop(state: Arc<AppState>) {
                     if let Some(snapshot) = build_serve_snapshot(&state).await {
                         // Awaited (not detached) so the reported signals are
                         // cleared only after a confirmed send. A failed send
-                        // retains web_seen / cockpit_seen / the create counter
+                        // retains the usage_seen counts / the create counter
                         // for the next snapshot instead of dropping them.
                         let outcome = if crate::telemetry::send_snapshot(snapshot).await {
                             crate::telemetry::SendOutcome::Sent
@@ -1696,32 +1695,28 @@ fn spawn_telemetry_loop(state: Arc<AppState>) {
 /// only after the send is confirmed. The clear is deferred (rather than reset at
 /// build time) so a failed send retains the signals for the next snapshot.
 struct ReportedServeSignals {
-    web_seen: u32,
-    cockpit_seen: u32,
+    usage_seen: std::collections::BTreeMap<String, u32>,
     session_creates: u32,
 }
 
 /// Build a serve `usage_snapshot` from the live session list, folding in the
-/// `web_seen` / `cockpit_seen` open counts and the session-create trend counter
-/// *without resetting them*. The reported counts are stashed in `AppState` so
+/// `usage_seen` open counts and the session-create trend counter *without
+/// resetting them*. The reported counts are stashed in `AppState` so
 /// [`clear_reported_serve_signals`] can subtract exactly what was reported once
 /// the send is confirmed. Returns `None` when telemetry is not opted in.
 async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::UsageSnapshot> {
     use std::sync::atomic::Ordering;
-    let web_seen = state.telemetry_web_seen.load(Ordering::Relaxed);
-    let cockpit_seen = state.telemetry_cockpit_seen.load(Ordering::Relaxed);
+    let usage_seen = state.telemetry_usage_seen.snapshot();
     let session_creates = state.telemetry_session_creates.load(Ordering::Relaxed);
     let instances = state.instances.read().await.clone();
     let snapshot = crate::telemetry::build_usage_snapshot(
         crate::telemetry::Surface::Serve,
         &instances,
-        web_seen > 0,
-        cockpit_seen > 0,
+        usage_seen.clone(),
         session_creates,
     )?;
     *state.telemetry_last_reported.lock().unwrap() = Some(ReportedServeSignals {
-        web_seen,
-        cockpit_seen,
+        usage_seen,
         session_creates,
     });
     Some(snapshot)
@@ -1730,11 +1725,10 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
 /// Clear the signals a serve snapshot reported, but only when the send was
 /// confirmed (`SendOutcome::Sent`). On `Deduped` the prior confirmed send
 /// already cleared them; on `Failed` they are retained so the next snapshot
-/// re-reports them. The create counter is decremented by exactly the reported
-/// value (not reset to 0). All three signals (the two `seen` open counts and the
-/// create counter) are decremented by exactly what was reported, so an open or a
-/// create that landed during the in-flight send survives into the next snapshot
-/// instead of being cleared away.
+/// re-reports them. Every signal (the `usage_seen` open counts and the create
+/// counter) is decremented by exactly what was reported, not reset to 0, so an
+/// open or a create that landed during the in-flight send survives into the
+/// next snapshot instead of being cleared away.
 fn clear_reported_serve_signals(state: &AppState, outcome: crate::telemetry::SendOutcome) {
     let Some(reported) = state.telemetry_last_reported.lock().unwrap().take() else {
         return;
@@ -1742,8 +1736,7 @@ fn clear_reported_serve_signals(state: &AppState, outcome: crate::telemetry::Sen
     if outcome != crate::telemetry::SendOutcome::Sent {
         return;
     }
-    decrement_reported_count(&state.telemetry_web_seen, reported.web_seen);
-    decrement_reported_count(&state.telemetry_cockpit_seen, reported.cockpit_seen);
+    state.telemetry_usage_seen.decrement(&reported.usage_seen);
     decrement_reported_count(&state.telemetry_session_creates, reported.session_creates);
 }
 

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -10,7 +10,10 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 /// Payload schema version. Bump on any breaking change to the field set.
-pub const SCHEMA_VERSION: u32 = 1;
+///
+/// v2 replaced the bespoke `web_seen` / `cockpit_seen` booleans with the
+/// allowlisted `usage_seen` count map (issue #1880).
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -84,10 +87,12 @@ pub struct UsageSnapshot {
     /// schema. See `telemetry::features`.
     pub features: BTreeMap<String, bool>,
 
-    /// The web dashboard was opened at least once since the last snapshot.
-    pub web_seen: bool,
-    /// The cockpit web UI was opened at least once since the last snapshot.
-    pub cockpit_seen: bool,
+    /// Window-scoped usage activity: allowlisted signal name -> times the
+    /// surface was opened since the last snapshot. Keyed by the fixed registry
+    /// in [`super::usage_signals`]; instrumenting a new surface is one registry
+    /// entry, not a schema field. Zero-valued keys stay present so the wire key
+    /// set is stable. See `telemetry::usage_signals`.
+    pub usage_seen: BTreeMap<String, u32>,
 
     /// Sessions created since the previous snapshot (a trend counter, not a
     /// per-session event stream).

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -22,6 +22,7 @@ pub mod events;
 pub mod features;
 pub mod sanitize;
 mod state;
+pub mod usage_signals;
 
 use std::collections::BTreeMap;
 use std::time::Duration;
@@ -137,8 +138,7 @@ pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
 pub fn build_usage_snapshot(
     surface: Surface,
     instances: &[Instance],
-    web_seen: bool,
-    cockpit_seen: bool,
+    usage_seen: BTreeMap<String, u32>,
     session_creates_since_last_snapshot: u32,
 ) -> Option<UsageSnapshot> {
     if !is_opted_in() {
@@ -217,8 +217,7 @@ pub fn build_usage_snapshot(
         sessions_by_agent,
         sessions_by_model_bucket,
         features,
-        web_seen,
-        cockpit_seen,
+        usage_seen,
         session_creates_since_last_snapshot,
     })
 }
@@ -469,8 +468,7 @@ mod tests {
             sessions_by_agent: BTreeMap::new(),
             sessions_by_model_bucket: BTreeMap::new(),
             features: BTreeMap::new(),
-            web_seen: false,
-            cockpit_seen: false,
+            usage_seen: usage_signals::zeroed(),
             session_creates_since_last_snapshot: 0,
         }
     }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -353,7 +353,7 @@ fn snapshot_matches_last(snapshot: &UsageSnapshot) -> bool {
 }
 
 /// Outcome of a snapshot flush, so a caller can decide whether to consume the
-/// state the snapshot reported (e.g. reset `web_seen` / a create counter).
+/// state the snapshot reported (e.g. the `usage_seen` counts / a create counter).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SendOutcome {
     /// Delivery was confirmed (a 2xx). Safe to consume the reported state.

--- a/src/telemetry/usage_signals.rs
+++ b/src/telemetry/usage_signals.rs
@@ -131,8 +131,12 @@ mod tests {
         counters.record("web");
         let snap = counters.snapshot();
         // Exactly the allowlist, no more, no less; untouched signals are zero.
+        // `snap` is a BTreeMap, so its keys come out sorted; compare against the
+        // registry sorted the same way rather than relying on its source order.
         let keys: Vec<&str> = snap.keys().map(String::as_str).collect();
-        assert_eq!(keys, USAGE_SIGNALS);
+        let mut expected: Vec<&str> = USAGE_SIGNALS.to_vec();
+        expected.sort_unstable();
+        assert_eq!(keys, expected);
         assert_eq!(snap.get("web"), Some(&2));
         assert_eq!(snap.get("cockpit"), Some(&0));
         // zeroed() (the TUI shape) matches the same key set.

--- a/src/telemetry/usage_signals.rs
+++ b/src/telemetry/usage_signals.rs
@@ -1,0 +1,186 @@
+//! Registry of usage "feature X was used this window" signals.
+//!
+//! This is the single, auditable place that decides which usage signals the
+//! snapshot may carry. The result is a map keyed by a **fixed set of short
+//! signal names** (the allowlist), so it can never carry a path, name, or
+//! other free-form value, and the gateway forwards it as allowlisted
+//! short-name -> count while dropping anything else.
+//!
+//! It mirrors [`super::features`] (install-level adoption) but tracks a
+//! different lifecycle: `features` is rebuilt from config on every snapshot,
+//! whereas these counters accumulate browser pings across a window and are
+//! decremented by exactly what a confirmed snapshot reported. Tracking a newly
+//! instrumented surface is one entry in [`USAGE_SIGNALS`]: the
+//! `/api/telemetry/seen` endpoint, the daemon aggregate, and the snapshot all
+//! derive from this slice, so no other code changes.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// The fixed allowlist of usage-signal names a snapshot may report. Adding a
+/// surface here is the only edit needed to instrument it end to end.
+pub const USAGE_SIGNALS: &[&str] = &["web", "cockpit"];
+
+/// Window-scoped "feature was used" counters, one per allowlisted signal in
+/// [`USAGE_SIGNALS`]. Built once at daemon start and only ever borrowed, so the
+/// atomics are never moved; increments and the decrement-on-confirmed-send are
+/// lock-free. The browser pings `POST /api/telemetry/seen`, which folds the
+/// count in here; the next opt-in snapshot reports the map and clears exactly
+/// what it reported once the send is confirmed.
+#[derive(Debug, Default)]
+pub struct UsageSeenCounters {
+    counts: BTreeMap<&'static str, AtomicU32>,
+}
+
+impl UsageSeenCounters {
+    pub fn new() -> Self {
+        Self {
+            counts: USAGE_SIGNALS
+                .iter()
+                .map(|&name| (name, AtomicU32::new(0)))
+                .collect(),
+        }
+    }
+
+    /// Record one use of an allowlisted signal. Returns `false` for an
+    /// unregistered name, which the endpoint turns into a 400; the count is
+    /// never created, so an off-list name can never reach the snapshot.
+    pub fn record(&self, name: &str) -> bool {
+        match self.counts.get(name) {
+            Some(counter) => {
+                counter.fetch_add(1, Ordering::Relaxed);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Current counts as `name -> count`, always the full allowlisted key set
+    /// (zeros included) so the wire map has a stable shape regardless of which
+    /// surfaces were touched. Mirrors how `features` always emits its full key
+    /// set.
+    pub fn snapshot(&self) -> BTreeMap<String, u32> {
+        self.counts
+            .iter()
+            .map(|(&name, counter)| (name.to_string(), counter.load(Ordering::Relaxed)))
+            .collect()
+    }
+
+    /// Subtract exactly the counts a confirmed snapshot reported. Iterates the
+    /// registry (not the reported map, which is treated as untrusted) and uses
+    /// a saturating subtract, so a count that exceeds the current value can
+    /// never underflow and wrap. An increment that landed between the snapshot
+    /// build and the confirmed send survives into the next window because only
+    /// the reported amount is removed.
+    pub fn decrement(&self, reported: &BTreeMap<String, u32>) {
+        for (&name, counter) in &self.counts {
+            let Some(&amount) = reported.get(name) else {
+                continue;
+            };
+            if amount == 0 {
+                continue;
+            }
+            let mut current = counter.load(Ordering::Relaxed);
+            loop {
+                let next = current.saturating_sub(amount);
+                match counter.compare_exchange_weak(
+                    current,
+                    next,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => break,
+                    Err(observed) => current = observed,
+                }
+            }
+        }
+    }
+}
+
+/// A full allowlisted key set with every count at zero. The TUI never hosts the
+/// web dashboard or cockpit, so it reports this stable shape rather than an
+/// empty (or absent) map, keeping the wire key set identical to the daemon's.
+pub fn zeroed() -> BTreeMap<String, u32> {
+    USAGE_SIGNALS
+        .iter()
+        .map(|&name| (name.to_string(), 0))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_rejects_unregistered_names() {
+        let counters = UsageSeenCounters::new();
+        assert!(counters.record("web"));
+        assert!(counters.record("cockpit"));
+        // An off-list name is rejected and never creates a key.
+        assert!(!counters.record("bogus"));
+        assert!(!counters.record("diff_panel"));
+        let snap = counters.snapshot();
+        assert!(!snap.contains_key("bogus"));
+        assert!(!snap.contains_key("diff_panel"));
+    }
+
+    #[test]
+    fn snapshot_emits_the_full_allowlisted_key_set_with_zeros() {
+        let counters = UsageSeenCounters::new();
+        counters.record("web");
+        counters.record("web");
+        let snap = counters.snapshot();
+        // Exactly the allowlist, no more, no less; untouched signals are zero.
+        let keys: Vec<&str> = snap.keys().map(String::as_str).collect();
+        assert_eq!(keys, USAGE_SIGNALS);
+        assert_eq!(snap.get("web"), Some(&2));
+        assert_eq!(snap.get("cockpit"), Some(&0));
+        // zeroed() (the TUI shape) matches the same key set.
+        assert_eq!(
+            zeroed().keys().collect::<Vec<_>>(),
+            snap.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn decrement_subtracts_exactly_reported_known_keys() {
+        let counters = UsageSeenCounters::new();
+        for _ in 0..5 {
+            counters.record("web");
+        }
+        counters.record("cockpit");
+
+        // An open lands during the in-flight send (after the snapshot read).
+        let reported = counters.snapshot();
+        counters.record("web");
+
+        counters.decrement(&reported);
+        let after = counters.snapshot();
+        // The web open that landed mid-send survives; cockpit is fully cleared.
+        assert_eq!(after.get("web"), Some(&1));
+        assert_eq!(after.get("cockpit"), Some(&0));
+    }
+
+    #[test]
+    fn decrement_ignores_unknown_reported_keys() {
+        let counters = UsageSeenCounters::new();
+        counters.record("web");
+        let mut reported = counters.snapshot();
+        reported.insert("phantom".to_string(), 99);
+        // The unknown key is ignored; known keys still clear.
+        counters.decrement(&reported);
+        assert_eq!(counters.snapshot().get("web"), Some(&0));
+    }
+
+    #[test]
+    fn decrement_saturates_instead_of_underflowing() {
+        let counters = UsageSeenCounters::new();
+        counters.record("web");
+        // A reported count larger than the current value (buggy/stale report)
+        // saturates at zero rather than wrapping to ~4 billion.
+        let mut reported = BTreeMap::new();
+        reported.insert("web".to_string(), 100);
+        counters.decrement(&reported);
+        assert_eq!(counters.snapshot().get("web"), Some(&0));
+    }
+}

--- a/src/telemetry/usage_signals.rs
+++ b/src/telemetry/usage_signals.rs
@@ -27,7 +27,7 @@ pub const USAGE_SIGNALS: &[&str] = &["web", "cockpit"];
 /// lock-free. The browser pings `POST /api/telemetry/seen`, which folds the
 /// count in here; the next opt-in snapshot reports the map and clears exactly
 /// what it reported once the send is confirmed.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct UsageSeenCounters {
     counts: BTreeMap<&'static str, AtomicU32>,
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1314,15 +1314,15 @@ impl App {
     }
 
     /// Build a `usage_snapshot` from the current session list, or `None` when
-    /// telemetry is not opted in. The TUI never hosts the web dashboard, so
-    /// `web_seen` / `cockpit_seen` are false and the create-trend counter is
-    /// left at 0 (the `aoe serve` daemon is the surface that tracks those).
+    /// telemetry is not opted in. The TUI never hosts the web dashboard, so the
+    /// `usage_seen` map is reported zeroed (a stable full key set) and the
+    /// create-trend counter is left at 0 (the `aoe serve` daemon is the surface
+    /// that tracks those).
     fn build_telemetry_snapshot(&self) -> Option<crate::telemetry::UsageSnapshot> {
         crate::telemetry::build_usage_snapshot(
             crate::telemetry::Surface::Tui,
             self.home.instances(),
-            false,
-            false,
+            crate::telemetry::usage_signals::zeroed(),
             0,
         )
     }

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -6,6 +6,7 @@
 //! user state is touched.
 
 use agent_of_empires::session::{save_config, Config, Instance};
+use agent_of_empires::telemetry::usage_signals::{self, UsageSeenCounters, USAGE_SIGNALS};
 use agent_of_empires::telemetry::{self, Surface};
 use serial_test::serial;
 
@@ -37,7 +38,9 @@ fn default_off_emits_nothing() {
     assert!(!telemetry::is_opted_in());
     assert_eq!(telemetry::install_id(), None);
     assert!(telemetry::build_process_start(Surface::Cli).is_none());
-    assert!(telemetry::build_usage_snapshot(Surface::Tui, &[], false, false, 0).is_none());
+    assert!(
+        telemetry::build_usage_snapshot(Surface::Tui, &[], usage_signals::zeroed(), 0).is_none()
+    );
 }
 
 /// Opting in generates an install id and lets events build; opting back out
@@ -100,9 +103,13 @@ fn snapshot_buckets_are_sanitized() {
     custom.detect_as = String::new();
     let claude = Instance::new("c", "/p");
 
-    let snapshot =
-        telemetry::build_usage_snapshot(Surface::Tui, &[custom, claude], false, false, 0)
-            .expect("snapshot built when opted in");
+    let snapshot = telemetry::build_usage_snapshot(
+        Surface::Tui,
+        &[custom, claude],
+        usage_signals::zeroed(),
+        0,
+    )
+    .expect("snapshot built when opted in");
 
     let serialized = serde_json::to_string(&snapshot).expect("serialize");
     // The raw custom command / project path must never appear in the payload.
@@ -134,13 +141,78 @@ fn snapshot_carries_session_create_count() {
     set_enabled(true);
     telemetry::apply_opt_in_change(true);
 
-    let none = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 0)
+    let none = telemetry::build_usage_snapshot(Surface::Serve, &[], usage_signals::zeroed(), 0)
         .expect("snapshot built when opted in");
     assert_eq!(none.session_creates_since_last_snapshot, 0);
 
-    let some = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 7)
+    let some = telemetry::build_usage_snapshot(Surface::Serve, &[], usage_signals::zeroed(), 7)
         .expect("snapshot built when opted in");
     assert_eq!(some.session_creates_since_last_snapshot, 7);
+}
+
+/// User story (#1880): a usage signal registered in the allowlist flows through
+/// the daemon aggregate (`UsageSeenCounters`) into the snapshot's `usage_seen`
+/// map with no other code changes. The map carries the recorded counts verbatim.
+#[test]
+#[serial]
+fn snapshot_carries_registered_usage_signals() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    // The daemon folds browser pings into these counters.
+    let counters = UsageSeenCounters::new();
+    assert!(counters.record("web"));
+    assert!(counters.record("web"));
+    assert!(counters.record("cockpit"));
+
+    let snapshot = telemetry::build_usage_snapshot(Surface::Serve, &[], counters.snapshot(), 0)
+        .expect("snapshot built when opted in");
+    assert_eq!(snapshot.usage_seen.get("web"), Some(&2));
+    assert_eq!(snapshot.usage_seen.get("cockpit"), Some(&1));
+}
+
+/// User story (#1880): an unregistered signal name is rejected by the registry
+/// (`record` returns false, which the endpoint turns into a 400) and never
+/// reaches the snapshot's `usage_seen` map.
+#[test]
+#[serial]
+fn unregistered_usage_signal_is_rejected_and_never_reported() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let counters = UsageSeenCounters::new();
+    // The endpoint would return 400 on this false.
+    assert!(!counters.record("web_terminal"));
+
+    let snapshot = telemetry::build_usage_snapshot(Surface::Serve, &[], counters.snapshot(), 0)
+        .expect("snapshot built when opted in");
+    assert!(!snapshot.usage_seen.contains_key("web_terminal"));
+}
+
+/// User story (#1880): the `usage_seen` map only ever carries allowlisted short
+/// names, never free-form input. Its key set is exactly the fixed registry and
+/// every key is a short identifier.
+#[test]
+#[serial]
+fn usage_seen_keys_are_only_allowlisted_short_names() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let snapshot = telemetry::build_usage_snapshot(Surface::Serve, &[], usage_signals::zeroed(), 0)
+        .expect("snapshot built when opted in");
+
+    let keys: Vec<&str> = snapshot.usage_seen.keys().map(String::as_str).collect();
+    assert_eq!(keys, USAGE_SIGNALS);
+    for key in snapshot.usage_seen.keys() {
+        assert!(
+            key.chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+            "usage_seen key `{key}` is not a short allowlisted identifier"
+        );
+    }
 }
 
 /// The CLI `process_start` is throttled to once per install per day so a user

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -204,8 +204,12 @@ fn usage_seen_keys_are_only_allowlisted_short_names() {
     let snapshot = telemetry::build_usage_snapshot(Surface::Serve, &[], usage_signals::zeroed(), 0)
         .expect("snapshot built when opted in");
 
+    // `usage_seen` is a BTreeMap, so its keys come out sorted; compare against
+    // the registry sorted the same way rather than relying on its source order.
     let keys: Vec<&str> = snapshot.usage_seen.keys().map(String::as_str).collect();
-    assert_eq!(keys, USAGE_SIGNALS);
+    let mut expected: Vec<&str> = USAGE_SIGNALS.to_vec();
+    expected.sort_unstable();
+    assert_eq!(keys, expected);
     for key in snapshot.usage_seen.keys() {
         assert!(
             key.chars()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -558,13 +558,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   }, [serverAboutLoaded, serverAbout?.read_only]);
 
   // Telemetry: report that the cockpit web UI was opened, folded into the
-  // daemon's next opt-in snapshot as `cockpit_seen`. `activeSession` drives
-  // both the desktop and mobile cockpit mounts, so this single effect covers
-  // both layouts. Same guard as the `"web"` ping above: skip until
-  // `serverAbout` loads, skip read-only servers (which can't persist). The
-  // backend folds repeated pings into a monotonic open-count (reported as the
-  // boolean `cockpit_seen` and decremented by exactly what each snapshot
-  // reported), so re-fires on session switch are harmless. See #1882.
+  // daemon's next opt-in snapshot under the `usage_seen` map's `cockpit` key.
+  // `activeSession` drives both the desktop and mobile cockpit mounts, so this
+  // single effect covers both layouts. Same guard as the `"web"` ping above:
+  // skip until `serverAbout` loads, skip read-only servers (which can't
+  // persist). The backend folds repeated pings into a monotonic open-count
+  // (decremented by exactly what each snapshot reported), so re-fires on
+  // session switch are harmless. See #1882.
   useEffect(() => {
     if (!serverAboutLoaded || serverAbout?.read_only) return;
     if (!activeSession?.cockpit_mode) return;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -445,7 +445,7 @@ export async function setTelemetryConsent(
 }
 
 /// Tell the daemon the web dashboard or cockpit UI was opened, so its next
-/// opt-in snapshot can carry web_seen / cockpit_seen. Best-effort.
+/// opt-in snapshot can carry the `usage_seen` open-count map. Best-effort.
 export function reportTelemetrySeen(surface: "web" | "cockpit"): void {
   void fetch("/api/telemetry/seen", {
     method: "POST",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Instrumenting a "was this surface used this window" telemetry signal was bespoke per signal: each one meant a dedicated `AtomicU32` on `AppState`, a hardcoded match arm in `POST /api/telemetry/seen`, a read in the serve snapshot builder, a positional bool argument on `build_usage_snapshot`, and a field on `UsageSnapshot`. Adding a third "seen" signal touched four files. That friction discourages adding the very usage data telemetry exists to collect.

This replaces the bespoke `web_seen` / `cockpit_seen` signals with a single allowlisted registry, mirroring the proven `features` registry pattern. A new `src/telemetry/usage_signals.rs` holds a fixed `USAGE_SIGNALS` allowlist plus `UsageSeenCounters`, lock-free per-signal `AtomicU32` counters built from the registry. The wire schema now carries one `usage_seen: BTreeMap<String, u32>` count map instead of two booleans, and `SCHEMA_VERSION` is bumped to 2. The `/api/telemetry/seen` endpoint validates the surface against the registry (400 for an off-list name) instead of a hardcoded match, and the serve snapshot loop decrements each reported count by exactly what it reported on a confirmed send (an open landing mid-send survives to the next window). Instrumenting a new surface (diff panel, web terminal) is now one entry in `USAGE_SIGNALS`, no schema-field churn.

Decisions: kept counts (not bools) since the counters and decrement-on-confirm machinery were already count-based; left `session_creates_since_last_snapshot` as its own field (it is semantically distinct from "surface opened" and already ships under its own wire name, so folding it would be a gratuitous schema break); kept `features` and `usage_seen` as two maps (different lifecycles, adoption vs activity). `decrement` iterates the registry (not the untrusted reported map) and saturates, so a stale or oversized reported count can never underflow.

The decrement and registry design was pressure-tested via a multi-model design debate; the saturating-subtract hardening came directly out of that.

**Telemetry gateway:** this lands entirely inside `agent-of-empires`. The `aoe-telemetry` gateway already forwards any shallow identifier-keyed number/bool map through its generic sanitizer with no change (verified by its own `test_sanitize_properties_forwards_shallow_bool_map` / `test_sanitize_properties_forwards_generic_count_map`), and it does not validate the schema version. No collector or ingest edits are required. A doc-sync of `aoe-telemetry/docs/SCHEMA.md` (still lists the old `web_seen` / `cockpit_seen` properties) is a non-blocking follow-up in that repo.

Closes #1880

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] Opt in to telemetry, point `AOE_TELEMETRY_ENDPOINT` at a local sink, run `aoe serve`, open the dashboard and a cockpit session, and confirm the next `usage_snapshot` carries `usage_seen: {web: N, cockpit: M}` with non-zero counts.
- [ ] `POST /api/telemetry/seen` with `{"surface":"bogus"}` returns 400, and `bogus` never appears in a snapshot.
- [ ] Run the TUI with telemetry on against the local sink and confirm its snapshot carries `usage_seen` zeroed (full key set, all 0).
- [ ] Confirm a single registry edit (add a name to `USAGE_SIGNALS`) is enough for that surface to flow through `/api/telemetry/seen` and into the snapshot.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The browser contract is unchanged: it still POSTs `{surface}` to `/api/telemetry/seen` and the accepted surfaces ("web", "cockpit") are identical, so the existing live spec `web/tests/live/cockpit-telemetry-seen.spec.ts` still covers the frontend behavior. Only backend wire shape and registry validation changed, covered by Rust tests.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The change is to the telemetry snapshot wire shape, covered by integration tests in `tests/telemetry.rs` (three new user-story tests for #1880) and unit tests in `src/telemetry/usage_signals.rs` (registry rejects unregistered names, full zeroed key set, saturating decrement).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, including a multi-model design debate on the registry data structure and decrement semantics. I made the design calls (counts vs bools, keeping session_creates separate, two maps) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR consolidates per-surface "seen" telemetry flags into a single, allowlisted, count-based usage registry and centralizes decrement/reset semantics.

What changed (high-level)
- Removed: per-signal atomic booleans/counters for individual surfaces (previous web/cockpit seen flags).
- Added:
  - A fixed allowlist of usage signals (USAGE_SIGNALS).
  - UsageSeenCounters: centralized per-signal AtomicU32 counters.
  - usage_seen: BTreeMap<String, u32> carried in telemetry snapshots (stable full key set including zeros).
- Updated:
  - /api/telemetry/seen now validates reported surface names against the allowlist and returns 400 for unknown names.
  - Serve snapshot and clear logic to use count-based usage_seen and to decrement confirmed counts using saturating subtraction.
  - Telemetry docs, tests, TUI, and minor web comments to reflect the new usage_seen shape.

Benefits
- Easier instrumentation: adding a surface is a single registry entry with no schema or AppState churn.
- Richer telemetry: counts provide frequency instead of binary presence.
- Safer concurrency: centralized decrement with CAS and saturating subtraction prevents underflow and race issues.
- Stronger validation and failure isolation: unregistered names are rejected and confirmed-send decrements preserve unconfirmed signals.

Technical details
- New module: src/telemetry/usage_signals.rs
  - USAGE_SIGNALS: &[&str] — fixed allowlist.
  - UsageSeenCounters with new(), record(name) -> bool, snapshot() -> BTreeMap<String,u32>, decrement(reported) which applies saturating subtraction with CAS, and zeroed() to produce a stable zero-filled map.
- Server:
  - AppState now holds telemetry_usage_seen: UsageSeenCounters (replacing the individual AtomicU32 fields); telemetry_session_creates remains unchanged.
  - post_telemetry_seen delegates to telemetry_usage_seen.record(...) and returns 400 for unknown names.
  - The serve snapshot loop emits usage_seen and only decrements counters on confirmed Sent outcomes using UsageSeenCounters::decrement.
- Wire/schema:
  - UsageSnapshot now carries usage_seen: BTreeMap<String, u32> (replacing per-surface booleans).
  - SCHEMA version was bumped alongside this shape change.
- Tests & docs:
  - Tests added/updated to assert registry validation (reject unregistered names), full zeroed key set in snapshots, and saturating decrement behavior.
  - docs/telemetry.md updated to describe the registry-driven usage_seen semantics and post-confirmation decrement behavior.

Closes `#1880`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->