### PR TITLE
feat(telemetry): report data-schema version and update staleness

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -12,8 +12,9 @@ Only when you opt in, and only aggregate counts. Two event kinds, both with a
 closed, versioned schema (see `src/telemetry/events.rs`):
 
 - **`process_start`** on boot: surface (`cli` / `tui` / `serve`), aoe version,
-  OS, and CPU arch. The `cli` surface is throttled to at most once per install
-  per day, so scripting `aoe` in a loop never floods the endpoint.
+  OS, CPU arch, and the version-health signals (see "Version health" below). The
+  `cli` surface is throttled to at most once per install per day, so scripting
+  `aoe` in a loop never floods the endpoint.
 - **`usage_snapshot`** from the TUI and `aoe serve`, on start and then every
   ~12 hours. It is a point-in-time summary of the current install, never a
   stream of actions:
@@ -24,7 +25,29 @@ closed, versioned schema (see `src/telemetry/events.rs`):
     short-lived sessions that start and end between two snapshots are still
     counted (populated by `aoe serve`; the TUI reports `0`),
   - which opt-in features are turned on (see "Feature flags" below),
-  - whether the web dashboard / cockpit was opened since the last snapshot.
+  - whether the web dashboard / cockpit was opened since the last snapshot,
+  - the same version-health signals carried on `process_start` (see below).
+
+### Version health
+
+Both events carry three coarse version-health fields so the maintainers can see
+whether the install base is on recent, patched versions and how large the
+backward-compat support burden is. None of them is a version string:
+
+- `data_schema_version`: a small integer, the data-schema version this build
+  targets (`migrations::CURRENT_VERSION`). Successful installs converge to it on
+  startup, since a failed migration aborts boot.
+- `update_status`: a coarse semver-distance bucket from the local update check,
+  one of `unknown` / `current` / `patch_behind` / `minor_behind` / `major_behind`.
+  `unknown` means no update check has been cached yet; it is never reported as
+  `current`.
+- `update_releases_behind`: how many cached releases are newer than the running
+  build, one of `unknown` / `current` / `one_behind` / `several_behind`. Counted
+  from the cached release list, so a fallback cache that only knows the latest
+  release reports the conservative `one_behind`.
+
+Both update fields are read from the local update-check cache; they never trigger
+a network call and never include the latest version number, only the coarse gap.
 
 In practice that is a handful of small (well under 1 KB) requests per active
 install per day. There is no offline buffering, so a flaky network drops events

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -92,6 +92,14 @@ const MIGRATIONS: &[Migration] = &[
     },
 ];
 
+/// The data-schema version this build targets, i.e. the version every install
+/// converges to after a successful startup (migration failures abort boot, so a
+/// running install is always at this version). Surfaced in telemetry as a coarse
+/// version-health signal; see `crate::telemetry`.
+pub fn current_schema_version() -> u32 {
+    CURRENT_VERSION
+}
+
 /// Check whether there are any pending migrations to run.
 pub fn has_pending_migrations() -> bool {
     get_current_version() < CURRENT_VERSION

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -10,7 +10,10 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 /// Payload schema version. Bump on any breaking change to the field set.
-pub const SCHEMA_VERSION: u32 = 1;
+///
+/// v2: added version-health fields (`data_schema_version`, `update_status`,
+/// `update_releases_behind`) to both events. See issue #1887.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -48,6 +51,14 @@ pub struct ProcessStart {
     pub aoe_version: String,
     pub os: String,
     pub arch: String,
+
+    /// On-disk data-schema version this build targets (`migrations::CURRENT_VERSION`).
+    /// A small integer, never a version string.
+    pub data_schema_version: u32,
+    /// Coarse update-staleness by semver distance, from the cached update check.
+    pub update_status: crate::update::UpdateStatus,
+    /// Coarse "how many releases behind", counted from the cached release list.
+    pub update_releases_behind: crate::update::ReleasesBehind,
 }
 
 /// Emitted by long-running surfaces (TUI, `aoe serve`) on start, then every
