### PR TITLE
feat(telemetry): capture serve deployment mode (auth + exposure)

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -24,7 +24,12 @@ closed, versioned schema (see `src/telemetry/events.rs`):
     short-lived sessions that start and end between two snapshots are still
     counted (populated by `aoe serve`; the TUI reports `0`),
   - which opt-in features are turned on (see "Feature flags" below),
-  - whether the web dashboard / cockpit was opened since the last snapshot.
+  - whether the web dashboard / cockpit was opened since the last snapshot,
+  - for `aoe serve` only, how the daemon is deployed, decided once at launch:
+    its auth mode (`token`, `passphrase`, or `none`) and its exposure mode
+    (`tunnel` for a Cloudflare quick or named tunnel, `tailscale` for a
+    Tailscale Funnel, or `local`). These are coarse enums only; the TUI reports
+    neither, since it hosts no server.
 
 In practice that is a handful of small (well under 1 KB) requests per active
 install per day. There is no offline buffering, so a flaky network drops events
@@ -55,8 +60,11 @@ in here, per-session usage is reported separately by the session counts above.
 
 Prompts, file or project paths, session titles, branch names, group paths,
 custom command lines, model strings, hostnames, usernames, or anything derived
-from them. The install id is a random UUID generated locally on opt-in; it is
-never derived from hostname, username, MAC, or filesystem.
+from them. For `aoe serve`, the deployment-mode signals carry only the coarse
+auth and exposure enums above: never a tunnel name, named-tunnel hostname,
+`.ts.net` URL, auth token, or passphrase. The install id is a random UUID
+generated locally on opt-in; it is never derived from hostname, username, MAC,
+or filesystem.
 
 ## Anonymous install id
 

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -699,13 +699,8 @@ pub struct ServerAbout {
 pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> {
     let auth_required = !state.token_manager.is_no_auth().await;
     let passphrase_enabled = state.login_manager.is_enabled();
-    let auth_mode = if auth_required {
-        "token"
-    } else if passphrase_enabled {
-        "passphrase"
-    } else {
-        "none"
-    };
+    let auth_mode =
+        crate::server::resolve_auth_mode(&state.token_manager, &state.login_manager).await;
     let cockpit_master_enabled = state
         .cockpit_master_enabled
         .load(std::sync::atomic::Ordering::Relaxed);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1710,6 +1710,10 @@ fn merge_runtime_fields(prior: Instance, mut fresh: Instance) -> Instance {
 fn spawn_serve_snapshot_loop(state: Arc<AppState>) {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(12 * 60 * 60));
+        // Skip, not burst, missed ticks: a daemon that was paused (laptop sleep)
+        // must not fire several back-to-back snapshots on resume; the 12h cadence
+        // is what matters, not catching up.
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tokio::select! {
                 _ = state.shutdown.cancelled() => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -251,6 +251,15 @@ pub struct AppState {
     pub rate_limiter: Arc<RateLimiter>,
     pub devices: RwLock<Vec<DeviceInfo>>,
     pub behind_tunnel: bool,
+    /// Coarse auth mode resolved once at launch (`"token"` / `"passphrase"` /
+    /// `"none"`). `/api/about` and the opt-in telemetry snapshot both read this
+    /// single value rather than re-deriving it; immutable for the daemon's
+    /// lifetime. Never the token or passphrase itself, only the mode.
+    pub auth_mode: &'static str,
+    /// Coarse exposure mode resolved once at launch from the active transport
+    /// (`"tunnel"` / `"tailscale"` / `"local"`), fed to the telemetry snapshot.
+    /// Never a tunnel name, hostname, or `.ts.net` URL, only the mode.
+    pub serve_mode: &'static str,
     /// Per-instance mutex guarding mutations that must not interleave
     /// (e.g. `ensure_session` decide-and-restart). Entries are created on
     /// first use and live for the lifetime of the process — there are only
@@ -463,6 +472,22 @@ pub struct ServerConfig<'a> {
     pub open_browser: bool,
 }
 
+/// Resolve the coarse auth-mode label the same way `/api/about` reports it, so
+/// the value is derived once from a single place. Token auth wins over a
+/// passphrase second factor when both are configured.
+pub(crate) async fn resolve_auth_mode(
+    token_manager: &TokenManager,
+    login_manager: &login::LoginManager,
+) -> &'static str {
+    if !token_manager.is_no_auth().await {
+        "token"
+    } else if login_manager.is_enabled() {
+        "passphrase"
+    } else {
+        "none"
+    }
+}
+
 pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     let ServerConfig {
         profile,
@@ -592,59 +617,16 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         supervisor
     };
 
-    let state = Arc::new(AppState {
-        profile: profile.to_string(),
-        read_only,
-        instances: RwLock::new(instances),
-        token_manager: Arc::clone(&token_manager),
-        login_manager: Arc::clone(&login_manager),
-        rate_limiter: Arc::clone(&rate_limiter),
-        devices: RwLock::new(Vec::new()),
-        behind_tunnel: remote || behind_proxy,
-        instance_locks: RwLock::new(std::collections::HashMap::new()),
-        recently_restarted: crate::session::recovery::new_recently_restarted(),
-        cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
-            // Seed with an already-stale timestamp so the first request
-            // forces a fresh resolve instead of handing out an empty map.
-            refreshed_at: std::time::Instant::now() - CLEANUP_DEFAULTS_TTL,
-            entries: std::collections::HashMap::new(),
-        }),
-        remote_owner_cache: RwLock::new(std::collections::HashMap::new()),
-        session_primaries: Arc::new(RwLock::new(std::collections::HashMap::new())),
-        session_pause_counts: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
-        status_tx: broadcast::channel(STATUS_CHANNEL_CAPACITY).0,
-        #[cfg(feature = "serve")]
-        cockpit_events_tx: cockpit_events_tx.clone(),
-        #[cfg(feature = "serve")]
-        cockpit_event_store: cockpit_event_store.clone(),
-        #[cfg(feature = "serve")]
-        cockpit_master_enabled,
-        #[cfg(feature = "serve")]
-        cockpit_supervisor: cockpit_supervisor.clone(),
-        push: push_state,
-        push_enabled,
-        web_config: config.web.clone(),
-        last_web_activity: std::sync::atomic::AtomicI64::new(0),
-        telemetry_web_seen: std::sync::atomic::AtomicU32::new(0),
-        telemetry_cockpit_seen: std::sync::atomic::AtomicU32::new(0),
-        telemetry_session_creates: std::sync::atomic::AtomicU32::new(0),
-        telemetry_last_reported: std::sync::Mutex::new(None),
-        shutdown: CancellationToken::new(),
-    });
+    // Telemetry (opt-in, no-op otherwise): announce the serve surface on boot.
+    // The boot announcement fires here, before transport setup, so a launch
+    // attempt is still recorded even if a remote tunnel later fails to come up.
+    // The periodic `usage_snapshot` loop is spawned only after the transport is
+    // resolved (below), so its first tick can report the real `serve_mode`.
+    crate::telemetry::spawn_process_start(crate::telemetry::Surface::Serve);
 
-    // Telemetry (opt-in, no-op otherwise): announce the serve surface on boot
-    // and refresh an aggregate snapshot periodically. Detached; errors are
-    // swallowed.
-    spawn_telemetry_loop(state.clone());
-
-    let app = build_router(state.clone());
-
-    // Cockpit workers for persisted sessions get auto-spawned by the
-    // reconciler in `status_poll_loop`. The poll interval's first tick
-    // fires immediately, so on cold startup this is equivalent to the
-    // old in-place loop here, while also covering sessions added via
-    // `aoe add --cockpit` while serve is already running. The
-    // reconciler short-circuits when `cockpit.enabled = false`.
+    // Resolve the coarse auth mode once at launch; `/api/about` and the
+    // telemetry snapshot both read this single value.
+    let auth_mode = resolve_auth_mode(&token_manager, &login_manager).await;
 
     let addr = format!("{}:{}", host, port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
@@ -822,6 +804,72 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
 
         None
     };
+
+    // Coarse exposure label for telemetry, read straight from the resolved
+    // transport so it cannot drift from what was actually spawned: the tunnel
+    // handle reports "tunnel" (Cloudflare quick or named) or "tailscale", and a
+    // local-only daemon has no handle. Named-tunnel names never leak; only the
+    // coarse mode is taken.
+    let serve_mode: &'static str = tunnel_handle
+        .as_ref()
+        .map(|h| h.mode_label())
+        .unwrap_or("local");
+
+    let state = Arc::new(AppState {
+        profile: profile.to_string(),
+        read_only,
+        instances: RwLock::new(instances),
+        token_manager: Arc::clone(&token_manager),
+        login_manager: Arc::clone(&login_manager),
+        rate_limiter: Arc::clone(&rate_limiter),
+        devices: RwLock::new(Vec::new()),
+        behind_tunnel: remote || behind_proxy,
+        auth_mode,
+        serve_mode,
+        instance_locks: RwLock::new(std::collections::HashMap::new()),
+        recently_restarted: crate::session::recovery::new_recently_restarted(),
+        cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
+            // Seed with an already-stale timestamp so the first request
+            // forces a fresh resolve instead of handing out an empty map.
+            refreshed_at: std::time::Instant::now() - CLEANUP_DEFAULTS_TTL,
+            entries: std::collections::HashMap::new(),
+        }),
+        remote_owner_cache: RwLock::new(std::collections::HashMap::new()),
+        session_primaries: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        session_pause_counts: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+        status_tx: broadcast::channel(STATUS_CHANNEL_CAPACITY).0,
+        #[cfg(feature = "serve")]
+        cockpit_events_tx: cockpit_events_tx.clone(),
+        #[cfg(feature = "serve")]
+        cockpit_event_store: cockpit_event_store.clone(),
+        #[cfg(feature = "serve")]
+        cockpit_master_enabled,
+        #[cfg(feature = "serve")]
+        cockpit_supervisor: cockpit_supervisor.clone(),
+        push: push_state,
+        push_enabled,
+        web_config: config.web.clone(),
+        last_web_activity: std::sync::atomic::AtomicI64::new(0),
+        telemetry_web_seen: std::sync::atomic::AtomicU32::new(0),
+        telemetry_cockpit_seen: std::sync::atomic::AtomicU32::new(0),
+        telemetry_session_creates: std::sync::atomic::AtomicU32::new(0),
+        telemetry_last_reported: std::sync::Mutex::new(None),
+        shutdown: CancellationToken::new(),
+    });
+
+    // Periodic opt-in `usage_snapshot` loop. Spawned after the transport is
+    // resolved so the first (immediate) tick reports the real `serve_mode`, and
+    // so a daemon whose tunnel failed to start never emits a snapshot at all.
+    spawn_serve_snapshot_loop(state.clone());
+
+    let app = build_router(state.clone());
+
+    // Cockpit workers for persisted sessions get auto-spawned by the
+    // reconciler in `status_poll_loop`. The poll interval's first tick
+    // fires immediately, so on cold startup this is equivalent to the
+    // old in-place loop here, while also covering sessions added via
+    // `aoe add --cockpit` while serve is already running. The
+    // reconciler short-circuits when `cockpit.enabled = false`.
 
     // Seed cockpit sessions' status from the on-disk event log before
     // any background task runs. The status_poll_loop overlay reads
