### PR TITLE
feat(web): enforce eslint in CI and add you-might-not-need-an-effect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,21 @@ jobs:
             exit 1
           fi
 
+  eslint:
+    name: ESLint (web)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+      - name: Run ESLint
+        working-directory: web
+        run: npm run lint
+
   deny:
     name: Supply Chain
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
             pname = "agent-of-empires-web";
             version = "0";
             src = ./web;
-            npmDepsHash = "sha256-9xAaj/bMTAbnATWhRvR34E/4zqjZ1R3NaMsXoJIo2bk=";
+            npmDepsHash = "sha256-GaxkyHIAguDXOTkRDuV6cEuqLvwFih1JOBKByexUxQk=";
             # tsc -b && vite build; output goes to web/dist
             installPhase = ''
               mkdir $out

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -1,0 +1,342 @@
+{
+  "src/App.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 4
+    },
+    "react-you-might-not-need-an-effect/no-chain-state-updates": {
+      "count": 3
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 4
+    }
+  },
+  "src/components/ConnectedDevices.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-external-store-subscription": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-initialize-state": {
+      "count": 1
+    }
+  },
+  "src/components/ElevationPrompt.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-chain-state-updates": {
+      "count": 3
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    }
+  },
+  "src/components/OwnerAvatar.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 1
+    }
+  },
+  "src/components/PairedTerminal.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 2
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    }
+  },
+  "src/components/ProjectsView.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-initialize-state": {
+      "count": 1
+    }
+  },
+  "src/components/SettingsView.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    },
+    "react-refresh/only-export-components": {
+      "count": 2
+    },
+    "react-you-might-not-need-an-effect/no-derived-state": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    }
+  },
+  "src/components/StatusGlyph.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/TerminalView.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 2
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 3
+    }
+  },
+  "src/components/UpdateBanner.tsx": {
+    "react-you-might-not-need-an-effect/no-external-store-subscription": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-initialize-state": {
+      "count": 1
+    }
+  },
+  "src/components/WorkspaceSidebar.tsx": {
+    "react-refresh/only-export-components": {
+      "count": 4
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 4
+    }
+  },
+  "src/components/cockpit/CockpitRuntime.tsx": {
+    "react-refresh/only-export-components": {
+      "count": 1
+    }
+  },
+  "src/components/cockpit/CockpitView.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 3
+    }
+  },
+  "src/components/cockpit/Composer.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-refresh/only-export-components": {
+      "count": 7
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 3
+    },
+    "react-you-might-not-need-an-effect/no-external-store-subscription": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-pass-data-to-parent": {
+      "count": 1
+    }
+  },
+  "src/components/cockpit/ContextPrimerBanner.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 2
+    }
+  },
+  "src/components/cockpit/Markdown.tsx": {
+    "react-refresh/only-export-components": {
+      "count": 1
+    }
+  },
+  "src/components/cockpit/SwitchAgentModal.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 2
+    }
+  },
+  "src/components/cockpit/ToolCards.tsx": {
+    "react-refresh/only-export-components": {
+      "count": 1
+    }
+  },
+  "src/components/cockpit/ToolDisplayMode.tsx": {
+    "react-refresh/only-export-components": {
+      "count": 2
+    }
+  },
+  "src/components/cockpit/useFilesIndex.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 1
+    }
+  },
+  "src/components/command-palette/CommandPalette.tsx": {
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    }
+  },
+  "src/components/diff/CopyPathContextMenu.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/diff/DiffFileViewer.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 2
+    }
+  },
+  "src/components/profiles/ProfilesPage.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    },
+    "react-you-might-not-need-an-effect/no-chain-state-updates": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    }
+  },
+  "src/components/session-wizard/steps/ProjectStep.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-refresh/only-export-components": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-chain-state-updates": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-derived-state": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 3
+    }
+  },
+  "src/components/session-wizard/steps/ReviewStep.tsx": {
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 2
+    }
+  },
+  "src/components/session-wizard/steps/SessionStep.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 1
+    }
+  },
+  "src/components/settings/ProfileSelector.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/hooks/useApprovalSound.ts": {
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    }
+  },
+  "src/hooks/useCockpit.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 6
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 2
+    },
+    "react-you-might-not-need-an-effect/no-external-store-subscription": {
+      "count": 6
+    }
+  },
+  "src/hooks/useDiffComments.ts": {
+    "react-you-might-not-need-an-effect/no-derived-state": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    }
+  },
+  "src/hooks/useDiffFiles.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 4
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    }
+  },
+  "src/hooks/useFileDiff.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/hooks/useMobileKeyboard.ts": {
+    "react-you-might-not-need-an-effect/no-external-store-subscription": {
+      "count": 1
+    }
+  },
+  "src/hooks/usePushSubscription.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/hooks/useSidebarTriage.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 1
+    }
+  },
+  "src/hooks/useTerminal.ts": {
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-external-store-subscription": {
+      "count": 1
+    }
+  },
+  "src/hooks/useTour.tsx": {
+    "react-refresh/only-export-components": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 1
+    }
+  },
+  "src/hooks/useWelcomePhase.ts": {
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": {
+      "count": 1
+    },
+    "react-you-might-not-need-an-effect/no-event-handler": {
+      "count": 2
+    }
+  },
+  "src/lib/agentProfileContext.tsx": {
+    "react-refresh/only-export-components": {
+      "count": 1
+    }
+  },
+  "src/lib/cockpitPrefs.tsx": {
+    "react-refresh/only-export-components": {
+      "count": 1
+    }
+  }
+}

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import youMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need-an-effect'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
@@ -32,14 +33,17 @@ export default defineConfig([
           caughtErrorsIgnorePattern: '^_',
         },
       ],
