### PR TITLE
feat(telemetry): instrument diff/comments/terminal usage signals

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -134,14 +134,22 @@ in here, per-session usage is reported separately by the session counts above.
 ### Usage signals
 
 The snapshot also includes a `usage_seen` map (allowlisted signal name ->
-open-count) so we can see which surfaces installs actually use within a window,
-for example `{web: 3, cockpit: 1}`. It is driven by a registry in
-`src/telemetry/usage_signals.rs`: instrumenting a new surface is one entry there
-(its short name), not a schema change. The key set is fixed and the values are
-counts, so a signal can never carry a path or free text, and the gateway
-forwards only this allowlisted shape. The web dashboard reports an open by
-pinging `POST /api/telemetry/seen`; an unregistered name is rejected. The TUI
-never hosts the web surfaces, so it reports the map zeroed.
+open-count) so we can see which surfaces and features installs actually use
+within a window, for example `{web: 3, cockpit: 1, diff_panel: 2}`. It is driven
+by a registry in `src/telemetry/usage_signals.rs`: instrumenting a new surface
+is one entry there (its short name), not a schema change. The key set is fixed
+and the values are counts, so a signal can never carry a path or free text, and
+the gateway forwards only this allowlisted shape. The web dashboard reports an
+open by pinging `POST /api/telemetry/seen`; an unregistered name is rejected.
+The TUI never hosts the web surfaces, so it reports the map zeroed.
+
+The allowlisted signals are whole-UI opens (`web`, `cockpit`) plus dashboard
+feature opens: `diff_panel` (the git diff panel was opened for a session),
+`diff_comments` (a count of diff-comment prompts sent to the agent), and
+`web_terminal` (the xterm.js terminal was opened). Scratch-session usage is not
+a `usage_seen` signal: it is cross-surface session state, reported point-in-time
+by the `scratch` bucket of the `sessions_by_substrate` census above, which
+covers scratch sessions created from the CLI, TUI, or web wizard alike.
 
 ## What is never sent
 

--- a/src/telemetry/usage_signals.rs
+++ b/src/telemetry/usage_signals.rs
@@ -19,7 +19,19 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 /// The fixed allowlist of usage-signal names a snapshot may report. Adding a
 /// surface here is the only edit needed to instrument it end to end.
-pub const USAGE_SIGNALS: &[&str] = &["web", "cockpit"];
+///
+/// `web` / `cockpit` are whole-UI opens; `diff_panel` / `diff_comments` /
+/// `web_terminal` (#1881) are feature-level opens within the dashboard, each
+/// fired from its own frontend trigger point. Scratch-session usage is not
+/// here: it is cross-surface session state, reported point-in-time by the
+/// `sessions_by_substrate` census, not a browser-fired open.
+pub const USAGE_SIGNALS: &[&str] = &[
+    "web",
+    "cockpit",
+    "diff_panel",
+    "diff_comments",
+    "web_terminal",
+];
 
 /// Window-scoped "feature was used" counters, one per allowlisted signal in
 /// [`USAGE_SIGNALS`]. Built once at daemon start and only ever borrowed, so the
@@ -124,10 +136,26 @@ mod tests {
         assert!(counters.record("cockpit"));
         // An off-list name is rejected and never creates a key.
         assert!(!counters.record("bogus"));
-        assert!(!counters.record("diff_panel"));
         let snap = counters.snapshot();
         assert!(!snap.contains_key("bogus"));
-        assert!(!snap.contains_key("diff_panel"));
+    }
+
+    #[test]
+    fn feature_signals_are_registered_and_reported() {
+        // The #1881 feature-level signals are allowlisted: they record and
+        // show up in the snapshot key set alongside the whole-UI opens.
+        let counters = UsageSeenCounters::new();
+        for name in ["diff_panel", "diff_comments", "web_terminal"] {
+            assert!(counters.record(name), "{name} should be allowlisted");
+        }
+        let snap = counters.snapshot();
+        assert_eq!(snap.get("diff_panel"), Some(&1));
+        assert_eq!(snap.get("diff_comments"), Some(&1));
+        assert_eq!(snap.get("web_terminal"), Some(&1));
+        // The TUI zero shape carries the same expanded key set.
+        for name in ["diff_panel", "diff_comments", "web_terminal"] {
+            assert_eq!(zeroed().get(name), Some(&0));
+        }
     }
 
     #[test]

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -496,6 +496,30 @@ fn snapshot_carries_registered_usage_signals() {
     assert_eq!(snapshot.usage_seen.get("cockpit"), Some(&1));
 }
 
