### PR TITLE
fix: on create hooks in container

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -811,7 +811,20 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                     println!("  {}", cmd);
                 }
                 let hook_env = repo_config::lifecycle_env_vars(&instance);
-                repo_config::execute_hooks(&hooks.on_create, &path, &hook_env)?;
+                if instance.sandbox_info.is_some() {
+                    instance.get_container_for_instance()?;
+                    let workdir = instance.container_workdir();
+                    let container_name =
+                        instance.sandbox_info.as_ref().unwrap().container_name.as_str();
+                    repo_config::execute_hooks_in_container(
+                        &hooks.on_create,
+                        container_name,
+                        &workdir,
+                        &hook_env,
+                    )?;
+                } else {
+                    repo_config::execute_hooks(&hooks.on_create, &path, &hook_env)?;
+                }
                 println!("✓ on_create hooks completed");
             }
         }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -814,14 +814,14 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 if instance.sandbox_info.is_some() {
                     instance.get_container_for_instance()?;
                     let workdir = instance.container_workdir();
-                    let container_name =
-                        instance.sandbox_info.as_ref().unwrap().container_name.as_str();
-                    repo_config::execute_hooks_in_container(
-                        &hooks.on_create,
-                        container_name,
-                        &workdir,
-                        &hook_env,
-                    )?;
+                    if let Some(ref sandbox) = instance.sandbox_info {
+                        repo_config::execute_hooks_in_container(
+                            &hooks.on_create,
+                            &sandbox.container_name,
+                            &workdir,
+                            &hook_env,
+                        )?;
+                    }
                 } else {
                     repo_config::execute_hooks(&hooks.on_create, &path, &hook_env)?;
                 }

--- a/tests/e2e/sandbox.rs
+++ b/tests/e2e/sandbox.rs
@@ -5,7 +5,7 @@ use crate::harness::TuiTestHarness;
 /// Exercises `aoe add --sandbox` which builds the full container config.
 /// This would have caught the duplicate mount points bug (commit 92d2e53).
 ///
-/// Requires a running Docker daemon -- marked `#[ignore]` for CI.
+/// Requires a running Docker daemon; marked `#[ignore]` for CI.
 #[test]
 #[serial]
 #[ignore = "requires Docker daemon"]
@@ -44,7 +44,7 @@ fn test_cli_add_with_sandbox() {
 /// `HookTarget::Local`, ignoring `sandbox_info`. The TUI already handled this
 /// correctly via `execute_hooks_in_container_streamed`.
 ///
-/// Requires a running Docker daemon -- marked `#[ignore]` for CI.
+/// Requires a running Docker daemon; marked `#[ignore]` for CI.
 #[test]
 #[serial]
 #[ignore = "requires Docker daemon"]

--- a/tests/e2e/sandbox.rs
+++ b/tests/e2e/sandbox.rs
@@ -36,3 +36,67 @@ fn test_cli_add_with_sandbox() {
         stdout
     );
 }
+
+/// Regression test for #1989: on_create hooks must execute inside the sandbox
+/// container, not on the host, when `aoe add --sandbox` is used.
+///
+/// Before the fix, the CLI called `execute_hooks()` unconditionally with
+/// `HookTarget::Local`, ignoring `sandbox_info`. The TUI already handled this
+/// correctly via `execute_hooks_in_container_streamed`.
+///
+/// Requires a running Docker daemon -- marked `#[ignore]` for CI.
+#[test]
+#[serial]
+#[ignore = "requires Docker daemon"]
+fn test_cli_add_sandbox_on_create_hooks_run_in_container() {
+    let h = TuiTestHarness::new("cli_sandbox_hooks");
+    let project = h.project_path();
+
+    // A path in /tmp that both host and container own as separate namespaces.
+    // If the hook runs on the HOST (the bug), this file appears on the host.
+    // If it runs correctly INSIDE the container, it only exists in the
+    // container's ephemeral /tmp and is invisible on the host.
+    let marker = format!("/tmp/aoe-sandbox-hook-{}", std::process::id());
+    // Guard against a stale marker from a prior crashed run.
+    let _ = std::fs::remove_file(&marker);
+
+    let aoe_config_dir = project.join(".agent-of-empires");
+    std::fs::create_dir_all(&aoe_config_dir).expect("create config dir");
+    std::fs::write(
+        aoe_config_dir.join("config.toml"),
+        format!("[hooks]\non_create = [\"touch {}\"]\n", marker),
+    )
+    .expect("write repo config");
+
+    let output = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "--sandbox",
+        "--trust-hooks",
+        "-t",
+        "SandboxHookTest",
+    ]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "aoe add --sandbox --trust-hooks failed:\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("on_create hooks completed"),
+        "expected 'on_create hooks completed' in stdout.\nstdout: {}",
+        stdout
+    );
+    // Regression guard: the marker must NOT exist on the host. Before the fix,
+    // the CLI ran hooks via HookTarget::Local so the file would have appeared
+    // here. The correct path runs the hook inside the container, where the
+    // host's /tmp is not visible.
+    assert!(
+        !std::path::Path::new(&marker).exists(),
+        "on_create hook ran on the host instead of inside the container \
+         (regression of #1989): marker found at {}",
+        marker
+    );
+}


