### PR TITLE
feat(diff): default diff comparison to the worktree base branch

### DIFF
--- a/docs/guides/diff-view.md
+++ b/docs/guides/diff-view.md
@@ -92,11 +92,20 @@ comments to the agent as a single prompt (#928).
 ## Per-session base override
 
 Each session has an optional `base_branch_override` that takes
-precedence over the profile default and auto-detection. Use it when
-the eventual PR target differs from the project default (stacked PRs,
-hotfix off `release/*`, branch rename). The override is sticky across
-restarts and only affects the comparison, not the worktree itself
-(no rebase). See #970.
+precedence over the worktree's recorded base, the profile default, and
+auto-detection. Use it when the eventual PR target differs from the
+project default (stacked PRs, hotfix off `release/*`, branch rename).
+The override is sticky across restarts and only affects the comparison,
+not the worktree itself (no rebase). See #970.
+
+When no override is set, the comparison defaults to the branch the
+worktree was actually forked from (`worktree_info.base_branch`, set at
+creation from an explicit session base, a per-project default, or the
+global/profile `worktree.default_base_branch`). So a worktree created
+off `release` compares against `release` rather than the repo's
+auto-detected default. The full precedence is: per-session override,
+then worktree base, then `diff.default_branch`, then auto-detection.
+See #1951.
 
 - **Web dashboard**: click the `vs <ref>` chip in the diff header, pick
   a branch from the typeahead (local + remote-only), or use

--- a/docs/guides/diff-view.md
+++ b/docs/guides/diff-view.md
@@ -108,8 +108,9 @@ then worktree base, then `diff.default_branch`, then auto-detection.
 See #1951.
 
 - **Web dashboard**: click the `vs <ref>` chip in the diff header, pick
-  a branch from the typeahead (local + remote-only), or use
-  "Reset to auto-detected" to clear.
+  a branch from the typeahead (local + remote-only), or reset to clear
+  the override (the comparison then falls back to the worktree base, or
+  auto-detection when none was recorded).
 - **TUI diff view**: press `b`, pick a branch; the choice is persisted
   to `sessions.json` and restored on next launch.
 - **CLI**: `aoe session set-base <session> <branch>` to set,

--- a/docs/guides/web/diff.md
+++ b/docs/guides/web/diff.md
@@ -28,8 +28,10 @@ Enter / Space opens a file or toggles a directory.
 
 ## Base override
 
-By default the diff is computed against the session's base branch. The
-**base picker** chip lets you override it per session: type to filter
+By default the diff is computed against the branch the worktree was
+forked from (its recorded base branch), falling back to the configured
+`diff.default_branch` and then auto-detection. The **base picker** chip
+lets you override it per session: type to filter
 branches, pick one, and the diff recomputes against the new base. A
 reset affordance appears while an override is active. The override is
 sent to the server (`PATCH /api/sessions/{id}/diff-base`) so it persists

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3270,6 +3270,10 @@ struct DiffContext {
     /// CLI, or the TUI diff view's `b` keybind). Wins over the
     /// profile-level default and the auto-detected ref. See #970.
     base_branch_override: Option<String>,
+    /// The branch the worktree was created from, recorded at creation
+    /// time. Slots below the explicit override but above the profile
+    /// default and auto-detection. See #1951.
+    base_from_worktree: Option<String>,
 }
 
 /// Expand a session into the list of repos whose diffs the sidebar
@@ -3306,18 +3310,27 @@ async fn resolve_diff_repos(
     Ok(DiffContext {
         repos,
         base_branch_override: inst.base_branch_override.clone(),
+        base_from_worktree: inst
+            .worktree_info
+            .as_ref()
+            .and_then(|w| w.base_branch.clone()),
     })
 }
 
 /// Resolve the diff base for one repo path. Override (per-session)
-/// wins over the profile's `DiffConfig.default_branch`, which wins
-/// over auto-detection (`get_default_base_ref`). See #970.
+/// wins over the worktree's recorded base, which wins over the
+/// profile's `DiffConfig.default_branch`, which wins over
+/// auto-detection (`get_default_base_ref`). See #970, #1951.
 fn resolve_diff_base(
     override_value: Option<&str>,
+    worktree_base: Option<&str>,
     config_default: Option<&str>,
     repo_path: &std::path::Path,
 ) -> String {
     if let Some(v) = override_value.map(str::trim).filter(|v| !v.is_empty()) {
+        return v.to_string();
+    }
+    if let Some(v) = worktree_base.map(str::trim).filter(|v| !v.is_empty()) {
         return v.to_string();
     }
     if let Some(v) = config_default.map(str::trim).filter(|v| !v.is_empty()) {
@@ -3350,6 +3363,7 @@ pub async fn session_diff_files(
             let path = std::path::Path::new(&repo.path);
             let base_branch = resolve_diff_base(
                 ctx.base_branch_override.as_deref(),
+                ctx.base_from_worktree.as_deref(),
                 config_default.as_deref(),
                 path,
             );
@@ -3463,6 +3477,7 @@ pub async fn session_diff_file(
     let project_path = selected_repo.path;
     let selected_repo_name = selected_repo.name;
     let base_branch_override = ctx.base_branch_override.clone();
+    let base_from_worktree = ctx.base_from_worktree.clone();
 
     let result =
         tokio::task::spawn_blocking(move || -> Result<RichFileDiffResponse, DiffFileError> {
@@ -3478,6 +3493,7 @@ pub async fn session_diff_file(
                 .clone();
             let base_branch = resolve_diff_base(
                 base_branch_override.as_deref(),
+                base_from_worktree.as_deref(),
                 config_default.as_deref(),
                 repo_path,
             );
@@ -3801,26 +3817,31 @@ mod tests {
     }
 
     #[test]
-    fn resolve_diff_base_prefers_override_then_config_then_auto() {
+    fn resolve_diff_base_prefers_override_then_worktree_then_config_then_auto() {
         let tmp = tempfile::tempdir().unwrap();
         // Override wins over everything.
         assert_eq!(
-            resolve_diff_base(Some("release-1.2"), Some("develop"), tmp.path()),
+            resolve_diff_base(Some("release-1.2"), None, Some("develop"), tmp.path()),
             "release-1.2"
         );
-        // Config wins when no override; empty / whitespace override falls
-        // through to the next layer.
+        // Worktree base wins after override; whitespace override falls through.
         assert_eq!(
-            resolve_diff_base(Some("   "), Some("develop"), tmp.path()),
+            resolve_diff_base(
+                Some("   "),
+                Some("worktree-base"),
+                Some("develop"),
+                tmp.path()
+            ),
+            "worktree-base"
+        );
+        // Config wins when no override and no worktree base.
+        assert_eq!(
+            resolve_diff_base(None, None, Some("develop"), tmp.path()),
             "develop"
         );
-        assert_eq!(
-            resolve_diff_base(None, Some("develop"), tmp.path()),
-            "develop"
-        );
-        // Auto-detect when neither is set. The tmp dir is not a repo so
+        // Auto-detect when nothing is set. The tmp dir is not a repo so
         // `get_default_base_ref` returns Err -> "main" fallback.
-        assert_eq!(resolve_diff_base(None, None, tmp.path()), "main");
+        assert_eq!(resolve_diff_base(None, None, None, tmp.path()), "main");
     }
 
     #[test]

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -133,7 +133,13 @@ impl DiffView {
             .map(str::trim)
             .filter(|v| !v.is_empty())
             .map(str::to_string)
-            .or_else(|| worktree_base.as_deref().map(str::to_string))
+            .or_else(|| {
+                worktree_base
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|v| !v.is_empty())
+                    .map(str::to_string)
+            })
             .or_else(|| config.diff.default_branch.clone())
             .or_else(|| get_default_base_ref(&repo_path).ok())
             .unwrap_or_else(|| "main".to_string());

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -103,18 +103,21 @@ impl DiffView {
     /// that have a session id should use `new_for_session` so the
     /// override persists.
     pub fn new(repo_path: PathBuf) -> anyhow::Result<Self> {
-        Self::new_for_session(repo_path, None, String::new(), None)
+        Self::new_for_session(repo_path, None, String::new(), None, None)
     }
 
     /// Create a diff view bound to a session. `base_override` (the
     /// session's persisted `base_branch_override`) wins over the
-    /// profile default and auto-detection. Subsequent calls to
-    /// `select_branch` persist the new ref back to the session record.
+    /// worktree's recorded base branch (`worktree_base`), which wins
+    /// over the profile default and auto-detection. Subsequent calls
+    /// to `select_branch` persist the new ref back to the session
+    /// record.
     pub fn new_for_session(
         repo_path: PathBuf,
         session_id: Option<String>,
         profile: String,
         base_override: Option<String>,
+        worktree_base: Option<String>,
     ) -> anyhow::Result<Self> {
         // Use the profile-merged config so a per-profile Diff override (e.g.
         // split_view) is honored on open. The session-agnostic path (empty
@@ -130,6 +133,7 @@ impl DiffView {
             .map(str::trim)
             .filter(|v| !v.is_empty())
             .map(str::to_string)
+            .or_else(|| worktree_base.as_deref().map(str::to_string))
             .or_else(|| config.diff.default_branch.clone())
             .or_else(|| get_default_base_ref(&repo_path).ok())
             .unwrap_or_else(|| "main".to_string());

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2193,7 +2193,17 @@ impl HomeView {
         let session_id_owned = inst.id.clone();
         let profile = inst.source_profile.clone();
         let base_override = inst.base_branch_override.clone();
-        match DiffView::new_for_session(repo_path, Some(session_id_owned), profile, base_override) {
+        let worktree_base = inst
+            .worktree_info
+            .as_ref()
+            .and_then(|w| w.base_branch.clone());
+        match DiffView::new_for_session(
+            repo_path,
+            Some(session_id_owned),
+            profile,
+            base_override,
+            worktree_base,
+        ) {
             Ok(view) => self.diff_view = Some(view),
             Err(e) => {
                 tracing::error!(target: "tui.input", "Failed to open diff view: {}", e);

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2339,7 +2339,8 @@
       "kind": "live-playwright",
       "risk": "medium",
       "specs": [
-        "tests/live/acp-stories/diff-base-picker.spec.ts"
+        "tests/live/acp-stories/diff-base-picker.spec.ts",
+        "tests/live/diff-base-from-worktree.spec.ts"
       ],
       "components": [
         "web/src/components/diff/DiffFileList.tsx"

--- a/web/tests/live/diff-base-from-worktree.spec.ts
+++ b/web/tests/live/diff-base-from-worktree.spec.ts
@@ -1,0 +1,133 @@
+// Worktree base branch sets the diff viewer's default comparison (#1951).
+//
+// When a worktree is created off a base branch X, the diff endpoint must
+// default its comparison to X (recorded on worktree_info.base_branch),
+// not to the repo's auto-detected default. An explicit per-session
+// override still wins, and clearing the override falls back to the
+// worktree base again.
+//
+// Drives the live `aoe serve` backend over REST. The repo is seeded on
+// disk before the server boots so the daemon picks it up on the create
+// call. The default-branch auto-detection would resolve to `main`, so an
+// observed base of `release` proves the worktree-base layer engaged.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnAoeServe, type ServeHandle } from "../helpers/aoeServe";
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+} as const;
+
+function run(cmd: string, args: string[], cwd: string) {
+  const res = spawnSync(cmd, args, {
+    cwd,
+    env: { ...process.env, ...GIT_ENV },
+    encoding: "utf8",
+  });
+  if (res.error || res.status !== 0) {
+    const errMsg = res.error ? String(res.error) : "non-zero exit";
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed in ${cwd}: ${errMsg}; status=${res.status}\nstdout=${res.stdout}\nstderr=${res.stderr}`,
+    );
+  }
+  return res.stdout.trim();
+}
+
+interface RepoBase {
+  repo_name: string | null;
+  base_branch: string;
+}
+
+async function diffBases(serve: ServeHandle, id: string): Promise<RepoBase[]> {
+  const res = await fetch(`${serve.baseUrl}/api/sessions/${id}/diff/files`);
+  if (!res.ok) {
+    throw new Error(`GET diff/files failed: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { per_repo_bases: RepoBase[] };
+  return body.per_repo_bases;
+}
+
+async function setDiffBase(serve: ServeHandle, id: string, baseBranch: string) {
+  const res = await fetch(`${serve.baseUrl}/api/sessions/${id}/diff-base`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ base_branch: baseBranch }),
+  });
+  if (!res.ok) {
+    throw new Error(`PATCH diff-base failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+base(
+  "diff base defaults to the worktree's base branch, override still wins",
+  async ({}, testInfo) => {
+    let serve: ServeHandle | undefined;
+    try {
+      serve = await spawnAoeServe({
+        authMode: "none",
+        workerIndex: testInfo.workerIndex,
+        parallelIndex: testInfo.parallelIndex,
+        seedFn: ({ home }) => {
+          // Healthy single repo: `main` with two commits, plus a
+          // `release` branch pinned at the first commit. Auto-detection
+          // resolves to `main`, so a later base of `release` can only
+          // come from the worktree base layer.
+          const primary = join(home, "primary");
+          run("git", ["init", "-q", "--initial-branch=main", primary], home);
+          writeFileSync(join(primary, "file.txt"), "hello\n");
+          run("git", ["add", "file.txt"], primary);
+          run("git", ["commit", "-q", "-m", "commit A"], primary);
+          run("git", ["branch", "release"], primary);
+          writeFileSync(join(primary, "file2.txt"), "world\n");
+          run("git", ["add", "file2.txt"], primary);
+          run("git", ["commit", "-q", "-m", "commit B"], primary);
+        },
+      });
+
+      const primary = join(serve.home, "primary");
+
+      const res = await fetch(`${serve.baseUrl}/api/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          path: primary,
+          tool: "claude",
+          title: "diff-base-from-worktree",
+          worktree_branch: "feature/diff-base-from-worktree",
+          create_new_branch: true,
+          base_branch: "release",
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(`POST /api/sessions failed: ${res.status} ${await res.text()}`);
+      }
+      const created = (await res.json()) as { id: string };
+
+      // No override set: the diff base follows the worktree's recorded
+      // base branch, not the auto-detected `main`.
+      const defaultBases = await diffBases(serve, created.id);
+      expect(defaultBases.length).toBe(1);
+      expect(defaultBases[0].base_branch).toBe("release");
+
+      // An explicit per-session override outranks the worktree base.
+      await setDiffBase(serve, created.id, "main");
+      const overriddenBases = await diffBases(serve, created.id);
+      expect(overriddenBases[0].base_branch).toBe("main");
+
+      // Clearing the override falls back to the worktree base again.
+      await setDiffBase(serve, created.id, "");
+      const clearedBases = await diffBases(serve, created.id);
+      expect(clearedBases[0].base_branch).toBe("release");
+    } finally {
+      await serve?.stop();
+    }
+  },
+);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

> **PR stack:** This PR is stacked on top of #1979 and targets its branch (`default-branch-in-project-viewer-editor`), not `main`. Review and merge #1979 first; this PR will retarget to `main` automatically once #1979 lands. The diff shown here is only this PR's changes.

## Description

When a managed worktree was created from a base branch X (an explicit session base, a per-project default, or the global/profile `worktree.default_base_branch`), the diff viewer now defaults its comparison to X instead of the repo's auto-detected default. Previously the diff base resolved only from an explicit per-session override, `DiffConfig.default_branch`, or auto-detection, so a worktree forked off `release` still compared against `main` until the user changed it by hand.

The session already records the resolved base on `worktree_info.base_branch`, so this wires that value into the existing precedence chain, slotted just below the explicit per-session override and above the profile default and auto-detection. Both surfaces are covered: the TUI diff view (`DiffView::new_for_session`) and the web diff endpoint (`resolve_diff_base`). For multi-repo workspaces, each repo's per-repo diff uses that repo's recorded base.

Resolution precedence is now: per-session override, then worktree base, then `diff.default_branch`, then auto-detection.

Follow-up from #1943.

Closes #1951

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a worktree session off a non-default base (e.g. `aoe add` with base `release` while the repo default is `main`).
- [ ] Open the TUI diff view for that session; confirm it compares against `release`, not `main`, without pressing `b`.
- [ ] Open the same session in the web dashboard; confirm the `vs <ref>` chip shows `release` by default.
- [ ] Set an explicit override (press `b` in the TUI, or use the base picker chip); confirm the override wins over the worktree base.
- [ ] Clear the override; confirm the comparison falls back to the worktree base (`release`).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [ ] Skipped a test, because: the TUI precedence is a thin `.or_else` layer over the same resolved `worktree_info.base_branch`; the web live spec exercises the resolution end-to-end and the `resolve_diff_base` unit test pins the ordering.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls, and own the testing steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This pull request updates how the diff viewer selects its default comparison branch. Previously, the diff viewer always defaulted to the repository's auto-detected default branch (e.g., `main`), regardless of what base branch the worktree was created from. Now, it intelligently defaults to the worktree's recorded base branch instead—providing a more intuitive experience when working with worktrees created from non-default branches (like `release`).

## What Was Added

- **Decision precedence layer**: A new priority level in how the diff viewer chooses its base branch. The worktree's base branch is now consulted as the second priority, after explicit user overrides but before profile defaults and auto-detection.
- **TUI support**: The TUI diff viewer now accepts and uses the worktree's base branch when constructing diff views.
- **Web API integration**: The server-side diff resolution logic now includes the worktree's base branch in its decision chain.
- **End-to-end test**: A new Playwright test validates the complete flow: verifies the worktree base is used by default, confirms explicit overrides take precedence, and ensures the view falls back to the worktree base when overrides are cleared.
- **Documentation**: Updated guides clarifying the new precedence order for diff base selection.

## What Was Updated

- TUI: `DiffView::new_for_session()` signature now includes a `worktree_base` parameter; the home input logic now extracts the base branch from the selected worktree and passes it through.
- Server: `DiffContext` now carries the worktree's recorded base branch; the diff base resolution function prioritizes it appropriately.
- Test coverage: Added new web test spec to the coverage matrix.

## Benefits

- **Intuitive defaults**: Users creating worktrees from non-default branches will see diffs comparing against their intended base by default, eliminating confusion.
- **Flexibility preserved**: Explicit overrides still win, giving users full control when needed.
- **Consistent experience**: Both TUI and web interfaces behave the same way.
- **Multi-repo support**: Each repository in a workspace can have its own recorded base, and each is respected independently.

## Technical Details

The implementation:
- Leverages the `worktree_info.base_branch` value already recorded during worktree creation.
- Threads this value through two code paths: the TUI's `DiffView::new_for_session()` and the server's `resolve_diff_base()` function.
- Establishes a new resolution chain: per-session override → worktree base → `diff.default_branch` config → auto-detection fallback.
- Includes unit tests for the server-side logic and end-to-end Playwright test for the web surface.
- Updates related documentation files to describe the new behavior and precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->