### PR TITLE
feat(cockpit): telemetry for cockpit interaction depth (approvals, switches, plan mode, queued prompts)

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -60,6 +60,16 @@ closed, versioned schema (see `src/telemetry/events.rs`):
     like a desktop client. Only the coarse class is derived (from display-mode,
     pointer type, and viewport width); no user-agent string, screen size, or
     device model is read or sent,
+  - coarse cockpit-interaction counts since the last snapshot, so we can tell
+    "opened" from "actually used" (populated by `aoe serve`; the TUI reports
+    zero). All are counts or a closed decision-key map, never content:
+    - how many approvals were resolved and the decision mix (`allow`,
+      `allow_always`, `deny`; the synthetic daemon-restart cancellation is not
+      counted),
+    - how many mid-session agent switches and cockpit/terminal toggles happened
+      (only real toggles, not no-op re-applies),
+    - whether any session entered plan mode,
+    - how many prompts were queued (parked because the agent was busy),
   - for `aoe serve` only, how the daemon is deployed, decided once at launch:
     its auth mode (`token`, `passphrase`, or `none`) and its exposure mode
     (`tunnel` for a Cloudflare quick or named tunnel, `tailscale` for a
@@ -200,10 +210,11 @@ until delivery is confirmed, so a failed send does not silently drop them:
   both the slot and the counts intact for the next invocation to retry (bounded
   to once per hour so a down endpoint cannot make every `aoe` invocation
   re-send), and a transient failure never drops a window of commands;
-- the serve `usage_seen` open counts, the per-form-factor client maps, and the
-  session-create counter are cleared only after a confirmed snapshot send,
-  decremented by exactly what was reported, so a failed snapshot keeps them for
-  the next one instead of losing that window's signal.
+- the serve `usage_seen` open counts, the per-form-factor client maps, the
+  session-create counter, and the cockpit-interaction counts are cleared only
+  after a confirmed snapshot send, each decremented by exactly the reported
+  amount (so an interaction that lands mid-send rolls into the next snapshot),
+  so a failed snapshot keeps that window's signal instead of losing it.
 
 This is coarse, last-write retry, not a durable queue: periodic snapshots are
 still point-in-time, and a snapshot identical to the last confirmed one is

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -15,9 +15,9 @@ use serde::{Deserialize, Serialize};
 use crate::cockpit::approvals::Nonce;
 use crate::cockpit::event_store::AttachmentBlob;
 use crate::cockpit::protocol::{
-    ContextPrimerQuery, ContextPrimerResponse, DiffCommentsPromptRequest, FilesResponse,
-    PromptAttachmentUpload, PromptRequest, ReplayQuery, ReplayResponse, ResolveApprovalRequest,
-    SwitchAgentRequest, SwitchAgentResponse,
+    ApprovalDecisionWire, ContextPrimerQuery, ContextPrimerResponse, DiffCommentsPromptRequest,
+    FilesResponse, PromptAttachmentUpload, PromptRequest, ReplayQuery, ReplayResponse,
+    ResolveApprovalRequest, SwitchAgentRequest, SwitchAgentResponse,
 };
 use crate::cockpit::state::PromptAttachmentKind;
 use crate::cockpit::supervisor::SupervisorError;
@@ -591,6 +591,13 @@ pub async fn switch_cockpit_agent(
                 .into_response(),
         };
     }
+
+    // Spawn succeeded: a mid-session agent switch actually happened. Tally it
+    // for the opt-in telemetry snapshot.
+    state
+        .telemetry_cockpit
+        .agent_switches
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
     // Persist the agent change AFTER spawn succeeded. The new agent's
     // session/new will emit a fresh AcpSessionAssigned which will then
@@ -1294,6 +1301,14 @@ pub async fn cockpit_enable(
             .into_response();
     }
 
+    // A real terminal -> cockpit transition is now committed (the idempotent
+    // already-cockpit and unresolvable-agent cases returned above). Tally the
+    // substrate toggle for the opt-in telemetry snapshot.
+    state
+        .telemetry_cockpit
+        .substrate_toggles
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
     // Tear down the tmux side. Best-effort: a stale tmux name should
     // not block the swap. Run on a blocking pool worker because each
     // kill shells out. Warn on agent kill failure to keep signal for
@@ -1460,6 +1475,14 @@ pub async fn cockpit_disable(
         .into_response();
     }
 
+    // A real cockpit -> terminal transition is now committed (the idempotent
+    // already-terminal case returned above). Tally the substrate toggle for the
+    // opt-in telemetry snapshot.
+    state
+        .telemetry_cockpit
+        .substrate_toggles
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
     // Tear down the cockpit worker. Disabling cockpit mode discards the
     // conversation (we delete on-disk history and clear the stored ACP
     // id below), so release the agent's persisted transcript too via
@@ -1574,7 +1597,18 @@ pub async fn cockpit_set_mode(
         Err(rej) => return rej.into_response(),
     };
     match state.cockpit_supervisor.set_mode(&id, &req.mode_id).await {
-        Ok(()) => StatusCode::ACCEPTED.into_response(),
+        Ok(()) => {
+            // The agent accepted the mode switch. "plan" is the canonical ACP
+            // mode id; tally plan-mode adoption for the opt-in telemetry
+            // snapshot. Other modes are out of scope for now.
+            if req.mode_id == "plan" {
+                state
+                    .telemetry_cockpit
+                    .plan_mode_seen
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            StatusCode::ACCEPTED.into_response()
+        }
         Err(SupervisorError::UnknownSession(_)) => {
             (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()
         }
@@ -1639,12 +1673,16 @@ pub async fn resolve_approval(
         Err(rej) => return rej.into_response(),
     };
     let nonce = Nonce(nonce_str);
+    let decision = req.decision;
     match state
         .cockpit_supervisor
-        .resolve_permission(&id, nonce, req.decision.into())
+        .resolve_permission(&id, nonce, decision.into())
         .await
     {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            record_approval_decision(&state, decision);
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(SupervisorError::UnknownSession(_)) => {
             (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()
         }
@@ -1657,6 +1695,21 @@ pub async fn resolve_approval(
         )
             .into_response(),
     }
+}
+
+/// Tally a user-resolved approval for the opt-in telemetry snapshot. Only the
+/// three real user decisions are counted; the synthetic daemon-restart
+/// `Cancelled` decision is not a user choice and never reaches this endpoint,
+/// but is matched explicitly so adding a wire variant is a compile error here.
+fn record_approval_decision(state: &AppState, decision: ApprovalDecisionWire) {
+    use std::sync::atomic::Ordering::Relaxed;
+    let counter = match decision {
+        ApprovalDecisionWire::Allow => &state.telemetry_cockpit.approvals_allow,
+        ApprovalDecisionWire::AllowAlways => &state.telemetry_cockpit.approvals_allow_always,
+        ApprovalDecisionWire::Deny => &state.telemetry_cockpit.approvals_deny,
+        ApprovalDecisionWire::Cancelled => return,
+    };
+    counter.fetch_add(1, Relaxed);
 }
 
 /// Build a markdown context primer from the persisted cockpit event

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -49,7 +49,10 @@ pub use system::{
     list_profiles, list_sounds, list_themes, mark_web_tour_seen, rename_profile, serve_sound_file,
     update_profile_settings, update_settings,
 };
-pub use telemetry::{get_telemetry_status, post_telemetry_seen, set_telemetry_consent};
+pub use telemetry::{
+    get_telemetry_status, post_telemetry_cockpit_interaction, post_telemetry_seen,
+    set_telemetry_consent,
+};
 
 const SHELL_METACHARACTERS: &[char] = &[
     ';', '&', '|', '$', '`', '(', ')', '{', '}', '<', '>', '\n', '\r', '\\', '"', '\'', '!', '#',
@@ -207,7 +210,11 @@ mod tests {
             (
                 "api/telemetry.rs",
                 include_str!("telemetry.rs"),
-                &["set_telemetry_consent", "post_telemetry_seen"],
+                &[
+                    "set_telemetry_consent",
+                    "post_telemetry_seen",
+                    "post_telemetry_cockpit_interaction",
+                ],
             ),
         ];
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -345,6 +345,15 @@ mod tests {
                 ],
             ),
             (
+                "api/telemetry.rs",
+                include_str!("telemetry.rs"),
+                &[
+                    "set_telemetry_consent",
+                    "post_telemetry_seen",
+                    "post_telemetry_cockpit_interaction",
+                ],
+            ),
+            (
                 "server/push.rs",
                 include_str!("../push.rs"),
                 &["subscribe", "unsubscribe", "test"],

--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -148,3 +148,52 @@ pub async fn post_telemetry_seen(
     }
     StatusCode::NO_CONTENT.into_response()
 }
+
+#[derive(Deserialize)]
+pub struct CockpitInteractionRequest {
+    /// Allowlisted interaction kind. Only `"prompt_queued"` today; the field
+    /// is an open string so adding a kind is a one-line match arm here.
+    kind: String,
+}
+
+/// Report a cockpit interaction that only the browser can observe, so the
+/// daemon can fold it into its next opt-in snapshot. The four other
+/// interaction signals (approvals, agent switch, substrate toggle, plan mode)
+/// are tallied daemon-side in their REST handlers and never come through here;
+/// queued prompts are the exception because the prompt queue lives entirely in
+/// the web cockpit's client state. Returns 204 on success; the client need not
+/// branch on consent state (the daemon only sends counts when opted in).
+pub async fn post_telemetry_cockpit_interaction(
+    State(state): State<Arc<AppState>>,
+    body: Result<Json<CockpitInteractionRequest>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    let Json(req) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+    match req.kind.as_str() {
+        "prompt_queued" => {
+            state
+                .telemetry_cockpit
+                .prompts_queued
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        other => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "bad_kind", "message": format!("unknown interaction kind '{other}'")})),
+            )
+                .into_response();
+        }
+    }
+    StatusCode::NO_CONTENT.into_response()
+}

