### PR TITLE
fix(telemetry): robustness cleanups (RMW lock, single config load, throttle comment, interval jitter)

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -13,10 +13,14 @@ closed, versioned schema (see `src/telemetry/events.rs`):
 
 - **`process_start`** on boot: surface (`cli` / `tui` / `serve`), aoe version,
   OS, and CPU arch. The `cli` surface is throttled to at most once per install
-  per day, so scripting `aoe` in a loop never floods the endpoint.
-- **`usage_snapshot`** from the TUI and `aoe serve`, on start and then every
-  ~12 hours. It is a point-in-time summary of the current install, never a
-  stream of actions:
+  per day, so scripting `aoe` in a loop never floods the endpoint. The long-lived
+  `tui` and `serve` surfaces emit one per launch (not throttled), so a restart is
+  visible; a pathological crash-loop is absorbed by the gateway rather than a
+  local cap.
+- **`usage_snapshot`** from the TUI and `aoe serve`, on start and then about
+  every 12 hours, with a small random jitter on the period so installs that boot
+  together don't snapshot in lockstep. It is a point-in-time summary of the
+  current install, never a stream of actions:
   - how many sessions exist and how many are running / idle / errored,
   - how many use a sandbox, the cockpit, or yolo mode,
   - a per-agent and per-model-family count (e.g. `{claude: 3, codex: 1}`),
@@ -62,8 +66,10 @@ never derived from hostname, username, MAC, or filesystem.
 
 Counting distinct installs needs a stable id. On opt-in, aoe generates a random
 `uuid::Uuid::new_v4()` and stores it in `<app_dir>/telemetry.json` (owner-only).