+/// User story (#1881): the dashboard feature signals (diff panel, diff comments,
+/// web terminal) are allowlisted and flow through the daemon aggregate into the
+/// snapshot's `usage_seen` map, exactly like the whole-UI opens.
+#[test]
+#[serial]
+fn snapshot_carries_feature_usage_signals() {
+    let _tmp = isolate();
+    set_enabled(true);
+    telemetry::apply_opt_in_change(true);
+
+    let counters = UsageSeenCounters::new();
+    assert!(counters.record("diff_panel"));
+    assert!(counters.record("diff_comments"));
+    assert!(counters.record("diff_comments"));
+    assert!(counters.record("web_terminal"));
+
+    let snapshot =
+        telemetry::build_usage_snapshot(Surface::Serve, &[], counters.snapshot(), 0, None, None)
+            .expect("snapshot built when opted in");
+    assert_eq!(snapshot.usage_seen.get("diff_panel"), Some(&1));
+    assert_eq!(snapshot.usage_seen.get("diff_comments"), Some(&2));
+    assert_eq!(snapshot.usage_seen.get("web_terminal"), Some(&1));
+}
+
 /// User story (#1880): an unregistered signal name is rejected by the registry
 /// (`record` returns false, which the endpoint turns into a 400) and never
 /// reaches the snapshot's `usage_seen` map.
@@ -507,13 +531,14 @@ fn unregistered_usage_signal_is_rejected_and_never_reported() {
     telemetry::apply_opt_in_change(true);
 
     let counters = UsageSeenCounters::new();
-    // The endpoint would return 400 on this false.
-    assert!(!counters.record("web_terminal"));
+    // The endpoint would return 400 on this false. `not_a_signal` is off the
+    // allowlist; the registered names are asserted elsewhere.
+    assert!(!counters.record("not_a_signal"));
 
     let snapshot =
         telemetry::build_usage_snapshot(Surface::Serve, &[], counters.snapshot(), 0, None, None)
             .expect("snapshot built when opted in");
-    assert!(!snapshot.usage_seen.contains_key("web_terminal"));
+    assert!(!snapshot.usage_seen.contains_key("not_a_signal"));
 }
 
 /// User story (#1880): the `usage_seen` map only ever carries allowlisted short

--- a/web/src/components/diff/comments/SendCommentsDialog.tsx
+++ b/web/src/components/diff/comments/SendCommentsDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CommentMarkdown } from "./CommentMarkdown";
 import { buildCommentsMarkdown, buildDiffCommentsPrompt } from "./buildPrompt";
 import type { DiffComment } from "./types";