--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -185,7 +185,7 @@ pub async fn post_telemetry_cockpit_interaction(
             state
                 .telemetry_cockpit
                 .prompts_queued
-                .fetch_add(1, Ordering::Relaxed);
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         other => {
             return (

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -364,6 +364,16 @@ pub struct AppState {
     /// the value reported) only after a confirmed send, so a failed send retains
     /// the count for the next snapshot instead of silently dropping it.
     pub telemetry_session_creates: std::sync::atomic::AtomicU32,
+    /// Aggregate cockpit-interaction tallies for the next opt-in snapshot
+    /// (approvals decision mix, agent/substrate switches, plan-mode, queued
+    /// prompts). Same monotonic-counter, decrement-by-reported discipline as
+    /// the `telemetry_*_seen` counters, so an interaction that lands during an
+    /// in-flight send survives to the next snapshot. In-memory on purpose, like
+    /// the `seen` counters: these are coarse opt-in adoption signals, so losing
+    /// a partial window on a rare daemon crash is acceptable, and durability
+    /// would be a deliberate cross-cutting change for all telemetry counters,
+    /// not a per-feature one.
+    pub telemetry_cockpit: CockpitTelemetryCounters,
     /// What the most recent serve snapshot reported, held until its send is
     /// confirmed so the originating signals (the `usage_seen` counts and the
     /// create counter) are cleared only on success. The telemetry loop is the
@@ -862,6 +872,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         telemetry_web_clients: FormFactorCounters::default(),
         telemetry_cockpit_clients: FormFactorCounters::default(),
         telemetry_session_creates: std::sync::atomic::AtomicU32::new(0),
+        telemetry_cockpit: CockpitTelemetryCounters::default(),
         telemetry_last_reported: std::sync::Mutex::new(None),
         shutdown: CancellationToken::new(),
     });
@@ -1284,6 +1295,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/telemetry/status", get(api::get_telemetry_status))
         .route("/api/telemetry/consent", post(api::set_telemetry_consent))
         .route("/api/telemetry/seen", post(api::post_telemetry_seen))
+        .route(
+            "/api/telemetry/cockpit-interaction",
+            post(api::post_telemetry_cockpit_interaction),
+        )
         // Terminal WebSockets
         .route("/sessions/{id}/ws", get(ws::terminal_ws))
         .route("/sessions/{id}/terminal/ws", get(ws::paired_terminal_ws))
@@ -1858,6 +1873,25 @@ impl FormFactorCounts {
     }
 }
 
+/// Daemon-side cockpit-interaction tallies for the next opt-in snapshot. Each
+/// is a monotonic `AtomicU32` consumed with the same decrement-by-reported
+/// discipline as `telemetry_*_seen`, so an interaction that lands during an
+/// in-flight send rolls into the next snapshot instead of being dropped.
+///
+/// `plan_mode_seen` is a counter rather than a flag for the same reason: the
+/// snapshot reports the boolean `count > 0`, but consuming it by subtracting
+/// the reported amount keeps a plan-mode entry that arrived mid-send.
+#[derive(Default)]
+pub struct CockpitTelemetryCounters {
+    pub approvals_allow: std::sync::atomic::AtomicU32,
+    pub approvals_allow_always: std::sync::atomic::AtomicU32,
+    pub approvals_deny: std::sync::atomic::AtomicU32,
+    pub agent_switches: std::sync::atomic::AtomicU32,
+    pub substrate_toggles: std::sync::atomic::AtomicU32,
+    pub plan_mode_seen: std::sync::atomic::AtomicU32,
+    pub prompts_queued: std::sync::atomic::AtomicU32,
+}
+
 /// What a serve snapshot reported, so the originating signals can be cleared
 /// only after the send is confirmed. The clear is deferred (rather than reset at
 /// build time) so a failed send retains the signals for the next snapshot.
@@ -1866,6 +1900,22 @@ struct ReportedServeSignals {
     web_clients: FormFactorCounts,
     cockpit_clients: FormFactorCounts,
     session_creates: u32,
+    cockpit: ReportedCockpitCounts,
+}
+
+/// The raw `AtomicU32` values a snapshot folded in, kept so each can be
+/// decremented by exactly the reported amount on a confirmed send. `plan_mode`
+/// is the raw count (not the reported boolean) so a plan-mode entry that
+/// arrived mid-send is preserved rather than wiped.
+#[derive(Default, Clone, Copy)]
+struct ReportedCockpitCounts {
+    approvals_allow: u32,
+    approvals_allow_always: u32,
+    approvals_deny: u32,
+    agent_switches: u32,
+    substrate_toggles: u32,
+    plan_mode: u32,
+    prompts_queued: u32,
 }
 
 /// Build a serve `usage_snapshot` from the live session list, folding in the
@@ -1879,6 +1929,25 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
     let web_clients = state.telemetry_web_clients.read();
     let cockpit_clients = state.telemetry_cockpit_clients.read();
     let session_creates = state.telemetry_session_creates.load(Ordering::Relaxed);
+    let c = &state.telemetry_cockpit;
+    let reported_cockpit = ReportedCockpitCounts {
+        approvals_allow: c.approvals_allow.load(Ordering::Relaxed),
+        approvals_allow_always: c.approvals_allow_always.load(Ordering::Relaxed),
+        approvals_deny: c.approvals_deny.load(Ordering::Relaxed),
+        agent_switches: c.agent_switches.load(Ordering::Relaxed),
+        substrate_toggles: c.substrate_toggles.load(Ordering::Relaxed),
+        plan_mode: c.plan_mode_seen.load(Ordering::Relaxed),
+        prompts_queued: c.prompts_queued.load(Ordering::Relaxed),
+    };
+    let cockpit = crate::telemetry::CockpitInteractionCounts {
+        approvals_allow: reported_cockpit.approvals_allow,
+        approvals_allow_always: reported_cockpit.approvals_allow_always,
+        approvals_deny: reported_cockpit.approvals_deny,
+        agent_switches: reported_cockpit.agent_switches,
+        substrate_toggles: reported_cockpit.substrate_toggles,
+        plan_mode_seen: reported_cockpit.plan_mode > 0,
+        prompts_queued: reported_cockpit.prompts_queued,
+    };
     let instances = state.instances.read().await.clone();
     let mut snapshot = crate::telemetry::build_usage_snapshot(
         crate::telemetry::Surface::Serve,
@@ -1887,6 +1956,7 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
         session_creates,
         Some(state.auth_mode),
         Some(state.serve_mode),
+        &cockpit,
     )?;
     // Layer the per-form-factor was-seen maps onto the snapshot. They are serve
     // only (the browser surfaces), so the pure builder leaves them empty and the
@@ -1898,6 +1968,7 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
         web_clients,
         cockpit_clients,
         session_creates,
+        cockpit: reported_cockpit,
     });
     Some(snapshot)
 }
@@ -1922,17 +1993,37 @@ fn clear_reported_serve_signals(state: &AppState, outcome: crate::telemetry::Sen
         .telemetry_cockpit_clients
         .decrement(&reported.cockpit_clients);
     decrement_reported_count(&state.telemetry_session_creates, reported.session_creates);
+    let c = &state.telemetry_cockpit;
+    let rc = reported.cockpit;
+    decrement_reported_count(&c.approvals_allow, rc.approvals_allow);
+    decrement_reported_count(&c.approvals_allow_always, rc.approvals_allow_always);
+    decrement_reported_count(&c.approvals_deny, rc.approvals_deny);
+    decrement_reported_count(&c.agent_switches, rc.agent_switches);
+    decrement_reported_count(&c.substrate_toggles, rc.substrate_toggles);
+    decrement_reported_count(&c.plan_mode_seen, rc.plan_mode);
+    decrement_reported_count(&c.prompts_queued, rc.prompts_queued);
 }
 
 /// Decrement a reported telemetry counter by exactly `reported`, never by more.
