### PR TITLE
fix(tui): coalesce jittery unbracketed pastes in live mode

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -49,6 +49,31 @@ const PASTE_BURST_INTER_KEY_MS: u64 = 5;
 /// individual key events so genuine typing isn't mistaken for a paste.
 const PASTE_BURST_MIN_LEN: usize = 3;
 
+/// Wider inter-key timeout used once a burst is established (two events
+/// already arrived within `PASTE_BURST_INTER_KEY_MS` of each other, which
+/// only a paste does). The tight 5ms window catches a paste that streams in
+/// without gaps, but an unbracketed paste delivered as raw key events (e.g.
+/// shift+Insert on terminals that don't bracket it, #1942) can arrive in
+/// jittery chunks whose gaps exceed 5ms, fragmenting the burst so interior
+/// Enters leak through as individual `submit` keystrokes. Widening the
+/// window after the burst is confirmed absorbs that jitter without taxing
+/// single keystrokes, which never reach the two-event threshold and so keep
+/// the tight window.
+const PASTE_BURST_ESTABLISHED_GAP_MS: u64 = 50;
+
+/// Inter-key timeout (ms) for the next poll while accumulating a paste
+/// burst, given how many events are already in the burst. The first
+/// follow-up poll (`len` == 1) uses the tight window so a single keystroke
+/// stays snappy; once a second event has joined (`len` >= 2, which only a
+/// paste produces) the window widens to absorb delivery jitter (#1942).
+fn paste_burst_gap_ms(burst_len: usize) -> u64 {
+    if burst_len >= 2 {
+        PASTE_BURST_ESTABLISHED_GAP_MS
+    } else {
+        PASTE_BURST_INTER_KEY_MS
+    }
+}
+
 struct UpdateStatus {
     text: String,
     expires_at: Option<std::time::Instant>,
@@ -652,8 +677,18 @@ impl App {
                                 let mut burst_keys: Vec<KeyEvent> = vec![key];
                                 let mut deferred: Option<Event> = None;
                                 loop {
+                                    // Once two events have arrived inside the tight
+                                    // inter-key window, this is unambiguously a paste
+                                    // (no human presses two keys 5ms apart), so widen
+                                    // the window to absorb the delivery jitter that
+                                    // splits an unbracketed paste such as shift+Insert,
+                                    // which some terminals send as raw key events
+                                    // rather than a bracketed `Event::Paste` (#1942).
+                                    // Single keystrokes never reach len 2, so typing
+                                    // and home-view shortcuts keep the tight window
+                                    // and stay snappy.
                                     let next = tokio::time::timeout(
-                                        Duration::from_millis(PASTE_BURST_INTER_KEY_MS),
+                                        Duration::from_millis(paste_burst_gap_ms(burst_keys.len())),
                                         self.event_stream.as_mut().expect("event_stream missing").next(),
                                     ).await;
                                     match next {
@@ -2826,5 +2861,17 @@ mod tests {
             Some('\n'),
             "Enter must map to \\n so embedded sentence-breaks land in the burst"
         );
+    }
+
+    #[test]
+    fn paste_burst_gap_widens_once_burst_is_established() {
+        // The first follow-up poll (one event so far) uses the tight window
+        // so single keystrokes stay snappy; a single key never reaches the
+        // two-event threshold and so never pays the wider gap.
+        assert_eq!(paste_burst_gap_ms(1), PASTE_BURST_INTER_KEY_MS);
+        // Two+ events within the tight window mean a paste, so the window
+        // widens to absorb jittery unbracketed delivery (#1942).
+        assert_eq!(paste_burst_gap_ms(2), PASTE_BURST_ESTABLISHED_GAP_MS);
+        assert_eq!(paste_burst_gap_ms(9), PASTE_BURST_ESTABLISHED_GAP_MS);
     }
 }


### PR DESCRIPTION
> **Draft.** The fix is a timing heuristic whose correct tuning depends on real-terminal paste delivery. Holding in draft until dogfooded on a real macOS terminal with shift+Insert (see Test plan). Second half of #1942; #1949 fixed the semicolon half.

## Description

In live-send mode, a multiline **shift+Insert** paste posted one command per line instead of arriving as a single block.

Root cause: aoe enables bracketed paste, and the `Event::Paste` path already wraps multiline pastes correctly (#1553). But some terminals deliver **shift+Insert** as raw key events rather than a bracketed `Event::Paste`. For that unbracketed stream, the paste-burst detector (originally built for Mosh, which also strips bracketed-paste markers) is what coalesces the keys into a single bracketed paste before forwarding. Its inter-key window is a tight 5ms, which fragments when the unbracketed stream arrives in jittery chunks whose gaps exceed 5ms; each interior `Enter` then leaks through as an individual `submit`, splitting the paste into separate commands.

Fix: once a burst is confirmed (two or more events arrived within the tight 5ms window, which only a paste produces, since no human presses two keys 5ms apart), widen the inter-key window to 50ms for the rest of the burst. This absorbs delivery jitter without taxing single keystrokes, which never reach the two-event threshold and so keep the snappy 5ms window.

### Why a heuristic (and why it can't be eliminated)

For an *unbracketed* key-stream paste there is no marker distinguishing a pasted `Enter` from a typed one; timing is the only available signal. The `Event::Paste` path (Cmd+V on terminals that bracket it) is unaffected and already correct. This change only hardens the fallback the burst detector provides.

### Measured envelope

Verified with a scripted live-send session against a stdin logger, injecting a jittered multiline key stream and inspecting the forwarded bytes:

| Inter-chunk gap | Before (main) | After |
| --- | --- | --- |
| 2ms (tight) | bracketed | bracketed |
| 20ms | raw CRs (one submit/line) | **bracketed** |
| 40ms | raw CRs | **bracketed** |
| 70ms (beyond window) | raw CRs | raw CRs (still fragments) |

So the fix reliably coalesces pastes whose chunks land within ~50ms of each other. A local shift+Insert paste is near-instant, so this should cover it; the open question the draft is gating on is whether any real terminal delivers chunks wider than 50ms.

Behavior that is provably unchanged: single keystrokes (still 5ms, never establish a burst), home-view shortcuts, and the `Event::Paste` path.

## PR Type
- [x] Bug Fix

## Checklist
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A)
- [x] For UI changes: included screenshot or recording (N/A; no visual change)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the behavior is async event-delivery timing (the burst window). A meaningful e2e would have to inject a key stream with gaps between 5ms and 50ms and assert the forwarded bytes are bracketed; that is inherently timing-sensitive and would flake on loaded CI runners (a slow runner could push even tight injection past 50ms, or deliver deliberate 20ms gaps as >50ms). Instead there is a unit test for the gap-selection logic (`paste_burst_gap_ms`), and the end-to-end behavior is validated by a scripted live-send reproduction (envelope table above) plus manual dogfooding on a real terminal.

## Test plan (dogfood before un-drafting)

On a real macOS terminal:

1. Build this branch and run `aoe`.
2. Tab into a running session to enter live mode (the `● LIVE` footer).
3. Copy a multiline block (3+ lines) and paste with **shift+Insert**.
4. Expect: the whole block lands in the agent's input as one paste, not one command per line.
5. Also sanity-check: typing a single Enter still submits; fast typing is unaffected; Cmd+V still works.

If it still fragments, run with `AGENT_OF_EMPIRES_DEBUG=1` and check `debug.log` for the `paste-burst: routed N chars` trace: its presence means the burst coalesced; its absence means the stream fragmented (chunks arriving >50ms apart), which would tell us 50ms needs raising.

## AI Usage
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-caused, implemented, and characterized with Claude Code; reasoning and decisions reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

Refs #1942