### PR TITLE
feat(xtask): optional --watch flag for cargo xtask dev to auto-rebuild and restart the backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5324,6 +5324,7 @@ dependencies = [
  "clap-markdown",
  "ctrlc",
  "nix 0.31.3",
+ "notify",
  "regex",
 ]
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,6 +45,19 @@ both. Ports are overridable with `--serve-port` / `--web-port`. See the
 [web dashboard guide](guides/web-dashboard.md#frontend-development) for the
 manual two-shell alternative.
 
+Add `--watch` to auto-rebuild the Rust backend on source edits:
+
+```bash
+cargo xtask dev --watch
+```
+
+It watches `src/**`, `Cargo.toml`, and `Cargo.lock`; on a change it runs
+`cargo build --features serve` and, if that succeeds, restarts `aoe serve`. A
+failed build leaves the running backend in place and prints the error. The Vite
+dev server is never restarted, so frontend HMR keeps working and the browser
+reconnects through the proxy once the backend is back. Note that the backend
+restart drops all live terminal and cockpit WebSocket connections.
+
 ### Dev namespace
 
 Debug builds use an isolated namespace so a local `cargo run` shares no

--- a/docs/development/web-dashboard.md
+++ b/docs/development/web-dashboard.md
@@ -22,6 +22,14 @@ cargo xtask dev
 # Ctrl-C stops both processes
 ```
 
+Pass `--watch` to auto-rebuild the Rust backend when you edit it:
+
+```bash
+cargo xtask dev --watch
+```
+
+It watches `src/**`, `Cargo.toml`, and `Cargo.lock`. On a change it runs `cargo build --features serve` and restarts `aoe serve` if the build succeeds; a failed build keeps the running backend up and prints the error. The Vite dev server stays up throughout (frontend HMR is unaffected), so the browser reconnects through the proxy once the backend is back. The restart drops live terminal and cockpit WebSocket connections, which is fine for a dev loop. Unix-only, same as the base command.
+
 ## Manual frontend development
 
 If you prefer to run the pieces by hand, the React frontend lives in `web/`:

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,3 +13,4 @@ regex = "1"
 [target.'cfg(unix)'.dependencies]
 ctrlc = "3"
 nix = { version = "0.31", features = ["signal"] }
+notify = "8.2"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -80,6 +80,10 @@ fn terminate_group(child: &mut std::process::Child, grace: std::time::Duration) 
     use nix::sys::signal::{killpg, Signal};
     use nix::unistd::Pid;
     use std::time::{Duration, Instant};
+    if child_exited(child) {
+        let _ = child.wait();
+        return;
+    }
     let pid = Pid::from_raw(child.id() as i32);
     let _ = killpg(pid, Signal::SIGTERM);
     let deadline = Instant::now() + grace;
@@ -136,8 +140,6 @@ fn is_watch_relevant(path: &Path) -> bool {
 /// so frontend HMR and the browser session survive the backend bounce.
 #[cfg(unix)]
 fn run_dev(args: DevArgs) {
-    use nix::sys::signal::{killpg, Signal};
-    use nix::unistd::Pid;
     use std::os::unix::process::CommandExt;
     use std::process::{Child, Command, Stdio};
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -204,8 +206,7 @@ fn run_dev(args: DevArgs) {
             // don't orphan a backend on the serve port.
             eprintln!("[xtask dev] failed to spawn `npm run dev`: {e}");
             if let Some(mut serve) = serve.take() {
-                let _ = killpg(Pid::from_raw(serve.id() as i32), Signal::SIGTERM);
-                let _ = serve.wait();
+                terminate_group(&mut serve, Duration::from_secs(2));
             }
             std::process::exit(1);
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -31,6 +31,10 @@ struct DevArgs {
     /// Port for the Vite dev server
     #[arg(long, default_value_t = 5173)]
     web_port: u16,
+    /// Watch `src/**`, `Cargo.toml`, and `Cargo.lock`; on change rebuild and
+    /// restart `aoe serve` (Vite stays up). Unix-only, same as the base command.
+    #[arg(long)]
+    watch: bool,
 }
 
 fn main() {
@@ -48,11 +52,88 @@ fn run_dev(_args: DevArgs) {
     std::process::exit(1);
 }
 
+/// Build the serve-enabled debug binary. Returns whether the build succeeded so
+/// the watch loop can keep the old backend running on a failed rebuild.
+#[cfg(unix)]
+fn build_serve() -> bool {
+    use std::process::Command;
+    eprintln!("[xtask dev] building aoe (--features serve)...");
+    Command::new("cargo")
+        .args(["build", "--features", "serve"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or_else(|e| {
+            eprintln!("[xtask dev] failed to run cargo build: {e}");
+            false
+        })
+}
+
+#[cfg(unix)]
+fn child_exited(child: &mut std::process::Child) -> bool {
+    matches!(child.try_wait(), Ok(Some(_)))
+}
+
+/// SIGTERM a child's process group, wait out a grace period, then SIGKILL the
+/// group if it is still alive. Reaps the child either way.
+#[cfg(unix)]
+fn terminate_group(child: &mut std::process::Child, grace: std::time::Duration) {
+    use nix::sys::signal::{killpg, Signal};
+    use nix::unistd::Pid;
+    use std::time::{Duration, Instant};
+    let pid = Pid::from_raw(child.id() as i32);
+    let _ = killpg(pid, Signal::SIGTERM);
+    let deadline = Instant::now() + grace;
+    while Instant::now() < deadline {
+        if child_exited(child) {
+            let _ = child.wait();
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let _ = killpg(pid, Signal::SIGKILL);
+    let _ = child.wait();
+}
+
+/// Wait until the backend port is bindable again before respawning, so a restart
+/// does not race the old listener and fail with "address already in use".
+#[cfg(unix)]
+fn wait_for_port(port: u16, timeout: std::time::Duration) {
+    use std::net::TcpListener;
+    use std::time::{Duration, Instant};
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    eprintln!("[xtask dev] port {port} still busy after waiting; respawning anyway");
+}
+
+/// Whether a changed path should trigger a backend rebuild: any `.rs` file, or
+/// the root `Cargo.toml` / `Cargo.lock`. The watch scope (src/ recursively plus
+/// the project root non-recursively) already excludes target/ and node_modules,
+/// so a plain extension and file-name check is enough.
+#[cfg(unix)]
+fn is_watch_relevant(path: &Path) -> bool {
+    if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+        return true;
+    }
+    matches!(
+        path.file_name().and_then(|n| n.to_str()),
+        Some("Cargo.toml") | Some("Cargo.lock")
+    )
+}
+
 /// Build the serve-enabled binary, then run it alongside the Vite dev server.
 /// Vite proxies `/api` and the `/sessions/*/ws` relays to the backend via the
 /// `VITE_PROXY` env var it already honors. Each child runs in its own process
 /// group so a single Ctrl-C tears the whole tree down (npm spawns vite, vite
 /// may spawn esbuild) with no orphans.
+///
+/// With `--watch`, edits under `src/**` (plus `Cargo.toml` / `Cargo.lock`)
+/// rebuild the backend and restart `aoe serve`; the Vite child is left running
+/// so frontend HMR and the browser session survive the backend bounce.
 #[cfg(unix)]
 fn run_dev(args: DevArgs) {
     use nix::sys::signal::{killpg, Signal};
@@ -65,13 +146,8 @@ fn run_dev(args: DevArgs) {
 
     // Build up front so build output doesn't interleave with Vite's startup
     // and a broken build fails fast before either server comes up.
-    eprintln!("[xtask dev] building aoe (--features serve)...");
-    let built = Command::new("cargo")
-        .args(["build", "--features", "serve"])
-        .status()
-        .expect("failed to run cargo build");
-    if !built.success() {
-        std::process::exit(built.code().unwrap_or(1));
+    if !build_serve() {
+        std::process::exit(1);
     }
 
     // Honor CARGO_TARGET_DIR; cargo wrote the debug binary under it.
@@ -90,12 +166,19 @@ fn run_dev(args: DevArgs) {
     // shortcuts when stdin is a TTY) would raise SIGTTOU and suspend the
     // child. Shutdown is driven by signals here, not per-server keystrokes,
     // so neither child needs the terminal.
-    let mut serve = Command::new(&bin)
-        .args(["serve", "--no-auth", "--port", &args.serve_port.to_string()])
-        .stdin(Stdio::null())
-        .process_group(0)
-        .spawn()
-        .expect("failed to spawn `aoe serve`");
+    let serve_port = args.serve_port;
+    let spawn_serve = || -> Child {
+        Command::new(&bin)
+            .args(["serve", "--no-auth", "--port", &serve_port.to_string()])
+            .stdin(Stdio::null())
+            .process_group(0)
+            .spawn()
+            .expect("failed to spawn `aoe serve`")
+    };
+
+    // Tracked as an Option so a backend that exits under --watch can be marked
+    // dead and respawned on the next rebuild without tearing down Vite.
+    let mut serve: Option<Child> = Some(spawn_serve());
 
     let mut vite = match Command::new("npm")
         .args([
@@ -120,55 +203,116 @@ fn run_dev(args: DevArgs) {
             // serve is already up; tear its group down before bailing so we
             // don't orphan a backend on the serve port.
             eprintln!("[xtask dev] failed to spawn `npm run dev`: {e}");
-            let _ = killpg(Pid::from_raw(serve.id() as i32), Signal::SIGTERM);
-            let _ = serve.wait();
+            if let Some(mut serve) = serve.take() {
+                let _ = killpg(Pid::from_raw(serve.id() as i32), Signal::SIGTERM);
+                let _ = serve.wait();
+            }
             std::process::exit(1);
         }
     };
 
     eprintln!(
-        "[xtask dev] aoe serve on :{} | open http://localhost:{}",
-        args.serve_port, args.web_port
+        "[xtask dev] aoe serve on :{} | open http://localhost:{}{}",
+        args.serve_port,
+        args.web_port,
+        if args.watch {
+            " | watching src for changes"
+        } else {
+            ""
+        }
     );
 
-    let exited = |child: &mut Child| matches!(child.try_wait(), Ok(Some(_)));
+    // Watch src/** plus the root Cargo.toml/Cargo.lock when --watch is set. The
+    // watcher must stay bound for the loop's lifetime; dropping it ends delivery.
+    let (watch_tx, watch_rx) = std::sync::mpsc::channel::<()>();
+    let _watcher = if args.watch {
+        use notify::{RecursiveMode, Watcher};
+        let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            if let Ok(event) = res {
+                if event.paths.iter().any(|p| is_watch_relevant(p)) {
+                    let _ = watch_tx.send(());
+                }
+            }
+        })
+        .expect("failed to create file watcher");
+        // src/ recursively for .rs edits; the project root non-recursively so an
+        // editor's atomic-save rename-replace of Cargo.toml/Cargo.lock is caught
+        // (a direct file watch would detach when the inode is swapped).
+        watcher
+            .watch(Path::new("src"), RecursiveMode::Recursive)
+            .expect("failed to watch src/");
+        watcher
+            .watch(Path::new("."), RecursiveMode::NonRecursive)
+            .expect("failed to watch project root");
+        Some(watcher)
+    } else {
+        drop(watch_tx);
+        None
+    };
 
-    // Supervise: stop when Ctrl-C arrives or either child dies on its own.
+    // Trailing debounce: the first change arms a deadline; rapid follow-up saves
+    // (rustfmt, editor temp-file dances) collapse into a single rebuild.
+    let debounce = Duration::from_millis(300);
+    let mut rebuild_at: Option<Instant> = None;
+
+    // Supervise: stop on Ctrl-C, on Vite exiting, or (without --watch) on the
+    // backend exiting. Under --watch, rebuild and restart the backend on change.
     loop {
         if shutdown.load(Ordering::SeqCst) {
             break;
         }
-        if exited(&mut serve) {
-            eprintln!("[xtask dev] `aoe serve` exited; stopping vite");
-            break;
-        }
-        if exited(&mut vite) {
+        if child_exited(&mut vite) {
             eprintln!("[xtask dev] vite exited; stopping `aoe serve`");
             break;
         }
+        if let Some(child) = serve.as_mut() {
+            if child_exited(child) {
+                if args.watch {
+                    eprintln!("[xtask dev] `aoe serve` exited; waiting for a change to rebuild");
+                    let _ = child.wait();
+                    serve = None;
+                } else {
+                    eprintln!("[xtask dev] `aoe serve` exited; stopping vite");
+                    break;
+                }
+            }
+        }
+
+        if args.watch {
+            let mut saw_change = false;
+            while watch_rx.try_recv().is_ok() {
+                saw_change = true;
+            }
+            if saw_change {
+                rebuild_at = Some(Instant::now() + debounce);
+            }
+            if let Some(at) = rebuild_at {
+                if Instant::now() >= at {
+                    rebuild_at = None;
+                    eprintln!("[xtask dev] change detected; rebuilding aoe...");
+                    if build_serve() {
+                        if let Some(mut old) = serve.take() {
+                            terminate_group(&mut old, Duration::from_secs(2));
+                        }
+                        wait_for_port(serve_port, Duration::from_secs(5));
+                        serve = Some(spawn_serve());
+                        eprintln!("[xtask dev] aoe serve restarted on :{serve_port}");
+                    } else {
+                        eprintln!("[xtask dev] build failed; keeping the running backend");
+                    }
+                }
+            }
+        }
+
         std::thread::sleep(Duration::from_millis(100));
     }
 
-    // Signal each process group: SIGTERM, brief grace, then SIGKILL so the
+    // Signal each live process group: SIGTERM, brief grace, then SIGKILL so the
     // ports are always freed even if a child ignores the term.
-    let groups = [serve.id() as i32, vite.id() as i32];
-    for pid in groups {
-        let _ = killpg(Pid::from_raw(pid), Signal::SIGTERM);
+    terminate_group(&mut vite, Duration::from_secs(2));
+    if let Some(mut child) = serve.take() {
+        terminate_group(&mut child, Duration::from_secs(2));
     }
-    let deadline = Instant::now() + Duration::from_secs(2);
-    while Instant::now() < deadline {
-        if exited(&mut serve) && exited(&mut vite) {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    if !(exited(&mut serve) && exited(&mut vite)) {
-        for pid in groups {
-            let _ = killpg(Pid::from_raw(pid), Signal::SIGKILL);
-        }
-    }
-    let _ = serve.wait();
-    let _ = vite.wait();
 }
 
 fn generate_cli_docs() {
@@ -367,4 +511,35 @@ fn check_skill_file(
 
     referenced.extend(skill_commands);
     has_error
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::is_watch_relevant;
+    use std::path::Path;
+
+    #[test]
+    fn rust_sources_are_relevant() {
+        assert!(is_watch_relevant(Path::new("src/main.rs")));
+        assert!(is_watch_relevant(Path::new("src/server/mod.rs")));
+        assert!(is_watch_relevant(Path::new(
+            "/abs/agent-of-empires/src/tui/app.rs"
+        )));
+    }
+
+    #[test]
+    fn cargo_manifests_are_relevant() {
+        assert!(is_watch_relevant(Path::new("Cargo.toml")));
+        assert!(is_watch_relevant(Path::new("./Cargo.lock")));
+        assert!(is_watch_relevant(Path::new("/abs/repo/Cargo.toml")));
+    }
+
+    #[test]
+    fn unrelated_paths_are_ignored() {
+        assert!(!is_watch_relevant(Path::new("README.md")));
+        assert!(!is_watch_relevant(Path::new("target/debug/aoe")));
+        assert!(!is_watch_relevant(Path::new(".git/index")));
+        assert!(!is_watch_relevant(Path::new("Cargo.toml.swp")));
+        assert!(!is_watch_relevant(Path::new("web/src/App.tsx")));
+    }
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds an optional `--watch` flag to `cargo xtask dev` so backend edits no longer require a manual Ctrl-C and rerun. Follow-up to #996 / #1729.

`cargo xtask dev` (from #1729) runs `aoe serve` plus the Vite dev server together. The frontend hot-reloads via Vite HMR, but the Rust backend is built once at startup, so editing a `.rs` file did nothing until you stopped and reran the command.

With `--watch`, xtask watches `src/**`, `Cargo.toml`, and `Cargo.lock` using the `notify` crate (already in the workspace lockfile, so no new dependency download and no global tool). On a change it debounces 300ms, runs `cargo build --features serve`, and if that succeeds it SIGTERMs the `aoe serve` process group, waits for the port to free, and respawns it with the same args. A failed build leaves the running backend in place and prints the error. The Vite child is never restarted, so frontend HMR and the browser session survive the backend bounce; the browser reconnects through the existing proxy once the backend is back. Without `--watch`, behavior is unchanged. Unix-only, matching the base command.

Implementation notes: the supervise loop now tracks `aoe serve` as an `Option<Child>` so a backend that exits under `--watch` is marked dead and respawned on the next change rather than tearing down Vite. Process helpers (`build_serve`, `child_exited`, `terminate_group`, `wait_for_port`) were extracted so the watch loop stays readable. Restarting the backend drops all live terminal and cockpit WebSocket connections, which is acceptable for a dev loop and is noted in the docs.

Closes #1755

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `cargo xtask dev` (no flag) and confirm behavior is unchanged: backend on :8081, Vite on :5173, one Ctrl-C stops both.
- [ ] Run `cargo xtask dev --watch`, edit a `.rs` file under `src/`, and confirm the backend rebuilds and `aoe serve` restarts while the Vite dev server stays up and the browser reconnects.
- [ ] With `--watch` running, introduce a compile error and save; confirm the old backend keeps running and the build error is printed (no restart).
- [ ] Fix the compile error and save; confirm the backend rebuilds and restarts.
- [ ] Touch `Cargo.toml` while `--watch` is running and confirm it triggers a rebuild + restart.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Note: `cargo xtask dev` is build automation in the `xtask` workspace, not an `aoe` CLI subcommand or TUI surface. The pure path-filter logic (`is_watch_relevant`) is covered by unit tests in `xtask/src/main.rs`; the process orchestration is verified by the manual smoke steps above.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the design debate (two-model consult on watcher library, port-free wait, crash semantics, debounce), and implementation were drafted by Claude under my direction. I made the design calls, reviewed each commit, and own the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds an optional Unix-only --watch flag to cargo xtask dev that watches backend sources and manifests, auto-rebuilds the Rust backend on changes, and restarts aoe serve on successful builds—removing the need for manual Ctrl-C + rerun during backend development.

## What changed (high-level)

- Added a --watch CLI flag to cargo xtask dev (DevArgs.watch).
- Introduced file-watching for src/**, Cargo.toml, and Cargo.lock with a 300ms debounce.
- On relevant changes, runs cargo build --features serve; on success, cleanly restarts the backend; on failure, preserves the running backend and prints errors.
- Keeps the Vite dev server running so frontend HMR and browser sessions persist through backend restarts.
- Extracted process/build helpers and refactored the supervision loop to track the backend as an Option<Child>.
- Added notify v8.2 as a Unix-only dependency.
- Documentation updates describing the workflow and noting that backend restarts drop live terminal/cockpit WebSocket connections.
- Tests: unit tests for is_watch_relevant to ensure correct file-filtering.

Also applied a follow-up fix to process-group cleanup: use terminate_group with an early child_exited check to avoid signaling re-used PIDs and to ensure bounded cleanup when npm spawn fails.

## Benefits

- Faster iteration: edits to the Rust backend trigger automatic rebuilds and restarts.
- Stable frontend dev experience: HMR and browser state survive backend restarts.
- Safer dev loop: failed builds do not crash the running backend; errors are reported for correction.
- Opt-in: default behavior unchanged when --watch is not used.

## Technical (concise)

- Platform: Unix-only (matches existing dev command).
- Watch targets: src/** (recursive) + project root (to catch Cargo.toml/Cargo.lock).
- Debounce: 300ms to avoid redundant rebuilds.
- Build: cargo build --features serve; on success SIGTERM the backend process group, wait for port to free, then respawn with same args.
- Failure handling: keep current backend running on build failure.
- Process cleanup: terminate_group with graceful SIGTERM→SIGKILL fallback; added child_exited check to avoid signalling stale PIDs.
- Dependency: notify = "8.2" under Unix target deps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->