### PR TITLE
fix(tmux): show Waiting when Claude is blocked on an approval prompt (#1913)

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3255,15 +3255,26 @@ impl Instance {
                     self.last_error = Some(summarize_error_from_pane(&pane_content));
                 }
             } else {
-                self.status = if detection_tool == "codex" && hook_status == Status::Running {
+                // Codex and Claude both report Running from hooks while their
+                // pane is actually parked on a blocking prompt, so when the
+                // hook says Running we capture the pane and let the agent's
+                // reconciler downgrade it (Codex: plan/numbered prompts;
+                // Claude: tool-approval prompts, see #1913).
+                let reconciles_running = detection_tool == "codex" || detection_tool == "claude";
+                self.status = if reconciles_running && hook_status == Status::Running {
                     match session.capture_pane(50) {
                         Ok(pane_content) => {
-                            tmux::reconcile_codex_hook_status(hook_status, &pane_content)
+                            if detection_tool == "codex" {
+                                tmux::reconcile_codex_hook_status(hook_status, &pane_content)
+                            } else {
+                                tmux::reconcile_claude_hook_status(hook_status, &pane_content)
+                            }
                         }
                         Err(e) => {
                             tracing::trace!(
-                                "status '{}': codex hook fallback pane capture failed: {}",
+                                "status '{}': {} hook fallback pane capture failed: {}",
                                 self.title,
+                                detection_tool,
                                 e
                             );
                             hook_status
@@ -7254,5 +7265,123 @@ mod tests {
                 "no tmux session must exist after refusal for id={poisoned:?}"
             );
         }
+    }
+
+    struct KillTmuxOnDrop(String);
+    impl Drop for KillTmuxOnDrop {
+        fn drop(&mut self) {
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &self.0])
+                .output();
+        }
+    }
+
+    fn tmux_available() -> bool {
+        std::process::Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// End-to-end regression for #1913 through the real status pipeline.
+    ///
+    /// A sandboxed (or hook-equipped) Claude session reports `running` from
+    /// its hook while the pane is actually parked on a tool-approval prompt:
+    /// the `Notification` -> waiting write gets clobbered by a running-mapped
+    /// hook that re-fires during concurrent turn activity, and Claude keeps
+    /// its live spinner rendered below the prompt. Before the fix the pipeline
+    /// trusted the hook's `running` and showed green; now it captures the pane
+    /// and reconciles to Waiting.
+    #[test]
+    #[serial_test::serial]
+    fn update_status_reconciles_running_hook_to_waiting_on_claude_approval_prompt() {
+        if !tmux_available() {
+            eprintln!("skipping: tmux not available");
+            return;
+        }
+
+        let mut inst = Instance::new("aoe_test_1913_wait", "/tmp");
+        assert_eq!(inst.tool, "claude");
+
+        // Pane shows the approval prompt with the live spinner still active
+        // below it, the exact shape from the issue screenshot. The spinner
+        // line means the bare pane detector would say Running, so a green
+        // reading here can only come from reconciliation doing its job.
+        let pane = "  Bash command\n    \
+touch /tmp/aoe_test_1913/marker.txt\n    Create marker file\n  \
+Do you want to proceed?\n  \u{276f} 1. Yes\n    \
+2. Yes, and always allow access to this project\n    3. No\n  \
+Esc to cancel \u{b7} Tab to amend \u{b7} ctrl+e to explain\n\
+\u{2736} Herding\u{2026} (53s \u{b7} \u{2193} 7.0k tokens)\n";
+        let pane_file = std::env::temp_dir().join(format!("aoe_test_1913_{}.txt", inst.id));
+        std::fs::write(&pane_file, pane).expect("write pane fixture");
+
+        let session_name = tmux::Session::generate_name(&inst.id, &inst.title);
+        let _guard = KillTmuxOnDrop(session_name.clone());
+        let launch = format!("cat {}; sleep 300", pane_file.to_string_lossy());
+        let created = std::process::Command::new("tmux")
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "120",
+                "-y",
+                "40",
+                &launch,
+            ])
+            .output()
+            .expect("spawn tmux");
+        assert!(
+            created.status.success(),
+            "tmux new-session failed: {}",
+            String::from_utf8_lossy(&created.stderr)
+        );
+
+        // The clobbered hook state that produced the green row.
+        let dir = crate::hooks::hook_status_dir(&inst.id).expect("hook dir");
+        std::fs::create_dir_all(&dir).expect("create hook dir");
+        std::fs::write(dir.join("status"), "running").expect("write status");
+        assert_eq!(
+            crate::hooks::read_hook_status(&inst.id),
+            Some(Status::Running),
+            "precondition: the raw hook signal is the Running that showed green"
+        );
+
+        // Wait for the pane to actually paint the cat output before the
+        // authoritative read; a fixed sleep is flaky under parallel test load.
+        let mut painted = false;
+        for _ in 0..50 {
+            let cap = std::process::Command::new("tmux")
+                .args(["capture-pane", "-p", "-t", &session_name])
+                .output();
+            if let Ok(out) = cap {
+                if String::from_utf8_lossy(&out.stdout).contains("Do you want to proceed?") {
+                    painted = true;
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        assert!(painted, "approval prompt never painted into the tmux pane");
+
+        // `Session::exists()` reads a process-global 2s session cache that a
+        // concurrent test may have snapshotted before this session existed,
+        // which surfaces as a spurious Error (and the 30s error latch would
+        // then pin it). Refresh from live tmux now that the pane is painted so
+        // the single authoritative read sees a true existence result.
+        crate::tmux::refresh_session_cache();
+        inst.update_status();
+
+        std::fs::remove_file(&pane_file).ok();
+        crate::hooks::cleanup_hook_status_dir(&inst.id);
+
+        assert_eq!(
+            inst.status,
+            Status::Waiting,
+            "Claude blocked on an approval prompt must reconcile Running -> Waiting (#1913)"
+        );
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -7319,7 +7319,12 @@ Esc to cancel \u{b7} Tab to amend \u{b7} ctrl+e to explain\n\
 
         let session_name = tmux::Session::generate_name(&inst.id, &inst.title);
         let _guard = KillTmuxOnDrop(session_name.clone());
-        let launch = format!("cat {}; sleep 300", pane_file.to_string_lossy());
+        // Single-quote the path so a temp dir with spaces or shell
+        // metacharacters (e.g. macOS `$TMPDIR`) can't break the launch
+        // command; embedded single quotes are closed/escaped/reopened.
+        let quoted_pane_file =
+            format!("'{}'", pane_file.to_string_lossy().replace('\'', r#"'\''"#));
+        let launch = format!("cat {quoted_pane_file}; sleep 300");
         let created = std::process::Command::new("tmux")
             .args([
                 "new-session",

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod utils;
 pub use session::Session;
 pub use status_bar::{get_session_info_for_current, get_status_for_current_session};
 pub use status_detection::detect_status_from_content;
-pub(crate) use status_detection::reconcile_codex_hook_status;
+pub(crate) use status_detection::{reconcile_claude_hook_status, reconcile_codex_hook_status};
 pub use terminal_session::{ContainerTerminalSession, TerminalSession};
 pub use tool_session::{kill_all_tool_sessions_for_id, ToolSession};
 pub use utils::tmux_prefix_display;

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -122,6 +122,16 @@ pub fn detect_claude_status(content: &str) -> Status {
     let recent_joined = recent.join("\n");
     let recent_lower = recent_joined.to_lowercase();
 
+    // A blocking approval prompt has to outrank the spinner. Claude keeps its
+    // live "Working…" line rendered *below* the permission prompt while it
+    // waits for the user, so a sandboxed session (whose in-container hook
+    // status the host can't read, see `claude_poll_fn_sandboxed`) would
+    // otherwise match the spinner and report Running the whole time it is
+    // blocked. See #1913.
+    if claude_has_approval_prompt(&recent, &recent_lower) {
+        return Status::Waiting;
+    }
+
     if recent_lower.contains("esc to interrupt") || recent_lower.contains("ctrl+c to interrupt") {
         return Status::Running;
     }
@@ -186,6 +196,59 @@ fn claude_line_is_active_spinner(line: &str) -> bool {
     let first_word = &rest[..first_word_end];
     let starts_uppercase = first_word.chars().next().is_some_and(|c| c.is_uppercase());
     starts_uppercase && first_word.contains('…')
+}
+
+/// Claude renders a blocking approval prompt when a tool needs the user's
+/// permission (Bash command, file edit, plan exit, ...). Every variant pairs
+/// a yes/no question ("Do you want to proceed?", "Do you want to make this
+/// edit to <file>?", "Would you like to proceed?") with a numbered choice
+/// menu. Requiring both keeps an assistant-authored numbered list from being
+/// mistaken for a prompt. `recent_lower` is the lowercased join of `recent`.
+fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
+    let has_question = recent_lower.contains("do you want to")
+        || recent_lower.contains("would you like to proceed");
+    has_question
+        && recent
+            .iter()
+            .any(|line| claude_line_is_numbered_choice(line))
+}
+
+/// A numbered menu option, optionally preceded by the `❯`/`>` selection
+/// cursor: `❯ 1. Yes`, `2. No`, `3. No, and tell Claude ...`.
+fn claude_line_is_numbered_choice(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let rest = trimmed
+        .strip_prefix('❯')
+        .or_else(|| trimmed.strip_prefix('>'))
+        .map(str::trim_start)
+        .unwrap_or(trimmed);
+    let mut chars = rest.chars();
+    matches!(chars.next(), Some('1'..='9')) && matches!(chars.next(), Some('.'))
+}
+
+/// Strip ANSI and scan the recent pane lines for an approval prompt. Shares
+/// the same recent-window shape as `detect_claude_status`; this entry point
+/// exists for callers that hold raw (un-stripped) `capture-pane -e` output.
+fn claude_pane_has_approval_prompt(raw_content: &str) -> bool {
+    let clean = strip_ansi(raw_content);
+    let non_empty: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
+    let recent: Vec<&str> = non_empty.iter().rev().take(30).rev().copied().collect();
+    let recent_lower = recent.join("\n").to_lowercase();
+    claude_has_approval_prompt(&recent, &recent_lower)
+}
+
+/// When Claude's status hook reports Running, the pane can still be parked on a
+/// blocking approval prompt. Claude keeps its live spinner rendered below the
+/// prompt and re-emits running-mapped hook events (`PreToolUse`,
+/// `UserPromptSubmit`) while the prompt is up, so the last hook write stays
+/// `running` even though the agent is blocked on the user. Mirrors
+/// `reconcile_codex_hook_status`: downgrade Running -> Waiting when the pane
+/// shows an approval prompt, otherwise trust the hook. See #1913.
+pub(crate) fn reconcile_claude_hook_status(hook_status: Status, raw_content: &str) -> Status {
+    if hook_status == Status::Running && claude_pane_has_approval_prompt(raw_content) {
+        return Status::Waiting;
+    }
+    hook_status
 }
 
 pub fn detect_opencode_status(raw_content: &str) -> Status {
@@ -1571,6 +1634,107 @@ enter to select · esc to cancel";
             content.push('\n');
         }
         assert_eq!(detect_claude_status(&content), Status::Running);
+    }
+
+    #[test]
+    fn test_detect_claude_status_waiting_on_bash_permission_prompt() {
+        // Regression for #1913: a sandboxed Claude session reaches the
+        // pane fallback (the host can't read the in-container hook status),
+        // and Claude keeps its live spinner line rendered *below* the
+        // approval prompt while it waits. The prompt must outrank the
+        // spinner or the session reports Running (green) the whole time
+        // it is blocked on the user.
+        let content = "\
+  Bash command
+
+    SANDBOX=aoe-sandbox-ee1a86c7
+    echo \"checking sandbox gitconfig\"
+
+  Do you want to proceed?
+  ❯ 1. Yes
+    2. No
+
+  Esc to cancel · Tab to amend
+
+✶ Herding… (53s · ↓ 7.0k tokens)
+  Tip: Use /bts to ask a quick side question without interrupting Claude's current work";
+        assert_eq!(detect_claude_status(content), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_claude_status_waiting_on_edit_permission_prompt() {
+        let content = "\
+  Do you want to make this edit to src/main.rs?
+  ❯ 1. Yes
+    2. Yes, allow all edits during this session (shift+tab)
+    3. No, and tell Claude what to do differently (esc)
+
+✶ Cooking… (8s · ↓ 412 tokens)";
+        assert_eq!(detect_claude_status(content), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_claude_status_waiting_on_plan_exit_prompt() {
+        let content = "\
+  Would you like to proceed?
+  ❯ 1. Yes, and auto-accept edits
+    2. Yes, and manually approve edits
+    3. No, keep planning";
+        assert_eq!(detect_claude_status(content), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_claude_status_running_not_confused_by_numbered_prose() {
+        // A numbered list in assistant prose must not be mistaken for an
+        // approval prompt: without a "do you want to" / "would you like to
+        // proceed" question, the live spinner still wins.
+        let content = "\
+  Here is the plan:
+  1. Read the config
+  2. Patch the parser
+
+✶ Working… (4s · ↓ 88 tokens)
+  esc to interrupt";
+        assert_eq!(detect_claude_status(content), Status::Running);
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_waiting_on_approval_prompt() {
+        // The hook reports Running (PreToolUse fired) but the pane is parked
+        // on a permission prompt with the spinner still alive below it. The
+        // reconciler must downgrade to Waiting. ANSI is preserved here to
+        // exercise the strip path the live capture goes through. See #1913.
+        let pane = "\x1b[1m  Do you want to proceed?\x1b[0m\n\
+  ❯ 1. Yes\n    2. No\n\n  Esc to cancel · Tab to amend\n\
+\x1b[38;5;174m✶\x1b[0m Herding… (53s · ↓ 7.0k tokens)";
+        assert_eq!(
+            reconcile_claude_hook_status(Status::Running, pane),
+            Status::Waiting
+        );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_keeps_running_without_prompt() {
+        let pane = "✶ Working… (4s · ↓ 88 tokens)\n  esc to interrupt";
+        assert_eq!(
+            reconcile_claude_hook_status(Status::Running, pane),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_passes_non_running_through() {
+        // A Notification(permission_prompt) hook that does fire writes
+        // Waiting directly; the reconciler must not second-guess it, and an
+        // Idle/Waiting hook is trusted as-is even with no pane evidence.
+        assert_eq!(
+            reconcile_claude_hook_status(Status::Waiting, ""),
+            Status::Waiting
+        );
+        assert_eq!(
+            reconcile_claude_hook_status(Status::Idle, "Do you want to proceed?\n1. Yes"),
+            Status::Idle
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #1913. Claude sessions run outside YOLO mode showed **green (Running)** while blocked on a tool-approval prompt, instead of **yellow (Waiting)**, so there was no visual signal that the agent needed attention.

Root cause: when a tool needs approval, Claude's `Notification(permission_prompt)` hook does write `waiting` (verified empirically), but that write gets clobbered by a `running`-mapped hook (`PreToolUse` / `ElicitationResult`) that re-fires during concurrent turn activity, and Claude keeps its live spinner rendered below the prompt. The status pipeline trusted the hook's `running` and never looked at the pane, so the row stayed green.

Fix mirrors the existing Codex reconciliation: when the Claude hook reports `Running`, capture the pane and downgrade to `Waiting` if it shows an approval prompt ("Do you want to proceed?" / "Would you like to proceed?" plus a numbered choice menu). The pane-based fallback used when hooks are unreachable (custom `--cmd`, first seconds of a session) learns the same shape, ranked ahead of the spinner check.

Why reconcile against the pane rather than fix the hook: the `Notification` matcher (`permission_prompt|elicitation_dialog`) is correct and the hook fires, but the hook value is inherently racy when Claude keeps working through a prompt. The visible prompt is the reliable source of truth, which is exactly the pattern AoE already uses for Codex.

### Verification

- Drove real Claude 2.1.162 in tmux with the production hooks and watched `/tmp/aoe-hooks/<id>/status` go `running` then `waiting` on a Bash approval, confirming the matcher works and isolating the clobber race.
- Added a live-pipeline regression test that stands up a real tmux pane showing the approval prompt with the spinner still active, writes the clobbered `running` hook file, and runs it through `update_status`. It fails (`Running`) without the fix and passes (`Waiting`) with it.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed; internal status-detection behavior)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (structured/ACP sessions return before this tmux status path; the change is tmux-backed status reconciliation)

**TUI / CLI (e2e test)**
- [x] Added or updated a test exercising session-lifecycle status detection. It is a live-pipeline regression test in `src/session/instance.rs` (real tmux pane plus a clobbered hook status file through `update_status`), alongside unit tests in `src/tmux/status_detection.rs`, rather than under `tests/e2e/`, because it exercises the exact `Instance::update_status` reconciliation path directly.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation, fix, and tests were produced by Claude Code through back-and-forth with @njbrake; the diagnosis and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a status display bug where Claude sessions showed green "Running" while actually blocked on a tool-approval prompt; they now correctly show yellow "Waiting".

## What Changed

- Reconciled Claude hook statuses the same way Codex is reconciled: when a hook reports Running, the tmux pane is captured and inspected; if it matches an approval prompt, the status is downgraded to Waiting.
- Made the pane-based fallback (used when hooks are unreachable) detect Claude approval prompts and prioritized it ahead of the spinner check.
- Re-exported the new Claude reconciliation helper so it’s available where needed.
- Added tests: unit tests for Claude approval-prompt detection and a live-pipeline regression test that reproduces the clobber race using a real tmux pane.

Files modified:
- src/session/instance.rs — add Claude hook reconciliation and use pane fallback earlier
- src/tmux/mod.rs — re-export reconcile_claude_hook_status
- src/tmux/status_detection.rs — implement Claude approval-prompt detection and reconciliation
- Tests — unit tests and an end-to-end regression test (src/session/instance.rs test additions)

## Benefits

- Users see the correct "Waiting" indicator when Claude is paused for approval, making required intervention obvious.
- Prevents hook race conditions from incorrectly showing Running by verifying pane contents.
- Aligns Claude behavior with existing Codex reconciliation, improving consistency.
- Regression-tested with a real tmux session to prevent regressions.

## Technical notes (brief)

- Approval prompt detection requires both (a) a consent-style question (e.g., "Do you want to proceed?" / "Would you like to proceed?") and (b) at least one numbered menu choice line (pattern like `1.`..`9.`), allowing an optional cursor (`❯`/`>`).
- When a hook reports Running for codex or claude, the code calls the tmux reconciliation routine; if pane capture fails, the raw hook status is used.
- The live test also ensures shell-quoting of temp pane paths to handle spaces or special chars in temp directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->