### PR TITLE
feat(serve): tee session-scoped tracing into per-session acp worker logs

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -169,6 +169,16 @@ Edge cases:
 - Daemon stop: file removal does not revert runner filters; the next daemon start writes a fresh value.
 - Garbled content: runner logs a `warn` to `log.runtime` and keeps its prior filter.
 
+## Per-session tee
+
+The daemon multiplexes many sessions, so its watchdog, cancel, and stop-reason breadcrumbs (target `acp.protocol`) all land in the one shared `debug.log`. To make `aoe acp logs --session <id>` useful during an incident, the daemon installs a `SessionTeeLayer` (`src/acp/session_tee.rs`) on top of its subscriber stack that mirrors each session-scoped event into that session's `acp-workers/<id>.log`.
+
+- **Routing.** Events are attributed by their `session` field. Each per-session connection task runs inside an `acp_session` span carrying that field, so events that do not set it explicitly still inherit it through the span scope; the layer reads the event's own fields first, then walks the scope.
+- **Additive.** The shared `debug.log` still receives everything; the tee is a copy, not a redirect.
+- **I/O.** Writes are synchronous through a per-session `SizeRotatingWriter` (10 MiB, keep 2), the same writer the shared log uses. Open writers are bounded (LRU, 64) so a long-lived daemon does not leak file descriptors.
+- **Scope.** Daemon only. The runner is single-session and keeps writing its startup marker and the agent's stderr directly. Events on the `acp.tee` target are skipped to prevent re-entrancy.
+- **Filtering.** The tee sits below the same dynamic `EnvFilter`, so `aoe log-level` changes apply to the per-session files too.
+
 ## Web client relay
 
 Browser-side `window.onerror`, `unhandledrejection`, React `ErrorBoundary`, and explicit `reportError()` calls are batched and POSTed to `/api/client-log`. The server re-emits them through `tracing` at target `web.client` so they land in the same `debug.log` as everything else.
@@ -187,7 +197,7 @@ Not captured (intentional, v1): `console.error`. Wrapping it produces noisy dupl
 | `<configured>.1` ... `<configured>.<keep_count>` | Rotated files, oldest at the highest number. |
 | `<configured>.lock` | Idle `fs2` advisory lock file used to serialize rotation across processes. Always present after the first rotation; do not delete while any aoe process is running. |
 | `~/.agent-of-empires/runtime_filter` | Atomically written on every successful `aoe log-level` swap; consumed by runner watchers. |
-| `~/.agent-of-empires/acp-workers/<session-id>.log` | Touched for compatibility; structured tracing lands in the shared configured log file. |
+| `~/.agent-of-empires/acp-workers/<session-id>.log` | Per-session diagnostics surfaced by `aoe acp logs --session <id>`. The runner writes its startup marker and the agent's stderr here directly; the daemon additionally tees every session-scoped tracing event into it (see Per-session tee below). Size-rotated at 10 MiB, keep 2. |
 | `~/.agent-of-empires/serve.log.legacy` | One-shot rename of the pre-consolidation `serve.log` by migration v007. Safe to delete once you've extracted any data you needed. |
 
 On Linux, replace `~/.agent-of-empires` with `$XDG_CONFIG_HOME/agent-of-empires`. Debug builds use `~/.agent-of-empires-dev` to avoid colliding with an installed release.

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -197,7 +197,7 @@ Not captured (intentional, v1): `console.error`. Wrapping it produces noisy dupl
 | `<configured>.1` ... `<configured>.<keep_count>` | Rotated files, oldest at the highest number. |
 | `<configured>.lock` | Idle `fs2` advisory lock file used to serialize rotation across processes. Always present after the first rotation; do not delete while any aoe process is running. |
 | `~/.agent-of-empires/runtime_filter` | Atomically written on every successful `aoe log-level` swap; consumed by runner watchers. |
-| `~/.agent-of-empires/acp-workers/<session-id>.log` | Per-session diagnostics surfaced by `aoe acp logs --session <id>`. The runner writes its startup marker and the agent's stderr here directly; the daemon additionally tees every session-scoped tracing event into it (see Per-session tee below). Size-rotated at 10 MiB, keep 2. |
+| `~/.agent-of-empires/acp-workers/<session-id>.log` | Per-session diagnostics surfaced by `aoe acp logs --session <id>`. The runner writes its startup marker and the agent's stderr here directly; the daemon additionally tees every session-scoped tracing event into it (see Per-session tee above). Size-rotated at 10 MiB, keep 2. |
 | `~/.agent-of-empires/serve.log.legacy` | One-shot rename of the pre-consolidation `serve.log` by migration v007. Safe to delete once you've extracted any data you needed. |
 
 On Linux, replace `~/.agent-of-empires` with `$XDG_CONFIG_HOME/agent-of-empires`. Debug builds use `~/.agent-of-empires-dev` to avoid colliding with an installed release.

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -235,9 +235,12 @@ from the host).
 
 ### Structured view feels "stuck" with no events
 
