### PR TITLE
fix(logging): silence no-op filter swaps to break file-watch OOM loop

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -29,7 +29,7 @@ Only a small set of sub-targets is enumerated in the settings dropdown (see `KNO
 | `hooks` | Agent hook integration (Claude/Settl/Hermes/Kiro) install/uninstall, hook status file lifecycle, user-configured status hook command failures, and attached status hook watcher failures. |
 | `sound` | Notification sound asset download/install and per-event playback. |
 | `telemetry` | Anonymous opt-in usage telemetry: install-id persistence, opt-in/opt-out transitions, and send outcomes (all at `debug`). The `aoe serve` consent route emits under `http.api.telemetry`. |
-| `log.runtime` | Filter swaps (REST + runner file-watch). |
+| `log.runtime` | Filter swaps (REST + runner file-watch). A swap whose new directive equals the active one is a silent no-op: it does not log or rewrite `runtime_filter`, so a watcher write cannot re-trigger itself. |
 
 ## Levels
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -212,14 +212,19 @@ pub fn apply_persisted_config(
     };
     match set_filter(&filter) {
         Ok(swap) => {
-            tracing::info!(
-                target: "log.runtime",
-                previous = %swap.previous,
-                current = %swap.current,
-                source = "settings",
-                "filter swapped"
-            );
-            persist_runtime_filter(&swap.current, app_dir);
+            // Skip the log and the disk write on a no-op: persisting an
+            // unchanged directive needlessly re-fires every runner's watcher
+            // (#1894).
+            if swap.changed {
+                tracing::info!(
+                    target: "log.runtime",
+                    previous = %swap.previous,
+                    current = %swap.current,
+                    source = "settings",
+                    "filter swapped"
+                );
+                persist_runtime_filter(&swap.current, app_dir);
+            }
         }
         Err(LogFilterError::Unavailable) => {
             // No reload handle installed (e.g. TUI process). Still persist
@@ -424,14 +429,30 @@ impl FilterController {
     }
 
     fn swap(&self, filter: EnvFilter, directive: String) -> Result<SwapResult, LogFilterError> {
-        let previous = self.current();
+        // Hold the `current` lock across the compare and the modify so two
+        // concurrent swaps cannot interleave and both observe `changed`.
+        let mut current = self.current.lock().unwrap();
+        let previous = current.clone();
+        // No-op: the active directive already equals the requested one.
+        // Skip the reload-handle modify entirely and report `changed=false`
+        // so callers stay silent. A no-op swap that logged at INFO is what
+        // fed the file-watch OOM loop in #1894: the log line landed in the
+        // watched dir and re-triggered the watcher.
+        if previous == directive {
+            return Ok(SwapResult {
+                previous,
+                current: directive,
+                changed: false,
+            });
+        }
         self.inner
             .modify(|f| *f = filter)
             .map_err(|e| LogFilterError::Invalid(e.to_string()))?;
-        *self.current.lock().unwrap() = directive.clone();
+        *current = directive.clone();
         Ok(SwapResult {
             previous,
             current: directive,
+            changed: true,
         })
     }
 }
@@ -440,6 +461,10 @@ impl FilterController {
 pub struct SwapResult {
     pub previous: String,
     pub current: String,
+    /// `false` when the requested directive already matched the active one,
+    /// so the swap was a no-op. Callers gate logging and persistence on this
+    /// to avoid the self-sustaining file-watch loop (#1894).
+    pub changed: bool,
 }
 
 #[derive(Debug)]
@@ -974,13 +999,16 @@ fn apply_filter_file(path: &std::path::Path) {
         return;
     }
     match set_filter(directive) {
-        Ok(swap) => tracing::info!(
+        // No-op swaps stay silent: logging here would write into the watched
+        // dir and re-trigger the watcher (#1894).
+        Ok(swap) if swap.changed => tracing::info!(
             target: "log.runtime",
             previous = %swap.previous,
             current = %swap.current,
             source = "file-watch",
             "runner filter swapped"
         ),
+        Ok(_) => {}
         Err(e) => tracing::warn!(
             target: "log.runtime",
             error = %e,
@@ -1004,6 +1032,44 @@ mod tests {
         assert_eq!(LogLevel::parse("warning"), Some(LogLevel::Warn));
         assert_eq!(LogLevel::parse("trace "), Some(LogLevel::Trace));
         assert_eq!(LogLevel::parse("bogus"), None);
+    }
+
+    /// Build a `FilterController` backed by a reload handle, installed as
+    /// the thread-local default subscriber so the reload handle's `modify`
+    /// can upgrade its weak reference. The returned guard must outlive the
+    /// controller; the default is thread-scoped, so it does not collide
+    /// with the process-global subscriber other tests install.
+    fn test_controller(initial: &str) -> (FilterController, tracing::subscriber::DefaultGuard) {
+        let filter = EnvFilter::builder()
+            .with_regex(false)
+            .parse(initial)
+            .expect("valid initial filter");
+        let (layer, handle) = reload::Layer::new(filter);
+        let guard = tracing::subscriber::set_default(Registry::default().with(layer));
+        let controller = FilterController {
+            inner: handle,
+            current: Mutex::new(initial.to_string()),
+        };
+        (controller, guard)
+    }
+
+    #[test]
+    fn swap_reports_changed_then_noop() {
+        let (c, _guard) = test_controller("agent_of_empires=info");
+        let first = c.set_filter("agent_of_empires=debug").expect("swap ok");
+        assert!(
+            first.changed,
+            "first swap to a new directive must report changed"
+        );
+        assert_eq!(first.previous, "agent_of_empires=info");
+        assert_eq!(first.current, "agent_of_empires=debug");
+
+        // Re-applying the identical directive (the #1894 file-watch case)
+        // must be a silent no-op so callers do not log or persist.
+        let second = c.set_filter("agent_of_empires=debug").expect("swap ok");
+        assert!(!second.changed, "identical re-apply must report no-op");
+        assert_eq!(second.previous, second.current);
+        assert_eq!(c.current(), "agent_of_empires=debug");
     }
 
     #[test]

--- a/src/server/api/log_level.rs
+++ b/src/server/api/log_level.rs
@@ -84,15 +84,19 @@ pub async fn patch_log_level(
 
     match result {
         Ok(swap) => {
-            tracing::info!(
-                target: "log.runtime",
-                previous = %swap.previous,
-                current = %swap.current,
-                source = "rest",
-                "filter swapped"
-            );
-            if let Ok(app_dir) = crate::session::get_app_dir() {
-                logging::persist_runtime_filter(&swap.current, &app_dir);
+            // Skip the log and persist on a no-op swap so an unchanged
+            // directive cannot feed the file-watch loop (#1894).
+            if swap.changed {
+                tracing::info!(
+                    target: "log.runtime",
+                    previous = %swap.previous,
+                    current = %swap.current,
+                    source = "rest",
+                    "filter swapped"
+                );
+                if let Ok(app_dir) = crate::session::get_app_dir() {
+                    logging::persist_runtime_filter(&swap.current, &app_dir);
+                }
             }
             Ok(Json(LogLevelResponse {
                 previous: swap.previous,


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The daemon and structured-view runners re-apply the logging filter on every `runtime_filter` watch event and log `filter swapped` at INFO, even when the new directive is identical to the active one (a pure no-op swap). On older builds that INFO line landed in the watched app dir and re-triggered the watcher, the self-sustaining feedback loop reported in #1894 that grew unbounded until the daemon was OOM-killed (13.4 GB anon-rss).

The catastrophic loop was already mitigated on `main` by #1734, which narrowed the watch to `FileMatcher::Exact(runtime_filter)` so `debug.log` writes no longer match the watch. That matcher is a heuristic on OS-emitted paths, though, not a guarantee: coarse-grained or duplicate kernel events can still reach the callback. This PR removes the remaining loop fuel and makes the invariant platform-independent.

`FilterController::swap` now compares the requested directive against the active one while holding the `current` lock, skips the reload-handle modify on a no-op, and reports `changed = false`. The three swap sites (file-watch, settings, REST) gate their INFO log on `changed`, and the settings/REST paths also skip the `persist_runtime_filter` disk write on a no-op so an unchanged directive cannot re-fire every runner's watcher. The result: a no-op swap is fully silent and writes nothing into the watched dir, regardless of log level. The `Unavailable` (TUI, no controller) branch still persists, and the REST response contract (`previous`/`current`/`ephemeral`) is unchanged.

Closes #1894

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start the daemon at the default `info` level, exercise a flow that produces logs, and confirm `debug.log` does not fill with repeated `filter swapped ... source="file-watch"` lines.
- [ ] Run `aoe log-level info` while the daemon is already at `info`; confirm no `filter swapped` line is emitted and `runtime_filter` is not rewritten (mtime unchanged).
- [ ] Run `aoe log-level warn` (a genuine change); confirm exactly one `filter swapped ... source="rest"` line is logged and `runtime_filter` is updated.
- [ ] Save settings in the TUI / web without changing the logging level; confirm no `filter swapped ... source="settings"` line and no `runtime_filter` rewrite.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Covered by a unit test in `src/logging.rs` (`swap_reports_changed_then_noop`): a swap to a new directive reports `changed = true`; an identical re-apply reports `changed = false` with `previous == current`. This is the no-op detection that keeps the swap silent.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (no-op silence over debounce, matcher hardening deferred to a follow-up), and ran the validation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR stops no-op logging filter re-applies from producing side effects that caused a file-watch feedback loop and OOM. Identical runtime filter directives are now treated as silent no-ops: they neither emit the INFO "filter swapped" message nor rewrite the runtime_filter file.

## What changed (high-level)
- Detect no-op swaps and avoid any logging or disk writes when the requested directive equals the active one.
- Make the file-watch, settings, and REST codepaths emit the "filter swapped" INFO event and persist runtime_filter only when an actual change occurs.
- Add a unit test covering change vs no-op behavior.
- Documentation updated to note runtime_filter no-ops are silent.

## Benefits
- Eliminates the self-triggering watcher loop and the resulting unbounded memory growth / OOM.
- Platform-independent and robust to coarse-grained or duplicate OS file events.
- Preserves behavior for real filter changes (single notification + persistence).
- Prevents unnecessary disk writes and log noise.

## Technical details (concise)
- FilterController::swap now holds the current mutex while comparing directives, performs the reload modification only when different, and returns SwapResult { previous, current, changed: bool }.
- Call sites check swap.changed; file-watch and REST/settings only log/persist when true. The TUI/no-controller branch still persists.
- New unit test: swap_reports_changed_then_noop verifies changed=true on real change and changed=false on identical re-apply.

Closes `#1894`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->