### PR TITLE
feat(acp): forward agent-native MCP config via live read-through, merged under global

### DIFF
--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -71,7 +71,7 @@ The native config read per agent:
 When the same server name appears in more than one source, the higher-precedence
 source wins (per server, not whole file):
 
-```
+```text
 agent-native  <  mcp.json (global)
 ```
 

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -50,6 +50,35 @@ Each entry is one of:
 The forwarded list is the same for fresh sessions (`session/new`) and resumed
 ones (`session/load`).
 
+## Native agent config (no double maintenance)
+
+If you already declared MCP servers in your agent's own config, AoE reads them
+too, so you do not have to copy them into `mcp.json`. At session start AoE reads
+the active agent's native config live (so edits are picked up on the next
+session) and merges those servers with your `mcp.json`. AoE only reads these
+files; it never writes to them.
+
+The native config read per agent:
+
+- **Claude**: `~/.claude.json` (top-level `mcpServers`).
+- **Gemini**: `~/.gemini/settings.json` (`mcpServers`; an entry's transport is
+  chosen by which key it sets, `command` for stdio, `httpUrl` for http, `url`
+  for sse).
+- **Codex**: `~/.codex/config.toml` (`[mcp_servers.<name>]` tables).
+
+### Precedence
+
+When the same server name appears in more than one source, the higher-precedence
+source wins (per server, not whole file):
+
+```
+agent-native  <  mcp.json (global)
+```
+
+So a server defined in both your agent's native config and `mcp.json` is taken
+from `mcp.json`. The override is logged. Per-profile and project-local sources
+are planned higher layers on top of this stack and are tracked separately.
+
 ## Capability gating
 
 Not every agent supports every transport. `stdio` works everywhere. `http` and
@@ -59,11 +88,13 @@ AoE never sends a request the agent would reject.
 
 ## Errors
 
-A missing `mcp.json` is normal and means no servers are forwarded, identical to
-the behavior before this feature. A malformed `mcp.json` is logged as a warning
-and no servers are forwarded, so a single typo never blocks your sessions from
-starting. Check the log (`debug.log` in the app directory) if a configured
-server does not show up.
+A missing `mcp.json` is normal and means no servers are forwarded from it,
+identical to the behavior before this feature. A malformed `mcp.json` is logged
+as a warning and contributes nothing, so a single typo never blocks your
+sessions from starting. The same isolation applies to native configs: a missing
+native file is normal, and a broken one (or a single broken entry inside it) is
+warned and skipped without dropping the rest or blocking the spawn. Check the
+log (`debug.log` in the app directory) if a configured server does not show up.
 
 ## Security
 

--- a/src/acp/mcp_config.rs
+++ b/src/acp/mcp_config.rs
@@ -24,6 +24,8 @@
 //! config, are tracked as follow-ups.
 
 use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::BufReader;
 use std::path::Path;
 
 use agent_client_protocol::schema::{
@@ -193,6 +195,258 @@ fn server_kind(server: &McpServer) -> &'static str {
     }
 }
 
+/// A named source of MCP servers for precedence merging. Layers are passed
+/// lowest-precedence first; on a server-name collision the higher (later) layer
+/// wins and both labels are logged so the override is visible. The `label` is
+/// the provenance the unified MCP surface (issue #1996) will display; it is
+/// read here today in the collision warning, so it is not dead state.
+pub struct McpLayer {
+    pub label: &'static str,
+    pub servers: Vec<McpServer>,
+}
+
+/// Merge MCP server layers by precedence. `layers` are ordered lowest first; a
+/// server in a later layer overrides one of the same name in an earlier layer
+/// (per-server, not whole-layer). Output is name-sorted so forwarding is
+/// deterministic. This is the reusable seam the per-profile (#1986) and
+/// project-local (#1985) layers extend by appending their own `McpLayer`.
+pub fn merge_by_precedence(layers: Vec<McpLayer>) -> Vec<McpServer> {
+    let mut by_name: BTreeMap<String, (&'static str, McpServer)> = BTreeMap::new();
+    for layer in layers {
+        for server in layer.servers {
+            let name = server_name(&server).to_string();
+            if let Some((shadowed, _)) = by_name.get(&name) {
+                warn!(
+                    target: "acp.mcp",
+                    server = %name,
+                    kept = layer.label,
+                    shadowed = *shadowed,
+                    "MCP server name defined in multiple sources; higher-precedence source wins"
+                );
+            }
+            by_name.insert(name, (layer.label, server));
+        }
+    }
+    by_name.into_values().map(|(_, server)| server).collect()
+}
+
+/// Where an agent keeps its own MCP server config, and in what shape. This is
+/// the per-agent seam: adding an agent is one match arm in `native_config_for`
+/// plus, if its format differs, one converter. AoE only ever reads these files;
+/// it never writes them.
+enum NativeMcpConfig {
+    /// Standard `{ "mcpServers": { ... } }` JSON with the ecosystem `type`/`url`
+    /// shape, at a home-relative path. Claude (`~/.claude.json`).
+    StandardJson(&'static str),
+    /// Gemini `settings.json`: an `mcpServers` block whose entries discriminate
+    /// transport by which key is present (`command` -> stdio, `httpUrl` -> http,
+    /// `url` -> sse) rather than by a `type` field.
+    GeminiJson(&'static str),
+    /// Codex `config.toml`: `[mcp_servers.<name>]` tables (stdio, or `url` for
+    /// streamable http on newer Codex).
+    CodexToml(&'static str),
+}
+
+/// Map an agent registry key to its native MCP config descriptor, or `None` for
+/// an agent AoE has no native reader for (those contribute no native servers).
+fn native_config_for(agent_key: &str) -> Option<NativeMcpConfig> {
+    match agent_key {
+        "claude" | "claude-code" => Some(NativeMcpConfig::StandardJson(".claude.json")),
+        "gemini" => Some(NativeMcpConfig::GeminiJson(".gemini/settings.json")),
+        "codex" => Some(NativeMcpConfig::CodexToml(".codex/config.toml")),
+        _ => None,
+    }
+}
+
+/// Read the active agent's own MCP config (the file its CLI reads) and convert
+/// it to ACP servers. Live read-through: called once per spawn, no caching, so
+/// edits are picked up on the next session. Returns an empty list for an agent
+/// with no known native reader and for a missing file. A present-but-unparseable
+/// file is an error the caller downgrades to a warning, so a broken native file
+/// (which AoE does not own) never blocks a spawn. Individual malformed server
+/// entries are skipped with a warning rather than failing the whole file.
+pub fn load_native_mcp_servers(agent_key: &str, home: &Path) -> Result<Vec<McpServer>> {
+    let Some(config) = native_config_for(agent_key) else {
+        return Ok(Vec::new());
+    };
+    match config {
+        NativeMcpConfig::StandardJson(rel) => read_standard_json(&home.join(rel)),
+        NativeMcpConfig::GeminiJson(rel) => read_gemini_json(&home.join(rel)),
+        NativeMcpConfig::CodexToml(rel) => read_codex_toml(&home.join(rel)),
+    }
+}
+
+/// Convenience wrapper that resolves the real home dir. Kept separate from
+/// `load_native_mcp_servers` so tests can inject a temp home.
+pub fn load_native_mcp_servers_from_home(agent_key: &str) -> Result<Vec<McpServer>> {
+    let home = dirs::home_dir().context("could not resolve home dir for native MCP config")?;
+    load_native_mcp_servers(agent_key, &home)
+}
+
+/// Convert a map of raw server entries, skipping (with a warning) any entry that
+/// fails to convert rather than failing the whole file. Native configs are owned
+/// by other tools, so one bad entry must not discard the user's other servers.
+fn convert_tolerant<R>(
+    servers: BTreeMap<String, R>,
+    path: &Path,
+    convert: impl Fn(&str, R) -> Result<McpServer>,
+) -> Vec<McpServer> {
+    servers
+        .into_iter()
+        .filter_map(|(name, raw)| match convert(&name, raw) {
+            Ok(server) => Some(server),
+            Err(e) => {
+                warn!(
+                    target: "acp.mcp",
+                    server = %name,
+                    path = %path.display(),
+                    error = %e,
+                    "skipping malformed MCP server in native config"
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+/// Read a JSON config in the standard `mcpServers` shape, streaming so a large
+/// host file (e.g. `~/.claude.json`, which also holds project history) is parsed
+/// without materializing the unrelated keys: serde skips them in the reader.
+fn read_standard_json(path: &Path) -> Result<Vec<McpServer>> {
+    let Some(file) = open_optional(path)? else {
+        return Ok(Vec::new());
+    };
+    let parsed: McpConfigFile = serde_json::from_reader(BufReader::new(file))
+        .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
+    Ok(convert_tolerant(parsed.mcp_servers, path, convert_server))
+}
+
+/// Gemini `settings.json` reader: same streaming approach as Claude, but entries
+/// discriminate transport by key rather than a `type` field.
+fn read_gemini_json(path: &Path) -> Result<Vec<McpServer>> {
+    let Some(file) = open_optional(path)? else {
+        return Ok(Vec::new());
+    };
+    let parsed: GeminiConfigFile = serde_json::from_reader(BufReader::new(file))
+        .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
+    Ok(convert_tolerant(
+        parsed.mcp_servers,
+        path,
+        convert_gemini_server,
+    ))
+}
+
+/// Codex `config.toml` reader. These files are small (no embedded history), so a
+/// whole-string read is fine; `toml` has no streaming reader.
+fn read_codex_toml(path: &Path) -> Result<Vec<McpServer>> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("reading native MCP config at {}", path.display()))
+        }
+    };
+    let parsed: CodexConfigFile = toml::from_str(&text)
+        .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
+    Ok(convert_tolerant(
+        parsed.mcp_servers,
+        path,
+        convert_codex_server,
+    ))
+}
+
+/// Open a config file, mapping "not found" to `None` (the user does not use that
+/// agent) and any other IO error to a context-tagged failure.
+fn open_optional(path: &Path) -> Result<Option<File>> {
+    match File::open(path) {
+        Ok(f) => Ok(Some(f)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => {
+            Err(e).with_context(|| format!("opening native MCP config at {}", path.display()))
+        }
+    }
+}
+
+/// On-disk shape of a Gemini `mcpServers` entry. Transport is selected by which
+/// of `command` / `httpUrl` / `url` is present; more than one is ambiguous.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiConfigFile {
+    #[serde(default)]
+    mcp_servers: BTreeMap<String, GeminiRawServer>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiRawServer {
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    http_url: Option<String>,
+    url: Option<String>,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+}
+
+fn convert_gemini_server(name: &str, raw: GeminiRawServer) -> Result<McpServer> {
+    match (raw.command, raw.http_url, raw.url) {
+        (Some(command), None, None) => Ok(McpServer::Stdio(
+            McpServerStdio::new(name, command)
+                .args(raw.args)
+                .env(to_env(raw.env)),
+        )),
+        (None, Some(http_url), None) => Ok(McpServer::Http(
+            McpServerHttp::new(name, http_url).headers(to_headers(raw.headers)),
+        )),
+        (None, None, Some(url)) => Ok(McpServer::Sse(
+            McpServerSse::new(name, url).headers(to_headers(raw.headers)),
+        )),
+        (None, None, None) => {
+            bail!("MCP server \"{name}\" has none of \"command\", \"httpUrl\", \"url\"")
+        }
+        _ => bail!("MCP server \"{name}\" sets more than one of \"command\", \"httpUrl\", \"url\""),
+    }
+}
+
+/// On-disk shape of a Codex `[mcp_servers.<name>]` entry. `command` selects
+/// stdio; `url` selects streamable http (newer Codex). The TOML key is already
+/// snake_case, so no rename is needed.
+#[derive(Debug, Deserialize)]
+struct CodexConfigFile {
+    #[serde(default)]
+    mcp_servers: BTreeMap<String, CodexRawServer>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexRawServer {
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    url: Option<String>,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+}
+
+fn convert_codex_server(name: &str, raw: CodexRawServer) -> Result<McpServer> {
+    match (raw.command, raw.url) {
+        (Some(command), None) => Ok(McpServer::Stdio(
+            McpServerStdio::new(name, command)
+                .args(raw.args)
+                .env(to_env(raw.env)),
+        )),
+        (None, Some(url)) => Ok(McpServer::Http(
+            McpServerHttp::new(name, url).headers(to_headers(raw.headers)),
+        )),
+        (None, None) => bail!("MCP server \"{name}\" has neither \"command\" nor \"url\""),
+        (Some(_), Some(_)) => bail!("MCP server \"{name}\" sets both \"command\" and \"url\""),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,5 +601,212 @@ mod tests {
         let s = summarize(&servers);
         assert_eq!(s, "fs(stdio)");
         assert!(!s.contains("supersecret"));
+    }
+
+    fn layer(label: &'static str, json: &str) -> McpLayer {
+        McpLayer {
+            label,
+            servers: parse_mcp_servers(json).unwrap(),
+        }
+    }
+
+    fn stdio_command(server: &McpServer) -> &str {
+        match server {
+            McpServer::Stdio(s) => s.command.to_str().unwrap(),
+            other => panic!("expected stdio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_higher_layer_overrides_same_name() {
+        // `low` first, `high` second; on the shared "fs" name, high wins.
+        let low = layer(
+            "agent-native",
+            r#"{ "mcpServers": { "fs": { "command": "native" } } }"#,
+        );
+        let high = layer(
+            "global",
+            r#"{ "mcpServers": { "fs": { "command": "global" } } }"#,
+        );
+        let merged = merge_by_precedence(vec![low, high]);
+        assert_eq!(names(&merged), vec!["fs"]);
+        assert_eq!(stdio_command(&merged[0]), "global");
+    }
+
+    #[test]
+    fn merge_unions_distinct_names_sorted() {
+        let low = layer(
+            "agent-native",
+            r#"{ "mcpServers": { "zebra": { "command": "z" }, "fs": { "command": "n" } } }"#,
+        );
+        let high = layer(
+            "global",
+            r#"{ "mcpServers": { "alpha": { "command": "a" } } }"#,
+        );
+        let merged = merge_by_precedence(vec![low, high]);
+        assert_eq!(names(&merged), vec!["alpha", "fs", "zebra"]);
+    }
+
+    #[test]
+    fn merge_empty_layers_is_empty() {
+        assert!(merge_by_precedence(vec![]).is_empty());
+        let empty = McpLayer {
+            label: "global",
+            servers: Vec::new(),
+        };
+        assert!(merge_by_precedence(vec![empty]).is_empty());
+    }
+
+    fn write(home: &Path, rel: &str, contents: &str) {
+        let path = home.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn native_unknown_agent_is_empty() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(load_native_mcp_servers("opencode", home.path())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn native_missing_file_is_empty() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(load_native_mcp_servers("claude", home.path())
+            .unwrap()
+            .is_empty());
+        assert!(load_native_mcp_servers("gemini", home.path())
+            .unwrap()
+            .is_empty());
+        assert!(load_native_mcp_servers("codex", home.path())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn native_claude_parses_and_ignores_history() {
+        let home = tempfile::tempdir().unwrap();
+        // `~/.claude.json` also holds unrelated keys (project history); they must
+        // be skipped without affecting the mcpServers parse.
+        write(
+            home.path(),
+            ".claude.json",
+            r#"{
+                "projects": { "/some/path": { "lastSessionId": "abc" } },
+                "numStartups": 42,
+                "mcpServers": {
+                    "fs": { "command": "mcp-fs", "args": ["--root", "."] },
+                    "remote": { "type": "http", "url": "https://e/mcp" }
+                }
+            }"#,
+        );
+        let servers = load_native_mcp_servers("claude", home.path()).unwrap();
+        assert_eq!(names(&servers), vec!["fs", "remote"]);
+        // `claude-code` is the legacy alias and resolves to the same reader.
+        let aliased = load_native_mcp_servers("claude-code", home.path()).unwrap();
+        assert_eq!(names(&aliased), vec!["fs", "remote"]);
+    }
+
+    #[test]
+    fn native_claude_skips_bad_entry_keeps_rest() {
+        let home = tempfile::tempdir().unwrap();
+        // The "broken" stdio entry has no command; it is skipped, "ok" survives.
+        write(
+            home.path(),
+            ".claude.json",
+            r#"{ "mcpServers": {
+                "broken": { "args": ["--x"] },
+                "ok": { "command": "good" }
+            } }"#,
+        );
+        let servers = load_native_mcp_servers("claude", home.path()).unwrap();
+        assert_eq!(names(&servers), vec!["ok"]);
+    }
+
+    #[test]
+    fn native_claude_malformed_file_is_error() {
+        let home = tempfile::tempdir().unwrap();
+        write(home.path(), ".claude.json", "{ not json");
+        assert!(load_native_mcp_servers("claude", home.path()).is_err());
+    }
+
+    #[test]
+    fn native_gemini_discriminates_transport_by_key() {
+        let home = tempfile::tempdir().unwrap();
+        write(
+            home.path(),
+            ".gemini/settings.json",
+            r#"{
+                "theme": "dark",
+                "mcpServers": {
+                    "local":  { "command": "g", "args": ["--x"] },
+                    "httpish": { "httpUrl": "https://e/mcp", "headers": { "Authorization": "Bearer x" } },
+                    "sseish":  { "url": "https://e/sse" }
+                }
+            }"#,
+        );
+        let servers = load_native_mcp_servers("gemini", home.path()).unwrap();
+        // BTreeMap order: httpish, local, sseish.
+        assert_eq!(names(&servers), vec!["httpish", "local", "sseish"]);
+        match &servers[0] {
+            McpServer::Http(h) => {
+                assert_eq!(h.url, "https://e/mcp");
+                assert_eq!(h.headers[0].name, "Authorization");
+            }
+            other => panic!("expected http from httpUrl, got {other:?}"),
+        }
+        assert!(matches!(&servers[1], McpServer::Stdio(_)));
+        assert!(matches!(&servers[2], McpServer::Sse(_)));
+    }
+
+    #[test]
+    fn native_gemini_ambiguous_entry_is_skipped() {
+        let home = tempfile::tempdir().unwrap();
+        // "ambiguous" sets both command and httpUrl; skipped, "ok" survives.
+        write(
+            home.path(),
+            ".gemini/settings.json",
+            r#"{ "mcpServers": {
+                "ambiguous": { "command": "c", "httpUrl": "https://e/mcp" },
+                "ok": { "command": "good" }
+            } }"#,
+        );
+        let servers = load_native_mcp_servers("gemini", home.path()).unwrap();
+        assert_eq!(names(&servers), vec!["ok"]);
+    }
+
+    #[test]
+    fn native_codex_parses_toml() {
+        let home = tempfile::tempdir().unwrap();
+        write(
+            home.path(),
+            ".codex/config.toml",
+            r#"
+model = "gpt-5"
+
+[mcp_servers.fs]
+command = "mcp-fs"
+args = ["--root", "."]
+env = { TOKEN = "secret" }
+
+[mcp_servers.remote]
+url = "https://e/mcp"
+"#,
+        );
+        let servers = load_native_mcp_servers("codex", home.path()).unwrap();
+        assert_eq!(names(&servers), vec!["fs", "remote"]);
+        assert_eq!(stdio_command(&servers[0]), "mcp-fs");
+        assert!(matches!(&servers[1], McpServer::Http(_)));
+        // Secret env value never appears in the summary.
+        assert!(!summarize(&servers).contains("secret"));
+    }
+
+    #[test]
+    fn native_codex_malformed_file_is_error() {
+        let home = tempfile::tempdir().unwrap();
+        write(home.path(), ".codex/config.toml", "this = = not toml");
+        assert!(load_native_mcp_servers("codex", home.path()).is_err());
     }
 }

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -1697,7 +1697,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                         guard.remove(&session_id);
                         return;
                     }
-                    let respawn_config: SpawnConfig =
+                    let mut respawn_config: SpawnConfig =
                         match restart_decision(&workers, &session_id).await {
                             RestartDecision::Respawn(cfg) => {
                                 info!(
@@ -1774,6 +1774,26 @@ impl<S: BroadcastSink> Supervisor<S> {
                         };
 
                     tokio::time::sleep(RESPAWN_BACKOFF).await;
+
+                    // Re-resolve the MCP layers rather than reusing the list
+                    // cached at first spawn: edits to the agent's native config
+                    // or `<app_dir>/mcp.json` made since then are forwarded on
+                    // `session/load` too, so a respawn must pick them up.
+                    let mcp_agent = respawn_config.agent_key.clone();
+                    let mcp_session = session_id.clone();
+                    respawn_config.mcp_servers = tokio::task::spawn_blocking(move || {
+                        resolve_mcp_layers(&mcp_agent, &mcp_session)
+                    })
+                    .await
+                    .unwrap_or_else(|e| {
+                        warn!(
+                            target: "acp.mcp",
+                            session = %session_id,
+                            error = %e,
+                            "MCP re-resolution on respawn failed; forwarding no servers"
+                        );
+                        Vec::new()
+                    });
 
                     let acp_session_id = AcpSessionId(session_id.clone());
                     let mut new_client =
@@ -2971,6 +2991,71 @@ mod tests {
         let sup = Supervisor::new(sink);
         assert_eq!(sup.count().await, 0);
         assert!(!sup.is_running("anything").await);
+    }
+
+    /// `resolve_mcp_layers` is the supervisor's own resolver: it reads the
+    /// agent's native config (HOME-relative) and the global `<app_dir>/mcp.json`,
+    /// then merges with global winning name collisions. The integration test in
+    /// `tests/integration/acp_mcp.rs` precomputes the merge itself and so never
+    /// covers this wiring; this test exercises it end to end against temp dirs.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn resolve_mcp_layers_merges_native_under_global() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // SAFETY: serialised by `#[serial]`; subsequent serial tests reassign
+        // these env vars, which is the existing pattern in this module.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+
+        // Native (Claude) layer: defines "native-only" and "shared".
+        std::fs::write(
+            tmp.path().join(".claude.json"),
+            r#"{ "mcpServers": {
+                "native-only": { "command": "n" },
+                "shared": { "command": "from-native" }
+            } }"#,
+        )
+        .unwrap();
+
+        // Global layer in the resolved app dir: adds "global-only" and overrides
+        // "shared". Resolve the dir via the same call the resolver uses so the
+        // namespace (release vs dev) always matches.
+        let app_dir = crate::session::get_app_dir().unwrap();
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(
+            app_dir.join("mcp.json"),
+            r#"{ "mcpServers": {
+                "global-only": { "command": "g" },
+                "shared": { "command": "from-global" }
+            } }"#,
+        )
+        .unwrap();
+
+        let merged = tokio::task::spawn_blocking(|| resolve_mcp_layers("claude", "resolve-test"))
+            .await
+            .unwrap();
+
+        let val = serde_json::to_value(&merged).unwrap();
+        let arr = val.as_array().expect("mcp_servers serializes to an array");
+        assert_eq!(arr.len(), 3, "native + global union, got {val}");
+        let shared = arr
+            .iter()
+            .find(|s| s["name"] == "shared")
+            .expect("shared server present");
+        assert_eq!(
+            shared["command"], "from-global",
+            "global must win the name collision, got {val}"
+        );
+        assert!(
+            arr.iter().any(|s| s["name"] == "native-only"),
+            "native-only must survive the merge, got {val}"
+        );
+        assert!(
+            arr.iter().any(|s| s["name"] == "global-only"),
+            "global-only must survive the merge, got {val}"
+        );
     }
 
     /// Watchdog: after MAX_RESPAWNS_IN_WINDOW respawn attempts inside

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -473,6 +473,82 @@ fn command_matches_binary(command: &str, binary: &str) -> bool {
             .is_some_and(|name| name == binary)
 }
 