-      // Deferred from the v10 upgrade. eslint-plugin-react-hooks v7 added
-      // compiler-aware rules (set-state-in-effect, immutability) and
-      // react-refresh tightened only-export-components. The codebase has
-      // ~30 pre-existing violations; re-enable after a dedicated cleanup
-      // pass instead of bundling it into the lint-engine bump.
-      'react-hooks/set-state-in-effect': 'off',
-      'react-hooks/immutability': 'off',
-      'react-refresh/only-export-components': 'off',
+      // Deferred from the v10 upgrade (react-hooks v7 compiler-aware rules
+      // plus react-refresh's tightened only-export-components). Now enabled at
+      // error severity with their pre-existing violations frozen in
+      // eslint-suppressions.json (immutability 1, set-state-in-effect 30,
+      // only-export-components 22). New violations fail; burn the suppressions
+      // down with `eslint --prune-suppressions`. set-state-in-effect overlaps
+      // eslint-plugin-react-you-might-not-need-an-effect, so its count will
+      // shrink as that suppression set is cleared.
+      'react-hooks/set-state-in-effect': 'error',
+      'react-hooks/immutability': 'error',
+      'react-refresh/only-export-components': 'error',
     },
   },
   {
@@ -79,5 +83,16 @@ export default defineConfig([
         },
       ],
     },