@@ -1652,13 +1700,12 @@ fn merge_runtime_fields(prior: Instance, mut fresh: Instance) -> Instance {
     fresh
 }
 
-/// Background task: emit an opt-in telemetry `process_start` for the serve
-/// surface, then a `usage_snapshot` immediately and every 12 hours, plus a
-/// final one on graceful shutdown. All sends are best-effort and swallow
-/// errors; nothing leaves the box unless the user opted in and an endpoint is
-/// configured.
-fn spawn_telemetry_loop(state: Arc<AppState>) {
-    crate::telemetry::spawn_process_start(crate::telemetry::Surface::Serve);
+/// Background task: emit an opt-in telemetry `usage_snapshot` immediately and
+/// every 12 hours, plus a final one on graceful shutdown. The boot
+/// `process_start` is emitted separately by the caller before transport setup.
+/// All sends are best-effort and swallow errors; nothing leaves the box unless
+/// the user opted in and an endpoint is configured.
+fn spawn_serve_snapshot_loop(state: Arc<AppState>) {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(12 * 60 * 60));
         loop {
@@ -1718,6 +1765,8 @@ async fn build_serve_snapshot(state: &AppState) -> Option<crate::telemetry::Usag
         web_seen > 0,
         cockpit_seen > 0,
         session_creates,
+        Some(state.auth_mode),
+        Some(state.serve_mode),
     )?;
     *state.telemetry_last_reported.lock().unwrap() = Some(ReportedServeSignals {
         web_seen,
@@ -3011,6 +3060,25 @@ mod tests {
             entries: std::collections::HashMap::new(),
         };
         assert!(cache.stale());
+    }
+
+    #[tokio::test]
+    async fn resolve_auth_mode_matches_about_precedence() {
+        let token = TokenManager::new(Some("abc123".to_string()), Duration::from_secs(3600));
+        let no_token = TokenManager::new(None, Duration::from_secs(3600));
+        let passphrase = login::LoginManager::new(Some("hunter2"));
+        let no_passphrase = login::LoginManager::new(None);
+
+        // A token wins over a passphrase second factor when both are set.
+        assert_eq!(resolve_auth_mode(&token, &passphrase).await, "token");
+        assert_eq!(resolve_auth_mode(&token, &no_passphrase).await, "token");
+        // No token but a passphrase reports passphrase auth.
+        assert_eq!(
+            resolve_auth_mode(&no_token, &passphrase).await,
+            "passphrase"
+        );
+        // Neither configured is the security-relevant fully-open mode.
+        assert_eq!(resolve_auth_mode(&no_token, &no_passphrase).await, "none");
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -857,11 +857,6 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         shutdown: CancellationToken::new(),
     });
 
-    // Periodic opt-in `usage_snapshot` loop. Spawned after the transport is
-    // resolved so the first (immediate) tick reports the real `serve_mode`, and
-    // so a daemon whose tunnel failed to start never emits a snapshot at all.
-    spawn_serve_snapshot_loop(state.clone());
-
     let app = build_router(state.clone());
 
     // Cockpit workers for persisted sessions get auto-spawned by the
@@ -887,6 +882,13 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // Phase B (the cascade workers) runs in a spawned task and holds
     // the lock until done.
     let recovery_inputs = daemon_startup_recovery_mark(state.clone()).await;
+
+    // Periodic opt-in `usage_snapshot` loop. Spawned after the transport is
+    // resolved (so the first, immediate tick reports the real `serve_mode` and a
+    // daemon whose tunnel failed to start emits nothing) and after cockpit
+    // status seeding plus the synchronous recovery marking (so that first tick's
+    // session counts reflect the restored state rather than a half-loaded one).
+    spawn_serve_snapshot_loop(state.clone());
 
     // GC the recently_restarted suppression map periodically; the TTL
     // check on read filters but does not remove entries. Without this,

--- a/src/server/tunnel.rs
+++ b/src/server/tunnel.rs
@@ -975,6 +975,35 @@ pub fn tailscale_funnel_cap_ready_sync() -> bool {
 mod tests {
     use super::*;
 
+    // The telemetry `serve_mode` signal reads `mode_label()`, so it must only
+    // ever emit the closed exposure set, and a named Cloudflare tunnel must
+    // bucket to "tunnel" rather than leak the configured tunnel name (#1885).
+    #[test]
+    fn mode_label_is_closed_and_never_leaks_tunnel_name() {
+        assert_eq!(TunnelKind::Quick.mode_label(), "tunnel");
+        assert_eq!(
+            TunnelKind::Named {
+                tunnel_name: "my-secret-corp-tunnel".to_string(),
+            }
+            .mode_label(),
+            "tunnel",
+        );
+        assert_eq!(TunnelKind::Tailscale.mode_label(), "tailscale");
+
+        for kind in [
+            TunnelKind::Quick,
+            TunnelKind::Named {
+                tunnel_name: "anything".to_string(),
+            },
+            TunnelKind::Tailscale,
+        ] {
+            assert!(
+                matches!(kind.mode_label(), "tunnel" | "tailscale"),
+                "mode_label must stay within the closed exposure set"
+            );
+        }
+    }
+
     #[test]
     fn extract_url_from_typical_output() {
         let line =

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -9,8 +9,9 @@ use std::collections::BTreeMap;
 
 use serde::Serialize;
 
-/// Payload schema version. Bump on any breaking change to the field set.
-pub const SCHEMA_VERSION: u32 = 1;
+/// Payload schema version. Bump on any change to the wire shape, including
+/// additive optional fields, so a reader can tell which fields to expect.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -92,4 +93,18 @@ pub struct UsageSnapshot {
     /// Sessions created since the previous snapshot (a trend counter, not a
     /// per-session event stream).
     pub session_creates_since_last_snapshot: u32,
+
+    /// Serve-only: how the daemon authenticates clients, decided once at
+    /// launch. One of `"token"`, `"passphrase"`, `"none"`. `None` for the
+    /// TUI / CLI surfaces, which host no server. Never carries the token or
+    /// passphrase value, only the coarse mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_mode: Option<String>,
+
+    /// Serve-only: how the daemon is exposed, decided once at launch. One of
+    /// `"tunnel"` (Cloudflare quick or named), `"tailscale"` (Tailscale
+    /// Funnel), or `"local"`. `None` for the TUI / CLI surfaces. Never carries
+    /// a tunnel name, hostname, or `.ts.net` URL, only the coarse mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serve_mode: Option<String>,
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -140,6 +140,8 @@ pub fn build_usage_snapshot(
     web_seen: bool,
     cockpit_seen: bool,
     session_creates_since_last_snapshot: u32,
+    auth_mode: Option<&str>,
+    serve_mode: Option<&str>,
 ) -> Option<UsageSnapshot> {
     if !is_opted_in() {
         return None;
@@ -220,6 +222,8 @@ pub fn build_usage_snapshot(
         web_seen,
         cockpit_seen,
         session_creates_since_last_snapshot,
+        auth_mode: auth_mode.map(str::to_string),
+        serve_mode: serve_mode.map(str::to_string),
     })
 }
 
@@ -472,7 +476,34 @@ mod tests {
             web_seen: false,
             cockpit_seen: false,
             session_creates_since_last_snapshot: 0,
+            auth_mode: None,
+            serve_mode: None,
         }
+    }
+
+    // The serve deployment-mode fields are part of the content fingerprint, so a
+    // daemon that switches exposure or auth mode between snapshots is not deduped
+    // away as an unchanged repeat (#1885).
+    #[test]
+    #[serial]
+    fn serve_mode_fields_change_the_fingerprint() {
+        let base = sample_snapshot();
+        let mut serve = sample_snapshot();
+        serve.auth_mode = Some("passphrase".to_string());
+        serve.serve_mode = Some("tailscale".to_string());
+        assert_ne!(
+            snapshot_fingerprint(&base),
+            snapshot_fingerprint(&serve),
+            "adding auth_mode / serve_mode must change the fingerprint"
+        );
+
+        let mut other = serve.clone();
+        other.serve_mode = Some("tunnel".to_string());
+        assert_ne!(
+            snapshot_fingerprint(&serve),
+            snapshot_fingerprint(&other),
+            "a different serve_mode must change the fingerprint"
+        );
     }
 
     // Regression for the duplicate `usage_snapshot` seen in dogfooding: the TUI

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -146,6 +146,18 @@ pub fn build_usage_snapshot(
     if !is_opted_in() {
         return None;
     }
+    // auth_mode / serve_mode are serve-only deployment metadata. Normalize here
+    // rather than trusting every caller to pass None, so a future non-serve call
+    // site can never leak them onto a TUI / CLI payload.
+    debug_assert!(
+        matches!(surface, Surface::Serve) || (auth_mode.is_none() && serve_mode.is_none()),
+        "auth_mode and serve_mode are serve-only fields"
+    );
+    let (auth_mode, serve_mode) = if matches!(surface, Surface::Serve) {
+        (auth_mode, serve_mode)
+    } else {
+        (None, None)
+    };
     let install_id = state::ensure_install_id()?;
     // Global, pre-profile-merge config on purpose: `features` is an install-level
     // default-adoption signal, not per-session usage. See `features::active_features`.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1324,6 +1324,9 @@ impl App {
             false,
             false,
             0,
+            // The TUI hosts no server, so it has no auth or exposure mode.
+            None,
+            None,
         )
     }
 

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -37,7 +37,9 @@ fn default_off_emits_nothing() {
     assert!(!telemetry::is_opted_in());
     assert_eq!(telemetry::install_id(), None);
     assert!(telemetry::build_process_start(Surface::Cli).is_none());
-    assert!(telemetry::build_usage_snapshot(Surface::Tui, &[], false, false, 0).is_none());
+    assert!(
+        telemetry::build_usage_snapshot(Surface::Tui, &[], false, false, 0, None, None).is_none()
+    );
 }
 
 /// Opting in generates an install id and lets events build; opting back out
@@ -100,15 +102,27 @@ fn snapshot_buckets_are_sanitized() {
     custom.detect_as = String::new();
     let claude = Instance::new("c", "/p");
 
-    let snapshot =
-        telemetry::build_usage_snapshot(Surface::Tui, &[custom, claude], false, false, 0)
-            .expect("snapshot built when opted in");
+    let snapshot = telemetry::build_usage_snapshot(
+        Surface::Tui,
+        &[custom, claude],
+        false,
+        false,
+        0,
+        None,
+        None,
+    )
+    .expect("snapshot built when opted in");
 
     let serialized = serde_json::to_string(&snapshot).expect("serialize");
     // The raw custom command / project path must never appear in the payload.
     assert!(!serialized.contains("my-internal-agent"));
     assert!(!serialized.contains("secret-project"));
     assert!(!serialized.contains("secret-session"));
+    // The TUI surface has no serve deployment mode, so the fields are omitted.
+    assert!(snapshot.auth_mode.is_none());
+    assert!(snapshot.serve_mode.is_none());
+    assert!(!serialized.contains("auth_mode"));
+    assert!(!serialized.contains("serve_mode"));
 
     assert_eq!(snapshot.sessions_by_agent.get("custom"), Some(&1));
     assert_eq!(snapshot.sessions_by_agent.get("claude"), Some(&1));
@@ -134,13 +148,77 @@ fn snapshot_carries_session_create_count() {
     set_enabled(true);
     telemetry::apply_opt_in_change(true);
 
-    let none = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 0)
+    let none = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 0, None, None)
         .expect("snapshot built when opted in");
     assert_eq!(none.session_creates_since_last_snapshot, 0);
 
-    let some = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 7)
+    let some = telemetry::build_usage_snapshot(Surface::Serve, &[], false, false, 7, None, None)
         .expect("snapshot built when opted in");
     assert_eq!(some.session_creates_since_last_snapshot, 7);
+}
+
+/// User stories (#1885): the serve snapshot carries the coarse deployment mode.
+/// A passphrase-auth daemon behind a Tailscale Funnel reports
+/// `auth_mode = "passphrase"` and `serve_mode = "tailscale"`; the token-gated
+/// local-only default reports `auth_mode = "token"` and `serve_mode = "local"`.
+/// Both fields are always from the closed allowlist and never carry a tunnel
+/// name, hostname, token, or passphrase.
+#[test]
+#[serial]
+fn serve_snapshot_carries_coarse_deployment_mode() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let tailscale = telemetry::build_usage_snapshot(
+        Surface::Serve,
+        &[],
+        false,
+        false,
+        0,
+        Some("passphrase"),
+        Some("tailscale"),
+    )
+    .expect("snapshot built when opted in");
+    assert_eq!(tailscale.auth_mode.as_deref(), Some("passphrase"));
+    assert_eq!(tailscale.serve_mode.as_deref(), Some("tailscale"));
+
+    let local = telemetry::build_usage_snapshot(
+        Surface::Serve,
+        &[],
+        false,
+        false,
+        0,
+        Some("token"),
+        Some("local"),
+    )
+    .expect("snapshot built when opted in");
+    assert_eq!(local.auth_mode.as_deref(), Some("token"));
+    assert_eq!(local.serve_mode.as_deref(), Some("local"));
+
+    // Both fields are constrained to their closed sets on the wire.
+    let serialized = serde_json::to_string(&tailscale).expect("serialize");
+    assert!(serialized.contains("\"auth_mode\":\"passphrase\""));
+    assert!(serialized.contains("\"serve_mode\":\"tailscale\""));
+}
+
+/// As an opted-out user, serve in any auth/exposure mode records nothing: the
+/// snapshot is not even built, regardless of the deployment-mode arguments.
+#[test]
+#[serial]
+fn opted_out_serve_builds_no_snapshot_with_deployment_mode() {
+    let _tmp = isolate();
+    assert!(!telemetry::is_opted_in());
+    assert!(telemetry::build_usage_snapshot(
+        Surface::Serve,
+        &[],
+        false,
+        false,
+        0,
+        Some("none"),
+        Some("tunnel"),
+    )
+    .is_none());
 }
 
 /// The CLI `process_start` is throttled to once per install per day so a user


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds two coarse, opt-in telemetry signals to the `aoe serve` usage snapshot so we can answer two concrete "how is serve used in the wild" questions: how daemons authenticate clients, and how they are exposed to the network. Both are decided once at daemon launch, so they are cheap, stable, launch-time signals with no per-action stream.

