### PR TITLE
feat(telemetry): track which CLI subcommands run via cli_usage

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -8,12 +8,22 @@ content, and it honors `DO_NOT_TRACK`.
 
 ## What is sent
 
-Only when you opt in, and only aggregate counts. Two event kinds, both with a
+Only when you opt in, and only aggregate counts. Three event kinds, all with a
 closed, versioned schema (see `src/telemetry/events.rs`):
 
-- **`process_start`** on boot: surface (`cli` / `tui` / `serve`), aoe version,
-  OS, and CPU arch. The `cli` surface is throttled to at most once per install
-  per day, so scripting `aoe` in a loop never floods the endpoint.
+- **`process_start`** on boot of a long-running surface (`tui` / `serve`): the
+  surface, aoe version, OS, and CPU arch.
+- **`cli_usage`** from short-lived `aoe <subcommand>` invocations: the surface
+  (`cli`), aoe version, OS, CPU arch, a window-start timestamp, and a
+  `command_counts` map of allowlisted subcommand name to invocation count
+  (e.g. `{add: 5, list: 2}`). Each `aoe` run is a separate short-lived process,
+  so counts accumulate on disk and flush as one POST per install per day; the
+  daily throttle means scripting `aoe` in a loop never floods the endpoint, and
+  the count mix answers "which subcommands this install actually uses" rather
+  than just "the CLI ran today". The map keys are the fixed clap subcommand set
+  (`add`, `session`, `telemetry`, ...), filtered against an allowlist before
+  sending, so no argument, flag, or path is ever attached; hidden internal
+  commands are never counted.
 - **`usage_snapshot`** from the TUI and `aoe serve`, on start and then every
   ~12 hours. It is a point-in-time summary of the current install, never a
   stream of actions:
@@ -98,9 +108,11 @@ non-success HTTP status (for example a rejected key or a schema rejection at the
 gateway) is treated as a failure, not a silent success. Signals are not consumed
 until delivery is confirmed, so a failed send does not silently drop them:
 
-- the CLI `process_start` daily slot is claimed only on a confirmed send, so a
-  failed send leaves it open for the next invocation to retry (bounded to once
-  per hour so a down endpoint cannot make every `aoe` invocation re-send);
+- the CLI `cli_usage` daily slot is claimed only on a confirmed send, and the
+  accumulated `command_counts` are cleared only then, so a failed send leaves
+  both the slot and the counts intact for the next invocation to retry (bounded
+  to once per hour so a down endpoint cannot make every `aoe` invocation
+  re-send), and a transient failure never drops a window of commands;
 - the serve `web_seen` / `cockpit_seen` flags and the session-create counter are
   cleared only after a confirmed snapshot send, so a failed snapshot keeps them
   for the next one instead of losing that window's signal.

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -192,3 +192,132 @@ pub enum Commands {
         shell: Shell,
     },
 }
