### PR TITLE
feat(acp): forward configured MCP servers to agents via newSession/loadSession

### DIFF
--- a/acp-worker/test-shim/shim.mjs
+++ b/acp-worker/test-shim/shim.mjs
@@ -80,6 +80,18 @@ class ShimAgent {
     if (process.env.SHIM_DELETE_CAPABILITY === "1") {
       agentCapabilities.sessionCapabilities = { delete: {} };
     }
+    // SHIM_MCP_CAPABILITY advertises mcpCapabilities so the Rust client's
+    // http/sse capability gating can be exercised. Comma list, e.g. "http",
+    // "sse", or "http,sse". Absent => neither advertised (stdio only).
+    if (process.env.SHIM_MCP_CAPABILITY) {
+      const caps = process.env.SHIM_MCP_CAPABILITY.split(",").map((s) =>
+        s.trim(),
+      );
+      agentCapabilities.mcpCapabilities = {
+        http: caps.includes("http"),
+        sse: caps.includes("sse"),
+      };
+    }
     return {
       protocolVersion: params.protocolVersion ?? acp.PROTOCOL_VERSION,
       agentCapabilities,
@@ -124,7 +136,14 @@ class ShimAgent {
     return {};
   }
 
-  async newSession(_params) {
+  async newSession(params) {
+    // SHIM_MCP_RECORD_FILE, when set, captures the mcp_servers the client
+    // forwarded on session/new so tests assert MCP forwarding end to end.
+    const recordFile = process.env.SHIM_MCP_RECORD_FILE;
+    if (recordFile) {
+      const fs = await import("node:fs/promises");
+      await fs.writeFile(recordFile, JSON.stringify(params?.mcpServers ?? []));
+    }
     const sessionId = "shim-" + Math.random().toString(36).slice(2, 10);
     this.sessions.set(sessionId, {});
     return { sessionId };

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -1,0 +1,79 @@
+# MCP Servers
+
+Agent of Empires forwards your configured [MCP](https://modelcontextprotocol.io)
+servers to structured-view agents (Claude, Gemini, Codex) when a session
+starts, so the agent can call those servers' tools. Without this, structured-view
+sessions reach no MCP servers at all.
+
+This applies to structured-view / ACP sessions only. tmux sessions run the
+agent's own CLI, which loads MCP config through that tool's normal mechanism.
+
+## Configuration
+
+Create `mcp.json` in your AoE app directory:
+
+- **Linux**: `$XDG_CONFIG_HOME/agent-of-empires/mcp.json` (defaults to
+  `~/.config/agent-of-empires/mcp.json`)
+- **macOS / Windows**: `~/.agent-of-empires/mcp.json`
+
+Debug builds use the `agent-of-empires-dev` namespace instead.
+
+The file uses the standard `.mcp.json` shape, the same `mcpServers` object
+Claude, Gemini, and Codex already understand, so you can reuse definitions you
+keep elsewhere:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "mcp-server-filesystem",
+      "args": ["--root", "/home/me/projects"],
+      "env": { "LOG_LEVEL": "info" }
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.example.com/mcp",
+      "headers": { "Authorization": "Bearer ghp_..." }
+    }
+  }
+}
+```
+
+Each entry is one of:
+
+- **stdio** (default when `type` is omitted): `command` is required; `args` and
+  `env` are optional. The agent launches the executable and speaks MCP over its
+  stdio.
+- **http** (`"type": "http"`): `url` is required; `headers` is optional.
+- **sse** (`"type": "sse"`): `url` is required; `headers` is optional.
+
+The forwarded list is the same for fresh sessions (`session/new`) and resumed
+ones (`session/load`).
+
+## Capability gating
+
+Not every agent supports every transport. `stdio` works everywhere. `http` and
+`sse` servers are forwarded only when the agent advertises support for them in
+its handshake; otherwise that server is dropped (with a warning in the log) so
+AoE never sends a request the agent would reject.
+
+## Errors
+
+A missing `mcp.json` is normal and means no servers are forwarded, identical to
+the behavior before this feature. A malformed `mcp.json` is logged as a warning
+and no servers are forwarded, so a single typo never blocks your sessions from
+starting. Check the log (`debug.log` in the app directory) if a configured
+server does not show up.
+
+## Security
+
+`mcp.json` lives in your app directory and is owned by you, so its `command`
+entries and any secrets in `env` / `headers` stay out of source control. Treat
+it like any file that can launch processes on your behalf: a stdio server runs
+its `command` locally when a session starts.
+
+Project-local `.mcp.json` (read from a repository) and per-profile MCP config
+are not supported yet. A repository-provided server config would let a cloned,
+untrusted repo launch commands the moment you open a session, so it must sit
+behind the same repo-trust gate AoE already uses for lifecycle hooks; that work
+is tracked separately.

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -21,14 +21,14 @@ use agent_client_protocol::schema::{
     AudioContent, BlobResourceContents, CancelNotification, ClientCapabilities, ContentBlock,
     CreateTerminalRequest, CreateTerminalResponse, EmbeddedResource, EmbeddedResourceResource,
     FileSystemCapabilities, ImageContent, InitializeRequest, KillTerminalRequest,
-    KillTerminalResponse, LoadSessionRequest, ModelId, NewSessionRequest, PermissionOptionKind,
-    PromptRequest, ProtocolVersion, ReadTextFileRequest, ReadTextFileResponse,
-    ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
-    SessionConfigId, SessionConfigValueId, SessionId, SessionModelState, SessionNotification,
-    SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
-    StopReason, TerminalId, TerminalOutputRequest, TerminalOutputResponse, TextContent,
-    WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
+    KillTerminalResponse, LoadSessionRequest, McpServer, ModelId, NewSessionRequest,
+    PermissionOptionKind, PromptRequest, ProtocolVersion, ReadTextFileRequest,
+    ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    SelectedPermissionOutcome, SessionConfigId, SessionConfigValueId, SessionId, SessionModelState,
+    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
+    SetSessionModelRequest, StopReason, TerminalId, TerminalOutputRequest, TerminalOutputResponse,
+    TextContent, WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
     WriteTextFileResponse,
 };
 use agent_client_protocol::{
@@ -46,6 +46,7 @@ use super::agent_registry::AgentSpec;
 use super::approvals::{is_destructive, ApprovalDecision, Nonce};
 use super::event_store::AttachmentBlob;
 use super::fs_handler::{self, FsPolicy, SandboxPathMap};
+use super::mcp_config;
 use super::permissions::build_approval;
 use super::state::{
     AcpSessionId, AvailableCommand, ConfigOptionCategory, ConfigOptionChoice,
@@ -287,6 +288,12 @@ pub struct SpawnConfig {
     /// structured view sandbox env mirrors the tmux view. `None` for
     /// non-sandboxed sessions.
     pub source_profile: Option<String>,
+    /// MCP servers to forward to the agent on `session/new` and
+    /// `session/load`, resolved from the global `<app_dir>/mcp.json` by the
+    /// supervisor. Capability gating (dropping `http`/`sse` the agent did not
+    /// advertise) happens later, against the `initialize` response. Empty when
+    /// no config file exists, which preserves pre-feature behavior.
+    pub mcp_servers: Vec<McpServer>,
 }
 
 /// Commands sent from `AcpClient` methods to the background connection task.
@@ -1241,6 +1248,7 @@ impl AcpClient {
         let install_binary = config.spec.command.clone();
         let source_profile_for_task = config.source_profile.clone();
         let default_effort = config.default_effort.clone();
+        let mcp_servers = config.mcp_servers.clone();
         if let Some(socket_path) = config.socket_path.clone() {
             // Supersede guard: a fresh spawn overwrites this session's
             // registry entry, so any runner already registered for it would
@@ -1267,6 +1275,7 @@ impl AcpClient {
                 install_binary,
                 source_profile_for_task,
                 default_effort.clone(),
+                mcp_servers,
             )
             .await;
         }
@@ -1289,6 +1298,7 @@ impl AcpClient {
             install_binary,
             source_profile_for_task,
             default_effort,
+            mcp_servers,
         )
         .await
     }
@@ -1310,6 +1320,7 @@ impl AcpClient {
         install_binary: String,
         source_profile: Option<String>,
         default_effort: Option<String>,
+        mcp_servers: Vec<McpServer>,
     ) -> Result<Self, AcpError> {
         let (stdin, stdout) = {
             let mut guard = child.lock().await;
@@ -1372,6 +1383,7 @@ impl AcpClient {
                 expected_agent,
                 source_profile,
                 default_effort,
+                mcp_servers,
             )
             .instrument(conn_span),
         );
@@ -1410,6 +1422,7 @@ impl AcpClient {
         install_binary: String,
         source_profile: Option<String>,
         default_effort: Option<String>,
+        mcp_servers: Vec<McpServer>,
     ) -> Result<Self, AcpError> {
         // Poll for the runner to finish binding the socket. The runner
         // binds before it spawns the agent so this is usually fast (a
@@ -1463,6 +1476,7 @@ impl AcpClient {
                 expected_agent,
                 source_profile,
                 default_effort,
+                mcp_servers,
             )
             .instrument(conn_span),
         );
@@ -1548,6 +1562,10 @@ impl AcpClient {
             install_binary,
             source_profile,
             None,
+            // Reattach uses ConnectMode::Resume, which reuses the stored ACP
+            // session id without sending session/new or session/load, so no
+            // MCP servers are forwarded here (they were sent on first connect).
+            Vec::new(),
         )
         .await
     }
@@ -3916,6 +3934,7 @@ async fn run_connection_task<W, R>(
     expected_agent: ExpectedAgent,
     source_profile: Option<String>,
     default_effort: Option<String>,
+    mcp_servers: Vec<McpServer>,
 ) where
     W: futures_util::AsyncWrite + Send + 'static,
     R: futures_util::AsyncRead + Send + 'static,
@@ -4293,6 +4312,16 @@ async fn run_connection_task<W, R>(
             let mut available_mode_ids: Option<Vec<String>> = None;
             let mut has_config_option_mode: bool = false;
 
+            // Drop any http/sse servers the agent did not advertise before they
+            // reach session/new or session/load; stdio is always kept. Computed
+            // once here so both the load-attempt and the fresh-session fallback
+            // forward the same gated list.
+            let mcp_servers = mcp_config::filter_for_capabilities(
+                mcp_servers,
+                &init.agent_capabilities.mcp_capabilities,
+                &session_label,
+            );
+
             let acp_session_id: SessionId = match mode {
                 ConnectMode::Resume {
                     acp_session_id: stored,
@@ -4363,7 +4392,8 @@ async fn run_connection_task<W, R>(
                             // key toolCallId-..."). Cleared on Err below if we fall
                             // back to session/new, which has no replay payload.
                             suppress_for_block.store(true, Ordering::Relaxed);
-                            let req = LoadSessionRequest::new(stored.clone(), cwd.clone());
+                            let req = LoadSessionRequest::new(stored.clone(), cwd.clone())
+                                .mcp_servers(mcp_servers.clone());
                             match connection.send_request(req).block_task().await {
                                 Ok(resp) => {
                                     info!(
@@ -4453,7 +4483,7 @@ async fn run_connection_task<W, R>(
                             "creating fresh session via session/new"
                         );
                         let new_session = connection
-                            .send_request(NewSessionRequest::new(cwd))
+                            .send_request(NewSessionRequest::new(cwd).mcp_servers(mcp_servers))
                             .block_task()
                             .await?;
                         let id = new_session.session_id.clone();
@@ -6473,6 +6503,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: Some(sandbox.clone()),
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         let argv = build_sandbox_docker_argv(&config, &sandbox, "/workspace/proj")
             .expect("docker argv built");
@@ -6539,6 +6570,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: Some(sandbox.clone()),
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         let argv = build_sandbox_docker_argv(&config, &sandbox, "/workspace/proj")
             .expect("docker argv built");
@@ -6607,6 +6639,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: Some(sandbox.clone()),
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         let argv = build_sandbox_docker_argv(&config, &sandbox, "/workspace/proj")
             .expect("docker argv built");
@@ -6652,6 +6685,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: None,
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         let result = AcpClient::spawn(config, AcpSessionId("s-1".into())).await;
         assert!(matches!(result, Err(AcpError::Spawn(_))));
@@ -6683,6 +6717,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: None,
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         let result = AcpClient::spawn(config, AcpSessionId("s-1".into())).await;
         match result {

--- a/src/acp/mcp_config.rs
+++ b/src/acp/mcp_config.rs
@@ -1,0 +1,351 @@
+//! Global MCP server config (`<app_dir>/mcp.json`) parsing and conversion
+//! to ACP `McpServer` values forwarded at session creation.
+//!
+//! AoE forwards the user's MCP servers to structured-view ACP agents through
+//! `session/new` and `session/load`; without this the agent reaches no MCP
+//! servers at all. The on-disk format mirrors the ecosystem-standard
+//! `.mcp.json` so users can reuse the definitions they already maintain for
+//! Claude, Gemini, and Codex:
+//!
+//! ```json
+//! {
+//!   "mcpServers": {
+//!     "fs":     { "command": "mcp-fs", "args": ["--root", "."], "env": { "K": "v" } },
+//!     "remote": { "type": "http", "url": "https://example/mcp", "headers": { "Authorization": "Bearer x" } }
+//!   }
+//! }
+//! ```
+//!
+//! Only a single global file in the AoE app dir is read today. A project-local
+//! `cwd/.mcp.json` is intentionally NOT read: AoE opens cloned and potentially
+//! untrusted repositories, and stdio MCP servers launch unconditionally when a
+//! session spawns, so project scope must sit behind the repo-trust gate (the
+//! same boundary that already protects lifecycle hooks). That, plus per-profile
+//! config, are tracked as follow-ups.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use agent_client_protocol::schema::{
+    EnvVariable, HttpHeader, McpCapabilities, McpServer, McpServerHttp, McpServerSse,
+    McpServerStdio,
+};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use tracing::warn;
+
+/// On-disk shape of `<app_dir>/mcp.json`. Unknown top-level keys are ignored.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct McpConfigFile {
+    #[serde(default)]
+    mcp_servers: BTreeMap<String, RawServer>,
+}
+
+/// A single server entry. Absent `type` (or `type: "stdio"`) selects the stdio
+/// transport; `type: "http"` / `type: "sse"` select the remote transports. Maps
+/// are `BTreeMap` so the converted output ordering is deterministic for tests.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawServer {
+    #[serde(default, rename = "type")]
+    transport: Option<String>,
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    url: Option<String>,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+}
+
+/// Read and parse the global `<app_dir>/mcp.json`. A missing file yields an
+/// empty list (the no-config case behaves exactly as before this feature). A
+/// present-but-malformed file is an error the caller surfaces; it must not be
+/// silently treated as "no servers".
+pub fn load_global_mcp_servers(app_dir: &Path) -> Result<Vec<McpServer>> {
+    let path = app_dir.join("mcp.json");
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(e).with_context(|| format!("reading MCP config at {}", path.display()))
+        }
+    };
+    parse_mcp_servers(&text).with_context(|| format!("parsing MCP config at {}", path.display()))
+}
+
+/// Parse the `.mcp.json` text into ACP `McpServer` values. Separated from the
+/// file read so the conversion rules can be unit-tested without touching disk.
+fn parse_mcp_servers(text: &str) -> Result<Vec<McpServer>> {
+    let parsed: McpConfigFile = serde_json::from_str(text)?;
+    parsed
+        .mcp_servers
+        .into_iter()
+        .map(|(name, raw)| convert_server(&name, raw))
+        .collect()
+}
+
+fn convert_server(name: &str, raw: RawServer) -> Result<McpServer> {
+    match raw.transport.as_deref() {
+        None | Some("stdio") => {
+            let command = raw
+                .command
+                .with_context(|| format!("MCP server \"{name}\" is missing \"command\""))?;
+            Ok(McpServer::Stdio(
+                McpServerStdio::new(name, command)
+                    .args(raw.args)
+                    .env(to_env(raw.env)),
+            ))
+        }
+        Some("http") => {
+            let url = raw
+                .url
+                .with_context(|| format!("MCP server \"{name}\" is missing \"url\""))?;
+            Ok(McpServer::Http(
+                McpServerHttp::new(name, url).headers(to_headers(raw.headers)),
+            ))
+        }
+        Some("sse") => {
+            let url = raw
+                .url
+                .with_context(|| format!("MCP server \"{name}\" is missing \"url\""))?;
+            Ok(McpServer::Sse(
+                McpServerSse::new(name, url).headers(to_headers(raw.headers)),
+            ))
+        }
+        Some(other) => bail!("MCP server \"{name}\" has unknown type \"{other}\""),
+    }
+}
+
+fn to_env(env: BTreeMap<String, String>) -> Vec<EnvVariable> {
+    env.into_iter()
+        .map(|(name, value)| EnvVariable::new(name, value))
+        .collect()
+}
+
+fn to_headers(headers: BTreeMap<String, String>) -> Vec<HttpHeader> {
+    headers
+        .into_iter()
+        .map(|(name, value)| HttpHeader::new(name, value))
+        .collect()
+}
+
+/// Drop servers the agent cannot accept: `stdio` is always supported, but
+/// `http` / `sse` are only valid when the agent advertised the matching
+/// capability in its `initialize` response. Forwarding an unadvertised remote
+/// transport is a protocol violation, so drop (with a warning) rather than
+/// send. Unknown future transports are dropped for the same reason.
+pub fn filter_for_capabilities(
+    servers: Vec<McpServer>,
+    caps: &McpCapabilities,
+    session: &str,
+) -> Vec<McpServer> {
+    servers
+        .into_iter()
+        .filter(|server| {
+            let keep = match server {
+                McpServer::Stdio(_) => true,
+                McpServer::Http(_) => caps.http,
+                McpServer::Sse(_) => caps.sse,
+                _ => false,
+            };
+            if !keep {
+                warn!(
+                    target: "acp.mcp",
+                    session = %session,
+                    server = server_name(server),
+                    transport = server_kind(server),
+                    "dropping MCP server: agent does not advertise this transport"
+                );
+            }
+            keep
+        })
+        .collect()
+}
+
+/// Names + transports of the configured servers for logging. Deliberately omits
+/// env values and header values so secrets never reach the log sink.
+pub fn summarize(servers: &[McpServer]) -> String {
+    servers
+        .iter()
+        .map(|s| format!("{}({})", server_name(s), server_kind(s)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn server_name(server: &McpServer) -> &str {
+    match server {
+        McpServer::Stdio(s) => &s.name,
+        McpServer::Http(s) => &s.name,
+        McpServer::Sse(s) => &s.name,
+        _ => "unknown",
+    }
+}
+
+fn server_kind(server: &McpServer) -> &'static str {
+    match server {
+        McpServer::Stdio(_) => "stdio",
+        McpServer::Http(_) => "http",
+        McpServer::Sse(_) => "sse",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(servers: &[McpServer]) -> Vec<&str> {
+        servers.iter().map(server_name).collect()
+    }
+
+    #[test]
+    fn missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let servers = load_global_mcp_servers(dir.path()).unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn loads_and_parses_app_dir_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mcp.json"),
+            r#"{ "mcpServers": { "fs": { "command": "mcp-fs" } } }"#,
+        )
+        .unwrap();
+        let servers = load_global_mcp_servers(dir.path()).unwrap();
+        assert_eq!(names(&servers), vec!["fs"]);
+    }
+
+    #[test]
+    fn malformed_app_dir_file_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("mcp.json"), "{ not json").unwrap();
+        assert!(load_global_mcp_servers(dir.path()).is_err());
+    }
+
+    #[test]
+    fn empty_or_absent_mcp_servers_key_is_empty() {
+        assert!(parse_mcp_servers("{}").unwrap().is_empty());
+        assert!(parse_mcp_servers(r#"{"mcpServers":{}}"#)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn parses_stdio_entry() {
+        let text = r#"{
+            "mcpServers": {
+                "fs": { "command": "mcp-fs", "args": ["--root", "."], "env": { "TOKEN": "secret" } }
+            }
+        }"#;
+        let servers = parse_mcp_servers(text).unwrap();
+        assert_eq!(servers.len(), 1);
+        match &servers[0] {
+            McpServer::Stdio(s) => {
+                assert_eq!(s.name, "fs");
+                assert_eq!(s.command.to_string_lossy(), "mcp-fs");
+                assert_eq!(s.args, vec!["--root".to_string(), ".".to_string()]);
+                assert_eq!(s.env.len(), 1);
+                assert_eq!(s.env[0].name, "TOKEN");
+                assert_eq!(s.env[0].value, "secret");
+            }
+            other => panic!("expected stdio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_remote_entries() {
+        let text = r#"{
+            "mcpServers": {
+                "h": { "type": "http", "url": "https://e/mcp", "headers": { "Authorization": "Bearer x" } },
+                "s": { "type": "sse", "url": "https://e/sse" }
+            }
+        }"#;
+        let servers = parse_mcp_servers(text).unwrap();
+        // BTreeMap key ordering: "h" before "s".
+        match &servers[0] {
+            McpServer::Http(h) => {
+                assert_eq!(h.name, "h");
+                assert_eq!(h.url, "https://e/mcp");
+                assert_eq!(h.headers[0].name, "Authorization");
+                assert_eq!(h.headers[0].value, "Bearer x");
+            }
+            other => panic!("expected http, got {other:?}"),
+        }
+        match &servers[1] {
+            McpServer::Sse(s) => assert_eq!(s.url, "https://e/sse"),
+            other => panic!("expected sse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ordering_is_deterministic() {
+        let text = r#"{ "mcpServers": {
+            "zebra": { "command": "z" },
+            "alpha": { "command": "a" },
+            "mike":  { "command": "m" }
+        }}"#;
+        let servers = parse_mcp_servers(text).unwrap();
+        assert_eq!(names(&servers), vec!["alpha", "mike", "zebra"]);
+    }
+
+    #[test]
+    fn unknown_type_is_error() {
+        let text = r#"{ "mcpServers": { "x": { "type": "carrier-pigeon", "url": "u" } } }"#;
+        assert!(parse_mcp_servers(text).is_err());
+    }
+
+    #[test]
+    fn stdio_without_command_is_error() {
+        let text = r#"{ "mcpServers": { "x": { "args": ["--y"] } } }"#;
+        assert!(parse_mcp_servers(text).is_err());
+    }
+
+    #[test]
+    fn remote_without_url_is_error() {
+        let text = r#"{ "mcpServers": { "x": { "type": "http" } } }"#;
+        assert!(parse_mcp_servers(text).is_err());
+    }
+
+    #[test]
+    fn invalid_json_is_error() {
+        assert!(parse_mcp_servers("{ not json").is_err());
+    }
+
+    #[test]
+    fn capability_filter_keeps_stdio_drops_unadvertised_remotes() {
+        let text = r#"{ "mcpServers": {
+            "stdio":  { "command": "c" },
+            "http":   { "type": "http", "url": "u" },
+            "sse":    { "type": "sse",  "url": "u" }
+        }}"#;
+        let servers = parse_mcp_servers(text).unwrap();
+
+        let none = McpCapabilities::new();
+        let kept = filter_for_capabilities(servers.clone(), &none, "t");
+        assert_eq!(names(&kept), vec!["stdio"]);
+
+        let http_only = McpCapabilities::new().http(true);
+        let kept = filter_for_capabilities(servers.clone(), &http_only, "t");
+        assert_eq!(names(&kept), vec!["http", "stdio"]);
+
+        let both = McpCapabilities::new().http(true).sse(true);
+        let kept = filter_for_capabilities(servers, &both, "t");
+        assert_eq!(names(&kept), vec!["http", "sse", "stdio"]);
+    }
+
+    #[test]
+    fn summarize_omits_secret_values() {
+        let text = r#"{ "mcpServers": {
+            "fs": { "command": "c", "env": { "TOKEN": "supersecret" } }
+        }}"#;
+        let servers = parse_mcp_servers(text).unwrap();
+        let s = summarize(&servers);
+        assert_eq!(s, "fs(stdio)");
+        assert!(!s.contains("supersecret"));
+    }
+}

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -23,6 +23,7 @@ pub mod context_primer;
 pub mod event_store;
 pub mod fs_handler;
 pub mod install_hints;
