### PR TITLE
feat(telemetry): capture client form-factor (desktop / mobile / PWA) on the seen ping

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -24,7 +24,15 @@ closed, versioned schema (see `src/telemetry/events.rs`):
     short-lived sessions that start and end between two snapshots are still
     counted (populated by `aoe serve`; the TUI reports `0`),
   - which opt-in features are turned on (see "Feature flags" below),
-  - whether the web dashboard / cockpit was opened since the last snapshot.
+  - whether the web dashboard / cockpit was opened since the last snapshot,
+    and a coarse client form-factor class for each (`desktop`, `desktop_pwa`,
+    `mobile`, `mobile_pwa`) so desktop, mobile, and installed-PWA usage can be
+    told apart. This is a was-seen flag per class, never a per-device id: the
+    snapshot's `os` / `arch` describe the daemon host, not the client device,
+    so without this a phone PWA talking to a desktop daemon looked like a
+    desktop client. Only the coarse class is derived (from display-mode,
+    pointer type, and viewport width); no user-agent string, screen size, or
+    device model is read or sent.
 
 In practice that is a handful of small (well under 1 KB) requests per active
 install per day. There is no offline buffering, so a flaky network drops events
@@ -101,9 +109,10 @@ until delivery is confirmed, so a failed send does not silently drop them:
 - the CLI `process_start` daily slot is claimed only on a confirmed send, so a
   failed send leaves it open for the next invocation to retry (bounded to once
   per hour so a down endpoint cannot make every `aoe` invocation re-send);
-- the serve `web_seen` / `cockpit_seen` flags and the session-create counter are
-  cleared only after a confirmed snapshot send, so a failed snapshot keeps them
-  for the next one instead of losing that window's signal.
+- the serve `web_seen` / `cockpit_seen` flags, their per-form-factor client
+  maps, and the session-create counter are cleared only after a confirmed
+  snapshot send, so a failed snapshot keeps them for the next one instead of
+  losing that window's signal.
 
 This is coarse, last-write retry, not a durable queue: periodic snapshots are
 still point-in-time, and a snapshot identical to the last confirmed one is
@@ -125,6 +134,9 @@ the install id and does all sending.
 
 **Schema contract.** The wire format is the flat, closed schema in
 `src/telemetry/events.rs`, mirrored by the gateway. New fields must be counts,
-booleans, or short identifier-like strings (and the two allowlisted bucket
-maps); the gateway drops free text, paths, branch-name-like strings, and any
-nested object, so anything richer than a count or flag will not survive ingest.
+booleans, or short identifier-like strings (and the allowlisted bucket maps:
+`sessions_by_agent`, `sessions_by_model_bucket`, `features`, and the
+`web_clients_seen` / `cockpit_clients_seen` form-factor maps, all keyed by short
+identifiers with numeric or boolean values); the gateway drops free text, paths,
+branch-name-like strings, and any nested object, so anything richer than a count
+or flag will not survive ingest.

--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -82,6 +82,12 @@ pub async fn set_telemetry_consent(
 pub struct SeenRequest {
     /// `"web"` or `"cockpit"`.
     surface: String,
+    /// Optional coarse client form-factor (`"desktop"` / `"desktop_pwa"` /
+    /// `"mobile"` / `"mobile_pwa"`). Absent on older clients; any value outside
+    /// the closed allowlist is rejected, never stored. See
+    /// `telemetry::form_factor` and #1883.
+    #[serde(default)]
+    form_factor: Option<String>,
 }
 
 /// Record that the web dashboard / cockpit web UI was opened. Folded into the
@@ -104,13 +110,14 @@ pub async fn post_telemetry_seen(
         Ok(b) => b,
         Err(rej) => return rej.into_response(),
     };
-    match req.surface.as_str() {
-        "web" => {
-            state.telemetry_web_seen.fetch_add(1, Ordering::Relaxed);
-        }
-        "cockpit" => {
-            state.telemetry_cockpit_seen.fetch_add(1, Ordering::Relaxed);
-        }
+    // Resolve the surface to its coarse counter and its per-form-factor
+    // counters in one place so both web and cockpit share the form-factor path.
+    let (coarse, clients) = match req.surface.as_str() {
+        "web" => (&state.telemetry_web_seen, &state.telemetry_web_clients),
+        "cockpit" => (
+            &state.telemetry_cockpit_seen,
+            &state.telemetry_cockpit_clients,
+        ),
         other => {
             return (
                 StatusCode::BAD_REQUEST,
@@ -118,6 +125,31 @@ pub async fn post_telemetry_seen(
             )
                 .into_response();
         }
+    };
+
+    // Reject an unknown form-factor before recording anything, the way an
+    // unknown surface is rejected: a non-allowlisted value (a user-agent
+    // string, a screen size, a typo) must never be stored or coerced.
+    let form_factor = match req.form_factor.as_deref() {
+        Some(value) => match crate::telemetry::form_factor::parse(value) {
+            Some(ff) => Some(ff),
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": "bad_form_factor", "message": format!("unknown form_factor '{value}'")})),
+                )
+                    .into_response();
+            }
+        },
+        None => None,
+    };
+
+    // The coarse `*_seen` counter always increments so an unclassified open
+    // (older frontend, no form_factor) still registers; a classified open also
+    // bumps its specific class.
+    coarse.fetch_add(1, Ordering::Relaxed);
+    if let Some(ff) = form_factor {
+        clients.increment(ff);
     }
     StatusCode::NO_CONTENT.into_response()
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -341,6 +341,14 @@ pub struct AppState {
     /// /api/telemetry/seen`), which folds the count into its own snapshot.
     pub telemetry_web_seen: std::sync::atomic::AtomicU32,
     pub telemetry_cockpit_seen: std::sync::atomic::AtomicU32,
+    /// Per-form-factor open counts for the web dashboard / cockpit, layered on
+    /// the coarse `*_seen` counters above so the snapshot can report which
+    /// client classes (desktop / mobile / PWA) used each surface. A classified
+    /// open bumps both the coarse counter and the matching class here; an
+    /// unclassified open (older frontend, no `form_factor`) bumps only the
+    /// coarse counter. See `telemetry::form_factor` and #1883.
+    pub telemetry_web_clients: FormFactorCounters,
+    pub telemetry_cockpit_clients: FormFactorCounters,
     /// Sessions created since the last opt-in telemetry snapshot. Feeds the
     /// `session_creates_since_last_snapshot` trend counter so short-lived sessions
     /// that start and end between two snapshots are still counted. Decremented (by
@@ -627,6 +635,8 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         last_web_activity: std::sync::atomic::AtomicI64::new(0),
         telemetry_web_seen: std::sync::atomic::AtomicU32::new(0),
         telemetry_cockpit_seen: std::sync::atomic::AtomicU32::new(0),
+        telemetry_web_clients: FormFactorCounters::default(),
+        telemetry_cockpit_clients: FormFactorCounters::default(),
         telemetry_session_creates: std::sync::atomic::AtomicU32::new(0),
         telemetry_last_reported: std::sync::Mutex::new(None),
         shutdown: CancellationToken::new(),
@@ -1692,12 +1702,118 @@ fn spawn_telemetry_loop(state: Arc<AppState>) {
     });
 }
 