- `auth_mode`: `token` (default), `passphrase`, or `none`. Resolved once at launch through a new shared `resolve_auth_mode` helper, which `/api/about` now also uses instead of re-deriving the same logic inline.
- `serve_mode`: `tunnel` (Cloudflare quick or named), `tailscale` (Tailscale Funnel), or `local`. Read straight from the resolved transport's `mode_label()` so it cannot drift from what was actually spawned.

Both are serve-only `Option` fields, omitted entirely from TUI/CLI snapshots, and both are closed enums: a named Cloudflare tunnel buckets to `tunnel` and never carries the tunnel name, hostname, `.ts.net` URL, token, or passphrase. `SCHEMA_VERSION` is bumped to 2 since the wire shape changed.

To report the real exposure mode on the very first snapshot (the snapshot loop's first tick fires immediately), `start_server` now spawns the periodic snapshot loop only after the transport is resolved. A daemon whose remote tunnel fails to start therefore emits no snapshot, while the boot `process_start` still fires before transport setup so a launch attempt is always recorded.

No `aoe-telemetry` gateway change is required: the gateway's generic sanitizer already forwards new top-level identifier-like scalar string properties, and all six enum values plus both keys pass its allowlist, with the privacy backstop bounding them.

Closes #1885

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] Opt in to telemetry, run `aoe serve` token-gated and local-only (the default), point `AOE_TELEMETRY_ENDPOINT` at a local sink, and confirm the snapshot reports `auth_mode: "token"` and `serve_mode: "local"`.
- [ ] Run `aoe serve --passphrase <pp>` behind a Tailscale Funnel and confirm the snapshot reports `auth_mode: "passphrase"` and `serve_mode: "tailscale"`.
- [ ] Run `aoe serve --remote --tunnel-name <name> --tunnel-url <host>` and confirm `serve_mode: "tunnel"` with no tunnel name, hostname, or token anywhere in the payload.
- [ ] Run the TUI opted in and confirm its snapshot omits `auth_mode` and `serve_mode` entirely.
- [ ] With telemetry off (or `DO_NOT_TRACK=1`), run serve in any mode and confirm nothing is built or sent.
- [ ] Hit `GET /api/about` and confirm the `auth_mode` field still reports the correct mode.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Rust coverage: integration tests in `tests/telemetry.rs` (serve snapshot carries both modes, TUI omits them, opted-out builds nothing), unit tests for `resolve_auth_mode` precedence, `mode_label` closed-set / no-name-leak, and the dedup fingerprint picking up the new fields.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, including a multi-model design debate on the snapshot-loop ordering and the builder shape. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Summary