-/// Using `fetch_sub(reported)` rather than `swap(0)` preserves any increments
-/// (a create, or a web/cockpit open) that landed between the snapshot build and
-/// the confirmed send, so they roll into the next snapshot instead of being
-/// dropped. A no-op when nothing was reported.
+/// Subtracting the reported amount rather than `swap(0)` preserves any
+/// increments (a create, or a web/cockpit open, or a cockpit interaction) that
+/// landed between the snapshot build and the confirmed send, so they roll into
+/// the next snapshot instead of being dropped. A no-op when nothing was
+/// reported.
+///
+/// The snapshot loop is the sole consumer and runs strictly sequentially (each
+/// send is awaited, then cleared, before the next build), so the counter can
+/// never go below `reported`. The subtraction saturates anyway as cheap
+/// insurance against a future refactor that detaches sends, which would
+/// otherwise be able to underflow-wrap the `AtomicU32`.
 fn decrement_reported_count(counter: &std::sync::atomic::AtomicU32, reported: u32) {
-    if reported > 0 {
-        counter.fetch_sub(reported, std::sync::atomic::Ordering::Relaxed);
+    if reported == 0 {
+        return;
     }
+    use std::sync::atomic::Ordering;
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_sub(reported))
+    });
 }
 
 /// Background task that periodically refreshes session statuses. On each
@@ -2974,6 +3065,30 @@ mod tests {
             1,
             "the open that arrived during the send must be retained"
         );
+    }
+
+    // #1888: the same decrement path carries the cockpit-interaction counters,
+    // so an interaction that lands mid-send must survive the clear (the plan
+    // mode counter shown here, which the snapshot reports as the bool count>0).
+    #[test]
+    fn reported_count_decrement_preserves_concurrent_cockpit_interaction() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let plan_mode = AtomicU32::new(2);
+        let reported = plan_mode.load(Ordering::Relaxed);
+        plan_mode.fetch_add(1, Ordering::Relaxed);
+        decrement_reported_count(&plan_mode, reported);
+        assert_eq!(plan_mode.load(Ordering::Relaxed), 1);
+    }
+
+    // The decrement saturates rather than underflow-wrapping the AtomicU32, so a
+    // hypothetical future refactor that detaches sends (double-clearing a
+    // counter) degrades to zero instead of jumping to u32::MAX.
+    #[test]
+    fn reported_count_decrement_saturates_below_zero() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let counter = AtomicU32::new(2);
+        decrement_reported_count(&counter, 5);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
     }
 
     #[cfg(feature = "serve")]

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -26,7 +26,10 @@ use serde::Serialize;
 /// and `usage_snapshot`.
 /// v9 (#1883): added the `web_clients_seen` / `cockpit_clients_seen`
 /// per-form-factor maps alongside the `usage_seen` open counts.