@@ -65,6 +76,14 @@ pub struct UsageSnapshot {
     pub aoe_version: String,
     pub os: String,
     pub arch: String,
+
+    /// On-disk data-schema version this build targets (`migrations::CURRENT_VERSION`).
+    /// A small integer, never a version string.
+    pub data_schema_version: u32,
+    /// Coarse update-staleness by semver distance, from the cached update check.
+    pub update_status: crate::update::UpdateStatus,
+    /// Coarse "how many releases behind", counted from the cached release list.
+    pub update_releases_behind: crate::update::ReleasesBehind,
 
     pub session_total: u32,
     pub session_running: u32,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -119,6 +119,8 @@ pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
         return None;
     }
     let install_id = state::ensure_install_id()?;
+    let (update_status, update_releases_behind) =
+        crate::update::cached_version_health(env!("CARGO_PKG_VERSION"));
     Some(ProcessStart {
         schema: SCHEMA_VERSION,
         event: "process_start",
@@ -128,6 +130,9 @@ pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
         aoe_version: env!("CARGO_PKG_VERSION").to_string(),
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
+        data_schema_version: crate::migrations::current_schema_version(),
+        update_status,
+        update_releases_behind,
     })
 }
 
@@ -198,6 +203,8 @@ pub fn build_usage_snapshot(
             .or_insert(0) += 1;
     }
 