+/// Resolve the MCP servers to forward for a spawn: the agent's native config
+/// (lowest precedence) merged under the global `<app_dir>/mcp.json`. Runs on a
+/// blocking thread (callers spawn_blocking it) because a native config can be
+/// large. Each layer is isolated: a missing, unreadable, or malformed source
+/// warns and contributes nothing rather than aborting, so a single broken file
+/// never blocks the spawn.
+fn resolve_mcp_layers(
+    agent_key: &str,
+    session_id: &str,
+) -> Vec<agent_client_protocol::schema::McpServer> {
+    use crate::acp::mcp_config::{
+        load_global_mcp_servers, load_native_mcp_servers_from_home, merge_by_precedence, summarize,
+        McpLayer,
+    };
+
+    let native = match load_native_mcp_servers_from_home(agent_key) {
+        Ok(servers) => servers,
+        Err(e) => {
+            warn!(
+                target: "acp.mcp",
+                session = %session_id,
+                agent = %agent_key,
+                error = %e,
+                "failed to load native MCP config; forwarding none from it"
+            );
+            Vec::new()
+        }
+    };
+
+    let global = match crate::session::get_app_dir() {
+        Ok(app_dir) => match load_global_mcp_servers(&app_dir) {
+            Ok(servers) => servers,
+            Err(e) => {
+                warn!(
+                    target: "acp.mcp",
+                    session = %session_id,
+                    error = %e,
+                    "failed to load global MCP config; forwarding none from it"
+                );
+                Vec::new()
+            }
+        },
+        Err(e) => {
+            warn!(
+                target: "acp.mcp",
+                session = %session_id,
+                error = %e,
+                "could not resolve app dir for MCP config; forwarding none from it"
+            );
+            Vec::new()
+        }
+    };
+
+    let merged = merge_by_precedence(vec![
+        McpLayer {
+            label: "agent-native",
+            servers: native,
+        },
+        McpLayer {
+            label: "global",
+            servers: global,
+        },
+    ]);
+
+    if !merged.is_empty() {
+        info!(
+            target: "acp.mcp",
+            session = %session_id,
+            count = merged.len(),
+            servers = %summarize(&merged),
+            "forwarding MCP servers"
+        );
+    }
+    merged
+}
+
 /// Overlay an instance command override onto a resolved `AgentSpec`.
 ///
 /// Applies only when the override is safe: the spec came from the
