### PR TITLE
feat(telemetry): per-event uuid idempotency key and model-family upkeep docs

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -37,6 +37,23 @@ agent command becomes `custom`, an unrecognized model becomes `other`. **Raw
 commands, file paths, titles, branch names, group paths, and prompts are never
 sent.**
 
+#### Model families and the `other` bucket
+
+`model_bucket` maps a model string to a small, closed vocabulary of family
+names (`claude`, `openai`, `gemini`, ...); anything it does not recognize
+becomes `other`, and an absent model becomes `unset`. The raw model string
+never leaves the sanitizer, so an internal or private model name can only ever
+be counted as `other`, never revealed.
+
+The family list is maintained by hand. Unlike the agent allowlist, which is
+derived from the built-in agent registry, there is no in-repo source of model
+names to generate it from, so adding a newly common public family is a
+deliberate edit in `sanitize.rs`. The signal that the list has drifted is the
+`other` rate in the `sessions_by_model_bucket` aggregate: when `other` climbs,
+a popular family is missing and should be added. By design that is the only
+discriminator for unknowns; no hashed or partial form of an unknown model name
+is emitted, since model names are low-entropy and a hash would be reversible.
+
 ### Feature flags
 
 The snapshot includes a small `features` map (allowlisted feature name ->

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -91,7 +91,7 @@ agent command becomes `custom`, an unrecognized model becomes `other`. **Raw
 commands, file paths, titles, branch names, group paths, and prompts are never
 sent.**
 
-#### Model families and the `other` bucket
+### Model families and the `other` bucket
 
 `model_bucket` maps a model string to a small, closed vocabulary of family
 names (`claude`, `openai`, `gemini`, ...); anything it does not recognize

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -128,3 +128,12 @@ the install id and does all sending.
 booleans, or short identifier-like strings (and the two allowlisted bucket
 maps); the gateway drops free text, paths, branch-name-like strings, and any
 nested object, so anything richer than a count or flag will not survive ingest.
+
+**Idempotency key.** Every event carries a per-event `uuid`, a random v4 UUID
+minted once when the event is built. It is distinct from the install id (stable
+per install) and `sent_at` (a per-emit timestamp), and is stable across any
+redelivery of the same logical event. The gateway forwards it as the PostHog
+event `uuid`, so a retried or redelivered POST is recognized as the same event
+and deduped downstream rather than double-counted. It is excluded from the
+in-process snapshot dedup fingerprint, so two snapshots with identical content
+still compare equal.

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 /// Payload schema version. Bump on any breaking change to the field set.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -41,6 +41,11 @@ pub struct ProcessStart {
     pub schema: u32,
     /// Always `"process_start"`.
     pub event: &'static str,
+    /// Random v4 UUID minted once when the event is built. Stable across any
+    /// redelivery of the same logical event, so the gateway can forward it as
+    /// the PostHog event `uuid` and let PostHog dedup retried POSTs. Distinct
+    /// from `install_id` (stable per install) and `sent_at` (per-emit stamp).
+    pub uuid: String,
     pub install_id: String,
     /// RFC 3339 UTC timestamp.
     pub sent_at: String,
@@ -59,6 +64,11 @@ pub struct UsageSnapshot {
     pub schema: u32,
     /// Always `"usage_snapshot"`.
     pub event: &'static str,
+    /// Random v4 UUID minted once when the event is built; see
+    /// [`ProcessStart::uuid`]. Excluded from the in-process dedup fingerprint
+    /// (`super::snapshot_fingerprint`) so two snapshots with identical content
+    /// still compare equal.
+    pub uuid: String,
     pub install_id: String,
     pub sent_at: String,
     pub surface: Surface,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -122,6 +122,7 @@ pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
     Some(ProcessStart {
         schema: SCHEMA_VERSION,
         event: "process_start",
+        uuid: uuid::Uuid::new_v4().to_string(),
         install_id,
         sent_at: now_rfc3339(),
         surface,
@@ -201,6 +202,7 @@ pub fn build_usage_snapshot(
     Some(UsageSnapshot {
         schema: SCHEMA_VERSION,
         event: "usage_snapshot",
+        uuid: uuid::Uuid::new_v4().to_string(),
         install_id,
         sent_at: now_rfc3339(),
         surface,
@@ -317,14 +319,17 @@ pub async fn flush_cli_process_start() {
 /// re-sending back to back.
 static LAST_SNAPSHOT_FP: std::sync::Mutex<Option<u64>> = std::sync::Mutex::new(None);
 
-/// Content fingerprint of a snapshot, excluding the volatile `sent_at` stamp.
-/// Everything else is included: `install_id` is stable per install, so two
-/// snapshots with the same counts hash equal. Used only for in-process dedup,
-/// never sent anywhere.
+/// Content fingerprint of a snapshot, excluding the volatile `sent_at` stamp
+/// and the per-emit random `uuid`. Everything else is included: `install_id` is
+/// stable per install, so two snapshots with the same counts hash equal. The
+/// `uuid` is freshly minted per build, so leaving it in would make every
+/// snapshot hash unique and defeat the exit-snapshot dedup entirely. Used only
+/// for in-process dedup, never sent anywhere.
 fn snapshot_fingerprint(snapshot: &UsageSnapshot) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut probe = snapshot.clone();
     probe.sent_at = String::new();
+    probe.uuid = String::new();
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     serde_json::to_string(&probe)
         .unwrap_or_default()
@@ -453,6 +458,7 @@ mod tests {
         UsageSnapshot {
             schema: SCHEMA_VERSION,
             event: "usage_snapshot",
+            uuid: "11111111-1111-4111-8111-111111111111".to_string(),
             install_id: "00000000-0000-0000-0000-000000000000".to_string(),
             sent_at: "2026-06-02T19:00:45Z".to_string(),
             surface: Surface::Tui,
@@ -489,14 +495,16 @@ mod tests {
         let boot = sample_snapshot();
         record_snapshot_fp(&boot);
 
-        // Quit right after, sessions unchanged: same content, newer stamp.
-        // The only difference is `sent_at`, which the fingerprint excludes, so
-        // the exit snapshot is recognised as a duplicate and not re-sent.
+        // Quit right after, sessions unchanged: same content, newer stamp and
+        // a freshly minted uuid. Both `sent_at` and `uuid` are per-emit and
+        // excluded from the fingerprint, so the exit snapshot is still
+        // recognised as a duplicate and not re-sent.
         let mut exit = sample_snapshot();
         exit.sent_at = "2026-06-02T19:00:47Z".to_string();
+        exit.uuid = "22222222-2222-4222-8222-222222222222".to_string();
         assert!(
             snapshot_matches_last(&exit),
-            "an unchanged exit snapshot must dedupe against the boot snapshot"
+            "an unchanged exit snapshot must dedupe against the boot snapshot despite a new uuid"
         );
 
         // A snapshot whose counts actually changed is not a duplicate, so it

--- a/src/telemetry/sanitize.rs
+++ b/src/telemetry/sanitize.rs
@@ -65,6 +65,14 @@ pub fn model_bucket(model: Option<&str>) -> &'static str {
     };
     let lower = model.to_ascii_lowercase();
     use Needle::{Substr, Token};
+    // Manually maintained, privacy-preserving allowlist. Unlike `agent_bucket`,
+    // which derives from `crate::agents::AGENTS`, there is no in-repo source of
+    // model names to generate this from, so adding a newly common public family
+    // is a deliberate release chore: add a `(family, &[needle...])` row here.
+    // A model matching no row buckets as `"other"` and its raw name never
+    // leaves this function, so unknowns are coarse-counted, never leaked. Watch
+    // the `other` rate in the model-bucket telemetry (PostHog) to know when this
+    // list has drifted and needs a new family. See `docs/telemetry.md`.
     const FAMILIES: &[(&str, &[Needle])] = &[
         (
             "claude",
@@ -158,6 +166,64 @@ mod tests {
                 "other",
                 "`{name}` must not bucket as openai"
             );
+        }
+    }
+
+    // #1878 user story (maintainer visibility): a model from an unlisted family
+    // is not silently swallowed. It buckets as the observable `"other"`
+    // discriminator, which the snapshot reports as a non-zero count, so the
+    // allowlist drift is visible in the aggregate instead of vanishing.
+    #[test]
+    fn unknown_family_is_observable_as_other() {
+        for name in [
+            "acme-internal-v2",
+            "future-model-9000",
+            "kimi-k2",
+            "phi-4",
+            "command-r-plus",
+        ] {
+            assert_eq!(
+                model_bucket(Some(name)),
+                "other",
+                "`{name}` from an unlisted family must surface as the observable `other` bucket"
+            );
+        }
+    }
+
+    // #1878 user story (privacy): no raw model name, nor any reversible form of
+    // it, escapes the sanitizer. Whatever is fed in, the output is always one of
+    // the fixed, closed vocabulary, so an internal or sensitive model name can
+    // never reach a payload.
+    #[test]
+    fn output_is_always_from_the_closed_vocabulary() {
+        const VOCAB: &[&str] = &[
+            "claude", "openai", "gemini", "qwen", "grok", "llama", "mistral", "deepseek", "other",
+            "unset",
+        ];
+        for input in [
+            None,
+            Some(""),
+            Some("   "),
+            Some("claude-opus-4-8"),
+            Some("gpt-5"),
+            Some("acme-secret-internal-llm-v7"),
+            Some("/opt/models/customer-private-finetune"),
+            Some("name with spaces and / slashes"),
+        ] {
+            let bucket = model_bucket(input);
+            assert!(
+                VOCAB.contains(&bucket),
+                "model_bucket({input:?}) returned `{bucket}`, outside the closed vocabulary"
+            );
+            if let Some(raw) = input {
+                let raw = raw.trim();
+                if !raw.is_empty() && !VOCAB.contains(&raw.to_ascii_lowercase().as_str()) {
+                    assert_ne!(
+                        bucket, raw,
+                        "the raw model string must never be returned verbatim"
+                    );
+                }
+            }
         }
     }
 

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -143,6 +143,56 @@ fn snapshot_carries_session_create_count() {
     assert_eq!(some.session_creates_since_last_snapshot, 7);
 }
 
+/// User stories (#1873): every built event carries a non-empty per-event
+/// `uuid`, distinct from `install_id` and `sent_at`, and two events built in the
+/// same process get different uuids. This is the idempotency key the gateway
+/// forwards as the PostHog event `uuid` for native redelivery dedup.
+#[test]
+#[serial]
+fn events_carry_distinct_idempotency_uuid() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let snap = telemetry::build_usage_snapshot(Surface::Tui, &[], false, false, 0)
+        .expect("snapshot built when opted in");
+    assert!(!snap.uuid.is_empty(), "snapshot uuid must be non-empty");
+    assert_ne!(
+        snap.uuid, snap.install_id,
+        "uuid must differ from install_id"
+    );
+    assert_ne!(snap.uuid, snap.sent_at, "uuid must differ from sent_at");
+    // It must serialize onto the wire so the gateway can read it.
+    let serialized = serde_json::to_string(&snap).expect("serialize");
+    assert!(
+        serialized.contains(&format!("\"uuid\":\"{}\"", snap.uuid)),
+        "uuid must be present in the serialized payload"
+    );
+
+    // Two events built in the same process must not collide.
+    let proc = telemetry::build_process_start(Surface::Cli).expect("process_start built");
+    let snap2 = telemetry::build_usage_snapshot(Surface::Tui, &[], false, false, 0)
+        .expect("second snapshot built");
+    assert_ne!(
+        snap.uuid, snap2.uuid,
+        "two snapshots must get distinct uuids"
+    );
+    assert_ne!(
+        proc.uuid, snap.uuid,
+        "process_start and snapshot must get distinct uuids"
+    );
+}
+
+/// Opted out (the default): no event, and therefore no `uuid`, is ever built.
+#[test]
+#[serial]
+fn opted_out_builds_no_uuid() {
+    let _tmp = isolate();
+    assert!(!telemetry::is_opted_in());
+    assert!(telemetry::build_process_start(Surface::Cli).is_none());
+    assert!(telemetry::build_usage_snapshot(Surface::Tui, &[], false, false, 0).is_none());
+}
+
 /// The CLI `process_start` is throttled to once per install per day so a user
 /// scripting `aoe` in a loop can't flood the endpoint: a send is due first, then
 /// not due once a confirmed send claims the daily slot.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two telemetry hardening changes from the #1762 follow-up set.

**#1873, per-event idempotency key.** Telemetry events carried no event id, so a redelivered POST (a future retry, an offline backlog flush, or a gateway-side retry to PostHog) would land twice and silently double-count. Both `ProcessStart` and `UsageSnapshot` now carry a random v4 `uuid`, minted once when the event is built, and the gateway forwards it as the PostHog event `uuid` so PostHog deduplicates redelivered events natively. `SCHEMA_VERSION` bumps to 2. The `uuid` is excluded from the in-process snapshot dedup fingerprint alongside `sent_at`, so two snapshots with identical content still compare equal instead of treating every fresh `uuid` as a change. The matching gateway change ships in a separate `aoe-telemetry` PR.

**#1878, model-family upkeep visibility.** The model-family list in `model_bucket` is maintained by hand, and there is no in-repo source of model names to derive it from (unlike the agent list, which derives from the agent registry). An unrecognized model already buckets to the closed `other` value, which is reported as a non-zero count in `sessions_by_model_bucket`, so unknowns are coarse-counted and never leaked. This change makes that contract explicit: it documents that the `other` rate is the drift signal to watch, marks the list as a known release chore in `sanitize.rs` and `docs/telemetry.md`, and adds regression tests pinning the two guarantees (an unknown family stays observable as `other`, and `model_bucket` only ever returns the closed vocabulary). No discriminator for unknown model names was added: model names are low-entropy and a hashed or partial form would be reversible, which would break the privacy boundary.

Closes #1873
Closes #1878

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Opt in (`aoe telemetry enable`), point `AOE_TELEMETRY_ENDPOINT` at a local sink, launch the TUI, and confirm the posted `usage_snapshot` JSON carries a non-empty `uuid` distinct from `install_id` and `sent_at`.
- [ ] Trigger a second event in the same run (e.g. a `process_start`) and confirm its `uuid` differs from the snapshot's.
- [ ] Launch then immediately quit with unchanged sessions and confirm the exit snapshot is still deduped (not re-sent), proving the fresh `uuid` does not defeat the in-process dedup.
- [ ] With telemetry disabled (default), confirm no event and therefore no `uuid` is built or sent.
- [ ] Run a session against a model from an unlisted family and confirm it is reported under the `other` model bucket rather than dropped.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated tests: Rust unit tests in `src/telemetry/sanitize.rs` and integration tests in `tests/telemetry.rs` covering the new `uuid` and model-bucket guarantees.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (uuid on both events, gateway uuid optional because the gateway is live, minimal scope for #1878 with no unknown-model discriminator on privacy grounds), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary of Changes

This PR delivers two telemetry hardening improvements: per-event idempotency keys for reliable deduplication, and explicit maintenance/documentation for model-family sanitization.

### What changed (high-level)
- Added a per-event random v4 UUID to ProcessStart and UsageSnapshot events; the UUID is minted once when the event is built and forwarded downstream so receivers can deduplicate by event id.
- Bumped telemetry wire schema version to reflect the new field.
- Updated in-process snapshot dedup logic to treat volatile fields (sent_at and uuid) as excluded so identical snapshots still deduplicate.
- Documented that model-family mapping is a manually maintained allowlist; unknown models are folded to the observable "other" bucket (not dropped), and rising "other" rates are the drift signal.
- Added regression/unit/integration tests and docs covering UUID behavior, opt-out semantics, snapshot dedup, and model-bucketing correctness.

Files changed (high-level): src/telemetry/events.rs, src/telemetry/mod.rs, src/telemetry/sanitize.rs, tests/telemetry.rs, docs/telemetry.md.

### Technical details (concise)
- New field: uuid: String added to ProcessStart and UsageSnapshot; generated with Uuid::new_v4() and serialized as a string.
- SCHEMA_VERSION incremented (wire version bump).
- snapshot_fingerprint clears sent_at and uuid before hashing/serializing so dedup compares only stable content.
- sanitize.rs documents the closed vocabulary for model families; unknown names map to "other"; sanitizer never returns raw or reversible model strings and no reversible discriminator was added.
- Tests added: presence/uniqueness of UUIDs when telemetry enabled; absence when opted out; snapshot dedup behavior with changing sent_at/uuid; model_bucket returns only closed vocabulary and maps unknowns to "other".

### Benefits
- Enables downstream deduplication and reduces duplicate-event noise via stable per-event IDs.
- Preserves internal deduplication correctness despite redeliveries.
- Makes model-family drift observable and maintainable through documented, manual allowlist upkeep.
- Maintains privacy by ensuring raw model identifiers never leave the sanitizer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->