+    let (update_status, update_releases_behind) =
+        crate::update::cached_version_health(env!("CARGO_PKG_VERSION"));
     Some(UsageSnapshot {
         schema: SCHEMA_VERSION,
         event: "usage_snapshot",
@@ -207,6 +214,9 @@ pub fn build_usage_snapshot(
         aoe_version: env!("CARGO_PKG_VERSION").to_string(),
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
+        data_schema_version: crate::migrations::current_schema_version(),
+        update_status,
+        update_releases_behind,
         session_total: instances.len() as u32,
         session_running: running,
         session_idle: idle,
@@ -459,6 +469,9 @@ mod tests {
             aoe_version: "0.0.0".to_string(),
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
+            data_schema_version: 11,
+            update_status: crate::update::UpdateStatus::Current,
+            update_releases_behind: crate::update::ReleasesBehind::Current,
             session_total: 7,
             session_running: 1,
             session_idle: 6,

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -44,6 +44,42 @@ pub struct UpdateInfo {
     pub latest_version: String,
 }
 
+/// Coarse update-staleness signal by semver distance, derived from the cached
+/// update check. Carries no raw version string, only the magnitude of the gap,
+/// so telemetry can answer "are installs on patched/recent versions" without
+/// leaking which version anyone runs. See `crate::telemetry`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateStatus {
+    /// No usable cache (never checked, or a malformed/unparsable cached latest).
+    Unknown,
+    /// The cached latest is not newer than the running build.
+    Current,
+    /// Behind by a patch only (major and minor match).
+    PatchBehind,
+    /// Behind by a minor (major matches).
+    MinorBehind,
+    /// Behind by a major.
+    MajorBehind,
+}
+
+/// Coarse "how many releases behind" signal, counted from the cached release
+/// list. Complements [`UpdateStatus`]: a `major_behind` + `one_behind` pair
+/// reveals a thin/fallback cache that only fetched the latest release, while
+/// `minor_behind` + `several_behind` is a genuinely lagging install.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleasesBehind {
+    /// No cache to count from.
+    Unknown,
+    /// On the cached latest.
+    Current,
+    /// Exactly one cached release is newer (or the cache only knows the latest).
+    OneBehind,
+    /// Two or more cached releases are newer.
+    SeveralBehind,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseInfo {
     pub version: String,
@@ -225,11 +261,8 @@ fn filter_releases(releases: Vec<ReleaseInfo>, from_version: Option<&str>) -> Ve
 }
 
 pub(crate) fn is_newer_version(latest: &str, current: &str) -> bool {
-    let parse_version =
-        |v: &str| -> Vec<u32> { v.split('.').filter_map(|s| s.parse().ok()).collect() };
-
-    let latest_parts = parse_version(latest);
-    let current_parts = parse_version(current);
+    let latest_parts = version_parts(latest);
+    let current_parts = version_parts(current);
 
     for i in 0..latest_parts.len().max(current_parts.len()) {
         let l = latest_parts.get(i).copied().unwrap_or(0);
@@ -242,6 +275,78 @@ pub(crate) fn is_newer_version(latest: &str, current: &str) -> bool {
         }
     }
     false
+}
+
+fn version_parts(v: &str) -> Vec<u32> {
+    v.split('.').filter_map(|s| s.parse().ok()).collect()
+}
+
+/// Classify the semver distance between the running build and a cached latest.
+/// Pure (no I/O) so the bucketing is unit-testable without app-dir/env coupling.
+/// An empty or unparsable cached latest is [`UpdateStatus::Unknown`], never
+/// silently treated as `Current`.
+fn classify_update_status(current: &str, cached_latest: Option<&str>) -> UpdateStatus {
+    let Some(latest) = cached_latest.map(str::trim).filter(|s| !s.is_empty()) else {
+        return UpdateStatus::Unknown;
+    };
+    let latest_parts = version_parts(latest);
+    if latest_parts.is_empty() {
+        return UpdateStatus::Unknown;
+    }
+    if !is_newer_version(latest, current) {
+        return UpdateStatus::Current;
+    }
+    let current_parts = version_parts(current);
+    let part = |parts: &[u32], i: usize| parts.get(i).copied().unwrap_or(0);
+    if part(&latest_parts, 0) > part(&current_parts, 0) {
+        UpdateStatus::MajorBehind
+    } else if part(&latest_parts, 1) > part(&current_parts, 1) {
+        UpdateStatus::MinorBehind
+    } else {
+        UpdateStatus::PatchBehind
+    }
+}
+
+/// Classify how many cached releases are newer than the running build. Pure (no
+/// I/O). When the cached latest is newer but the release list does not enumerate
+/// it (an old or fallback cache that only stored the latest), reports the
+/// conservative [`ReleasesBehind::OneBehind`] rather than overstating the depth.
+fn classify_releases_behind(
+    current: &str,
+    cached_latest: Option<&str>,
+    releases: &[ReleaseInfo],
+) -> ReleasesBehind {
+    let Some(latest) = cached_latest.map(str::trim).filter(|s| !s.is_empty()) else {
+        return ReleasesBehind::Unknown;
+    };
+    if version_parts(latest).is_empty() {
+        return ReleasesBehind::Unknown;
+    }
+    if !is_newer_version(latest, current) {
+        return ReleasesBehind::Current;
+    }
+    let newer = releases
+        .iter()
+        .filter(|r| is_newer_version(&r.version, current))
+        .count();
+    if newer >= 2 {
+        ReleasesBehind::SeveralBehind
+    } else {
+        ReleasesBehind::OneBehind
+    }
+}
+
+/// Read the cached update check (no network) and classify both version-health
+/// signals in one pass. Returns [`UpdateStatus::Unknown`] / [`ReleasesBehind::Unknown`]
+/// when no cache exists. Used by telemetry; the opt-in gate is the caller's job.
+pub fn cached_version_health(current: &str) -> (UpdateStatus, ReleasesBehind) {
+    let cache = load_cache();
+    let latest = cache.as_ref().map(|c| c.latest_version.as_str());
+    let releases: &[ReleaseInfo] = cache.as_ref().map(|c| c.releases.as_slice()).unwrap_or(&[]);
+    (
+        classify_update_status(current, latest),
+        classify_releases_behind(current, latest, releases),
+    )
 }
 
 pub async fn print_update_notice() {
@@ -356,6 +461,57 @@ mod tests {
         let filtered = filter_releases(releases.clone(), Some("0.3.0"));
 
         assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn test_classify_update_status_buckets_by_semver_distance() {
+        use UpdateStatus::*;
+        // No cache / empty / unparsable latest => Unknown, never Current.
+        assert_eq!(classify_update_status("1.2.3", None), Unknown);
+        assert_eq!(classify_update_status("1.2.3", Some("")), Unknown);
+        assert_eq!(classify_update_status("1.2.3", Some("   ")), Unknown);
+        assert_eq!(classify_update_status("1.2.3", Some("garbage")), Unknown);
+        // Latest not newer => Current.
+        assert_eq!(classify_update_status("1.2.3", Some("1.2.3")), Current);
+        assert_eq!(classify_update_status("1.2.3", Some("1.2.0")), Current);
+        // Distance buckets.
+        assert_eq!(classify_update_status("1.2.3", Some("1.2.4")), PatchBehind);
+        assert_eq!(classify_update_status("1.2.3", Some("1.3.0")), MinorBehind);
+        assert_eq!(classify_update_status("1.2.3", Some("2.0.0")), MajorBehind);
+    }
+
+    #[test]
+    fn test_classify_releases_behind_counts_cached_releases() {
+        use ReleasesBehind::*;
+        let releases = vec![
+            make_release("1.3.0"),
+            make_release("1.2.5"),
+            make_release("1.2.3"),
+            make_release("1.2.0"),
+        ];
+        // No cache => Unknown.
+        assert_eq!(classify_releases_behind("1.2.3", None, &[]), Unknown);
+        // Latest not newer => Current.
+        assert_eq!(
+            classify_releases_behind("1.3.0", Some("1.3.0"), &releases),
+            Current
+        );
+        // Two cached releases newer than 1.2.3 (1.3.0, 1.2.5) => SeveralBehind.
+        assert_eq!(
+            classify_releases_behind("1.2.3", Some("1.3.0"), &releases),
+            SeveralBehind
+        );
+        // Exactly one newer => OneBehind.
+        assert_eq!(
+            classify_releases_behind("1.2.5", Some("1.3.0"), &releases),
+            OneBehind
+        );
+        // Thin/fallback cache: latest newer but list does not enumerate it =>
+        // conservative OneBehind, not overstated.
+        assert_eq!(
+            classify_releases_behind("1.2.3", Some("9.9.9"), &[]),
+            OneBehind
+        );
     }
 
     #[test]

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -7,6 +7,7 @@
 
 use agent_of_empires::session::{save_config, Config, Instance};
 use agent_of_empires::telemetry::{self, Surface};
+use agent_of_empires::update::{ReleasesBehind, UpdateStatus};
 use serial_test::serial;
 
 /// Redirect the app dir at a temp location and clear the telemetry-related env
@@ -26,6 +27,27 @@ fn set_enabled(enabled: bool) {
     let mut config = Config::load_or_warn();
     config.telemetry.enabled = enabled;
     save_config(&config).expect("save config");
+}
+
+/// Write a synthetic update-check cache into the isolated app dir so the
+/// version-health classifiers have deterministic input (no network). `releases`
+/// is newest-first, matching what the updater stores.
+fn write_update_cache(latest: &str, releases: &[&str]) {
+    let dir = agent_of_empires::session::get_app_dir().expect("app dir");
+    let releases_json: Vec<_> = releases
+        .iter()
+        .map(|v| serde_json::json!({ "version": v, "body": "", "published_at": null }))
+        .collect();
+    let cache = serde_json::json!({
+        "checked_at": "2026-06-03T00:00:00Z",
+        "latest_version": latest,
+        "releases": releases_json,
+    });
+    std::fs::write(
+        dir.join("update_cache.json"),
+        serde_json::to_string(&cache).expect("serialize cache"),
+    )
+    .expect("write update cache");
 }
 
 /// Default-off must hold: a fresh install reports no opt-in, no install id,
@@ -225,4 +247,107 @@ fn unreachable_endpoint_never_blocks() {
     );
 
     unsafe { std::env::remove_var("AOE_TELEMETRY_ENDPOINT") };
+}
+
+/// User story (#1887): an opted-in install reports its data-schema version on
+/// `process_start` (covers all surfaces, including CLI-only installs). It is the
+/// build's `migrations::CURRENT_VERSION`, a small integer.
+#[test]
+#[serial]
+fn process_start_carries_data_schema_version() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let event = telemetry::build_process_start(Surface::Cli).expect("event built when opted in");
+    assert_eq!(
+        event.data_schema_version,
+        agent_of_empires::migrations::current_schema_version()
+    );
+    // With no update cache yet, staleness is Unknown, never a false "current".
+    assert_eq!(event.update_status, UpdateStatus::Unknown);
+    assert_eq!(event.update_releases_behind, ReleasesBehind::Unknown);
+}
+
+/// User story (#1887): when the cached update check shows a newer release, both
+/// events reflect the staleness buckets. A latest far above any real build is
+/// `major_behind`; two cached newer releases is `several_behind`, one is
+/// `one_behind`.
+#[test]
+#[serial]
+fn version_health_reflects_cached_update() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    // Two cached releases newer than any plausible current build.
+    write_update_cache("9999.0.0", &["9999.0.0", "9998.0.0"]);
+    let snapshot = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 0)
+        .expect("snapshot built when opted in");
+    assert_eq!(snapshot.update_status, UpdateStatus::MajorBehind);
+    assert_eq!(
+        snapshot.update_releases_behind,
+        ReleasesBehind::SeveralBehind
+    );
+
+    let event = telemetry::build_process_start(Surface::Cli).expect("event built when opted in");
+    assert_eq!(event.update_status, UpdateStatus::MajorBehind);
+    assert_eq!(event.update_releases_behind, ReleasesBehind::SeveralBehind);
+
+    // Exactly one cached newer release is one_behind.
+    write_update_cache("9999.0.0", &["9999.0.0"]);
+    let snapshot = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 0)
+        .expect("snapshot built when opted in");
+    assert_eq!(snapshot.update_releases_behind, ReleasesBehind::OneBehind);
+}
+
+/// User story (#1887, privacy reviewer): version-health signals leave the client
+/// only as a small integer and coarse bucket strings. The raw cached "latest"
+/// version string is never serialized into either event.
+#[test]
+#[serial]
+fn version_health_never_leaks_version_string() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let secret_latest = "9999.1234.5678";
+    write_update_cache(secret_latest, &[secret_latest]);
+
+    let snapshot = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 0)
+        .expect("snapshot built when opted in");
+    let event = telemetry::build_process_start(Surface::Tui).expect("event built when opted in");
+
+    for serialized in [
+        serde_json::to_string(&snapshot).expect("serialize snapshot"),
+        serde_json::to_string(&event).expect("serialize process_start"),
+    ] {
+        assert!(
+            !serialized.contains(secret_latest),
+            "raw cached latest version leaked into payload: {serialized}"
+        );
+        assert!(
+            !serialized.contains("1234"),
+            "a fragment of the cached version leaked: {serialized}"
+        );
+        // Only the coarse bucket leaves the client.
+        assert!(
+            serialized.contains("major_behind"),
+            "expected the coarse staleness bucket in the payload: {serialized}"
+        );
+    }
+}
+
+/// User story (#1887, opted-out): even with an update cache present and a schema
+/// version on disk, nothing is built or sent when the user has not opted in.
+#[test]
+#[serial]
+fn opted_out_emits_nothing_even_with_version_health_available() {
+    let _tmp = isolate();
+    // Cache present, but telemetry left at its default-off state.
+    write_update_cache("9999.0.0", &["9999.0.0", "9998.0.0"]);
+
+    assert!(!telemetry::is_opted_in());
+    assert!(telemetry::build_process_start(Surface::Cli).is_none());
+    assert!(telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 0).is_none());
 }

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -326,8 +326,10 @@ fn version_health_never_leaks_version_string() {
             !serialized.contains(secret_latest),
             "raw cached latest version leaked into payload: {serialized}"
         );
