### PR TITLE
feat(telemetry): time-aggregated serve usage snapshots (sample 30m, send 4h)

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -33,6 +33,8 @@ closed, versioned schema (see `src/telemetry/events.rs`):
   current install, never a stream of actions:
   - how many sessions exist and how many are running / idle / errored,
   - how many use a sandbox, the cockpit, or yolo mode,
+  - the peak concurrent session count seen across the window since the last
+    snapshot (point-in-time on the TUI, which does not aggregate),
   - how many sessions are currently pinned, snoozed, or archived (a
     point-in-time count of the session-organization states, not how often
     those actions were taken),
@@ -45,6 +47,11 @@ closed, versioned schema (see `src/telemetry/events.rs`):
     so the `sandbox` bucket means "sandboxed and not also one of the others",
     not "all sandboxed sessions",
   - a per-agent and per-model-family count (e.g. `{claude: 3, codex: 1}`),
+    point-in-time at the snapshot moment,
+  - a per-agent and per-model-family count of the **distinct sessions seen
+    across the window** since the last snapshot, so short-lived sessions caught
+    by a sample still contribute their agent/model mix (populated by `aoe
+    serve`; empty on the TUI). Its sum can exceed the point-in-time total,
   - how many sessions were created since the last snapshot, a trend counter so
     short-lived sessions that start and end between two snapshots are still
     counted (populated by `aoe serve`; the TUI reports `0`),
@@ -66,6 +73,18 @@ closed, versioned schema (see `src/telemetry/events.rs`):
     Tailscale Funnel, or `local`). These are coarse enums only; the TUI reports
     neither, since it hosts no server,
   - the same version-health signals carried on `process_start` (see below).
+
+  To capture the agent/model mix and peak concurrency of short-lived sessions
+  without sending more often, `aoe serve` samples the live session list locally
+  about every 30 minutes and folds each sample into an in-memory aggregate; the
+  send cadence stays at one POST per 12 hours. The sampling is purely local, so
+  network and server load are unchanged. The aggregate lives in memory only: a
+  daemon crash or restart mid-window loses the partial window (only a graceful
+  shutdown flushes it), while machine sleep makes the loop miss sample ticks
+  rather than clearing the window. A session that opens and closes entirely
+  between two ~30-minute samples is still missed by the windowed maps, though
+  its raw count survives in `session_creates_since_last_snapshot`. The TUI keeps
+  the start / shutdown / 12h point-in-time behavior and does not aggregate.
 
 ### Version health
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -28,9 +28,12 @@ closed, versioned schema (see `src/telemetry/events.rs`):
   allowlist before sending, so no argument, flag, or path is ever attached;
   hidden internal commands are never counted.
 - **`usage_snapshot`** from the TUI and `aoe serve`, on start and then about
-  every 12 hours, with a small random jitter on the period so installs that boot
-  together don't snapshot in lockstep. It is a point-in-time summary of the
-  current install, never a stream of actions:
+  every 4 hours, with a small random jitter on the period so installs that boot
+  together don't snapshot in lockstep. Start and graceful-shutdown snapshots
+  bracket every run, so a short session that never stays up that long is still
+  reported; the periodic cadence only adds mid-life snapshots for a long-running
+  daemon. It is a point-in-time summary of the current install, never a stream
+  of actions:
   - how many sessions exist and how many are running / idle / errored,
   - how many use a sandbox, the cockpit, or yolo mode,
   - the peak concurrent session count seen across the window since the last
@@ -77,14 +80,15 @@ closed, versioned schema (see `src/telemetry/events.rs`):
   To capture the agent/model mix and peak concurrency of short-lived sessions
   without sending more often, `aoe serve` samples the live session list locally
   about every 30 minutes and folds each sample into an in-memory aggregate; the
-  send cadence stays at one POST per 12 hours. The sampling is purely local, so
+  send cadence stays at one POST per ~4 hours. The sampling is purely local, so
   network and server load are unchanged. The aggregate lives in memory only: a
-  daemon crash or restart mid-window loses the partial window (only a graceful
-  shutdown flushes it), while machine sleep makes the loop miss sample ticks
-  rather than clearing the window. A session that opens and closes entirely
-  between two ~30-minute samples is still missed by the windowed maps, though
-  its raw count survives in `session_creates_since_last_snapshot`. The TUI keeps
-  the start / shutdown / 12h point-in-time behavior and does not aggregate.
+  graceful shutdown flushes it, but a hard kill (power-off, crash, or `SIGKILL`)
+  loses the partial window, bounded to that ~4h since the last send; machine
+  sleep makes the loop miss sample ticks rather than clearing the window. A
+  session that opens and closes entirely between two ~30-minute samples is still
+  missed by the windowed maps, though its raw count survives in
+  `session_creates_since_last_snapshot`. The TUI keeps the start / shutdown /
+  periodic point-in-time behavior and does not aggregate.
 
 ### Version health
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1712,20 +1712,20 @@ fn merge_runtime_fields(prior: Instance, mut fresh: Instance) -> Instance {
 }
 
 /// Background task: emit an opt-in telemetry `usage_snapshot` immediately and