This PR enhances telemetry for `aoe serve` by capturing two new deployment configuration signals: **auth_mode** (how users authenticate: "token", "passphrase", or "none") and **serve_mode** (how the service is exposed: "tunnel" for Cloudflare, "tailscale" for Tailscale Funnel, or "local" for local-only). These fields are optional, serve-only, and designed to be coarse identifiers that never leak sensitive details like tokens, passphrases, hostnames, or URLs.

**What was added:**
- Two new optional telemetry fields to the usage snapshot (`auth_mode` and `serve_mode`)
- A new `resolve_auth_mode` helper function that determines authentication mode at daemon startup (consistently applied to both telemetry and the `/api/about` API endpoint)
- New startup logic that defers the periodic telemetry snapshot loop until after the transport is fully resolved, ensuring the first snapshot reports actual deployment values
- Comprehensive test coverage for the new fields, including validation that they use only allowed closed-set values and proper deduplication behavior
- Updated documentation explaining what deployment details are captured and what never is

**What was changed:**
- Telemetry schema version bumped from 1 to 2
- `AppState` now stores the resolved `auth_mode` and `serve_mode` as static string references
- `start_server` logic reordered to separate early telemetry signaling (`process_start` event) from the periodic snapshot loop
- All call sites of `build_usage_snapshot` updated to provide the new optional parameters
- Documentation clarified to highlight the closed-set, coarse-grained nature of the new fields

**What was removed:**
- Inline `auth_mode` computation logic in `get_about` (now delegated to the shared helper)

## Benefits

- **Better deployment insights:** Teams can now understand patterns in how `aoe serve` is being used (which auth mechanisms and tunnel types are popular) without exposing individual configuration details.
- **No data leakage:** By design, the fields use fixed buckets and never carry sensitive identifiers, hostnames, tokens, or passphrases.
- **Consistency:** The auth mode resolution is now centralized in one helper, ensuring `/api/about` and telemetry report the same values.
- **Accurate telemetry:** Deferred snapshot spawning ensures the first telemetry event reflects the actual deployed transport, not a default or transitional state.
- **Future-ready:** The schema version bump and closed-set design support clean integration with downstream telemetry systems and registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->