+        // A dotted fragment, so it can never collide with the dashless hex
+        // install-id UUID (nor with any bucket string).
         assert!(
-            !serialized.contains("1234"),
+            !serialized.contains("1234.5678"),
             "a fragment of the cached version leaked: {serialized}"
         );
         // Only the coarse bucket leaves the client.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds two privacy-safe version-health signals to the anonymous, opt-in telemetry so the maintainers can answer "are installs on patched/recent versions" and "how big is the backward-compat support burden" without leaking any version string beyond the existing `aoe_version`.

Both events (`process_start` and `usage_snapshot`) now carry three new fields:

- `data_schema_version` (u32): the data-schema version this build targets (`migrations::CURRENT_VERSION`). A failed migration aborts boot, so any running install has converged to it; sending it gives the schema-version distribution without the backend maintaining a version-to-schema map.
- `update_status` (enum): coarse semver-distance bucket from the local update cache, one of `unknown` / `current` / `patch_behind` / `minor_behind` / `major_behind`. `unknown` means no update check has been cached yet and is never reported as `current`.
- `update_releases_behind` (enum): how many cached releases are newer than the running build, one of `unknown` / `current` / `one_behind` / `several_behind`. Counted from the cached release list, so a fallback cache that only knows the latest release reports the conservative `one_behind`.