+
+/// Every command name [`command_name`] can return, used as the closed
+/// allowlist when building the `cli_usage` telemetry event: any key loaded from
+/// a hand-edited or corrupt `telemetry.json` that is not in this set is dropped
+/// before sending, so the wire payload can only ever carry these tokens. The
+/// `serve` / `url` / `cockpit` / `log_level` names are listed unconditionally
+/// even though their variants are `serve`-feature-gated; in a TUI-only build
+/// those commands cannot run, so the extra allowlist entries are simply never
+/// matched. Keep in sync with [`command_name`]; the unit test asserts every
+/// `command_name` output is a member.
+pub const CLI_COMMAND_NAMES: &[&str] = &[
+    "add",
+    "agents",
+    "init",
+    "list",
+    "logs",
+    "log_level",
+    "remove",
+    "send",
+    "status",
+    "session",
+    "group",
+    "profile",
+    "project",
+    "worktree",
+    "tmux",
+    "sounds",
+    "theme",
+    "telemetry",
+    "serve",
+    "url",
+    "cockpit",
+    "uninstall",
+    "update",
+    "completion",
+];
+
+/// The canonical, telemetry-safe name of a CLI subcommand, or `None` for the
+/// hidden internal commands that are machine-spawned rather than user-invoked
+/// (`__cockpit-runner`, `__extract-session-id`) and must never be counted.
+///
+/// This is an exhaustive match with **no catch-all**: adding a [`Commands`]
+/// variant fails to compile until it is named here, so the telemetry vocabulary
+/// can never silently drift. The returned tokens are identifier-safe
+/// (`snake_case`, never clap's kebab-case like `log-level`) because the
+/// telemetry gateway drops map keys that do not match `^[a-z][a-z0-9_]{0,63}$`.
+/// They carry no arguments, flags, or paths, only the closed command name.
+pub fn command_name(command: &Commands) -> Option<&'static str> {
+    Some(match command {
+        Commands::Add(_) => "add",
+        Commands::Agents => "agents",
+        Commands::Init(_) => "init",
+        Commands::List(_) => "list",
+        Commands::Logs(_) => "logs",
+        #[cfg(feature = "serve")]
+        Commands::LogLevel(_) => "log_level",
+        Commands::Remove(_) => "remove",
+        Commands::Send(_) => "send",
+        Commands::Status(_) => "status",
+        Commands::Session { .. } => "session",
+        Commands::Group { .. } => "group",
+        Commands::Profile { .. } => "profile",
+        Commands::Project { .. } => "project",
+        Commands::Worktree { .. } => "worktree",
+        Commands::Tmux { .. } => "tmux",
+        Commands::Sounds { .. } => "sounds",
+        Commands::Theme { .. } => "theme",
+        Commands::Telemetry { .. } => "telemetry",
+        #[cfg(feature = "serve")]
+        Commands::Serve(_) => "serve",
+        #[cfg(feature = "serve")]
+        Commands::Url(_) => "url",
+        #[cfg(feature = "serve")]
+        Commands::Cockpit { .. } => "cockpit",
+        // Internal, machine-spawned commands: never a user action, never counted.
+        #[cfg(feature = "serve")]
+        Commands::CockpitRunner(_) => return None,
+        Commands::ExtractSessionId(_) => return None,
+        Commands::Uninstall(_) => "uninstall",
+        Commands::Update(_) => "update",
+        Commands::Completion { .. } => "completion",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Every name `command_name` returns must be in the `CLI_COMMAND_NAMES`
+    /// allowlist and be an identifier-safe token (no args, no kebab-case), so a
+    /// privacy reviewer can trust the only strings reaching the wire are closed
+    /// command names. Parsed via clap so alias collapse (`ls` -> `list`,
+    /// `rm` -> `remove`) and the real kebab/underscore mapping are exercised.
+    #[test]
+    fn command_name_is_allowlisted_and_identifier_safe() {
+        let cases: &[(&[&str], &str)] = &[
+            (&["aoe", "add", "demo"], "add"),
+            (&["aoe", "agents"], "agents"),
+            (&["aoe", "ls"], "list"), // alias collapses to canonical
+            (&["aoe", "rm", "demo"], "remove"),
+            (&["aoe", "session", "list"], "session"),
+            (&["aoe", "telemetry", "status"], "telemetry"),
+            (&["aoe", "update"], "update"),
+            (&["aoe", "completion", "bash"], "completion"),
+        ];
+        for (argv, expected) in cases {
+            let cli = Cli::try_parse_from(*argv).expect("parse");
+            let name = command_name(cli.command.as_ref().expect("command")).expect("named");
+            assert_eq!(name, *expected, "argv {argv:?}");
+            assert!(
+                CLI_COMMAND_NAMES.contains(&name),
+                "`{name}` missing from CLI_COMMAND_NAMES"
+            );
+            assert!(
+                name.bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_'),
+                "`{name}` is not an identifier-safe token"
+            );
+        }
+    }
+
+    /// Hidden, machine-spawned commands are never counted.
+    #[test]
+    fn hidden_commands_are_not_named() {
+        let cli = Cli::try_parse_from(["aoe", "__extract-session-id"]).expect("parse");
+        assert_eq!(command_name(cli.command.as_ref().expect("command")), None);
+    }
+}

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -320,4 +320,29 @@ mod tests {
         let cli = Cli::try_parse_from(["aoe", "__extract-session-id"]).expect("parse");
         assert_eq!(command_name(cli.command.as_ref().expect("command")), None);
     }
+
+    /// The compiler forces a `command_name` arm per `Commands` variant, but
+    /// nothing forces a matching `CLI_COMMAND_NAMES` entry. Without this guard a
+    /// contributor could add a counted command and silently drop it from the
+    /// `cli_usage` payload (`build_cli_usage` filters unknown keys). Assert every
+    /// visible clap subcommand is in the allowlist (subset direction: the
+    /// allowlist may carry extra `serve`-only names in a TUI-only build, which is
+    /// a harmless never-matched filter key). `log-level` maps to `log_level`.
+    #[test]
+    fn allowlist_covers_every_visible_subcommand() {
+        use clap::CommandFactory;
+        let visible: Vec<String> = Cli::command()
+            .get_subcommands()
+            .filter(|s| !s.is_hide_set())
+            .map(|s| s.get_name().replace('-', "_"))
+            .collect();
+        assert!(!visible.is_empty(), "expected visible subcommands");
+        for name in &visible {
+            assert!(
+                CLI_COMMAND_NAMES.contains(&name.as_str()),
+                "visible subcommand `{name}` is missing from CLI_COMMAND_NAMES; \
+                 it would be silently dropped from cli_usage telemetry"
+            );
+        }
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,7 +31,7 @@ pub mod update;
 pub mod url;
 pub mod worktree;
 
-pub use definition::{Cli, Commands};
+pub use definition::{command_name, Cli, Commands, CLI_COMMAND_NAMES};
 
 use crate::session::Instance;
 use anyhow::{bail, Result};

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,6 +191,21 @@ async fn main() -> Result<()> {
         }
     }
 
+    // Record which CLI subcommand ran for opt-in telemetry, before dispatch so
+    // early-returning commands (e.g. `aoe update`, `aoe telemetry`) are counted
+    // too. A true no-op unless the install is opted in: `track_cli_command`
+    // gates on a non-creating app-dir check first, so app-data-free commands
+    // (`aoe completion`, `aoe init`, ...) never materialize the app dir and keep
+    // working in read-only / sandboxed (Nix) environments. Skipped for the
+    // detached `--daemon-child` re-exec so `aoe serve --daemon` counts the
+    // user's invocation once, not the machinery fork. The once-per-day flush is
+    // bounded so a dead endpoint can never hang the command.
+    if !is_daemon_child {
+        if let Some(name) = cli.command.as_ref().and_then(cli::command_name) {
+            agent_of_empires::telemetry::track_cli_command(name).await;
+        }
+    }
+
     // Handle commands that don't need app data or migrations.
     // These work in read-only/sandboxed environments (e.g. Nix builds).
     match cli.command {
@@ -266,18 +281,6 @@ async fn main() -> Result<()> {
         migrations::run_migrations()?;
     }
 
-    // Whether this invocation is a short-lived CLI command. The long-running
-    // surfaces (TUI, serve) emit their own `process_start` with the correct
-    // surface and run their own snapshot loop, so they're excluded here.
-    #[cfg(feature = "serve")]
-    let cli_oneshot = cli.command.is_some()
-        && !matches!(
-            cli.command,
-            Some(Commands::Serve(_)) | Some(Commands::CockpitRunner(_))
-        );
-    #[cfg(not(feature = "serve"))]
-    let cli_oneshot = cli.command.is_some();
-
     let result = match cli.command {
         Some(Commands::Add(args)) => cli::add::run(&profile, *args).await,
         Some(Commands::List(args)) => cli::list::run(&profile, args).await,
@@ -316,14 +319,6 @@ async fn main() -> Result<()> {
         }
         _ => unreachable!(),
     };
-
-    // Emit `process_start` for a short-lived CLI command AFTER it runs, so the
-    // command's own output isn't delayed. Throttled to once per install per
-    // day and awaited with a hard timeout so a dead endpoint can't hang exit;
-    // a no-op unless the user opted in, so default-off users pay nothing.
-    if cli_oneshot {
-        agent_of_empires::telemetry::flush_cli_process_start().await;
-    }
 
     result
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -91,6 +91,16 @@ pub fn get_app_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
+/// Whether the app data dir already exists, **without** creating it (unlike
+/// [`get_app_dir`], which auto-creates). Lets side-effect-sensitive callers
+/// probe install state cheaply: the per-command telemetry recorder uses it to
+/// stay a true no-op for app-data-free commands (`aoe completion`, `aoe init`,
+/// ...) on an install that is not opted in, so those commands keep working in
+/// read-only / sandboxed (e.g. Nix) environments without materializing the dir.
+pub fn app_dir_exists() -> bool {
+    get_app_dir_path().map(|p| p.exists()).unwrap_or(false)
+}
+
 fn get_app_dir_path() -> Result<PathBuf> {
     #[cfg(target_os = "linux")]
     let dir = dirs::config_dir()

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -10,7 +10,9 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 /// Payload schema version. Bump on any breaking change to the field set.
-pub const SCHEMA_VERSION: u32 = 1;
+/// v2 added the [`CliUsage`] event and retired the `cli`-surface
+/// [`ProcessStart`] in favor of it.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -34,8 +36,11 @@ impl Surface {
     }
 }
 
-/// Emitted once on boot. Captures short-lived invocations that a periodic
-/// snapshot would miss. Carries no session details.
+/// Emitted once on boot by the long-running surfaces (TUI, `aoe serve`).
+/// Captures launches that a periodic snapshot would miss. Carries no session
+/// details. Short-lived `aoe <subcommand>` invocations no longer emit this;
+/// they report through [`CliUsage`] instead, which carries the same
+/// "this install ran the CLI" signal plus the per-command mix.
 #[derive(Debug, Clone, Serialize)]
 pub struct ProcessStart {
     pub schema: u32,
@@ -48,6 +53,39 @@ pub struct ProcessStart {
     pub aoe_version: String,
     pub os: String,
     pub arch: String,
+}
+
+/// Emitted by short-lived `aoe <subcommand>` invocations, throttled to at most
+/// once per install per day. Replaces the `cli`-surface [`ProcessStart`]: a
+/// non-empty `command_counts` carries the same "this install ran the CLI today"
+/// signal, plus which subcommands actually ran and how often.
+///
+/// Counts accumulate on disk across invocations (each `aoe` run is a separate
+/// short-lived process, so there is no in-memory aggregation) and flush as one
+/// POST per day. `command_counts` keys are the closed clap subcommand set
+/// produced by [`crate::cli::command_name`]; they carry no args, flags, or
+/// paths, and every key is filtered against the allowlist before sending, so
+/// the event fits the closed-schema rule.
+#[derive(Debug, Clone, Serialize)]
+pub struct CliUsage {
+    pub schema: u32,
+    /// Always `"cli_usage"`.
+    pub event: &'static str,
+    pub install_id: String,
+    pub sent_at: String,
+    pub surface: Surface,
+    pub aoe_version: String,
+    pub os: String,
+    pub arch: String,
+
+    /// RFC 3339 UTC timestamp of the first command counted in this window. The
+    /// window length varies (a user may run `aoe` once, then again days later),
+    /// so this lets the aggregator compute honest per-day rates rather than
+    /// assuming a fixed 24h window.
+    pub window_start: String,
+    /// Allowlisted clap subcommand name -> invocation count since the last
+    /// confirmed flush (e.g. `{"add": 5, "list": 2}`).
+    pub command_counts: BTreeMap<String, u32>,
 }
 
 /// Emitted by long-running surfaces (TUI, `aoe serve`) on start, then every

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -26,8 +26,10 @@ mod state;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-pub use events::{ProcessStart, Surface, UsageSnapshot, SCHEMA_VERSION};
-pub use state::{cli_process_start_due, install_id, record_cli_process_start, reset_install_id};
+pub use events::{CliUsage, ProcessStart, Surface, UsageSnapshot, SCHEMA_VERSION};
+pub use state::{
+    cli_usage_due, install_id, record_cli_command, record_cli_usage_flush, reset_install_id,
+};
 
 use crate::session::Instance;
 
@@ -52,16 +54,17 @@ const DEFAULT_ENDPOINT: &str = "https://telemetry.agent-of-empires.com/v1/ingest
 /// gateway must be configured to require this exact value.
 const TELEMETRY_KEY: &str = "7bc5a4e45ce861662b9690a7105da988";
 
-/// CLI `process_start` is the only unbounded event source (one per `aoe`
-/// invocation), so it is throttled to at most once per install per day. That
-/// still answers "did this install run the CLI today" without a POST per
-/// command.
-const CLI_PROCESS_START_MIN_GAP: Duration = Duration::from_secs(24 * 60 * 60);
+/// CLI `cli_usage` is the only unbounded event source (one per `aoe`
+/// invocation could accumulate counts), so its flush is throttled to at most
+/// once per install per day. Per-command counts accumulate on disk between
+/// flushes, so a single daily POST still answers "which commands did this
+/// install run" without a POST per command.
+const CLI_USAGE_MIN_GAP: Duration = Duration::from_secs(24 * 60 * 60);
 
-/// Retry backoff after a *failed* CLI `process_start` send. While the daily slot
+/// Retry backoff after a *failed* CLI `cli_usage` send. While the daily slot
 /// stays open (a failed send never claims it), this bounds re-attempts to once
 /// per hour so a down endpoint can't make every `aoe` invocation re-send.
-const CLI_PROCESS_START_RETRY_GAP: Duration = Duration::from_secs(60 * 60);
+const CLI_USAGE_RETRY_GAP: Duration = Duration::from_secs(60 * 60);
 
 /// True when `DO_NOT_TRACK` is set to an affirmative value. This is the
 /// absolute override: it wins over `config.telemetry.enabled`.
@@ -274,38 +277,70 @@ pub fn spawn_process_start(surface: Surface) {
     }
 }
 
-/// Emit a `process_start`, awaiting delivery with a hard timeout so the event
-/// has a chance to flush before the process exits. Returns whether delivery was
-/// *confirmed* (a 2xx), so a throttled caller can defer claiming its slot until
-/// the send actually succeeds. Bounded by the connect and send timeouts, so a
-/// dead endpoint can never hang the caller; a no-op (returns `false`) for the
-/// common default-off (not opted in) case.
-pub async fn flush_process_start(surface: Surface) -> bool {
-    let Some(event) = build_process_start(surface) else {
-        return false;
-    };
-    matches!(
-        tokio::time::timeout(SEND_TIMEOUT, post(&event)).await,
-        Ok(true)
-    )
+/// Build a `cli_usage` event from the accumulated per-command counts, or `None`
+/// when not opted in or there is nothing to report. Every key is filtered
+/// against the closed [`crate::cli::CLI_COMMAND_NAMES`] allowlist, so a
+/// hand-edited or corrupt `telemetry.json` can never smuggle an arbitrary
+/// string onto the wire: the in-process recorder only ever writes allowlisted
+/// names, and this is the defense-in-depth re-check before sending.
+pub fn build_cli_usage() -> Option<CliUsage> {
+    if !is_opted_in() {
+        return None;
+    }
+    let (counts, window_start) = state::cli_usage_window();
+    let command_counts: BTreeMap<String, u32> = counts
+        .into_iter()
+        .filter(|(name, _)| crate::cli::CLI_COMMAND_NAMES.contains(&name.as_str()))
+        .collect();
+    if command_counts.is_empty() {
+        return None;
+    }
+    let install_id = state::ensure_install_id()?;
+    let window_start = window_start
+        .map(|w| w.to_rfc3339())
+        .unwrap_or_else(now_rfc3339);
+    Some(CliUsage {
+        schema: SCHEMA_VERSION,
+        event: "cli_usage",
+        install_id,
+        sent_at: now_rfc3339(),
+        surface: Surface::Cli,
+        aoe_version: env!("CARGO_PKG_VERSION").to_string(),
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        window_start,
+        command_counts,
+    })
 }
 
-/// CLI entrypoint for `process_start`: same as [`flush_process_start`] for the
-/// `cli` surface, but throttled to at most once per install per day so a user
-/// scripting `aoe` in a loop can't flood the endpoint. The daily slot is claimed
-/// only after the send is *confirmed*, so a failed send leaves it open for the
-/// next invocation to retry (bounded by [`CLI_PROCESS_START_RETRY_GAP`] so a down
-/// endpoint can't make every invocation re-send). Nothing touches disk unless
-/// opted in and a send is actually due.
-pub async fn flush_cli_process_start() {
-    if !is_opted_in() {
+/// Record one CLI subcommand invocation and flush the accumulated `cli_usage`
+/// event if a send is due. Called once per `aoe <subcommand>` run.
+///
+/// Side-effect-free unless the install is opted in: the [`app_dir_exists`] gate
+/// is a non-creating check, so app-data-free commands (`aoe completion`,
+/// `aoe init`, ...) on a not-opted-in install never materialize the app dir and
+/// keep working in read-only / sandboxed environments. The daily slot is claimed
+/// only after a *confirmed* send, so a failed send leaves the counts and the slot
+/// intact for the next invocation to retry (bounded by [`CLI_USAGE_RETRY_GAP`]).
+/// Awaited with a hard timeout so a dead endpoint can never hang the CLI's exit.
+pub async fn track_cli_command(name: &str) {
+    // Cheap non-creating gate first: opt-in creates the app dir, so its absence
+    // means the install cannot be opted in, and we must not create it here.
+    if !crate::session::app_dir_exists() || !is_opted_in() {
         return;
     }
-    if !cli_process_start_due(CLI_PROCESS_START_MIN_GAP, CLI_PROCESS_START_RETRY_GAP) {
+    state::record_cli_command(name);
+    if !cli_usage_due(CLI_USAGE_MIN_GAP, CLI_USAGE_RETRY_GAP) {
         return;
     }
-    let confirmed = flush_process_start(Surface::Cli).await;
-    record_cli_process_start(confirmed);
+    let Some(event) = build_cli_usage() else {
+        return;
+    };
+    let confirmed = matches!(
+        tokio::time::timeout(SEND_TIMEOUT, post(&event)).await,
+        Ok(true)
+    );
+    record_cli_usage_flush(confirmed);
 }
 
 /// Fingerprint of the last `usage_snapshot` whose send we initiated this

--- a/src/telemetry/state.rs
+++ b/src/telemetry/state.rs
@@ -130,6 +130,12 @@ pub fn reset_install_id() -> Option<String> {
 /// failure is logged at `debug` and dropped, since the counts are themselves a
 /// best-effort signal. Caller is responsible for the opt-in gate.
 pub fn record_cli_command(name: &str) {
+    // Defense in depth: never persist a name outside the closed clap vocabulary,
+    // so a buggy caller cannot leave an arg or path in telemetry.json.
+    // build_cli_usage filtering only protects the wire, not the on-disk file.
+    if !crate::cli::CLI_COMMAND_NAMES.contains(&name) {
+        return;
+    }
     let mut state = load_state();
     *state
         .cli_command_counts

--- a/src/telemetry/state.rs
+++ b/src/telemetry/state.rs
@@ -8,6 +8,7 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -17,17 +18,38 @@ use crate::session::get_app_dir;
 struct TelemetryState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     install_id: Option<String>,
-    /// Last time a CLI `process_start` was *confirmed delivered*, used to throttle
+    /// Last time a CLI `cli_usage` event was *confirmed delivered*, used to throttle
     /// the one unbounded event source to at most once per install per day. Long-lived
     /// surfaces (TUI / serve) emit once per launch and need no throttle. Only stamped
     /// on a successful send, so a failed send leaves the daily slot open for retry.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    last_cli_process_start: Option<DateTime<Utc>>,
-    /// Last time a CLI `process_start` send was *attempted* (success or failure).
+    /// The `serde(alias)` reads the pre-#1879 field name so an in-place upgrade keeps
+    /// its throttle stamp instead of triggering an immediate flush on every install.
+    #[serde(
+        default,
+        alias = "last_cli_process_start",
+        skip_serializing_if = "Option::is_none"
+    )]
+    last_cli_usage_flush: Option<DateTime<Utc>>,
+    /// Last time a CLI `cli_usage` send was *attempted* (success or failure).
     /// Bounds retries: while the daily slot is open after a failed send, this stops
     /// every `aoe` invocation from re-attempting against a down endpoint.
+    #[serde(
+        default,
+        alias = "last_cli_process_start_attempt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    last_cli_usage_flush_attempt: Option<DateTime<Utc>>,
+    /// Per-subcommand invocation counts accumulated since the last confirmed
+    /// flush. CLI runs are short-lived separate processes, so the mix is
+    /// persisted here rather than aggregated in memory. Reset only on a
+    /// confirmed 2xx send. Keys are the closed clap command set.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    cli_command_counts: BTreeMap<String, u32>,
+    /// When the current count window opened (first command counted since the
+    /// last confirmed flush). Lets the aggregator normalize variable-length
+    /// windows. Set when the first command lands, cleared on a confirmed flush.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    last_cli_process_start_attempt: Option<DateTime<Utc>>,
+    cli_usage_window_start: Option<DateTime<Utc>>,
 }
 
 fn state_path() -> Result<PathBuf> {
@@ -103,14 +125,39 @@ pub fn reset_install_id() -> Option<String> {
     ensure_install_id()
 }
 
-/// Whether a CLI `process_start` send is due. Due when the last *confirmed*
-/// send is older than `success_gap` (or never) AND the last *attempt* is older
-/// than `retry_gap` (or never). `success_gap` is the real once-per-day throttle
-/// that bounds the only unbounded telemetry source; `retry_gap` bounds how often
-/// a failed send is retried so a down endpoint can't turn every `aoe` invocation
+/// Increment the persisted count for one CLI subcommand and open the window if
+/// this is the first command since the last flush. Best-effort: a load/save
+/// failure is logged at `debug` and dropped, since the counts are themselves a
+/// best-effort signal. Caller is responsible for the opt-in gate.
+pub fn record_cli_command(name: &str) {
+    let mut state = load_state();
+    *state
+        .cli_command_counts
+        .entry(name.to_string())
+        .or_insert(0) += 1;
+    if state.cli_usage_window_start.is_none() {
+        state.cli_usage_window_start = Some(Utc::now());
+    }
+    if let Err(e) = save_state(&state) {
+        tracing::debug!(target: "telemetry", "failed to persist cli command count: {e}");
+    }
+}
+
+/// The accumulated command counts and the window-start stamp, for building a
+/// `cli_usage` event. Read-only.
+pub fn cli_usage_window() -> (BTreeMap<String, u32>, Option<DateTime<Utc>>) {
+    let state = load_state();
+    (state.cli_command_counts, state.cli_usage_window_start)
+}
+
+/// Whether a CLI `cli_usage` send is due. Due when the last *confirmed* send is
+/// older than `success_gap` (or never) AND the last *attempt* is older than
+/// `retry_gap` (or never). `success_gap` is the real once-per-day throttle that
+/// bounds the only unbounded telemetry source; `retry_gap` bounds how often a
+/// failed send is retried so a down endpoint can't turn every `aoe` invocation
 /// into a fresh attempt. Caller is responsible for the opt-in gate. Read-only:
-/// the stamps are written by [`record_cli_process_start`] after the send.
-pub fn cli_process_start_due(success_gap: Duration, retry_gap: Duration) -> bool {
+/// the stamps are written by [`record_cli_usage_flush`] after the send.
+pub fn cli_usage_due(success_gap: Duration, retry_gap: Duration) -> bool {
     let state = load_state();
     let now = Utc::now();
     // A stamp is "fresh" when its positive elapsed is still inside the gap. A
@@ -119,21 +166,25 @@ pub fn cli_process_start_due(success_gap: Duration, retry_gap: Duration) -> bool
         Some(last) => matches!((now - last).to_std(), Ok(elapsed) if elapsed < gap),
         None => false,
     };
-    !fresh(state.last_cli_process_start, success_gap)
-        && !fresh(state.last_cli_process_start_attempt, retry_gap)
+    !fresh(state.last_cli_usage_flush, success_gap)
+        && !fresh(state.last_cli_usage_flush_attempt, retry_gap)
 }
 
-/// Record a CLI `process_start` send. Always stamps the attempt (so `retry_gap`
-/// bounds retries); stamps the confirmed-delivery slot only when `success`, so a
-/// failed send leaves the daily slot open for the next invocation to retry.
-pub fn record_cli_process_start(success: bool) {
+/// Record a CLI `cli_usage` send. Always stamps the attempt (so `retry_gap`
+/// bounds retries). On a confirmed delivery it also stamps the daily slot and
+/// clears the accumulated counts + window, so the next window starts fresh; a
+/// failed send leaves the counts and the daily slot intact for the next
+/// invocation to retry, so a transient failure never drops a window.
+pub fn record_cli_usage_flush(success: bool) {
     let mut state = load_state();
     let now = Utc::now();
-    state.last_cli_process_start_attempt = Some(now);
+    state.last_cli_usage_flush_attempt = Some(now);
     if success {
-        state.last_cli_process_start = Some(now);
+        state.last_cli_usage_flush = Some(now);
+        state.cli_command_counts.clear();
+        state.cli_usage_window_start = None;
     }
     if let Err(e) = save_state(&state) {
-        tracing::debug!(target: "telemetry", "failed to persist cli throttle stamp: {e}");
+        tracing::debug!(target: "telemetry", "failed to persist cli usage flush state: {e}");
     }
 }

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -143,12 +143,12 @@ fn snapshot_carries_session_create_count() {
     assert_eq!(some.session_creates_since_last_snapshot, 7);
 }
 
-/// The CLI `process_start` is throttled to once per install per day so a user
+/// The CLI `cli_usage` flush is throttled to once per install per day so a user
 /// scripting `aoe` in a loop can't flood the endpoint: a send is due first, then
 /// not due once a confirmed send claims the daily slot.
 #[test]
 #[serial]
-fn cli_process_start_throttled_to_once_per_window() {
+fn cli_usage_flush_throttled_to_once_per_window() {
     let _tmp = isolate();
     set_enabled(true);
     telemetry::apply_opt_in_change(true);
@@ -156,29 +156,29 @@ fn cli_process_start_throttled_to_once_per_window() {
     let day = std::time::Duration::from_secs(24 * 60 * 60);
     let hour = std::time::Duration::from_secs(60 * 60);
     assert!(
-        telemetry::cli_process_start_due(day, hour),
+        telemetry::cli_usage_due(day, hour),
         "first send in the window should be due"
     );
     // A confirmed send claims the daily slot.
-    telemetry::record_cli_process_start(true);
+    telemetry::record_cli_usage_flush(true);
     assert!(
-        !telemetry::cli_process_start_due(day, hour),
+        !telemetry::cli_usage_due(day, hour),
         "within the day, no further send is due after a confirmed send"
     );
     // Zero gaps always re-grant (every stamp is always older than zero).
-    assert!(telemetry::cli_process_start_due(
+    assert!(telemetry::cli_usage_due(
         std::time::Duration::ZERO,
         std::time::Duration::ZERO
     ));
 }
 
-/// User story (#1875): when a CLI `process_start` send fails, the daily throttle
+/// User story (#1875): when a CLI `cli_usage` send fails, the daily throttle
 /// slot is NOT consumed, so the next invocation retries instead of losing the
 /// whole day to one transient failure. The retry gap still bounds how often the
 /// failed send is re-attempted.
 #[test]
 #[serial]
-fn failed_cli_process_start_leaves_daily_slot_open() {
+fn failed_cli_usage_flush_leaves_daily_slot_open() {
     let _tmp = isolate();
     set_enabled(true);
     telemetry::apply_opt_in_change(true);
@@ -187,24 +187,110 @@ fn failed_cli_process_start_leaves_daily_slot_open() {
     let hour = std::time::Duration::from_secs(60 * 60);
 
     // Simulate a failed send: it stamps the attempt but never claims the slot.
-    telemetry::record_cli_process_start(false);
+    telemetry::record_cli_usage_flush(false);
 
     // The retry gap blocks an immediate re-attempt against a still-down endpoint.
     assert!(
-        !telemetry::cli_process_start_due(day, hour),
+        !telemetry::cli_usage_due(day, hour),
         "retry gap must block an immediate re-attempt after a failed send"
     );
     // But the daily slot is still open: once the retry gap elapses, a send is due
     // again, unlike the old behaviour that lost the whole day on one failure.
     assert!(
-        telemetry::cli_process_start_due(day, std::time::Duration::ZERO),
+        telemetry::cli_usage_due(day, std::time::Duration::ZERO),
         "a failed send must leave the daily slot open for retry"
     );
 }
 
-/// An unreachable / slow endpoint must never block the CLI: `flush_process_start`
-/// is bounded and returns well within the timeout even when the endpoint
-/// black-holes the connection.
+/// User story (#1879, maintainer): when an opted-in install runs several CLI
+/// subcommands, the `cli_usage` event reflects the full mix (with repeats),
+/// not just the first command of the day.
+#[test]
+#[serial]
+fn cli_usage_records_each_subcommand() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    telemetry::record_cli_command("add");
+    telemetry::record_cli_command("session");
+    telemetry::record_cli_command("add");
+
+    let event = telemetry::build_cli_usage().expect("event built when opted in with counts");
+    assert_eq!(event.event, "cli_usage");
+    assert_eq!(event.surface, telemetry::Surface::Cli);
+    assert_eq!(event.command_counts.get("add"), Some(&2));
+    assert_eq!(event.command_counts.get("session"), Some(&1));
+    assert_eq!(event.command_counts.len(), 2);
+    assert!(!event.window_start.is_empty());
+
+    // A confirmed flush resets the window so the next event starts fresh.
+    telemetry::record_cli_usage_flush(true);
+    assert!(
+        telemetry::build_cli_usage().is_none(),
+        "counts must reset after a confirmed flush"
+    );
+}
+
+/// User story (#1879, privacy): a reported command is an allowlisted command
+/// name with no args, paths, or flags. The builder filters any key that is not
+/// in the closed clap vocabulary, so a corrupt/hand-edited `telemetry.json`
+/// cannot smuggle arbitrary strings onto the wire.
+#[test]
+#[serial]
+fn cli_usage_drops_non_allowlisted_keys() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    telemetry::record_cli_command("add");
+    // A key that is not a real clap command (as if injected into the state file).
+    telemetry::record_cli_command("/home/me/secret-project");
+
+    let event = telemetry::build_cli_usage().expect("event built");
+    assert_eq!(event.command_counts.get("add"), Some(&1));
+    for key in event.command_counts.keys() {
+        assert!(
+            agent_of_empires::cli::CLI_COMMAND_NAMES.contains(&key.as_str()),
+            "non-allowlisted key `{key}` leaked into command_counts"
+        );
+        assert!(
+            key.bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_'),
+            "key `{key}` is not an identifier-safe token"
+        );
+    }
+    let serialized = serde_json::to_string(&event).expect("serialize");
+    assert!(!serialized.contains("secret-project"));
+}
+
+/// User story (#1879, opted-out): when telemetry is off, recording a CLI command
+/// builds nothing and the no-op recorder never materializes the app dir.
+#[test]
+#[serial]
+fn cli_usage_default_off_records_nothing() {
+    let _tmp = isolate();
+    assert!(!telemetry::is_opted_in());
+    assert!(
+        telemetry::build_cli_usage().is_none(),
+        "no event when not opted in"
+    );
+
+    // The per-command tracker is a true no-op for a not-opted-in install: it must
+    // not create the app dir (so app-data-free commands stay pure) and must not
+    // record or send anything.
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(telemetry::track_cli_command("add"));
+    assert!(
+        !agent_of_empires::session::app_dir_exists(),
+        "tracking must not create the app dir when not opted in"
+    );
+    assert!(telemetry::build_cli_usage().is_none());
+}
+
+/// An unreachable / slow endpoint must never block the CLI: `track_cli_command`
+/// (the per-invocation recorder + flush) is bounded and returns well within the
+/// timeout even when the endpoint black-holes the connection.
 #[test]
 #[serial]
 fn unreachable_endpoint_never_blocks() {
@@ -217,11 +303,13 @@ fn unreachable_endpoint_never_blocks() {
 
     let rt = tokio::runtime::Runtime::new().expect("runtime");
     let start = std::time::Instant::now();
-    rt.block_on(telemetry::flush_process_start(Surface::Cli));
+    // Records "add" then flushes (due on a fresh install) against the dead
+    // endpoint; the send is bounded so this returns fast.
+    rt.block_on(telemetry::track_cli_command("add"));
     let elapsed = start.elapsed();
     assert!(
         elapsed < std::time::Duration::from_secs(5),
-        "flush_process_start blocked for {elapsed:?}; must be bounded"
+        "track_cli_command blocked for {elapsed:?}; must be bounded"
     );
 
     unsafe { std::env::remove_var("AOE_TELEMETRY_ENDPOINT") };


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to #1863. A short-lived `aoe <subcommand>` only emitted `process_start{surface=cli}`, throttled to once per install per day, so telemetry could see "this install ran the CLI today" but not *which* subcommand ran, nor the mix. That left the core product question (which CLI commands matter) unanswerable.

This adds a new `cli_usage` event that replaces the cli-surface `process_start`. Each `aoe` run is a separate short-lived process, so per-subcommand counts accumulate on disk in `telemetry.json` and flush as **one POST per install per day**, carrying a `command_counts` map (e.g. `{add: 5, list: 2}`) plus a `window_start` stamp so the aggregator can normalize variable-length windows. A non-empty `cli_usage` carries the same "ran the CLI" signal the old event did, plus the breakdown. `SCHEMA_VERSION` bumps to 2. The TUI / `serve` `process_start` is untouched.

Key design points:
- **Closed vocabulary.** `command_name()` is an exhaustive, catch-all-free match over the clap `Commands` enum, returning identifier-safe `snake_case` tokens (`log_level`, not kebab `log-level`, since the gateway drops hyphenated map keys). Adding a subcommand fails to compile until it is named, so the telemetry vocabulary can never silently drift. Hidden machine commands (`__cockpit-runner`, `__extract-session-id`) return `None` and are never counted.
- **Every user subcommand is counted**, including the early-returning ones (`update`, `telemetry`, ...) and `serve`. Recording happens before dispatch; the detached `serve --daemon-child` re-exec is skipped so `aoe serve --daemon` counts the invocation once.
- **Stays pure when not opted in.** `track_cli_command` gates on a new non-creating `session::app_dir_exists()` check before touching config or state, so app-data-free commands (`aoe completion`, `aoe init`, ...) never materialize the app dir and keep working in read-only / sandboxed (Nix) environments.
- **No data loss on failure.** Counts and the daily slot reset only on a confirmed 2xx (reusing the #1875 `is_success` gate); a transient failure retains the window for the next invocation. Renamed throttle stamps keep a `serde(alias)` so an in-place upgrade preserves them (no thundering-herd of flushes).
- **Privacy, three layers.** Only allowlisted names are ever recorded in-process; `build_cli_usage` re-filters keys against `CLI_COMMAND_NAMES` before sending (so a hand-edited / corrupt `telemetry.json` can't smuggle a path); the gateway re-sanitizes as a backstop. No args, flags, or paths are ever attached.

**Telemetry gateway:** no changes needed in `aoe-telemetry`. The gateway's `extra="allow"` envelope and permissive map sanitizer forward a new `cli_usage` event with a shallow identifier-keyed integer map and the `window_start` string as-is (verified against `app/schema.py`, `app/privacy.py`, `app/main.py`). This lands entirely in `agent-of-empires`.

Known gaps, all pre-accepted by the issue and tracked elsewhere: idempotency / double-count on an ambiguous send (#1873, no `uuid` yet); the `telemetry.json` read-modify-write race (#1877); and the trailing window (counts after the last-ever invocation never flush, matching today's best-effort model).

Closes #1879

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] With telemetry opted in and `AOE_TELEMETRY_ENDPOINT` pointed at a local sink, run `aoe list` then `aoe status`; confirm a single `cli_usage` POST within the day carries `command_counts: {list: 1, status: 1}` and a `surface: cli`.
- [ ] Run the same command twice more across the day; confirm the daily throttle holds (no second POST) while counts keep accumulating on disk in `telemetry.json`.
- [ ] Point the endpoint at a black-holed address and confirm the command still exits promptly (bounded send) and the counts are retained, not dropped.
- [ ] With telemetry **off**, run any `aoe` subcommand and confirm nothing is recorded or sent, and `aoe completion zsh` still works with no app dir created.
- [ ] Confirm a hidden command (`aoe __extract-session-id`) is never counted.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test: `tests/telemetry.rs` covers the #1879 user stories (subcommand mix recorded, allowlisted/identifier-safe keys with non-allowlisted keys dropped, opted-out no-op without materializing the app dir), plus a `src/cli/definition.rs` unit test for `command_name`. These exercise the recorder/builder directly rather than driving the full binary, which is the deterministic layer for this logic.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction (with a `/debate` consult on the design). I made the design calls, reviewed each commit, and own the testing steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR introduces privacy-preserving, per-subcommand CLI telemetry via a new cli_usage event and replaces the prior short-lived CLI process_start reporting for short-lived aoe subcommands. The CLI now accumulates allowlisted subcommand invocation counts locally per-install per-day, and sends one aggregated report (command_counts map + window_start) once per day; failed sends are retried and do not clear local counts. Hidden/internal commands and all args/flags/paths are never recorded; telemetry-disabled installs do not create app data or send events. Tests were added to ensure allowlist coverage, aggregation, retry behavior, and opt-out purity.

### What changed (non-technical)
- Track which visible CLI subcommands are used (counts per subcommand) and report them as a single daily aggregate.
- Replace short-lived CLI process_start reporting with cli_usage for short-lived invocations; process_start remains for long-running surfaces (TUI/serve).
- Only allowlisted subcommand tokens are recorded/sent; hidden/internal commands are excluded.
- Preserve opt-out: no app data is created and no telemetry is recorded/sent when telemetry is disabled.
- Added tests to cover aggregation, allowlist exhaustivity, retry semantics, and opted-out behavior.

### Notable technical additions
- New telemetry event: CliUsage with schema version bumped (events.rs: SCHEMA_VERSION = 6). Fields include window_start and command_counts: BTreeMap<String,u32>.
- CLI allowlist and mapping: CLI_COMMAND_NAMES constant and command_name(&Commands) -> Option<&'static str> that converts clap Commands to identifier-safe snake_case tokens; hidden commands return None.
- Persistence and APIs: per-subcommand counters and cli_usage_window_start persisted in telemetry.json; new state APIs record_cli_command, cli_usage_window, cli_usage_due, and record_cli_usage_flush(success).
- Recording flow: telemetry::track_cli_command(name) records counts (only if app_dir_exists() and opted-in), builds the CliUsage via build_cli_usage() (re-filtering keys through CLI_COMMAND_NAMES), posts with a timeout, and only clears local counts on confirmed 2xx responses.
- Main integration: command tracking invoked before dispatch in main so short-lived subcommands are counted; daemon-child re-execified runs are skipped.
- Backoff/throttling: daily send window with an hourly retry gap on failure.
- Tests: exhaustive allowlist test (fail build if a visible subcommand is missing), aggregation and reset tests, non-allowlist drop tests, opt-out no-op test, and throttling/retry tests.

### Removed / changed behavior
- Removed CLI short-lived process_start reservation/flush logic; process_start still exists for long-lived surfaces.
- Telemetry module reworked to shift CLI throttling from process_start to cli_usage semantics.

### Benefits
- Privacy-first: only a closed, allowlisted set of command tokens is reported; no arguments, flags, or file paths are recorded.
- Lower telemetry volume: one per-install daily aggregate reduces POST frequency and exposure.
- Resilient: failed sends do not consume the daily slot and counts persist until a confirmed successful send.
- Accurate: early recording ensures short-lived CLI runs are captured.
- Build-time safety: exhaustive allowlist test prevents silent omissions of visible subcommands.

### Known gaps tracked separately
- Idempotency / double-send handling (`#1873`).
- telemetry.json read-modify-write race conditions (`#1877`).
- Trailing-window flush edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->