### PR TITLE
fix(tui): let 'j'/'k' reach list picker filters instead of navigating

### DIFF
--- a/src/tui/components/list_picker.rs
+++ b/src/tui/components/list_picker.rs
@@ -1,6 +1,6 @@
 //! Reusable list picker overlay component
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 use tui_input::backend::crossterm::EventHandler;
@@ -142,15 +142,16 @@ impl ListPicker {
                 self.active = false;
                 result
             }
-            KeyCode::Up | KeyCode::Char('k') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            // Arrow keys only for navigation: every printable char belongs to
+            // the filter input (a "j" or "k" in a project/branch/group name
+            // must be typable), matching DirPicker and the command palette.
+            KeyCode::Up => {
                 if self.selected > 0 {
                     self.selected -= 1;
                 }
                 ListPickerResult::Continue
             }
-            KeyCode::Down | KeyCode::Char('j')
-                if !key.modifiers.contains(KeyModifiers::CONTROL) =>
-            {
+            KeyCode::Down => {
                 if filtered_len > 0 && self.selected < filtered_len - 1 {
                     self.selected += 1;
                 }
@@ -273,7 +274,7 @@ impl ListPicker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crossterm::event::KeyEvent;
+    use crossterm::event::{KeyEvent, KeyModifiers};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -343,15 +344,25 @@ mod tests {
     }
 
     #[test]
-    fn test_navigation_jk() {
+    fn test_j_and_k_type_into_filter_not_navigate() {
         let mut picker = ListPicker::new("Test");
-        picker.activate(sample_items());
+        picker.activate(vec![
+            "jukebox".to_string(),
+            "kanban".to_string(),
+            "webapp".to_string(),
+        ]);
 
         picker.handle_key(key(KeyCode::Char('j')));
-        assert_eq!(picker.selected, 1);
+        assert_eq!(picker.selected, 0, "'j' must not move the selection");
+        assert_eq!(picker.filter.value(), "j");
+        assert_eq!(picker.filtered_items().len(), 1);
 
+        picker.handle_key(key(KeyCode::Backspace));
         picker.handle_key(key(KeyCode::Char('k')));
-        assert_eq!(picker.selected, 0);
+        picker.handle_key(key(KeyCode::Char('a')));
+        assert_eq!(picker.selected, 0, "'k' must not move the selection");
+        assert_eq!(picker.filter.value(), "ka");
+        assert_eq!(*picker.filtered_items()[0], "kanban");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #1963.

`ListPicker::handle_key` matched `Char('j')`/`Char('k')` as up/down navigation before the catch-all `Char(_)` arm that feeds the filter input, so the letters `j` and `k` could never be typed into the filter of any `ListPicker`-based dialog (New Session from Project picker, the new-session group/branch/registered-project pickers, the rename dialog's group picker). Any project, branch, or group with `j` or `k` in its name was impossible to filter for.

This PR removes the `j`/`k` navigation arms from the shared component so every printable character reaches the filter, matching how the other type-to-filter surfaces (`DirPicker`, command palette) already behave: arrow keys navigate, typing filters. Since all five picker dialogs share `ListPicker`, the one change fixes them all.

**Before** (typing `juke`: `j`/`k` move the selection, filter ends up as `ue`, no matches):

![before](https://raw.githubusercontent.com/markphilipp/agent-of-empires/assets/list-picker-jk-gifs/before.gif)

**After** (typing `juke` filters to `jukebox-api`):

![after](https://raw.githubusercontent.com/markphilipp/agent-of-empires/assets/list-picker-jk-gifs/after.gif)

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression test lives next to the logic as a `ListPicker` unit test (`test_j_and_k_type_into_filter_not_navigate`), which covers all five dialogs that share the component; the behavior is pure key-handling with no session/tmux lifecycle involved

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**
Investigation, fix, tests, and recordings produced with Claude Code, directed and reviewed by me. Verified by hand against real before/after binaries (the GIFs above are from those runs); `cargo fmt`, `cargo clippy`, and the full `cargo test` suite pass locally.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes an issue where the letters 'j' and 'k' could not be typed into filter inputs within ListPicker-based dialogs (such as "New Session from Project", group/branch pickers, and rename dialogs). Previously, these characters were intercepted as navigation keys (up/down movement), preventing users from filtering lists containing words like "jukebox" or "kanban".

## Changes Made

**File Modified:** `src/tui/components/list_picker.rs`

- **Removed:** Dedicated key handling for 'j' and 'k' characters that triggered up/down navigation
- **Updated:** Key event handling logic so that only arrow keys (`Up`/`Down`) perform list navigation, while printable characters including 'j' and 'k' are passed through to the filter input
- **Replaced test:** The old `test_navigation_jk` test was removed and replaced with `test_j_and_k_type_into_filter_not_navigate`, which verifies that typing 'j' and 'k' updates the filter without changing selection
- **Updated imports:** Added `KeyModifiers` to the test module's crossterm imports for proper `KeyEvent` construction

**Lines changed:** +21/-10

## Benefits

- Users can now filter projects, branches, and groups by typing 'j' or 'k' characters
- Behavior is now consistent with other type-to-filter components in the application (DirPicker, command palette)
- Arrow keys remain the dedicated navigation mechanism, providing a clear separation between filtering and navigation interactions
- Applies uniformly across all ListPicker-based dialogs in the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->