+/// Per-form-factor open counters for one web surface (dashboard or cockpit).
+/// A fixed, lock-free set over the closed [`crate::telemetry::WebClientFormFactor`]
+/// allowlist: the seen endpoint increments the matching class, the snapshot
+/// reads exact counts, and a confirmed send decrements by exactly what it
+/// reported (so an open landing during an in-flight send survives, mirroring
+/// the coarse `telemetry_web_seen` counter). Named fields rather than a map so
+/// no free-form string key can ever enter daemon state.
+#[derive(Default)]
+pub struct FormFactorCounters {
+    desktop: std::sync::atomic::AtomicU32,
+    desktop_pwa: std::sync::atomic::AtomicU32,
+    mobile: std::sync::atomic::AtomicU32,
+    mobile_pwa: std::sync::atomic::AtomicU32,
+}
+
+impl FormFactorCounters {
+    fn field(&self, ff: crate::telemetry::WebClientFormFactor) -> &std::sync::atomic::AtomicU32 {
+        use crate::telemetry::WebClientFormFactor::*;
+        match ff {
+            Desktop => &self.desktop,
+            DesktopPwa => &self.desktop_pwa,
+            Mobile => &self.mobile,
+            MobilePwa => &self.mobile_pwa,
+        }
+    }
+
+    /// Record one classified open of the given client class.
+    pub fn increment(&self, ff: crate::telemetry::WebClientFormFactor) {
+        self.field(ff)
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Point-in-time read of every class count, so the snapshot loop can later
+    /// decrement by exactly the values it reported.
+    fn read(&self) -> FormFactorCounts {
+        use std::sync::atomic::Ordering;
+        let mut counts = FormFactorCounts::default();
+        for ff in crate::telemetry::WebClientFormFactor::ALL {
+            counts.set(ff, self.field(ff).load(Ordering::Relaxed));
+        }
+        counts
+    }
+
+    /// Subtract exactly the reported counts after a confirmed send. Never zeroes,
+    /// so an open that landed mid-send rolls into the next snapshot.
+    fn decrement(&self, reported: &FormFactorCounts) {
+        for ff in crate::telemetry::WebClientFormFactor::ALL {
+            let n = reported.get(ff);
+            if n > 0 {
+                self.field(ff)
+                    .fetch_sub(n, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+/// A snapshot's reported per-class counts. Plain values (not atomics) so they
+/// can be stashed in [`ReportedServeSignals`] and replayed on confirm.
+#[derive(Default, Clone, Copy)]
+struct FormFactorCounts {
+    desktop: u32,
+    desktop_pwa: u32,
+    mobile: u32,
+    mobile_pwa: u32,
+}
+
+impl FormFactorCounts {
+    fn slot(&mut self, ff: crate::telemetry::WebClientFormFactor) -> &mut u32 {
+        use crate::telemetry::WebClientFormFactor::*;
+        match ff {
+            Desktop => &mut self.desktop,
+            DesktopPwa => &mut self.desktop_pwa,
+            Mobile => &mut self.mobile,
+            MobilePwa => &mut self.mobile_pwa,
+        }
+    }
+
+    fn set(&mut self, ff: crate::telemetry::WebClientFormFactor, n: u32) {
+        *self.slot(ff) = n;
+    }
+
+    fn get(&self, ff: crate::telemetry::WebClientFormFactor) -> u32 {
+        match ff {
+            crate::telemetry::WebClientFormFactor::Desktop => self.desktop,
+            crate::telemetry::WebClientFormFactor::DesktopPwa => self.desktop_pwa,
+            crate::telemetry::WebClientFormFactor::Mobile => self.mobile,
+            crate::telemetry::WebClientFormFactor::MobilePwa => self.mobile_pwa,
+        }
+    }
+
+    /// Per-class was-seen map for the snapshot wire: only classes with a
+    /// positive count appear, each as `true`. Empty (and so omitted) when no
+    /// classified client opened the surface.
+    fn seen_map(&self) -> std::collections::BTreeMap<String, bool> {
+        let mut map = std::collections::BTreeMap::new();
+        for ff in crate::telemetry::WebClientFormFactor::ALL {
+            if self.get(ff) > 0 {
+                map.insert(ff.key().to_string(), true);
+            }
+        }
+        map
+    }
+}
+
 /// What a serve snapshot reported, so the originating signals can be cleared
 /// only after the send is confirmed. The clear is deferred (rather than reset at
 /// build time) so a failed send retains the signals for the next snapshot.
 struct ReportedServeSignals {
     web_seen: u32,
     cockpit_seen: u32,
+    web_clients: FormFactorCounts,
+    cockpit_clients: FormFactorCounts,
     session_creates: u32,
 }
 
@@ -1710,6 +1826,8 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
     use std::sync::atomic::Ordering;
     let web_seen = state.telemetry_web_seen.load(Ordering::Relaxed);
     let cockpit_seen = state.telemetry_cockpit_seen.load(Ordering::Relaxed);
+    let web_clients = state.telemetry_web_clients.read();
+    let cockpit_clients = state.telemetry_cockpit_clients.read();
     let session_creates = state.telemetry_session_creates.load(Ordering::Relaxed);
     let instances = state.instances.read().await.clone();
     let snapshot = crate::telemetry::build_usage_snapshot(
@@ -1717,11 +1835,15 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
         &instances,
         web_seen > 0,
         cockpit_seen > 0,
+        web_clients.seen_map(),
+        cockpit_clients.seen_map(),
         session_creates,
     )?;
     *state.telemetry_last_reported.lock().unwrap() = Some(ReportedServeSignals {
         web_seen,
         cockpit_seen,
+        web_clients,
+        cockpit_clients,
         session_creates,
     });
     Some(snapshot)
@@ -1744,6 +1866,10 @@ fn clear_reported_serve_signals(state: &AppState, outcome: crate::telemetry::Sen
     }
     decrement_reported_count(&state.telemetry_web_seen, reported.web_seen);
     decrement_reported_count(&state.telemetry_cockpit_seen, reported.cockpit_seen);
+    state.telemetry_web_clients.decrement(&reported.web_clients);
+    state
+        .telemetry_cockpit_clients
+        .decrement(&reported.cockpit_clients);
     decrement_reported_count(&state.telemetry_session_creates, reported.session_creates);
 }
 
@@ -2762,6 +2888,41 @@ mod tests {
         let counter = AtomicU32::new(3);
         decrement_reported_count(&counter, 0);
         assert_eq!(counter.load(Ordering::Relaxed), 3);
+    }
+
+    // #1883: the per-form-factor counters dedup repeated same-class opens to a
+    // single was-seen entry, and the confirmed-send decrement subtracts exactly
+    // what was reported so a class opened during an in-flight send survives.
+    #[test]
+    fn form_factor_counters_dedup_and_preserve_in_flight_opens() {
+        use crate::telemetry::WebClientFormFactor::{Desktop, MobilePwa};
+
+        let counters = FormFactorCounters::default();
+        // Two desktop opens and one mobile-PWA open before the snapshot builds.
+        counters.increment(Desktop);
+        counters.increment(Desktop);
+        counters.increment(MobilePwa);
+
+        let reported = counters.read();
+        // Repeated same-class pings collapse to one was-seen entry on the wire.
+        let map = reported.seen_map();
+        assert_eq!(map.get("desktop"), Some(&true));
+        assert_eq!(map.get("mobile_pwa"), Some(&true));
+        assert_eq!(map.get("mobile"), None, "unseen classes are absent");
+        assert_eq!(map.len(), 2);
+
+        // A mobile-PWA open lands while the snapshot is in flight.
+        counters.increment(MobilePwa);
+        // The confirmed send clears only the reported counts.
+        counters.decrement(&reported);
+
+        let after = counters.read();
+        assert_eq!(after.get(Desktop), 0, "reported desktop opens cleared");
+        assert_eq!(
+            after.get(MobilePwa),
+            1,
+            "the open that arrived during the send must be retained"
+        );
     }
 
     #[cfg(feature = "serve")]

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -10,7 +10,11 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 /// Payload schema version. Bump on any breaking change to the field set.
-pub const SCHEMA_VERSION: u32 = 1;
+///
+/// v2 (#1883): the `usage_snapshot` gained the `web_clients_seen` /
+/// `cockpit_clients_seen` per-form-factor maps alongside the coarse
+/// `web_seen` / `cockpit_seen` flags.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -88,6 +92,18 @@ pub struct UsageSnapshot {
     pub web_seen: bool,
     /// The cockpit web UI was opened at least once since the last snapshot.
     pub cockpit_seen: bool,
+
+    /// Coarse client form-factor classes that opened the web dashboard since
+    /// the last snapshot: allowlisted class key (`desktop` / `desktop_pwa` /
+    /// `mobile` / `mobile_pwa`) -> was-seen. A boolean, not a count, on the
+    /// wire: it answers "which client classes used the dashboard" without
+    /// leaking open frequency. Empty (and so omitted) on surfaces that host no
+    /// web client, e.g. the TUI. See `telemetry::form_factor`.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub web_clients_seen: BTreeMap<String, bool>,
+    /// Same per-class was-seen map for the cockpit web UI.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub cockpit_clients_seen: BTreeMap<String, bool>,
 
     /// Sessions created since the previous snapshot (a trend counter, not a
     /// per-session event stream).

--- a/src/telemetry/form_factor.rs
+++ b/src/telemetry/form_factor.rs
@@ -1,0 +1,87 @@
+//! Coarse client form-factor classification for the seen ping (issue #1883).
+//!
+//! The `seen` ping reports that the web dashboard / cockpit was opened. The
+//! snapshot's `os` / `arch` describe the daemon host, not the device the user
+//! is looking at, so a phone PWA talking to a Mac daemon was indistinguishable
+//! from a desktop tab. The frontend derives one of a **closed set** of coarse
+//! classes and sends it; everything outside the set is rejected, never stored,
+//! so no user-agent string, screen size, or device model can ride in.
+//!
+//! The set is deliberately flat (`desktop` / `desktop_pwa` / `mobile` /
+//! `mobile_pwa`) rather than two fields, so it maps to a single allowlisted
+//! identifier-keyed map at the snapshot and gateway boundary and preserves the
+//! joint pwa-by-form-factor distribution.
+
+/// A coarse, allowlisted client class. The only values the daemon will record;
+/// anything else is rejected at the endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WebClientFormFactor {
+    Desktop,
+    DesktopPwa,
+    Mobile,
+    MobilePwa,
+}
+
+impl WebClientFormFactor {
+    /// Stable wire key. Lowercase identifier so it satisfies the gateway's
+    /// map-key allowlist (`^[a-z][a-z0-9_]{0,63}$`) and is safe as a snapshot
+    /// map key.
+    pub fn key(self) -> &'static str {
+        match self {
+            WebClientFormFactor::Desktop => "desktop",
+            WebClientFormFactor::DesktopPwa => "desktop_pwa",
+            WebClientFormFactor::Mobile => "mobile",
+            WebClientFormFactor::MobilePwa => "mobile_pwa",
+        }
+    }
+
+    /// Every class, for iterating the closed set (snapshot map assembly, tests).
+    pub const ALL: [WebClientFormFactor; 4] = [
+        WebClientFormFactor::Desktop,
+        WebClientFormFactor::DesktopPwa,
+        WebClientFormFactor::Mobile,
+        WebClientFormFactor::MobilePwa,
+    ];
+}
+
+/// Parse an incoming form-factor string against the closed allowlist. Returns
+/// `None` for anything outside the set, so the endpoint can reject it the way
+/// it already rejects an unknown `surface` rather than coercing or storing it.
+pub fn parse(value: &str) -> Option<WebClientFormFactor> {
+    match value {
+        "desktop" => Some(WebClientFormFactor::Desktop),
+        "desktop_pwa" => Some(WebClientFormFactor::DesktopPwa),
+        "mobile" => Some(WebClientFormFactor::Mobile),
+        "mobile_pwa" => Some(WebClientFormFactor::MobilePwa),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_every_allowlisted_class_round_trip() {
+        for ff in WebClientFormFactor::ALL {
+            assert_eq!(parse(ff.key()), Some(ff), "round-trip failed for {ff:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_anything_outside_the_closed_set() {
+        // Empty, unknown labels, a user-agent string, a screen size, and case
+        // / separator variants must all be rejected, never coerced.
+        for bad in [
+            "",
+            "tablet",
+            "DESKTOP",
+            "mobile-pwa",
+            "Mozilla/5.0 (iPhone)",
+            "1920x1080",
+            "desktop_pwa ",
+        ] {
+            assert_eq!(parse(bad), None, "`{bad}` should not parse");
+        }
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -20,6 +20,7 @@
 
 pub mod events;
 pub mod features;
+pub mod form_factor;
 pub mod sanitize;
 mod state;
 
@@ -27,6 +28,7 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 pub use events::{ProcessStart, Surface, UsageSnapshot, SCHEMA_VERSION};
+pub use form_factor::WebClientFormFactor;
 pub use state::{cli_process_start_due, install_id, record_cli_process_start, reset_install_id};
 
 use crate::session::Instance;
@@ -139,6 +141,8 @@ pub fn build_usage_snapshot(
     instances: &[Instance],
     web_seen: bool,
     cockpit_seen: bool,
+    web_clients_seen: BTreeMap<String, bool>,
+    cockpit_clients_seen: BTreeMap<String, bool>,
     session_creates_since_last_snapshot: u32,
 ) -> Option<UsageSnapshot> {
     if !is_opted_in() {
@@ -219,6 +223,8 @@ pub fn build_usage_snapshot(
         features,
         web_seen,
         cockpit_seen,
+        web_clients_seen,
+        cockpit_clients_seen,
         session_creates_since_last_snapshot,
     })
 }
@@ -471,6 +477,8 @@ mod tests {
             features: BTreeMap::new(),
             web_seen: false,
             cockpit_seen: false,
+            web_clients_seen: BTreeMap::new(),
+            cockpit_clients_seen: BTreeMap::new(),
             session_creates_since_last_snapshot: 0,
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1315,14 +1315,17 @@ impl App {
 
     /// Build a `usage_snapshot` from the current session list, or `None` when
     /// telemetry is not opted in. The TUI never hosts the web dashboard, so
-    /// `web_seen` / `cockpit_seen` are false and the create-trend counter is
-    /// left at 0 (the `aoe serve` daemon is the surface that tracks those).
+    /// `web_seen` / `cockpit_seen` are false, the per-client form-factor maps
+    /// are empty (and so omitted), and the create-trend counter is left at 0
+    /// (the `aoe serve` daemon is the surface that tracks those).
     fn build_telemetry_snapshot(&self) -> Option<crate::telemetry::UsageSnapshot> {
         crate::telemetry::build_usage_snapshot(
             crate::telemetry::Surface::Tui,
             self.home.instances(),
             false,
             false,
+            std::collections::BTreeMap::new(),
+            std::collections::BTreeMap::new(),
             0,
         )
     }

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -28,6 +28,12 @@ fn set_enabled(enabled: bool) {
     save_config(&config).expect("save config");
 }
 
+/// An empty per-form-factor map, for the snapshot builders that take no web
+/// client classes (TUI, or a serve snapshot with no classified opens).
+fn empty() -> std::collections::BTreeMap<String, bool> {
+    std::collections::BTreeMap::new()
+}
+
 /// Default-off must hold: a fresh install reports no opt-in, no install id,
 /// and builds no events.
 #[test]
@@ -37,7 +43,10 @@ fn default_off_emits_nothing() {
     assert!(!telemetry::is_opted_in());
     assert_eq!(telemetry::install_id(), None);
     assert!(telemetry::build_process_start(Surface::Cli).is_none());
-    assert!(telemetry::build_usage_snapshot(Surface::Tui, &[], false, false, 0).is_none());
+    assert!(
+        telemetry::build_usage_snapshot(Surface::Tui, &[], false, false, empty(), empty(), 0)
+            .is_none()
+    );
 }
 
 /// Opting in generates an install id and lets events build; opting back out
@@ -100,9 +109,16 @@ fn snapshot_buckets_are_sanitized() {
     custom.detect_as = String::new();
     let claude = Instance::new("c", "/p");
 
-    let snapshot =
-        telemetry::build_usage_snapshot(Surface::Tui, &[custom, claude], false, false, 0)
-            .expect("snapshot built when opted in");
+    let snapshot = telemetry::build_usage_snapshot(
+        Surface::Tui,
+        &[custom, claude],
+        false,
+        false,
+        empty(),
+        empty(),
+        0,
+    )
+    .expect("snapshot built when opted in");
 
     let serialized = serde_json::to_string(&snapshot).expect("serialize");
     // The raw custom command / project path must never appear in the payload.
@@ -124,6 +140,44 @@ fn snapshot_buckets_are_sanitized() {
     }
 }
 
+/// User story (#1883): the snapshot carries the per-class client form-factor
+/// map. A desktop browser and a mobile PWA against the same daemon both appear
+/// as distinct was-seen classes, not one undifferentiated `web_seen`, while the
+/// coarse `web_seen` flag still summarises "the dashboard was opened".
+#[test]
+#[serial]
+fn snapshot_carries_per_class_web_clients() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let mut web_clients = std::collections::BTreeMap::new();
+    web_clients.insert("desktop".to_string(), true);
+    web_clients.insert("mobile_pwa".to_string(), true);
+
+    let snapshot =
+        telemetry::build_usage_snapshot(Surface::Serve, &[], true, false, web_clients, empty(), 0)
+            .expect("snapshot built when opted in");
+
+    assert!(
+        snapshot.web_seen,
+        "coarse web_seen still summarises the open"
+    );
+    assert_eq!(snapshot.web_clients_seen.get("desktop"), Some(&true));
+    assert_eq!(snapshot.web_clients_seen.get("mobile_pwa"), Some(&true));
+    // Classes that were never seen are absent, not `false`: the map is a
+    // presence set, so it stays small and the gateway forwards only real opens.
+    assert_eq!(snapshot.web_clients_seen.get("mobile"), None);
+
+    // An empty form-factor map is omitted from the wire entirely (the TUI and
+    // any surface with no classified opens), never serialized as `{}`.
+    let serialized = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(
+        !serialized.contains("cockpit_clients_seen"),
+        "empty cockpit_clients_seen must be skipped, not emitted as {{}}"
+    );
+}
+
 /// User story (#1874): the create-trend counter carries a real value. When N
 /// sessions were created during the window, the snapshot reports
 /// `session_creates_since_last_snapshot == N`; with none created it reports 0.
@@ -134,12 +188,14 @@ fn snapshot_carries_session_create_count() {
     set_enabled(true);
     telemetry::apply_opt_in_change(true);
 
-    let none = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 0)
-        .expect("snapshot built when opted in");
+    let none =
+        telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, empty(), empty(), 0)
+            .expect("snapshot built when opted in");
     assert_eq!(none.session_creates_since_last_snapshot, 0);
 
-    let some = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 7)
-        .expect("snapshot built when opted in");
+    let some =
+        telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, empty(), empty(), 7)
+            .expect("snapshot built when opted in");
     assert_eq!(some.session_creates_since_last_snapshot, 7);
 }
 

--- a/web/src/lib/__tests__/formFactor.test.ts
+++ b/web/src/lib/__tests__/formFactor.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { clientFormFactor } from "../formFactor";
+
+/** Drive the three media-query primitives `clientFormFactor` reads by query
+ *  string, plus the iOS `navigator.standalone` flag. Every query the helper
+ *  does not set is reported as not-matching. */
+function stubClient(opts: {
+  standalone?: boolean; // display-mode: standalone
+  iosStandalone?: boolean; // navigator.standalone
+  coarse?: boolean; // pointer: coarse
+  wide?: boolean; // min-width: 768px
+}) {
+  window.matchMedia = vi.fn((query: string) => {
+    const matches =
+      (query === "(display-mode: standalone)" && !!opts.standalone) ||
+      (query === "(pointer: coarse)" && !!opts.coarse) ||
+      (query === "(min-width: 768px)" && !!opts.wide);
+    return { matches, media: query } as MediaQueryList;
+  }) as unknown as typeof window.matchMedia;
+  (window.navigator as unknown as { standalone?: boolean }).standalone =
+    opts.iosStandalone ?? false;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window.navigator as unknown as { standalone?: boolean }).standalone;
+});
+
+describe("clientFormFactor", () => {
+  it("classifies a wide fine-pointer client as desktop", () => {
+    stubClient({ wide: true, coarse: false });
+    expect(clientFormFactor()).toBe("desktop");
+  });
+
+  it("classifies a narrow coarse-pointer client as mobile", () => {
+    stubClient({ wide: false, coarse: true });
+    expect(clientFormFactor()).toBe("mobile");
+  });
+
+  it("adds the pwa suffix when running standalone", () => {
+    stubClient({ wide: true, coarse: false, standalone: true });
+    expect(clientFormFactor()).toBe("desktop_pwa");
+  });
+
+  it("treats an installed mobile PWA as mobile_pwa", () => {
+    stubClient({ wide: false, coarse: true, standalone: true });
+    expect(clientFormFactor()).toBe("mobile_pwa");
+  });
+
+  it("honors iOS navigator.standalone for the pwa suffix", () => {
+    stubClient({ wide: false, coarse: true, iosStandalone: true });
+    expect(clientFormFactor()).toBe("mobile_pwa");
+  });
+
+  it("keeps a wide coarse-pointer touch laptop on desktop", () => {
+    // Coarse pointer alone must not flip to mobile: a touch laptop stays
+    // desktop because the viewport is wide.
+    stubClient({ wide: true, coarse: true });
+    expect(clientFormFactor()).toBe("desktop");
+  });
+
+  it("keeps a narrow fine-pointer desktop window on desktop", () => {
+    // A narrow viewport alone must not flip to mobile: a small desktop window
+    // has a fine pointer.
+    stubClient({ wide: false, coarse: false });
+    expect(clientFormFactor()).toBe("desktop");
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { clientFormFactor } from "./formFactor";
 import type {
   SessionResponse,
   RichDiffFilesResponse,
@@ -445,12 +446,15 @@ export async function setTelemetryConsent(
 }
 
 /// Tell the daemon the web dashboard or cockpit UI was opened, so its next
-/// opt-in snapshot can carry web_seen / cockpit_seen. Best-effort.
+/// opt-in snapshot can carry web_seen / cockpit_seen plus the coarse client
+/// form-factor class (#1883). Best-effort. The browser never posts to the
+/// telemetry backend; it pings the local daemon, which folds the class into its
+/// own snapshot.
 export function reportTelemetrySeen(surface: "web" | "cockpit"): void {
   void fetch("/api/telemetry/seen", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ surface }),
+    body: JSON.stringify({ surface, form_factor: clientFormFactor() }),
   }).catch(() => {});
 }
 

--- a/web/src/lib/formFactor.ts
+++ b/web/src/lib/formFactor.ts
@@ -1,0 +1,46 @@
+// Coarse client form-factor classification for the telemetry seen ping (#1883).
+//
+// The daemon snapshot's os/arch describe the host running `aoe serve`, not the
+// device the user is looking at, so a phone PWA talking to a Mac daemon was
+// indistinguishable from a desktop tab. This derives one of a closed set of
+// coarse classes from the same media-query primitives the layout hooks already
+// use (`usePushSubscription` standalone detection, `useIsCoarsePointer`,
+// `useIsWideViewport`), so the seen ping can carry it. No user-agent string,
+// screen size, or device model is ever read or sent.
+
+/** The closed set of classes the daemon accepts; anything else is rejected
+ *  server-side and never stored. Mirrors `telemetry::form_factor` in Rust. */
+export type ClientFormFactor =
+  | "desktop"
+  | "desktop_pwa"
+  | "mobile"
+  | "mobile_pwa";
+
+const matchesMedia = (query: string): boolean =>
+  typeof window !== "undefined" &&
+  Boolean(window.matchMedia?.(query).matches);
+
+/** Installed / standalone PWA: iOS exposes `navigator.standalone`; every other
+ *  platform reports `(display-mode: standalone)`. Either counts. */
+const isStandalone = (): boolean => {
+  if (typeof window === "undefined") return false;
+  const ios =
+    (window.navigator as unknown as { standalone?: boolean }).standalone ===
+    true;
+  return ios || matchesMedia("(display-mode: standalone)");
+};
+
+/** Classify the current client. Precedence is documented and deterministic so a
+ *  touch laptop or a tablet lands in exactly one bucket:
+ *  - `pwa` suffix iff the app is running standalone / installed;
+ *  - `mobile` iff the primary pointer is coarse AND the viewport is below the
+ *    `md` breakpoint (768px); a wide coarse-pointer client (touch laptop) and a
+ *    narrow fine-pointer client (small desktop window) both stay `desktop`;
+ *  - `desktop` otherwise. */
+export function clientFormFactor(): ClientFormFactor {
+  const pwa = isStandalone();
+  const mobile =
+    matchesMedia("(pointer: coarse)") && !matchesMedia("(min-width: 768px)");
+  const base = mobile ? "mobile" : "desktop";
+  return pwa ? `${base}_pwa` : base;
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -174,6 +174,19 @@
       ]
     },
     {
+      "id": "telemetry.form-factor",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/telemetry-form-factor.spec.ts",
+        "src/lib/__tests__/formFactor.test.ts"
+      ],
+      "components": [
+        "web/src/lib/formFactor.ts",
+        "web/src/lib/api.ts"
+      ]
+    },
+    {
       "id": "settings.theme-persistence-passphrase",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/telemetry-form-factor.spec.ts
+++ b/web/tests/live/telemetry-form-factor.spec.ts
@@ -1,0 +1,128 @@
+// Client form-factor on the telemetry seen ping (#1883).
+//
+// The seen ping now carries a coarse client class so the daemon snapshot can
+// tell desktop, mobile, and installed-PWA web usage apart instead of collapsing
+// every client into one `web_seen` bool. This drives one `aoe serve` from two
+// browser contexts, a desktop one and an emulated mobile PWA, and asserts each
+// reports its own class in the `POST /api/telemetry/seen` body. The class is
+// derived from media-query primitives (display-mode, pointer, viewport); the
+// mobile context injects those deterministically so the transport assertion does
+// not hinge on Chromium emulation quirks (the pure classifier is unit-tested in
+// `web/src/lib/__tests__/formFactor.test.ts`).
+
+import type { BrowserContext, Page } from "@playwright/test";
+import { test, expect } from "../helpers/liveTest";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+/** Capture every `POST /api/telemetry/seen` body a context's page sends,
+ *  parsed into `{ surface, form_factor }`. */
+function captureSeenPings(
+  page: Page,
+): Array<{ surface?: string; form_factor?: string }> {
+  const pings: Array<{ surface?: string; form_factor?: string }> = [];
+  page.on("request", (req) => {
+    if (
+      req.method() === "POST" &&
+      req.url().includes("/api/telemetry/seen")
+    ) {
+      const body = req.postData();
+      if (!body) return;
+      try {
+        pings.push(JSON.parse(body));
+      } catch {
+        // Ignore unparseable bodies; assertions only care about the
+        // well-formed posts the helper emits.
+      }
+    }
+  });
+  return pings;
+}
+
+/** Force the standalone + coarse-pointer + narrow-viewport media queries so the
+ *  classifier deterministically yields `mobile_pwa`, independent of how the
+ *  emulated device reports them. */
+async function emulateMobilePwa(ctx: BrowserContext): Promise<void> {
+  await ctx.addInitScript(() => {
+    const orig = window.matchMedia.bind(window);
+    window.matchMedia = ((query: string) => {
+      const forced: Record<string, boolean> = {
+        "(display-mode: standalone)": true,
+        "(pointer: coarse)": true,
+        "(min-width: 768px)": false,
+      };
+      if (query in forced) {
+        return {
+          matches: forced[query],
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        } as unknown as MediaQueryList;
+      }
+      return orig(query);
+    }) as typeof window.matchMedia;
+  });
+}
+
+test("desktop and mobile-PWA clients report distinct form-factor classes", async ({
+  browser,
+}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+  try {
+    // Desktop: a wide, fine-pointer context classifies as `desktop`.
+    const desktopCtx = await browser.newContext({
+      viewport: { width: 1280, height: 800 },
+    });
+    const desktopPage = await desktopCtx.newPage();
+    const desktopPings = captureSeenPings(desktopPage);
+    await desktopPage.goto(serve.baseUrl);
+
+    // Mobile PWA: a narrow, coarse-pointer, standalone context => `mobile_pwa`.
+    const mobileCtx = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      isMobile: true,
+    });
+    await emulateMobilePwa(mobileCtx);
+    const mobilePage = await mobileCtx.newPage();
+    const mobilePings = captureSeenPings(mobilePage);
+    await mobilePage.goto(serve.baseUrl);
+
+    await expect
+      .poll(
+        () =>
+          desktopPings.some(
+            (p) => p.surface === "web" && p.form_factor === "desktop",
+          ),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    await expect
+      .poll(
+        () =>
+          mobilePings.some(
+            (p) => p.surface === "web" && p.form_factor === "mobile_pwa",
+          ),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    // The two classes are genuinely distinct, not one undifferentiated client.
+    expect(
+      desktopPings.some((p) => p.form_factor === "mobile_pwa"),
+    ).toBe(false);
+
+    await desktopCtx.close();
+    await mobileCtx.close();
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Telemetry could not tell desktop from mobile from PWA web usage. Every web client flipped one daemon-side `web_seen` bool, and the snapshot's `os` / `arch` describe the machine running `aoe serve`, not the device the user is looking at, so a phone PWA talking to a Mac daemon was indistinguishable from a desktop tab. The mobile audience was invisible.

This wires a coarse, allowlisted client class through the existing seen ping. The frontend derives one of `desktop` / `desktop_pwa` / `mobile` / `mobile_pwa` from the same media-query primitives the layout hooks already use (display-mode standalone / `navigator.standalone` for PWA, `pointer: coarse` plus a sub-768px viewport for mobile) and attaches it to the web and cockpit seen pings. No user-agent string, screen size, or device model is read or sent. The daemon keeps the coarse `web_seen` / `cockpit_seen` flags and layers per-class lock-free counters on top; the snapshot reports per-class was-seen maps (`web_clients_seen` / `cockpit_clients_seen`) as boolean presence sets, omitted when empty. `SCHEMA_VERSION` bumps to 2.

An unknown form-factor value is rejected with 400 the way an unknown surface is, so a non-allowlisted value is never stored. A classified open bumps both the coarse counter and its class; an unclassified open (older frontend) still bumps the coarse counter. The per-class counters share the confirmed-send reconcile path from #1875, so a class opened during an in-flight snapshot survives into the next one.

No `aoe-telemetry` (gateway) changes are needed: the gateway allows extra fields and forwards any identifier-keyed numeric/boolean map untouched, with no per-field allowlist and no schema-version check, so `web_clients_seen` flows straight through to PostHog. This lands entirely inside `agent-of-empires`.

Closes #1883

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Opt in to telemetry, point `AOE_TELEMETRY_ENDPOINT` at a local sink, run `aoe serve`, open the dashboard in a desktop browser, then open it from a phone (or an installed PWA) against the same daemon; confirm the next snapshot's `web_clients_seen` carries both a `desktop` and a `mobile` (or `mobile_pwa`) entry, not one undifferentiated `web_seen`.
- [ ] Reload the dashboard several times from the same device; confirm the class stays a single was-seen entry, not one per reload.
- [ ] `POST /api/telemetry/seen` with `{"surface":"web","form_factor":"tablet"}` (or a user-agent string); confirm a 400 `bad_form_factor` and that nothing is recorded.
- [ ] With telemetry opted out, open the dashboard from any device; confirm no snapshot is built or sent.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

`web/tests/live/telemetry-form-factor.spec.ts` drives a desktop and an emulated mobile-PWA context against one `aoe serve` and asserts each reports its own class. `web/src/lib/__tests__/formFactor.test.ts` (Vitest) covers the classifier matrix and precedence. Rust: `tests/telemetry.rs` covers the snapshot per-class map, and `src/server/mod.rs` / `src/telemetry/form_factor.rs` unit-test the counter dedup/decrement and the parse reject path.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, design debate, and implementation drafted by Claude under my direction. I made the design calls (keep `web_seen` additive, boolean wire maps, typed counters, reject unknowns) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a coarse, allowlisted client form-factor to telemetry "seen" pings so the daemon can distinguish desktop / desktop_pwa / mobile / mobile_pwa clients. It is additive and privacy-preserving: only a short enum is sent (no UA, identifiers, or raw dimensions). Backend aggregates per-form-factor as deduped presence maps and retains existing web/cockpit booleans; schema version is bumped and unknown form_factor values are rejected.

What changed, at a glance:
- Frontend: derive a single flattened form-factor enum from media-query primitives (display-mode / navigator.standalone, pointer: coarse, viewport width) and include it as form_factor in telemetry seen POSTs.
- API: SeenRequest accepts optional allowlisted form_factor; invalid values return 400 and are ignored (no counter updates).
- Server: new per-form-factor atomic counters per surface, snapshot exposes web_clients_seen / cockpit_clients_seen maps (omitted when empty), confirmed-send reconcile decrements reported counts so concurrent opens persist.
- Schema: telemetry SCHEMA_VERSION bumped to reflect the new usage_snapshot wire shape.
- Tests: unit tests, Vitest classifier tests, Playwright live test (desktop + emulated mobile PWA), and Rust integration tests for parsing, aggregation, dedupe/decrement, and snapshot behavior.

Benefits:
- More accurate telemetry separating mobile vs desktop and PWA installs.
- Maintains privacy by sending only a small allowlisted enum.
- Backwards compatible: older clients still increment coarse flags.
- Correct deduplication and snapshot reconciliation for in-flight opens.

## Technical details

Backend (Rust):
- New module src/telemetry/form_factor.rs: WebClientFormFactor enum (Desktop, DesktopPwa, Mobile, MobilePwa) with key() and parse() accepting only allowlisted keys.
- SeenRequest gains form_factor: Option<String> (serde default); handler validates form_factor and surface, rejects unknowns with 400 before updating counters.
- AppState adds telemetry_web_clients and telemetry_cockpit_clients as FormFactorCounters (new exported type) providing increment, snapshot, and decrement semantics.
- UsageSnapshot now includes web_clients_seen and cockpit_clients_seen: BTreeMap<String, bool>, skipped in serialization when empty.
- Confirmed-send logic decrements per-form-factor counters by exactly the reported counts to preserve opens that arrive during in-flight sends.
- SCHEMA_VERSION incremented to reflect usage_snapshot change.

Frontend (TypeScript):
- New web/src/lib/formFactor.ts: clientFormFactor() determines one of "desktop" | "desktop_pwa" | "mobile" | "mobile_pwa" using (display-mode: standalone) or navigator.standalone, pointer: coarse, and a 768px viewport threshold. PWA detection appends _pwa.
- reportTelemetrySeen(surface) now includes form_factor: clientFormFactor() in POST /api/telemetry/seen.
- Vitest tests validate classification and precedence (coarse pointer alone or narrow viewport alone do not misclassify).

Tests:
- Rust unit and integration tests for parse(), aggregation, dedupe/decrement, and snapshot maps.
- Vitest/JSDOM tests for classification across pointer/viewport/display-mode combinations.
- Playwright live test asserting different form_factor values between desktop and emulated mobile PWA.
- Integration test ensures empty per-class maps are omitted from serialized snapshots.

Closes `#1883`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->