+import { reportTelemetrySeen } from "../../../lib/api";
 
 interface Props {
   sessionId: string;
@@ -82,6 +83,9 @@ export function SendCommentsDialog({
         }
         return;
       }
+      // Count each successful diff-comments send (a low-frequency action, so a
+      // count is more useful than a boolean). Only on a confirmed 2xx.
+      reportTelemetrySeen("diff_comments");
       onSent();
     } catch (e) {
       const message = e instanceof Error ? e.message : "Network error";

--- a/web/src/hooks/useDiffFiles.ts
+++ b/web/src/hooks/useDiffFiles.ts
@@ -34,6 +34,9 @@ export function useDiffFiles(
   // Session the `diff_panel` usage signal last fired for, so opening the panel
   // reports once per session rather than on every 10s poll tick or re-render.
   const diffPanelSeenForRef = useRef<string | null>(null);
+  // Mirrors `enabled` so fetchFiles can read the current panel state without
+  // taking it as a dep (which would tear down and re-run the fetch effects).
+  const enabledRef = useRef(enabled);
 
   const fetchFiles = useCallback(async () => {
     if (!sessionId) return;
@@ -51,9 +54,25 @@ export function useDiffFiles(
         setWarning(resp.warning ?? null);
         setRevision((r) => r + 1);
       }
+      // The diff list loaded successfully: report diff_panel once per session.
+      // Gated on enabledRef so a background fetch fired on session change while
+      // the panel is closed does not count, and on the per-session ref so the
+      // 10s poll does not re-fire it.
+      if (
+        enabledRef.current &&
+        diffPanelSeenForRef.current !== capturedSessionId
+      ) {
+        diffPanelSeenForRef.current = capturedSessionId;
+        reportTelemetrySeen("diff_panel");
+      }
     }
     setLoading(false);
   }, [sessionId]);
+
+  // Keep enabledRef in sync with the latest panel state.
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
 
   // Fetch on session change; invalidate any in-flight requests.
   useEffect(() => {
@@ -77,12 +96,6 @@ export function useDiffFiles(
       intervalRef.current = null;
     }
     if (enabled && sessionId) {
-      // The diff panel is open for this session: report a feature-usage signal
-      // once per session activation (deduped by sessionId), not per poll tick.
-      if (diffPanelSeenForRef.current !== sessionId) {
-        diffPanelSeenForRef.current = sessionId;
-        reportTelemetrySeen("diff_panel");
-      }
       intervalRef.current = setInterval(() => void fetchFiles(), POLL_INTERVAL);
     }
     return () => {

--- a/web/src/hooks/useDiffFiles.ts
+++ b/web/src/hooks/useDiffFiles.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { getSessionDiffFiles } from "../lib/api";
+import { getSessionDiffFiles, reportTelemetrySeen } from "../lib/api";
 import type { RepoBase, RichDiffFile } from "../lib/types";
 
 const POLL_INTERVAL = 10_000;
@@ -31,6 +31,9 @@ export function useDiffFiles(
   const lastFingerprintRef = useRef("");
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const requestIdRef = useRef(0);
+  // Session the `diff_panel` usage signal last fired for, so opening the panel
+  // reports once per session rather than on every 10s poll tick or re-render.
+  const diffPanelSeenForRef = useRef<string | null>(null);
 
   const fetchFiles = useCallback(async () => {
     if (!sessionId) return;
@@ -74,6 +77,12 @@ export function useDiffFiles(
       intervalRef.current = null;
     }
     if (enabled && sessionId) {
+      // The diff panel is open for this session: report a feature-usage signal
+      // once per session activation (deduped by sessionId), not per poll tick.
+      if (diffPanelSeenForRef.current !== sessionId) {
+        diffPanelSeenForRef.current = sessionId;
+        reportTelemetrySeen("diff_panel");
+      }
       intervalRef.current = setInterval(() => void fetchFiles(), POLL_INTERVAL);
     }
     return () => {

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -11,6 +11,7 @@ import type {
   ResumeOutputMessage,
 } from "../lib/types";
 import { getOrCreateDeviceBindingSecret } from "../lib/deviceBinding";
+import { reportTelemetrySeen } from "../lib/api";
 import { getToken } from "../lib/token";
 import { useWebSettings } from "./useWebSettings";
 import { TerminalTiming } from "../lib/terminalTiming";
@@ -223,6 +224,10 @@ export function useTerminal(
   // ws.close() on a CLOSED socket is a no-op, which was the bug behind
   // the dead Retry button after retries exhausted. See #1009.
   const connectRef = useRef<(() => void) | null>(null);
+  // Fire the `web_terminal` usage signal once per hook lifetime, not on every
+  // reconnect: ws.onopen runs again after a WiFi blip, and the telemetry intent
+  // is "this terminal was opened", not "the socket reconnected N times".
+  const telemetrySeenRef = useRef(false);
   // Reverse pointer so the `online` / `pageshow` listeners installed
   // inside the connect-effect can call manualReconnect (defined below
   // the effect) without re-running the effect itself.
@@ -641,6 +646,10 @@ export function useTerminal(
           readyState: ws.readyState,
           protocol: ws.protocol,
         });
+        if (!telemetrySeenRef.current) {
+          telemetrySeenRef.current = true;
+          reportTelemetrySeen("web_terminal");
+        }
         // Reset the dedup baseline so the first resize on a fresh
         // connection always reaches the server, even if it matches
         // the size we last sent on the previous (now-closed) socket.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -445,12 +445,23 @@ export async function setTelemetryConsent(
   }
 }
 
-/// Tell the daemon the web dashboard or cockpit UI was opened, so its next
+/// Allowlisted usage-signal names the daemon accepts on `/api/telemetry/seen`.
+/// Mirrors `USAGE_SIGNALS` in `src/telemetry/usage_signals.rs`; an off-list
+/// name is rejected with a 400 server-side. `web` / `cockpit` are whole-UI
+/// opens; the rest are feature-level opens within the dashboard (#1881).
+export type TelemetrySignal =
+  | "web"
+  | "cockpit"
+  | "diff_panel"
+  | "diff_comments"
+  | "web_terminal";
+
+/// Tell the daemon an allowlisted surface or feature was opened, so its next
 /// opt-in snapshot can carry the `usage_seen` open-count map plus the coarse
-/// client form-factor class (#1883). Best-effort. The browser never posts to the
-/// telemetry backend; it pings the local daemon, which folds both into its own
-/// snapshot.
-export function reportTelemetrySeen(surface: "web" | "cockpit"): void {
+/// client form-factor class (#1883). Best-effort; the daemon only forwards the
+/// count when the install is opted in. The browser never posts to the telemetry
+/// backend; it pings the local daemon, which folds both into its own snapshot.
+export function reportTelemetrySeen(surface: TelemetrySignal): void {
   void fetch("/api/telemetry/seen", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -187,6 +187,21 @@
       ]
     },
     {
+      "id": "telemetry.feature-usage-signals",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/feature-usage-signals.spec.ts",
+        "tests/diff-comments.spec.ts"
+      ],
+      "components": [
+        "web/src/hooks/useDiffFiles.ts",
+        "web/src/hooks/useTerminal.ts",
+        "web/src/components/diff/comments/SendCommentsDialog.tsx",
+        "web/src/lib/api.ts"
+      ]
+    },
+    {
       "id": "settings.theme-persistence-passphrase",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/diff-comments.spec.ts
+++ b/web/tests/diff-comments.spec.ts
@@ -249,6 +249,18 @@ test.describe("Diff comments (#928)", () => {
         return r.fulfill({ json: {} });
       },
     );
+    // Capture the usage-signal pings so we can assert `diff_comments` fires
+    // on a confirmed send (#1881).
+    const seenSignals: string[] = [];
+    await page.route("**/api/telemetry/seen", (r) => {
+      try {
+        const body = JSON.parse(r.request().postData() || "{}");
+        if (typeof body.surface === "string") seenSignals.push(body.surface);
+      } catch {
+        // Ignore unparseable bodies.
+      }
+      return r.fulfill({ status: 204, body: "" });
+    });
     await openSessionAndFile(page);
     await startSingleLineComment(page, "new", 3);
     await page
@@ -279,6 +291,8 @@ test.describe("Diff comments (#928)", () => {
     expect(captured?.assembledMarkdown).not.toContain("aoe:diff-comments");
     // Banner cleared.
     await expect(page.getByText(/^1 comment$/)).toHaveCount(0);
+    // The confirmed send fired the diff_comments usage signal (#1881).
+    await expect.poll(() => seenSignals).toContain("diff_comments");
   });
 
   test("hides feature for non-cockpit sessions", async ({ page }) => {

--- a/web/tests/live/feature-usage-signals.spec.ts
+++ b/web/tests/live/feature-usage-signals.spec.ts
@@ -1,0 +1,110 @@
+// Feature-usage telemetry signals (#1881).
+//
+// #1880 shipped the allowlisted usage_seen registry; this pins the three
+// dashboard feature opens that land on it: diff_panel (the diff panel is
+// opened for a session), web_terminal (the xterm.js terminal connects), and
+// the opted-out/read-only short-circuit. diff_comments needs a live cockpit
+// worker to accept the prompt, so it is covered by the mocked send-flow spec
+// (tests/diff-comments.spec.ts) instead.
+
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test, expect } from "../helpers/liveTest";
+import { spawnAoeServe, resolveAoeBinary } from "../helpers/aoeServe";
+import { commitAll, initWorkingRepo, writeFiles } from "../helpers/gitFixture";
+
+/** Capture every `POST /api/telemetry/seen` body, parsed into `{ surface }`.
+ *  Attach before `page.goto` so the on-load pings are observed. */
+function captureSeenPings(
+  page: import("@playwright/test").Page,
+): Array<{ surface?: string }> {
+  const pings: Array<{ surface?: string }> = [];
+  page.on("request", (req) => {
+    if (
+      req.method() === "POST" &&
+      req.url().includes("/api/telemetry/seen")
+    ) {
+      const body = req.postData();
+      if (!body) return;
+      try {
+        pings.push(JSON.parse(body));
+      } catch {
+        // Ignore unparseable bodies.
+      }
+    }
+  });
+  return pings;
+}
+
+test("opening a session fires the diff_panel and web_terminal signals", async ({
+  page,
+}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      const projectDir = join(home, "project");
+      initWorkingRepo(projectDir);
+      writeFiles(projectDir, { "src/a.ts": "export const a = 1;\n" });
+      commitAll(projectDir, "baseline");
+      // Uncommitted edit so the diff endpoint returns a file and the diff
+      // panel has something to show.
+      writeFiles(projectDir, { "src/a.ts": "export const a = 11;\n" });
+      const addRes = spawnSync(
+        resolveAoeBinary(),
+        ["add", projectDir, "-t", "usage-signals", "-c", "claude"],
+        { env },
+      );
+      if (addRes.status !== 0) {
+        throw new Error(
+          `aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    },
+  });
+  try {
+    const pings = captureSeenPings(page);
+    await page.goto(`${serve.baseUrl}/`);
+    const sessionRow = page
+      .getByRole("link")
+      .filter({ hasText: "usage-signals" })
+      .first();
+    await expect(sessionRow).toBeVisible({ timeout: 10_000 });
+    await sessionRow.click();
+
+    // Terminal connects on open -> web_terminal; diff panel mounts for the
+    // session -> diff_panel. Both fire without any extra user action.
+    await expect
+      .poll(() => pings.some((p) => p.surface === "web_terminal"), {
+        timeout: 10_000,
+      })
+      .toBe(true);
+    await expect
+      .poll(() => pings.some((p) => p.surface === "diff_panel"), {
+        timeout: 10_000,
+      })
+      .toBe(true);
+  } finally {
+    await serve.stop();
+  }
+});
+
+test("a read-only server fires no feature-usage signals", async ({
+  serveReadOnly,
+  page,
+}) => {
+  // The seen-ping guard skips read-only servers (they cannot persist a
+  // snapshot), so none of the feature signals leave the browser.
+  const pings = captureSeenPings(page);
+
+  const aboutPromise = page.waitForResponse(
+    (r) => r.url().endsWith("/api/about") && r.status() === 200,
+    { timeout: 10_000 },
+  );
+  await page.goto(serveReadOnly.baseUrl);
+  await aboutPromise;
+  await page.waitForTimeout(500);
+
+  expect(pings).toHaveLength(0);
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Instruments the dashboard feature-usage telemetry signals from #1881, landing them on the allowlisted `usage_seen` registry that #1880 shipped (`src/telemetry/usage_signals.rs`), not on bespoke booleans.

Three browser-fired feature opens are added as one-line registry entries plus one call site each:

- `diff_panel`: fired once per session when the diff panel is opened (`useDiffFiles`), deduped by session so the 10s poll does not re-fire it.
- `diff_comments`: a count, fired on each confirmed diff-comments send (`SendCommentsDialog`), since the action is low-frequency.
- `web_terminal`: fired once per terminal hook lifetime in `ws.onopen` (`useTerminal`), guarded so reconnects after a network blip do not inflate the count.

The frontend `reportTelemetrySeen` helper is broadened to a `TelemetrySignal` union mirroring the Rust allowlist; an off-list name is still rejected server-side with a 400.

The fourth signal in #1881, scratch sessions, needs no new code: it is already reported point-in-time and cross-surface by the `scratch` bucket of the `sessions_by_substrate` census (#1929), which covers scratch sessions created from the CLI, TUI, or web wizard alike. Adding a `usage_seen` entry for it would double-count and would miss CLI/TUI creation, so this PR documents the distinction in `docs/telemetry.md` and points the scratch user story at the existing substrate test rather than adding a redundant signal.

No schema field change and no `SCHEMA_VERSION` bump: per the registry design, instrumenting a new surface is one allowlist entry, not a schema change (the same property the `features` map has). The gateway already forwards new `usage_seen` keys without change, so this lands entirely inside `agent-of-empires` with no `aoe-telemetry` edits.

Closes #1881

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Opt in to telemetry, run `aoe serve`, open a session with a diff in the dashboard, and confirm the next usage snapshot's `usage_seen` map carries `diff_panel > 0` and `web_terminal > 0`.
- [ ] In a cockpit session, add a diff comment and send it; confirm `usage_seen.diff_comments` increments by one per send.
- [ ] Open the web terminal, drop the connection (toggle WiFi) so it reconnects, and confirm `web_terminal` counted the open once, not once per reconnect.
- [ ] Create a scratch session via `aoe add --scratch` (no web UI opened) and confirm the next snapshot reports `sessions_by_substrate["scratch"] >= 1`.
- [ ] POST `/api/telemetry/seen` with an off-list name (e.g. `{"surface":"not_a_signal"}`) and confirm a 400, with nothing reaching the snapshot.
- [ ] With telemetry opted out (or a read-only server), use all of the above and confirm nothing is recorded or sent.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
<!-- New live spec tests/live/feature-usage-signals.spec.ts (diff_panel + web_terminal + read-only short-circuit); mocked tests/diff-comments.spec.ts extended for diff_comments; new telemetry.feature-usage-signals matrix entry. -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
<!-- Scratch is covered by the existing Rust substrate-census tests in tests/telemetry.rs; the registry flow is covered by new unit + integration tests there. -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. The plan was stress-tested with a multi-model design debate before #1880 merged; once it merged the approach simplified to landing on its registry. I reviewed each commit and made the design calls.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR instruments three dashboard feature-usage telemetry signals so product can measure adoption without changing the telemetry schema. It records when users load the diff panel, send diff-comments, and open the web terminal using the existing allowlisted usage_seen registry.

## What Changed (plain)

- Added three allowlisted usage signals: diff_panel, diff_comments, web_terminal.
- Frontend now reports those signals:
  - diff_panel: emitted once per session when the diff file list loads in the right panel (deduped per session, gated to avoid background/poll refires).
  - diff_comments: counted and incremented on each confirmed diff-comments send.
  - web_terminal: emitted once per terminal hook lifetime when the terminal WebSocket opens (guarded so reconnects don’t inflate counts).
- Server-side validation expanded to reject off-list names (400).
- Frontend API widened: added TelemetrySignal union and updated reportTelemetrySeen(surface) to accept allowlisted signals.
- docs/telemetry.md updated to list the new signals and clarify scratch-session usage is tracked via the sessions_by_substrate census (avoids double-counting).
- Tests added/updated:
  - Playwright live spec capturing /api/telemetry/seen pings.
  - Mocked E2E diff-comments test asserting diff_comments is posted on send.
  - Rust unit/integration tests verifying recording, snapshot/zeroed shapes, and rejection of unlisted names.
- No telemetry schema or SCHEMA_VERSION bump required; gateway already forwards usage_seen keys.

## Benefits

- Enables low-risk, fine-grained feature-usage measurement to guide prioritization.
- Reuses existing allowlist-based mechanism—no DB/schema migration.
- Respects opt-out/validation and avoids duplicate reporting for scratch sessions by relying on existing session census.

## Technical Details (concise)

- Rust:
  - USAGE_SIGNALS expanded from ["web","cockpit"] → ["web","cockpit","diff_panel","diff_comments","web_terminal"].
  - Tests updated to assert record(), snapshot(), zeroed() behaviors and to reject unallowed names.
- Frontend:
  - web/src/lib/api.ts: added TelemetrySignal type and updated reportTelemetrySeen signature.
  - web/src/hooks/useDiffFiles.ts: reports "diff_panel" once per session after successful fetch, using refs to dedupe and respect enabled state.
  - web/src/components/diff/comments/SendCommentsDialog.tsx: reports "diff_comments" on successful send.
  - web/src/hooks/useTerminal.ts: reports "web_terminal" once per terminal lifecycle in WS onopen, guarded against reconnects.
- Tests:
  - web/tests/live/feature-usage-signals.spec.ts: live Playwright spec capturing pings.
  - web/tests/diff-comments.spec.ts: mocked telemetry capture for diff_comments.
  - tests/telemetry.rs: new opt-in integration test and adjusted rejection test.

## Potential Improvements / Notes

- Consider adding a short-term monitoring dashboard or alert to validate incoming counts and spot integration regressions after deployment.
- If additional feature signals are added later, keep the allowlist pattern to avoid schema churn and ensure server-side rejection for unknown names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->