### PR TITLE
feat(config): support the XDG config path on macOS (opt-in, no forced move)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,8 @@ Coverage runs on every PR via the merge of Vitest + Playwright LCOVs (see `web/s
 
 - Runtime config/data location:
   - **Linux**: `$XDG_CONFIG_HOME/agent-of-empires/` (defaults to `~/.config/agent-of-empires/`)
-  - **macOS/Windows**: `~/.agent-of-empires/`
+  - **macOS**: `~/.agent-of-empires/` by default, or `$XDG_CONFIG_HOME/agent-of-empires/` when `XDG_CONFIG_HOME` is set or that dir already exists (issue #1948). Resolution is `get_app_dir_path` -> `macos_app_dir`; nothing is moved automatically, so an existing `~/.agent-of-empires/` keeps being used.
+  - **Windows**: `~/.agent-of-empires/`
 - Keep user data out of commits. For repo-local experiments, use ignored paths like `./.agent-of-empires/`, `.env`, and `.mcp.json`.
 - `aoe serve` writes several files to the app dir while running. All are owner-only (0600) where they contain secrets. The daemon cleans them up on shutdown; `daemon_pid()`'s stale-PID check sweeps them otherwise.
   - `serve.pid`: daemon PID for `--stop` and reattach detection.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -15,7 +15,9 @@ All settings below can also be edited from the TUI settings screen (press `s` or
 | Platform | Global Config |
 |----------|--------------|
 | Linux | `$XDG_CONFIG_HOME/agent-of-empires/config.toml` (defaults to `~/.config/agent-of-empires/`) |
-| macOS | `~/.agent-of-empires/config.toml` |
+| macOS | `~/.agent-of-empires/config.toml` by default, or `$XDG_CONFIG_HOME/agent-of-empires/config.toml` when you opt into the XDG layout (see below) |
+
+On macOS, AoE reads from `$XDG_CONFIG_HOME/agent-of-empires/` (e.g. `~/.config/agent-of-empires/`) when you set `XDG_CONFIG_HOME`, or whenever that directory already exists, so a dotfile manager like chezmoi can share one config path with Linux. Otherwise it uses `~/.agent-of-empires/`. Nothing is moved automatically: an existing `~/.agent-of-empires/` keeps being used even after you set `XDG_CONFIG_HOME`, until you relocate it yourself.
 
 ```
 ~/.agent-of-empires/

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1476,7 +1476,7 @@ mod cockpit_reject_tests {
     async fn set_session_id_rejects_cockpit_mode_session() {
         let temp = tempdir().unwrap();
         std::env::set_var("HOME", temp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
         let storage = Storage::new("cockpit-reject").unwrap();

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -45,9 +45,9 @@ pub async fn run(args: UninstallArgs) -> Result<()> {
 
     let home_dir = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot find home directory"))?;
 
-    // Collect all possible data directory locations. The legacy home-dotfile
-    // path is always included so an install that upgraded but never re-launched
-    // (and thus never migrated) is still cleaned up.
+    // Collect all possible data directory locations. The home-dotfile path is
+    // always included (it is the macOS default and the pre-XDG Linux location),
+    // alongside the XDG path, so either layout is cleaned up.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     let data_dirs = {
         let mut dirs = vec![home_dir.join(".agent-of-empires")];

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -45,16 +45,18 @@ pub async fn run(args: UninstallArgs) -> Result<()> {
 
     let home_dir = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot find home directory"))?;
 
-    // Collect all possible data directory locations
-    #[cfg(target_os = "linux")]
+    // Collect all possible data directory locations. The legacy home-dotfile
+    // path is always included so an install that upgraded but never re-launched
+    // (and thus never migrated) is still cleaned up.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     let data_dirs = {
         let mut dirs = vec![home_dir.join(".agent-of-empires")];
-        if let Some(config_dir) = dirs::config_dir() {
-            dirs.push(config_dir.join("agent-of-empires"));
+        if let Ok(base) = crate::session::xdg_config_base() {
+            dirs.push(base.join("agent-of-empires"));
         }
         dirs
     };
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let data_dirs = vec![home_dir.join(".agent-of-empires")];
 
     let mut found_items: Vec<FoundItem> = Vec::new();

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1543,7 +1543,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let _guard = CodexHomeGuard::unset();
         std::env::set_var("HOME", tmp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
 
         let codex_home = tmp.path().join("profile-codex-home");

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -164,12 +164,13 @@ fn set_version(version: u32) -> Result<()> {
 fn get_all_possible_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
-    // Legacy home-dotfile location: pre-XDG on Linux/macOS, current on Windows.
+    // Home-dotfile location: the macOS default, the pre-XDG Linux location, and
+    // the only location on Windows.
     if let Some(home) = dirs::home_dir() {
         dirs.push(home.join(crate::session::APP_DIR_NAME_OTHER));
     }
 
-    // XDG location: current on Linux and macOS.
+    // XDG location: always current on Linux, and the opt-in layout on macOS.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     if let Ok(base) = crate::session::xdg_config_base() {
         dirs.push(base.join(crate::session::APP_DIR_NAME_XDG));

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -164,13 +164,15 @@ fn set_version(version: u32) -> Result<()> {
 fn get_all_possible_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
+    // Legacy home-dotfile location: pre-XDG on Linux/macOS, current on Windows.
     if let Some(home) = dirs::home_dir() {
         dirs.push(home.join(crate::session::APP_DIR_NAME_OTHER));
     }
 
-    #[cfg(target_os = "linux")]
-    if let Some(config_dir) = dirs::config_dir() {
-        dirs.push(config_dir.join(crate::session::APP_DIR_NAME_LINUX));
+    // XDG location: current on Linux and macOS.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    if let Ok(base) = crate::session::xdg_config_base() {
+        dirs.push(base.join(crate::session::APP_DIR_NAME_XDG));
     }
 
     dirs

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4127,13 +4127,13 @@ mod tests {
     }
 
     fn isolated_app_dir(temp_home: &std::path::Path) -> std::path::PathBuf {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
             let config_home = temp_home.join(".config");
             std::env::set_var("XDG_CONFIG_HOME", &config_home);
-            config_home.join(crate::session::APP_DIR_NAME_LINUX)
+            config_home.join(crate::session::APP_DIR_NAME_XDG)
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
             temp_home.join(crate::session::APP_DIR_NAME_OTHER)
         }
@@ -5057,7 +5057,7 @@ mod workspace_ordering_tests {
 
     fn setup_test_home(temp: &std::path::Path) {
         std::env::set_var("HOME", temp);
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
     }
 

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -1341,13 +1341,13 @@ mod tests {
     }
 
     fn isolated_app_dir(temp_home: &std::path::Path) -> std::path::PathBuf {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
             let config_home = temp_home.join(".config");
             std::env::set_var("XDG_CONFIG_HOME", &config_home);
-            config_home.join(crate::session::APP_DIR_NAME_LINUX)
+            config_home.join(crate::session::APP_DIR_NAME_XDG)
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
             temp_home.join(crate::session::APP_DIR_NAME_OTHER)
         }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2075,15 +2075,15 @@ mod tests {
     fn test_effective_profile_falls_back_to_global_default_when_empty() {
         let temp_home = tempfile::TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let app_dir = temp_home
             .path()
             .join(".config")
-            .join(crate::session::APP_DIR_NAME_LINUX);
-        #[cfg(not(target_os = "linux"))]
+            .join(crate::session::APP_DIR_NAME_XDG);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
 
         std::fs::create_dir_all(&app_dir).unwrap();
@@ -2101,15 +2101,15 @@ mod tests {
     fn test_load_or_warn_returns_defaults_on_malformed_toml() {
         let temp_home = tempfile::TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let app_dir = temp_home
             .path()
             .join(".config")
-            .join(crate::session::APP_DIR_NAME_LINUX);
-        #[cfg(not(target_os = "linux"))]
+            .join(crate::session::APP_DIR_NAME_XDG);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
 
         std::fs::create_dir_all(&app_dir).unwrap();

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -2524,7 +2524,7 @@ mod tests {
         // Isolate HOME so global/profile config doesn't interfere
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         // Create a project directory with repo config
@@ -2615,7 +2615,7 @@ extra_volumes = ["/host/data:/container/data:ro"]
     fn test_build_container_config_sibling_worktree_loads_main_repo_extra_volumes() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         // Main repo with repo config under .agent-of-empires/
@@ -2690,7 +2690,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
     fn test_build_container_config_installs_codex_hooks_files() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let project_dir = TempDir::new().unwrap();
@@ -2744,7 +2744,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
     fn test_build_container_config_refuses_unsafe_instance_id() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let project_dir = TempDir::new().unwrap();
@@ -2785,7 +2785,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
     fn test_build_container_config_respects_profile_hooks_disabled() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let profile_dir = crate::session::get_profile_dir("sandbox-hooks-disabled").unwrap();
@@ -2838,7 +2838,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
     fn test_build_container_config_uses_detected_codex_for_custom_wrapper_hooks() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let mut global = crate::session::config::Config::default();
@@ -2905,7 +2905,7 @@ agent_detect_as = { "wrapped-codex" = "codex" }
     fn test_refresh_agent_configs_preserves_codex_hooks_and_trust_state() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let codex_dir = temp_home.path().join(".codex");
@@ -2968,7 +2968,7 @@ trusted_hash = "keep"
     fn test_build_container_config_mounts_codex_home_from_extra_env() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let project_dir = TempDir::new().unwrap();
@@ -3011,7 +3011,7 @@ trusted_hash = "keep"
     fn test_build_container_config_mounts_codex_home_from_sandbox_environment() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let project_dir = TempDir::new().unwrap();
@@ -3069,15 +3069,15 @@ environment = ["CODEX_HOME=/root/profile-codex"]
     fn test_build_container_config_uses_passed_profile_not_global_default() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let app_dir = temp_home
             .path()
             .join(".config")
-            .join(crate::session::APP_DIR_NAME_LINUX);
-        #[cfg(not(target_os = "linux"))]
+            .join(crate::session::APP_DIR_NAME_XDG);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
 
         let profiles_dir = app_dir.join("profiles");
@@ -3217,7 +3217,7 @@ extra_volumes = ["/host/personal-only:/container/personal-only:ro"]
     fn test_volume_ignores_applied_to_parent_repo_mount() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let (_dir, repo_path) = setup_regular_repo();
@@ -3334,7 +3334,7 @@ volume_ignores = ["target", "node_modules"]
     fn test_volume_ignores_applied_to_bare_repo_worktree() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let (_dir, main_repo_path, worktree_path) = setup_bare_repo_with_worktree();
@@ -3549,7 +3549,7 @@ volume_ignores = ["target"]
     fn test_vertex_mounts_default_adc_when_flag_set_and_tool_is_claude() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
         std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
         std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
@@ -3575,7 +3575,7 @@ volume_ignores = ["target"]
     fn test_vertex_mounts_custom_path_from_google_application_credentials() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
         std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
 
@@ -3605,7 +3605,7 @@ volume_ignores = ["target"]
     fn test_vertex_skips_mount_when_flag_unset() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
         std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
         std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
@@ -3626,7 +3626,7 @@ volume_ignores = ["target"]
     fn test_vertex_skips_mount_when_tool_is_not_claude() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
         std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
         std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
@@ -3649,7 +3649,7 @@ volume_ignores = ["target"]
     fn test_vertex_skips_mount_when_flag_is_empty_string() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
         std::env::set_var("CLAUDE_CODE_USE_VERTEX", "");
         std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
@@ -3672,7 +3672,7 @@ volume_ignores = ["target"]
     fn test_vertex_skips_mount_when_adc_file_missing() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
         std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
         std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -1159,7 +1159,7 @@ mod tests {
         fn isolate_app_dir() -> tempfile::TempDir {
             let tmp = tempfile::tempdir().expect("create temp home for scratch deletion tests");
             std::env::set_var("HOME", tmp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
             tmp
         }

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -577,16 +577,16 @@ mod tests {
     fn test_build_docker_env_args_uses_passed_profile_not_global_default() {
         let temp_home = tempfile::TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         // Determine app dir layout (matches session::get_app_dir_path).
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let app_dir = temp_home
             .path()
             .join(".config")
-            .join(crate::session::APP_DIR_NAME_LINUX);
-        #[cfg(not(target_os = "linux"))]
+            .join(crate::session::APP_DIR_NAME_XDG);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
 
         let profiles_dir = app_dir.join("profiles");

--- a/src/session/idle_reap.rs
+++ b/src/session/idle_reap.rs
@@ -398,7 +398,7 @@ mod tests {
         let _env = EnvGuard::capture();
         let temp = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", temp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
         let inst = idle_instance("claimable");

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3639,7 +3639,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let _codex_home_guard = CodexHomeGuard::unset();
         std::env::set_var("HOME", tmp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
 
         let mut inst = Instance::new("wrapped", "/tmp/test");
@@ -3660,7 +3660,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let _codex_home_guard = CodexHomeGuard::unset();
         std::env::set_var("HOME", tmp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
 
         let codex_home = tmp.path().join("profile-codex-home");
@@ -3690,7 +3690,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let _codex_home_guard = CodexHomeGuard::unset();
         std::env::set_var("HOME", tmp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
 
         let profile_dir = crate::session::get_profile_dir("hooks-disabled").unwrap();
@@ -3715,7 +3715,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let _codex_home_guard = CodexHomeGuard::unset();
         std::env::set_var("HOME", tmp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
 
         let mut global = crate::session::config::Config::default();
@@ -5610,7 +5610,7 @@ mod tests {
         fn persist_session_to_storage_skips_on_cas_mismatch() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("cas-persist-mismatch").unwrap();
@@ -5639,7 +5639,7 @@ mod tests {
         fn persist_session_to_storage_writes_on_cas_match() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("cas-persist-match").unwrap();
@@ -5668,7 +5668,7 @@ mod tests {
         fn reconcile_from_disk_picks_up_peer_persist() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("reconcile-test").unwrap();
@@ -5707,7 +5707,7 @@ mod tests {
         fn reconcile_from_disk_picks_up_peer_clear() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("reconcile-clear").unwrap();
@@ -5857,7 +5857,7 @@ mod tests {
         fn reconcile_from_disk_picks_up_peer_resume_intent() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("intent-reconcile").unwrap();
@@ -5923,7 +5923,7 @@ mod tests {
         fn reconcile_sidecar_adopts_fresh_sid_for_claude_default() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "sidecar-adopt";
@@ -5961,7 +5961,7 @@ mod tests {
         fn reconcile_sidecar_noop_when_tool_not_claude() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "sidecar-noop-tool";
@@ -5993,7 +5993,7 @@ mod tests {
         fn reconcile_sidecar_noop_when_intent_use() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "sidecar-noop-use";
@@ -6025,7 +6025,7 @@ mod tests {
         fn reconcile_sidecar_noop_when_intent_cleared() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "sidecar-noop-cleared";
@@ -6057,7 +6057,7 @@ mod tests {
         fn reconcile_sidecar_noop_when_sid_in_retroactive_excludes() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "sidecar-noop-excluded";
@@ -6091,7 +6091,7 @@ mod tests {
         fn reconcile_sidecar_noop_when_sidecar_absent() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "sidecar-absent";
@@ -6120,7 +6120,7 @@ mod tests {
         fn reconcile_sidecar_reloads_on_cas_skip() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "sidecar-cas-skip";
@@ -6172,7 +6172,7 @@ mod tests {
         fn persist_session_id_reloads_memory_on_skipped() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("persist-skipped-reload").unwrap();
@@ -6209,7 +6209,7 @@ mod tests {
         fn persist_session_id_atomic_writes_both_fields_on_match() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("persist-atomic-match").unwrap();
@@ -6252,7 +6252,7 @@ mod tests {
         fn persist_session_id_writes_sid_only_on_default_intent() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("persist-default-intent").unwrap();
@@ -6294,7 +6294,7 @@ mod tests {
         fn persist_session_id_persists_sid_when_intent_cas_mismatches() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("persist-intent-mismatch").unwrap();
@@ -6348,7 +6348,7 @@ mod tests {
         fn persist_session_id_skipped_reloads_both_fields() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage =
@@ -6407,7 +6407,7 @@ mod tests {
         fn clear_for_resume_fallback_atomically_clears_and_downgrades() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "fallback-clear-happy";
@@ -6433,7 +6433,7 @@ mod tests {
         fn clear_for_resume_fallback_intent_already_default() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "fallback-clear-default";
@@ -6458,7 +6458,7 @@ mod tests {
         fn clear_for_resume_fallback_preserves_user_repin() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "fallback-clear-repin";
@@ -6498,7 +6498,7 @@ mod tests {
         fn clear_for_resume_fallback_skips_on_sid_cas_mismatch() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "fallback-clear-sid-mismatch";
@@ -6543,7 +6543,7 @@ mod tests {
         fn clear_for_resume_fallback_heals_legacy_stuck_state() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "fallback-clear-heal-legacy";
@@ -6580,7 +6580,7 @@ mod tests {
         fn clear_for_resume_fallback_skips_on_user_repin_with_none_sid() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "fallback-clear-repin-none-sid";
@@ -6621,7 +6621,7 @@ mod tests {
         fn clear_for_resume_fallback_intent_cleared_not_downgraded() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "fallback-clear-intent-cleared";
@@ -6650,7 +6650,7 @@ mod tests {
         fn clear_for_resume_fallback_returns_failed_on_missing_row() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let profile = "fallback-clear-missing";
@@ -6675,7 +6675,7 @@ mod tests {
         fn restart_outcome_for_cockpit_session_is_fresh() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let mut inst = Instance::new("cockpit_test", "/tmp/x");
@@ -6700,7 +6700,7 @@ mod tests {
             }
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let storage = crate::session::storage::Storage::new("fb-test").unwrap();
@@ -6774,7 +6774,7 @@ mod tests {
             }
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let _storage = crate::session::storage::Storage::new("fb-test-live").unwrap();
@@ -6856,7 +6856,7 @@ mod tests {
             }
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
             let _storage = crate::session::storage::Storage::new("fb-test-grace").unwrap();
@@ -6986,7 +6986,7 @@ mod tests {
 
         fn isolate_home(temp: &TempDir) {
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
         }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -66,22 +66,94 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-/// Linux app dir name (under `$XDG_CONFIG_HOME`). Debug builds use a `-dev`
-/// suffix so a `cargo run` instance shares no state with an installed
+/// App dir name under the XDG config base (`$XDG_CONFIG_HOME`, default
+/// `~/.config`). Always used on Linux; used on macOS when the user opts into
+/// the XDG layout (see [`get_app_dir_path`] and issue #1948). Debug builds use
+/// a `-dev` suffix so a `cargo run` instance shares no state with an installed
 /// release binary.
-pub const APP_DIR_NAME_LINUX: &str = if cfg!(debug_assertions) {
+pub const APP_DIR_NAME_XDG: &str = if cfg!(debug_assertions) {
     "agent-of-empires-dev"
 } else {
     "agent-of-empires"
 };
 
-/// macOS/Windows app dir name (under `$HOME`). Debug builds use a `-dev`
-/// suffix; see `APP_DIR_NAME_LINUX`.
+/// Home-dotfile app dir name (under `$HOME`). The default on macOS and the
+/// only location on Windows. Debug builds use a `-dev` suffix; see
+/// `APP_DIR_NAME_XDG`.
 pub const APP_DIR_NAME_OTHER: &str = if cfg!(debug_assertions) {
     ".agent-of-empires-dev"
 } else {
     ".agent-of-empires"
 };
+
+/// Resolve the XDG-style config base directory: `$XDG_CONFIG_HOME` when set to
+/// an absolute path, otherwise `~/.config`.
+///
+/// On Linux this matches `dirs::config_dir()`. macOS uses it for the XDG layout
+/// (rather than `dirs::config_dir()`, which there resolves to `~/Library/
+/// Application Support`) so a dotfile manager like chezmoi can share one global
+/// config path with Linux. See issue #1948.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn xdg_config_base() -> Result<PathBuf> {
+    if let Some(dir) = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from) {
+        if dir.is_absolute() {
+            return Ok(dir);
+        }
+    }
+    Ok(dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot find home directory"))?
+        .join(".config"))
+}
+
+/// Whether `$XDG_CONFIG_HOME` is set to an absolute path, i.e. the user has
+/// meaningfully opted into the XDG layout. A relative or empty value is ignored
+/// per the XDG spec (and by [`xdg_config_base`]), so it does not count.
+#[cfg(target_os = "macos")]
+fn xdg_config_home_set() -> bool {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .map(|v| std::path::Path::new(&v).is_absolute())
+        .unwrap_or(false)
+}
+
+/// macOS app-dir resolution: prefer the XDG location, fall back to the
+/// home-dotfile location, without ever moving data. See issue #1948.
+///
+/// Precedence (the first matching rule wins):
+/// 1. the XDG dir already exists -> use it (picks up a `~/.config` tree synced
+///    from Linux even when `$XDG_CONFIG_HOME` is unset);
+/// 2. the legacy dir already exists -> use it (an existing install keeps its
+///    data in place even after the user later sets `$XDG_CONFIG_HOME`);
+/// 3. `$XDG_CONFIG_HOME` is set -> use the XDG dir (a fresh XDG opt-in);
+/// 4. otherwise -> the home-dotfile dir (the historical macOS default).
+///
+/// `xdg_name` / `legacy_name` are passed in (rather than read from the
+/// constants) so the dev/release namespace warning can resolve the release
+/// pair from a debug build.
+#[cfg(target_os = "macos")]
+fn macos_app_dir(xdg_name: &str, legacy_name: &str) -> Option<PathBuf> {
+    let xdg = xdg_config_base().ok()?.join(xdg_name);
+    let legacy = dirs::home_dir()?.join(legacy_name);
+    Some(resolve_app_dir_with_fallback(
+        xdg,
+        legacy,
+        xdg_config_home_set(),
+    ))
+}
+
+/// Pure precedence used by [`macos_app_dir`]; split out so the rule is testable
+/// off-macOS. See that function for the meaning of each branch.
+#[cfg(any(target_os = "macos", test))]
+fn resolve_app_dir_with_fallback(xdg: PathBuf, legacy: PathBuf, xdg_env_set: bool) -> PathBuf {
+    if xdg.exists() {
+        xdg
+    } else if legacy.exists() {
+        legacy
+    } else if xdg_env_set {
+        xdg
+    } else {
+        legacy
+    }
+}
 
 pub fn get_app_dir() -> Result<PathBuf> {
     let dir = get_app_dir_path()?;
@@ -103,11 +175,13 @@ pub fn app_dir_exists() -> bool {
 
 fn get_app_dir_path() -> Result<PathBuf> {
     #[cfg(target_os = "linux")]
-    let dir = dirs::config_dir()
-        .ok_or_else(|| anyhow::anyhow!("Cannot find config directory"))?
-        .join(APP_DIR_NAME_LINUX);
+    let dir = xdg_config_base()?.join(APP_DIR_NAME_XDG);
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
+    let dir = macos_app_dir(APP_DIR_NAME_XDG, APP_DIR_NAME_OTHER)
+        .ok_or_else(|| anyhow::anyhow!("Cannot find home directory"))?;
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let dir = dirs::home_dir()
         .ok_or_else(|| anyhow::anyhow!("Cannot find home directory"))?
         .join(APP_DIR_NAME_OTHER);
@@ -134,13 +208,17 @@ pub fn debug_namespace_drift() -> Option<(PathBuf, PathBuf)> {
     }
 
     #[cfg(target_os = "linux")]
-    let release_dir = dirs::config_dir()?.join("agent-of-empires");
-    #[cfg(not(target_os = "linux"))]
+    let release_dir = xdg_config_base().ok()?.join("agent-of-empires");
+    #[cfg(target_os = "macos")]
+    let release_dir = macos_app_dir("agent-of-empires", ".agent-of-empires")?;
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let release_dir = dirs::home_dir()?.join(".agent-of-empires");
 
     #[cfg(target_os = "linux")]
-    let dev_dir = dirs::config_dir()?.join(APP_DIR_NAME_LINUX);
-    #[cfg(not(target_os = "linux"))]
+    let dev_dir = xdg_config_base().ok()?.join(APP_DIR_NAME_XDG);
+    #[cfg(target_os = "macos")]
+    let dev_dir = macos_app_dir(APP_DIR_NAME_XDG, APP_DIR_NAME_OTHER)?;
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let dev_dir = dirs::home_dir()?.join(APP_DIR_NAME_OTHER);
 
     let release_populated = fs::read_dir(&release_dir)
@@ -566,18 +644,103 @@ mod tests {
     fn isolate_app_dir() -> tempfile::TempDir {
         let temp_home = tempfile::TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
         temp_home
     }
 
     fn app_dir(temp_home: &tempfile::TempDir) -> PathBuf {
-        #[cfg(target_os = "linux")]
-        let dir = temp_home.path().join(".config").join(APP_DIR_NAME_LINUX);
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        let dir = temp_home.path().join(".config").join(APP_DIR_NAME_XDG);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         let dir = temp_home.path().join(APP_DIR_NAME_OTHER);
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    #[serial_test::serial]
+    fn test_xdg_config_base_prefers_absolute_xdg_config_home() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp.path());
+        let custom = temp.path().join("custom-xdg");
+        std::env::set_var("XDG_CONFIG_HOME", &custom);
+
+        assert_eq!(xdg_config_base().unwrap(), custom);
+        // The global config path is derived from that base on both Linux and
+        // macOS, so a dotfile manager sees a single location. See issue #1948.
+        assert_eq!(get_app_dir_path().unwrap(), custom.join(APP_DIR_NAME_XDG));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    #[serial_test::serial]
+    fn test_xdg_config_base_falls_back_to_home_dot_config() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp.path());
+        // A relative (non-absolute) value is ignored per the XDG spec.
+        std::env::set_var("XDG_CONFIG_HOME", "relative/path");
+
+        assert_eq!(xdg_config_base().unwrap(), temp.path().join(".config"));
+
+        std::env::remove_var("XDG_CONFIG_HOME");
+        assert_eq!(xdg_config_base().unwrap(), temp.path().join(".config"));
+    }
+
+    // Precedence behind the macOS read-fallback resolution (issue #1948). These
+    // exercise the pure rule, so they run on every platform's CI, not just
+    // macOS where `macos_app_dir` is compiled.
+    #[test]
+    fn test_fallback_prefers_existing_xdg_dir_even_over_legacy() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let xdg = tmp.path().join(".config").join("agent-of-empires");
+        let legacy = tmp.path().join(".agent-of-empires");
+        fs::create_dir_all(&xdg).unwrap();
+        fs::create_dir_all(&legacy).unwrap();
+
+        // Both present: XDG wins, so there is never a split brain.
+        assert_eq!(
+            resolve_app_dir_with_fallback(xdg.clone(), legacy.clone(), true),
+            xdg
+        );
+        assert_eq!(
+            resolve_app_dir_with_fallback(xdg.clone(), legacy, false),
+            xdg
+        );
+    }
+
+    #[test]
+    fn test_fallback_keeps_legacy_when_xdg_absent_even_if_env_set() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let xdg = tmp.path().join(".config").join("agent-of-empires");
+        let legacy = tmp.path().join(".agent-of-empires");
+        fs::create_dir_all(&legacy).unwrap();
+
+        // An existing install that later sets XDG_CONFIG_HOME keeps reading its
+        // data in place; nothing appears as a fresh install.
+        assert_eq!(
+            resolve_app_dir_with_fallback(xdg, legacy.clone(), true),
+            legacy
+        );
+    }
+
+    #[test]
+    fn test_fallback_fresh_install_follows_env() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let xdg = tmp.path().join(".config").join("agent-of-empires");
+        let legacy = tmp.path().join(".agent-of-empires");
+
+        // Neither dir exists yet: XDG_CONFIG_HOME set -> XDG opt-in; unset ->
+        // the historical macOS home-dotfile default.
+        assert_eq!(
+            resolve_app_dir_with_fallback(xdg.clone(), legacy.clone(), true),
+            xdg
+        );
+        assert_eq!(
+            resolve_app_dir_with_fallback(xdg, legacy.clone(), false),
+            legacy
+        );
     }
 
     #[test]
@@ -650,9 +813,9 @@ mod tests {
     }
 
     fn release_dir_in(temp: &tempfile::TempDir) -> PathBuf {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let d = temp.path().join(".config").join("agent-of-empires");
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         let d = temp.path().join(".agent-of-empires");
         d
     }

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -322,7 +322,7 @@ mod tests {
 
     fn setup(temp: &Path) {
         std::env::set_var("HOME", temp);
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
     }
 

--- a/src/session/scratch.rs
+++ b/src/session/scratch.rs
@@ -79,7 +79,7 @@ mod tests {
         // (or $XDG_CONFIG_HOME on Linux) forces get_app_dir() into a temp.
         let tmp = tempfile::tempdir().expect("create temp home for scratch tests");
         std::env::set_var("HOME", tmp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
         tmp
     }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -425,7 +425,7 @@ mod tests {
 
     fn setup_test_home(temp: &std::path::Path) {
         std::env::set_var("HOME", temp);
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
     }
 

--- a/src/tui/dialogs/hooks_install.rs
+++ b/src/tui/dialogs/hooks_install.rs
@@ -488,7 +488,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let _guard = CodexHomeGuard::unset();
         std::env::set_var("HOME", tmp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
 
         let codex_home = tmp.path().join("profile-codex-home");

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1151,7 +1151,7 @@ fn test_profile_switch_reloads_sandbox_env_without_session_override() {
     let old_home = std::env::var_os("HOME");
     let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
     std::env::set_var("HOME", temp_home.path());
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
     std::env::set_var("OLD_THING", "1");
     std::env::set_var("NEW_THING", "2");
@@ -1226,7 +1226,7 @@ fn test_set_path_reloads_repo_sandbox_env_without_session_override() {
     let old_home = std::env::var_os("HOME");
     let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
     std::env::set_var("HOME", temp_home.path());
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
     let app_dir = crate::session::get_app_dir().expect("app dir");
@@ -1291,7 +1291,7 @@ fn test_sandbox_config_refreshes_typed_path_repo_env_without_session_override() 
     let old_home = std::env::var_os("HOME");
     let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
     std::env::set_var("HOME", temp_home.path());
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
     let app_dir = crate::session::get_app_dir().expect("app dir");

--- a/src/tui/diff/input.rs
+++ b/src/tui/diff/input.rs
@@ -342,7 +342,7 @@ mod tests {
 
         let temp_home = tempfile::TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let mut view = make_diff_view_no_warning();

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -17,7 +17,7 @@ fn key(code: KeyCode) -> KeyEvent {
 
 fn setup_test_home(temp: &TempDir) {
     std::env::set_var("HOME", temp.path());
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 }
 

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -1002,7 +1002,7 @@ mod tests {
 
         fn setup_test_home(temp: &TempDir) {
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
         }
 
@@ -1167,7 +1167,7 @@ mod tests {
 
         fn setup_test_home(temp: &TempDir) {
             std::env::set_var("HOME", temp.path());
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
         }
 

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -1440,7 +1440,7 @@ mod field_height_tests {
 
     fn setup_test_home(temp: &TempDir) {
         std::env::set_var("HOME", temp.path());
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
     }
 

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -26,9 +26,9 @@ use tempfile::TempDir;
 
 /// Return the app dir under the given test home, matching `get_app_dir_path`.
 pub fn app_dir_in(home: &Path) -> PathBuf {
-    if cfg!(target_os = "linux") {
+    if cfg!(any(target_os = "linux", target_os = "macos")) {
         home.join(".config")
-            .join(agent_of_empires::session::APP_DIR_NAME_LINUX)
+            .join(agent_of_empires::session::APP_DIR_NAME_XDG)
     } else {
         home.join(agent_of_empires::session::APP_DIR_NAME_OTHER)
     }
@@ -244,9 +244,10 @@ impl TuiTestHarness {
         // popup (gated on that flag alone in `App::new`) never renders over the
         // TUI and swallows input in the general e2e tests; the telemetry consent
         // surfaces are covered directly by their own unit and integration tests.
-        // On Linux the app uses $XDG_CONFIG_HOME/agent-of-empires[-dev]/ (set
-        // below), on macOS it uses $HOME/.agent-of-empires[-dev]/. The `-dev`
-        // suffix kicks in on debug builds, which is what `cargo test` produces.
+        // On Linux and macOS the app uses $XDG_CONFIG_HOME/agent-of-empires[-dev]/
+        // (set below); other platforms use $HOME/.agent-of-empires[-dev]/. The
+        // `-dev` suffix kicks in on debug builds, which is what `cargo test`
+        // produces.
         let config_dir = app_dir_in(home_dir.path());
         std::fs::create_dir_all(&config_dir).expect("create config dir");
         let config_content = format!(

--- a/tests/e2e/update_command.rs
+++ b/tests/e2e/update_command.rs
@@ -40,7 +40,7 @@ fn update_calls_brew_when_method_is_homebrew() {
     // dir to the `-dev` namespace.
     let app_dir = config_home
         .path()
-        .join(agent_of_empires::session::APP_DIR_NAME_LINUX);
+        .join(agent_of_empires::session::APP_DIR_NAME_XDG);
     fs::create_dir_all(&app_dir).unwrap();
 
     let cache = serde_json::json!({

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -48,8 +48,9 @@ pub fn shim_ready() -> Result<(), String> {
     Ok(())
 }
 
-/// Set `HOME` (and `XDG_CONFIG_HOME` on Linux) to a fresh temp dir so tests
-/// read and write to isolated state. Returns the guard; drop it to clean up.
+/// Set `HOME` (and `XDG_CONFIG_HOME` on Linux/macOS) to a fresh temp dir so
+/// tests read and write to isolated state. Returns the guard; drop it to clean
+/// up.
 ///
 /// # Safety caveat
 /// `set_var` is not thread-safe. Callers must be `#[serial]`.
@@ -63,6 +64,6 @@ pub fn setup_temp_home() -> TempDir {
 /// files under the same path before returning the guard).
 pub fn set_temp_home(path: &Path) {
     std::env::set_var("HOME", path);
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     std::env::set_var("XDG_CONFIG_HOME", path.join(".config"));
 }


### PR DESCRIPTION
## Description

macOS resolved the global app dir to `~/.agent-of-empires/` while Linux used `$XDG_CONFIG_HOME/agent-of-empires/` (default `~/.config/agent-of-empires/`). Dotfile managers like chezmoi that sync one logical config across both OSes saw the file land at a different path per machine, so app-driven rewrites (schema migrations, defaults) merged back into different source files and the two copies drifted. Fixes #1948.

This lets macOS use the XDG location too, but as an opt-in that never moves data. macOS app-dir resolution now applies this precedence (first match wins):

1. the XDG dir already exists, so use it (picks up a `~/.config` tree synced from Linux even when `XDG_CONFIG_HOME` is unset);
2. the legacy dir already exists, so use it (an existing install keeps its data in place even after the user later sets `XDG_CONFIG_HOME`);
3. `XDG_CONFIG_HOME` is set, so use the XDG dir (a fresh XDG opt-in);
4. otherwise `~/.agent-of-empires/` (the historical macOS default).

So the default macOS location is unchanged and no migration is required. A chezmoi user sets `XDG_CONFIG_HOME` (or already has a `~/.config/agent-of-empires` tree) and gets the same path as Linux. Because `dirs::config_dir()` points at `~/Library/Application Support` on macOS, a shared `xdg_config_base()` helper reads `XDG_CONFIG_HOME` (when absolute) and otherwise falls back to `~/.config`.

The pure precedence is factored into `resolve_app_dir_with_fallback` so it is unit-tested off macOS (Linux CI). `uninstall` and migration discovery (`get_all_possible_dirs`) learn the macOS XDG location. Windows is unchanged. The configuration guide documents the opt-in.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the new behavior is the macOS app-dir resolution, which is pure logic covered by unit tests (`resolve_app_dir_with_fallback`, `xdg_config_base`, and the macOS app-dir precedence). e2e runs on Linux CI, where resolution is unchanged. The e2e harness helper was updated to match the new constant.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Code (Opus 4.8), driven interactively by @njbrake. The design decision (opt-in read-fallback rather than a forced migration) was his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR adds **opt-in XDG config path support on macOS**, allowing macOS users to store their configuration in `$XDG_CONFIG_HOME/agent-of-empires/` (defaulting to `~/.config/agent-of-empires/`) instead of the historical `~/.agent-of-empires/`. This aligns macOS behavior with Linux for users who manage their dotfiles across multiple operating systems.

**No existing data is migrated automatically.** The app uses a smart fallback system:
1. Use the XDG directory if it already exists
2. Otherwise, use the legacy `~/.agent-of-empires/` if it exists
3. Otherwise, follow `$XDG_CONFIG_HOME` if set
4. Otherwise, fall back to `~/.agent-of-empires/`

## What Moved & What Was Added

**Removed:**
- `APP_DIR_NAME_LINUX` constant (replaced with a more generic XDG approach)

**Added:**
- `APP_DIR_NAME_XDG` constant for the shared XDG directory naming across Linux and macOS
- `xdg_config_base()` helper function to resolve the XDG config directory
- Precedence-based directory resolution logic specifically for macOS

## What Was Updated

**Core logic** (`src/session/mod.rs`):
- Refactored app directory path resolution to support XDG on macOS
- Updated debug namespace drift detection to use the new XDG-aware logic
- Added unit test coverage for the new XDG and macOS precedence logic

**Data discovery** (`src/cli/uninstall.rs`, `src/migrations/mod.rs`):
- Updated uninstall to discover config directories in both legacy and XDG locations
- Updated migration discovery to recognize XDG-based directories on both Linux and macOS

**Testing infrastructure** (30+ files):
- Expanded test compilation across the codebase to run on both Linux and macOS
- Updated test helpers to use `XDG_CONFIG_HOME` environment variable on both platforms
- Adjusted expected file paths in tests to reflect XDG directory structure

**Documentation** (`AGENTS.md`, `docs/guides/configuration.md`):
- Added macOS-specific guidance explaining the XDG config path behavior and opt-in nature
- Documented which function handles the directory resolution (`get_app_dir_path` → `macos_app_dir`)

## Benefits

- **Cross-platform consistency**: Dotfile managers (like GNU Stow) can now manage config consistently across Linux and macOS
- **No breaking changes**: Existing macOS users are unaffected; the app continues reading from `~/.agent-of-empires/` by default
- **User choice**: Users can opt-in to XDG by either setting `$XDG_CONFIG_HOME` or manually moving their config directory
- **Better standards compliance**: Aligns with XDG Base Directory specification on macOS, similar to Linux

## Technical Details

The implementation:
- Introduces `xdg_config_base()` which reads `$XDG_CONFIG_HOME` (absolute path) or defaults to `~/.config`
- Implements `resolve_app_dir_with_fallback()` for macOS precedence logic (checks existence before deciding which path to use)
- Updates all path-dependent code paths: app directory resolution, uninstall discovery, migration detection, and debug drift detection
- Maintains Windows behavior unchanged (no XDG support on Windows)
- All changes are backward-compatible; no automatic migration or forced directory moves

<!-- end of auto-generated comment: release notes by coderabbit.ai -->