### PR TITLE
fix(tui): forward typed semicolons in live mode

### DIFF
--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -765,6 +765,22 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
     cmd.stderr(Stdio::null());
     match action {
         TmuxAction::Literal(s) => {
+            // tmux's command parser treats a trailing `;` in a
+            // `send-keys -l` payload as a command separator and silently
+            // drops it, even after the `--` end-of-options marker, so a
+            // lone or trailing semicolon never reaches the pane (#1942).
+            // Peel the trailing semicolons off and deliver them as raw
+            // hex bytes (`-H 3b`), which tmux passes through verbatim;
+            // the remaining head still rides the literal path. Embedded
+            // and leading semicolons survive `-l` fine, so only the
+            // trailing run needs the hex detour.
+            let (head, semis) = peel_trailing_semicolons(s);
+            if semis > 0 {
+                if !head.is_empty() {
+                    send_literal(&target, head)?;
+                }
+                return dispatch_hex_bytes(&target, &vec![0x3b; semis]);
+            }
             // `-l --` mirrors `send_literal_no_enter`: literal-mode
             // send, followed by the end-of-options marker so a payload
             // starting with `-` isn't reparsed as a flag.
@@ -812,6 +828,38 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
 /// 4 KiB per fork keeps every argv under ~45 KiB, comfortably below the
 /// limit on every platform while keeping the fork count low.
 const MAX_HEX_BYTES_PER_SEND: usize = 4096;
+
+/// Split a literal payload into its leading content and the number of
+/// trailing `;` bytes. tmux's command parser drops a trailing `;` from a
+/// `send-keys -l` payload, reading it as a command separator even after the
+/// `--` end-of-options marker, so the trailing run never reaches the pane
+/// (#1942). The caller sends `head` on the literal path and the peeled
+/// semicolons as raw hex bytes. Embedded and leading semicolons survive
+/// `-l` untouched, so only the trailing run is peeled.
+fn peel_trailing_semicolons(s: &str) -> (&str, usize) {
+    let head = s.trim_end_matches(';');
+    (head, s.len() - head.len())
+}
+
+/// Send a literal string to the pane via one `tmux send-keys -l --` fork.
+/// Used for the head of a payload whose trailing semicolons were peeled
+/// off (see the `Literal` arm of [`dispatch_via_fork`]).
+fn send_literal(target: &str, s: &str) -> anyhow::Result<()> {
+    use std::process::{Command, Stdio};
+    let mut cmd = Command::new("tmux");
+    cmd.stderr(Stdio::null());
+    cmd.args(["send-keys", "-t", target, "-l", "--", s]);
+    let status = cmd
+        .status()
+        .map_err(|e| anyhow::anyhow!("spawn live-send tmux subprocess: {}", e))?;
+    if !status.success() {
+        anyhow::bail!(
+            "live-send tmux subprocess exited non-zero for literal {:?}",
+            s
+        );
+    }
+    Ok(())
+}
 
 /// Dispatch a raw byte payload as one or more `tmux send-keys -H` forks,
 /// each bounded by [`MAX_HEX_BYTES_PER_SEND`]. tmux injects the bytes
@@ -1522,6 +1570,23 @@ mod tests {
         let batches = hex_send_batches(&payload);
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].first().map(String::as_str), Some("1b"));
+    }
+
+    #[test]
+    fn peel_trailing_semicolons_splits_trailing_run_only() {
+        // tmux eats a trailing `;` from a `send-keys -l` payload, so the
+        // dispatcher peels the trailing run and sends it as raw hex (#1942).
+        // Lone, trailing, and multi-trailing semicolons get peeled.
+        assert_eq!(peel_trailing_semicolons(";"), ("", 1));
+        assert_eq!(peel_trailing_semicolons("ls;"), ("ls", 1));
+        assert_eq!(peel_trailing_semicolons(";;"), ("", 2));
+        assert_eq!(peel_trailing_semicolons("a;;"), ("a", 2));
+        // Embedded and leading semicolons survive `-l`, so they stay on the
+        // literal head and nothing is peeled.
+        assert_eq!(peel_trailing_semicolons("a;b"), ("a;b", 0));
+        assert_eq!(peel_trailing_semicolons(";a"), (";a", 0));
+        assert_eq!(peel_trailing_semicolons("hello"), ("hello", 0));
+        assert_eq!(peel_trailing_semicolons(""), ("", 0));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes one of the two input-fidelity bugs in **live-send** mode reported in #1942 (the keystroke relay you get when you Tab/click a session instead of fully attaching): a typed semicolon vanished.

tmux's command parser treats a trailing `;` in a `send-keys -l` payload as a command separator and silently drops it, even after the `--` end-of-options marker. So a lone `;` (or any coalesced literal run ending in `;`) never reached the agent pane. Embedded and leading semicolons (`a;b`, `;a`) were always fine.

Fix: peel the trailing semicolons off the literal payload and send them as raw hex bytes (`-H 3b`), which tmux passes through verbatim; the head still rides the literal path.

> The multiline-paste half of #1942 (shift+Insert posting one command per line) is split into its own branch/PR so the heuristic timing fix there can be dogfooded and reviewed separately. This PR does not close #1942 on its own.

### Verification

Reproduced and verified end to end by driving a real live-send session against a stdin logger: before, lone/trailing `;` were dropped; after, `;`, `ls;`, and `a;;b` all arrive intact. Embedded and leading semicolons unaffected.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A; no user-facing docs affected)
- [x] For UI changes: included screenshot or recording (N/A; no visual change)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the fix hinges on real `tmux send-keys` argv parsing (the trailing-`;` drop), which an e2e test can't assert deterministically without a live tmux session and is awkward to keep stable in CI. Instead I added a unit test for the extracted pure helper (`peel_trailing_semicolons`) and verified the end-to-end behavior manually by driving a live-send session against a stdin logger (described above).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-caused, implemented, and verified with Claude Code; reasoning and decisions reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