Both staleness fields read the existing local update-check cache (`update_cache.json`); they never trigger a network call and never include the latest version number, only the coarse gap. Cross-referencing the two reveals cache shape too: `major_behind` + `one_behind` is a thin/fallback cache, `minor_behind` + `several_behind` is a genuinely lagging install. Computation happens only after the opt-in gate, so an opted-out or `DO_NOT_TRACK` install builds and sends nothing.

The fields land on both events on purpose: each event stays self-contained (robust to a dropped `process_start`), and putting them on `process_start` covers CLI-only installs too. `SCHEMA_VERSION` is bumped 1 -> 2.

The choice of the const `migrations::CURRENT_VERSION` over the on-disk `.schema_version`, and a coarse bucket over a bare bool, came out of a `/debate` design pass: under fail-hard migration boot the on-disk value always equals the const for any emitting install, and a bare bool conflates "current" with "never checked".

**Telemetry gateway:** no change needed in `aoe-telemetry`. Its envelope is `extra="allow"` and the sanitizer forwards any number, boolean, or short identifier-string property untouched, so a `u32` and snake_case bucket strings flow through with no collector/ingest edit. (The gateway's `docs/SCHEMA.md` conventional-properties list could be refreshed for hygiene, but that is a separate repo and not required for this to work.)

**PostHog dashboard:** the "aoe usage (v2)" dashboard (1662307) gets new version-health tiles, each tile description naming this PR. They populate once telemetry v2 ships.

Closes #1887

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Enable telemetry (`aoe telemetry enable`), point `AOE_TELEMETRY_ENDPOINT` at a local sink, run `aoe` and confirm `process_start` carries `data_schema_version`, `update_status`, `update_releases_behind`.
- [ ] With no `update_cache.json` present, confirm both events report `update_status: "unknown"` and `update_releases_behind: "unknown"` (never `current`).
- [ ] Seed `update_cache.json` with a `latest_version` newer than the running build and confirm the buckets reflect the gap (e.g. a several-major jump reads `major_behind` / `several_behind`).
- [ ] Confirm no raw latest-version string appears in the emitted payload, only the bucket strings and the integer.
- [ ] With telemetry disabled (or `DO_NOT_TRACK=1`), confirm nothing is built or sent even with a cache and schema present.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

This is a telemetry-payload change, covered by Rust unit tests (`src/update/mod.rs` pure classifiers) and integration tests (`tests/telemetry.rs`) for the four user stories: schema version reported, staleness buckets reflect an injected cache, no version string leaks, opted-out emits nothing.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the design debate, and implementation were drafted by Claude under my direction. I made the design calls (both staleness taxonomies, const vs on-disk schema version), reviewed each commit, and own the result.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds privacy-preserving version-health telemetry to allow maintainers to measure schema-version distribution and coarse update staleness across installs without leaking raw version strings or making network calls.

## What changed (high level)

- New fields added to both process_start and usage_snapshot telemetry events:
  - data_schema_version (u32)
  - update_status (enum: unknown / current / patch_behind / minor_behind / major_behind)
  - update_releases_behind (enum: unknown / current / one_behind / several_behind)
- New public helpers/enums:
  - migrations::current_schema_version()
  - update::UpdateStatus and update::ReleasesBehind
  - update::cached_version_health(current) to compute both signals from the local update cache
- Telemetry event structs extended and telemetry-build paths populate the new fields after the opt-in gate
- Telemetry schema version bumped (wire format extended)
- Tests added/updated:
  - Unit tests for staleness classification and edge cases
  - Integration tests verifying telemetry emission only when opted-in, correct bucketing from injected caches, and no raw-version leakage
- Documentation updated to describe the new “Version health” fields and privacy constraints

## Benefits

- Privacy-first: emits only small integers and short bucket identifiers; raw latest-version strings are never sent
- No extra network activity: staleness is derived from the existing local update-check cache only
- Opt-in only: nothing emitted for opted-out or DO_NOT_TRACK installs
- Each event is self-contained (both process_start and usage_snapshot) so CLI-only runs are covered
- Provides actionable, bounded signals to measure schema rollout and how far installs lag

## Technical notes (concise)

- New classification helpers (classify_update_status, classify_releases_behind) bucket semver distance and count newer cached releases; they handle empty/unparsable caches and "thin" caches conservatively
- Version comparison logic refactored to reuse a shared semver-parts helper
- assemble_usage_snapshot initializes fallback/empty values; build_* functions overwrite with cached results after reading update_cache.json (no network)
- Tests ensure no raw-version leakage (including checking for dotted fragments) and that telemetry is omitted when not opted-in
<!-- end of auto-generated comment: release notes by coderabbit.ai -->