+pub mod mcp_config;
 pub mod node;
 pub mod permissions;
 pub mod protocol;

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -1240,6 +1240,46 @@ impl<S: BroadcastSink> Supervisor<S> {
             SupervisorError::Acp(AcpError::Spawn(format!("worker socket path: {e}")))
         })?;
 
+        // Resolve the user's MCP servers from the global `<app_dir>/mcp.json`
+        // so they reach the agent on session/new and session/load. A malformed
+        // file warns and forwards nothing rather than failing every spawn; a
+        // single typo must not brick all structured-view sessions. Project-local
+        // and per-profile sources are deferred (see issue follow-ups).
+        let mcp_servers = match crate::session::get_app_dir() {
+            Ok(app_dir) => match crate::acp::mcp_config::load_global_mcp_servers(&app_dir) {
+                Ok(servers) => {
+                    if !servers.is_empty() {
+                        info!(
+                            target: "acp.mcp",
+                            session = %session_id,
+                            count = servers.len(),
+                            servers = %crate::acp::mcp_config::summarize(&servers),
+                            "forwarding MCP servers from global config"
+                        );
+                    }
+                    servers
+                }
+                Err(e) => {
+                    warn!(
+                        target: "acp.mcp",
+                        session = %session_id,
+                        error = %e,
+                        "failed to load MCP config; forwarding no servers"
+                    );
+                    Vec::new()
+                }
+            },
+            Err(e) => {
+                warn!(
+                    target: "acp.mcp",
+                    session = %session_id,
+                    error = %e,
+                    "could not resolve app dir for MCP config; forwarding no servers"
+                );
+                Vec::new()
+            }
+        };
+
         let config = SpawnConfig {
             agent_key: agent.clone(),
             spec,
@@ -1251,6 +1291,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             stored_acp_session_id: stored_acp_session_id.clone(),
             sandbox_info,
             source_profile,
+            mcp_servers,
         };
 
         debug!(
@@ -2914,6 +2955,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: None,
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         // Save a registry record so the runner-managed `registry_gone`
         // check returns false and we exercise the budget path.
@@ -3004,6 +3046,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: None,
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         {
             let mut workers = sup.workers.lock().await;
@@ -3077,6 +3120,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: None,
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         {
             let mut workers = sup.workers.lock().await;
@@ -3150,6 +3194,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: None,
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         {
             let mut workers = sup.workers.lock().await;
@@ -3276,6 +3321,7 @@ mod tests {
             stored_acp_session_id: None,
             sandbox_info: None,
             source_profile: None,
+            mcp_servers: Vec::new(),
         };
         {
             let mut workers = sup.workers.lock().await;

--- a/tests/integration/acp_mcp.rs
+++ b/tests/integration/acp_mcp.rs
@@ -79,7 +79,7 @@ async fn configured_mcp_servers_reach_new_session() {
     let mut config = base_config(std::env::temp_dir(), record.path());
     config.mcp_servers = servers;
 
-    let mut client = AcpClient::spawn(config, AcpSessionId("mcp-forward".into()))
+    let client = AcpClient::spawn(config, AcpSessionId("mcp-forward".into()))
         .await
         .expect("spawn shim agent");
 
@@ -109,7 +109,7 @@ async fn no_config_forwards_empty_list() {
     let mut config = base_config(std::env::temp_dir(), record.path());
     config.mcp_servers = servers;
 
-    let mut client = AcpClient::spawn(config, AcpSessionId("mcp-empty".into()))
+    let client = AcpClient::spawn(config, AcpSessionId("mcp-empty".into()))
         .await
         .expect("spawn shim agent");
 

--- a/tests/integration/acp_mcp.rs
+++ b/tests/integration/acp_mcp.rs
@@ -75,15 +75,18 @@ async fn configured_mcp_servers_reach_new_session() {
     let servers = mcp_config::load_global_mcp_servers(app_dir.path()).unwrap();
     assert_eq!(servers.len(), 1, "fixture should parse one server");
 
-    let record = tempfile::NamedTempFile::new().unwrap();
-    let mut config = base_config(std::env::temp_dir(), record.path());
+    // A tempdir + plain path, not NamedTempFile: the shim writes this file from
+    // a separate process, so we must not hold an open handle to it.
+    let record_dir = tempfile::tempdir().unwrap();
+    let record_path = record_dir.path().join("record.json");
+    let mut config = base_config(std::env::temp_dir(), &record_path);
     config.mcp_servers = servers;
 
     let client = AcpClient::spawn(config, AcpSessionId("mcp-forward".into()))
         .await
         .expect("spawn shim agent");
 
-    let body = read_record(record.path());
+    let body = read_record(&record_path);
     let _ = client.shutdown().await;
 
     let parsed: serde_json::Value = serde_json::from_str(&body).expect("record is JSON");
@@ -105,15 +108,16 @@ async fn no_config_forwards_empty_list() {
     let servers = mcp_config::load_global_mcp_servers(app_dir.path()).unwrap();
     assert!(servers.is_empty());
 
-    let record = tempfile::NamedTempFile::new().unwrap();
-    let mut config = base_config(std::env::temp_dir(), record.path());
+    let record_dir = tempfile::tempdir().unwrap();
+    let record_path = record_dir.path().join("record.json");
+    let mut config = base_config(std::env::temp_dir(), &record_path);
     config.mcp_servers = servers;
 
     let client = AcpClient::spawn(config, AcpSessionId("mcp-empty".into()))
         .await
         .expect("spawn shim agent");
 
-    let body = read_record(record.path());
+    let body = read_record(&record_path);
     let _ = client.shutdown().await;
 
     let parsed: serde_json::Value = serde_json::from_str(&body).expect("record is JSON");

--- a/tests/integration/acp_mcp.rs
+++ b/tests/integration/acp_mcp.rs
@@ -1,0 +1,125 @@
+//! End-to-end: the Rust ACP client forwards configured MCP servers to the
+//! agent on `session/new`.
+//!
+//! The shim records the `mcp_servers` it receives to `SHIM_MCP_RECORD_FILE`
+//! (passed through `provider_env`), so these tests assert AoE actually
+//! populates the request rather than dropping the config on the floor.
+//!
+//! Skipped automatically if `node` is not on PATH.
+
+use std::time::Duration;
+
+use agent_of_empires::acp::acp_client::{AcpClient, SpawnConfig};
+use agent_of_empires::acp::agent_registry::AgentSpec;
+use agent_of_empires::acp::mcp_config;
+use agent_of_empires::acp::state::AcpSessionId;
+
+use crate::common::{shim_path, shim_ready};
+
+/// Config with no MCP servers; callers set `mcp_servers` afterward so this
+/// helper never has to name the schema's `McpServer` type.
+fn base_config(cwd: std::path::PathBuf, record_path: &std::path::Path) -> SpawnConfig {
+    let shim = shim_path();
+    SpawnConfig {
+        agent_key: "claude".into(),
+        spec: AgentSpec {
+            command: "node".into(),
+            args: vec![shim.to_string_lossy().to_string()],
+            description: "test shim".into(),
+            env_allowlist: None,
+        },
+        cwd,
+        additional_dirs: vec![],
+        provider_env: vec![(
+            "SHIM_MCP_RECORD_FILE".into(),
+            record_path.to_string_lossy().to_string(),
+        )],
+        default_effort: None,
+        socket_path: None,
+        stored_acp_session_id: None,
+        sandbox_info: None,
+        source_profile: None,
+        mcp_servers: Vec::new(),
+    }
+}
+
+/// Read the shim's record file, retrying briefly: the shim writes it during
+/// `newSession`, which completes inside `spawn`, but the write is async.
+fn read_record(path: &std::path::Path) -> String {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(s) = std::fs::read_to_string(path) {
+            return s;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("shim never wrote {}", path.display());
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[tokio::test]
+async fn configured_mcp_servers_reach_new_session() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+
+    // Resolve servers the same way the supervisor does: a global mcp.json.
+    let app_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        app_dir.path().join("mcp.json"),
+        r#"{ "mcpServers": { "probe": { "command": "echo", "args": ["hi"] } } }"#,
+    )
+    .unwrap();
+    let servers = mcp_config::load_global_mcp_servers(app_dir.path()).unwrap();
+    assert_eq!(servers.len(), 1, "fixture should parse one server");
+
+    let record = tempfile::NamedTempFile::new().unwrap();
+    let mut config = base_config(std::env::temp_dir(), record.path());
+    config.mcp_servers = servers;
+
+    let mut client = AcpClient::spawn(config, AcpSessionId("mcp-forward".into()))
+        .await
+        .expect("spawn shim agent");
+
+    let body = read_record(record.path());
+    let _ = client.shutdown().await;
+
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("record is JSON");
+    let arr = parsed.as_array().expect("mcp_servers is an array");
+    assert_eq!(arr.len(), 1, "expected one forwarded server, got {body}");
+    assert_eq!(arr[0]["name"], "probe", "forwarded server name, got {body}");
+    assert_eq!(arr[0]["command"], "echo", "forwarded command, got {body}");
+}
+
+#[tokio::test]
+async fn no_config_forwards_empty_list() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+
+    // No mcp.json in the app dir => empty list, unchanged from pre-feature.
+    let app_dir = tempfile::tempdir().unwrap();
+    let servers = mcp_config::load_global_mcp_servers(app_dir.path()).unwrap();
+    assert!(servers.is_empty());
+
+    let record = tempfile::NamedTempFile::new().unwrap();
+    let mut config = base_config(std::env::temp_dir(), record.path());
+    config.mcp_servers = servers;
+
+    let mut client = AcpClient::spawn(config, AcpSessionId("mcp-empty".into()))
+        .await
+        .expect("spawn shim agent");
+
+    let body = read_record(record.path());
+    let _ = client.shutdown().await;
+
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("record is JSON");
+    assert_eq!(
+        parsed.as_array().map(|a| a.len()),
+        Some(0),
+        "expected empty mcp_servers, got {body}"
+    );
+}

--- a/tests/integration/acp_session_delete.rs
+++ b/tests/integration/acp_session_delete.rs
@@ -38,6 +38,7 @@ fn spawn_config_with_shim_env(shim: PathBuf, env: Vec<(String, String)>) -> Spaw
         stored_acp_session_id: None,
         sandbox_info: None,
         source_profile: None,
+        mcp_servers: Vec::new(),
     }
 }
 

--- a/tests/integration/acp_smoke.rs
+++ b/tests/integration/acp_smoke.rs
@@ -43,6 +43,7 @@ async fn shim_agent_round_trips_prompt() {
         stored_acp_session_id: None,
         sandbox_info: None,
         source_profile: None,
+        mcp_servers: Vec::new(),
     };
 
     let mut client = AcpClient::spawn(config, AcpSessionId("smoke".into()))
@@ -164,6 +165,7 @@ async fn shim_agent_round_trips_approval_allow() {
         stored_acp_session_id: None,
         sandbox_info: None,
         source_profile: None,
+        mcp_servers: Vec::new(),
     };
 
     let mut client = AcpClient::spawn(config, AcpSessionId("approve".into()))
@@ -261,6 +263,7 @@ async fn shim_agent_round_trips_fs() {
         stored_acp_session_id: None,
         sandbox_info: None,
         source_profile: None,
+        mcp_servers: Vec::new(),
     };
 
     let mut client = AcpClient::spawn(config, AcpSessionId("fs".into()))
@@ -332,6 +335,7 @@ async fn shim_agent_round_trips_terminal() {
         stored_acp_session_id: None,
         sandbox_info: None,
         source_profile: None,
+        mcp_servers: Vec::new(),
     };
 
     let mut client = AcpClient::spawn(config, AcpSessionId("term".into()))
@@ -415,6 +419,7 @@ async fn shim_agent_set_mode_emits_current_mode_changed() {
         stored_acp_session_id: None,
         sandbox_info: None,
         source_profile: None,
+        mcp_servers: Vec::new(),
     };
 
     let mut client = AcpClient::spawn(config, AcpSessionId("set-mode".into()))
@@ -482,6 +487,7 @@ async fn shim_agent_emits_rate_limit_event() {
         stored_acp_session_id: None,
         sandbox_info: None,
         source_profile: None,
+        mcp_servers: Vec::new(),
     };
 
     let mut client = AcpClient::spawn(config, AcpSessionId("rl".into()))

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -30,6 +30,9 @@ mod update_command;
 mod worktree_integration;
 
 #[cfg(feature = "serve")]
+mod acp_mcp;
+
+#[cfg(feature = "serve")]
 mod acp_smoke;
 
 #[cfg(feature = "serve")]

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -41,6 +41,13 @@ const PAGES = [
       "Per-repo configuration and hooks for Agent of Empires sessions.",
   },
   {
+    source: "docs/guides/mcp-servers.md",
+    dest: "guides/mcp-servers.md",
+    title: "MCP Servers",
+    description:
+      "Forward configured MCP servers to structured-view agents via mcp.json.",
+  },
+  {
     source: "docs/guides/sandbox.md",
     dest: "guides/sandbox.md",
     title: "Docker Sandbox: Quick Reference",
@@ -369,6 +376,7 @@ const URL_MAP = {
   "docs/guides/shell-completions.md": "/guides/shell-completions/",
   "docs/guides/diff-view.md": "/guides/diff-view/",
   "docs/guides/repo-config.md": "/guides/repo-config/",
+  "docs/guides/mcp-servers.md": "/guides/mcp-servers/",
   "docs/guides/sandbox.md": "/guides/sandbox/",
   "docs/guides/tmux-status-bar.md": "/guides/tmux-status-bar/",
   "docs/guides/web-dashboard.md": "/guides/web-dashboard/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -35,6 +35,7 @@ export const docsNav: NavSection[] = [
       { title: "tmux Status Bar", href: "/guides/tmux-status-bar/", description: "Show live session status in your tmux status bar." },
       { title: "Agent Command Overrides", href: "/guides/agent-override/", description: "Customize the command used to launch each agent." },
       { title: "Tool Sessions", href: "/guides/tool-sessions/", description: "Run plain shell or tool sessions alongside your agents." },
+      { title: "MCP Servers", href: "/guides/mcp-servers/", description: "Forward configured MCP servers to structured-view agents." },
       { title: "Session Resume (Claude)", href: "/guides/session-resume/", description: "Resume a previous Claude Code conversation in a session." },
       { title: "Shell Completions", href: "/guides/shell-completions/", description: "Install and refresh tab-completion for the aoe CLI." },
       { title: "Sound Effects", href: "/docs/sounds/", description: "Play sounds when agents need input or finish work." },


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Structured-view / ACP sessions were created with an empty `mcp_servers` list, so agents launched through AoE (Claude, Gemini, Codex) could not reach any user-configured MCP servers even though the protocol and the agents support it.

This populates `NewSessionRequest.mcp_servers` and `LoadSessionRequest.mcp_servers` from a global `<app_dir>/mcp.json` written in the standard `.mcp.json` format (the same `mcpServers` object the agents already understand). The supervisor reads and parses the file when it builds the spawn config; the resolved list is threaded through to the connection task and attached to both `session/new` and `session/load`. `http`/`sse` servers are dropped unless the agent advertised the matching capability in its initialize handshake; `stdio` is always forwarded. A missing file forwards nothing (unchanged behavior); a malformed file warns and forwards nothing rather than failing every spawn.

Scope is intentionally global-only for now. Project-local `cwd/.mcp.json` and per-profile MCP config are deferred: a repository-provided config would let a cloned, untrusted repo launch commands the moment a session starts, so it must sit behind the same repo-trust gate AoE already uses for lifecycle hooks. Those are filed as follow-ups.

Closes #1822

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create `~/.agent-of-empires/mcp.json` (or `$XDG_CONFIG_HOME/agent-of-empires/mcp.json` on Linux) with `{ "mcpServers": { "fs": { "command": "<some-mcp-server>", "args": [] } } }`, start a structured-view session, and confirm the agent can list/call that server's tools.
- [ ] Start a structured-view session with no `mcp.json` present and confirm sessions behave exactly as before (no servers, no errors).
- [ ] Put an `http` server in `mcp.json`, start a session on an agent that does not advertise http MCP support, and confirm that server is dropped (warning in `debug.log`) while any `stdio` server still arrives.
- [ ] Write a malformed `mcp.json` and confirm the session still starts, with a warning logged and no servers forwarded.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (no settings surface added; config is file-based)
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

<!-- Note: the regression coverage lives in tests/integration/acp_mcp.rs (full ACP client round-trip against the Node shim asserting newSession.mcp_servers), plus unit tests in src/acp/mcp_config.rs for parsing and capability gating. -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (pressure-tested with a two-model `/debate` on scoping and security), and implementation were drafted by Claude under my direction. I made the design calls (global-only v1, file-based format, deferring project-local behind the trust gate), reviewed each commit, and ran the test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR forwards a configured list of MCP servers from a global <app_dir>/mcp.json into ACP agent sessions (both new and resumed), so structured-view agents (Claude, Gemini, Codex) can be given user-configured MCP endpoints at startup.

## What changed (high-level)

- Added global MCP config loading and parsing (new src/acp/mcp_config.rs).
- Supervisor now reads <app_dir>/mcp.json and populates SpawnConfig.mcp_servers.
- SpawnConfig gained a new pub field mcp_servers: Vec<McpServer> and the field is threaded through spawn/start code into the connection task.
- Acp client now attaches capability-filtered mcp_servers to both NewSessionRequest and LoadSessionRequest; reattaches forward nothing on reconnects.
- Capability gating: stdio servers are always forwarded; http/sse servers are forwarded only if the agent advertises matching MCP capabilities.
- Malformed or missing mcp.json does not block spawns: missing file => no servers; malformed file => warning and no servers.
- Tests: new integration test verifies shim records forwarded newSession.mcp_servers; unit tests cover parsing, capability filtering, summaries, and error cases.
- Docs/site: added a guide (docs/guides/mcp-servers.md) and navigation entry; build script updated to include the page.
- Test updates: many SpawnConfig literals in tests updated to include the new mcp_servers field.

## Key technical notes

- New functions: load_global_mcp_servers(app_dir), filter_for_capabilities(servers, caps, session), summarize(servers).
- The supervisor reads the global config only (cwd/.mcp.json and per-profile configs are intentionally deferred for repo-trust/security reasons).
- Dropped servers due to capability mismatch emit tracing::warn entries with compact summaries that avoid leaking secrets.
- On attach/reattach the code forwards an empty list (servers are assumed forwarded on original connect).

## Benefits

- Centralized/global MCP configuration is automatically made available to agents.
- Agents only receive transports they support (avoids incompatibility).
- Misconfiguration is non-fatal and logged, improving robustness.
- Documentation and tests provide guidance and verification for the behavior.

## Potential follow-ups / enhancements

- Support project-local or per-profile mcp.json after introducing repo-trust gating.
- Consider more granular logging levels or metrics for forwarded vs dropped servers.
- Expose a UI or CLI to validate/preview resolved servers before spawning agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->