-/// every ~12 hours (jittered), plus a final one on graceful shutdown. The boot
+/// every ~4 hours (jittered), plus a final one on graceful shutdown. The boot
 /// `process_start` is emitted separately by the caller before transport setup.
 /// All sends are best-effort and swallow errors; nothing leaves the box unless
 /// the user opted in and an endpoint is configured.
 fn spawn_serve_snapshot_loop(state: Arc<AppState>) {
     tokio::spawn(async move {
-        // Jittered period (12h + up to 30m) so installs that boot together don't
+        // Jittered period (4h + up to 30m) so installs that boot together don't
         // snapshot in lockstep; the first tick is still immediate (boot
         // snapshot). `Delay` avoids a burst of catch-up ticks after a stall.
         let mut interval = tokio::time::interval(crate::telemetry::snapshot_interval());
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         // Sample the live session list more often than we send, folding each
         // sample into a window aggregate so short-lived sessions' agent/model
-        // mix and the concurrency peak survive into the 12h snapshot (#1870).
+        // mix and the concurrency peak survive into the periodic snapshot (#1870).
         // Both tickers share this one task, so a sample tick and a flush tick
         // never run concurrently: the aggregate needs no locking and a plain
         // reset after a confirmed send is race-free. `Skip` so a long suspend
@@ -1737,7 +1737,7 @@ fn spawn_serve_snapshot_loop(state: Arc<AppState>) {
             tokio::select! {
                 _ = state.shutdown.cancelled() => {
                     // Deduped: a serve process that starts and stops between
-                    // 12h ticks would otherwise emit the initial first-tick
+                    // periodic ticks would otherwise emit the initial first-tick
                     // snapshot and an identical shutdown snapshot seconds apart.
                     // We exit after this, so the aggregate is dropped; no reset.
                     if let Some(snapshot) = build_serve_snapshot(&state, &mut aggregator).await {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1723,20 +1723,31 @@ fn spawn_serve_snapshot_loop(state: Arc<AppState>) {
         // snapshot). `Delay` avoids a burst of catch-up ticks after a stall.
         let mut interval = tokio::time::interval(crate::telemetry::snapshot_interval());
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Sample the live session list more often than we send, folding each
+        // sample into a window aggregate so short-lived sessions' agent/model
+        // mix and the concurrency peak survive into the 12h snapshot (#1870).
+        // Both tickers share this one task, so a sample tick and a flush tick
+        // never run concurrently: the aggregate needs no locking and a plain
+        // reset after a confirmed send is race-free. `Skip` so a long suspend
+        // does not fire a run of catch-up samples on wake.
+        let mut sample = tokio::time::interval(std::time::Duration::from_secs(30 * 60));
+        sample.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut aggregator = crate::telemetry::aggregate::UsageAggregator::default();
         loop {
             tokio::select! {
                 _ = state.shutdown.cancelled() => {
                     // Deduped: a serve process that starts and stops between
                     // 12h ticks would otherwise emit the initial first-tick
                     // snapshot and an identical shutdown snapshot seconds apart.
-                    if let Some(snapshot) = build_serve_snapshot(&state).await {
+                    // We exit after this, so the aggregate is dropped; no reset.
+                    if let Some(snapshot) = build_serve_snapshot(&state, &mut aggregator).await {
                         let outcome = crate::telemetry::flush_snapshot_if_changed(snapshot).await;
                         clear_reported_serve_signals(&state, outcome);
                     }
                     break;
                 }
                 _ = interval.tick() => {
-                    if let Some(snapshot) = build_serve_snapshot(&state).await {
+                    if let Some(snapshot) = build_serve_snapshot(&state, &mut aggregator).await {
                         // Awaited (not detached) so the reported signals are
                         // cleared only after a confirmed send. A failed send
                         // retains the usage_seen counts / the create counter
@@ -1747,7 +1758,17 @@ fn spawn_serve_snapshot_loop(state: Arc<AppState>) {
                             crate::telemetry::SendOutcome::Failed
                         };
                         clear_reported_serve_signals(&state, outcome);
+                        // Reset the window only after a confirmed send, mirroring
+                        // the signal-clear discipline: a failed send keeps the
+                        // aggregate so the next flush re-reports the full window.
+                        if outcome == crate::telemetry::SendOutcome::Sent {
+                            aggregator = crate::telemetry::aggregate::UsageAggregator::default();
+                        }
                     }
+                }
+                _ = sample.tick() => {
+                    let instances = state.instances.read().await.clone();
+                    aggregator.sample(&instances);
                 }
             }
         }
@@ -1873,13 +1894,23 @@ struct ReportedServeSignals {
 /// resetting them*. The reported counts are stashed in `AppState` so
 /// [`clear_reported_serve_signals`] can subtract exactly what was reported once
 /// the send is confirmed. Returns `None` when telemetry is not opted in.
-async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::UsageSnapshot> {
+///
+/// The live read is also folded into `aggregator` as the flush-moment sample,
+/// then the window's peak concurrency and distinct-sessions-seen maps override
+/// the point-in-time defaults `build_usage_snapshot` produced (#1870). The
+/// point-in-time `session_total` and status/sandbox/yolo/cockpit counts keep
+/// their instant-of-flush meaning.
+async fn build_serve_snapshot(
+    state: &AppState,
+    aggregator: &mut crate::telemetry::aggregate::UsageAggregator,
+) -> Option<crate::telemetry::UsageSnapshot> {
     use std::sync::atomic::Ordering;
     let usage_seen = state.telemetry_usage_seen.snapshot();
     let web_clients = state.telemetry_web_clients.read();
     let cockpit_clients = state.telemetry_cockpit_clients.read();
     let session_creates = state.telemetry_session_creates.load(Ordering::Relaxed);
     let instances = state.instances.read().await.clone();
+    aggregator.sample(&instances);
     let mut snapshot = crate::telemetry::build_usage_snapshot(
         crate::telemetry::Surface::Serve,
         &instances,
@@ -1893,6 +1924,9 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
     // daemon fills them here from its client counters.
     snapshot.web_clients_seen = web_clients.seen_map();
     snapshot.cockpit_clients_seen = cockpit_clients.seen_map();
+    snapshot.peak_concurrent_sessions = aggregator.peak_concurrent_sessions();
+    snapshot.distinct_sessions_by_agent = aggregator.distinct_by_agent();
+    snapshot.distinct_sessions_by_model_bucket = aggregator.distinct_by_model();
     *state.telemetry_last_reported.lock().unwrap() = Some(ReportedServeSignals {
         usage_seen,
         web_clients,

--- a/src/telemetry/aggregate.rs
+++ b/src/telemetry/aggregate.rs
@@ -1,0 +1,176 @@
+//! Windowed aggregate of live session state for `aoe serve`.
+//!
+//! A point-in-time `usage_snapshot` only sees sessions alive at the instant the
+//! 12h tick fires, so a session that opens and closes between two ticks is
+//! invisible in the agent/model attribution and never lifts the concurrency
+//! peak. `aoe serve` folds a sample of the live session list into a
+//! [`UsageAggregator`] every ~30 min and reports the window's peak concurrency
+//! and distinct-sessions-seen maps at flush time, while keeping the send cadence
+//! at one POST per 12h (see `src/server/mod.rs`).
+//!
+//! Sampling is coarse on purpose (the issue, #1870, chose a ~30-min interval):
+//! a session born and gone entirely between two samples is still missed, but
+//! its raw count survives in `session_creates_since_last_snapshot`. What this
+//! recovers is the agent/model mix and peak/typical concurrency of sessions
+//! that live long enough to be sampled at least once.
+
+use std::collections::BTreeMap;
+
+use crate::session::Instance;
+
+/// Soft cap on distinct session ids tracked in one window. The aggregate is
+/// reset only on a confirmed send, so a daemon whose endpoint stays unreachable
+/// for a long stretch would otherwise keep folding new ids forever. Past the
+/// cap we stop adding new ids (peak concurrency and already-seen sessions still
+/// update), bounding worst-case memory without touching the happy path. The
+/// limit is far above any realistic distinct-session count for one 12h window.
+const MAX_SEEN: usize = 10_000;
+
+/// In-memory accumulator folded by the serve telemetry loop. Reset (dropped /
+/// re-defaulted) only after a confirmed send so a failed send retains the
+/// window for the next attempt.
+#[derive(Default)]
+pub struct UsageAggregator {
+    peak_concurrent_sessions: u32,
+    /// session id -> (agent bucket, model bucket), latest observed. Keyed by
+    /// session id so a session sampled in multiple windows-internal ticks
+    /// counts once; storing the *latest* buckets (rather than a per-bucket set)
+    /// means a session whose model bucket changes mid-window is counted in one
+    /// bucket, not double-counted.
+    seen: BTreeMap<String, (String, String)>,
+}
+
+impl UsageAggregator {
+    /// Fold one sample of the live session list into the running window.
+    pub fn sample(&mut self, instances: &[Instance]) {
+        self.peak_concurrent_sessions = self.peak_concurrent_sessions.max(instances.len() as u32);
+        for inst in instances {
+            let buckets = super::instance_buckets(inst);
+            // Refresh an already-seen session's bucket regardless; only gate
+            // *new* ids on the cap so a stuck-offline daemon can't grow `seen`
+            // without bound.
+            if self.seen.contains_key(&inst.id) || self.seen.len() < MAX_SEEN {
+                self.seen.insert(inst.id.clone(), buckets);
+            }
+        }
+    }
+
+    /// Max concurrent `session_total` seen across the window.
+    pub fn peak_concurrent_sessions(&self) -> u32 {
+        self.peak_concurrent_sessions
+    }
+
+    /// Distinct sessions seen per agent bucket across the window.
+    pub fn distinct_by_agent(&self) -> BTreeMap<String, u32> {
+        let mut out: BTreeMap<String, u32> = BTreeMap::new();
+        for (agent, _model) in self.seen.values() {
+            *out.entry(agent.clone()).or_insert(0) += 1;
+        }
+        out
+    }
+
+    /// Distinct sessions seen per model bucket across the window.
+    pub fn distinct_by_model(&self) -> BTreeMap<String, u32> {
+        let mut out: BTreeMap<String, u32> = BTreeMap::new();
+        for (_agent, model) in self.seen.values() {
+            *out.entry(model.clone()).or_insert(0) += 1;
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{Instance, Status};
+
+    fn inst(id: &str, tool: &str, status: Status) -> Instance {
+        let mut i = Instance::new("t", "/p");
+        i.id = id.to_string();
+        i.tool = tool.to_string();
+        i.status = status;
+        i
+    }
+
+    #[test]
+    fn folds_distinct_sessions_across_samples() {
+        let mut agg = UsageAggregator::default();
+        // Window: two sessions early, a different one later. None concurrent
+        // with all the others, but all three are "seen" across the window.
+        agg.sample(&[
+            inst("a", "claude", Status::Running),
+            inst("b", "claude", Status::Idle),
+        ]);
+        agg.sample(&[inst("c", "codex", Status::Running)]);
+
+        let by_agent = agg.distinct_by_agent();
+        assert_eq!(by_agent.get("claude"), Some(&2));
+        assert_eq!(by_agent.get("codex"), Some(&1));
+        // Distinct-seen total (3) exceeds any single concurrent count.
+        let distinct_total: u32 = by_agent.values().sum();
+        assert_eq!(distinct_total, 3);
+    }
+
+    #[test]
+    fn tracks_peak_concurrency_not_the_last_sample() {
+        let mut agg = UsageAggregator::default();
+        agg.sample(&[inst("a", "claude", Status::Running)]); // 1
+        agg.sample(&[
+            inst("a", "claude", Status::Running),
+            inst("b", "claude", Status::Running),
+            inst("c", "claude", Status::Running),
+        ]); // 3
+        agg.sample(&[inst("a", "claude", Status::Idle)]); // 1
+        assert_eq!(agg.peak_concurrent_sessions(), 3);
+    }
+
+    #[test]
+    fn same_session_counts_once_with_latest_bucket() {
+        let mut agg = UsageAggregator::default();
+        // The same session id sampled twice must count once; a later sample's
+        // bucket wins, so it is never double-counted across buckets.
+        agg.sample(&[inst("a", "claude", Status::Running)]);
+        agg.sample(&[inst("a", "codex", Status::Running)]);
+
+        let by_agent = agg.distinct_by_agent();
+        assert_eq!(by_agent.get("claude"), None);
+        assert_eq!(by_agent.get("codex"), Some(&1));
+        assert_eq!(by_agent.values().sum::<u32>(), 1);
+    }
+
+    #[test]
+    fn caps_distinct_ids_but_keeps_tracking_peak() {
+        let mut agg = UsageAggregator::default();
+        // Fill `seen` past the cap with distinct ids across many samples.
+        for i in 0..(MAX_SEEN + 50) {
+            agg.sample(&[inst(&format!("s{i}"), "claude", Status::Running)]);
+        }
+        assert_eq!(
+            agg.seen.len(),
+            MAX_SEEN,
+            "new ids stop being added past cap"
+        );
+
+        // A large concurrent sample still lifts the peak even when `seen` is full.
+        let big: Vec<Instance> = (0..MAX_SEEN + 200)
+            .map(|i| inst(&format!("s{i}"), "claude", Status::Running))
+            .collect();
+        agg.sample(&big);
+        assert_eq!(agg.peak_concurrent_sessions(), (MAX_SEEN + 200) as u32);
+
+        // An already-seen id still refreshes its bucket past the cap.
+        agg.sample(&[inst("s0", "codex", Status::Running)]);
+        assert_eq!(
+            agg.seen.get("s0"),
+            Some(&("codex".to_string(), "unset".to_string()))
+        );
+    }
+
+    #[test]
+    fn empty_window_reports_zero() {
+        let agg = UsageAggregator::default();
+        assert_eq!(agg.peak_concurrent_sessions(), 0);
+        assert!(agg.distinct_by_agent().is_empty());
+        assert!(agg.distinct_by_model().is_empty());
+    }
+}

--- a/src/telemetry/aggregate.rs
+++ b/src/telemetry/aggregate.rs
@@ -1,12 +1,12 @@
 //! Windowed aggregate of live session state for `aoe serve`.
 //!
 //! A point-in-time `usage_snapshot` only sees sessions alive at the instant the
-//! 12h tick fires, so a session that opens and closes between two ticks is
+//! periodic tick fires, so a session that opens and closes between two ticks is
 //! invisible in the agent/model attribution and never lifts the concurrency
 //! peak. `aoe serve` folds a sample of the live session list into a
 //! [`UsageAggregator`] every ~30 min and reports the window's peak concurrency
 //! and distinct-sessions-seen maps at flush time, while keeping the send cadence
-//! at one POST per 12h (see `src/server/mod.rs`).
+//! at one POST per send window (see `src/server/mod.rs`).
 //!
 //! Sampling is coarse on purpose (the issue, #1870, chose a ~30-min interval):
 //! a session born and gone entirely between two samples is still missed, but
@@ -23,7 +23,7 @@ use crate::session::Instance;
 /// for a long stretch would otherwise keep folding new ids forever. Past the
 /// cap we stop adding new ids (peak concurrency and already-seen sessions still
 /// update), bounding worst-case memory without touching the happy path. The
-/// limit is far above any realistic distinct-session count for one 12h window.
+/// limit is far above any realistic distinct-session count for one send window.
 const MAX_SEEN: usize = 10_000;
 
 /// In-memory accumulator folded by the serve telemetry loop. Reset (dropped /

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -26,7 +26,9 @@ use serde::Serialize;
 /// and `usage_snapshot`.
 /// v9 (#1883): added the `web_clients_seen` / `cockpit_clients_seen`
 /// per-form-factor maps alongside the `usage_seen` open counts.
-pub const SCHEMA_VERSION: u32 = 9;
+/// v10 (#1870): added serve windowed fields `peak_concurrent_sessions` and the
+/// `distinct_sessions_by_agent` / `distinct_sessions_by_model_bucket` maps.
+pub const SCHEMA_VERSION: u32 = 10;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -152,6 +154,13 @@ pub struct UsageSnapshot {
     pub session_sandboxed: u32,
     pub session_yolo: u32,
 
+    /// Peak concurrent `session_total` observed across the window since the
+    /// last snapshot. `aoe serve` folds a sample every ~30 min into a local
+    /// aggregate and reports the max here, so a short-lived burst of sessions
+    /// that opens and closes between two 12h sends is still captured. The TUI
+    /// does not aggregate, so it reports the point-in-time `session_total`.
+    pub peak_concurrent_sessions: u32,
+
     /// Sessions currently pinned, snoozed (future `snoozed_until`), or
     /// archived at snapshot time. Point-in-time state prevalence, not action
     /// counts; the three are mutually exclusive per the session triage
@@ -181,6 +190,17 @@ pub struct UsageSnapshot {
     /// workspace / worktree", NOT "all sandboxed sessions"; use
     /// `session_sandboxed` for the latter.
     pub sessions_by_substrate: BTreeMap<String, u32>,
+
+    /// Allowlisted agent bucket -> distinct sessions *seen* across the window
+    /// since the last snapshot (not concurrent at the tick), so short-lived
+    /// sessions caught by a ~30-min sample still contribute their agent mix.
+    /// The sum can exceed `session_total`. Populated by `aoe serve`; empty on
+    /// the TUI, which does not aggregate.
+    pub distinct_sessions_by_agent: BTreeMap<String, u32>,
+    /// Coarse model family bucket -> distinct sessions seen across the window.
+    /// Same window semantics as [`Self::distinct_sessions_by_agent`]; serve-only.
+    pub distinct_sessions_by_model_bucket: BTreeMap<String, u32>,
+
     /// Install-level feature adoption: allowlisted feature name -> active.
     /// Keyed by the fixed registry in [`super::features`]; lets new gated
     /// features be tracked by registering the flag, not by extending the

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -118,7 +118,7 @@ pub struct CliUsage {
 }
 
 /// Emitted by long-running surfaces (TUI, `aoe serve`) on start, then every
-/// ~12 hours, and best-effort on graceful shutdown. Carries current
+/// ~4 hours, and best-effort on graceful shutdown. Carries current
 /// aggregate state, never a per-action stream. Every string-valued bucket
 /// has already passed through [`super::sanitize`].
 #[derive(Debug, Clone, Serialize)]
@@ -157,7 +157,7 @@ pub struct UsageSnapshot {
     /// Peak concurrent `session_total` observed across the window since the
     /// last snapshot. `aoe serve` folds a sample every ~30 min into a local
     /// aggregate and reports the max here, so a short-lived burst of sessions
-    /// that opens and closes between two 12h sends is still captured. The TUI
+    /// that opens and closes between two 4h sends is still captured. The TUI
     /// does not aggregate, so it reports the point-in-time `session_total`.
     pub peak_concurrent_sessions: u32,
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -77,14 +77,19 @@ const CLI_USAGE_MIN_GAP: Duration = Duration::from_secs(24 * 60 * 60);
 const CLI_USAGE_RETRY_GAP: Duration = Duration::from_secs(60 * 60);
 
 /// Base cadence for periodic `usage_snapshot` sends (TUI and serve). The real
-/// period is this plus bounded jitter (see [`snapshot_interval`]).
-pub const SNAPSHOT_BASE_INTERVAL: Duration = Duration::from_secs(12 * 60 * 60);
+/// period is this plus bounded jitter (see [`snapshot_interval`]). Set to 4h so
+/// the steady-state heartbeat covers a typical workday about twice and a hard
+/// kill (power-off / crash, which skips the graceful-shutdown flush) loses at
+/// most one ~4h window rather than 12h. Short-lived runs are already bracketed
+/// by the immediate boot snapshot and the shutdown flush, so this only shapes
+/// the cadence of a long-running daemon.
+pub const SNAPSHOT_BASE_INTERVAL: Duration = Duration::from_secs(4 * 60 * 60);
 
 /// Upper bound on the random jitter added to [`SNAPSHOT_BASE_INTERVAL`].
 const SNAPSHOT_JITTER: Duration = Duration::from_secs(30 * 60);
 
 /// Periodic snapshot period: [`SNAPSHOT_BASE_INTERVAL`] plus a random offset in
-/// `[0, SNAPSHOT_JITTER)`. A fixed 12h period anchored to process start means a
+/// `[0, SNAPSHOT_JITTER)`. A fixed 4h period anchored to process start means a
 /// fleet that boots together (e.g. a post-update restart wave) keeps snapshotting
 /// in lockstep forever; rolling a per-process jitter decorrelates the periodic
 /// ticks so they spread apart by the second tick. The boot snapshot is sent

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -18,6 +18,7 @@
 //!   are coerced to a closed allowlist; raw commands, paths, titles, branch
 //!   names, and prompts are never emitted.
 
+pub mod aggregate;
 pub mod events;
 pub mod features;
 pub mod form_factor;
@@ -235,6 +236,29 @@ struct InstanceMetrics {
     by_substrate: BTreeMap<String, u32>,
 }
 
+/// Map an instance to its `(agent bucket, model bucket)` telemetry labels, both
+/// already coerced to the [`sanitize`] allowlist. Shared by [`aggregate_instances`]
+/// (point-in-time) and the serve windowed aggregator ([`aggregate`]) so both
+/// bucket sessions identically. The model bucket only exists in `serve` builds;
+/// elsewhere it is treated as absent (`unset`).
+pub(crate) fn instance_buckets(inst: &Instance) -> (String, String) {
+    // Prefer the canonical detection name; fall back to the raw tool string.
+    // Either way it is coerced to an allowlisted bucket.
+    let agent_src = if inst.detect_as.trim().is_empty() {
+        inst.tool.as_str()
+    } else {
+        inst.detect_as.as_str()
+    };
+    #[cfg(feature = "serve")]
+    let model = inst.cockpit_model.as_deref();
+    #[cfg(not(feature = "serve"))]
+    let model: Option<&str> = None;
+    (
+        sanitize::agent_bucket(agent_src),
+        sanitize::model_bucket(model).to_string(),
+    )
+}
+
 fn aggregate_instances(instances: &[Instance]) -> InstanceMetrics {
     let mut by_agent: BTreeMap<String, u32> = BTreeMap::new();
     let mut by_model_bucket: BTreeMap<String, u32> = BTreeMap::new();
@@ -307,23 +331,9 @@ fn aggregate_instances(instances: &[Instance]) -> InstanceMetrics {
             archived += 1;
         }
 
-        // Prefer the canonical detection name; fall back to the raw tool
-        // string. Either way it is coerced to an allowlisted bucket.
-        let agent_src = if inst.detect_as.trim().is_empty() {
-            inst.tool.as_str()
-        } else {
-            inst.detect_as.as_str()
-        };
-        *by_agent
-            .entry(sanitize::agent_bucket(agent_src))
-            .or_insert(0) += 1;
-
-        #[cfg(feature = "serve")]
-        let model = inst.cockpit_model.as_deref();
-        #[cfg(not(feature = "serve"))]
-        let model: Option<&str> = None;
-        let bucket = sanitize::model_bucket(model);
-        *by_model_bucket.entry(bucket.to_string()).or_insert(0) += 1;
+        let (agent, model) = instance_buckets(inst);
+        *by_agent.entry(agent).or_insert(0) += 1;
+        *by_model_bucket.entry(model).or_insert(0) += 1;
     }
 
     InstanceMetrics {
@@ -438,12 +448,19 @@ fn assemble_usage_snapshot(
         session_cockpit: metrics.cockpit,
         session_sandboxed: metrics.sandboxed,
         session_yolo: metrics.yolo,
+        // Point-in-time default: equals the instant total. The serve loop
+        // overrides this with its window peak; the TUI keeps the instant value.
+        peak_concurrent_sessions: metrics.total,
         session_pinned: metrics.pinned,
         session_snoozed: metrics.snoozed,
         session_archived: metrics.archived,
         sessions_by_agent: metrics.by_agent,
         sessions_by_model_bucket: metrics.by_model_bucket,
         sessions_by_substrate: metrics.by_substrate,
+        // Window aggregates are serve-only; empty here. The serve loop fills
+        // them from its `UsageAggregator`, the TUI leaves them empty.
+        distinct_sessions_by_agent: BTreeMap::new(),
+        distinct_sessions_by_model_bucket: BTreeMap::new(),
         features,
         usage_seen,
         // Serve-only per-form-factor maps; the disk-free assembler leaves them
@@ -748,12 +765,15 @@ mod tests {
             session_cockpit: 0,
             session_sandboxed: 2,
             session_yolo: 0,
+            peak_concurrent_sessions: 7,
             session_pinned: 0,
             session_snoozed: 0,
             session_archived: 0,
             sessions_by_agent: BTreeMap::new(),
             sessions_by_model_bucket: BTreeMap::new(),
             sessions_by_substrate: SUBSTRATES.iter().map(|s| (s.to_string(), 0)).collect(),
+            distinct_sessions_by_agent: BTreeMap::new(),
+            distinct_sessions_by_model_bucket: BTreeMap::new(),
             features: BTreeMap::new(),
             usage_seen: usage_signals::zeroed(),
             web_clients_seen: BTreeMap::new(),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -578,7 +578,7 @@ impl App {
         // Telemetry (opt-in, no-op otherwise): announce this surface on boot,
         // send an initial snapshot, then refresh it periodically and once more
         // on graceful exit. All sends are detached and swallow errors. The
-        // periodic interval carries bounded jitter (12h + up to 30m) so installs
+        // periodic interval carries bounded jitter (4h + up to 30m) so installs
         // that boot together don't snapshot in lockstep; the boot snapshot above
         // stays immediate.
         let telemetry_snapshot_interval = crate::telemetry::snapshot_interval();

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -161,6 +161,12 @@ fn snapshot_buckets_are_sanitized() {
     assert_eq!(snapshot.sessions_by_agent.get("claude"), Some(&1));
     assert_eq!(snapshot.session_total, 2);
 
+    // The base builder leaves the serve window fields at their point-in-time /
+    // empty defaults; only `aoe serve` overrides them from its aggregator.
+    assert_eq!(snapshot.peak_concurrent_sessions, 2);
+    assert!(snapshot.distinct_sessions_by_agent.is_empty());
+    assert!(snapshot.distinct_sessions_by_model_bucket.is_empty());
+
     // The feature-adoption map is present with its fixed allowlisted keys
     // (values reflect config; all false under a default config).
     for key in ["worktree", "sandbox", "cockpit", "auto_update"] {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The serve `usage_snapshot` was a strictly point-in-time read of the live session list at each periodic tick. A session that started and ended between two ticks was invisible in the agent/model attribution and never lifted the concurrency peak. Raw volume was already preserved by `session_creates_since_last_snapshot`; what was lost was the agent/model mix and peak/typical concurrency of short-lived sessions.

This adds a local window aggregate for `aoe serve`. A new `UsageAggregator` (`src/telemetry/aggregate.rs`) folds a sample of the live session list every ~30 minutes, keyed by session id (latest agent/model bucket wins, so a session whose model changes mid-window is not double-counted). At the periodic flush the snapshot reports the window's peak concurrency and distinct-sessions-seen maps. The sampling is purely local, so network and server load are unchanged.

**Send cadence lowered 12h -> 4h.** `SNAPSHOT_BASE_INTERVAL` drops from 12h to 4h (both TUI and serve inherit it via `snapshot_interval()`; the up-to-30m jitter is unchanged). A 4h heartbeat covers a typical workday about twice and, more importantly, bounds the data lost on a hard kill (power-off, crash, or `SIGKILL`, which all skip the graceful-shutdown flush) to at most one ~4h window instead of 12h. Short-lived runs are unaffected: every launch already emits an immediate boot snapshot and a `process_start`, and a graceful exit flushes a final snapshot, so a session that never stays up 4h is still reported. Payload stays well under 1 KB, so the higher cadence is a negligible bandwidth change.

Schema changes (`SCHEMA_VERSION` 7 -> 8, additive, no migration since the gateway is not yet live):
- `peak_concurrent_sessions: u32`, the window max (point-in-time `session_total` on the TUI, which does not aggregate).
- `distinct_sessions_by_agent`, `distinct_sessions_by_model_bucket`: distinct sessions seen across the window per bucket. Serve-only (empty on the TUI), mirroring the existing `session_creates_since_last_snapshot` "populated by serve, TUI reports 0" precedent. Their sum can exceed `session_total`, which is the point.

The existing point-in-time `session_total` and status/sandbox/yolo/cockpit counts and the `sessions_by_agent` / `sessions_by_model_bucket` maps keep their instant-of-flush meaning, so no field silently changes semantics across surfaces (an explicit design call after a `/debate` pass: new field names beat overloading the existing maps).

Per-field semantics, design notes, and the documented sampling-granularity limitation (a session born and gone entirely between two ~30-min samples is still missed by the windowed maps, though its raw count survives in the create counter; a graceful shutdown flushes the window, while a hard kill loses it bounded to the ~4h since the last send, and machine sleep just misses sample ticks) are written up in `docs/telemetry.md`.

**Telemetry gateway (`aoe-telemetry`):** no code change is required there. The gateway's `IncomingEvent` uses pydantic `extra="allow"` and its sanitizer passes any integer scalar and identifier-keyed int maps, so the new field, the `schema` bump, and the new maps flow through ingest with zero gateway edits. A companion doc-only update to that repo's `docs/SCHEMA.md` + `docs/sample_snapshot.json` is advisable to keep the documented contract in lockstep, tracked separately.

**PostHog dashboard:** the [aoe usage (v2) dashboard](https://us.posthog.com/project/451327/dashboard/1662307) gains tiles for the new signals; each carries a description linking back to this PR.

Closes #1870

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Opt in to telemetry and point `AOE_TELEMETRY_ENDPOINT` at a local sink (e.g. a netcat / small HTTP echo).
- [ ] Run `aoe serve`, open a couple of sessions, close one, open another over a few minutes.
- [ ] Confirm one `usage_snapshot` POST lands per ~4h (no extra traffic from the 30-min sampling), plus the immediate boot snapshot.
- [ ] In the posted snapshot, confirm `peak_concurrent_sessions` >= the instant `session_total`, and `distinct_sessions_by_agent` / `distinct_sessions_by_model_bucket` reflect every session seen across the window (sum can exceed `session_total`).
- [ ] Trigger a graceful shutdown (Ctrl-C / `aoe serve --stop`) and confirm the final flush snapshot carries the window aggregate.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The change is a serve-side background telemetry loop. The aggregator is pure logic, covered by unit tests in `src/telemetry/aggregate.rs` (distinct folding across samples, peak concurrency, latest-bucket-wins de-dup, empty window) plus an integration assertion in `tests/telemetry.rs` that the snapshot's new window fields default sanely.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, including a `/debate` design pass on the mixed-semantics question. I made the design calls (new field names over overloading the existing maps, serve-only scope per the issue) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
High-Level Summary

This PR adds a local, time-windowed aggregator to serve telemetry so usage snapshots include sampled window metrics in addition to existing point-in-time fields. Serve now reports a window peak concurrent sessions metric and distinct-session attribution (by agent and model-bucket) while preserving the original instant-of-flush counters. Telemetry send cadence is reduced to ~4 hours (with the existing ~30-minute sampling interval and up-to-30m jitter), schema is bumped, and docs/tests are updated.

What changed, at a glance
- Added: UsageAggregator (src/telemetry/aggregate.rs) — samples live sessions (~30m), tracks the window max concurrent sessions, and records each session’s latest agent/model bucket for distinct-session counts (with a MAX_SEEN soft cap).
- Updated: serve telemetry loop (src/server/mod.rs) — decouples sampling and flush ticks; samples feed the aggregator and aggregator-derived fields are merged into snapshots at flush; aggregator is flushed on graceful shutdown and reset after a confirmed send.
- Updated: telemetry types & docs (src/telemetry/events.rs, src/telemetry/mod.rs, docs/telemetry.md) — new UsageSnapshot fields: peak_concurrent_sessions, distinct_sessions_by_agent, distinct_sessions_by_model_bucket; schema version incremented; docs explain local sampling, send cadence, and limitations.
- Robustness: added MAX_SEEN to bound memory growth when offline; set MissedTickBehavior::Skip for sample/flush intervals to avoid burst backfill after suspend/wake.
- Tests: unit tests for UsageAggregator behaviors and an integration assertion verifying snapshot defaults/initialization.

Benefits
- Captures short-lived sessions and preserves agent/model attribution that point-in-time snapshots missed.
- Reports window peak concurrency instead of only an instant value.
- No extra network traffic beyond the reduced 4h POST cadence (sampling is local).
- Memory and wake/suspend burst risks are bounded by MAX_SEEN and Skip behavior.
- Backwards-compatible: existing instant-of-flush fields keep their semantics; new fields are additive with a schema bump and documentation.

Technical Details (concise)
- Sampling & aggregation: UsageAggregator.sample(instances) updates window peak_concurrent_sessions and a capped map of session_id → (agent_bucket, model_bucket); latest-observed bucket wins for a session. New session ids stop being added after MAX_SEEN but existing entries still refresh.
- Distinct counts: distinct_sessions_by_agent and distinct_sessions_by_model_bucket are computed by counting unique session IDs per their latest bucket across the window (serve-only; TUI remains empty for these).
- Window lifecycle: aggregator accumulates across ~30m samples, is merged into the snapshot at each flush (~4h), and is reset only after a confirmed send; a final flush on graceful shutdown includes the in-flight window.
- Compatibility: point-in-time counters (session_total, sessions_by_agent/model_bucket, status/mode counts) retain instant-of-flush semantics; new fields are additive and schema version updated.

Potential follow-ups
- Expose MAX_SEEN and sampling cadence as runtime configuration.
- Consider probabilistic or bounded summarization strategies for extremely high churn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->