Refs #1942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes trailing semicolon handling in live-send mode (Tab/click session selection), where tmux's command parser was silently dropping trailing semicolons from literal payloads.

## What Changed

**Added semicolon-handling logic in `dispatch_via_fork` (src/tui/home/live_send.rs):**
- New helper `peel_trailing_semicolons()`: detaches trailing semicolons from the input string while preserving embedded and leading semicolons
- New helper `send_literal()`: executes a one-shot `tmux send-keys -l --` invocation for the literal text head
- Modified `TmuxAction::Literal` dispatch path to split payloads: sends the leading text via the literal path, then resends peeled trailing semicolons as raw hex bytes (`0x3b`), bypassing tmux's command parser

**Added large-paste safety improvements:**
- New helper `dispatch_hex_bytes()`: breaks large hex payloads into bounded `tmux send-keys -H` forks to avoid overflowing the OS `execve` argv limit (macOS ARG_MAX = 256 KiB), which was causing large pastes to fail silently with E2BIG
- New helper `hex_send_batches()`: splits bytes into chunks under `MAX_HEX_BYTES_PER_SEND` (4096 bytes per fork)
- Added unit tests verifying batch splitting and byte-order preservation

**Added validation test:**
- `peel_trailing_semicolons_splits_trailing_run_only`: verifies lone, trailing, and multi-trailing semicolons are peeled while embedded/leading ones are preserved

## Benefits

- Lone and trailing semicolons (`;`, `ls;`, `a;;b`) now arrive intact in live-send mode, matching attach-mode behavior
- Large clipboard pastes no longer fail silently; they split across multiple forks and deliver completely
- End-to-end verified against a real live-send session piping to a stdin logger

## Note

The PR objectives mention fixing a second issue ("jittery unbracketed multiline pastes" with `paste_burst_gap_ms`), but this commit addresses only the semicolon fix. The burst/jitter handling does not appear to be included in this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->