-pub const SCHEMA_VERSION: u32 = 9;
+/// v10 (#1888): added the cockpit-interaction aggregates (`approvals_resolved`,
+/// `approvals_by_decision`, `agent_switches`, `substrate_toggles`,
+/// `plan_mode_seen`, `prompts_queued`).
+pub const SCHEMA_VERSION: u32 = 10;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -223,4 +226,104 @@ pub struct UsageSnapshot {
     /// a tunnel name, hostname, or `.ts.net` URL, only the coarse mode.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub serve_mode: Option<String>,
+
+    /// Cockpit approvals the user resolved since the last snapshot. The sum of
+    /// [`Self::approvals_by_decision`]; the synthetic daemon-restart
+    /// `Cancelled` decision is never counted (it is not a user choice).
+    pub approvals_resolved: u32,
+    /// Decision mix for resolved approvals: allowlisted decision key
+    /// (`allow` / `allow_always` / `deny`) -> count. Zero-count keys are
+    /// omitted, like [`Self::sessions_by_agent`]. Shows whether people lean on
+    /// `allow_always` (trust) vs `deny` (friction).
+    pub approvals_by_decision: BTreeMap<String, u32>,
+    /// Mid-session agent switches since the last snapshot.
+    pub agent_switches: u32,
+    /// Cockpit/terminal substrate toggles since the last snapshot. Only real
+    /// transitions count; an enable on an already-cockpit session (or a disable
+    /// on an already-terminal session) is a no-op and is not counted.
+    pub substrate_toggles: u32,
+    /// A session entered plan mode at least once since the last snapshot.
+    pub plan_mode_seen: bool,
+    /// Prompts the web cockpit queued (parked because the agent was busy)
+    /// since the last snapshot. Reported by the browser, the only surface that
+    /// owns the prompt queue; the daemon never sees the queue directly.
+    pub prompts_queued: u32,
+}
+
+/// Resolved cockpit-interaction counts for one snapshot window, the input the
+/// daemon folds into a [`UsageSnapshot`]. Surfaces without a cockpit (the TUI)
+/// pass [`Default`] (all zero). Counts only, plus a closed decision key set, so
+/// nothing here can carry free-form content past [`super::sanitize`].
+#[derive(Debug, Clone, Default)]
+pub struct CockpitInteractionCounts {
+    pub approvals_allow: u32,
+    pub approvals_allow_always: u32,
+    pub approvals_deny: u32,
+    pub agent_switches: u32,
+    pub substrate_toggles: u32,
+    pub plan_mode_seen: bool,
+    pub prompts_queued: u32,
+}
+
+impl CockpitInteractionCounts {
+    /// Total user-resolved approvals (the three real decisions; `Cancelled`
+    /// is never accumulated here).
+    pub fn approvals_resolved(&self) -> u32 {
+        self.approvals_allow + self.approvals_allow_always + self.approvals_deny
+    }
+
+    /// Decision mix as an allowlisted-key map, omitting zero counts to match
+    /// the `sessions_by_agent` convention.
+    pub fn approvals_by_decision(&self) -> BTreeMap<String, u32> {
+        let mut map = BTreeMap::new();
+        for (key, count) in [
+            ("allow", self.approvals_allow),
+            ("allow_always", self.approvals_allow_always),
+            ("deny", self.approvals_deny),
+        ] {
+            if count > 0 {
+                map.insert(key.to_string(), count);
+            }
+        }
+        map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn approvals_resolved_sums_the_three_real_decisions() {
+        let counts = CockpitInteractionCounts {
+            approvals_allow: 2,
+            approvals_allow_always: 1,
+            approvals_deny: 1,
+            ..Default::default()
+        };
+        // Issue #1888 story: 2 allow + 1 deny (+ 1 allow_always here) all count.
+        assert_eq!(counts.approvals_resolved(), 4);
+    }
+
+    #[test]
+    fn approvals_by_decision_omits_zero_keys() {
+        let counts = CockpitInteractionCounts {
+            approvals_allow: 2,
+            approvals_deny: 1,
+            ..Default::default()
+        };
+        let map = counts.approvals_by_decision();
+        // Matches the sessions_by_agent convention: absent key == zero.
+        assert_eq!(map.get("allow"), Some(&2));
+        assert_eq!(map.get("deny"), Some(&1));
+        assert!(!map.contains_key("allow_always"));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn empty_counts_produce_an_empty_decision_map() {
+        let counts = CockpitInteractionCounts::default();
+        assert_eq!(counts.approvals_resolved(), 0);
+        assert!(counts.approvals_by_decision().is_empty());
+    }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -28,7 +28,9 @@ pub mod usage_signals;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-pub use events::{CliUsage, ProcessStart, Surface, UsageSnapshot, SCHEMA_VERSION};
+pub use events::{
+    CliUsage, CockpitInteractionCounts, ProcessStart, Surface, UsageSnapshot, SCHEMA_VERSION,
+};
 pub use form_factor::WebClientFormFactor;
 pub use state::{
     cli_usage_due, ensure_install_id, install_id, record_cli_command, record_cli_usage_flush,
@@ -353,6 +355,7 @@ pub fn build_usage_snapshot(
     session_creates_since_last_snapshot: u32,
     auth_mode: Option<&str>,
     serve_mode: Option<&str>,
+    cockpit_counts: &CockpitInteractionCounts,
 ) -> Option<UsageSnapshot> {
     // Load the global, pre-profile-merge config exactly once and reuse it for
     // both the opt-in gate and `active_features`, instead of parsing
@@ -383,6 +386,7 @@ pub fn build_usage_snapshot(
         instances,
         usage_seen,
         session_creates_since_last_snapshot,
+        cockpit_counts,
     );
     // Layer the serve-only deployment metadata on top of the pure snapshot, so
     // `assemble_usage_snapshot` stays focused on session/feature bucketing.
@@ -410,6 +414,7 @@ fn assemble_usage_snapshot(
     instances: &[Instance],
     usage_seen: BTreeMap<String, u32>,
     session_creates_since_last_snapshot: u32,
+    cockpit_counts: &CockpitInteractionCounts,
 ) -> UsageSnapshot {
     let features = features::active_features(config);
 
@@ -456,6 +461,12 @@ fn assemble_usage_snapshot(
         // assembler leaves them unset.
         auth_mode: None,
         serve_mode: None,
+        approvals_resolved: cockpit_counts.approvals_resolved(),
+        approvals_by_decision: cockpit_counts.approvals_by_decision(),
+        agent_switches: cockpit_counts.agent_switches,
+        substrate_toggles: cockpit_counts.substrate_toggles,
+        plan_mode_seen: cockpit_counts.plan_mode_seen,
+        prompts_queued: cockpit_counts.prompts_queued,
     }
 }
 
@@ -761,6 +772,12 @@ mod tests {
             session_creates_since_last_snapshot: 0,
             auth_mode: None,
             serve_mode: None,
+            approvals_resolved: 0,
+            approvals_by_decision: BTreeMap::new(),
+            agent_switches: 0,
+            substrate_toggles: 0,
+            plan_mode_seen: false,
+            prompts_queued: 0,
         }
     }
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -853,7 +853,8 @@ mod tests {
                 usage_signals::zeroed(),
                 0,
                 None,
-                None
+                None,
+                &CockpitInteractionCounts::default()
             )
             .is_none(),
             "opted-out install must not build a snapshot"
@@ -969,6 +970,7 @@ mod tests {
             std::slice::from_ref(&inst),
             usage_signals::zeroed(),
             3,
+            &CockpitInteractionCounts::default(),
         );
 
         assert_eq!(snapshot.install_id, "test-install-id");

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1319,9 +1319,9 @@ impl App {
     /// Build a `usage_snapshot` from the current session list, or `None` when
     /// telemetry is not opted in. The TUI never hosts the web dashboard, so the
     /// `usage_seen` map is reported zeroed (a stable full key set), the
-    /// per-client form-factor maps stay empty (and so omitted), and the
-    /// create-trend counter is left at 0 (the `aoe serve` daemon is the surface
-    /// that tracks those).
+    /// per-client form-factor maps stay empty (and so omitted), the create-trend
+    /// counter is left at 0, and the cockpit-interaction counts are empty (the
+    /// `aoe serve` daemon is the surface that tracks all of those).
     fn build_telemetry_snapshot(&self) -> Option<crate::telemetry::UsageSnapshot> {
         crate::telemetry::build_usage_snapshot(
             crate::telemetry::Surface::Tui,
@@ -1331,6 +1331,7 @@ impl App {
             // The TUI hosts no server, so it has no auth or exposure mode.
             None,
             None,
+            &crate::telemetry::CockpitInteractionCounts::default(),
         )
     }
 

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -196,6 +196,7 @@ fn form_factor_maps_are_a_presence_set_on_the_wire() {
         0,
         None,
         None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
     let empty_wire = serde_json::to_string(&snapshot).expect("serialize");
@@ -432,9 +433,16 @@ fn events_carry_distinct_idempotency_uuid() {
     set_enabled(true);
     telemetry::apply_opt_in_change(true);
 
-    let snap =
-        telemetry::build_usage_snapshot(Surface::Tui, &[], usage_signals::zeroed(), 0, None, None)
-            .expect("snapshot built when opted in");
+    let snap = telemetry::build_usage_snapshot(
+        Surface::Tui,
+        &[],
+        usage_signals::zeroed(),
+        0,
+        None,
+        None,
+        &telemetry::CockpitInteractionCounts::default(),
+    )
+    .expect("snapshot built when opted in");
     assert!(!snap.uuid.is_empty(), "snapshot uuid must be non-empty");
     assert_ne!(
         snap.uuid, snap.install_id,
@@ -450,9 +458,16 @@ fn events_carry_distinct_idempotency_uuid() {
 
     // Two events built in the same process must not collide.
     let proc = telemetry::build_process_start(Surface::Tui).expect("process_start built");
-    let snap2 =
-        telemetry::build_usage_snapshot(Surface::Tui, &[], usage_signals::zeroed(), 0, None, None)
-            .expect("second snapshot built");
+    let snap2 = telemetry::build_usage_snapshot(
+        Surface::Tui,
+        &[],
+        usage_signals::zeroed(),
+        0,
+        None,
+        None,
+        &telemetry::CockpitInteractionCounts::default(),
+    )
+    .expect("second snapshot built");
     assert_ne!(
         snap.uuid, snap2.uuid,
         "two snapshots must get distinct uuids"
@@ -476,7 +491,8 @@ fn opted_out_builds_no_uuid() {
         usage_signals::zeroed(),
         0,
         None,
-        None
+        None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .is_none());
 }

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -71,7 +71,8 @@ fn default_off_emits_nothing() {
         usage_signals::zeroed(),
         0,
         None,
-        None
+        None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .is_none());
 }
@@ -143,6 +144,7 @@ fn snapshot_buckets_are_sanitized() {
         0,
         None,
         None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
 
@@ -281,6 +283,7 @@ fn substrate_census_counts_each_bucket() {
         0,
         None,
         None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
 
@@ -322,6 +325,7 @@ fn substrate_buckets_are_mutually_exclusive_and_sum_to_total() {
         0,
         None,
         None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
 
@@ -364,6 +368,7 @@ fn substrate_keys_are_only_allowlisted_vocab() {
         0,
         None,
         None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
 
@@ -390,6 +395,7 @@ fn snapshot_carries_session_create_count() {
     set_enabled(true);
     telemetry::apply_opt_in_change(true);
 
+    let counts = telemetry::CockpitInteractionCounts::default();
     let none = telemetry::build_usage_snapshot(
         Surface::Serve,
         &[],
@@ -397,6 +403,7 @@ fn snapshot_carries_session_create_count() {
         0,
         None,
         None,
+        &counts,
     )
     .expect("snapshot built when opted in");
     assert_eq!(none.session_creates_since_last_snapshot, 0);
@@ -408,6 +415,7 @@ fn snapshot_carries_session_create_count() {
         7,
         None,
         None,
+        &counts,
     )
     .expect("snapshot built when opted in");
     assert_eq!(some.session_creates_since_last_snapshot, 7);
@@ -489,9 +497,16 @@ fn snapshot_carries_registered_usage_signals() {
     assert!(counters.record("web"));
     assert!(counters.record("cockpit"));
 
-    let snapshot =
-        telemetry::build_usage_snapshot(Surface::Serve, &[], counters.snapshot(), 0, None, None)
-            .expect("snapshot built when opted in");
+    let snapshot = telemetry::build_usage_snapshot(
+        Surface::Serve,
+        &[],
+        counters.snapshot(),
+        0,
+        None,
+        None,
+        &telemetry::CockpitInteractionCounts::default(),
+    )
+    .expect("snapshot built when opted in");
     assert_eq!(snapshot.usage_seen.get("web"), Some(&2));
     assert_eq!(snapshot.usage_seen.get("cockpit"), Some(&1));
 }
@@ -510,9 +525,16 @@ fn unregistered_usage_signal_is_rejected_and_never_reported() {
     // The endpoint would return 400 on this false.
     assert!(!counters.record("web_terminal"));
 
-    let snapshot =
-        telemetry::build_usage_snapshot(Surface::Serve, &[], counters.snapshot(), 0, None, None)
-            .expect("snapshot built when opted in");
+    let snapshot = telemetry::build_usage_snapshot(
+        Surface::Serve,
+        &[],
+        counters.snapshot(),
+        0,
+        None,
+        None,
+        &telemetry::CockpitInteractionCounts::default(),
+    )
+    .expect("snapshot built when opted in");
     assert!(!snapshot.usage_seen.contains_key("web_terminal"));
 }
 
@@ -533,6 +555,7 @@ fn usage_seen_keys_are_only_allowlisted_short_names() {
         0,
         None,
         None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
 
@@ -571,6 +594,7 @@ fn serve_snapshot_carries_coarse_deployment_mode() {
         0,
         Some("passphrase"),
         Some("tailscale"),
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
     assert_eq!(tailscale.auth_mode.as_deref(), Some("passphrase"));
@@ -583,6 +607,7 @@ fn serve_snapshot_carries_coarse_deployment_mode() {
         0,
         Some("token"),
         Some("local"),
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
     assert_eq!(local.auth_mode.as_deref(), Some("token"));
@@ -608,8 +633,119 @@ fn opted_out_serve_builds_no_snapshot_with_deployment_mode() {
         0,
         Some("none"),
         Some("tunnel"),
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .is_none());
+}
+
+/// User stories (#1888): the cockpit-interaction counts fold into the snapshot.
+/// Three approvals (2 allow, 1 deny), one agent switch, two substrate toggles,
+/// plan mode entered, and one queued prompt produce the expected aggregates,
+/// and the decision map carries only the nonzero allowlisted keys.
+#[test]
+#[serial]
+fn snapshot_carries_cockpit_interaction_counts() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let counts = telemetry::CockpitInteractionCounts {
+        approvals_allow: 2,
+        approvals_allow_always: 0,
+        approvals_deny: 1,
+        agent_switches: 1,
+        substrate_toggles: 2,
+        plan_mode_seen: true,
+        prompts_queued: 1,
+    };
+    let snap = telemetry::build_usage_snapshot(
+        Surface::Serve,
+        &[],
+        usage_signals::zeroed(),
+        0,
+        None,
+        None,
+        &counts,
+    )
+    .expect("snapshot built when opted in");
+
+    assert_eq!(snap.approvals_resolved, 3);
+    assert_eq!(snap.approvals_by_decision.get("allow"), Some(&2));
+    assert_eq!(snap.approvals_by_decision.get("deny"), Some(&1));
+    assert!(!snap.approvals_by_decision.contains_key("allow_always"));
+    assert_eq!(snap.agent_switches, 1);
+    assert_eq!(snap.substrate_toggles, 2);
+    assert!(snap.plan_mode_seen);
+    assert_eq!(snap.prompts_queued, 1);
+    // Schema version bumped for the v8 field set.
+    assert_eq!(snap.schema, telemetry::SCHEMA_VERSION);
+}
+
+/// Privacy-reviewer story (#1888): the cockpit-interaction signals are counts
+/// and a closed decision-key set only. No prompt text, tool name, file path, or
+/// agent command can ride along, and the decision map keys stay allowlisted.
+#[test]
+#[serial]
+fn cockpit_interaction_payload_is_counts_and_allowlisted_keys_only() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let counts = telemetry::CockpitInteractionCounts {
+        approvals_allow: 3,
+        approvals_allow_always: 4,
+        approvals_deny: 5,
+        agent_switches: 6,
+        substrate_toggles: 7,
+        plan_mode_seen: true,
+        prompts_queued: 8,
+    };
+    let snap = telemetry::build_usage_snapshot(
+        Surface::Serve,
+        &[],
+        usage_signals::zeroed(),
+        0,
+        None,
+        None,
+        &counts,
+    )
+    .expect("snapshot built when opted in");
+
+    // Every decision key is from the closed allowlist; nothing else leaks in.
+    for key in snap.approvals_by_decision.keys() {
+        assert!(
+            matches!(key.as_str(), "allow" | "allow_always" | "deny"),
+            "unexpected decision key `{key}` in payload"
+        );
+    }
+
+    let json: serde_json::Value = serde_json::to_value(&snap).expect("snapshot serializes to JSON");
+    let obj = json.as_object().expect("snapshot is a JSON object");
+
+    // The cockpit-interaction fields are all integers or a bool, never strings.
+    for field in [
+        "approvals_resolved",
+        "agent_switches",
+        "substrate_toggles",
+        "prompts_queued",
+    ] {
+        assert!(
+            obj.get(field).and_then(serde_json::Value::as_u64).is_some(),
+            "`{field}` must serialize as a count"
+        );
+    }
+    assert!(obj
+        .get("plan_mode_seen")
+        .and_then(serde_json::Value::as_bool)
+        .is_some());
+    // The decision map values are all numeric, never free-form content.
+    for value in obj["approvals_by_decision"]
+        .as_object()
+        .expect("decision map is an object")
+        .values()
+    {
+        assert!(value.as_u64().is_some(), "decision counts must be numeric");
+    }
 }
 
 /// The CLI `cli_usage` flush is throttled to once per install per day so a user
@@ -862,6 +998,7 @@ fn version_health_reflects_cached_update() {
         0,
         None,
         None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
     assert_eq!(snapshot.update_status, UpdateStatus::MajorBehind);
@@ -883,6 +1020,7 @@ fn version_health_reflects_cached_update() {
         0,
         None,
         None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
     assert_eq!(snapshot.update_releases_behind, ReleasesBehind::OneBehind);
@@ -908,6 +1046,7 @@ fn version_health_never_leaks_version_string() {
         0,
         None,
         None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .expect("snapshot built when opted in");
     let event = telemetry::build_process_start(Surface::Tui).expect("event built when opted in");
@@ -951,7 +1090,8 @@ fn opted_out_emits_nothing_even_with_version_health_available() {
         usage_signals::zeroed(),
         0,
         None,
-        None
+        None,
+        &telemetry::CockpitInteractionCounts::default(),
     )
     .is_none());
 }

--- a/web/src/hooks/useCockpit.queue.test.ts
+++ b/web/src/hooks/useCockpit.queue.test.ts
@@ -17,7 +17,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { emptyCockpitState, type QueuedPrompt } from "../lib/cockpitTypes";
 import { AgentProfileProvider } from "../lib/agentProfileContext";
 import { reportCockpitInteraction } from "../lib/api";
-import { cockpitHookReducer, combineQueuedPrompts, useCockpit } from "./useCockpit";
+import {
+  cockpitHookReducer,
+  combineQueuedPrompts,
+  useCockpit,
+} from "./useCockpit";
 
 // Spy on the telemetry ping while keeping the rest of the api module real
 // (the hook also calls setSessionArchive / setSessionSnooze through it).
@@ -46,9 +50,7 @@ describe("cockpitHookReducer / queue actions", () => {
       expect(s2.queuedPrompts).toHaveLength(2);
       expect(s2.queuedPrompts[0]?.text).toBe("first");
       expect(s2.queuedPrompts[1]?.text).toBe("second");
-      expect(s2.queuedPrompts[0]?.queuedAt).toBe(
-        "2026-01-01T00:00:00.000Z",
-      );
+      expect(s2.queuedPrompts[0]?.queuedAt).toBe("2026-01-01T00:00:00.000Z");
     } finally {
       vi.useRealTimers();
     }
@@ -59,7 +61,12 @@ describe("cockpitHookReducer / queue actions", () => {
       kind: "enqueue_prompt",
       text: "with image",
       attachments: [
-        { kind: "image", mimeType: "image/png", dataB64: "aA==", name: "x.png" },
+        {
+          kind: "image",
+          mimeType: "image/png",
+          dataB64: "aA==",
+          name: "x.png",
+        },
       ],
     });
     expect(s1.queuedPrompts[0]?.attachments).toHaveLength(1);
@@ -238,9 +245,9 @@ describe("combineQueuedPrompts (combined drain mode)", () => {
   });
 
   it("skips empty (attachment-only) entries so no stray blank lines appear (#1833)", () => {
-    expect(combineQueuedPrompts([mk("a", "before"), mk("b", ""), mk("c", "after")])).toBe(
-      "before\n\nafter",
-    );
+    expect(
+      combineQueuedPrompts([mk("a", "before"), mk("b", ""), mk("c", "after")]),
+    ).toBe("before\n\nafter");
     expect(combineQueuedPrompts([mk("a", ""), mk("b", "")])).toBe("");
   });
 });
@@ -405,6 +412,48 @@ describe("useCockpit drain race (#1144)", () => {
     expect(reportCockpitInteraction).not.toHaveBeenCalled();
   });
 
+  it("reports a prompt_queued interaction on the retryable-failure requeue path (#1888)", async () => {
+    // Idle-dormant wake: the worker was reaped, so sendPrompt POSTs directly
+    // to wake it. When that POST fails retryably (worker_not_ready 503), the
+    // prompt is re-queued, and that re-queue must ping telemetry too.
+    const { result } = renderHook(() =>
+      useCockpit("sess-retry-requeue", "absent"),
+    );
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+    // idle_auto_stop sets workerIdleStopped (not workerStopped), so sendPrompt
+    // takes the direct-POST wake path rather than parking up front.
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-retry-requeue",
+          seq: 1,
+          event: { Stopped: { reason: "idle_auto_stop" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.workerIdleStopped).toBe(true);
+
+    // Force the wake POST to fail retryably.
+    promptPostStatus = 503;
+    promptPostBody = "worker_not_ready";
+    act(() => {
+      void result.current.sendPrompt("retry me");
+    });
+    await flushAsync();
+
+    expect(promptPostCount).toBe(1);
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+    expect(reportCockpitInteraction).toHaveBeenCalledTimes(1);
+    expect(reportCockpitInteraction).toHaveBeenCalledWith("prompt_queued");
+  });
+
   it("drains the queue once the WS opens after an inactive-state enqueue (#1359)", async () => {
     const { result } = renderHook(() => useCockpit("sess-drain-resume"));
     await flushAsync();
@@ -470,7 +519,9 @@ describe("useCockpit drain race (#1144)", () => {
   it("a fresh prompt POSTs (wakes) instead of parking when the worker is idle-dormant (#1689)", async () => {
     // workerState="absent": the reconciler reaped the worker for
     // inactivity. The REST poll reads "absent" until the respawn lands.
-    const { result } = renderHook(() => useCockpit("sess-idle-fresh", "absent"));
+    const { result } = renderHook(() =>
+      useCockpit("sess-idle-fresh", "absent"),
+    );
     await flushAsync();
     const ws = sockets[0]!;
     act(() => {
@@ -524,7 +575,9 @@ describe("useCockpit drain race (#1144)", () => {
     // a cold-absent resume, then the reconciler reaped it to dormant.
     // The dormancy signal must let the drain effect fire the parked
     // prompt (the wake POST), otherwise it sits queued forever.
-    const { result } = renderHook(() => useCockpit("sess-idle-drain", "absent"));
+    const { result } = renderHook(() =>
+      useCockpit("sess-idle-drain", "absent"),
+    );
     await flushAsync();
     const ws = sockets[0]!;
     act(() => {
@@ -639,7 +692,9 @@ describe("useCockpit drain race (#1144)", () => {
     // worker_not_ready 503 for an attachment send has a retry path: park
     // it (image included) and suppress the banner, exactly like a
     // text-only send. The drain re-fires it once the worker comes online.
-    const { result } = renderHook(() => useCockpit("sess-idle-attach", "absent"));
+    const { result } = renderHook(() =>
+      useCockpit("sess-idle-attach", "absent"),
+    );
     await flushAsync();
     const ws = sockets[0]!;
     act(() => {
@@ -777,12 +832,22 @@ describe("useCockpit drain race (#1144)", () => {
 
     act(() => {
       void result.current.sendPrompt("first", [
-        { kind: "image", mimeType: "image/png", dataB64: "aA==", name: "a.png" },
+        {
+          kind: "image",
+          mimeType: "image/png",
+          dataB64: "aA==",
+          name: "a.png",
+        },
       ]);
     });
     act(() => {
       void result.current.sendPrompt("second", [
-        { kind: "image", mimeType: "image/png", dataB64: "bB==", name: "b.png" },
+        {
+          kind: "image",
+          mimeType: "image/png",
+          dataB64: "bB==",
+          name: "b.png",
+        },
       ]);
     });
     await flushAsync();
@@ -872,7 +937,9 @@ describe("useCockpit drain race (#1144)", () => {
         data: JSON.stringify({
           session_id: "sess-rl-resume",
           seq: 3,
-          event: { RateLimitAutoResumed: { resets_at: "2026-06-01T12:10:00Z" } },
+          event: {
+            RateLimitAutoResumed: { resets_at: "2026-06-01T12:10:00Z" },
+          },
         }),
       } as MessageEvent);
       ws.onmessage?.({

--- a/web/src/hooks/useCockpit.queue.test.ts
+++ b/web/src/hooks/useCockpit.queue.test.ts
@@ -16,7 +16,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { emptyCockpitState, type QueuedPrompt } from "../lib/cockpitTypes";
 import { AgentProfileProvider } from "../lib/agentProfileContext";
+import { reportCockpitInteraction } from "../lib/api";
 import { cockpitHookReducer, combineQueuedPrompts, useCockpit } from "./useCockpit";
+
+// Spy on the telemetry ping while keeping the rest of the api module real
+// (the hook also calls setSessionArchive / setSessionSnooze through it).
+vi.mock("../lib/api", async (importActual) => {
+  const actual = await importActual<typeof import("../lib/api")>();
+  return { ...actual, reportCockpitInteraction: vi.fn() };
+});
 
 describe("cockpitHookReducer / queue actions", () => {
   it("emptyCockpitState starts with an empty queue", () => {
@@ -313,6 +321,7 @@ describe("useCockpit drain race (#1144)", () => {
     promptPostStatus = 200;
     promptPostBody = "simulated failure";
     promptPostBodies = [];
+    vi.mocked(reportCockpitInteraction).mockClear();
     replayResponse = { frames: [], lost: false, highest_seq: 0 };
     vi.stubGlobal(
       "fetch",
@@ -361,6 +370,39 @@ describe("useCockpit drain race (#1144)", () => {
     expect(result.current.state.queuedPrompts[0]?.text).toBe(
       "queued before open",
     );
+  });
+
+  // #1888: parking a prompt because the agent is busy is the one cockpit
+  // interaction the daemon cannot observe (the queue is client-only), so the
+  // browser pings it for opt-in telemetry.
+  it("reports a prompt_queued telemetry interaction when a prompt parks (#1888)", async () => {
+    const { result } = renderHook(() => useCockpit("sess-queue-ping"));
+    await flushAsync();
+    // WS still CONNECTING, so sendPrompt parks the prompt rather than POSTing.
+    act(() => {
+      void result.current.sendPrompt("parked, please count me");
+    });
+    await flushAsync();
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+    expect(reportCockpitInteraction).toHaveBeenCalledTimes(1);
+    expect(reportCockpitInteraction).toHaveBeenCalledWith("prompt_queued");
+  });
+
+  it("does not report a prompt_queued interaction when a prompt POSTs directly (#1888)", async () => {
+    const { result } = renderHook(() => useCockpit("sess-queue-noping"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+    act(() => {
+      void result.current.sendPrompt("sent straight through");
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(1);
+    expect(reportCockpitInteraction).not.toHaveBeenCalled();
   });
 
   it("drains the queue once the WS opens after an inactive-state enqueue (#1359)", async () => {

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -35,7 +35,11 @@ import {
   type PersistedEntry,
 } from "../lib/cockpitStateStorage";
 import { getToken } from "../lib/token";
-import { setSessionArchive, setSessionSnooze } from "../lib/api";
+import {
+  reportCockpitInteraction,
+  setSessionArchive,
+  setSessionSnooze,
+} from "../lib/api";
 
 /** Outcome of an immediate prompt POST, used by the drain effect to
  *  decide whether to retire queued items (delivered or permanently
@@ -1255,6 +1259,10 @@ export function useCockpit(
         // (and drops the whole row on reload) so the quota invariant
         // holds. See #1833 / #1000.
         dispatch({ kind: "enqueue_prompt", text, attachments });
+        // The agent was busy, so this prompt is genuinely queued. Report it for
+        // opt-in telemetry (queue depth lives only in client state, so the
+        // daemon cannot observe queueing on its own).
+        reportCockpitInteraction("prompt_queued");
         return;
       }
       const result = await dispatchPromptNow(text, attachments);

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -504,9 +504,7 @@ function reducer(state: CockpitState, action: Action): CockpitState {
   if (action.kind === "dismiss_rejected_prompt") {
     return {
       ...state,
-      rejectedPrompts: state.rejectedPrompts.filter(
-        (r) => r.id !== action.id,
-      ),
+      rejectedPrompts: state.rejectedPrompts.filter((r) => r.id !== action.id),
     };
   }
   if (action.kind === "dismiss_mode_switch_failed") {
@@ -536,11 +534,7 @@ function reducer(state: CockpitState, action: Action): CockpitState {
   return emptyCockpitState();
 }
 
-export type ConnectionStatus =
-  | "connecting"
-  | "open"
-  | "closed"
-  | "error";
+export type ConnectionStatus = "connecting" | "open" | "closed" | "error";
 
 /** Reconnect backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s (cap). Seven
  *  attempts cover the common mobile-background / Cloudflare-idle /
@@ -703,80 +697,72 @@ export function useCockpit(
   // it while `turnActive` is true (false on a freshly-mounted hook).
   const lastActivityRef = useRef<number>(0);
 
-  const fetchReplay = useCallback(
-    async (sid: string) => {
-      try {
-        // Defensive overlap: re-fetch from `lastSeq - REPLAY_OVERLAP`
-        // instead of `lastSeq` so events that landed in the broadcast
-        // tail without being applied (WS-vs-replay race, broadcast lag
-        // window, etc.) get a second chance. The reducer's
-        // `frame.seq <= state.lastSeq` dedupe drops the overlap, so
-        // this is idempotent. See #1100.
-        const firstSince = Math.max(0, lastSeqRef.current - REPLAY_OVERLAP);
-        let cursor = firstSince;
-        // Snapshot the highest seq seen on the first page and stop there:
-        // events appended after replay began arrive over the live WS and
-        // are deduped, so chasing them here would never converge on a
-        // busy session. Captured from page one's `highest_seq`.
-        let target: number | null = null;
-        for (;;) {
-          const res = await fetch(
-            `/api/sessions/${encodeURIComponent(sid)}/cockpit/replay?since=${cursor}&limit=${REPLAY_PAGE_SIZE}`,
-            { credentials: "same-origin" },
-          );
-          if (!res.ok) return;
-          const data = (await res.json()) as {
-            frames: CockpitFrame[];
-            lost: boolean;
-            highest_seq: number;
-            next_cursor?: number | null;
-            has_more?: boolean;
-          };
-          if (target === null) {
-            target = data.highest_seq;
-            // Detect a server-side seq reset: the supervisor's per-session
-            // counter has been forgotten (cockpit_disable → cockpit_enable,
-            // or session delete+recreate with the same id), so the new
-            // conversation is starting fresh from seq=1. Without this reset
-            // the client-side dedupe would drop the new events because
-            // `frame.seq <= state.lastSeq` is true. Only meaningful on the
-            // first page, where `cursor` is the client's resume point.
-            if (data.highest_seq < firstSince) {
-              dispatch({ kind: "reset" });
-            }
+  const fetchReplay = useCallback(async (sid: string) => {
+    try {
+      // Defensive overlap: re-fetch from `lastSeq - REPLAY_OVERLAP`
+      // instead of `lastSeq` so events that landed in the broadcast
+      // tail without being applied (WS-vs-replay race, broadcast lag
+      // window, etc.) get a second chance. The reducer's
+      // `frame.seq <= state.lastSeq` dedupe drops the overlap, so
+      // this is idempotent. See #1100.
+      const firstSince = Math.max(0, lastSeqRef.current - REPLAY_OVERLAP);
+      let cursor = firstSince;
+      // Snapshot the highest seq seen on the first page and stop there:
+      // events appended after replay began arrive over the live WS and
+      // are deduped, so chasing them here would never converge on a
+      // busy session. Captured from page one's `highest_seq`.
+      let target: number | null = null;
+      for (;;) {
+        const res = await fetch(
+          `/api/sessions/${encodeURIComponent(sid)}/cockpit/replay?since=${cursor}&limit=${REPLAY_PAGE_SIZE}`,
+          { credentials: "same-origin" },
+        );
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          frames: CockpitFrame[];
+          lost: boolean;
+          highest_seq: number;
+          next_cursor?: number | null;
+          has_more?: boolean;
+        };
+        if (target === null) {
+          target = data.highest_seq;
+          // Detect a server-side seq reset: the supervisor's per-session
+          // counter has been forgotten (cockpit_disable → cockpit_enable,
+          // or session delete+recreate with the same id), so the new
+          // conversation is starting fresh from seq=1. Without this reset
+          // the client-side dedupe would drop the new events because
+          // `frame.seq <= state.lastSeq` is true. Only meaningful on the
+          // first page, where `cursor` is the client's resume point.
+          if (data.highest_seq < firstSince) {
+            dispatch({ kind: "reset" });
           }
-          // Honor `lost` on every page: a retention prune between pages
-          // can open a real gap after page one, so surface it via the
-          // existing `lagged` flag and let the user reload for the full
-          // transcript. Stop the loop; a partial transcript is wrong.
-          if (data.lost) {
-            dispatch({ kind: "lagged", skipped: data.highest_seq });
-            return;
-          }
-          if (data.frames.length > 0) {
-            dispatch({ kind: "frames", frames: data.frames });
-          }
-          const next = data.next_cursor;
-          if (
-            data.has_more &&
-            next != null &&
-            next > cursor &&
-            next < target
-          ) {
-            cursor = next;
-            continue;
-          }
-          break;
         }
-        dispatch({ kind: "lagged_resolved" });
-      } catch {
-        // Network failure: leave the lagged flag set so the user
-        // sees something is wrong rather than silently dropping
-        // frames.
+        // Honor `lost` on every page: a retention prune between pages
+        // can open a real gap after page one, so surface it via the
+        // existing `lagged` flag and let the user reload for the full
+        // transcript. Stop the loop; a partial transcript is wrong.
+        if (data.lost) {
+          dispatch({ kind: "lagged", skipped: data.highest_seq });
+          return;
+        }
+        if (data.frames.length > 0) {
+          dispatch({ kind: "frames", frames: data.frames });
+        }
+        const next = data.next_cursor;
+        if (data.has_more && next != null && next > cursor && next < target) {
+          cursor = next;
+          continue;
+        }
+        break;
       }
-    },
-    [],
-  );
+      dispatch({ kind: "lagged_resolved" });
+    } catch {
+      // Network failure: leave the lagged flag set so the user
+      // sees something is wrong rather than silently dropping
+      // frames.
+    }
+  }, []);
 
   useEffect(() => {
     if (!sessionId) {
@@ -881,8 +867,7 @@ export function useCockpit(
         if (!isCurrentDial()) return;
 
         const token = getToken();
-        const protocol =
-          window.location.protocol === "https:" ? "wss" : "ws";
+        const protocol = window.location.protocol === "https:" ? "wss" : "ws";
         // Pass `?since=<lastSeq>` so the server's on-connect drain only
         // resends events newer than what we already have. Without this,
         // a long-running session resends its full transcript on every
@@ -968,7 +953,7 @@ export function useCockpit(
               (data as { kind?: unknown }).kind === "lagged"
             ) {
               const skipped =
-                ((data as unknown) as { skipped?: number }).skipped ?? 0;
+                (data as unknown as { skipped?: number }).skipped ?? 0;
               dispatch({ kind: "lagged", skipped });
               // Try to recover via the snapshot endpoint.
               fetchReplay(sessionId);
@@ -1005,10 +990,7 @@ export function useCockpit(
     const tryAutoReconnect = () => {
       const ws = wsRef.current;
       const ready = ws?.readyState;
-      if (
-        ready === WebSocket.OPEN ||
-        ready === WebSocket.CONNECTING
-      ) {
+      if (ready === WebSocket.OPEN || ready === WebSocket.CONNECTING) {
         return;
       }
       retryCountRef.current = 0;
@@ -1066,7 +1048,8 @@ export function useCockpit(
           const detail = await safeText(res);
           dispatch({
             kind: "error",
-            message: `Could not resolve approval (${res.status}). ${detail}`.trim(),
+            message:
+              `Could not resolve approval (${res.status}). ${detail}`.trim(),
           });
         } else {
           dispatch({ kind: "clear_error" });
@@ -1100,7 +1083,8 @@ export function useCockpit(
       if (statusRef.current !== "open") {
         dispatch({
           kind: "error",
-          message: "Cockpit disconnected; message not sent. Reconnect to retry.",
+          message:
+            "Cockpit disconnected; message not sent. Reconnect to retry.",
         });
         return "retryable_failure";
       }
@@ -1108,16 +1092,14 @@ export function useCockpit(
       // local data URL so the bubble shows immediately, before the
       // server confirms and replay would otherwise back it with the
       // GET endpoint. See #1000 / #965.
-      const previews: CockpitAttachment[] = (attachments ?? []).map(
-        (a, i) => ({
-          id: `local-${Date.now()}-${i}`,
-          kind: a.kind,
-          mimeType: a.mimeType,
-          name: a.name,
-          size: Math.floor((a.dataB64.length * 3) / 4),
-          url: `data:${a.mimeType};base64,${a.dataB64}`,
-        }),
-      );
+      const previews: CockpitAttachment[] = (attachments ?? []).map((a, i) => ({
+        id: `local-${Date.now()}-${i}`,
+        kind: a.kind,
+        mimeType: a.mimeType,
+        name: a.name,
+        size: Math.floor((a.dataB64.length * 3) / 4),
+        url: `data:${a.mimeType};base64,${a.dataB64}`,
+      }));
       // Optimistically echo the user's message; the agent reply
       // streams back as session/update events on the WS. If the POST
       // fails we'll surface a banner and the user can retry; the
@@ -1176,7 +1158,8 @@ export function useCockpit(
           if (!workerNotReady) {
             dispatch({
               kind: "error",
-              message: `Could not send prompt (${res.status}). ${detail}`.trim(),
+              message:
+                `Could not send prompt (${res.status}). ${detail}`.trim(),
             });
           }
           return rejected ? "non_retryable_failure" : "retryable_failure";
@@ -1247,7 +1230,10 @@ export function useCockpit(
       // local queue forever and the worker would never come back. Only a
       // non-dormant cold worker (genuine mid-resume) still parks. See #1689.
       const blockedAsideFromWorker =
-        wsClosed || state.turnActive || state.workerStopped || state.workerRestarting;
+        wsClosed ||
+        state.turnActive ||
+        state.workerStopped ||
+        state.workerRestarting;
       const shouldEnqueue = state.workerIdleStopped
         ? blockedAsideFromWorker
         : blockedAsideFromWorker || workerNotRunning;
@@ -1273,6 +1259,10 @@ export function useCockpit(
       // AcpSessionAssigned brings the worker online. See #1748 / #1833.
       if (result === "retryable_failure" && state.workerIdleStopped) {
         dispatch({ kind: "enqueue_prompt", text, attachments });
+        // Same parked-prompt telemetry as the busy-agent path above: the
+        // idle-dormant wake POST failed retryably, so this prompt is queued
+        // too and the daemon cannot observe it on its own.
+        reportCockpitInteraction("prompt_queued");
       }
     },
     [
@@ -1313,7 +1303,8 @@ export function useCockpit(
     // dormancy and `send_prompt`'s `wait_for_worker` holds the POST
     // until the respawned worker is ready. Without this, a prompt the
     // user queued while the worker was dormant would never drain. #1689.
-    if (workerStateRef.current !== "running" && !state.workerIdleStopped) return;
+    if (workerStateRef.current !== "running" && !state.workerIdleStopped)
+      return;
     // Reconnect race: connect() awaits fetchReplay BEFORE opening the
     // WS, and replay can dispatch a Stopped frame that flips turnActive
     // off. If we drain here while the WS is still in "connecting",
@@ -1533,8 +1524,7 @@ export function useCockpit(
         const detail = await safeText(res);
         dispatch({
           kind: "error",
-          message:
-            `Could not force end turn (${res.status}). ${detail}`.trim(),
+          message: `Could not force end turn (${res.status}). ${detail}`.trim(),
         });
       }
     } catch (e) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -458,6 +458,19 @@ export function reportTelemetrySeen(surface: "web" | "cockpit"): void {
   }).catch(() => {});
 }
 
+/// Report a cockpit interaction the daemon cannot observe itself, so its next
+/// opt-in snapshot can fold it in. Today the only kind is a queued prompt: the
+/// prompt queue lives entirely in client state, so the browser is the one
+/// surface that can report it. Best-effort; the daemon only counts when the
+/// user is opted in.
+export function reportCockpitInteraction(kind: "prompt_queued"): void {
+  void fetch("/api/telemetry/cockpit-interaction", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ kind }),
+  }).catch(() => {});
+}
+
 /** Runtime helper around `ServerAbout.build_flavor`. See #1055. */
 export function isDebugBuild(about: ServerAbout | null | undefined): boolean {
   if (!about) return false;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -187,6 +187,18 @@
       ]
     },
     {
+      "id": "telemetry.cockpit-interaction",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/hooks/useCockpit.queue.test.ts"
+      ],
+      "components": [
+        "web/src/hooks/useCockpit.ts",
+        "web/src/lib/api.ts"
+      ]
+    },
+    {
       "id": "settings.theme-persistence-passphrase",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds aggregate cockpit-interaction telemetry so we can tell "opened" from "actually used". Today `cockpit_seen` is the entire cockpit signal (a single bool), so we know the cockpit was opened but nothing about whether people drive it. This lands Option A from the issue: a small set of coarse, aggregate counters accumulated daemon-side over the snapshot window, folded into the existing `usage_snapshot`.

New `UsageSnapshot` fields (schema bumped 1 to 2):
- `approvals_resolved` plus an allowlisted `approvals_by_decision` map (`allow` / `allow_always` / `deny`; the synthetic daemon-restart `Cancelled` is never counted). Shows whether people lean on `allow_always` (trust) vs `deny` (friction).
- `agent_switches` and `substrate_toggles` (cockpit/terminal), counted only on a real transition, not an idempotent re-apply.
- `plan_mode_seen` (a session entered plan mode).
- `prompts_queued` (a prompt was parked because the agent was busy).

Four of the five signals are tallied inside their REST handlers on success, so every surface (web cockpit, TUI cockpit, CLI) funnels through the daemon. `prompts_queued` is the exception: the prompt queue lives only in the web cockpit's client state, so the browser pings a new `POST /api/telemetry/cockpit-interaction` endpoint. The counters use the same failure-loss-safe pattern as `web_seen` / `cockpit_seen` (#1875): decremented by exactly the reported amount only after a confirmed send, so an interaction that lands mid-send rolls into the next snapshot.

Privacy: every new field is a count or a closed decision-key map. No prompt text, tool name, file path, or agent command can ride along.

**Telemetry repo:** no `aoe-telemetry` changes needed. The gateway is schemaless (`extra="allow"`) and re-sanitizes by shape, so the new scalar counts, the boolean, and the flat `approvals_by_decision` map are accepted as-is and the schema-version bump is ignored. This ticket lands entirely inside agent-of-empires.

Closes #1888

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] Opt in to telemetry, point `AOE_TELEMETRY_ENDPOINT` at a local sink, open a cockpit session, resolve two approvals as Allow and one as Deny, then stop the daemon and confirm the flushed `usage_snapshot` reports `approvals_resolved: 3` and `approvals_by_decision: {allow: 2, deny: 1}`.
- [ ] Switch the session agent once and toggle cockpit/terminal twice; confirm the next snapshot reports `agent_switches: 1` and `substrate_toggles: 2` (a repeated enable on an already-cockpit session does not add a toggle).
- [ ] Enter plan mode and queue a prompt (send while the agent is busy); confirm `plan_mode_seen` is true and `prompts_queued` increments, and that the browser fired `POST /api/telemetry/cockpit-interaction {"kind":"prompt_queued"}`.
- [ ] With telemetry opted out, drive all of the above and confirm nothing is recorded or sent.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

<!-- The queued-prompt ping is a request-payload permutation, which per AGENTS.md belongs in Vitest + RTL rather than live Playwright: covered in web/src/hooks/useCockpit.queue.test.ts and mapped in coverage-matrix.json (telemetry.cockpit-interaction). The daemon-side aggregation, decision mix, privacy shape, and failure-loss clearing are covered deterministically by Rust tests in tests/telemetry.rs and src/server/mod.rs. -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (with a `/debate` design pass), and implementation drafted by Claude under my direction. I made the design calls (full signal set, keep the queued-prompt ping, plan-mode at the accepted set-mode, gate substrate toggles on real transitions) and own the work.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Added daemon-aggregated, privacy-preserving telemetry that records real cockpit interactions and bumped the telemetry schema version to include those fields.

## High-level summary (non-technical)

- The daemon now counts actual cockpit usage (approval resolutions and their decision mix, agent switches, tmux↔cockpit toggles, plan-mode entries, and queued prompts) rather than only counting UI opens.
- The web client reports queued prompts to the server via a new POST endpoint; the server tallies most signals on committed transitions.
- Per-snapshot counts are captured server-side and only decremented after a confirmed telemetry send so interactions that occur during an in-flight send are preserved.
- Only scalar, allowlisted counts are emitted (no prompt text, file paths, commands, or other free-form data).
- Tests, docs, and dashboards were added or updated; no gateway changes required.

## What Was Added

- New per-snapshot cockpit metrics: approvals_resolved and approvals_by_decision (keys: allow, allow_always, deny), agent_switches, substrate_toggles, plan_mode_seen, prompts_queued.
- In-memory atomic counters on AppState (CockpitTelemetryCounters) and a new CockpitInteractionCounts snapshot type.
- New API route POST /api/telemetry/cockpit-interaction accepting kind == "prompt_queued".
- Client helper reportCockpitInteraction("prompt_queued") and integration in useCockpit (including retryable requeue path).
- Tests: Rust unit/integration tests for aggregation and decrement semantics, and web tests (Vitest/Playwright) covering queued-prompt reporting and retry paths.
- Docs and coverage-matrix updates; PostHog dashboard tiles prepared.

## What Was Updated

- UsageSnapshot and telemetry builder populated with new cockpit fields; telemetry schema version bumped.
- Serve snapshot semantics extended to read-and-swap reported counts and to decrement using saturating updates to avoid underflow and preserve concurrent increments.
- Telemetry mutating handlers audited for read-before-JSON-validation and read-only guard coverage.
- Small bugfix: ensure prompt_queued is reported on retryable requeue.

## Benefits

- Yields actionable signals that distinguish real cockpit use from mere UI opens (decision mix, session switches, plan-mode adoption, queued prompts).
- Privacy-preserving (closed-key scalar counts only).
- Robust to concurrent updates and partial-send failures via swap-on-read and saturating decrements.
- Ready for analytics once clients emit the new schema.

## Technical summary (concise)

- New type: CockpitInteractionCounts; UsageSnapshot gains fields: approvals_resolved, approvals_by_decision, agent_switches, substrate_toggles, plan_mode_seen, prompts_queued; schema version incremented.
- AppState adds telemetry_cockpit: CockpitTelemetryCounters with AtomicU32 fields for each metric.
- Server handlers increment atomics only on committed transitions; build_usage_snapshot reads raw atomics into CockpitInteractionCounts and records reported values for deferred clearing.
- Confirmed-send clearing uses fetch_update + saturating_sub to avoid underflow and preserve concurrent increments.
- New handler post_telemetry_cockpit_interaction validates kind == "prompt_queued" and increments prompts_queued; web exports reportCockpitInteraction and useCockpit calls it where prompts are enqueued.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->