+  },
+  {
+    // Flag effects that React doesn't need (derived state, event-handler logic,
+    // prop-sync, etc.). Enabled at error severity, but the ~89 pre-existing
+    // violations are frozen in eslint-suppressions.json so they don't block
+    // CI; new violations fail. Burn the suppressions down file-by-file with
+    // `eslint --prune-suppressions`, then delete the file once empty.
+    // See https://react.dev/learn/you-might-not-need-an-effect.
+    ...youMightNotNeedAnEffect.configs.strict,
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/**/*.test.{ts,tsx}', 'src/**/__tests__/**'],
   },
 ])

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -45,6 +45,7 @@
         "eslint": "^10.4.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "eslint-plugin-react-you-might-not-need-an-effect": "^1.0.0",
         "geist": "^1.7.1",
         "globals": "^17.4.0",
         "jsdom": "^29.1.1",
@@ -146,6 +147,7 @@
       "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.14.13.tgz",
       "integrity": "sha512-ns+Obvj2uZiI5YS5/pWaZsxGqD7r3JMsb+QrM2S7vl+tjFOSq8+y8srvO8S4vZIbLBtvTf3y/JYWGGo0XXCBgg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@assistant-ui/core": "^0.2.9",
         "@assistant-ui/store": "^0.2.13",
@@ -207,6 +209,7 @@
       "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.13.tgz",
       "integrity": "sha512-7NL6HWMBxe1ndLWO4kHkjQ0Syyc0D/Aj+zxdpcy4yrplG71X04CzFimMBBSQAk+AnGBf+d96D7cuUZdjHkTavg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "use-effect-event": "^2.0.3"
       },
@@ -226,6 +229,7 @@
       "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.5.14.tgz",
       "integrity": "sha512-SAy0ip8nKo72U8K9MuU7gYUR4tzoIi6k+HAQgev3zA/sWN7hr/QDDUTblrn5QB9Y/yycRiq8s98WD1vnDy8WMQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^18 || ^19"
@@ -270,6 +274,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -599,6 +604,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -647,6 +653,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -668,6 +675,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -702,27 +710,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1047,7 +1034,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1065,7 +1051,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1089,7 +1074,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1113,7 +1097,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1131,7 +1114,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1149,7 +1131,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1167,7 +1148,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1185,7 +1165,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1203,7 +1182,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1221,7 +1199,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1239,7 +1216,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1257,7 +1233,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1275,7 +1250,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1293,7 +1267,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1317,7 +1290,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1341,7 +1313,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1365,7 +1336,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1389,7 +1359,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1413,7 +1382,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1437,7 +1405,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1461,7 +1428,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1482,7 +1448,6 @@
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -1506,7 +1471,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1527,7 +1491,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1548,7 +1511,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1853,8 +1815,7 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
       "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "16.2.6",
@@ -1869,7 +1830,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1887,7 +1847,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1905,7 +1864,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1923,7 +1881,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1941,7 +1898,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1959,7 +1915,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1977,7 +1932,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1995,7 +1949,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2153,6 +2106,7 @@
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.60.0"
       },
@@ -6102,7 +6056,6 @@
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -6370,6 +6323,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6525,6 +6479,7 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -6534,6 +6489,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6544,6 +6500,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6616,6 +6573,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -6852,6 +6810,7 @@
       "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.7",
@@ -7023,6 +6982,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7146,6 +7106,7 @@
       "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.30.tgz",
       "integrity": "sha512-nvkCybhddbRYsAuZuueRaftvi0XRUTGVU3kNAn5jOz4bVCk6ZQqxuULrR4NkEwuZ5RIpxb6jwDcgGEFL4a9H7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assistant-stream": "^0.3.18"
       }
@@ -7268,6 +7229,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7394,8 +7356,7 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -7724,6 +7685,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7802,6 +7764,35 @@
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-plugin-react-you-might-not-need-an-effect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-you-might-not-need-an-effect/-/eslint-plugin-react-you-might-not-need-an-effect-1.0.0.tgz",
+      "integrity": "sha512-8exakZ5dCJdZb7TA3P8vD47HlnM3IllA9sjKzU22wyLEx0PZBDjFPxT5+5Rb10tSE6uWmwoBsgClIDNuJ8UW6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^16.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-you-might-not-need-an-effect/node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {
@@ -10021,6 +10012,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -10361,6 +10353,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10420,7 +10413,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -10442,7 +10434,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -10646,6 +10637,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10655,6 +10647,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11101,7 +11094,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -11147,7 +11139,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11350,7 +11341,6 @@
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -11599,6 +11589,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11925,6 +11916,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12083,6 +12075,7 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",
@@ -12357,6 +12350,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12379,6 +12373,7 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -147,7 +147,6 @@
       "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.14.13.tgz",
       "integrity": "sha512-ns+Obvj2uZiI5YS5/pWaZsxGqD7r3JMsb+QrM2S7vl+tjFOSq8+y8srvO8S4vZIbLBtvTf3y/JYWGGo0XXCBgg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@assistant-ui/core": "^0.2.9",
         "@assistant-ui/store": "^0.2.13",
@@ -209,7 +208,6 @@
       "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.13.tgz",
       "integrity": "sha512-7NL6HWMBxe1ndLWO4kHkjQ0Syyc0D/Aj+zxdpcy4yrplG71X04CzFimMBBSQAk+AnGBf+d96D7cuUZdjHkTavg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "use-effect-event": "^2.0.3"
       },
@@ -229,7 +227,6 @@
       "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.5.14.tgz",
       "integrity": "sha512-SAy0ip8nKo72U8K9MuU7gYUR4tzoIi6k+HAQgev3zA/sWN7hr/QDDUTblrn5QB9Y/yycRiq8s98WD1vnDy8WMQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^18 || ^19"
@@ -274,7 +271,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -604,7 +600,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -653,7 +648,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -675,7 +669,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -710,6 +703,27 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1034,6 +1048,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1051,6 +1066,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1074,6 +1090,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1097,6 +1114,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1114,6 +1132,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1131,6 +1150,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1148,6 +1168,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1165,6 +1186,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1182,6 +1204,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1199,6 +1222,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1216,6 +1240,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1233,6 +1258,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1250,6 +1276,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1267,6 +1294,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1290,6 +1318,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1313,6 +1342,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1336,6 +1366,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1359,6 +1390,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1382,6 +1414,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1405,6 +1438,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1428,6 +1462,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1448,6 +1483,7 @@
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -1471,6 +1507,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1491,6 +1528,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1511,6 +1549,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1815,7 +1854,8 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
       "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "16.2.6",
@@ -1830,6 +1870,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1847,6 +1888,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1864,6 +1906,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1881,6 +1924,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1898,6 +1942,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1915,6 +1960,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1932,6 +1978,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1949,6 +1996,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2106,7 +2154,6 @@
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.60.0"
       },
@@ -6056,6 +6103,7 @@
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -6323,7 +6371,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6479,7 +6526,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -6489,7 +6535,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6500,7 +6545,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6573,7 +6617,6 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -6810,7 +6853,6 @@
       "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.7",
@@ -6982,7 +7024,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7106,7 +7147,6 @@
       "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.30.tgz",
       "integrity": "sha512-nvkCybhddbRYsAuZuueRaftvi0XRUTGVU3kNAn5jOz4bVCk6ZQqxuULrR4NkEwuZ5RIpxb6jwDcgGEFL4a9H7w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assistant-stream": "^0.3.18"
       }
@@ -7229,7 +7269,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7356,7 +7395,8 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -7685,7 +7725,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -10012,7 +10051,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -10353,7 +10391,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10413,6 +10450,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -10434,6 +10472,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -10637,7 +10676,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10647,7 +10685,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11094,6 +11131,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -11139,6 +11177,7 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11341,6 +11380,7 @@
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -11589,7 +11629,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11916,7 +11955,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12075,7 +12113,6 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",
@@ -12350,7 +12387,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12373,7 +12409,6 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 6",
     "preview": "vite preview",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
@@ -52,6 +52,7 @@
     "eslint": "^10.4.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-react-you-might-not-need-an-effect": "^1.0.0",
     "geist": "^1.7.1",
     "globals": "^17.4.0",
     "jsdom": "^29.1.1",

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1816,6 +1816,11 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
         }`}
         style={headerStyle}
       >
+        {/* dnd-kit's setActivatorNodeRef is a ref-setter callback meant for
+            JSX ref=; react-hooks/refs misreads the "Ref"-named prop as a ref
+            value read during render and taints the whole dragHandle object.
+            We never touch .current here, so the warning is a false positive. */}
+        {/* eslint-disable react-hooks/refs */}
         {dragHandle && (
           <button
             ref={dragHandle.setActivatorNodeRef}
@@ -1829,6 +1834,7 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
             <GripVertical className="h-3.5 w-3.5" />
           </button>
         )}