@@ -1240,45 +1316,27 @@ impl<S: BroadcastSink> Supervisor<S> {
             SupervisorError::Acp(AcpError::Spawn(format!("worker socket path: {e}")))
         })?;
 
-        // Resolve the user's MCP servers from the global `<app_dir>/mcp.json`
-        // so they reach the agent on session/new and session/load. A malformed
-        // file warns and forwards nothing rather than failing every spawn; a
-        // single typo must not brick all structured-view sessions. Project-local
-        // and per-profile sources are deferred (see issue follow-ups).
-        let mcp_servers = match crate::session::get_app_dir() {
-            Ok(app_dir) => match crate::acp::mcp_config::load_global_mcp_servers(&app_dir) {
-                Ok(servers) => {
-                    if !servers.is_empty() {
-                        info!(
-                            target: "acp.mcp",
-                            session = %session_id,
-                            count = servers.len(),
-                            servers = %crate::acp::mcp_config::summarize(&servers),
-                            "forwarding MCP servers from global config"
-                        );
-                    }
-                    servers
-                }
-                Err(e) => {
+        // Resolve the MCP servers to forward on session/new and session/load:
+        // the agent's own native config (lowest precedence) merged under the
+        // global `<app_dir>/mcp.json`, so a server defined in both is taken from
+        // the global file. Disk reads and parsing run off the async runtime
+        // because a native config (e.g. `~/.claude.json`) can be large. Any
+        // broken layer warns and contributes nothing rather than failing the
+        // spawn; project-local and per-profile sources are deferred (follow-ups).
+        let mcp_agent = agent.clone();
+        let mcp_session = session_id.clone();
+        let mcp_servers =
+            tokio::task::spawn_blocking(move || resolve_mcp_layers(&mcp_agent, &mcp_session))
+                .await
+                .unwrap_or_else(|e| {
                     warn!(
                         target: "acp.mcp",
                         session = %session_id,
                         error = %e,
-                        "failed to load MCP config; forwarding no servers"
+                        "MCP resolution task failed; forwarding no servers"
                     );
                     Vec::new()
-                }
-            },
-            Err(e) => {
-                warn!(
-                    target: "acp.mcp",
-                    session = %session_id,
-                    error = %e,
-                    "could not resolve app dir for MCP config; forwarding no servers"
-                );
-                Vec::new()
-            }
-        };
+                });
 
         let config = SpawnConfig {
             agent_key: agent.clone(),

--- a/tests/integration/acp_mcp.rs
+++ b/tests/integration/acp_mcp.rs
@@ -97,6 +97,88 @@ async fn configured_mcp_servers_reach_new_session() {
 }
 
 #[tokio::test]
+async fn native_and_global_merge_reaches_new_session() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+
+    // Native layer (lowest precedence): the agent's own `~/.claude.json`. It
+    // defines "shared" (collides with global) and "native-only".
+    let home = tempfile::tempdir().unwrap();
+    std::fs::write(
+        home.path().join(".claude.json"),
+        r#"{ "mcpServers": {
+            "shared": { "command": "from-native" },
+            "native-only": { "command": "n" }
+        } }"#,
+    )
+    .unwrap();
+    let native = mcp_config::load_native_mcp_servers("claude", home.path()).unwrap();
+
+    // Global layer (higher precedence): `<app_dir>/mcp.json`. It overrides
+    // "shared" and adds "global-only".
+    let app_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        app_dir.path().join("mcp.json"),
+        r#"{ "mcpServers": {
+            "shared": { "command": "from-global" },
+            "global-only": { "command": "g" }
+        } }"#,
+    )
+    .unwrap();
+    let global = mcp_config::load_global_mcp_servers(app_dir.path()).unwrap();
+
+    let merged = mcp_config::merge_by_precedence(vec![
+        mcp_config::McpLayer {
+            label: "agent-native",
+            servers: native,
+        },
+        mcp_config::McpLayer {
+            label: "global",
+            servers: global,
+        },
+    ]);
+
+    let record_dir = tempfile::tempdir().unwrap();
+    let record_path = record_dir.path().join("record.json");
+    let mut config = base_config(std::env::temp_dir(), &record_path);
+    config.mcp_servers = merged;
+
+    let client = AcpClient::spawn(config, AcpSessionId("mcp-native-merge".into()))
+        .await
+        .expect("spawn shim agent");
+
+    let body = read_record(&record_path);
+    let _ = client.shutdown().await;
+
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("record is JSON");
+    let arr = parsed.as_array().expect("mcp_servers is an array");
+    assert_eq!(
+        arr.len(),
+        3,
+        "expected merged union of three servers, got {body}"
+    );
+
+    let shared = arr
+        .iter()
+        .find(|s| s["name"] == "shared")
+        .expect("shared server present");
+    assert_eq!(
+        shared["command"], "from-global",
+        "global must override native on name collision, got {body}"
+    );
+    assert!(
+        arr.iter().any(|s| s["name"] == "native-only"),
+        "native-only server must survive the merge, got {body}"
+    );
+    assert!(
+        arr.iter().any(|s| s["name"] == "global-only"),
+        "global-only server must survive the merge, got {body}"
+    );
+}
+
+#[tokio::test]
 async fn no_config_forwards_empty_list() {
     if let Err(reason) = shim_ready() {
         eprintln!("skipping: {reason}");


### PR DESCRIPTION
## Description

Closes #1994.

#1984 shipped global `<app_dir>/mcp.json` forwarding to structured-view / ACP agents, but that created a second source of truth: a user who already configured MCP servers for their CLI (Claude in `~/.claude.json`, Gemini in `~/.gemini/settings.json`, Codex in `~/.codex/config.toml`) had to re-declare them in AoE's `mcp.json` to reach structured view.

This PR removes that duplication via **live read-through** (the agreed Option B from #1994, chosen over the one-shot import helper so AoE stays on par with each agent's native config and so later provenance / drift / conflict work in the management surface #1996 has live signal). At spawn time the supervisor reads the active agent's native MCP config and merges it **under** the global `mcp.json`.

What changed:

- `src/acp/mcp_config.rs`: native-config readers behind a per-agent seam (`native_config_for`), one match arm per agent: Claude (`.claude.json` standard JSON, history ignored), Gemini (`.gemini/settings.json`, transport discriminated by key), Codex (`.codex/config.toml`). Adds `merge_by_precedence` for layered merge (higher layer wins per server name) and `summarize` for log output.
- `src/acp/supervisor.rs`: resolves native + global on a blocking thread at spawn, merges by precedence (`agent-native` lowest, `global` over it), threads the result into `SpawnConfig.mcp_servers`. A malformed native file is downgraded to a warning and forwards nothing from that layer, not a hard spawn failure.
- `docs/guides/mcp-servers.md`: documents the native read-through and precedence.

AoE never writes back to a native config: sync is native to AoE only. Per-profile (#1986) and project-local (#1985) layers are out of scope here; this PR establishes the precedence framework they slot into.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A, no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (backend forwarding only, no web changes)

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped an e2e test, because: no TUI rendering or new CLI subcommand changed. Covered instead by 25 unit tests on the converters and precedence merge (`src/acp/mcp_config.rs`) plus 3 integration tests on the native-to-forwarded path (`tests/integration/acp_mcp.rs`).

### How I tested

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features serve --all-targets` clean (acp is gated behind the `serve` feature, so it must be built with `--features serve`)
- [x] `cargo test --features serve --lib -- mcp_config`: 25 passed
- [x] `cargo test --features serve --test integration -- acp_mcp`: 3 passed

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus)

**Any Additional AI Details you'd like to share:** Claude implemented the readers, precedence merge, and tests, and drafted this description. Idea, the Option B decision, and review are mine.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

AoE now reads agent-native MCP server configurations at session start and merges them under the global <app_dir>/mcp.json. Native configs are treated as a lower-precedence layer so the global mcp.json overrides same-named servers. Native reads are non-destructive (AoE never writes native files) and non-fatal: missing or malformed native files/logged entries are warned and skipped, not blocking spawn.

## What changed (high level)

- Added per-agent native MCP readers and converters for:
  - Claude (~/.claude.json)
  - Gemini (~/.gemini/settings.json)
  - Codex (~/.codex/config.toml)
- Added a precedence-based merging system and a McpLayer abstraction to merge layered server lists deterministically (higher layer wins on name collisions).
- Supervisor now resolves native + global MCP layers on a blocking thread at spawn (and on respawn), merges them, and sets SpawnConfig.mcp_servers.
- Malformed native entries are downgraded to warnings and skipped; unreadable native files emit warnings and contribute nothing.
- Docs updated to describe native read-through behavior and precedence rules.
- Tests: 25 unit tests for converters/merge behavior and 3 integration tests covering the native-to-forwarded path; CI/lint passed.

## Benefits

- Removes duplication of MCP declarations between agent-native configs and AoE’s global mcp.json.
- Keeps forwarded server list in sync with the active agent’s native config (live read-through at spawn).
- Non-invasive and safe: AoE does not modify native configs and tolerates errors without failing sessions.
- Establishes a clear precedence framework that supports adding future layers (per-profile, project-local) later.

## Technical notes (concise)

- New exports: McpLayer, merge_by_precedence(), load_native_mcp_servers(_from_home).
- Merge is deterministic and name-sorted; later/higher-precedence layers override earlier ones per server name.
- Agent readers parse different formats and discriminate transport by keys (e.g., Gemini: command vs httpUrl vs url). Ambiguous entries are skipped with warnings.
- Supervisor spawn/respanw now re-resolves layers each time (no stale cached mcp_servers) using spawn_blocking; join failures fall back to forwarding no servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->