### PR DESCRIPTION
## Description

Fixes #1989.

When using `aoe add . --sandbox` from the CLI, `on_create` hooks were running on the host machine instead of inside the sandbox container. This caused failures on macOS where host paths like `/workspace/...` don't exist and SIP makes the filesystem read-only. The issue reporter also observed the wrong tool versions (host's CPython 3.11.13 vs the container's 3.11.15), confirming the hook environment was the host, not the container.

Root cause: `src/cli/add.rs` called `execute_hooks()` unconditionally with `HookTarget::Local`, ignoring the `sandbox_info` populated by `--sandbox`. The TUI path in `creation_poller.rs` already handled this correctly via `execute_hooks_in_container_streamed`.

Fix: check for `sandbox_info` before executing hooks. If set, start the container via `get_container_for_instance()` and route through `execute_hooks_in_container()`. Otherwise fall back to the existing local path. The CLI path now mirrors the TUI logic exactly.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Added `test_cli_add_sandbox_on_create_hooks_run_in_container` to `tests/e2e/sandbox.rs`. The hook writes a marker to `/tmp/aoe-sandbox-hook-{pid}`. Host and container each have an independent `/tmp` namespace, so if the hook ran on the host (the bug) the file appears there and the assertion fails. Combined with asserting `aoe add` exited successfully (proving the hook ran somewhere), the two together prove it executed inside the container. Marked `#[ignore = "requires Docker daemon"]` matching the existing sandbox test convention. Verified locally with Docker.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (Claude Code)

**Any Additional AI Details you'd like to share:** Used Claude Code to identify the root cause, implement the fix, and write the regression test. Reviewed and verified each step manually, including running the e2e test against a live Docker daemon.

- [ ] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

- Fixed CLI so `on_create` hooks run inside the sandbox container when `aoe add ... --sandbox` is used, making CLI behavior match the TUI.
- CLI now checks for sandbox mode; if sandboxed it starts the container and executes hooks inside it, otherwise it falls back to executing hooks on the host.
- Added an e2e regression test (ignored in CI — requires Docker) that verifies the hook executes inside the container by creating a container-only /tmp marker.

Benefits:
- Prevents hook failures on macOS caused by missing container paths or read-only system volumes.
- Ensures consistent behavior between CLI and TUI.
- Avoids surprises from mismatched tool versions between host and container.

Technical details

- Files changed:
  - src/cli/add.rs: branch on `instance.sandbox_info`; for sandboxed instances call `get_container_for_instance()` and `repo_config::execute_hooks_in_container(...)` instead of always calling `execute_hooks()` — (+14 / -1).
  - tests/e2e/sandbox.rs: added ignored Docker-dependent test `test_cli_add_sandbox_on_create_hooks_run_in_container` that asserts hooks run in the container by writing a container-only /tmp marker — (~+64).

- Key calls:
  - `instance.sandbox_info.is_some()`
  - `instance.get_container_for_instance()`
  - `instance.container_workdir()`
  - `repo_config::execute_hooks_in_container(...)`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->