+        {/* eslint-enable react-hooks/refs */}
         <span className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`} />
         <button
           onClick={onClick}


### PR DESCRIPTION
## Description

There was no ESLint gate on `web/` before this PR: `npm run lint` was advisory and **nothing in CI ran it**, so existing violations went unnoticed (lint was in fact red on 4 `react-hooks/refs` errors). This introduces ESLint enforcement and lays a suppression-baseline foundation for incrementally adopting stricter React-effect rules.

**What changed:**
- **CI gate** — added an `ESLint (web)` job to `ci.yml` next to `clippy`/`fmt`, so lint now gates PRs.
- **Warning budget** — capped the lint script at `--max-warnings 6` (the existing tolerated `exhaustive-deps` + unused-directive warnings); any new warning fails.
- **Fixed the 4 `react-hooks/refs` errors** in `WorkspaceSidebar.tsx` — a false positive on dnd-kit's `setActivatorNodeRef` ref-setter passed to JSX `ref=`, scoped behind a documented block disable (no behavior change).
- **Adopted `eslint-plugin-react-you-might-not-need-an-effect`** (strict) scoped to `src` non-test, and re-enabled the three rules deferred from the v10 bump (`react-hooks/set-state-in-effect`, `react-hooks/immutability`, `react-refresh/only-export-components`) at **error** severity.
- **Froze all 142 pre-existing violations** (across 41 files) in `eslint-suppressions.json` so they don't block CI; **new** violations fail. Burn down with `eslint --prune-suppressions` and delete the file once empty.

| Rule | Frozen |
|---|---:|
| `react-you-might-not-need-an-effect/*` | 89 |
| `react-hooks/set-state-in-effect` | 30 |
| `react-refresh/only-export-components` | 22 |
| `react-hooks/immutability` | 1 |

## PR Type

- [x] Infrastructure / CI
- [x] Bug Fix

## Checklist

- [x] New and existing tests pass (`npm run lint` exits 0; no test changes)
- [x] Documentation was updated where necessary (rationale documented inline in `eslint.config.js`)
- [ ] For UI changes: included screenshot or recording — N/A, no UI change

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow. The only source change (`WorkspaceSidebar.tsx`) adds `eslint-disable` comments with zero runtime behavior change; everything else is lint config / CI.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Used to measure violation counts, wire the CI job, generate the suppression baseline, and fix the ref false positive.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Enforces ESLint for the web package in CI and adopts stricter React-effect-related linting while freezing a suppression baseline so existing issues don't break PRs.

## What changed (high-level)

- CI: added an "ESLint (web)" job to run linting for web/ on PRs (Node.js 22, npm ci, npm run lint).
- Lint command: updated web lint script to run eslint . --max-warnings 6 so new warnings fail CI.
- Rules: enabled eslint-plugin-react-you-might-not-need-an-effect (strict) for src non-test files and re-enabled three previously deferred rules at error severity: react-hooks/set-state-in-effect, react-hooks/immutability, react-refresh/only-export-components.
- Suppressions: added web/eslint-suppressions.json to freeze 142 pre-existing violations across 41 files (counts: 89 react-you-might-not-need-an-effect/*, 30 react-hooks/set-state-in-effect, 22 react-refresh/only-export-components, 1 react-hooks/immutability). New violations will fail CI; suppressions can be pruned with eslint --prune-suppressions.
- Small code fix: scoped an eslint-disable/enable around a false-positive react-hooks/refs warning in web/src/components/WorkspaceSidebar.tsx (no runtime change).
- Lockfile/build: regenerated package-lock (node:22 / npm 10) and bumped flake.nix npmDepsHash so CI installs succeed on Linux.

## Files touched (concise)

- .github/workflows/ci.yml — added eslint job.
- web/package.json — lint script updated; devDependency added.
- web/eslint.config.js — plugin added and rules tightened; comments/documentation updated.
- web/eslint-suppressions.json — suppression baseline added.
- web/src/components/WorkspaceSidebar.tsx — scoped eslint disable for false positive.
- flake.nix — updated npmDepsHash; package-lock.json regenerated.

## Benefits

- Prevents new lint regressions by gating PRs with ESLint.
- Enables stricter React-effect and refresh rules to improve correctness.
- Allows incremental cleanup by freezing current violations; new issues are enforced.
- CI reliability fixed by aligning lockfile/hash for Linux CI.

## Technical notes / jargon

- ESLint job runs on ubuntu-latest with Node 22.
- eslint-plugin-react-you-might-not-need-an-effect applied to src/**/*.{ts,tsx} (tests excluded).
- --max-warnings 6 makes up to six existing warnings tolerated; any additional warnings fail CI.
- Suppressions recorded per-file with counts; use eslint --prune-suppressions to remove entries as violations are fixed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->