-- Check `aoe acp logs --session <id>` for the runner stderr drain;
-  the dashboard exposes the same content via the **Open agent log**
-  affordance on the red startup-error banner.
+- Check `aoe acp logs --session <id>`. Besides the runner stderr
+  drain, it now also carries the daemon's session-scoped breadcrumbs
+  (handshake, watchdog fires, `session/cancel`, stop reasons), which
+  previously only reached the shared `debug.log` (#1864). The dashboard
+  exposes the same file via the **Open agent log** affordance on the
+  red startup-error banner.
 - Check the dashboard's connection chrome at the top of the structured view
   view; it shows reconnect status if the WebSocket is degraded.
 - The supervisor watchdog respawns the agent up to 3 times in 60s
@@ -368,7 +371,10 @@ then SIGTERMs the runner and respawns via `session/load` so the
 transcript is preserved. The web UI shows a distinct banner ("Agent
 finished but didn't notify the daemon. Restarting worker; your
 transcript will be preserved.") so the user can tell this apart from
-the cancel-escalation path (`agent_unresponsive`). See #1240.
+the cancel-escalation path (`agent_unresponsive`). See #1240. The
+`silent-orphan watchdog fired` and `sending session/cancel` breadcrumbs
+are teed into `aoe acp logs --session <id>` (#1864), so you can confirm
+the cause without grepping the shared `debug.log`.
 
 The detector fires only when ALL hold for the current prompt:
 - `tool_calls_in_flight` is empty (no open tool call; long-running

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn, Instrument};
 
 use super::agent_compat::{self, ExpectedAgent};
 use super::agent_profiles;
@@ -1350,23 +1350,31 @@ impl AcpClient {
 
         let (ready_tx, ready_rx) = oneshot::channel::<Result<(), AcpError>>();
 
-        tokio::spawn(run_connection_task(
-            transport,
-            event_tx,
-            cmd_rx,
-            cwd,
-            session_label.clone(),
-            Some(child_for_task),
-            pending_for_task,
-            resources,
-            None,
-            mode,
-            Some(ready_tx),
-            profile,
-            expected_agent,
-            source_profile,
-            default_effort,
-        ));
+        // Wrap the per-session connection task in a span carrying the
+        // session id so every nested event inherits it; the daemon's
+        // per-session log tee routes by that field (#1864). The span name
+        // must match `crate::acp::session_tee::SESSION_SPAN`.
+        let conn_span = tracing::info_span!("acp_session", session = %session_label);
+        tokio::spawn(
+            run_connection_task(
+                transport,
+                event_tx,
+                cmd_rx,
+                cwd,
+                session_label.clone(),
+                Some(child_for_task),
+                pending_for_task,
+                resources,
+                None,
+                mode,
+                Some(ready_tx),
+                profile,
+                expected_agent,
+                source_profile,
+                default_effort,
+            )
+            .instrument(conn_span),
+        );
 
         wait_for_handshake(&session_label, ready_rx, Some(&child), &install_binary).await?;
 
@@ -1434,23 +1442,30 @@ impl AcpClient {
 
         let (ready_tx, ready_rx) = oneshot::channel::<Result<(), AcpError>>();
 
-        tokio::spawn(run_connection_task(
-            transport,
-            event_tx,
-            cmd_rx,
-            cwd,
-            session_label.clone(),
-            None,
-            pending_for_task,
-            resources,
-            None,
-            mode,
-            Some(ready_tx),
-            profile,
-            expected_agent,
-            source_profile,
-            default_effort,
-        ));
+        // See the sibling spawn in `spawn`: the connection task runs inside
+        // an `acp_session` span so per-session log teeing (#1864) catches
+        // events that do not set the `session` field explicitly.
+        let conn_span = tracing::info_span!("acp_session", session = %session_label);
+        tokio::spawn(
+            run_connection_task(
+                transport,
+                event_tx,
+                cmd_rx,
+                cwd,
+                session_label.clone(),
+                None,
+                pending_for_task,
+                resources,
+                None,
+                mode,
+                Some(ready_tx),
+                profile,
+                expected_agent,
+                source_profile,
+                default_effort,
+            )
+            .instrument(conn_span),
+        );
 
         wait_for_handshake(&session_label, ready_rx, None, &install_binary).await?;
 

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -29,6 +29,7 @@ pub mod protocol;
 pub mod runner;
 #[cfg(feature = "serve")]
 pub mod sandbox;
+pub mod session_tee;
 pub mod state;
 pub mod supervisor;
 pub mod terminal_handler;

--- a/src/acp/runner.rs
+++ b/src/acp/runner.rs
@@ -1002,8 +1002,15 @@ fn init_runner_logging(session_id: &str) -> Result<()> {
     let resolution =
         crate::logging::resolve_sink(&log_cfg, &app_dir, crate::logging::ProcessContext::Runner);
 
-    let init =
-        crate::logging::init_subscriber_with_options(resolution.target, filter, log_cfg.show_spans);
+    // The runner is single-session; its tracing still flows to the shared
+    // debug.log. The per-session tee runs only in the daemon (#1864), so
+    // no tee layer is installed here.
+    let init = crate::logging::init_subscriber_with_options(
+        resolution.target,
+        filter,
+        log_cfg.show_spans,
+        None,
+    );
     if let Some(c) = init.controller {
         crate::logging::install_controller(c);
     }

--- a/src/acp/session_tee.rs
+++ b/src/acp/session_tee.rs
@@ -97,22 +97,27 @@ impl SessionTeeLayer {
             return Some(entry.writer.clone());
         }
         let path = crate::acp::worker_registry::log_path_for(session).ok()?;
+        // At capacity: evict the oldest entry whose writer is idle
+        // (`strong_count == 1`, only the cache holds it). Evicting a writer
+        // still in flight on another thread would let this call open a
+        // second `SizeRotatingWriter` on the same file and race its appends
+        // and rotation. If every cached writer is in flight, drop this event
+        // rather than open a racing writer.
+        if cache.map.len() >= MAX_OPEN_SESSION_LOGS {
+            let evict = cache
+                .map
+                .iter()
+                .filter(|(_, e)| Arc::strong_count(&e.writer) == 1)
+                .min_by_key(|(_, e)| e.last_used)
+                .map(|(k, _)| k.clone())?;
+            cache.map.remove(&evict);
+        }
         let policy = RotationPolicy {
             kind: RotationKind::Size,
             max_size_bytes: PER_SESSION_MAX_BYTES,
             keep_count: PER_SESSION_KEEP,
         };
         let writer = Arc::new(Mutex::new(SizeRotatingWriter::new(path, policy).ok()?));
-        if cache.map.len() >= MAX_OPEN_SESSION_LOGS {
-            if let Some(evict) = cache
-                .map
-                .iter()
-                .min_by_key(|(_, e)| e.last_used)
-                .map(|(k, _)| k.clone())
-            {
-                cache.map.remove(&evict);
-            }
-        }
         cache.map.insert(
             session.to_string(),
             Entry {
@@ -285,28 +290,41 @@ mod tests {
     use tracing_subscriber::Registry;
 
     /// Point `get_app_dir` at a throwaway home so `log_path_for` resolves
-    /// under a temp dir. Mirrors `worker_registry::tests::with_temp_home`.
+    /// under a temp dir. Restoration runs from an RAII guard so a panicking
+    /// `f()` cannot leak the temp env into later serialized tests.
     fn with_temp_home<F: FnOnce()>(f: F) {
+        struct EnvGuard {
+            home: Option<std::ffi::OsString>,
+            xdg: Option<std::ffi::OsString>,
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                // SAFETY: tests are serialized via `#[serial]`.
+                unsafe {
+                    match self.home.take() {
+                        Some(v) => std::env::set_var("HOME", v),
+                        None => std::env::remove_var("HOME"),
+                    }
+                    match self.xdg.take() {
+                        Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                        None => std::env::remove_var("XDG_CONFIG_HOME"),
+                    }
+                }
+            }
+        }
+
         let tmp = TempDir::new().unwrap();
-        let original = std::env::var_os("HOME");
-        let original_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        // SAFETY: tests are serialized via `#[serial]`; the env mutation
-        // window is bounded to this closure and restored on exit.
+        let _guard = EnvGuard {
+            home: std::env::var_os("HOME"),
+            xdg: std::env::var_os("XDG_CONFIG_HOME"),
+        };
+        // SAFETY: tests are serialized via `#[serial]`; the guard restores
+        // the originals on scope exit, including an unwind.
         unsafe {
             std::env::set_var("HOME", tmp.path());
             std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
         }
         f();
-        unsafe {
-            match original {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-            match original_xdg {
-                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-                None => std::env::remove_var("XDG_CONFIG_HOME"),
-            }
-        }
     }
 
     fn read_log(session: &str) -> String {

--- a/src/acp/session_tee.rs
+++ b/src/acp/session_tee.rs
@@ -1,0 +1,392 @@
+//! Per-session tracing tee: mirrors session-scoped events into each
+//! session's `acp-workers/<id>.log` so `aoe acp logs --session <id>`
+//! surfaces the daemon's watchdog/cancel breadcrumbs, not just the
+//! startup marker plus agent stderr. Additive: events still flow to the
+//! shared `debug.log`. See issue #1864.
+//!
+//! Capture. Events are routed by their `session` (or rare `session_id`)
+//! field. A `tracing::info_span!("acp_session", session = %id)` wraps
+//! each daemon per-session connection task, so events that do not set the
+//! field explicitly still inherit it through the span scope. The layer
+//! reads the event's own fields first, then walks the span scope.
+//!
+//! I/O. Synchronous best-effort writes through a `SizeRotatingWriter` per
+//! session, mirroring the shared `debug.log` writer (same rare-rotation
+//! stall profile, so no new failure class). Writers are bounded by count
+//! and the least-recently-used one is evicted, so a long-lived daemon
+//! does not leak file handles. No background thread, no channel: dropping
+//! a breadcrumb during a spike would lose exactly the diagnostics this
+//! exists to capture.
+//!
+//! Re-entrancy. The writer never emits tracing; events with target
+//! `acp.tee` are skipped so any future self-reporting cannot loop.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use tracing::field::{Field, Visit};
+use tracing::span::Attributes;
+use tracing::{Event, Id, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+use crate::logging::{RotationPolicy, SizeRotatingWriter};
+use crate::session::config::RotationKind;
+
+// The layer is installed generically (un-boxed) in the daemon subscriber
+// stack so its `Layer<S> for any S` impl resolves against the full layered
+// subscriber type, which a `Box<dyn Layer<Registry>>` could not name.
+
+/// Span name carrying the session id for scope-based capture. Entered at
+/// the daemon per-session connection task so nested events inherit the
+/// `session` field even when they do not set it explicitly.
+pub const SESSION_SPAN: &str = "acp_session";
+
+/// Target reserved for the tee's own diagnostics; skipped on the event
+/// path to prevent re-entrancy.
+const TEE_TARGET: &str = "acp.tee";
+
+/// Cap on simultaneously-open per-session log files. Realistic concurrent
+/// session counts sit well under this; the bound only matters for a
+/// daemon that churns through many sessions over days.
+const MAX_OPEN_SESSION_LOGS: usize = 64;
+const PER_SESSION_MAX_BYTES: u64 = 10 * 1024 * 1024;
+const PER_SESSION_KEEP: u8 = 2;
+
+/// Cached session id stored in a span's extensions on creation, so the
+/// per-event scope walk is a pointer chase rather than a field re-visit.
+struct SessionTag(String);
+
+pub struct SessionTeeLayer {
+    writers: Mutex<WriterCache>,
+}
+
+struct WriterCache {
+    map: HashMap<String, Entry>,
+    /// Monotonic counter stamping each access; the smallest stamp is the
+    /// least-recently-used entry to evict when the cap is reached.
+    tick: u64,
+}
+
+struct Entry {
+    writer: Arc<Mutex<SizeRotatingWriter>>,
+    last_used: u64,
+}
+
+impl SessionTeeLayer {
+    pub fn new() -> Self {
+        Self {
+            writers: Mutex::new(WriterCache {
+                map: HashMap::new(),
+                tick: 0,
+            }),
+        }
+    }
+
+    /// Resolve (or open) the per-session writer, updating LRU bookkeeping.
+    /// Returns `None` when the session id is unsafe or the file cannot be
+    /// opened; the caller silently drops the line in that case.
+    fn writer_for(&self, session: &str) -> Option<Arc<Mutex<SizeRotatingWriter>>> {
+        let mut cache = lock(&self.writers);
+        cache.tick += 1;
+        let now = cache.tick;
+        if let Some(entry) = cache.map.get_mut(session) {
+            entry.last_used = now;
+            return Some(entry.writer.clone());
+        }
+        let path = crate::acp::worker_registry::log_path_for(session).ok()?;
+        let policy = RotationPolicy {
+            kind: RotationKind::Size,
+            max_size_bytes: PER_SESSION_MAX_BYTES,
+            keep_count: PER_SESSION_KEEP,
+        };
+        let writer = Arc::new(Mutex::new(SizeRotatingWriter::new(path, policy).ok()?));
+        if cache.map.len() >= MAX_OPEN_SESSION_LOGS {
+            if let Some(evict) = cache
+                .map
+                .iter()
+                .min_by_key(|(_, e)| e.last_used)
+                .map(|(k, _)| k.clone())
+            {
+                cache.map.remove(&evict);
+            }
+        }
+        cache.map.insert(
+            session.to_string(),
+            Entry {
+                writer: writer.clone(),
+                last_used: now,
+            },
+        );
+        Some(writer)
+    }
+}
+
+impl Default for SessionTeeLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for SessionTeeLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        if attrs.metadata().name() != SESSION_SPAN {
+            return;
+        }
+        let mut v = SessionVisitor::default();
+        attrs.record(&mut v);
+        if let Some(session) = v.session {
+            if let Some(span) = ctx.span(id) {
+                span.extensions_mut().insert(SessionTag(session));
+            }
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if event.metadata().target() == TEE_TARGET {
+            return;
+        }
+        // Collect the renderable line and any explicit session field in a
+        // single pass, then fall back to span-scope inheritance.
+        let mut visitor = LineVisitor::default();
+        event.record(&mut visitor);
+        let session = match visitor.session.clone() {
+            Some(s) => s,
+            None => match session_from_scope(event, &ctx) {
+                Some(s) => s,
+                None => return,
+            },
+        };
+        let Some(writer) = self.writer_for(&session) else {
+            return;
+        };
+        let line = visitor.format(event);
+        let mut w = lock(&writer);
+        let _ = w.write_all(line.as_bytes());
+        let _ = w.flush();
+    }
+}
+
+fn session_from_scope<S>(event: &Event<'_>, ctx: &Context<'_, S>) -> Option<String>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let scope = ctx.event_scope(event)?;
+    for span in scope.from_root() {
+        if let Some(tag) = span.extensions().get::<SessionTag>() {
+            return Some(tag.0.clone());
+        }
+    }
+    None
+}
+
+/// Lock that never panics on poison: a writer panic must not propagate
+/// out of the tracing event path. Recovers the inner guard instead.
+fn lock<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Debug-formatted values arrive quoted (`"abc"`); strip surrounding
+/// quotes so `session` values pass `log_path_for` validation and the
+/// rendered line reads cleanly. Mirrors `StageRecorder` in `deletion.rs`.
+fn unquote(s: &str) -> String {
+    s.trim_matches('"').to_string()
+}
+
+#[derive(Default)]
+struct SessionVisitor {
+    session: Option<String>,
+}
+
+impl SessionVisitor {
+    fn capture(&mut self, field: &Field, value: String) {
+        match field.name() {
+            "session" => self.session = Some(value),
+            "session_id" if self.session.is_none() => self.session = Some(value),
+            _ => {}
+        }
+    }
+}
+
+impl Visit for SessionVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.capture(field, value.to_string());
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.capture(field, unquote(&format!("{value:?}")));
+    }
+}
+
+/// Visitor that both finds the session id and collects the renderable
+/// message plus remaining fields for the per-session line. The session
+/// field itself is not echoed into the line: the file is already
+/// per-session, so repeating it would be noise.
+#[derive(Default)]
+struct LineVisitor {
+    session: Option<String>,
+    message: Option<String>,
+    kv: String,
+}
+
+impl LineVisitor {
+    fn push(&mut self, field: &Field, value: String) {
+        match field.name() {
+            "message" => self.message = Some(value),
+            "session" => self.session = Some(value),
+            "session_id" => {
+                if self.session.is_none() {
+                    self.session = Some(value);
+                }
+            }
+            name => {
+                self.kv.push(' ');
+                self.kv.push_str(name);
+                self.kv.push('=');
+                self.kv.push_str(&value);
+            }
+        }
+    }
+
+    fn format(&self, event: &Event<'_>) -> String {
+        let meta = event.metadata();
+        let ts = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        let msg = self.message.as_deref().unwrap_or("");
+        format!(
+            "{ts}  {} {}: {}{}\n",
+            meta.level(),
+            meta.target(),
+            msg,
+            self.kv
+        )
+    }
+}
+
+impl Visit for LineVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.push(field, value.to_string());
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.push(field, unquote(&format!("{value:?}")));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use tempfile::TempDir;
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Registry;
+
+    /// Point `get_app_dir` at a throwaway home so `log_path_for` resolves
+    /// under a temp dir. Mirrors `worker_registry::tests::with_temp_home`.
+    fn with_temp_home<F: FnOnce()>(f: F) {
+        let tmp = TempDir::new().unwrap();
+        let original = std::env::var_os("HOME");
+        let original_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: tests are serialized via `#[serial]`; the env mutation
+        // window is bounded to this closure and restored on exit.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+        f();
+        unsafe {
+            match original {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match original_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+
+    fn read_log(session: &str) -> String {
+        let p = crate::acp::worker_registry::log_path_for(session).unwrap();
+        std::fs::read_to_string(p).unwrap_or_default()
+    }
+
+    #[test]
+    #[serial]
+    fn routes_event_with_session_field_to_its_file() {
+        with_temp_home(|| {
+            let sub = Registry::default().with(SessionTeeLayer::new());
+            with_default(sub, || {
+                tracing::warn!(target: "acp.protocol", session = %"sess-a", "watchdog fired");
+            });
+            let body = read_log("sess-a");
+            assert!(body.contains("watchdog fired"), "got: {body}");
+            assert!(body.contains("acp.protocol"), "got: {body}");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn no_cross_session_leakage() {
+        with_temp_home(|| {
+            let sub = Registry::default().with(SessionTeeLayer::new());
+            with_default(sub, || {
+                tracing::info!(target: "acp.protocol", session = %"sess-x", "x only");
+                tracing::info!(target: "acp.protocol", session = %"sess-y", "y only");
+            });
+            let x = read_log("sess-x");
+            let y = read_log("sess-y");
+            assert!(x.contains("x only") && !x.contains("y only"), "x log: {x}");
+            assert!(y.contains("y only") && !y.contains("x only"), "y log: {y}");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn drops_event_without_session() {
+        with_temp_home(|| {
+            let sub = Registry::default().with(SessionTeeLayer::new());
+            with_default(sub, || {
+                tracing::info!(target: "acp.protocol", "no session here");
+            });
+            let dir = crate::acp::worker_registry::workers_dir().unwrap();
+            let count = std::fs::read_dir(&dir).map(|rd| rd.count()).unwrap_or(0);
+            assert_eq!(count, 0, "a sessionless event must not create a log file");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn inherits_session_from_span_scope() {
+        with_temp_home(|| {
+            let sub = Registry::default().with(SessionTeeLayer::new());
+            with_default(sub, || {
+                let span = tracing::info_span!("acp_session", session = %"sess-span");
+                let _g = span.enter();
+                // Event carries no explicit `session` field; it must be
+                // attributed via the enclosing span scope.
+                tracing::warn!(target: "acp.protocol", "inherited via span");
+            });
+            let body = read_log("sess-span");
+            assert!(body.contains("inherited via span"), "got: {body}");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn skips_tee_target_to_avoid_reentrancy() {
+        with_temp_home(|| {
+            let sub = Registry::default().with(SessionTeeLayer::new());
+            with_default(sub, || {
+                tracing::warn!(target: "acp.tee", session = %"sess-z", "internal");
+            });
+            assert!(
+                read_log("sess-z").is_empty(),
+                "events on the acp.tee target must be skipped"
+            );
+        });
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -489,8 +489,18 @@ impl std::fmt::Display for LogFilterError {
 
 impl std::error::Error for LogFilterError {}
 
+/// Optional top-of-stack layer injected at subscriber init. Only the
+/// serve daemon supplies a real one (the per-session tee, see
+/// `crate::acp::session_tee`); the acp module is `serve`-gated, so without
+/// that feature the slot is the no-op `Identity` layer and callers always
+/// pass `None`.
+#[cfg(feature = "serve")]
+pub type TeeLayer = crate::acp::session_tee::SessionTeeLayer;
+#[cfg(not(feature = "serve"))]
+pub type TeeLayer = tracing_subscriber::layer::Identity;
+
 pub fn init_subscriber(target: SubscriberTarget, filter: String) -> InitResult {
-    init_subscriber_with_options(target, filter, false)
+    init_subscriber_with_options(target, filter, false, None)
 }
 
 /// Event formatter that mirrors the default Full output (RFC3339-ish
@@ -534,6 +544,7 @@ pub fn init_subscriber_with_options(
     target: SubscriberTarget,
     filter: String,
     show_spans: bool,
+    session_tee: Option<TeeLayer>,
 ) -> InitResult {
     let parsed = match EnvFilter::builder().with_regex(false).parse(&filter) {
         Ok(f) => f,
@@ -571,6 +582,7 @@ pub fn init_subscriber_with_options(
                     Registry::default()
                         .with(reload_layer)
                         .with(fmt_layer)
+                        .with(session_tee)
                         .try_init()
                         .map_err(|e| e.to_string())
                 } else {
@@ -581,6 +593,7 @@ pub fn init_subscriber_with_options(
                     Registry::default()
                         .with(reload_layer)
                         .with(fmt_layer)
+                        .with(session_tee)
                         .try_init()
                         .map_err(|e| e.to_string())
                 }
@@ -596,6 +609,7 @@ pub fn init_subscriber_with_options(
                 Registry::default()
                     .with(reload_layer)
                     .with(fmt_layer)
+                    .with(session_tee)
                     .try_init()
                     .map_err(|e| e.to_string())
             } else {
@@ -605,6 +619,7 @@ pub fn init_subscriber_with_options(
                 Registry::default()
                     .with(reload_layer)
                     .with(fmt_layer)
+                    .with(session_tee)
                     .try_init()
                     .map_err(|e| e.to_string())
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,10 +128,26 @@ async fn main() -> Result<()> {
                     SubscriberTarget::File(p, _) => Some(p.clone()),
                     SubscriberTarget::Stdout => None,
                 };
+                // Only the serve daemon multiplexes many sessions, so it is
+                // the one process that tees session-scoped tracing into each
+                // session's acp-workers/<id>.log (#1864). The acp module is
+                // serve-gated, so the tee only exists in serve builds.
+                #[cfg(feature = "serve")]
+                let session_tee = if matches!(
+                    ctx,
+                    ProcessContext::ServeForeground | ProcessContext::ServeDaemonChild
+                ) {
+                    Some(agent_of_empires::acp::session_tee::SessionTeeLayer::new())
+                } else {
+                    None
+                };
+                #[cfg(not(feature = "serve"))]
+                let session_tee: Option<logging::TeeLayer> = None;
                 let res = logging::init_subscriber_with_options(
                     resolution.target,
                     filter,
                     log_cfg.show_spans,
+                    session_tee,
                 );
                 if let Some(w) = resolution.warning {
                     // Emit through the subscriber that just came up.

--- a/tests/e2e/acp_session_log_tee_e2e.rs
+++ b/tests/e2e/acp_session_log_tee_e2e.rs
@@ -1,0 +1,174 @@
+//! Full-stack e2e: daemon session-scoped tracing is teed into the
+//! per-session worker log (#1864).
+//!
+//! Before the fix, `aoe acp logs --session <id>` read only the per-worker
+//! file, which received just the runner startup marker plus agent stderr.
+//! The daemon's `acp.protocol` breadcrumbs (handshake, watchdog, cancel)
+//! went to the shared debug.log, so the command was empty of anything
+//! diagnostic. This proves a daemon-emitted, session-scoped `acp.protocol`
+//! breadcrumb now lands in the per-session log surfaced by `aoe acp logs`.
+//!
+//! Compiled only with `--features serve`. Run via:
+//!
+//! ```sh
+//! cargo test --test e2e --features serve -- acp_session_log_tee
+//! ```
+#![cfg(feature = "serve")]
+
+use std::time::{Duration, Instant};
+
+use serial_test::serial;
+
+use crate::harness::{pick_free_port, require_node, require_tmux, wait_for_port, TuiTestHarness};
+
+/// Minimal one-turn fake-ACP script: just end the turn. We only need the
+/// worker to spawn and complete the ACP handshake, which is what makes the
+/// daemon emit the session-scoped `acp.protocol` breadcrumbs we assert on.
+const SCRIPT: &str = r#"{
+  "turns": [
+    { "updates": [], "stopReason": "end_turn" }
+  ]
+}"#;
+
+fn parse_session_id(add_stdout: &str) -> String {
+    add_stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("ID:"))
+        .map(|rest| rest.trim().to_string())
+        .unwrap_or_else(|| panic!("could not find session ID in `aoe add` output:\n{add_stdout}"))
+}
+
+/// `aoe acp prompt` 404s until the worker is live and handshaked, so a
+/// successful call is the readiness oracle: by the time it returns, the
+/// daemon has emitted the handshake breadcrumbs.
+fn prompt_until_accepted(h: &TuiTestHarness, session_id: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let out = h.run_cli(&["acp", "prompt", session_id, "hello"]);
+        if out.status.success() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "worker never accepted a prompt within {timeout:?}.\nstdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// Poll `aoe acp logs --session <id>` until its output contains `needle`.
+/// Returns the final output for further assertions, or panics on timeout.
+fn logs_until_contains(
+    h: &TuiTestHarness,
+    session_id: &str,
+    needle: &str,
+    timeout: Duration,
+) -> String {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let out = h.run_cli(&["acp", "logs", "--session", session_id]);
+        let body = String::from_utf8_lossy(&out.stdout).to_string();
+        if body.contains(needle) {
+            return body;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "`aoe acp logs` never contained {needle:?} within {timeout:?}.\nlast output:\n{body}"
+            );
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+#[test]
+#[serial]
+fn daemon_breadcrumbs_reach_per_session_log() {
+    require_tmux!();
+    require_node!();
+
+    let mut h = TuiTestHarness::new_in_tmp("acp_session_log_tee");
+
+    let script_path = h.home_path().join("tee-script.json");
+    std::fs::write(&script_path, SCRIPT).expect("write fake-acp script");
+    h.install_acp_shim(&script_path);
+    h.stop_daemon_on_drop();
+
+    // A structured view session needs a git repo as its workspace.
+    let project = h.project_path();
+    for args in [
+        vec!["init", "-q"],
+        vec!["commit", "--allow-empty", "-q", "-m", "init"],
+    ] {
+        let out = std::process::Command::new("git")
+            .args(&args)
+            .current_dir(&project)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("run git");
+        assert!(out.status.success(), "git {args:?} failed");
+    }
+
+    let port = pick_free_port();
+    let port_s = port.to_string();
+    let start = h.run_cli(&["serve", "--daemon", "--port", &port_s, "--no-auth"]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {port}"
+    );
+
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "tee-log",
+        "-c",
+        "claude",
+        "--structured-view",
+    ]);
+    assert!(
+        add.status.success(),
+        "aoe add --structured-view failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&add.stdout),
+        String::from_utf8_lossy(&add.stderr),
+    );
+    let session_id = parse_session_id(&String::from_utf8_lossy(&add.stdout));
+
+    // Worker spawns + handshakes; the daemon emits session-scoped
+    // `acp.protocol` breadcrumbs during the handshake.
+    prompt_until_accepted(&h, &session_id, Duration::from_secs(30));
+
+    // The fix: a daemon-side breadcrumb (target `acp.protocol`, carrying the
+    // session field) is teed into the per-session log. Before #1864 only the
+    // runner startup marker landed here.
+    let body = logs_until_contains(
+        &h,
+        &session_id,
+        "initializing ACP agent",
+        Duration::from_secs(10),
+    );
+
+    // Same file still carries the runner startup marker, confirming the tee
+    // is additive rather than a redirect.
+    assert!(
+        body.contains("runner.startup"),
+        "per-session log should still contain the runner startup marker:\n{body}"
+    );
+    // And it carries the daemon-side target, which previously only reached
+    // the shared debug.log.
+    assert!(
+        body.contains("acp.protocol"),
+        "per-session log should contain the daemon acp.protocol breadcrumb:\n{body}"
+    );
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -18,6 +18,7 @@
 mod harness;
 
 mod acp_focus_isolation_e2e;
+mod acp_session_log_tee_e2e;
 mod acp_tool_cards_e2e;
 mod cli;
 mod command_palette;


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

During an incident, the natural command an operator reaches for is `aoe acp logs --session <id>`, but it showed almost nothing: the per-worker file at `acp-workers/<id>.log` received only the runner startup marker plus the agent's stderr. The breadcrumbs that actually explain a wedged session (`silent-orphan watchdog fired`, `sending session/cancel`, the terminal stop reason) are emitted by the daemon to the shared `debug.log`, not where the command points. This surfaced during the #1858 investigation, where `aoe acp logs` showed only `runner.startup`.

This adds a `SessionTeeLayer` (`src/acp/session_tee.rs`) installed on the daemon's tracing subscriber stack. It mirrors each session-scoped event into that session's `acp-workers/<id>.log`, additively: `debug.log` still receives everything. Events are attributed by their `session` field, and each per-session connection task now runs inside an `acp_session` span so events that do not set the field explicitly still inherit it through the span scope. The CLI stays dumb (read one file).

Per the #1858 design panel, this is approach B (tee at the subscriber layer), chosen over merging `debug.log` in every consumer. The remaining design forks were resolved via an LLM debate:

- Writes are synchronous through a per-session `SizeRotatingWriter` (10 MiB, keep 2), mirroring the shared `debug.log` writer's profile (same rare-rotation stall, no new failure class). A background-thread/channel design was rejected because its drop-on-full would lose exactly the diagnostics this exists to capture, during the very incident it targets.
- Open writers are bounded (LRU, cap 64) so a long-lived daemon does not leak file descriptors; no supervisor lifecycle hook needed.
- Daemon-only: the runner is single-session and keeps writing its marker and the agent's stderr directly. Events on the `acp.tee` target are skipped to prevent re-entrancy. The acp module is `serve`-gated, so the tee slot is the no-op `Identity` layer in non-serve builds.

Closes #1864

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a daemon: `aoe serve --daemon`, then create a structured-view session against a repo and let its worker spawn.
- [ ] Run `aoe acp logs --session <id>` and confirm it shows daemon `acp.protocol` breadcrumbs (e.g. `initializing ACP agent`) in addition to the `runner.startup` marker, where before it showed only the marker.
- [ ] Drive a wedge (or watch a real one) and confirm `silent-orphan watchdog fired` / `sending session/cancel` now appear in `aoe acp logs --session <id>`, not only in `debug.log`.
- [ ] Run two sessions concurrently and confirm each session's log shows only its own breadcrumbs (no cross-session leakage).
- [ ] Confirm `debug.log` still contains all of the above (the tee is additive, not a redirect).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

`tests/e2e/acp_session_log_tee_e2e.rs` stands up a live daemon plus a fake-ACP worker and asserts a daemon breadcrumb reaches the per-session log (story 1). Unit tests in `src/acp/session_tee.rs` cover session-field routing, span-scope inheritance, no cross-session leakage (story 2), sessionless-event drop, and the `acp.tee` re-entrancy skip.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (with an LLM design debate over the capture mechanism, writer lifecycle, rotation, and scope forks), and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds daemon-side per-session tracing teeing so session-scoped diagnostic events are mirrored into per-session worker log files (`acp-workers/<session-id>.log`) while keeping the shared `debug.log` unchanged. This makes `aoe acp logs --session <id>` the single source of truth for what happened in a session, including daemon-emitted breadcrumbs (handshake, watchdog/cancel, stop reasons).

## What changed

- Added SessionTeeLayer (src/acp/session_tee.rs) that routes tracing events to per-session files by session field or by inheriting session from an `acp_session` span.
- Per-session writers: synchronous SizeRotatingWriter (10 MiB, keep 2), cached with an LRU cap (64) and eviction of idle writers to bound file-descriptor usage.
- Prevent re-entrancy by skipping events on target `acp.tee`.
- Instrumented per-session background connection tasks with an `acp_session` tracing span (src/acp/acp_client.rs) so events inherit session scope.
- Logging initialization updated to accept an optional session tee and include it only under the `serve` feature (src/logging.rs, src/main.rs, src/acp/runner.rs).
- Public export added: `pub mod session_tee;` in src/acp/mod.rs.
- Documentation: added “Per-session tee” docs and updated troubleshooting notes to reflect daemon breadcrumbs in per-session logs (docs/...).
- Tests: e2e test (tests/e2e/acp_session_log_tee_e2e.rs) verifying daemon breadcrumbs reach per-session logs; unit tests in src/acp/session_tee.rs covering routing, span inheritance, isolation, sessionless-event drop, and re-entrancy skip.
- Minor fixes/cleanup: adjusted writer eviction to avoid racing writers; test helper RAII for env restoration; doc pointer fix.

## Benefits

- Better diagnostics: per-session logs include daemon and runner breadcrumbs for full session history.
- Isolation: no cross-session leakage even with concurrent sessions.
- Resource safety: bounded writer cache and eviction prevent unbounded FD growth.
- Non-invasive: additive tee — debug.log still contains all events.
- Serve-gated: no overhead for non-serve builds (no-op Identity layer).

## Potential areas for follow-up / enhancement

- Consider async background flushing to reduce synchronous-blocking cost during heavy bursts (tradeoff vs. reliability).
- Expose configurable rotation/retention and LRU cap via daemon config for deployments with different retention or concurrency needs.
- Add observability/metrics (e.g., dropped events due to writer contention, current cached-writer count) for operational visibility.

## Technical notes

- Session resolution: prefers `session` (or `session_id`) field; if absent, resolves session from a span extension recorded on entering spans named `SESSION_SPAN` (`"acp_session"`).
- Formatting: UTC RFC3339 timestamps (microsecond), level, target, message, and all non-session key/value fields; session ID is encoded in filename.
- Writes are best-effort synchronous writes + flush; failures are logged at debug level and do not remove the shared debug.log sink.
- The tee layer is compiled only under `feature = "serve"`; otherwise `TeeLayer` is an identity/no-op layer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->