-It is kept **out of `config.toml`** on purpose, since people routinely paste
-their config into bug reports. Opting out deletes the file; `aoe telemetry
+Updates to that file are serialized with an advisory lock (a `.telemetry.lock`
+sidecar) so concurrent `aoe` processes (TUI, CLI, `aoe serve`) can't clobber each
+other's writes. It is kept **out of `config.toml`** on purpose, since people
+routinely paste their config into bug reports. Opting out deletes the file; `aoe telemetry
 reset-id` rotates it. Resetting mints a brand-new id, so that install then
 counts as a new one in the aggregate distinct-install and retention numbers;
 only reset if you actually want to disassociate from prior counts.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1653,14 +1653,18 @@ fn merge_runtime_fields(prior: Instance, mut fresh: Instance) -> Instance {
 }
 
 /// Background task: emit an opt-in telemetry `process_start` for the serve
-/// surface, then a `usage_snapshot` immediately and every 12 hours, plus a
-/// final one on graceful shutdown. All sends are best-effort and swallow
+/// surface, then a `usage_snapshot` immediately and every ~12 hours (jittered),
+/// plus a final one on graceful shutdown. All sends are best-effort and swallow
 /// errors; nothing leaves the box unless the user opted in and an endpoint is
 /// configured.
 fn spawn_telemetry_loop(state: Arc<AppState>) {
     crate::telemetry::spawn_process_start(crate::telemetry::Surface::Serve);
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(12 * 60 * 60));
+        // Jittered period (12h + up to 30m) so installs that boot together don't
+        // snapshot in lockstep; the first tick is still immediate (boot
+        // snapshot). `Delay` avoids a burst of catch-up ticks after a stall.
+        let mut interval = tokio::time::interval(crate::telemetry::snapshot_interval());
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             tokio::select! {
                 _ = state.shutdown.cancelled() => {

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -27,7 +27,10 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 pub use events::{ProcessStart, Surface, UsageSnapshot, SCHEMA_VERSION};
-pub use state::{cli_process_start_due, install_id, record_cli_process_start, reset_install_id};
+pub use state::{
+    confirm_cli_process_start, ensure_install_id, install_id, reserve_cli_process_start,
+    reset_install_id,
+};
 
 use crate::session::Instance;
 
@@ -52,16 +55,40 @@ const DEFAULT_ENDPOINT: &str = "https://telemetry.agent-of-empires.com/v1/ingest
 /// gateway must be configured to require this exact value.
 const TELEMETRY_KEY: &str = "7bc5a4e45ce861662b9690a7105da988";
 
-/// CLI `process_start` is the only unbounded event source (one per `aoe`
-/// invocation), so it is throttled to at most once per install per day. That
-/// still answers "did this install run the CLI today" without a POST per
-/// command.
+/// CLI `process_start` is the only *high-frequency* event source in normal use
+/// (one per `aoe` invocation, and users script `aoe` in loops), so it is
+/// throttled locally to at most once per install per day. That still answers
+/// "did this install run the CLI today" without a POST per command. TUI and
+/// `aoe serve` `process_start` stay per-launch and are deliberately not capped:
+/// one emit per launch is the signal we want, and suppressing it would hide
+/// legitimate restarts. A pathological crash-loop could still flood from those
+/// surfaces; that is accepted as a telemetry-only risk, absorbed by the
+/// gateway's `X-Telemetry-Key` rate limiting rather than a local throttle.
 const CLI_PROCESS_START_MIN_GAP: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Retry backoff after a *failed* CLI `process_start` send. While the daily slot
 /// stays open (a failed send never claims it), this bounds re-attempts to once
 /// per hour so a down endpoint can't make every `aoe` invocation re-send.
 const CLI_PROCESS_START_RETRY_GAP: Duration = Duration::from_secs(60 * 60);
+
+/// Base cadence for periodic `usage_snapshot` sends (TUI and serve). The real
+/// period is this plus bounded jitter (see [`snapshot_interval`]).
+pub const SNAPSHOT_BASE_INTERVAL: Duration = Duration::from_secs(12 * 60 * 60);
+
+/// Upper bound on the random jitter added to [`SNAPSHOT_BASE_INTERVAL`].
+const SNAPSHOT_JITTER: Duration = Duration::from_secs(30 * 60);
+
+/// Periodic snapshot period: [`SNAPSHOT_BASE_INTERVAL`] plus a random offset in
+/// `[0, SNAPSHOT_JITTER)`. A fixed 12h period anchored to process start means a
+/// fleet that boots together (e.g. a post-update restart wave) keeps snapshotting
+/// in lockstep forever; rolling a per-process jitter decorrelates the periodic
+/// ticks so they spread apart by the second tick. The boot snapshot is sent
+/// separately and stays immediate, so this only shapes the steady-state cadence.
+pub fn snapshot_interval() -> Duration {
+    use rand::RngExt;
+    let jitter_ms = rand::rng().random_range(0..SNAPSHOT_JITTER.as_millis() as u64);
+    SNAPSHOT_BASE_INTERVAL + Duration::from_millis(jitter_ms)
+}
 
 /// True when `DO_NOT_TRACK` is set to an affirmative value. This is the
 /// absolute override: it wins over `config.telemetry.enabled`.
@@ -93,6 +120,13 @@ pub fn is_opted_in() -> bool {
     crate::session::get_telemetry_settings().enabled && !do_not_track()
 }
 
+/// Opt-in check against an already-loaded `Config`, so a caller that needs the
+/// full config anyway (e.g. [`build_usage_snapshot`] for `active_features`)
+/// doesn't parse `config.toml` a second time via [`is_opted_in`].
+fn opted_in_with(config: &crate::session::Config) -> bool {
+    config.telemetry.enabled && !do_not_track()
+}
+
 /// Apply an opt-in/opt-out transition's side effect on the install id. The
 /// caller is responsible for persisting `config.telemetry.enabled`; this only
 /// manages `telemetry.json`. Enabling (when not suppressed) generates the id;
@@ -119,7 +153,14 @@ pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
         return None;
     }
     let install_id = state::ensure_install_id()?;
-    Some(ProcessStart {
+    Some(process_start_event(surface, install_id))
+}
+
+/// Assemble a `process_start` event from an already-resolved install id. Shared
+/// by [`build_process_start`] (which ensures the id) and the CLI flush path
+/// (which gets the id from [`state::reserve_cli_process_start`]).
+fn process_start_event(surface: Surface, install_id: String) -> ProcessStart {
+    ProcessStart {
         schema: SCHEMA_VERSION,
         event: "process_start",
         install_id,
@@ -128,7 +169,7 @@ pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
         aoe_version: env!("CARGO_PKG_VERSION").to_string(),
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
-    })
+    }
 }
 
 /// Build a `usage_snapshot` from the current sessions, or `None` when not
@@ -141,13 +182,41 @@ pub fn build_usage_snapshot(
     cockpit_seen: bool,
     session_creates_since_last_snapshot: u32,
 ) -> Option<UsageSnapshot> {
-    if !is_opted_in() {
+    // Load the global, pre-profile-merge config exactly once and reuse it for
+    // both the opt-in gate and `active_features`, instead of parsing
+    // `config.toml` twice (once via `is_opted_in`, once for features). It is the
+    // install-level config on purpose: `features` is a default-adoption signal,
+    // not per-session usage. See `features::active_features`.
+    let config = crate::session::Config::load_or_warn();
+    if !opted_in_with(&config) {
         return None;
     }
     let install_id = state::ensure_install_id()?;
-    // Global, pre-profile-merge config on purpose: `features` is an install-level
-    // default-adoption signal, not per-session usage. See `features::active_features`.
-    let features = features::active_features(&crate::session::Config::load_or_warn());
+    Some(assemble_usage_snapshot(
+        surface,
+        install_id,
+        &config,
+        instances,
+        web_seen,
+        cockpit_seen,
+        session_creates_since_last_snapshot,
+    ))
+}
+
+/// Pure assembly of a `usage_snapshot` from an already-resolved install id and
+/// config: no disk reads, no opt-in gate, no id generation. Split out of
+/// [`build_usage_snapshot`] so the bucketing and feature-map logic can be unit
+/// tested with an injected `Config` and no filesystem or env mutation.
+fn assemble_usage_snapshot(
+    surface: Surface,
+    install_id: String,
+    config: &crate::session::Config,
+    instances: &[Instance],
+    web_seen: bool,
+    cockpit_seen: bool,
+    session_creates_since_last_snapshot: u32,
+) -> UsageSnapshot {
+    let features = features::active_features(config);
 
     let mut sessions_by_agent: BTreeMap<String, u32> = BTreeMap::new();
     let mut sessions_by_model_bucket: BTreeMap<String, u32> = BTreeMap::new();
@@ -198,7 +267,7 @@ pub fn build_usage_snapshot(
             .or_insert(0) += 1;
     }
 
-    Some(UsageSnapshot {
+    UsageSnapshot {
         schema: SCHEMA_VERSION,
         event: "usage_snapshot",
         install_id,
@@ -220,7 +289,7 @@ pub fn build_usage_snapshot(
         web_seen,
         cockpit_seen,
         session_creates_since_last_snapshot,
-    })
+    }
 }
 
 /// POST a serialized event to the endpoint. Returns `true` only on a *confirmed*
@@ -301,11 +370,26 @@ pub async fn flush_cli_process_start() {
     if !is_opted_in() {
         return;
     }
-    if !cli_process_start_due(CLI_PROCESS_START_MIN_GAP, CLI_PROCESS_START_RETRY_GAP) {
+    // Reserve the daily slot under the state lock *before* sending: the check,
+    // the id, and the attempt stamp are one transaction, so two concurrent `aoe`
+    // invocations can't both pass the gate and both send. `None` means not due,
+    // suppressed, or the lock was contended; in every case there is nothing to
+    // send.
+    let Some(install_id) =
+        state::reserve_cli_process_start(CLI_PROCESS_START_MIN_GAP, CLI_PROCESS_START_RETRY_GAP)
+    else {
         return;
+    };
+    let event = process_start_event(Surface::Cli, install_id.clone());
+    let confirmed = matches!(
+        tokio::time::timeout(SEND_TIMEOUT, post(&event)).await,
+        Ok(true)
+    );
+    if confirmed {
+        // Claim the confirmed-delivery slot. A no-op if an opt-out / reset-id
+        // changed the install id while the send was in flight.
+        state::confirm_cli_process_start(&install_id);
     }
-    let confirmed = flush_process_start(Surface::Cli).await;
-    record_cli_process_start(confirmed);
 }
 
 /// Fingerprint of the last `usage_snapshot` whose send we initiated this
@@ -537,5 +621,48 @@ mod tests {
             "peeking must not record the fingerprint, so it still does not match"
         );
         *LAST_SNAPSHOT_FP.lock().unwrap() = None;
+    }
+
+    // Item B (#1877): the pure assembler builds a snapshot from an injected
+    // `Config` and install id with no disk reads, no opt-in gate, and no id
+    // generation. `build_usage_snapshot` therefore parses `config.toml` exactly
+    // once (for both the opt-in check and `active_features`) instead of twice.
+    #[test]
+    fn assemble_usage_snapshot_uses_injected_config_without_disk() {
+        use crate::session::{Config, Instance};
+        let config = Config::default();
+        let inst = Instance::new("s", "/p");
+
+        let snapshot = assemble_usage_snapshot(
+            Surface::Tui,
+            "test-install-id".to_string(),
+            &config,
+            std::slice::from_ref(&inst),
+            false,
+            false,
+            3,
+        );
+
+        assert_eq!(snapshot.install_id, "test-install-id");
+        assert_eq!(snapshot.session_total, 1);
+        assert_eq!(snapshot.session_creates_since_last_snapshot, 3);
+        // The feature map comes from the injected config, proving the assembler
+        // consumes it rather than re-loading from disk.
+        assert_eq!(snapshot.features, features::active_features(&config));
+    }
+
+    // Item D (#1877): the jittered snapshot period always lands in
+    // `[base, base + jitter)`, so the cadence is bounded while still spreading
+    // installs apart.
+    #[test]
+    fn snapshot_interval_stays_within_jitter_bound() {
+        for _ in 0..1000 {
+            let period = snapshot_interval();
+            assert!(period >= SNAPSHOT_BASE_INTERVAL, "below base: {period:?}");
+            assert!(
+                period < SNAPSHOT_BASE_INTERVAL + SNAPSHOT_JITTER,
+                "above base+jitter: {period:?}"
+            );
+        }
     }
 }

--- a/src/telemetry/state.rs
+++ b/src/telemetry/state.rs
@@ -7,11 +7,33 @@
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::time::Duration;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use crate::session::get_app_dir;
+
+/// Sidecar advisory-lock file next to `telemetry.json`. Mirrors the `.lock`
+/// sidecars used by `src/session/storage.rs` and `src/logging.rs`; left on disk
+/// (never removed) so two processes can't race to recreate and re-lock it.
+const STATE_LOCK_FILENAME: &str = ".telemetry.lock";
+
+/// How long [`update_state_locked`] will wait for the cross-process flock before
+/// giving up. Telemetry is fire-and-forget and must never stall a user command,
+/// so a contended lock is abandoned (the update is skipped) rather than waited
+/// on; the only loss is a single deferred stamp, recovered on the next call.
+const LOCK_ACQUIRE_BUDGET: Duration = Duration::from_millis(500);
+
+/// Poll cadence for the flock acquire. Well below human perception and far
+/// above the microsecond hold time of a single tiny-file read-modify-write.
+const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Serializes the `telemetry.json` read-modify-write across threads *within*
+/// this process; the file flock serializes it across processes. Always taken
+/// before the flock so the ordering can never invert into a deadlock.
+static STATE_RMW_MUTEX: Mutex<()> = Mutex::new(());
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct TelemetryState {
@@ -58,6 +80,101 @@ fn save_state(state: &TelemetryState) -> Result<()> {
     Ok(())
 }
 
+/// RAII guard for the held cross-process advisory flock. `fs2` (and the kernel
+/// on fd close / process exit, including SIGKILL) releases the lock on drop, so
+/// a panic in the critical section still frees it for the next process.
+struct StateFlock {
+    file: std::fs::File,
+}
+
+impl Drop for StateFlock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+/// Acquire the exclusive advisory flock on `<app_dir>/.telemetry.lock`, polling
+/// `try_lock_exclusive` until granted or [`LOCK_ACQUIRE_BUDGET`] elapses. Bounded
+/// (unlike the storage flock's indefinite wait) because telemetry must never
+/// block the caller. Open semantics mirror the storage / logging locks
+/// (read+write, create, no truncate, `0o600` on Unix).
+fn acquire_state_flock() -> Result<StateFlock> {
+    let path = get_app_dir()?.join(STATE_LOCK_FILENAME);
+    #[cfg(unix)]
+    let file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(&path)?
+    };
+    #[cfg(not(unix))]
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)?;
+
+    let started = Instant::now();
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(StateFlock { file }),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if started.elapsed() >= LOCK_ACQUIRE_BUDGET {
+                    anyhow::bail!("telemetry state lock contended beyond budget");
+                }
+                std::thread::sleep(LOCK_POLL_INTERVAL);
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+/// Run a `telemetry.json` read-modify-write under both the process-local mutex
+/// and the cross-process flock, so concurrent updaters (TUI, CLI, `aoe serve`)
+/// can never lose each other's writes (the lost-update race in #1877). `f`
+/// receives the loaded state and returns `(value, dirty)`; the state is
+/// persisted only when `dirty` is true, so a pure check never recreates the
+/// file. Returns `Err` (and writes nothing) when the lock is contended past the
+/// budget; callers treat that as "skip this update".
+fn update_state_locked<R>(f: impl FnOnce(&mut TelemetryState) -> (R, bool)) -> Result<R> {
+    let _guard = STATE_RMW_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _flock = acquire_state_flock()?;
+    let mut state = load_state();
+    let (value, dirty) = f(&mut state);
+    if dirty {
+        save_state(&state)?;
+    }
+    Ok(value)
+}
+
+/// Whether a CLI `process_start` send is due given an already-loaded `state`.
+/// Due when the last *confirmed* send is older than `success_gap` (or never)
+/// AND the last *attempt* is older than `retry_gap` (or never). Pure: the
+/// caller evaluates it under the lock in [`reserve_cli_process_start`] so the
+/// check and the claim are one transaction.
+fn due_in_state(
+    state: &TelemetryState,
+    now: DateTime<Utc>,
+    success_gap: Duration,
+    retry_gap: Duration,
+) -> bool {
+    // A stamp is "fresh" when its positive elapsed is still inside the gap. A
+    // negative elapsed (clock skew) counts as not fresh, so the send is allowed.
+    let fresh = |stamp: Option<DateTime<Utc>>, gap: Duration| match stamp {
+        Some(last) => matches!((now - last).to_std(), Ok(elapsed) if elapsed < gap),
+        None => false,
+    };
+    !fresh(state.last_cli_process_start, success_gap)
+        && !fresh(state.last_cli_process_start_attempt, retry_gap)
+}
+
 /// The current install id, if one has been generated. Read-only: never
 /// generates. Returns `None` when telemetry was never opted into.
 pub fn install_id() -> Option<String> {
@@ -71,21 +188,31 @@ pub fn ensure_install_id() -> Option<String> {
     if super::do_not_track() {
         return None;
     }
-    let mut state = load_state();
-    if let Some(id) = state.install_id.as_ref().filter(|s| !s.trim().is_empty()) {
-        return Some(id.clone());
+    let result = update_state_locked(|state| {
+        if let Some(id) = state.install_id.as_ref().filter(|s| !s.trim().is_empty()) {
+            return (Some(id.clone()), false);
+        }
+        let id = uuid::Uuid::new_v4().to_string();
+        state.install_id = Some(id.clone());
+        (Some(id), true)
+    });
+    match result {
+        Ok(value) => value,
+        Err(e) => {
+            tracing::debug!(target: "telemetry", "failed to persist install id: {e}");
+            None
+        }
     }
-    let id = uuid::Uuid::new_v4().to_string();
-    state.install_id = Some(id.clone());
-    if let Err(e) = save_state(&state) {
-        tracing::debug!(target: "telemetry", "failed to persist install id: {e}");
-        return None;
-    }
-    Some(id)
 }
 
 /// Delete the install id (and its file) on opt-out. Idempotent.
 pub fn delete_install_id() -> Result<()> {
+    // Held under the same mutex + flock as the writers so an opt-out can't race
+    // a concurrent `ensure_install_id` and leave a half-state behind.
+    let _guard = STATE_RMW_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _flock = acquire_state_flock()?;
     let path = state_path()?;
     if path.exists() {
         std::fs::remove_file(&path)?;
@@ -103,37 +230,55 @@ pub fn reset_install_id() -> Option<String> {
     ensure_install_id()
 }
 
-/// Whether a CLI `process_start` send is due. Due when the last *confirmed*
-/// send is older than `success_gap` (or never) AND the last *attempt* is older
-/// than `retry_gap` (or never). `success_gap` is the real once-per-day throttle
-/// that bounds the only unbounded telemetry source; `retry_gap` bounds how often
-/// a failed send is retried so a down endpoint can't turn every `aoe` invocation
-/// into a fresh attempt. Caller is responsible for the opt-in gate. Read-only:
-/// the stamps are written by [`record_cli_process_start`] after the send.
-pub fn cli_process_start_due(success_gap: Duration, retry_gap: Duration) -> bool {
-    let state = load_state();
-    let now = Utc::now();
-    // A stamp is "fresh" when its positive elapsed is still inside the gap. A
-    // negative elapsed (clock skew) counts as not fresh, so the send is allowed.
-    let fresh = |stamp: Option<DateTime<Utc>>, gap: Duration| match stamp {
-        Some(last) => matches!((now - last).to_std(), Ok(elapsed) if elapsed < gap),
-        None => false,
-    };
-    !fresh(state.last_cli_process_start, success_gap)
-        && !fresh(state.last_cli_process_start_attempt, retry_gap)
+/// Atomically reserve a CLI `process_start` send, returning the install id to
+/// send with when one is *due*, or `None` when not due, suppressed by
+/// `DO_NOT_TRACK`, or the lock is contended. Due when the last *confirmed* send
+/// is older than `success_gap` (or never) AND the last *attempt* older than
+/// `retry_gap` (or never). The whole check-and-claim runs under the lock: the
+/// attempt stamp is written and an install id ensured in the same transaction,
+/// so two concurrent `aoe` invocations can never both pass the gate and both
+/// send (the duplicate-send race in #1877). `success_gap` is the once-per-day
+/// throttle that bounds the only high-frequency source; `retry_gap` bounds how
+/// often a failed send is retried so a down endpoint can't turn every
+/// invocation into a fresh attempt. Caller owns the opt-in gate.
+pub fn reserve_cli_process_start(success_gap: Duration, retry_gap: Duration) -> Option<String> {
+    if super::do_not_track() {
+        return None;
+    }
+    update_state_locked(|state| {
+        let now = Utc::now();
+        if !due_in_state(state, now, success_gap, retry_gap) {
+            return (None, false);
+        }
+        let id = match state.install_id.as_ref().filter(|s| !s.trim().is_empty()) {
+            Some(id) => id.clone(),
+            None => {
+                let id = uuid::Uuid::new_v4().to_string();
+                state.install_id = Some(id.clone());
+                id
+            }
+        };
+        state.last_cli_process_start_attempt = Some(now);
+        (Some(id), true)
+    })
+    .ok()
+    .flatten()
 }
 
-/// Record a CLI `process_start` send. Always stamps the attempt (so `retry_gap`
-/// bounds retries); stamps the confirmed-delivery slot only when `success`, so a
-/// failed send leaves the daily slot open for the next invocation to retry.
-pub fn record_cli_process_start(success: bool) {
-    let mut state = load_state();
-    let now = Utc::now();
-    state.last_cli_process_start_attempt = Some(now);
-    if success {
-        state.last_cli_process_start = Some(now);
-    }
-    if let Err(e) = save_state(&state) {
+/// Confirm a reserved CLI `process_start` send was delivered, claiming the daily
+/// slot. A no-op (writing nothing, so the file is never recreated) when the
+/// install id no longer matches, i.e. an opt-out or `reset-id` landed during the
+/// in-flight send. The attempt stamp was already written by
+/// [`reserve_cli_process_start`]; this only stamps the confirmed-delivery slot.
+pub fn confirm_cli_process_start(install_id: &str) {
+    let result = update_state_locked(|state| {
+        if state.install_id.as_deref() != Some(install_id) {
+            return ((), false);
+        }
+        state.last_cli_process_start = Some(Utc::now());
+        ((), true)
+    });
+    if let Err(e) = result {
         tracing::debug!(target: "telemetry", "failed to persist cli throttle stamp: {e}");
     }
 }

--- a/src/telemetry/state.rs
+++ b/src/telemetry/state.rs
@@ -95,10 +95,43 @@ impl Drop for StateFlock {
 
 /// Acquire the exclusive advisory flock on `<app_dir>/.telemetry.lock`, polling
 /// `try_lock_exclusive` until granted or [`LOCK_ACQUIRE_BUDGET`] elapses. Bounded
-/// (unlike the storage flock's indefinite wait) because telemetry must never
-/// block the caller. Open semantics mirror the storage / logging locks
-/// (read+write, create, no truncate, `0o600` on Unix).
+/// (unlike the storage flock's indefinite wait) because fire-and-forget telemetry
+/// must never block the caller. User-initiated mutations use
+/// [`acquire_state_flock_blocking`] instead.
 fn acquire_state_flock() -> Result<StateFlock> {
+    let file = open_state_lock_file()?;
+    let started = Instant::now();
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(StateFlock { file }),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if started.elapsed() >= LOCK_ACQUIRE_BUDGET {
+                    anyhow::bail!("telemetry state lock contended beyond budget");
+                }
+                std::thread::sleep(LOCK_POLL_INTERVAL);
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+/// Acquire the exclusive flock with a *blocking* wait, for user-initiated
+/// mutations (opt-out / `reset-id`) whose documented contract is that the file
+/// is actually deleted. Unlike [`acquire_state_flock`], it does not give up on
+/// contention: the bounded skip is right for fire-and-forget telemetry, but an
+/// explicit opt-out must not silently leave `telemetry.json` behind. The kernel
+/// releases the lock on fd close / process exit, so a crashed peer can't wedge
+/// this forever.
+fn acquire_state_flock_blocking() -> Result<StateFlock> {
+    let file = open_state_lock_file()?;
+    FileExt::lock_exclusive(&file)?;
+    Ok(StateFlock { file })
+}
+
+/// Open (creating if needed) the sidecar lock file. Shared by the bounded and
+/// blocking acquire paths. Open semantics mirror the storage / logging locks
+/// (read+write, create, no truncate, `0o600` on Unix).
+fn open_state_lock_file() -> Result<std::fs::File> {
     let path = get_app_dir()?.join(STATE_LOCK_FILENAME);
     #[cfg(unix)]
     let file = {
@@ -118,20 +151,7 @@ fn acquire_state_flock() -> Result<StateFlock> {
         .create(true)
         .truncate(false)
         .open(&path)?;
-
-    let started = Instant::now();
-    loop {
-        match file.try_lock_exclusive() {
-            Ok(()) => return Ok(StateFlock { file }),
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                if started.elapsed() >= LOCK_ACQUIRE_BUDGET {
-                    anyhow::bail!("telemetry state lock contended beyond budget");
-                }
-                std::thread::sleep(LOCK_POLL_INTERVAL);
-            }
-            Err(e) => return Err(e.into()),
-        }
-    }
+    Ok(file)
 }
 
 /// Run a `telemetry.json` read-modify-write under both the process-local mutex
@@ -212,7 +232,9 @@ pub fn delete_install_id() -> Result<()> {
     let _guard = STATE_RMW_MUTEX
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let _flock = acquire_state_flock()?;
+    // Blocking acquire, not the fire-and-forget bounded one: an explicit opt-out
+    // must delete the file even under contention, per the documented contract.
+    let _flock = acquire_state_flock_blocking()?;
     let path = state_path()?;
     if path.exists() {
         std::fs::remove_file(&path)?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -577,8 +577,11 @@ impl App {
 
         // Telemetry (opt-in, no-op otherwise): announce this surface on boot,
         // send an initial snapshot, then refresh it periodically and once more
-        // on graceful exit. All sends are detached and swallow errors.
-        const TELEMETRY_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(12 * 60 * 60);
+        // on graceful exit. All sends are detached and swallow errors. The
+        // periodic interval carries bounded jitter (12h + up to 30m) so installs
+        // that boot together don't snapshot in lockstep; the boot snapshot above
+        // stays immediate.
+        let telemetry_snapshot_interval = crate::telemetry::snapshot_interval();
         crate::telemetry::spawn_process_start(crate::telemetry::Surface::Tui);
         self.emit_telemetry_snapshot();
         let mut last_telemetry_snapshot = std::time::Instant::now();
@@ -1181,7 +1184,7 @@ impl App {
                 last_heartbeat = std::time::Instant::now();
             }
 
-            if last_telemetry_snapshot.elapsed() >= TELEMETRY_SNAPSHOT_INTERVAL {
+            if last_telemetry_snapshot.elapsed() >= telemetry_snapshot_interval {
                 last_telemetry_snapshot = std::time::Instant::now();
                 self.emit_telemetry_snapshot();
             }

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -8,6 +8,9 @@
 use agent_of_empires::session::{save_config, Config, Instance};
 use agent_of_empires::telemetry::{self, Surface};
 use serial_test::serial;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::time::Duration;
 
 /// Redirect the app dir at a temp location and clear the telemetry-related env
 /// vars. Returns the guard; keep it alive for the test's duration.
@@ -144,8 +147,8 @@ fn snapshot_carries_session_create_count() {
 }
 
 /// The CLI `process_start` is throttled to once per install per day so a user
-/// scripting `aoe` in a loop can't flood the endpoint: a send is due first, then
-/// not due once a confirmed send claims the daily slot.
+/// scripting `aoe` in a loop can't flood the endpoint: a reservation succeeds
+/// first, then fails once a confirmed send claims the daily slot.
 #[test]
 #[serial]
 fn cli_process_start_throttled_to_once_per_window() {
@@ -153,29 +156,25 @@ fn cli_process_start_throttled_to_once_per_window() {
     set_enabled(true);
     telemetry::apply_opt_in_change(true);
 
-    let day = std::time::Duration::from_secs(24 * 60 * 60);
-    let hour = std::time::Duration::from_secs(60 * 60);
-    assert!(
-        telemetry::cli_process_start_due(day, hour),
-        "first send in the window should be due"
-    );
+    let day = Duration::from_secs(24 * 60 * 60);
+    let hour = Duration::from_secs(60 * 60);
+    let id = telemetry::reserve_cli_process_start(day, hour)
+        .expect("first send in the window should reserve");
+    assert!(!id.is_empty());
     // A confirmed send claims the daily slot.
-    telemetry::record_cli_process_start(true);
+    telemetry::confirm_cli_process_start(&id);
     assert!(
-        !telemetry::cli_process_start_due(day, hour),
-        "within the day, no further send is due after a confirmed send"
+        telemetry::reserve_cli_process_start(day, hour).is_none(),
+        "within the day, no further send reserves after a confirmed send"
     );
     // Zero gaps always re-grant (every stamp is always older than zero).
-    assert!(telemetry::cli_process_start_due(
-        std::time::Duration::ZERO,
-        std::time::Duration::ZERO
-    ));
+    assert!(telemetry::reserve_cli_process_start(Duration::ZERO, Duration::ZERO).is_some());
 }
 
-/// User story (#1875): when a CLI `process_start` send fails, the daily throttle
-/// slot is NOT consumed, so the next invocation retries instead of losing the
-/// whole day to one transient failure. The retry gap still bounds how often the
-/// failed send is re-attempted.
+/// User story (#1875): when a CLI `process_start` send fails (reserved but never
+/// confirmed), the daily throttle slot is NOT consumed, so the next invocation
+/// retries instead of losing the whole day to one transient failure. The retry
+/// gap still bounds how often the failed send is re-attempted.
 #[test]
 #[serial]
 fn failed_cli_process_start_leaves_daily_slot_open() {
@@ -183,22 +182,117 @@ fn failed_cli_process_start_leaves_daily_slot_open() {
     set_enabled(true);
     telemetry::apply_opt_in_change(true);
 
-    let day = std::time::Duration::from_secs(24 * 60 * 60);
-    let hour = std::time::Duration::from_secs(60 * 60);
+    let day = Duration::from_secs(24 * 60 * 60);
+    let hour = Duration::from_secs(60 * 60);
 
-    // Simulate a failed send: it stamps the attempt but never claims the slot.
-    telemetry::record_cli_process_start(false);
+    // A reservation that is never confirmed (failed send) stamps the attempt but
+    // never claims the daily slot.
+    telemetry::reserve_cli_process_start(day, hour).expect("first reservation should be due");
 
     // The retry gap blocks an immediate re-attempt against a still-down endpoint.
     assert!(
-        !telemetry::cli_process_start_due(day, hour),
+        telemetry::reserve_cli_process_start(day, hour).is_none(),
         "retry gap must block an immediate re-attempt after a failed send"
     );
     // But the daily slot is still open: once the retry gap elapses, a send is due
     // again, unlike the old behaviour that lost the whole day on one failure.
     assert!(
-        telemetry::cli_process_start_due(day, std::time::Duration::ZERO),
+        telemetry::reserve_cli_process_start(day, Duration::ZERO).is_some(),
         "a failed send must leave the daily slot open for retry"
+    );
+}
+
+/// A late `confirm` whose install id no longer matches (an opt-out or reset-id
+/// landed while the send was in flight) must not recreate `telemetry.json`.
+#[test]
+#[serial]
+fn confirm_after_opt_out_does_not_recreate_state() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let day = Duration::from_secs(24 * 60 * 60);
+    let hour = Duration::from_secs(60 * 60);
+    let id = telemetry::reserve_cli_process_start(day, hour).expect("reservation due");
+
+    // Opt out mid-flight: deletes telemetry.json and its install id.
+    telemetry::apply_opt_in_change(false);
+    assert_eq!(telemetry::install_id(), None);
+
+    // A late confirm with the stale id is a no-op, not a resurrection.
+    telemetry::confirm_cli_process_start(&id);
+    assert_eq!(telemetry::install_id(), None);
+}
+
+/// Item A (#1877): the `telemetry.json` read-modify-write is serialized across
+/// threads/processes, so a concurrent id-generation race can't lose an update.
+/// Without the lock, barrier-synced threads each load an empty state, generate
+/// distinct UUIDs, and return different ids (last-writer-wins); with it, the
+/// first writer wins and every caller observes the same id.
+#[test]
+#[serial]
+fn concurrent_ensure_install_id_yields_single_id() {
+    let _tmp = isolate();
+
+    const N: usize = 32;
+    let barrier = Arc::new(Barrier::new(N));
+    let handles: Vec<_> = (0..N)
+        .map(|_| {
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                telemetry::ensure_install_id()
+            })
+        })
+        .collect();
+
+    let ids: Vec<Option<String>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let first = ids[0].clone().expect("an id is generated");
+    for (i, id) in ids.iter().enumerate() {
+        assert_eq!(
+            id.as_deref(),
+            Some(first.as_str()),
+            "thread {i} returned a different id; a concurrent RMW lost an update"
+        );
+    }
+    assert_eq!(telemetry::install_id(), Some(first));
+}
+
+/// Item A (#1877): exactly one of many concurrent CLI reservations claims the
+/// daily slot. The reserve transaction (due-check + attempt stamp) runs under
+/// the lock, so two `aoe` invocations can't both pass the gate and both send.
+#[test]
+#[serial]
+fn only_one_concurrent_cli_reservation_wins() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let day = Duration::from_secs(24 * 60 * 60);
+    let hour = Duration::from_secs(60 * 60);
+
+    const N: usize = 32;
+    let barrier = Arc::new(Barrier::new(N));
+    let wins = Arc::new(AtomicUsize::new(0));
+    let handles: Vec<_> = (0..N)
+        .map(|_| {
+            let barrier = Arc::clone(&barrier);
+            let wins = Arc::clone(&wins);
+            std::thread::spawn(move || {
+                barrier.wait();
+                if telemetry::reserve_cli_process_start(day, hour).is_some() {
+                    wins.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+    assert_eq!(
+        wins.load(Ordering::SeqCst),
+        1,
+        "exactly one concurrent reservation must claim the daily slot"
     );
 }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Robustness cleanups for the opt-in telemetry module (follow-up to #1863), addressing all four audited items in #1877. No wire-schema change: the gateway payload, collector, and ingest are untouched, so this lands entirely in agent-of-empires.

- **A. `telemetry.json` read-modify-write race.** Every mutation now runs through a process-local mutex plus a cross-process advisory flock (a `.telemetry.lock` sidecar, mirroring the existing `storage.rs` / `logging.rs` pattern), so concurrent TUI / CLI / `aoe serve` updates can no longer clobber each other (lost-update). The CLI `process_start` now **reserves** its daily slot under the lock before sending and **confirms** it only after a 2xx, closing the check-then-send race that previously let two invocations both emit in one day. Reserve-before-send also fixes a latent bug where a failed send could write a throttle-only file with no install id. Lock acquisition is bounded (500ms) and skips on contention, so telemetry never stalls the caller.
- **B. Redundant config reads.** `build_usage_snapshot` loaded `config.toml` twice (once via `is_opted_in`, once for `active_features`). It now loads the global `Config` once and threads it into a pure `assemble_usage_snapshot`.
- **C. `process_start` throttle comment drift.** The comment claimed CLI was "the only unbounded source"; corrected to reflect that CLI is the only high-frequency source, while TUI / serve stay per-launch (a restart is intentionally observable) and crash-loop floods are absorbed gateway-side, not by a local cap. Comment-only, no behavior change.
- **D. No jitter on the 12h interval.** Anchor-to-boot intervals made fleets that restart together snapshot in lockstep. Added `telemetry::snapshot_interval` (12h + up to 30m bounded jitter), used by both the serve loop (with `MissedTickBehavior::Delay`) and the TUI periodic snapshot. The boot snapshot stays immediate.

Closes #1877

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Opt in (`aoe telemetry enable`), point `AOE_TELEMETRY_ENDPOINT` at a local sink, run two `aoe` CLI invocations in the same day, and confirm only one `process_start` is sent (the second is throttled).
- [ ] With the endpoint down, run `aoe` once, confirm the daily slot is not consumed, then bring the endpoint up within the day and confirm the next run retries.
- [ ] Race two `aoe` processes that both touch `telemetry.json` (e.g. a TUI launch and a CLI invocation at once) and confirm the install id and throttle stamps both survive (no lost update).
- [ ] Opt out (`aoe telemetry disable`) and confirm `telemetry.json` is deleted and not resurrected by a late confirm.
- [ ] Inspect a built `usage_snapshot` (local sink) and confirm the feature map and session buckets are correct.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR changes telemetry internals only (no TUI rendering, CLI subcommand, or session lifecycle change); covered by the Rust integration suite in `tests/telemetry.rs` (concurrent id race, single-reservation, stale-confirm, pure assembler, jitter bound) and unit tests in `src/telemetry/mod.rs`

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (pressure-tested with a multi-model debate), and implementation drafted by Claude under my direction. I made the design calls (full reserve/confirm for A, comment-only for C, jitter in for D) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR strengthens the opt-in telemetry module by fixing concurrent write races, eliminating redundant config reads, clarifying throttling semantics, and de-synchronizing periodic snapshots across processes.

## What changed (high-level)

- Serialized telemetry state updates with a process-local mutex plus a cross-process advisory lock (.telemetry.lock) to prevent telemetry.json read–modify–write races.
- Replaced the CLI telemetry "due/record" API with a "reserve/confirm" flow that atomically reserves the daily send slot before posting and confirms only after a successful send.
- Loaded the global Config once and refactored snapshot assembly into a pure assemble_usage_snapshot called by build_usage_snapshot to avoid redundant disk reads.
- Clarified comments/docs: CLI `process_start` is throttled (once per install per day); TUI and serve emit per-launch and rely on gateway-side protections for crash-loop floods.
- Added bounded jitter (0–30 min) to the 12-hour snapshot interval and applied it to both serve and TUI periodic snapshots; boot snapshot remains immediate.
- Changed opt-out (delete_install_id) to acquire a blocking flock so telemetry.json is reliably removed on opt-out, while keeping the nonblocking bounded-skip behavior for fire-and-forget updates.

## Files touched (high-impact)

- docs/telemetry.md — clarified throttling and lock-sidecar behavior (doc only)
- src/telemetry/state.rs — added in-process mutex + advisory flock, centralized locked update path, reserve/confirm API, blocking flock for opt-out
- src/telemetry/mod.rs — threaded Config into a pure assembler, added snapshot jitter API and exports
- src/server/mod.rs & src/tui/app.rs — switched periodic snapshot loops to use jittered interval and Delay behavior
- tests/telemetry.rs — new and updated unit/integration tests for concurrency, reservation semantics, opt-out, and jitter bounds

## Technical notes (concise)

- Locking: advisory flock sidecar + process-local mutex; nonblocking acquisition retries up to 500ms then skips to avoid stalling callers. A blocking variant exists for opt-out.
- CLI flow: reserve_cli_process_start(...) writes an "attempt" stamp under lock and returns an install id if allowed; confirm_cli_process_start(install_id) writes the confirmed-delivery stamp only if the stored install id matches.
- Config loading: build_usage_snapshot parses Config once and passes it into assemble_usage_snapshot (pure function) to eliminate redundant file reads.
- Snapshot jitter: snapshot_interval() = 12h + uniform(0..30m); used by serve (MissedTickBehavior::Delay) and TUI periodic loop.
- Tests: cover concurrent install-id generation, single reservation under contention, stale confirms, pure assembler (single config load), and snapshot jitter bounds.

## Benefits

- Prevents lost updates and races when multiple processes write telemetry.json.
- Reduces disk I/O and simplifies snapshot assembly.
- Avoids synchronized fleet snapshots and thundering-herd effects.
- Makes CLI throttling behavior explicit and robust against concurrent CLI invocations.
- Ensures opt-out reliably deletes persisted telemetry state.

## Potential follow-ups / enhancements

- Consider configurable lock timeout or backoff strategy for high-load environments that frequently contend on telemetry updates.
- Expose snapshot jitter bounds as config to allow tuning per deployment.
- Add observability metrics around lock contention and skipped updates to monitor real-world contention rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->