### PR TITLE
feat(projects): honor per-project default base branch for the launch repo and allow editing it

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -757,7 +757,7 @@ Add a project to the registry
   Possible values: `global`, `profile`
 
 * `--allow-override` — Allow registering this path even if it already exists in the other scope. Without this flag the command errors when the same canonical path is already registered globally (when adding to profile) or in any profile (when adding globally). When override is allowed and both scopes hold the same path, the profile entry shadows the global one
-* `--base-branch <BASE_BRANCH>` — Default base branch for new worktree branches created against this project in a multi-repo workspace. When omitted, falls back to the global/profile `worktree.default_base_branch`, then the repo's detected default branch
+* `--base-branch <BASE_BRANCH>` — Default base branch for new worktree branches created against this project, whether it is the launch repo or an extra repo in a multi-repo workspace. An explicit session base wins; when omitted, falls back to the global/profile `worktree.default_base_branch`, then the repo's detected default branch
 
 
 

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -73,8 +73,9 @@ pub struct ProjectAddArgs {
     allow_override: bool,
 
     /// Default base branch for new worktree branches created against this
-    /// project in a multi-repo workspace. When omitted, falls back to the
-    /// global/profile `worktree.default_base_branch`, then the repo's
+    /// project, whether it is the launch repo or an extra repo in a multi-repo
+    /// workspace. An explicit session base wins; when omitted, falls back to
+    /// the global/profile `worktree.default_base_branch`, then the repo's
     /// detected default branch.
     #[arg(long = "base-branch")]
     base_branch: Option<String>,

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -33,7 +33,7 @@ pub use acp::{
 pub use client_log::post_client_log;
 pub use git::{clone_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
-pub use projects::{create_project, delete_project, list_projects};
+pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
     list_sessions, read_output, rename_session, send_message, session_diff_file,
@@ -168,7 +168,7 @@ mod tests {
             (
                 "api/projects.rs",
                 include_str!("projects.rs"),
-                &["create_project", "delete_project"],
+                &["create_project", "delete_project", "update_project"],
             ),
             (
                 "api/system.rs",
@@ -310,7 +310,7 @@ mod tests {
             (
                 "api/projects.rs",
                 include_str!("projects.rs"),
-                &["create_project", "delete_project"],
+                &["create_project", "delete_project", "update_project"],
             ),
             (
                 "api/system.rs",

--- a/src/server/api/projects.rs
+++ b/src/server/api/projects.rs
@@ -282,12 +282,24 @@ pub async fn delete_project(
     }
 }
 
-#[derive(Deserialize)]
-pub struct UpdateProjectBody {
-    /// New default base branch. The key is required (a missing key is a
-    /// malformed request); `null` or an empty string clears it, a value sets
-    /// it. Empty/whitespace is normalized to unset by the registry.
-    pub default_base_branch: Option<String>,
+/// Extract the new `default_base_branch` from a PATCH body. The key is
+/// required: a plain `Option<String>` field can't enforce that because serde
+/// deserializes a missing field to `None`, indistinguishable from an explicit
+/// `null`, so a `{}` body would silently clear the stored value. Inspect the
+/// raw JSON instead. `Ok(None)` clears, `Ok(Some(_))` sets, `Err((code, msg))`
+/// is a malformed request. Empty/whitespace is normalized to unset downstream.
+fn parse_base_branch_update(
+    body: &serde_json::Value,
+) -> Result<Option<String>, (&'static str, &'static str)> {
+    match body.get("default_base_branch") {
+        None => Err((
+            "missing_field",
+            "default_base_branch is required (use null to clear)",
+        )),
+        Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(s)) => Ok(Some(s.clone())),
+        Some(_) => Err(("bad_field", "default_base_branch must be a string or null")),
+    }
 }
 
 #[tracing::instrument(target = "http.api.projects", skip_all, fields(name = %name, scope = q.scope.as_deref().unwrap_or("global")))]
@@ -295,7 +307,7 @@ pub async fn update_project(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
     Query(q): Query<DeleteQuery>,
-    body: Result<Json<UpdateProjectBody>, axum::extract::rejection::JsonRejection>,
+    body: Result<Json<serde_json::Value>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
         tracing::warn!(target: "http.api.projects", reason = "read_only", "rejected update");
@@ -329,7 +341,19 @@ pub async fn update_project(
         }
     };
 
-    match projects::update_base_branch(&state.profile, scope, &name, body.default_base_branch) {
+    let base = match parse_base_branch_update(&body) {
+        Ok(base) => base,
+        Err((err, msg)) => {
+            tracing::warn!(target: "http.api.projects", reason = err, "rejected update");
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": err, "message": msg })),
+            )
+                .into_response();
+        }
+    };
+
+    match projects::update_base_branch(&state.profile, scope, &name, base) {
         Ok(updated) => {
             tracing::info!(target: "http.api.projects", name = %updated.name, path = %updated.path, scope = updated.scope.as_str(), "updated project");
             (StatusCode::OK, Json(ProjectResponse::from(updated))).into_response()
@@ -358,5 +382,38 @@ pub async fn update_project(
             )
                 .into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_base_branch_update;
+    use serde_json::json;
+
+    #[test]
+    fn base_branch_update_requires_the_key() {
+        // A missing key is a malformed request, not an intent to clear: this is
+        // the guard that stops a `{}` body from silently wiping the default.
+        assert_eq!(
+            parse_base_branch_update(&json!({})),
+            Err((
+                "missing_field",
+                "default_base_branch is required (use null to clear)"
+            ))
+        );
+        // null and string both parse; null/empty clears downstream, a value sets.
+        assert_eq!(
+            parse_base_branch_update(&json!({"default_base_branch": null})),
+            Ok(None)
+        );
+        assert_eq!(
+            parse_base_branch_update(&json!({"default_base_branch": "develop"})),
+            Ok(Some("develop".to_string()))
+        );
+        // Wrong type is rejected.
+        assert_eq!(
+            parse_base_branch_update(&json!({"default_base_branch": 42})),
+            Err(("bad_field", "default_base_branch must be a string or null"))
+        );
     }
 }

--- a/src/server/api/projects.rs
+++ b/src/server/api/projects.rs
@@ -101,7 +101,8 @@ pub struct CreateProjectBody {
     #[serde(default)]
     pub allow_override: bool,
     /// Default base branch for new worktree branches created against this
-    /// project in a multi-repo workspace. Empty/whitespace is treated as unset.
+    /// project, whether it is the launch repo or an extra repo in a multi-repo
+    /// workspace. Empty/whitespace is treated as unset.
     #[serde(default)]
     pub default_base_branch: Option<String>,
 }
@@ -275,6 +276,85 @@ pub async fn delete_project(
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"error": "remove_failed", "message": e.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct UpdateProjectBody {
+    /// New default base branch. The key is required (a missing key is a
+    /// malformed request); `null` or an empty string clears it, a value sets
+    /// it. Empty/whitespace is normalized to unset by the registry.
+    pub default_base_branch: Option<String>,
+}
+
+#[tracing::instrument(target = "http.api.projects", skip_all, fields(name = %name, scope = q.scope.as_deref().unwrap_or("global")))]
+pub async fn update_project(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Query(q): Query<DeleteQuery>,
+    body: Result<Json<UpdateProjectBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        tracing::warn!(target: "http.api.projects", reason = "read_only", "rejected update");
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+
+    let Json(body) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+
+    let scope = match q.scope.as_deref() {
+        Some("profile") => ProjectScope::Profile,
+        Some("global") | None => ProjectScope::Global,
+        Some(other) => {
+            tracing::warn!(target: "http.api.projects", scope = other, "rejected bad scope");
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "bad_scope",
+                    "message": format!("Unknown scope '{}'. Use 'global' or 'profile'.", other),
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    match projects::update_base_branch(&state.profile, scope, &name, body.default_base_branch) {
+        Ok(updated) => {
+            tracing::info!(target: "http.api.projects", name = %updated.name, path = %updated.path, scope = updated.scope.as_str(), "updated project");
+            (StatusCode::OK, Json(ProjectResponse::from(updated))).into_response()
+        }
+        Err(RegistryError::NotFound(msg)) => {
+            tracing::warn!(target: "http.api.projects", reason = "not_found", message = %msg, "rejected update");
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "not_found", "message": msg})),
+            )
+                .into_response()
+        }
+        Err(RegistryError::Conflict(msg)) => {
+            tracing::warn!(target: "http.api.projects", reason = "conflict", message = %msg, "rejected update");
+            (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({"error": "conflict", "message": msg})),
+            )
+                .into_response()
+        }
+        Err(RegistryError::Other(e)) => {
+            tracing::error!(target: "http.api.projects", error = %e, "update_failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "update_failed", "message": e.to_string()})),
             )
                 .into_response()
         }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1561,6 +1561,7 @@ mod tests {
         assert!(!requires_elevation(&Method::POST, "/api/git/clone"));
         assert!(!requires_elevation(&Method::POST, "/api/projects"));
         assert!(!requires_elevation(&Method::DELETE, "/api/projects/myproj"));
+        assert!(!requires_elevation(&Method::PATCH, "/api/projects/myproj"));
         assert!(!requires_elevation(&Method::POST, "/api/push/subscribe"));
         assert!(!requires_elevation(&Method::POST, "/api/push/unsubscribe"));
         // Cosmetic UI state: marking the web tour seen flips one bool and

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1230,7 +1230,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/projects",
             get(api::list_projects).post(api::create_project),
         )
-        .route("/api/projects/{name}", delete(api::delete_project))
+        .route(
+            "/api/projects/{name}",
+            patch(api::update_project).delete(api::delete_project),
+        )
         .route("/api/docker/status", get(api::docker_status))
         // Settings + themes
         .route(

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -98,9 +98,28 @@ pub(crate) fn resolve_base_branch(
         .or_else(|| normalize_base(global))
 }
 
+/// Resolve one repo's effective base branch, consulting its registered
+/// per-project default. The registry stores each project at its repo root, so
+/// the lookup keys on `find_main_repo(repo_path)`; `repo_path` itself may be a
+/// subdirectory or a worktree, which would miss a root-keyed entry. Precedence:
+/// explicit session base > per-project default > global/profile default.
+fn resolve_repo_base_branch(
+    repo_path: &std::path::Path,
+    session: Option<&str>,
+    project_bases: &std::collections::HashMap<String, String>,
+    global: Option<&str>,
+) -> Option<String> {
+    let main_repo =
+        GitWorktree::find_main_repo(repo_path).unwrap_or_else(|_| repo_path.to_path_buf());
+    let key = crate::session::projects::canonical_key(&main_repo.to_string_lossy());
+    let project = project_bases.get(&key).map(String::as_str);
+    resolve_base_branch(session, project, global)
+}
+
 /// Map of canonical repo path to configured default base branch for every
 /// registered project (global + profile) that sets one. Used to fill in the
-/// per-project layer of `resolve_base_branch` when building a workspace.
+/// per-project layer of `resolve_repo_base_branch` for the launch repo and any
+/// extra repos when building a session.
 pub(crate) fn project_base_branches(profile: &str) -> std::collections::HashMap<String, String> {
     crate::session::projects::load_merged(profile)
         .unwrap_or_else(|e| {
@@ -110,7 +129,7 @@ pub(crate) fn project_base_branches(profile: &str) -> std::collections::HashMap<
             tracing::warn!(
                 target: "session.create",
                 "Failed to load project registry for base-branch defaults; \
-                 extra repos fall back to the global default: {e}"
+                 repos fall back to the global default: {e}"
             );
             Vec::new()
         })
@@ -462,20 +481,18 @@ pub fn build_instance(
             let session_base = params.base_branch.as_deref();
             let global_default = config.worktree.default_base_branch.as_deref();
             let project_bases = project_base_branches(profile);
-            let resolve_extra = |path: &std::path::Path| -> Option<String> {
-                let project = project_bases
-                    .get(&crate::session::projects::canonical_key(
-                        &path.to_string_lossy(),
-                    ))
-                    .map(String::as_str);
-                resolve_base_branch(session_base, project, global_default)
-            };
 
-            // The primary repo is the launch repo, not a registered extra
-            // project, so it never consults the per-project layer: explicit
-            // session base, then the global/profile default.
+            // Every repo, including the launch repo, forks from its own
+            // registered per-project default when no explicit session base is
+            // given. Keyed by repo root so a launch path inside a subdirectory
+            // still matches a root-registered project.
             let primary = WorkspaceRepoSpec {
-                base_branch: resolve_base_branch(session_base, None, global_default),
+                base_branch: resolve_repo_base_branch(
+                    &primary_path,
+                    session_base,
+                    &project_bases,
+                    global_default,
+                ),
                 path: primary_path,
             };
             let extra_repos: Vec<WorkspaceRepoSpec> = params
@@ -484,7 +501,12 @@ pub fn build_instance(
                 .map(|p| {
                     let path = PathBuf::from(p);
                     WorkspaceRepoSpec {
-                        base_branch: resolve_extra(&path),
+                        base_branch: resolve_repo_base_branch(
+                            &path,
+                            session_base,
+                            &project_bases,
+                            global_default,
+                        ),
                         path,
                     }
                 })
@@ -567,11 +589,14 @@ pub fn build_instance(
                     return Err(GitError::WorktreeAlreadyExists(worktree_path.clone()).into());
                 }
 
-                // Single-repo sessions only have the launch repo, so fall back
-                // from the explicit session base to the global/profile default.
-                let base = resolve_base_branch(
+                // The launch repo forks from its registered per-project default
+                // when no explicit session base is given (then global/profile,
+                // then auto-detect). Keyed by repo root via the shared helper.
+                let project_bases = project_base_branches(profile);
+                let base = resolve_repo_base_branch(
+                    &main_repo_path,
                     params.base_branch.as_deref(),
-                    None,
+                    &project_bases,
                     config.worktree.default_base_branch.as_deref(),
                 );
 
@@ -1249,6 +1274,58 @@ mod tests {
             Some("global".to_string())
         );
         assert_eq!(resolve_base_branch(Some("  "), None, None), None);
+    }
+
+    #[test]
+    fn resolve_repo_base_branch_keys_launch_repo_by_root() {
+        let (parent, _tip) = init_repo_with_branch("proj", "release");
+        let root = parent.path().join("proj");
+        let key = crate::session::projects::canonical_key(&root.to_string_lossy());
+        let mut bases = std::collections::HashMap::new();
+        bases.insert(key, "develop".to_string());
+
+        // No explicit session base: the launch repo forks from its registered
+        // per-project default.
+        assert_eq!(
+            resolve_repo_base_branch(&root, None, &bases, Some("global")),
+            Some("develop".to_string())
+        );
+
+        // Explicit session base still wins over the per-project default.
+        assert_eq!(
+            resolve_repo_base_branch(&root, Some("hotfix"), &bases, Some("global")),
+            Some("hotfix".to_string())
+        );
+
+        // No registered entry for this repo: fall back to the global default.
+        let empty = std::collections::HashMap::new();
+        assert_eq!(
+            resolve_repo_base_branch(&root, None, &empty, Some("global")),
+            Some("global".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_repo_base_branch_matches_when_launching_from_a_worktree() {
+        // A session launched from a linked worktree of the registered repo
+        // still resolves the project default, because find_main_repo maps the
+        // worktree back to its main repo (the registry's key).
+        let (parent, _tip) = init_repo_with_branch("proj", "release");
+        let root = parent.path().join("proj");
+        let main_wt = GitWorktree::new(root.clone()).unwrap();
+        let wt_path = parent.path().join("proj-wt");
+        main_wt
+            .create_worktree("wt-branch", &wt_path, true, None)
+            .unwrap();
+
+        let key = crate::session::projects::canonical_key(&root.to_string_lossy());
+        let mut bases = std::collections::HashMap::new();
+        bases.insert(key, "develop".to_string());
+
+        assert_eq!(
+            resolve_repo_base_branch(&wt_path, None, &bases, None),
+            Some("develop".to_string())
+        );
     }
 
     /// Create a repo with `main` plus a second branch holding a distinct

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -65,9 +65,10 @@ pub struct Project {
     pub name: String,
     pub path: String,
     /// Default base branch for new worktree branches created against this
-    /// project's repo in a multi-repo workspace. When `None`, resolution falls
-    /// back to the global/profile `worktree.default_base_branch`, then the
-    /// repo's detected default branch.
+    /// project's repo, whether it is the launch repo or an extra repo in a
+    /// multi-repo workspace. An explicit session base wins; when `None`,
+    /// resolution falls back to the global/profile `worktree.default_base_branch`,
+    /// then the repo's detected default branch.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_base_branch: Option<String>,
     /// Populated by the loader; not persisted.
@@ -285,6 +286,45 @@ pub fn remove(
     Ok(removed)
 }
 
+/// Set or clear the default base branch on the entry matching `name_or_path`
+/// in the given scope. `base` is normalized via `Project::with_base_branch`
+/// (trimmed; empty becomes unset). Returns the updated project, or `NotFound`
+/// if no entry matches.
+///
+/// This is a read-modify-write over the scope's registry file. There is no
+/// optimistic-concurrency guard; for a single-user local tool last-writer-wins
+/// across racing `aoe` processes is acceptable.
+pub fn update_base_branch(
+    profile: &str,
+    scope: ProjectScope,
+    name_or_path: &str,
+    base: Option<String>,
+) -> std::result::Result<Project, RegistryError> {
+    let mut existing = match scope {
+        ProjectScope::Global => load_global().map_err(RegistryError::Other)?,
+        ProjectScope::Profile => load_profile(profile).map_err(RegistryError::Other)?,
+    };
+
+    let canonical_target = canonical_key(name_or_path);
+    let idx = existing
+        .iter()
+        .position(|p| {
+            p.name.eq_ignore_ascii_case(name_or_path) || canonical_key(&p.path) == canonical_target
+        })
+        .ok_or_else(|| {
+            RegistryError::NotFound(format!(
+                "No project '{}' in {} scope",
+                name_or_path,
+                scope.as_str()
+            ))
+        })?;
+
+    existing[idx] = existing[idx].clone().with_base_branch(base);
+    let updated = existing[idx].clone();
+    save_scope(profile, scope, &existing).map_err(RegistryError::Other)?;
+    Ok(updated)
+}
+
 /// Resolve a list of project names against the merged registry. Errors on the
 /// first unknown name with the available names listed.
 pub fn resolve_names(profile: &str, names: &[String]) -> Result<Vec<Project>> {
@@ -362,6 +402,52 @@ mod tests {
         let loaded = load_global()?;
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].default_base_branch.as_deref(), Some("develop"));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn update_base_branch_sets_clears_and_reports_not_found() -> Result<()> {
+        let temp = tempdir()?;
+        setup(temp.path());
+        let repo = temp.path().join("repoUpd");
+        let _ = git2::Repository::init(&repo);
+
+        add(
+            "default",
+            ProjectScope::Global,
+            Project::new("repoUpd", repo.to_string_lossy(), ProjectScope::Global),
+            false,
+        )?;
+
+        // Set, looking the project up by name.
+        let updated = update_base_branch(
+            "default",
+            ProjectScope::Global,
+            "repoUpd",
+            Some("develop".into()),
+        )?;
+        assert_eq!(updated.default_base_branch.as_deref(), Some("develop"));
+        assert_eq!(
+            load_global()?[0].default_base_branch.as_deref(),
+            Some("develop")
+        );
+
+        // Whitespace clears it back to unset, looking up by canonical path.
+        let cleared = update_base_branch(
+            "default",
+            ProjectScope::Global,
+            &repo.to_string_lossy(),
+            Some("   ".into()),
+        )?;
+        assert_eq!(cleared.default_base_branch, None);
+        assert_eq!(load_global()?[0].default_base_branch, None);
+
+        // Unknown project is a NotFound.
+        assert!(matches!(
+            update_base_branch("default", ProjectScope::Global, "nope", Some("x".into())),
+            Err(RegistryError::NotFound(_))
+        ));
         Ok(())
     }
 

--- a/web/src/components/ProjectsView.tsx
+++ b/web/src/components/ProjectsView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { ProjectInfo } from "../lib/types";
-import { fetchProjects, createProject, deleteProject } from "../lib/api";
+import { fetchProjects, createProject, deleteProject, updateProject } from "../lib/api";
 import { DirectoryBrowser } from "./DirectoryBrowser";
 
 interface Props {
@@ -22,6 +22,13 @@ export function ProjectsView({ onClose, readOnly }: Props) {
   const [allowOverride, setAllowOverride] = useState(false);
   const [showBrowser, setShowBrowser] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+
+  // Inline per-row base-branch edit state, keyed by `${scope}:${path}`.
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editBranch, setEditBranch] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
+
+  const projectKey = (p: ProjectInfo) => `${p.scope}:${p.path}`;
 
   const reload = async () => {
     setLoading(true);
@@ -69,6 +76,31 @@ export function ProjectsView({ onClose, readOnly }: Props) {
       setError(result.error || "Remove failed");
       return;
     }
+    await reload();
+  };
+
+  const startEdit = (p: ProjectInfo) => {
+    setError(null);
+    setEditingKey(projectKey(p));
+    setEditBranch(p.default_base_branch ?? "");
+  };
+
+  const cancelEdit = () => {
+    setEditingKey(null);
+    setEditBranch("");
+  };
+
+  const handleSaveEdit = async (p: ProjectInfo) => {
+    setSavingEdit(true);
+    setError(null);
+    const trimmed = editBranch.trim();
+    const result = await updateProject(p.name, p.scope, trimmed || null);
+    setSavingEdit(false);
+    if (!result.ok) {
+      setError(result.error || "Update failed");
+      return;
+    }
+    cancelEdit();
     await reload();
   };
 
@@ -149,7 +181,7 @@ export function ProjectsView({ onClose, readOnly }: Props) {
               className="w-full px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 mb-3"
             />
 
-            <label className="block text-[12px] text-text-dim mb-1">Default base branch for extra repos (optional)</label>
+            <label className="block text-[12px] text-text-dim mb-1">Default base branch (optional)</label>
             <input
               type="text"
               value={baseBranch}
@@ -269,21 +301,62 @@ export function ProjectsView({ onClose, readOnly }: Props) {
                   <p className="text-[11px] font-mono text-text-dim truncate mt-0.5" title={p.path}>
                     {p.path}
                   </p>
-                  {p.default_base_branch && (
-                    <p className="text-[11px] text-text-dim mt-0.5">
-                      base branch:{" "}
-                      <span className="font-mono text-text-secondary">{p.default_base_branch}</span>
-                    </p>
+                  {editingKey === projectKey(p) ? (
+                    <div className="mt-1.5 flex items-center gap-2">
+                      <input
+                        type="text"
+                        autoFocus
+                        value={editBranch}
+                        onChange={(e) => setEditBranch(e.target.value)}
+                        placeholder="blank = inherit global default, then auto-detect"
+                        className="flex-1 px-2 py-1 text-[12px] bg-surface-900 border border-surface-700/40 rounded text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 font-mono"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => handleSaveEdit(p)}
+                        disabled={savingEdit}
+                        className={`px-2 py-1 text-xs rounded-md font-medium ${
+                          savingEdit
+                            ? "bg-brand-600/40 text-surface-900/60 cursor-not-allowed"
+                            : "bg-brand-600 hover:bg-brand-700 text-surface-900 cursor-pointer"
+                        }`}
+                      >
+                        {savingEdit ? "Saving…" : "Save"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={cancelEdit}
+                        className="px-2 py-1 text-xs border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    p.default_base_branch && (
+                      <p className="text-[11px] text-text-dim mt-0.5">
+                        base branch:{" "}
+                        <span className="font-mono text-text-secondary">{p.default_base_branch}</span>
+                      </p>
+                    )
                   )}
                 </div>
-                {!readOnly && (
-                  <button
-                    type="button"
-                    onClick={() => handleRemove(p)}
-                    className="px-2 py-1 text-xs border border-surface-700 text-text-dim hover:text-status-error hover:border-status-error/40 rounded-md cursor-pointer"
-                  >
-                    Remove
-                  </button>
+                {!readOnly && editingKey !== projectKey(p) && (
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => startEdit(p)}
+                      className="px-2 py-1 text-xs border border-surface-700 text-text-dim hover:text-text-primary hover:border-surface-700 rounded-md cursor-pointer"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(p)}
+                      className="px-2 py-1 text-xs border border-surface-700 text-text-dim hover:text-status-error hover:border-status-error/40 rounded-md cursor-pointer"
+                    >
+                      Remove
+                    </button>
+                  </div>
                 )}
               </li>
             ))}

--- a/web/src/components/ProjectsView.tsx
+++ b/web/src/components/ProjectsView.tsx
@@ -12,9 +12,12 @@ export function ProjectsView({ onClose, readOnly }: Props) {
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [showAdd, setShowAdd] = useState(false);
+  // The project currently being edited, or null when adding / closed. The form
+  // modal opens when `showAdd` is true (add) or `editing` is set (edit).
+  const [editing, setEditing] = useState<ProjectInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Add-form state
+  // Form state, shared by the add and edit modes.
   const [path, setPath] = useState("");
   const [name, setName] = useState("");
   const [baseBranch, setBaseBranch] = useState("");
@@ -23,12 +26,8 @@ export function ProjectsView({ onClose, readOnly }: Props) {
   const [showBrowser, setShowBrowser] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
-  // Inline per-row base-branch edit state, keyed by `${scope}:${path}`.
-  const [editingKey, setEditingKey] = useState<string | null>(null);
-  const [editBranch, setEditBranch] = useState("");
-  const [savingEdit, setSavingEdit] = useState(false);
-
-  const projectKey = (p: ProjectInfo) => `${p.scope}:${p.path}`;
+  const isEdit = editing !== null;
+  const formOpen = (showAdd || isEdit) && !readOnly;
 
   const reload = async () => {
     setLoading(true);
@@ -40,6 +39,40 @@ export function ProjectsView({ onClose, readOnly }: Props) {
   useEffect(() => {
     reload();
   }, []);
+
+  const resetForm = () => {
+    setPath("");
+    setName("");
+    setBaseBranch("");
+    setScope("global");
+    setAllowOverride(false);
+  };
+
+  const openAdd = () => {
+    setError(null);
+    resetForm();
+    setEditing(null);
+    setShowAdd(true);
+  };
+
+  const openEdit = (p: ProjectInfo) => {
+    setError(null);
+    setShowAdd(false);
+    setPath(p.path);
+    setName(p.name);
+    setBaseBranch(p.default_base_branch ?? "");
+    setScope(p.scope);
+    setAllowOverride(false);
+    setEditing(p);
+  };
+
+  const closeForm = () => {
+    setShowAdd(false);
+    setEditing(null);
+    setShowBrowser(false);
+    resetForm();
+    setError(null);
+  };
 
   const handleAdd = async () => {
     const trimmedPath = path.trim();
@@ -58,13 +91,25 @@ export function ProjectsView({ onClose, readOnly }: Props) {
       setError(result.error || "Add failed");
       return;
     }
-    setPath("");
-    setName("");
-    setBaseBranch("");
-    setScope("global");
-    setAllowOverride(false);
-    setShowAdd(false);
-    setShowBrowser(false);
+    closeForm();
+    await reload();
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editing) return;
+    setSubmitting(true);
+    setError(null);
+    const result = await updateProject(
+      editing.name,
+      editing.scope,
+      baseBranch.trim() || null,
+    );
+    setSubmitting(false);
+    if (!result.ok) {
+      setError(result.error || "Update failed");
+      return;
+    }
+    closeForm();
     await reload();
   };
 
@@ -79,30 +124,8 @@ export function ProjectsView({ onClose, readOnly }: Props) {
     await reload();
   };
 
-  const startEdit = (p: ProjectInfo) => {
-    setError(null);
-    setEditingKey(projectKey(p));
-    setEditBranch(p.default_base_branch ?? "");
-  };
-
-  const cancelEdit = () => {
-    setEditingKey(null);
-    setEditBranch("");
-  };
-
-  const handleSaveEdit = async (p: ProjectInfo) => {
-    setSavingEdit(true);
-    setError(null);
-    const trimmed = editBranch.trim();
-    const result = await updateProject(p.name, p.scope, trimmed || null);
-    setSavingEdit(false);
-    if (!result.ok) {
-      setError(result.error || "Update failed");
-      return;
-    }
-    cancelEdit();
-    await reload();
-  };
+  const lockedFieldClass =
+    "w-full px-3 py-2 text-sm bg-surface-900/60 border border-surface-700/30 rounded-md text-text-dim cursor-not-allowed mb-3";
 
   return (
     <div className="flex flex-col h-full bg-surface-900">
@@ -114,10 +137,10 @@ export function ProjectsView({ onClose, readOnly }: Props) {
           </p>
         </div>
         <div className="flex gap-2">
-          {!readOnly && !showAdd && (
+          {!readOnly && !formOpen && (
             <button
               type="button"
-              onClick={() => setShowAdd(true)}
+              onClick={openAdd}
               className="px-3 py-1.5 text-sm bg-brand-600 hover:bg-brand-700 text-surface-900 rounded-md cursor-pointer font-medium"
             >
               + Add project
@@ -139,46 +162,72 @@ export function ProjectsView({ onClose, readOnly }: Props) {
         </div>
       )}
 
-      {showAdd && !readOnly && (
-        <div className="px-4 pt-4">
-          <div className="bg-surface-800 border border-surface-700/40 rounded-lg p-4">
-            <h2 className="text-sm font-medium text-text-primary mb-3">Add project</h2>
+      {formOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={closeForm}
+        >
+          <div
+            className="w-full max-w-lg max-h-[90vh] overflow-y-auto bg-surface-800 border border-surface-700/40 rounded-lg p-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-sm font-medium text-text-primary mb-3">
+              {isEdit ? `Edit project '${editing?.name}'` : "Add project"}
+            </h2>
 
             <label className="block text-[12px] text-text-dim mb-1">Path</label>
-            <div className="flex gap-2 mb-3">
+            {isEdit ? (
               <input
                 type="text"
                 value={path}
-                onChange={(e) => setPath(e.target.value)}
-                placeholder="/path/to/repo"
-                className="flex-1 px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 font-mono"
+                disabled
+                title="Path is fixed; remove and re-add the project to change it"
+                className={`${lockedFieldClass} font-mono`}
               />
-              <button
-                type="button"
-                onClick={() => setShowBrowser((b) => !b)}
-                className="px-3 py-2 text-sm border border-surface-700 text-text-secondary hover:bg-surface-700/40 rounded-md cursor-pointer"
-              >
-                {showBrowser ? "Hide browser" : "Browse"}
-              </button>
-            </div>
-            {showBrowser && (
-              <div className="mb-3">
-                <DirectoryBrowser
-                  onSelect={(p) => {
-                    setPath(p);
-                    setShowBrowser(false);
-                  }}
-                />
-              </div>
+            ) : (
+              <>
+                <div className="flex gap-2 mb-3">
+                  <input
+                    type="text"
+                    value={path}
+                    onChange={(e) => setPath(e.target.value)}
+                    placeholder="/path/to/repo"
+                    className="flex-1 px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowBrowser((b) => !b)}
+                    className="px-3 py-2 text-sm border border-surface-700 text-text-secondary hover:bg-surface-700/40 rounded-md cursor-pointer"
+                  >
+                    {showBrowser ? "Hide browser" : "Browse"}
+                  </button>
+                </div>
+                {showBrowser && (
+                  <div className="mb-3">
+                    <DirectoryBrowser
+                      onSelect={(p) => {
+                        setPath(p);
+                        setShowBrowser(false);
+                      }}
+                    />
+                  </div>
+                )}
+              </>
             )}
 
-            <label className="block text-[12px] text-text-dim mb-1">Name (optional)</label>
+            <label className="block text-[12px] text-text-dim mb-1">Name{isEdit ? "" : " (optional)"}</label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="defaults to directory name"
-              className="w-full px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 mb-3"
+              disabled={isEdit}
+              placeholder={isEdit ? undefined : "defaults to directory name"}
+              title={isEdit ? "Rename is not supported yet; remove and re-add to rename" : undefined}
+              className={
+                isEdit
+                  ? lockedFieldClass
+                  : "w-full px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 mb-3"
+              }
             />
 
             <label className="block text-[12px] text-text-dim mb-1">Default base branch (optional)</label>
@@ -187,72 +236,80 @@ export function ProjectsView({ onClose, readOnly }: Props) {
               value={baseBranch}
               onChange={(e) => setBaseBranch(e.target.value)}
               placeholder="blank = inherit global default, then auto-detect"
-              className="w-full px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 font-mono mb-3"
+              className="w-full px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 font-mono mb-1"
             />
+            <p className="text-[11px] text-text-dim mb-3">
+              Base branch new worktree branches for this project fork from. An
+              explicit per-session base wins; blank inherits the global default,
+              then the repo's detected default branch.
+            </p>
 
             <label className="block text-[12px] text-text-dim mb-1">Scope</label>
-            <div className="flex gap-2 mb-4">
-              {(["global", "profile"] as const).map((s) => (
-                <button
-                  key={s}
-                  type="button"
-                  onClick={() => setScope(s)}
-                  className={`px-3 py-1.5 text-sm rounded-md cursor-pointer transition-colors ${
-                    scope === s
-                      ? "bg-brand-600/20 border border-brand-600/40 text-text-primary"
-                      : "bg-surface-900 border border-surface-700/40 text-text-secondary hover:border-surface-700"
-                  }`}
-                >
-                  {s === "global" ? "Global (all profiles)" : "Profile-only"}
-                </button>
-              ))}
-            </div>
+            {isEdit ? (
+              <p className="mb-4 text-sm text-text-secondary capitalize">{scope}</p>
+            ) : (
+              <div className="flex gap-2 mb-4">
+                {(["global", "profile"] as const).map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() => setScope(s)}
+                    className={`px-3 py-1.5 text-sm rounded-md cursor-pointer transition-colors ${
+                      scope === s
+                        ? "bg-brand-600/20 border border-brand-600/40 text-text-primary"
+                        : "bg-surface-900 border border-surface-700/40 text-text-secondary hover:border-surface-700"
+                    }`}
+                  >
+                    {s === "global" ? "Global (all profiles)" : "Profile-only"}
+                  </button>
+                ))}
+              </div>
+            )}
 
-            <label className="flex items-start gap-2 mb-4 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={allowOverride}
-                onChange={(e) => setAllowOverride(e.target.checked)}
-                className="mt-0.5 cursor-pointer"
-              />
-              <span className="text-[12px] text-text-secondary">
-                Allow override
-                <span className="block text-text-dim text-[11px] mt-0.5">
-                  Permit registering even if this path already exists in the
-                  other scope. The profile entry will shadow the global one in
-                  merged views.
+            {!isEdit && (
+              <label className="flex items-start gap-2 mb-4 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={allowOverride}
+                  onChange={(e) => setAllowOverride(e.target.checked)}
+                  className="mt-0.5 cursor-pointer"
+                />
+                <span className="text-[12px] text-text-secondary">
+                  Allow override
+                  <span className="block text-text-dim text-[11px] mt-0.5">
+                    Permit registering even if this path already exists in the
+                    other scope. The profile entry will shadow the global one in
+                    merged views.
+                  </span>
                 </span>
-              </span>
-            </label>
+              </label>
+            )}
 
             <div className="flex justify-end gap-2">
               <button
                 type="button"
-                onClick={() => {
-                  setShowAdd(false);
-                  setShowBrowser(false);
-                  setPath("");
-                  setName("");
-                  setBaseBranch("");
-                  setScope("global");
-                  setAllowOverride(false);
-                  setError(null);
-                }}
+                onClick={closeForm}
                 className="px-3 py-1.5 text-sm border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer"
               >
                 Cancel
               </button>
               <button
                 type="button"
-                onClick={handleAdd}
-                disabled={!path.trim() || submitting}
+                onClick={isEdit ? handleSaveEdit : handleAdd}
+                disabled={(!isEdit && !path.trim()) || submitting}
                 className={`px-3 py-1.5 text-sm rounded-md font-medium ${
-                  !path.trim() || submitting
+                  (!isEdit && !path.trim()) || submitting
                     ? "bg-brand-600/40 text-surface-900/60 cursor-not-allowed"
                     : "bg-brand-600 hover:bg-brand-700 text-surface-900 cursor-pointer"
                 }`}
               >
-                {submitting ? "Adding…" : "Add"}
+                {isEdit
+                  ? submitting
+                    ? "Saving…"
+                    : "Save"
+                  : submitting
+                    ? "Adding…"
+                    : "Add"}
               </button>
             </div>
           </div>
@@ -301,50 +358,18 @@ export function ProjectsView({ onClose, readOnly }: Props) {
                   <p className="text-[11px] font-mono text-text-dim truncate mt-0.5" title={p.path}>
                     {p.path}
                   </p>
-                  {editingKey === projectKey(p) ? (
-                    <div className="mt-1.5 flex items-center gap-2">
-                      <input
-                        type="text"
-                        autoFocus
-                        value={editBranch}
-                        onChange={(e) => setEditBranch(e.target.value)}
-                        placeholder="blank = inherit global default, then auto-detect"
-                        className="flex-1 px-2 py-1 text-[12px] bg-surface-900 border border-surface-700/40 rounded text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 font-mono"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => handleSaveEdit(p)}
-                        disabled={savingEdit}
-                        className={`px-2 py-1 text-xs rounded-md font-medium ${
-                          savingEdit
-                            ? "bg-brand-600/40 text-surface-900/60 cursor-not-allowed"
-                            : "bg-brand-600 hover:bg-brand-700 text-surface-900 cursor-pointer"
-                        }`}
-                      >
-                        {savingEdit ? "Saving…" : "Save"}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={cancelEdit}
-                        className="px-2 py-1 text-xs border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer"
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  ) : (
-                    p.default_base_branch && (
-                      <p className="text-[11px] text-text-dim mt-0.5">
-                        base branch:{" "}
-                        <span className="font-mono text-text-secondary">{p.default_base_branch}</span>
-                      </p>
-                    )
+                  {p.default_base_branch && (
+                    <p className="text-[11px] text-text-dim mt-0.5">
+                      base branch:{" "}
+                      <span className="font-mono text-text-secondary">{p.default_base_branch}</span>
+                    </p>
                   )}
                 </div>
-                {!readOnly && editingKey !== projectKey(p) && (
+                {!readOnly && (
                   <div className="flex gap-2">
                     <button
                       type="button"
-                      onClick={() => startEdit(p)}
+                      onClick={() => openEdit(p)}
                       className="px-2 py-1 text-xs border border-surface-700 text-text-dim hover:text-text-primary hover:border-surface-700 rounded-md cursor-pointer"
                     >
                       Edit

--- a/web/src/components/ProjectsView.tsx
+++ b/web/src/components/ProjectsView.tsx
@@ -49,6 +49,7 @@ export function ProjectsView({ onClose, readOnly }: Props) {
   };
 
   const openAdd = () => {
+    if (submitting) return;
     setError(null);
     resetForm();
     setEditing(null);
@@ -56,6 +57,7 @@ export function ProjectsView({ onClose, readOnly }: Props) {
   };
 
   const openEdit = (p: ProjectInfo) => {
+    if (submitting) return;
     setError(null);
     setShowAdd(false);
     setPath(p.path);
@@ -67,6 +69,7 @@ export function ProjectsView({ onClose, readOnly }: Props) {
   };
 
   const closeForm = () => {
+    if (submitting) return;
     setShowAdd(false);
     setEditing(null);
     setShowBrowser(false);
@@ -114,6 +117,7 @@ export function ProjectsView({ onClose, readOnly }: Props) {
   };
 
   const handleRemove = async (project: ProjectInfo) => {
+    if (submitting) return;
     if (!confirm(`Remove project '${project.name}' from ${project.scope} scope?`)) return;
     setError(null);
     const result = await deleteProject(project.name, project.scope);
@@ -164,8 +168,8 @@ export function ProjectsView({ onClose, readOnly }: Props) {
 
       {formOpen && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          onClick={closeForm}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={submitting ? undefined : closeForm}
         >
           <div
             className="w-full max-w-lg max-h-[90vh] overflow-y-auto bg-surface-800 border border-surface-700/40 rounded-lg p-4"
@@ -289,7 +293,8 @@ export function ProjectsView({ onClose, readOnly }: Props) {
               <button
                 type="button"
                 onClick={closeForm}
-                className="px-3 py-1.5 text-sm border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer"
+                disabled={submitting}
+                className="px-3 py-1.5 text-sm border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Cancel
               </button>
@@ -370,14 +375,16 @@ export function ProjectsView({ onClose, readOnly }: Props) {
                     <button
                       type="button"
                       onClick={() => openEdit(p)}
-                      className="px-2 py-1 text-xs border border-surface-700 text-text-dim hover:text-text-primary hover:border-surface-700 rounded-md cursor-pointer"
+                      disabled={submitting}
+                      className="px-2 py-1 text-xs border border-surface-700 text-text-dim hover:text-text-primary hover:border-surface-700 rounded-md cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       Edit
                     </button>
                     <button
                       type="button"
                       onClick={() => handleRemove(p)}
-                      className="px-2 py-1 text-xs border border-surface-700 text-text-dim hover:text-status-error hover:border-status-error/40 rounded-md cursor-pointer"
+                      disabled={submitting}
+                      className="px-2 py-1 text-xs border border-surface-700 text-text-dim hover:text-status-error hover:border-status-error/40 rounded-md cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       Remove
                     </button>

--- a/web/src/components/__tests__/ProjectsView.test.tsx
+++ b/web/src/components/__tests__/ProjectsView.test.tsx
@@ -20,12 +20,14 @@ vi.mock("../../lib/api", () => ({
   fetchProjects: vi.fn(),
   createProject: vi.fn(),
   deleteProject: vi.fn(),
+  updateProject: vi.fn(),
 }));
 
-import { fetchProjects, createProject } from "../../lib/api";
+import { fetchProjects, createProject, updateProject } from "../../lib/api";
 
 const mockFetch = fetchProjects as ReturnType<typeof vi.fn>;
 const mockCreate = createProject as ReturnType<typeof vi.fn>;
+const mockUpdate = updateProject as ReturnType<typeof vi.fn>;
 
 afterEach(() => {
   cleanup();
@@ -103,6 +105,40 @@ describe("ProjectsView default base branch", () => {
 
     expect(await screen.findByText("plain")).toBeTruthy();
     expect(screen.queryByText(/base branch:/i)).toBeNull();
+  });
+
+  it("edits a project's base branch via the inline editor", async () => {
+    mockFetch.mockResolvedValue([
+      { name: "extra", path: "/repo/extra", scope: "global", default_base_branch: "develop" },
+    ]);
+    mockUpdate.mockResolvedValue({ ok: true });
+
+    render(<ProjectsView onClose={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+
+    const input = screen.getByDisplayValue("develop");
+    fireEvent.change(input, { target: { value: "release" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith("extra", "global", "release"),
+    );
+  });
+
+  it("clears the base branch by saving an empty inline editor", async () => {
+    mockFetch.mockResolvedValue([
+      { name: "extra", path: "/repo/extra", scope: "global", default_base_branch: "develop" },
+    ]);
+    mockUpdate.mockResolvedValue({ ok: true });
+
+    render(<ProjectsView onClose={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByDisplayValue("develop"), { target: { value: "  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith("extra", "global", null),
+    );
   });
 
   it("clears the base branch field when the add form is cancelled", async () => {

--- a/web/src/components/__tests__/ProjectsView.test.tsx
+++ b/web/src/components/__tests__/ProjectsView.test.tsx
@@ -107,7 +107,7 @@ describe("ProjectsView default base branch", () => {
     expect(screen.queryByText(/base branch:/i)).toBeNull();
   });
 
-  it("edits a project's base branch via the inline editor", async () => {
+  it("edits a project's base branch via the edit modal", async () => {
     mockFetch.mockResolvedValue([
       { name: "extra", path: "/repo/extra", scope: "global", default_base_branch: "develop" },
     ]);
@@ -125,7 +125,7 @@ describe("ProjectsView default base branch", () => {
     );
   });
 
-  it("clears the base branch by saving an empty inline editor", async () => {
+  it("clears the base branch by saving an empty value in the edit modal", async () => {
     mockFetch.mockResolvedValue([
       { name: "extra", path: "/repo/extra", scope: "global", default_base_branch: "develop" },
     ]);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -697,6 +697,37 @@ export async function deleteProject(
   }
 }
 
+/** Update a project's default base branch. Pass `null` to clear it. */
+export async function updateProject(
+  name: string,
+  scope: "global" | "profile",
+  defaultBaseBranch: string | null,
+): Promise<{ ok: boolean; error?: string; project?: ProjectInfo }> {
+  try {
+    const res = await fetch(
+      `/api/projects/${encodeURIComponent(name)}?scope=${scope}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ default_base_branch: defaultBaseBranch }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      try {
+        const data = JSON.parse(text);
+        return { ok: false, error: data.message || `Server error (${res.status})` };
+      } catch {
+        return { ok: false, error: text || `Server error (${res.status})` };
+      }
+    }
+    const project = (await res.json()) as ProjectInfo;
+    return { ok: true, project };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
 export async function fetchDockerStatus(): Promise<DockerStatusResponse> {
   return (
     (await fetchJson<DockerStatusResponse>("/api/docker/status")) ?? {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2144,6 +2144,17 @@
       ]
     },
     {
+      "id": "story.projects-edit",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/acp-stories/projects-edit.spec.ts"
+      ],
+      "components": [
+        "web/src/components/ProjectsView.tsx"
+      ]
+    },
+    {
       "id": "story.projects-remove",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/live/acp-stories/projects-edit.spec.ts
+++ b/web/tests/live/acp-stories/projects-edit.spec.ts
@@ -60,9 +60,12 @@ base("edit a project's base branch from the Projects view", async ({ page }, tes
       timeout: 5_000,
     });
 
-    // Edit the base branch inline.
+    // Edit the base branch via the edit modal.
     await page.getByRole("button", { name: "Edit", exact: true }).click();
-    const editor = page.getByDisplayValue("develop");
+    const editor = page.getByPlaceholder(
+      "blank = inherit global default, then auto-detect",
+    );
+    await expect(editor).toHaveValue("develop");
     await editor.fill("release");
     await page.getByRole("button", { name: "Save", exact: true }).click();
 

--- a/web/tests/live/acp-stories/projects-edit.spec.ts
+++ b/web/tests/live/acp-stories/projects-edit.spec.ts
@@ -1,0 +1,84 @@
+// User story: edit a project's default base branch from the Projects view.
+//
+// Add a project with a base branch, click Edit on its row, change the branch
+// in the inline editor, Save. The new value renders, and it persists across a
+// page reload (proving the PATCH wrote through to the registry).
+
+import { mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+
+base("edit a project's base branch from the Projects view", async ({ page }, testInfo) => {
+  let projectPath = "";
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      projectPath = join(home, "story-projects-edit");
+      mkdirSync(projectPath, { recursive: true });
+      const init = spawnSync("git", ["init", "-q"], { cwd: projectPath });
+      if (init.status !== 0) {
+        throw new Error(`git init failed: ${init.stderr?.toString() ?? ""}`);
+      }
+      const commit = spawnSync(
+        "git",
+        ["commit", "--allow-empty", "-q", "-m", "init"],
+        {
+          cwd: projectPath,
+          env: {
+            ...env,
+            GIT_AUTHOR_NAME: "t",
+            GIT_AUTHOR_EMAIL: "t@t",
+            GIT_COMMITTER_NAME: "t",
+            GIT_COMMITTER_EMAIL: "t@t",
+          },
+        },
+      );
+      if (commit.status !== 0) {
+        throw new Error(`git commit failed: ${commit.stderr?.toString() ?? ""}`);
+      }
+    },
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/projects`);
+    await expect(
+      page.getByRole("heading", { name: "Projects", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Register the project with an initial base branch.
+    await page.getByRole("button", { name: "+ Add project" }).click();
+    await page.getByPlaceholder("/path/to/repo").fill(projectPath);
+    await page
+      .getByPlaceholder("blank = inherit global default, then auto-detect")
+      .fill("develop");
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await expect(page.getByText("develop", { exact: true }).first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Edit the base branch inline.
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const editor = page.getByDisplayValue("develop");
+    await editor.fill("release");
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+
+    await expect(page.getByText("release", { exact: true }).first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Reload: the change persisted to the registry.
+    await page.reload();
+    await expect(
+      page.getByRole("heading", { name: "Projects", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("release", { exact: true }).first()).toBeVisible({
+      timeout: 5_000,
+    });
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The per-project `default_base_branch` added in #1943 was only consulted for extra repos in a multi-repo workspace. The launch/primary repo passed `None` for the per-project layer in both the single-repo and multi-repo build paths, so creating a session in a project ignored its configured base branch (the common single-repo case). On top of that, the web Projects view had no way to change a project's base branch after registration; you could only add or delete.

This makes a project's default base branch apply when creating a session in that project, and lets you edit it from `/projects`.

Backend: a shared `resolve_repo_base_branch` helper keyed on the repo root (`find_main_repo`) now resolves the base for the launch repo and extras alike, so precedence is uniformly `session > per-project > global > auto-detect`. Launching from a linked worktree of a registered repo also resolves the project default. A new `projects::update_base_branch` does in-place edits (`add()` can't, it rejects same-scope collisions), exposed as `PATCH /api/projects/{name}` (key required; `null` or empty clears, a value sets; same auth posture as the other project routes).

Web: an inline per-row base-branch editor (Edit reveals an input with Save/Cancel) backed by a new `updateProject` helper. The add-form label drops the now-inaccurate "for extra repos" qualifier.

Note on scope: only the web label said "for extra repos"; the CLI/TUI never did, and the documented precedence never carved out an extras-only exception, so the launch-repo behavior is treated as a bug fix, not a compat break.

Closes #1977

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Register a project pointing at a repo, set its default base branch (e.g. `aoe project add <repo> --base-branch develop` or the `/projects` add form).
- [ ] Create a single-repo session in that project with no explicit base; confirm the new worktree branch forks from `develop` (not the repo's default branch).
- [ ] Create a session passing an explicit session base; confirm the explicit base still wins.
- [ ] On `/projects`, click Edit on the project's row, change the base branch, Save; confirm it persists across a page reload.
- [ ] Clear the base branch via the inline editor (empty Save); confirm the row no longer shows a base branch and a new session auto-detects.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added `web/tests/live/acp-stories/projects-edit.spec.ts` (`story.projects-edit`) and Vitest coverage for the inline editor (set and clear) in `ProjectsView.test.tsx`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The launch-repo resolution is covered by Rust unit tests on `resolve_repo_base_branch` (precedence, root and worktree keying) and `projects::update_base_branch` (set/clear/NotFound). The `--base-branch` CLI help text changed; `docs/cli/reference.md` was regenerated via `cargo xtask gen-docs`.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan (reviewed by a multi-model `/debate`), and implementation drafted by Claude under my direction. The debate caught the keying bug (use the repo root via `find_main_repo`, not the raw launch path) and steered the web UX to an inline editor. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed (high-level)
- Backend now honors a project's configured default_base_branch when creating sessions for the launch/primary repo (single-repo and primary in multi-repo workspaces) and when launching from linked worktrees.
- Base-branch selection is centralized with a resolver that enforces a single precedence order: explicit session > per-project > global/profile > auto-detect.
- Projects can be edited in-place: added a PATCH API to set or clear a project's default base branch, plus a web edit flow (modal) in the Projects view so projects no longer need to be deleted/recreated to change this setting.
- UI wording and forms updated to remove the misleading "for extra repos" label and to lock add/edit controls while saves are in flight.
- Tests and docs updated: Rust unit tests, Playwright E2E, Vitest component tests, and regenerated CLI docs.

## Benefits
- Consistent, predictable base-branch behavior across session types and worktrees.
- Safer, easier project management via non-destructive edits from the UI.
- Centralized resolver reduces duplication and mismatch risk.
- Improved test coverage and docs increase confidence and maintainability.

## Technical summary (concise)
- Server:
  - New helper resolve_repo_base_branch (keys by repo root via GitWorktree::find_main_repo) and used throughout session creation paths.
  - New PATCH /api/projects/{name} handler (update_project) that requires the default_base_branch key in JSON, accepts string or null (to clear), rejects missing or invalid types (400), and returns the updated project.
  - Router and security-audit tests updated to include the new handler.
- Registry/session:
  - Added session::projects::update_base_branch for read-modify-write updates (trims/normalizes empty → unset); unit tests verify set/clear and NotFound behavior.
- Web:
  - Added web/lib/api.updateProject and integrated an edit modal/flow into ProjectsView; add/edit share a single modal with guarded controls during submission.
  - Component tests mock and assert updateProject behavior; Playwright test covers edit-and-persist flow.
- Tests/docs:
  - Rust unit tests for resolver and update_base_branch; Playwright live test and Vitest component tests for UI flow.
  - CLI help/docs regenerated to reflect the broader default-base-branch behavior.
- Notes:
  - Missing-key parsing now returns 400 (fixed); some visual/style tweaks intentionally deferred to broader dashboard styling passes; AI-assisted implementation noted in commit history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->