### PR TITLE
feat(mcp): unified MCP management surface (read model, conflict, keep-on-removal, CLI, web)

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -66,6 +66,8 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe telemetry enable`↴](#aoe-telemetry-enable)
 * [`aoe telemetry disable`↴](#aoe-telemetry-disable)
 * [`aoe telemetry reset-id`↴](#aoe-telemetry-reset-id)
+* [`aoe mcp`↴](#aoe-mcp)
+* [`aoe mcp list`↴](#aoe-mcp-list)
 * [`aoe serve`↴](#aoe-serve)
 * [`aoe url`↴](#aoe-url)
 * [`aoe acp`↴](#aoe-acp)
@@ -116,6 +118,7 @@ Run without arguments to launch the TUI dashboard.
 * `sounds` — Manage sound effects for agent state transitions
 * `theme` — Manage color themes (list, export, customize)
 * `telemetry` — Manage anonymous opt-in usage telemetry
+* `mcp` — Inspect the effective MCP server set (provenance, conflicts, drift)
 * `serve` — Start a web dashboard for remote session access
 * `url` — Print the current dashboard URL of a running `aoe serve` daemon
 * `acp` — Manage the ACP structured-view workers (doctor, ps, logs, prompt, approve, ...)
@@ -987,6 +990,31 @@ Opt out of telemetry (deletes the local install id)
 Generate a fresh anonymous install id (only while opted in)
 
 **Usage:** `aoe telemetry reset-id`
+
+
+
+## `aoe mcp`
+
+Inspect the effective MCP server set (provenance, conflicts, drift)
+
+**Usage:** `aoe mcp <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List the merged effective MCP server set with provenance, plus any conflicts and servers kept after removal from a native config
+
+
+
+## `aoe mcp list`
+
+List the merged effective MCP server set with provenance, plus any conflicts and servers kept after removal from a native config
+
+**Usage:** `aoe mcp list [OPTIONS]`
+
+###### **Options:**
+
+* `--agent <AGENT>` — Agent whose effective set to resolve. Defaults to the configured default tool. MCP forwarding is per-agent because the agent-native layer differs
+* `--json` — Output machine-readable JSON instead of a table
 
 
 

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -125,6 +125,48 @@ taken from the per-profile file; and a trusted project-local server outranks all
 of them. Each override is logged. The project-local layer only participates once
 the repository is trusted (see Project-local servers above).
 
+## Inspecting the effective set
+
+Because the effective set is merged from up to four layers, AoE gives you one
+surface to see exactly which servers an agent will reach and where each came
+from. Every value is redacted: you see a server's command, args, or URL, and the
+names of its env vars and headers, but never their secret values.
+
+### CLI
+
+```text
+aoe mcp list                 # effective set for the default tool
+aoe mcp list --agent gemini  # for a specific agent
+aoe mcp list --json          # machine-readable, same redaction
+```
+
+Each row shows the server name, transport, its winning provenance
+(`agent-native:claude`, `global`, `profile:<name>`, `project-local`), and which
+lower layers it shadowed on a name collision.
+
+### Web dashboard
+
+The dashboard has an **MCP servers** tab under Settings (when running
+`aoe serve`). It shows the same merged set with provenance, plus two things the
+CLI surfaces read-only:
+
+- **Conflicts.** AoE remembers the last definition it saw for each server in an
+  agent's native config. If that file changes on disk, the next time you open the
+  surface the changed server is flagged as a conflict, and you choose which side
+  wins. Keeping AoE's version stores it in the global `mcp.json` (which outranks
+  the native layer); choosing the native version simply accepts the new
+  definition. AoE never writes back to an agent-native config.
+- **Kept after removal.** If a server disappears from a native config, AoE keeps
+  it in view and warns rather than silently dropping it. You can **keep** it
+  (promoting it into the global `mcp.json` so it keeps forwarding) or **drop** it.
+
+AoE remembers this last-seen state in `mcp_state.json` in the app directory,
+written owner-only. The stored definitions keep their secret values (so a kept
+server still works) but those values are redacted everywhere they are displayed.
+
+Live connection status and reconnect / authenticate actions are tracked
+separately and are not part of this surface yet.
+
 ## Capability gating
 
 Not every agent supports every transport. `stdio` works everywhere. `http` and
@@ -149,6 +191,12 @@ its `command` locally when a session starts.
 A per-profile `mcp.json` lives in the profile directory under your app
 directory, so it is owned by you with the same trust as the global file. Treat
 it the same way: its `command` entries can launch processes on your behalf.
+
+The drift store `mcp_state.json` (used by the management surface) also lives in
+your app directory, owner-only. It records the last-seen definition of each
+agent-native server, including secret values, so keep-on-removal and conflict
+resolution can reconstruct a working server; treat it with the same care as
+`mcp.json`. Those values are redacted on every surface that displays them.
 
 A project-local `.mcp.json` is repository-provided, so unlike the files above it
 is NOT implicitly trusted: a cloned, untrusted repo could otherwise launch its

--- a/src/acp/mcp_config.rs
+++ b/src/acp/mcp_config.rs
@@ -1,141 +1,43 @@
-//! Global MCP server config (`<app_dir>/mcp.json`) parsing and conversion
-//! to ACP `McpServer` values forwarded at session creation.
+//! ACP boundary for MCP server forwarding.
 //!
-//! AoE forwards the user's MCP servers to structured-view ACP agents through
-//! `session/new` and `session/load`; without this the agent reaches no MCP
-//! servers at all. The on-disk format mirrors the ecosystem-standard
-//! `.mcp.json` so users can reuse the definitions they already maintain for
-//! Claude, Gemini, and Codex:
-//!
-//! ```json
-//! {
-//!   "mcpServers": {
-//!     "fs":     { "command": "mcp-fs", "args": ["--root", "."], "env": { "K": "v" } },
-//!     "remote": { "type": "http", "url": "https://example/mcp", "headers": { "Authorization": "Bearer x" } }
-//!   }
-//! }
-//! ```
-//!
-//! The global file in the AoE app dir and a per-profile `<profile_dir>/mcp.json`
-//! (issue #1986) are both read; the per-profile layer merges above global. A
-//! project-local `cwd/.mcp.json` is intentionally NOT read: AoE opens cloned and
-//! potentially untrusted repositories, and stdio MCP servers launch
-//! unconditionally when a session spawns, so project scope must sit behind the
-//! repo-trust gate (the same boundary that already protects lifecycle hooks).
-//! That project-local layer is tracked as a follow-up.
-
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::Path;
+//! Parsing, layering, provenance, and the precedence merge all live in the
+//! always-compiled `session::mcp_model` resolver, which the unified management
+//! surface (#1996), the CLI, and the TUI also read. This serve-gated module is
+//! the thin edge that converts the resolver's winning set into ACP `McpServer`
+//! wire values and drops any transport the agent did not advertise. Sharing one
+//! resolver across forwarding and display guarantees what the user sees equals
+//! what the agent receives.
 
 use agent_client_protocol::schema::{
     EnvVariable, HttpHeader, McpCapabilities, McpServer, McpServerHttp, McpServerSse,
     McpServerStdio,
 };
-use anyhow::{bail, Context, Result};
-use serde::Deserialize;
+use std::collections::BTreeMap;
 use tracing::warn;
 
-/// On-disk shape of `<app_dir>/mcp.json`. Unknown top-level keys are ignored.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct McpConfigFile {
-    #[serde(default)]
-    mcp_servers: BTreeMap<String, RawServer>,
-}
+use crate::session::project_mcp::{ProjectMcpServer, ProjectMcpTransport};
 
-/// A single server entry. Absent `type` (or `type: "stdio"`) selects the stdio
-/// transport; `type: "http"` / `type: "sse"` select the remote transports. Maps
-/// are `BTreeMap` so the converted output ordering is deterministic for tests.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RawServer {
-    #[serde(default, rename = "type")]
-    transport: Option<String>,
-    command: Option<String>,
-    #[serde(default)]
-    args: Vec<String>,
-    #[serde(default)]
-    env: BTreeMap<String, String>,
-    url: Option<String>,
-    #[serde(default)]
-    headers: BTreeMap<String, String>,
-}
-
-/// Read and parse the global `<app_dir>/mcp.json`. A missing file yields an
-/// empty list (the no-config case behaves exactly as before this feature). A
-/// present-but-malformed file is an error the caller surfaces; it must not be
-/// silently treated as "no servers".
-pub fn load_global_mcp_servers(app_dir: &Path) -> Result<Vec<McpServer>> {
-    read_mcp_json(&app_dir.join("mcp.json"))
-}
-
-/// Read and parse a profile's `<profile_dir>/mcp.json` (issue #1986). Same
-/// on-disk shape and same missing/malformed semantics as the global file; it is
-/// just resolved from the active session's profile directory. The per-profile
-/// layer is merged ABOVE global (so a same-named server in the profile file
-/// overrides the global one) and below project-local. Per-profile entries are
-/// AoE state only: they are never written back to any agent's native config.
-pub fn load_profile_mcp_servers(profile_dir: &Path) -> Result<Vec<McpServer>> {
-    read_mcp_json(&profile_dir.join("mcp.json"))
-}
-
-/// Read and parse an `mcp.json` at `path`. A missing file yields an empty list;
-/// a present-but-malformed file is an error the caller surfaces. Shared by the
-/// global and per-profile loaders so both layers behave identically.
-fn read_mcp_json(path: &Path) -> Result<Vec<McpServer>> {
-    let text = match std::fs::read_to_string(path) {
-        Ok(t) => t,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => {
-            return Err(e).with_context(|| format!("reading MCP config at {}", path.display()))
-        }
-    };
-    parse_mcp_servers(&text).with_context(|| format!("parsing MCP config at {}", path.display()))
-}
-
-/// Parse the `.mcp.json` text into ACP `McpServer` values. Separated from the
-/// file read so the conversion rules can be unit-tested without touching disk.
-fn parse_mcp_servers(text: &str) -> Result<Vec<McpServer>> {
-    let parsed: McpConfigFile = serde_json::from_str(text)?;
-    parsed
-        .mcp_servers
+/// Convert resolved, transport-typed servers (parsed and merged by
+/// `session::mcp_model`) into ACP `McpServer` values for forwarding through
+/// `session/new` and `session/load`. The caller passes the winning set of the
+/// precedence merge, so the converted list is exactly what reaches the agent.
+pub fn project_servers_to_acp(servers: Vec<ProjectMcpServer>) -> Vec<McpServer> {
+    servers
         .into_iter()
-        .map(|(name, raw)| convert_server(&name, raw))
+        .map(|server| match server.transport {
+            ProjectMcpTransport::Stdio { command, args, env } => McpServer::Stdio(
+                McpServerStdio::new(server.name, command)
+                    .args(args)
+                    .env(to_env(env)),
+            ),
+            ProjectMcpTransport::Http { url, headers } => {
+                McpServer::Http(McpServerHttp::new(server.name, url).headers(to_headers(headers)))
+            }
+            ProjectMcpTransport::Sse { url, headers } => {
+                McpServer::Sse(McpServerSse::new(server.name, url).headers(to_headers(headers)))
+            }
+        })
         .collect()
-}
-
-fn convert_server(name: &str, raw: RawServer) -> Result<McpServer> {
-    match raw.transport.as_deref() {
-        None | Some("stdio") => {
-            let command = raw
-                .command
-                .with_context(|| format!("MCP server \"{name}\" is missing \"command\""))?;
-            Ok(McpServer::Stdio(
-                McpServerStdio::new(name, command)
-                    .args(raw.args)
-                    .env(to_env(raw.env)),
-            ))
-        }
-        Some("http") => {
-            let url = raw
-                .url
-                .with_context(|| format!("MCP server \"{name}\" is missing \"url\""))?;
-            Ok(McpServer::Http(
-                McpServerHttp::new(name, url).headers(to_headers(raw.headers)),
-            ))
-        }
-        Some("sse") => {
-            let url = raw
-                .url
-                .with_context(|| format!("MCP server \"{name}\" is missing \"url\""))?;
-            Ok(McpServer::Sse(
-                McpServerSse::new(name, url).headers(to_headers(raw.headers)),
-            ))
-        }
-        Some(other) => bail!("MCP server \"{name}\" has unknown type \"{other}\""),
-    }
 }
 
 fn to_env(env: BTreeMap<String, String>) -> Vec<EnvVariable> {
@@ -184,16 +86,6 @@ pub fn filter_for_capabilities(
         .collect()
 }
 
-/// Names + transports of the configured servers for logging. Deliberately omits
-/// env values and header values so secrets never reach the log sink.
-pub fn summarize(servers: &[McpServer]) -> String {
-    servers
-        .iter()
-        .map(|s| format!("{}({})", server_name(s), server_kind(s)))
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
 fn server_name(server: &McpServer) -> &str {
     match server {
         McpServer::Stdio(s) => &s.name,
@@ -212,342 +104,31 @@ fn server_kind(server: &McpServer) -> &'static str {
     }
 }
 
-/// Convert the always-compiled project-local servers (parsed and fingerprinted
-/// by `session::project_mcp` outside the serve gate) into ACP `McpServer`
-/// values for forwarding (#1985). The supervisor calls this only after the repo
-/// is trusted for the matching fingerprint, so the converted set is exactly the
-/// reviewed set.
-pub fn project_servers_to_acp(
-    servers: Vec<crate::session::project_mcp::ProjectMcpServer>,
-) -> Vec<McpServer> {
-    use crate::session::project_mcp::ProjectMcpTransport;
-    servers
-        .into_iter()
-        .map(|server| match server.transport {
-            ProjectMcpTransport::Stdio { command, args, env } => McpServer::Stdio(
-                McpServerStdio::new(server.name, command)
-                    .args(args)
-                    .env(to_env(env)),
-            ),
-            ProjectMcpTransport::Http { url, headers } => {
-                McpServer::Http(McpServerHttp::new(server.name, url).headers(to_headers(headers)))
-            }
-            ProjectMcpTransport::Sse { url, headers } => {
-                McpServer::Sse(McpServerSse::new(server.name, url).headers(to_headers(headers)))
-            }
-        })
-        .collect()
-}
-
-/// A named source of MCP servers for precedence merging. Layers are passed
-/// lowest-precedence first; on a server-name collision the higher (later) layer
-/// wins and both labels are logged so the override is visible. The `label` is
-/// the provenance the unified MCP surface (issue #1996) will display; it is
-/// read here today in the collision warning, so it is not dead state.
-pub struct McpLayer {
-    pub label: &'static str,
-    pub servers: Vec<McpServer>,
-}
-
-/// Merge MCP server layers by precedence. `layers` are ordered lowest first; a
-/// server in a later layer overrides one of the same name in an earlier layer
-/// (per-server, not whole-layer). Output is name-sorted so forwarding is
-/// deterministic. This is the reusable seam the per-profile (#1986) and
-/// project-local (#1985) layers extend by appending their own `McpLayer`.
-pub fn merge_by_precedence(layers: Vec<McpLayer>) -> Vec<McpServer> {
-    let mut by_name: BTreeMap<String, (&'static str, McpServer)> = BTreeMap::new();
-    for layer in layers {
-        for server in layer.servers {
-            let name = server_name(&server).to_string();
-            if let Some((shadowed, _)) = by_name.get(&name) {
-                warn!(
-                    target: "acp.mcp",
-                    server = %name,
-                    kept = layer.label,
-                    shadowed = *shadowed,
-                    "MCP server name defined in multiple sources; higher-precedence source wins"
-                );
-            }
-            by_name.insert(name, (layer.label, server));
-        }
-    }
-    by_name.into_values().map(|(_, server)| server).collect()
-}
-
-/// Where an agent keeps its own MCP server config, and in what shape. This is
-/// the per-agent seam: adding an agent is one match arm in `native_config_for`
-/// plus, if its format differs, one converter. AoE only ever reads these files;
-/// it never writes them.
-enum NativeMcpConfig {
-    /// Standard `{ "mcpServers": { ... } }` JSON with the ecosystem `type`/`url`
-    /// shape, at a home-relative path. Claude (`~/.claude.json`).
-    StandardJson(&'static str),
-    /// Gemini `settings.json`: an `mcpServers` block whose entries discriminate
-    /// transport by which key is present (`command` -> stdio, `httpUrl` -> http,
-    /// `url` -> sse) rather than by a `type` field.
-    GeminiJson(&'static str),
-    /// Codex `config.toml`: `[mcp_servers.<name>]` tables (stdio, or `url` for
-    /// streamable http on newer Codex).
-    CodexToml(&'static str),
-}
-
-/// Map an agent registry key to its native MCP config descriptor, or `None` for
-/// an agent AoE has no native reader for (those contribute no native servers).
-fn native_config_for(agent_key: &str) -> Option<NativeMcpConfig> {
-    match agent_key {
-        "claude" | "claude-code" => Some(NativeMcpConfig::StandardJson(".claude.json")),
-        "gemini" => Some(NativeMcpConfig::GeminiJson(".gemini/settings.json")),
-        "codex" => Some(NativeMcpConfig::CodexToml(".codex/config.toml")),
-        _ => None,
-    }
-}
-
-/// Read the active agent's own MCP config (the file its CLI reads) and convert
-/// it to ACP servers. Live read-through: called once per spawn, no caching, so
-/// edits are picked up on the next session. Returns an empty list for an agent
-/// with no known native reader and for a missing file. A present-but-unparseable
-/// file is an error the caller downgrades to a warning, so a broken native file
-/// (which AoE does not own) never blocks a spawn. Individual malformed server
-/// entries are skipped with a warning rather than failing the whole file.
-pub fn load_native_mcp_servers(agent_key: &str, home: &Path) -> Result<Vec<McpServer>> {
-    let Some(config) = native_config_for(agent_key) else {
-        return Ok(Vec::new());
-    };
-    match config {
-        NativeMcpConfig::StandardJson(rel) => read_standard_json(&home.join(rel)),
-        NativeMcpConfig::GeminiJson(rel) => read_gemini_json(&home.join(rel)),
-        NativeMcpConfig::CodexToml(rel) => read_codex_toml(&home.join(rel)),
-    }
-}
-
-/// Convenience wrapper that resolves the real home dir. Kept separate from
-/// `load_native_mcp_servers` so tests can inject a temp home.
-pub fn load_native_mcp_servers_from_home(agent_key: &str) -> Result<Vec<McpServer>> {
-    let home = dirs::home_dir().context("could not resolve home dir for native MCP config")?;
-    load_native_mcp_servers(agent_key, &home)
-}
-
-/// Convert a map of raw server entries, skipping (with a warning) any entry that
-/// fails to convert rather than failing the whole file. Native configs are owned
-/// by other tools, so one bad entry must not discard the user's other servers.
-fn convert_tolerant<R>(
-    servers: BTreeMap<String, R>,
-    path: &Path,
-    convert: impl Fn(&str, R) -> Result<McpServer>,
-) -> Vec<McpServer> {
-    servers
-        .into_iter()
-        .filter_map(|(name, raw)| match convert(&name, raw) {
-            Ok(server) => Some(server),
-            Err(e) => {
-                warn!(
-                    target: "acp.mcp",
-                    server = %name,
-                    path = %path.display(),
-                    error = %e,
-                    "skipping malformed MCP server in native config"
-                );
-                None
-            }
-        })
-        .collect()
-}
-
-/// Read a JSON config in the standard `mcpServers` shape, streaming so a large
-/// host file (e.g. `~/.claude.json`, which also holds project history) is parsed
-/// without materializing the unrelated keys: serde skips them in the reader.
-fn read_standard_json(path: &Path) -> Result<Vec<McpServer>> {
-    let Some(file) = open_optional(path)? else {
-        return Ok(Vec::new());
-    };
-    let parsed: McpConfigFile = serde_json::from_reader(BufReader::new(file))
-        .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
-    Ok(convert_tolerant(parsed.mcp_servers, path, convert_server))
-}
-
-/// Gemini `settings.json` reader: same streaming approach as Claude, but entries
-/// discriminate transport by key rather than a `type` field.
-fn read_gemini_json(path: &Path) -> Result<Vec<McpServer>> {
-    let Some(file) = open_optional(path)? else {
-        return Ok(Vec::new());
-    };
-    let parsed: GeminiConfigFile = serde_json::from_reader(BufReader::new(file))
-        .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
-    Ok(convert_tolerant(
-        parsed.mcp_servers,
-        path,
-        convert_gemini_server,
-    ))
-}
-
-/// Codex `config.toml` reader. These files are small (no embedded history), so a
-/// whole-string read is fine; `toml` has no streaming reader.
-fn read_codex_toml(path: &Path) -> Result<Vec<McpServer>> {
-    let text = match std::fs::read_to_string(path) {
-        Ok(t) => t,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => {
-            return Err(e)
-                .with_context(|| format!("reading native MCP config at {}", path.display()))
-        }
-    };
-    let parsed: CodexConfigFile = toml::from_str(&text)
-        .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
-    Ok(convert_tolerant(
-        parsed.mcp_servers,
-        path,
-        convert_codex_server,
-    ))
-}
-
-/// Open a config file, mapping "not found" to `None` (the user does not use that
-/// agent) and any other IO error to a context-tagged failure.
-fn open_optional(path: &Path) -> Result<Option<File>> {
-    match File::open(path) {
-        Ok(f) => Ok(Some(f)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => {
-            Err(e).with_context(|| format!("opening native MCP config at {}", path.display()))
-        }
-    }
-}
-
-/// On-disk shape of a Gemini `mcpServers` entry. Transport is selected by which
-/// of `command` / `httpUrl` / `url` is present; more than one is ambiguous.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct GeminiConfigFile {
-    #[serde(default)]
-    mcp_servers: BTreeMap<String, GeminiRawServer>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct GeminiRawServer {
-    command: Option<String>,
-    #[serde(default)]
-    args: Vec<String>,
-    #[serde(default)]
-    env: BTreeMap<String, String>,
-    http_url: Option<String>,
-    url: Option<String>,
-    #[serde(default)]
-    headers: BTreeMap<String, String>,
-}
-
-fn convert_gemini_server(name: &str, raw: GeminiRawServer) -> Result<McpServer> {
-    match (raw.command, raw.http_url, raw.url) {
-        (Some(command), None, None) => Ok(McpServer::Stdio(
-            McpServerStdio::new(name, command)
-                .args(raw.args)
-                .env(to_env(raw.env)),
-        )),
-        (None, Some(http_url), None) => Ok(McpServer::Http(
-            McpServerHttp::new(name, http_url).headers(to_headers(raw.headers)),
-        )),
-        (None, None, Some(url)) => Ok(McpServer::Sse(
-            McpServerSse::new(name, url).headers(to_headers(raw.headers)),
-        )),
-        (None, None, None) => {
-            bail!("MCP server \"{name}\" has none of \"command\", \"httpUrl\", \"url\"")
-        }
-        _ => bail!("MCP server \"{name}\" sets more than one of \"command\", \"httpUrl\", \"url\""),
-    }
-}
-
-/// On-disk shape of a Codex `[mcp_servers.<name>]` entry. `command` selects
-/// stdio; `url` selects streamable http (newer Codex). The TOML key is already
-/// snake_case, so no rename is needed.
-#[derive(Debug, Deserialize)]
-struct CodexConfigFile {
-    #[serde(default)]
-    mcp_servers: BTreeMap<String, CodexRawServer>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CodexRawServer {
-    command: Option<String>,
-    #[serde(default)]
-    args: Vec<String>,
-    #[serde(default)]
-    env: BTreeMap<String, String>,
-    url: Option<String>,
-    #[serde(default)]
-    headers: BTreeMap<String, String>,
-}
-
-fn convert_codex_server(name: &str, raw: CodexRawServer) -> Result<McpServer> {
-    match (raw.command, raw.url) {
-        (Some(command), None) => Ok(McpServer::Stdio(
-            McpServerStdio::new(name, command)
-                .args(raw.args)
-                .env(to_env(raw.env)),
-        )),
-        (None, Some(url)) => Ok(McpServer::Http(
-            McpServerHttp::new(name, url).headers(to_headers(raw.headers)),
-        )),
-        (None, None) => bail!("MCP server \"{name}\" has neither \"command\" nor \"url\""),
-        (Some(_), Some(_)) => bail!("MCP server \"{name}\" sets both \"command\" and \"url\""),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::project_mcp::parse_standard_mcp_servers;
 
     fn names(servers: &[McpServer]) -> Vec<&str> {
         servers.iter().map(server_name).collect()
     }
 
-    #[test]
-    fn missing_file_is_empty() {
-        let dir = tempfile::tempdir().unwrap();
-        let servers = load_global_mcp_servers(dir.path()).unwrap();
-        assert!(servers.is_empty());
+    fn to_acp(json: &str) -> Vec<McpServer> {
+        project_servers_to_acp(parse_standard_mcp_servers(json).unwrap())
     }
 
     #[test]
-    fn loads_and_parses_app_dir_file() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("mcp.json"),
-            r#"{ "mcpServers": { "fs": { "command": "mcp-fs" } } }"#,
-        )
-        .unwrap();
-        let servers = load_global_mcp_servers(dir.path()).unwrap();
-        assert_eq!(names(&servers), vec!["fs"]);
-    }
-
-    #[test]
-    fn malformed_app_dir_file_is_error() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("mcp.json"), "{ not json").unwrap();
-        assert!(load_global_mcp_servers(dir.path()).is_err());
-    }
-
-    #[test]
-    fn empty_or_absent_mcp_servers_key_is_empty() {
-        assert!(parse_mcp_servers("{}").unwrap().is_empty());
-        assert!(parse_mcp_servers(r#"{"mcpServers":{}}"#)
-            .unwrap()
-            .is_empty());
-    }
-
-    #[test]
-    fn parses_stdio_entry() {
-        let text = r#"{
-            "mcpServers": {
+    fn converts_stdio_with_args_and_env() {
+        let servers = to_acp(
+            r#"{ "mcpServers": {
                 "fs": { "command": "mcp-fs", "args": ["--root", "."], "env": { "TOKEN": "secret" } }
-            }
-        }"#;
-        let servers = parse_mcp_servers(text).unwrap();
-        assert_eq!(servers.len(), 1);
+            } }"#,
+        );
         match &servers[0] {
             McpServer::Stdio(s) => {
                 assert_eq!(s.name, "fs");
                 assert_eq!(s.command.to_string_lossy(), "mcp-fs");
                 assert_eq!(s.args, vec!["--root".to_string(), ".".to_string()]);
-                assert_eq!(s.env.len(), 1);
                 assert_eq!(s.env[0].name, "TOKEN");
                 assert_eq!(s.env[0].value, "secret");
             }
@@ -556,400 +137,50 @@ mod tests {
     }
 
     #[test]
-    fn parses_remote_entries() {
-        let text = r#"{
-            "mcpServers": {
+    fn converts_remote_transports() {
+        let servers = to_acp(
+            r#"{ "mcpServers": {
                 "h": { "type": "http", "url": "https://e/mcp", "headers": { "Authorization": "Bearer x" } },
                 "s": { "type": "sse", "url": "https://e/sse" }
-            }
-        }"#;
-        let servers = parse_mcp_servers(text).unwrap();
-        // BTreeMap key ordering: "h" before "s".
+            } }"#,
+        );
         match &servers[0] {
             McpServer::Http(h) => {
-                assert_eq!(h.name, "h");
                 assert_eq!(h.url, "https://e/mcp");
                 assert_eq!(h.headers[0].name, "Authorization");
                 assert_eq!(h.headers[0].value, "Bearer x");
             }
             other => panic!("expected http, got {other:?}"),
         }
-        match &servers[1] {
-            McpServer::Sse(s) => assert_eq!(s.url, "https://e/sse"),
-            other => panic!("expected sse, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn ordering_is_deterministic() {
-        let text = r#"{ "mcpServers": {
-            "zebra": { "command": "z" },
-            "alpha": { "command": "a" },
-            "mike":  { "command": "m" }
-        }}"#;
-        let servers = parse_mcp_servers(text).unwrap();
-        assert_eq!(names(&servers), vec!["alpha", "mike", "zebra"]);
-    }
-
-    #[test]
-    fn unknown_type_is_error() {
-        let text = r#"{ "mcpServers": { "x": { "type": "carrier-pigeon", "url": "u" } } }"#;
-        assert!(parse_mcp_servers(text).is_err());
-    }
-
-    #[test]
-    fn stdio_without_command_is_error() {
-        let text = r#"{ "mcpServers": { "x": { "args": ["--y"] } } }"#;
-        assert!(parse_mcp_servers(text).is_err());
-    }
-
-    #[test]
-    fn remote_without_url_is_error() {
-        let text = r#"{ "mcpServers": { "x": { "type": "http" } } }"#;
-        assert!(parse_mcp_servers(text).is_err());
-    }
-
-    #[test]
-    fn invalid_json_is_error() {
-        assert!(parse_mcp_servers("{ not json").is_err());
+        assert!(matches!(&servers[1], McpServer::Sse(_)));
     }
 
     #[test]
     fn capability_filter_keeps_stdio_drops_unadvertised_remotes() {
-        let text = r#"{ "mcpServers": {
-            "stdio":  { "command": "c" },
-            "http":   { "type": "http", "url": "u" },
-            "sse":    { "type": "sse",  "url": "u" }
-        }}"#;
-        let servers = parse_mcp_servers(text).unwrap();
+        let servers = to_acp(
+            r#"{ "mcpServers": {
+                "stdio":  { "command": "c" },
+                "http":   { "type": "http", "url": "u" },
+                "sse":    { "type": "sse",  "url": "u" }
+            } }"#,
+        );
 
         let none = McpCapabilities::new();
-        let kept = filter_for_capabilities(servers.clone(), &none, "t");
-        assert_eq!(names(&kept), vec!["stdio"]);
+        assert_eq!(
+            names(&filter_for_capabilities(servers.clone(), &none, "t")),
+            vec!["stdio"]
+        );
 
         let http_only = McpCapabilities::new().http(true);
-        let kept = filter_for_capabilities(servers.clone(), &http_only, "t");
-        assert_eq!(names(&kept), vec!["http", "stdio"]);
+        assert_eq!(
+            names(&filter_for_capabilities(servers.clone(), &http_only, "t")),
+            vec!["http", "stdio"]
+        );
 
         let both = McpCapabilities::new().http(true).sse(true);
-        let kept = filter_for_capabilities(servers, &both, "t");
-        assert_eq!(names(&kept), vec!["http", "sse", "stdio"]);
-    }
-
-    #[test]
-    fn summarize_omits_secret_values() {
-        let text = r#"{ "mcpServers": {
-            "fs": { "command": "c", "env": { "TOKEN": "supersecret" } }
-        }}"#;
-        let servers = parse_mcp_servers(text).unwrap();
-        let s = summarize(&servers);
-        assert_eq!(s, "fs(stdio)");
-        assert!(!s.contains("supersecret"));
-    }
-
-    fn layer(label: &'static str, json: &str) -> McpLayer {
-        McpLayer {
-            label,
-            servers: parse_mcp_servers(json).unwrap(),
-        }
-    }
-
-    fn stdio_command(server: &McpServer) -> &str {
-        match server {
-            McpServer::Stdio(s) => s.command.to_str().unwrap(),
-            other => panic!("expected stdio, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn merge_higher_layer_overrides_same_name() {
-        // `low` first, `high` second; on the shared "fs" name, high wins.
-        let low = layer(
-            "agent-native",
-            r#"{ "mcpServers": { "fs": { "command": "native" } } }"#,
+        assert_eq!(
+            names(&filter_for_capabilities(servers, &both, "t")),
+            vec!["http", "sse", "stdio"]
         );
-        let high = layer(
-            "global",
-            r#"{ "mcpServers": { "fs": { "command": "global" } } }"#,
-        );
-        let merged = merge_by_precedence(vec![low, high]);
-        assert_eq!(names(&merged), vec!["fs"]);
-        assert_eq!(stdio_command(&merged[0]), "global");
-    }
-
-    #[test]
-    fn merge_unions_distinct_names_sorted() {
-        let low = layer(
-            "agent-native",
-            r#"{ "mcpServers": { "zebra": { "command": "z" }, "fs": { "command": "n" } } }"#,
-        );
-        let high = layer(
-            "global",
-            r#"{ "mcpServers": { "alpha": { "command": "a" } } }"#,
-        );
-        let merged = merge_by_precedence(vec![low, high]);
-        assert_eq!(names(&merged), vec!["alpha", "fs", "zebra"]);
-    }
-
-    #[test]
-    fn merge_empty_layers_is_empty() {
-        assert!(merge_by_precedence(vec![]).is_empty());
-        let empty = McpLayer {
-            label: "global",
-            servers: Vec::new(),
-        };
-        assert!(merge_by_precedence(vec![empty]).is_empty());
-    }
-
-    #[test]
-    fn profile_missing_file_is_empty() {
-        let dir = tempfile::tempdir().unwrap();
-        let servers = load_profile_mcp_servers(dir.path()).unwrap();
-        assert!(servers.is_empty());
-    }
-
-    #[test]
-    fn profile_loads_and_parses_file() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("mcp.json"),
-            r#"{ "mcpServers": { "fs": { "command": "profile-fs" } } }"#,
-        )
-        .unwrap();
-        let servers = load_profile_mcp_servers(dir.path()).unwrap();
-        assert_eq!(names(&servers), vec!["fs"]);
-    }
-
-    #[test]
-    fn profile_malformed_file_is_error() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("mcp.json"), "{ not json").unwrap();
-        assert!(load_profile_mcp_servers(dir.path()).is_err());
-    }
-
-    #[test]
-    fn merge_profile_overrides_global() {
-        // Ordering native < global < per-profile: on the shared "fs" name, the
-        // per-profile layer (highest of the three) wins.
-        let native = layer(
-            "agent-native",
-            r#"{ "mcpServers": { "fs": { "command": "native" } } }"#,
-        );
-        let global = layer(
-            "global",
-            r#"{ "mcpServers": { "fs": { "command": "global" } } }"#,
-        );
-        let profile = layer(
-            "per-profile",
-            r#"{ "mcpServers": { "fs": { "command": "profile" } } }"#,
-        );
-        let merged = merge_by_precedence(vec![native, global, profile]);
-        assert_eq!(names(&merged), vec!["fs"]);
-        assert_eq!(stdio_command(&merged[0]), "profile");
-    }
-
-    #[test]
-    fn project_servers_to_acp_converts_all_transports() {
-        use crate::session::project_mcp::{ProjectMcpServer, ProjectMcpTransport};
-        let mut env = BTreeMap::new();
-        env.insert("TOKEN".to_string(), "secret".to_string());
-        let mut headers = BTreeMap::new();
-        headers.insert("Authorization".to_string(), "Bearer x".to_string());
-        let project = vec![
-            ProjectMcpServer {
-                name: "a-stdio".to_string(),
-                transport: ProjectMcpTransport::Stdio {
-                    command: "cmd".to_string(),
-                    args: vec!["--arg".to_string()],
-                    env,
-                },
-            },
-            ProjectMcpServer {
-                name: "b-http".to_string(),
-                transport: ProjectMcpTransport::Http {
-                    url: "https://e/mcp".to_string(),
-                    headers,
-                },
-            },
-            ProjectMcpServer {
-                name: "c-sse".to_string(),
-                transport: ProjectMcpTransport::Sse {
-                    url: "https://e/sse".to_string(),
-                    headers: BTreeMap::new(),
-                },
-            },
-        ];
-        let acp = project_servers_to_acp(project);
-        assert_eq!(names(&acp), vec!["a-stdio", "b-http", "c-sse"]);
-        match &acp[0] {
-            McpServer::Stdio(s) => {
-                assert_eq!(s.command.to_string_lossy(), "cmd");
-                assert_eq!(s.args, vec!["--arg".to_string()]);
-                assert_eq!(s.env[0].name, "TOKEN");
-                assert_eq!(s.env[0].value, "secret");
-            }
-            other => panic!("expected stdio, got {other:?}"),
-        }
-        match &acp[1] {
-            McpServer::Http(h) => {
-                assert_eq!(h.url, "https://e/mcp");
-                assert_eq!(h.headers[0].name, "Authorization");
-            }
-            other => panic!("expected http, got {other:?}"),
-        }
-        assert!(matches!(&acp[2], McpServer::Sse(_)));
-    }
-
-    fn write(home: &Path, rel: &str, contents: &str) {
-        let path = home.join(rel);
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, contents).unwrap();
-    }
-
-    #[test]
-    fn native_unknown_agent_is_empty() {
-        let home = tempfile::tempdir().unwrap();
-        assert!(load_native_mcp_servers("opencode", home.path())
-            .unwrap()
-            .is_empty());
-    }
-
-    #[test]
-    fn native_missing_file_is_empty() {
-        let home = tempfile::tempdir().unwrap();
-        assert!(load_native_mcp_servers("claude", home.path())
-            .unwrap()
-            .is_empty());
-        assert!(load_native_mcp_servers("gemini", home.path())
-            .unwrap()
-            .is_empty());
-        assert!(load_native_mcp_servers("codex", home.path())
-            .unwrap()
-            .is_empty());
-    }
-
-    #[test]
-    fn native_claude_parses_and_ignores_history() {
-        let home = tempfile::tempdir().unwrap();
-        // `~/.claude.json` also holds unrelated keys (project history); they must
-        // be skipped without affecting the mcpServers parse.
-        write(
-            home.path(),
-            ".claude.json",
-            r#"{
-                "projects": { "/some/path": { "lastSessionId": "abc" } },
-                "numStartups": 42,
-                "mcpServers": {
-                    "fs": { "command": "mcp-fs", "args": ["--root", "."] },
-                    "remote": { "type": "http", "url": "https://e/mcp" }
-                }
-            }"#,
-        );
-        let servers = load_native_mcp_servers("claude", home.path()).unwrap();
-        assert_eq!(names(&servers), vec!["fs", "remote"]);
-        // `claude-code` is the legacy alias and resolves to the same reader.
-        let aliased = load_native_mcp_servers("claude-code", home.path()).unwrap();
-        assert_eq!(names(&aliased), vec!["fs", "remote"]);
-    }
-
-    #[test]
-    fn native_claude_skips_bad_entry_keeps_rest() {
-        let home = tempfile::tempdir().unwrap();
-        // The "broken" stdio entry has no command; it is skipped, "ok" survives.
-        write(
-            home.path(),
-            ".claude.json",
-            r#"{ "mcpServers": {
-                "broken": { "args": ["--x"] },
-                "ok": { "command": "good" }
-            } }"#,
-        );
-        let servers = load_native_mcp_servers("claude", home.path()).unwrap();
-        assert_eq!(names(&servers), vec!["ok"]);
-    }
-
-    #[test]
-    fn native_claude_malformed_file_is_error() {
-        let home = tempfile::tempdir().unwrap();
-        write(home.path(), ".claude.json", "{ not json");
-        assert!(load_native_mcp_servers("claude", home.path()).is_err());
-    }
-
-    #[test]
-    fn native_gemini_discriminates_transport_by_key() {
-        let home = tempfile::tempdir().unwrap();
-        write(
-            home.path(),
-            ".gemini/settings.json",
-            r#"{
-                "theme": "dark",
-                "mcpServers": {
-                    "local":  { "command": "g", "args": ["--x"] },
-                    "httpish": { "httpUrl": "https://e/mcp", "headers": { "Authorization": "Bearer x" } },
-                    "sseish":  { "url": "https://e/sse" }
-                }
-            }"#,
-        );
-        let servers = load_native_mcp_servers("gemini", home.path()).unwrap();
-        // BTreeMap order: httpish, local, sseish.
-        assert_eq!(names(&servers), vec!["httpish", "local", "sseish"]);
-        match &servers[0] {
-            McpServer::Http(h) => {
-                assert_eq!(h.url, "https://e/mcp");
-                assert_eq!(h.headers[0].name, "Authorization");
-            }
-            other => panic!("expected http from httpUrl, got {other:?}"),
-        }
-        assert!(matches!(&servers[1], McpServer::Stdio(_)));
-        assert!(matches!(&servers[2], McpServer::Sse(_)));
-    }
-
-    #[test]
-    fn native_gemini_ambiguous_entry_is_skipped() {
-        let home = tempfile::tempdir().unwrap();
-        // "ambiguous" sets both command and httpUrl; skipped, "ok" survives.
-        write(
-            home.path(),
-            ".gemini/settings.json",
-            r#"{ "mcpServers": {
-                "ambiguous": { "command": "c", "httpUrl": "https://e/mcp" },
-                "ok": { "command": "good" }
-            } }"#,
-        );
-        let servers = load_native_mcp_servers("gemini", home.path()).unwrap();
-        assert_eq!(names(&servers), vec!["ok"]);
-    }
-
-    #[test]
-    fn native_codex_parses_toml() {
-        let home = tempfile::tempdir().unwrap();
-        write(
-            home.path(),
-            ".codex/config.toml",
-            r#"
-model = "gpt-5"
-
-[mcp_servers.fs]
-command = "mcp-fs"
-args = ["--root", "."]
-env = { TOKEN = "secret" }
-
-[mcp_servers.remote]
-url = "https://e/mcp"
-"#,
-        );
-        let servers = load_native_mcp_servers("codex", home.path()).unwrap();
-        assert_eq!(names(&servers), vec!["fs", "remote"]);
-        assert_eq!(stdio_command(&servers[0]), "mcp-fs");
-        assert!(matches!(&servers[1], McpServer::Http(_)));
-        // Secret env value never appears in the summary.
-        assert!(!summarize(&servers).contains("secret"));
-    }
-
-    #[test]
-    fn native_codex_malformed_file_is_error() {
-        let home = tempfile::tempdir().unwrap();
-        write(home.path(), ".codex/config.toml", "this = = not toml");
-        assert!(load_native_mcp_servers("codex", home.path()).is_err());
     }
 }

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -490,9 +490,10 @@ fn resolve_mcp_layers(
     profile: Option<&str>,
     cwd: &std::path::Path,
 ) -> Vec<agent_client_protocol::schema::McpServer> {
-    use crate::acp::mcp_config::{
+    use crate::acp::mcp_config::project_servers_to_acp;
+    use crate::session::mcp_model::{
         load_global_mcp_servers, load_native_mcp_servers_from_home, load_profile_mcp_servers,
-        merge_by_precedence, project_servers_to_acp, summarize, McpLayer,
+        resolve, summarize, McpLayer, McpProvenance,
     };
 
     let native = match load_native_mcp_servers_from_home(agent_key) {
@@ -576,7 +577,7 @@ fn resolve_mcp_layers(
         Ok(servers) => {
             let hash = crate::session::project_mcp::fingerprint(&servers);
             match crate::session::repo_config::is_repo_trusted(&source, None, Some(&hash)) {
-                Ok(true) => project_servers_to_acp(servers),
+                Ok(true) => servers,
                 Ok(false) => {
                     warn!(
                         target: "acp.mcp",
@@ -611,21 +612,25 @@ fn resolve_mcp_layers(
         }
     };
 
-    let merged = merge_by_precedence(vec![
+    let merged = resolve(vec![
         McpLayer {
-            label: "agent-native",
+            provenance: McpProvenance::AgentNative {
+                agent: agent_key.to_string(),
+            },
             servers: native,
         },
         McpLayer {
-            label: "global",
+            provenance: McpProvenance::Global,
             servers: global,
         },
         McpLayer {
-            label: "per-profile",
+            provenance: McpProvenance::Profile {
+                name: profile.unwrap_or_default().to_string(),
+            },
             servers: per_profile,
         },
         McpLayer {
-            label: "project-local",
+            provenance: McpProvenance::ProjectLocal,
             servers: project_local,
         },
     ]);
@@ -639,7 +644,8 @@ fn resolve_mcp_layers(
             "forwarding MCP servers"
         );
     }
-    merged
+    // Convert only the winning set to ACP wire values just before forwarding.
+    project_servers_to_acp(merged.into_iter().map(|s| s.def).collect())
 }
 
 /// Overlay an instance command override onto a resolved `AgentSpec`.

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -490,151 +490,12 @@ fn resolve_mcp_layers(
     profile: Option<&str>,
     cwd: &std::path::Path,
 ) -> Vec<agent_client_protocol::schema::McpServer> {
-    use crate::acp::mcp_config::project_servers_to_acp;
-    use crate::session::mcp_model::{
-        load_global_mcp_servers, load_native_mcp_servers_from_home, load_profile_mcp_servers,
-        resolve, summarize, McpLayer, McpProvenance,
-    };
+    use crate::session::mcp_model::{resolve_effective, summarize};
 
-    let native = match load_native_mcp_servers_from_home(agent_key) {
-        Ok(servers) => servers,
-        Err(e) => {
-            warn!(
-                target: "acp.mcp",
-                session = %session_id,
-                agent = %agent_key,
-                error = %e,
-                "failed to load native MCP config; forwarding none from it"
-            );
-            Vec::new()
-        }
-    };
-
-    let global = match crate::session::get_app_dir() {
-        Ok(app_dir) => match load_global_mcp_servers(&app_dir) {
-            Ok(servers) => servers,
-            Err(e) => {
-                warn!(
-                    target: "acp.mcp",
-                    session = %session_id,
-                    error = %e,
-                    "failed to load global MCP config; forwarding none from it"
-                );
-                Vec::new()
-            }
-        },
-        Err(e) => {
-            warn!(
-                target: "acp.mcp",
-                session = %session_id,
-                error = %e,
-                "could not resolve app dir for MCP config; forwarding none from it"
-            );
-            Vec::new()
-        }
-    };
-
-    // Per-profile layer: `<profile_dir>/mcp.json` for the session's profile,
-    // resolved read-only so a session under a profile with no MCP file never
-    // creates a stub directory. An empty/None profile resolves to the default.
-    let per_profile = match crate::session::get_profile_dir_path(profile.unwrap_or_default()) {
-        Ok(profile_dir) => match load_profile_mcp_servers(&profile_dir) {
-            Ok(servers) => servers,
-            Err(e) => {
-                warn!(
-                    target: "acp.mcp",
-                    session = %session_id,
-                    error = %e,
-                    "failed to load per-profile MCP config; forwarding none from it"
-                );
-                Vec::new()
-            }
-        },
-        Err(e) => {
-            warn!(
-                target: "acp.mcp",
-                session = %session_id,
-                error = %e,
-                "could not resolve profile dir for MCP config; forwarding none from it"
-            );
-            Vec::new()
-        }
-    };
-
-    // Project-local layer (#1985): the repo's `.mcp.json`, highest precedence,
-    // but forwarded ONLY when the repo is trusted for the file's current
-    // fingerprint. A repo-provided stdio server launches its `command` the
-    // moment the session spawns, so an untrusted (or changed) file is a
-    // zero-click RCE surface: skip it and log, exactly like the create-time
-    // trust gate refuses to run untrusted hooks. The file is read from the main
-    // repo (resolved from a worktree path), the same source the trust dialog
-    // reviewed, so the forwarded set equals the reviewed set. The gate runs on
-    // every spawn and respawn, so an edit to `.mcp.json` re-locks it until the
-    // user re-approves at session-create.
-    let source = crate::session::repo_config::repo_config_source_path(cwd);
-    let project_local = match crate::session::project_mcp::load_project_mcp_servers(&source) {
-        Ok(servers) if servers.is_empty() => Vec::new(),
-        Ok(servers) => {
-            let hash = crate::session::project_mcp::fingerprint(&servers);
-            match crate::session::repo_config::is_repo_trusted(&source, None, Some(&hash)) {
-                Ok(true) => servers,
-                Ok(false) => {
-                    warn!(
-                        target: "acp.mcp",
-                        session = %session_id,
-                        repo = %source.display(),
-                        count = servers.len(),
-                        "skipping project-local MCP servers: repo not trusted at this .mcp.json fingerprint; review and approve by creating a session for this repo in the TUI or CLI"
-                    );
-                    Vec::new()
-                }
-                Err(e) => {
-                    warn!(
-                        target: "acp.mcp",
-                        session = %session_id,
-                        repo = %source.display(),
-                        error = %e,
-                        "could not check project-local MCP trust; forwarding none from it"
-                    );
-                    Vec::new()
-                }
-            }
-        }
-        Err(e) => {
-            warn!(
-                target: "acp.mcp",
-                session = %session_id,
-                repo = %source.display(),
-                error = %e,
-                "failed to load project-local MCP config; forwarding none from it"
-            );
-            Vec::new()
-        }
-    };
-
-    let merged = resolve(vec![
-        McpLayer {
-            provenance: McpProvenance::AgentNative {
-                agent: agent_key.to_string(),
-            },
-            servers: native,
-        },
-        McpLayer {
-            provenance: McpProvenance::Global,
-            servers: global,
-        },
-        McpLayer {
-            provenance: McpProvenance::Profile {
-                name: profile.unwrap_or_default().to_string(),
-            },
-            servers: per_profile,
-        },
-        McpLayer {
-            provenance: McpProvenance::ProjectLocal,
-            servers: project_local,
-        },
-    ]);
-
+    // One resolver for forwarding and the management surfaces (#1996): assemble
+    // the trust-gated, provenance-tagged effective set, then convert only the
+    // winning definitions to ACP wire values just before forwarding.
+    let merged = resolve_effective(agent_key, profile, cwd);
     if !merged.is_empty() {
         info!(
             target: "acp.mcp",
@@ -644,8 +505,7 @@ fn resolve_mcp_layers(
             "forwarding MCP servers"
         );
     }
-    // Convert only the winning set to ACP wire values just before forwarding.
-    project_servers_to_acp(merged.into_iter().map(|s| s.def).collect())
+    crate::acp::mcp_config::project_servers_to_acp(merged.into_iter().map(|s| s.def).collect())
 }
 
 /// Overlay an instance command override onto a resolved `AgentSpec`.

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -16,6 +16,7 @@ use super::list::ListArgs;
 #[cfg(feature = "serve")]
 use super::log_level::LogLevelArgs;
 use super::logs::LogsArgs;
+use super::mcp::McpCommands;
 use super::profile::ProfileCommands;
 use super::project::ProjectCommands;
 use super::remove::RemoveArgs;
@@ -151,6 +152,12 @@ pub enum Commands {
         command: TelemetryCommands,
     },
 
+    /// Inspect the effective MCP server set (provenance, conflicts, drift)
+    Mcp {
+        #[command(subcommand)]
+        command: McpCommands,
+    },
+
     /// Start a web dashboard for remote session access
     #[cfg(feature = "serve")]
     Serve(ServeArgs),
@@ -221,6 +228,7 @@ pub const CLI_COMMAND_NAMES: &[&str] = &[
     "sounds",
     "theme",
     "telemetry",
+    "mcp",
     "serve",
     "url",
     "acp",
@@ -260,6 +268,7 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::Sounds { .. } => "sounds",
         Commands::Theme { .. } => "theme",
         Commands::Telemetry { .. } => "telemetry",
+        Commands::Mcp { .. } => "mcp",
         #[cfg(feature = "serve")]
         Commands::Serve(_) => "serve",
         #[cfg(feature = "serve")]

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,0 +1,144 @@
+//! `aoe mcp` CLI: inspect the effective MCP server set (#1996).
+//!
+//! Mirrors the read model the web and TUI surfaces render, so a user can debug
+//! "which MCP servers will my agent reach, and where did each come from" without
+//! a serve build. Top-level (not under the serve-gated `aoe acp` group) and
+//! always compiled, because inspecting config is useful before any session runs.
+//! Every value is redacted: command/args/url identify a server, env and header
+//! VALUES are reduced to names.
+
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::session::mcp_model::{resolve_surface, McpSurfaceView};
+
+#[derive(Subcommand, Debug)]
+pub enum McpCommands {
+    /// List the merged effective MCP server set with provenance, plus any
+    /// conflicts and servers kept after removal from a native config.
+    List(McpListArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct McpListArgs {
+    /// Agent whose effective set to resolve. Defaults to the configured default
+    /// tool. MCP forwarding is per-agent because the agent-native layer differs.
+    #[arg(long)]
+    pub agent: Option<String>,
+
+    /// Output machine-readable JSON instead of a table.
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub async fn run(profile: &str, command: McpCommands) -> Result<()> {
+    match command {
+        McpCommands::List(args) => list(profile, args),
+    }
+}
+
+fn list(profile: &str, args: McpListArgs) -> Result<()> {
+    let agent = args.agent.unwrap_or_else(|| {
+        crate::session::profile_config::resolve_config_or_warn(profile)
+            .session
+            .default_tool
+            .unwrap_or_else(|| "claude".to_string())
+    });
+    let profile_opt = (!profile.is_empty()).then_some(profile);
+    let cwd = std::env::current_dir()?;
+
+    let view = resolve_surface(&agent, profile_opt, &cwd);
+
+    if args.json {
+        print_json(&agent, &view);
+    } else {
+        print_table(&agent, &view);
+    }
+    Ok(())
+}
+
+fn print_json(agent: &str, view: &McpSurfaceView) {
+    let conflicts: Vec<_> = view
+        .conflicts
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "name": c.current.name,
+                "agent": c.agent,
+                // Redacted one-line summaries: never the raw env/header values.
+                "previous": c.previous.redacted_summary(),
+                "current": c.current.redacted_summary(),
+            })
+        })
+        .collect();
+    let out = serde_json::json!({
+        "agent": agent,
+        "effective": view.effective.iter().map(|s| s.redacted()).collect::<Vec<_>>(),
+        "keptOnRemoval": view.kept_on_removal.iter().map(|s| s.redacted()).collect::<Vec<_>>(),
+        "conflicts": conflicts,
+        "driftPaused": view.drift_paused,
+    });
+    println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
+}
+
+fn print_table(agent: &str, view: &McpSurfaceView) {
+    println!("MCP servers for agent `{agent}`:\n");
+    if view.effective.is_empty() {
+        println!("  (no servers forwarded)");
+    } else {
+        for s in &view.effective {
+            let r = s.redacted();
+            print!("  {}  [{}]  {}", r.name, r.provenance, transport_detail(&r));
+            if !r.shadowed.is_empty() {
+                print!("  (shadows {})", r.shadowed.join(", "));
+            }
+            println!();
+        }
+    }
+
+    if !view.kept_on_removal.is_empty() {
+        println!("\nKept after removal from the native config (not forwarded; keep or drop):");
+        for s in &view.kept_on_removal {
+            let r = s.redacted();
+            println!("  {}  {}", r.name, transport_detail(&r));
+        }
+    }
+
+    if !view.conflicts.is_empty() {
+        println!("\nConflicts (native config changed since AoE last saw it):");
+        for c in &view.conflicts {
+            println!("  {}", c.current.name);
+            println!("    AoE:    {}", c.previous.redacted_summary());
+            println!("    native: {}", c.current.redacted_summary());
+        }
+    }
+
+    if view.drift_paused {
+        println!(
+            "\nNote: drift detection is paused for `{agent}` because its native MCP \
+             config has a malformed entry."
+        );
+    }
+}
+
+fn transport_detail(r: &crate::session::mcp_model::RedactedMcpServer) -> String {
+    let mut s = match (&r.command, &r.url) {
+        (Some(command), _) => {
+            let mut d = format!("{} ({})", command, r.transport);
+            if !r.args.is_empty() {
+                d.push(' ');
+                d.push_str(&r.args.join(" "));
+            }
+            d
+        }
+        (None, Some(url)) => format!("{} ({})", url, r.transport),
+        (None, None) => r.transport.to_string(),
+    };
+    if !r.env_names.is_empty() {
+        s.push_str(&format!("  [env: {}]", r.env_names.join(", ")));
+    }
+    if !r.header_names.is_empty() {
+        s.push_str(&format!("  [headers: {}]", r.header_names.join(", ")));
+    }
+    s
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ pub mod list;
 #[cfg(feature = "serve")]
 pub mod log_level;
 pub mod logs;
+pub mod mcp;
 pub mod output;
 pub mod profile;
 pub mod project;

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,6 +256,10 @@ async fn main() -> Result<()> {
             };
         }
         Some(Commands::Telemetry { command }) => return cli::telemetry::run(command),
+        Some(Commands::Mcp { command }) => {
+            let profile = cli.profile.clone().unwrap_or_default();
+            return cli::mcp::run(&profile, command).await;
+        }
         Some(Commands::Uninstall(args)) => return cli::uninstall::run(args).await,
         Some(Commands::Update(args)) => return cli::update::run(args).await,
         _ => {}

--- a/src/server/api/mcp.rs
+++ b/src/server/api/mcp.rs
@@ -1,0 +1,225 @@
+//! REST handlers for the unified MCP management surface (#1996).
+//!
+//! `GET /api/mcp/servers` resolves the effective MCP set for an agent and
+//! returns the redaction-safe view (provenance, shadow chain, kept-on-removal,
+//! conflicts) the dashboard renders. The mutating routes resolve a conflict
+//! (feature C) and keep / drop a server removed from a native config
+//! (feature D). All values are redacted; AoE never writes an agent-native
+//! config. The project-local layer reflects the daemon's working directory.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+
+use super::AppState;
+use crate::session::mcp_state::{self, ConflictWinner};
+use crate::session::{mcp_model, profile_config};
+
+#[derive(Debug, Deserialize)]
+pub struct AgentQuery {
+    /// Agent whose effective set to resolve; defaults to the configured tool.
+    agent: Option<String>,
+}
+
+/// Resolve the agent to inspect: explicit query value, else the profile's
+/// configured default tool, else `claude`.
+fn resolve_agent(state: &AppState, requested: Option<String>) -> String {
+    requested.unwrap_or_else(|| {
+        profile_config::resolve_config_or_warn(&state.profile)
+            .session
+            .default_tool
+            .unwrap_or_else(|| "claude".to_string())
+    })
+}
+
+/// `GET /api/mcp/servers?agent=<a>` — the effective set plus drift, redacted.
+pub async fn get_mcp_servers(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<AgentQuery>,
+) -> impl IntoResponse {
+    let agent = resolve_agent(&state, query.agent);
+    let profile = state.profile.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let profile_opt = (!profile.is_empty()).then_some(profile.as_str());
+        let view = mcp_model::resolve_surface(&agent, profile_opt, &cwd);
+        serde_json::json!({
+            "agent": agent,
+            "effective": view.effective.iter().map(|s| s.redacted()).collect::<Vec<_>>(),
+            "keptOnRemoval": view.kept_on_removal.iter().map(|s| s.redacted()).collect::<Vec<_>>(),
+            "conflicts": view
+                .conflicts
+                .iter()
+                .map(|c| serde_json::json!({
+                    "name": c.current.name,
+                    "agent": c.agent,
+                    "previous": c.previous.redacted_summary(),
+                    "current": c.current.redacted_summary(),
+                    // Optimistic-concurrency token for the resolve endpoint.
+                    "fingerprint": c.fingerprint(),
+                }))
+                .collect::<Vec<_>>(),
+            "driftPaused": view.drift_paused,
+        })
+    })
+    .await;
+
+    match result {
+        Ok(body) => Json(body).into_response(),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "resolve_failed"})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResolveConflictBody {
+    agent: String,
+    /// "aoe" keeps AoE's last-seen definition (promoted to global mcp.json);
+    /// "native" accepts the native config's current definition.
+    winner: String,
+    /// The token the surface captured when it opened the modal; the resolution
+    /// is rejected as stale if the snapshot changed since.
+    fingerprint: String,
+}
+
+/// `POST /api/mcp/servers/{name}/resolve` — resolve a conflict (feature C).
+pub async fn resolve_mcp_conflict(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    body: Result<Json<ResolveConflictBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return read_only_response();
+    }
+    let Ok(Json(body)) = body else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "invalid_body"})),
+        )
+            .into_response();
+    };
+    let winner = match body.winner.as_str() {
+        "aoe" => ConflictWinner::Aoe,
+        "native" => ConflictWinner::Native,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid_winner"})),
+            )
+                .into_response()
+        }
+    };
+
+    let result = tokio::task::spawn_blocking(move || {
+        // Re-resolve the current conflicts and find the one for `name`. The
+        // fingerprint guard in resolve_conflict rejects a stale resolution.
+        let read = mcp_model::load_native_mcp_servers_checked_from_home(&body.agent)?;
+        let reconcile = mcp_state::reconcile_agent(&body.agent, &read)?;
+        let Some(conflict) = reconcile
+            .conflicts
+            .into_iter()
+            .find(|c| c.current.name == name)
+        else {
+            return Ok(mcp_state::ResolveStatus::Stale);
+        };
+        mcp_state::resolve_conflict(&conflict, winner, &body.fingerprint)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(mcp_state::ResolveStatus::Applied)) => {
+            Json(serde_json::json!({"status": "applied"})).into_response()
+        }
+        Ok(Ok(mcp_state::ResolveStatus::Stale)) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"status": "stale"})),
+        )
+            .into_response(),
+        _ => internal_error(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AgentBody {
+    agent: String,
+}
+
+/// `POST /api/mcp/servers/{name}/keep` — keep a removed server (feature D),
+/// promoting it into the global `mcp.json`.
+pub async fn keep_mcp_server(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    body: Result<Json<AgentBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return read_only_response();
+    }
+    let Ok(Json(body)) = body else {
+        return bad_body();
+    };
+    let result =
+        tokio::task::spawn_blocking(move || mcp_state::keep_removed(&body.agent, &name)).await;
+    match result {
+        Ok(Ok(true)) => Json(serde_json::json!({"status": "kept"})).into_response(),
+        Ok(Ok(false)) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"status": "not_found"})),
+        )
+            .into_response(),
+        _ => internal_error(),
+    }
+}
+
+/// `POST /api/mcp/servers/{name}/drop` — drop a kept-on-removal server without
+/// promoting it (feature D).
+pub async fn drop_mcp_server(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    body: Result<Json<AgentBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return read_only_response();
+    }
+    let Ok(Json(body)) = body else {
+        return bad_body();
+    };
+    let result =
+        tokio::task::spawn_blocking(move || mcp_state::forget_native(&body.agent, &name)).await;
+    match result {
+        Ok(Ok(())) => Json(serde_json::json!({"status": "dropped"})).into_response(),
+        _ => internal_error(),
+    }
+}
+
+fn read_only_response() -> axum::response::Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"})),
+    )
+        .into_response()
+}
+
+fn bad_body() -> axum::response::Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({"error": "invalid_body"})),
+    )
+        .into_response()
+}
+
+fn internal_error() -> axum::response::Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({"error": "internal"})),
+    )
+        .into_response()
+}

--- a/src/server/api/mcp.rs
+++ b/src/server/api/mcp.rs
@@ -38,7 +38,7 @@ fn resolve_agent(state: &AppState, requested: Option<String>) -> String {
     })
 }
 
-/// `GET /api/mcp/servers?agent=<a>` — the effective set plus drift, redacted.
+/// `GET /api/mcp/servers?agent=<a>`: the effective set plus drift, redacted.
 pub async fn get_mcp_servers(
     State(state): State<Arc<AppState>>,
     Query(query): Query<AgentQuery>,
@@ -91,7 +91,7 @@ pub struct ResolveConflictBody {
     fingerprint: String,
 }
 
-/// `POST /api/mcp/servers/{name}/resolve` — resolve a conflict (feature C).
+/// `POST /api/mcp/servers/{name}/resolve`: resolve a conflict (feature C).
 pub async fn resolve_mcp_conflict(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -153,7 +153,7 @@ pub struct AgentBody {
     agent: String,
 }
 
-/// `POST /api/mcp/servers/{name}/keep` — keep a removed server (feature D),
+/// `POST /api/mcp/servers/{name}/keep`: keep a removed server (feature D),
 /// promoting it into the global `mcp.json`.
 pub async fn keep_mcp_server(
     State(state): State<Arc<AppState>>,
@@ -179,7 +179,7 @@ pub async fn keep_mcp_server(
     }
 }
 
-/// `POST /api/mcp/servers/{name}/drop` — drop a kept-on-removal server without
+/// `POST /api/mcp/servers/{name}/drop`: drop a kept-on-removal server without
 /// promoting it (feature D).
 pub async fn drop_mcp_server(
     State(state): State<Arc<AppState>>,

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -16,6 +16,7 @@ mod acp;
 mod client_log;
 mod git;
 mod log_level;
+mod mcp;
 mod projects;
 mod sessions;
 mod system;
@@ -33,6 +34,7 @@ pub use acp::{
 pub use client_log::post_client_log;
 pub use git::{clone_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
+pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_conflict};
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
@@ -160,6 +162,11 @@ mod tests {
                 ],
             ),
             ("api/git.rs", include_str!("git.rs"), &["clone_repo"]),
+            (
+                "api/mcp.rs",
+                include_str!("mcp.rs"),
+                &["resolve_mcp_conflict", "keep_mcp_server", "drop_mcp_server"],
+            ),
             (
                 "api/log_level.rs",
                 include_str!("log_level.rs"),
@@ -302,6 +309,11 @@ mod tests {
                 ],
             ),
             ("api/git.rs", include_str!("git.rs"), &["clone_repo"]),
+            (
+                "api/mcp.rs",
+                include_str!("mcp.rs"),
+                &["resolve_mcp_conflict", "keep_mcp_server", "drop_mcp_server"],
+            ),
             (
                 "api/log_level.rs",
                 include_str!("log_level.rs"),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1174,6 +1174,14 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/workspace-ordering",
             put(api::update_workspace_ordering),
         )
+        // Unified MCP management surface (#1996)
+        .route("/api/mcp/servers", get(api::get_mcp_servers))
+        .route(
+            "/api/mcp/servers/{name}/resolve",
+            post(api::resolve_mcp_conflict),
+        )
+        .route("/api/mcp/servers/{name}/keep", post(api::keep_mcp_server))
+        .route("/api/mcp/servers/{name}/drop", post(api::drop_mcp_server))
         .route(
             "/api/sessions/{id}",
             patch(api::rename_session).delete(api::delete_session),

--- a/src/session/mcp_model.rs
+++ b/src/session/mcp_model.rs
@@ -1,0 +1,746 @@
+//! Always-compiled, ACP-free model of the merged MCP server set (#1996).
+//!
+//! AoE assembles an effective MCP server set from up to four layers
+//! (`agent-native` -> `global` -> `per-profile` -> `project-local`, higher wins
+//! per server name). The serve-gated `acp::mcp_config` used to own both the
+//! parsing and the merge, but it returned ACP `McpServer` wire types and dropped
+//! the layer label on merge, so the unified management surface had nowhere to
+//! read the merged set, its provenance, or its shadowing.
+//!
+//! This module is the single resolver for both jobs. It lives outside the serve
+//! gate (like [`super::project_mcp`]) so the TUI panel, the CLI, and the
+//! always-compiled drift store can read the model without depending on the ACP
+//! schema. Serve-side forwarding consumes the SAME resolver and converts only
+//! the winning set to ACP just before sending, so what the user sees and what
+//! the agent receives can never diverge.
+//!
+//! Secret values (env values, header values) are kept in memory because
+//! forwarding and the drift store need them, but every display path goes through
+//! [`ProjectMcpServer::redacted_summary`], so names reach a screen, a log, or
+//! CLI output and values never do.
+
+use std::collections::BTreeMap;
+use std::io::BufReader;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use tracing::warn;
+
+use super::project_mcp::{ProjectMcpServer, ProjectMcpTransport};
+
+/// Where a resolved server came from, carrying the dynamic name where the layer
+/// needs one (the agent key, the profile name). `label` renders the provenance
+/// string the management surfaces display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpProvenance {
+    /// The active agent's own config (`~/.claude.json`, `~/.gemini/...`, ...).
+    AgentNative { agent: String },
+    /// The global `<app_dir>/mcp.json`.
+    Global,
+    /// A per-profile `<profile_dir>/mcp.json`.
+    Profile { name: String },
+    /// The repo's trusted `cwd/.mcp.json`.
+    ProjectLocal,
+}
+
+impl McpProvenance {
+    /// The provenance string shown on every surface, e.g. `agent-native:claude`,
+    /// `profile:rust`, `global`, `project-local`.
+    pub fn label(&self) -> String {
+        match self {
+            McpProvenance::AgentNative { agent } => format!("agent-native:{agent}"),
+            McpProvenance::Global => "global".to_string(),
+            McpProvenance::Profile { name } => format!("profile:{name}"),
+            McpProvenance::ProjectLocal => "project-local".to_string(),
+        }
+    }
+}
+
+/// One layer of the precedence stack, lowest first. The `provenance` is owned so
+/// the per-profile layer can carry the dynamic profile name (the old
+/// `&'static str` label could not).
+pub struct McpLayer {
+    pub provenance: McpProvenance,
+    pub servers: Vec<ProjectMcpServer>,
+}
+
+/// A server in the merged effective set: its winning definition, the layer it
+/// won from, and every lower layer it shadowed (in precedence order, lowest
+/// first). `shadowed` is what lets the surface explain "this `fs` came from
+/// per-profile and overrode the agent-native one".
+#[derive(Debug, Clone)]
+pub struct ResolvedMcpServer {
+    pub def: ProjectMcpServer,
+    pub provenance: McpProvenance,
+    pub shadowed: Vec<McpProvenance>,
+}
+
+/// Merge layers by precedence. `layers` are ordered lowest first; a server in a
+/// later layer overrides one of the same name in an earlier layer (per server,
+/// not whole layer). The shadowed provenances accumulate in precedence order so
+/// the surface can render the full override chain. Output is name-sorted (the
+/// `BTreeMap` key order) so every surface lists servers deterministically.
+pub fn resolve(layers: Vec<McpLayer>) -> Vec<ResolvedMcpServer> {
+    let mut by_name: BTreeMap<String, ResolvedMcpServer> = BTreeMap::new();
+    for layer in layers {
+        for server in layer.servers {
+            match by_name.get_mut(&server.name) {
+                Some(existing) => {
+                    let shadowed =
+                        std::mem::replace(&mut existing.provenance, layer.provenance.clone());
+                    existing.shadowed.push(shadowed);
+                    existing.def = server;
+                }
+                None => {
+                    by_name.insert(
+                        server.name.clone(),
+                        ResolvedMcpServer {
+                            def: server,
+                            provenance: layer.provenance.clone(),
+                            shadowed: Vec::new(),
+                        },
+                    );
+                }
+            }
+        }
+    }
+    by_name.into_values().collect()
+}
+
+/// Names + transports of a resolved set for logging. Reuses the redaction-safe
+/// `kind()` so no secret value can reach the log sink.
+pub fn summarize(servers: &[ResolvedMcpServer]) -> String {
+    servers
+        .iter()
+        .map(|s| format!("{}({})", s.def.name, s.def.kind()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// ---------------------------------------------------------------------------
+// Standard `.mcp.json` layers: global and per-profile.
+// ---------------------------------------------------------------------------
+
+/// Read and parse the global `<app_dir>/mcp.json`. A missing file yields an
+/// empty list; a present-but-malformed file is an error the caller surfaces.
+pub fn load_global_mcp_servers(app_dir: &Path) -> Result<Vec<ProjectMcpServer>> {
+    super::project_mcp::load_standard_mcp_servers(&app_dir.join("mcp.json"))
+}
+
+/// Read and parse a profile's `<profile_dir>/mcp.json` (#1986). Same on-disk
+/// shape and missing/malformed semantics as the global file.
+pub fn load_profile_mcp_servers(profile_dir: &Path) -> Result<Vec<ProjectMcpServer>> {
+    super::project_mcp::load_standard_mcp_servers(&profile_dir.join("mcp.json"))
+}
+
+// ---------------------------------------------------------------------------
+// Agent-native layer: each agent's own MCP config, read live (no caching).
+// ---------------------------------------------------------------------------
+
+/// Where an agent keeps its own MCP server config, and in what shape. Adding an
+/// agent is one match arm in [`native_config_for`] plus, if its format differs,
+/// one converter. AoE only ever READS these files; it never writes them.
+enum NativeMcpConfig {
+    /// Standard `{ "mcpServers": { ... } }` JSON with the ecosystem `type`/`url`
+    /// shape, at a home-relative path. Claude (`~/.claude.json`).
+    StandardJson(&'static str),
+    /// Gemini `settings.json`: entries discriminate transport by which key is
+    /// present (`command` -> stdio, `httpUrl` -> http, `url` -> sse).
+    GeminiJson(&'static str),
+    /// Codex `config.toml`: `[mcp_servers.<name>]` tables (stdio, or `url` for
+    /// streamable http on newer Codex).
+    CodexToml(&'static str),
+}
+
+/// Map an agent registry key to its native MCP config descriptor, or `None` for
+/// an agent AoE has no native reader for (those contribute no native servers).
+fn native_config_for(agent_key: &str) -> Option<NativeMcpConfig> {
+    match agent_key {
+        "claude" | "claude-code" => Some(NativeMcpConfig::StandardJson(".claude.json")),
+        "gemini" => Some(NativeMcpConfig::GeminiJson(".gemini/settings.json")),
+        "codex" => Some(NativeMcpConfig::CodexToml(".codex/config.toml")),
+        _ => None,
+    }
+}
+
+/// Read the active agent's own MCP config (the file its CLI reads) and convert
+/// it to neutral servers. Live read-through: called once per spawn, no caching,
+/// so edits are picked up on the next session. Returns an empty list for an
+/// agent with no known native reader and for a missing file. A
+/// present-but-unparseable file is an error the caller downgrades to a warning,
+/// so a broken native file (which AoE does not own) never blocks a spawn.
+/// Individual malformed server entries are skipped with a warning.
+pub fn load_native_mcp_servers(agent_key: &str, home: &Path) -> Result<Vec<ProjectMcpServer>> {
+    let Some(config) = native_config_for(agent_key) else {
+        return Ok(Vec::new());
+    };
+    match config {
+        NativeMcpConfig::StandardJson(rel) => read_standard_json(&home.join(rel)),
+        NativeMcpConfig::GeminiJson(rel) => read_gemini_json(&home.join(rel)),
+        NativeMcpConfig::CodexToml(rel) => read_codex_toml(&home.join(rel)),
+    }
+}
+
+/// Convenience wrapper that resolves the real home dir. Kept separate from
+/// [`load_native_mcp_servers`] so tests can inject a temp home.
+pub fn load_native_mcp_servers_from_home(agent_key: &str) -> Result<Vec<ProjectMcpServer>> {
+    let home = dirs::home_dir().context("could not resolve home dir for native MCP config")?;
+    load_native_mcp_servers(agent_key, &home)
+}
+
+/// Convert a map of raw server entries, skipping (with a warning) any entry that
+/// fails to convert rather than failing the whole file. Native configs are owned
+/// by other tools, so one bad entry must not discard the user's other servers.
+fn convert_tolerant<R>(
+    servers: BTreeMap<String, R>,
+    path: &Path,
+    convert: impl Fn(String, R) -> Result<ProjectMcpServer>,
+) -> Vec<ProjectMcpServer> {
+    servers
+        .into_iter()
+        .filter_map(|(name, raw)| match convert(name.clone(), raw) {
+            Ok(server) => Some(server),
+            Err(e) => {
+                warn!(
+                    target: "acp.mcp",
+                    server = %name,
+                    path = %path.display(),
+                    error = %e,
+                    "skipping malformed MCP server in native config"
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+/// Open a config file, mapping "not found" to `None` (the user does not use that
+/// agent) and any other IO error to a context-tagged failure.
+fn open_optional(path: &Path) -> Result<Option<std::fs::File>> {
+    match std::fs::File::open(path) {
+        Ok(f) => Ok(Some(f)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => {
+            Err(e).with_context(|| format!("opening native MCP config at {}", path.display()))
+        }
+    }
+}
+
+/// On-disk shape of a standard `mcpServers` entry (Claude `~/.claude.json` and
+/// the AoE-owned `mcp.json` layers share this shape). Unknown keys are ignored.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StandardConfigFile {
+    #[serde(default)]
+    mcp_servers: BTreeMap<String, StandardRawServer>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StandardRawServer {
+    #[serde(default, rename = "type")]
+    transport: Option<String>,
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    url: Option<String>,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+}
+
+fn convert_standard(name: String, raw: StandardRawServer) -> Result<ProjectMcpServer> {
+    let transport = match raw.transport.as_deref() {
+        None | Some("stdio") => ProjectMcpTransport::Stdio {
+            command: raw
+                .command
+                .with_context(|| format!("MCP server \"{name}\" is missing \"command\""))?,
+            args: raw.args,
+            env: raw.env,
+        },
+        Some("http") => ProjectMcpTransport::Http {
+            url: raw
+                .url
+                .with_context(|| format!("MCP server \"{name}\" is missing \"url\""))?,
+            headers: raw.headers,
+        },
+        Some("sse") => ProjectMcpTransport::Sse {
+            url: raw
+                .url
+                .with_context(|| format!("MCP server \"{name}\" is missing \"url\""))?,
+            headers: raw.headers,
+        },
+        Some(other) => bail!("MCP server \"{name}\" has unknown type \"{other}\""),
+    };
+    Ok(ProjectMcpServer { name, transport })
+}
+
+/// Read a standard `mcpServers` JSON config, streaming so a large host file
+/// (e.g. `~/.claude.json`, which also holds project history) is parsed without
+/// materializing the unrelated keys.
+fn read_standard_json(path: &Path) -> Result<Vec<ProjectMcpServer>> {
+    let Some(file) = open_optional(path)? else {
+        return Ok(Vec::new());
+    };
+    let parsed: StandardConfigFile = serde_json::from_reader(BufReader::new(file))
+        .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
+    Ok(convert_tolerant(parsed.mcp_servers, path, convert_standard))
+}
+
+/// On-disk shape of a Gemini `mcpServers` entry. Transport is selected by which
+/// of `command` / `httpUrl` / `url` is present; more than one is ambiguous.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiConfigFile {
+    #[serde(default)]
+    mcp_servers: BTreeMap<String, GeminiRawServer>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiRawServer {
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    http_url: Option<String>,
+    url: Option<String>,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+}
+
+fn convert_gemini(name: String, raw: GeminiRawServer) -> Result<ProjectMcpServer> {
+    let transport = match (raw.command, raw.http_url, raw.url) {
+        (Some(command), None, None) => ProjectMcpTransport::Stdio {
+            command,
+            args: raw.args,
+            env: raw.env,
+        },
+        (None, Some(http_url), None) => ProjectMcpTransport::Http {
+            url: http_url,
+            headers: raw.headers,
+        },
+        (None, None, Some(url)) => ProjectMcpTransport::Sse {
+            url,
+            headers: raw.headers,
+        },
+        (None, None, None) => {
+            bail!("MCP server \"{name}\" has none of \"command\", \"httpUrl\", \"url\"")
+        }
+        _ => bail!("MCP server \"{name}\" sets more than one of \"command\", \"httpUrl\", \"url\""),
+    };
+    Ok(ProjectMcpServer { name, transport })
+}
+
+fn read_gemini_json(path: &Path) -> Result<Vec<ProjectMcpServer>> {
+    let Some(file) = open_optional(path)? else {
+        return Ok(Vec::new());
+    };
+    let parsed: GeminiConfigFile = serde_json::from_reader(BufReader::new(file))
+        .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
+    Ok(convert_tolerant(parsed.mcp_servers, path, convert_gemini))
+}
+
+/// On-disk shape of a Codex `[mcp_servers.<name>]` entry. `command` selects
+/// stdio; `url` selects streamable http (newer Codex). The TOML key is already
+/// snake_case, so no rename is needed.
+#[derive(Debug, Deserialize)]
+struct CodexConfigFile {
+    #[serde(default)]
+    mcp_servers: BTreeMap<String, CodexRawServer>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexRawServer {
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    url: Option<String>,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+}
+
+fn convert_codex(name: String, raw: CodexRawServer) -> Result<ProjectMcpServer> {
+    let transport = match (raw.command, raw.url) {
+        (Some(command), None) => ProjectMcpTransport::Stdio {
+            command,
+            args: raw.args,
+            env: raw.env,
+        },
+        (None, Some(url)) => ProjectMcpTransport::Http {
+            url,
+            headers: raw.headers,
+        },
+        (None, None) => bail!("MCP server \"{name}\" has neither \"command\" nor \"url\""),
+        (Some(_), Some(_)) => bail!("MCP server \"{name}\" sets both \"command\" and \"url\""),
+    };
+    Ok(ProjectMcpServer { name, transport })
+}
+
+/// Codex config files are small (no embedded history), so a whole-string read is
+/// fine; `toml` has no streaming reader.
+fn read_codex_toml(path: &Path) -> Result<Vec<ProjectMcpServer>> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("reading native MCP config at {}", path.display()))
+        }
+    };
+    let parsed: CodexConfigFile = toml::from_str(&text)
+        .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
+    Ok(convert_tolerant(parsed.mcp_servers, path, convert_codex))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(servers: &[ProjectMcpServer]) -> Vec<&str> {
+        servers.iter().map(|s| s.name.as_str()).collect()
+    }
+
+    fn resolved_names(servers: &[ResolvedMcpServer]) -> Vec<&str> {
+        servers.iter().map(|s| s.def.name.as_str()).collect()
+    }
+
+    fn write(home: &Path, rel: &str, contents: &str) {
+        let path = home.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn stdio_command(server: &ProjectMcpServer) -> &str {
+        match &server.transport {
+            ProjectMcpTransport::Stdio { command, .. } => command,
+            other => panic!("expected stdio, got {other:?}"),
+        }
+    }
+
+    fn layer(provenance: McpProvenance, servers: Vec<ProjectMcpServer>) -> McpLayer {
+        McpLayer {
+            provenance,
+            servers,
+        }
+    }
+
+    fn standard(json: &str) -> Vec<ProjectMcpServer> {
+        super::super::project_mcp::parse_standard_mcp_servers(json).unwrap()
+    }
+
+    #[test]
+    fn provenance_labels() {
+        assert_eq!(
+            McpProvenance::AgentNative {
+                agent: "claude".into()
+            }
+            .label(),
+            "agent-native:claude"
+        );
+        assert_eq!(McpProvenance::Global.label(), "global");
+        assert_eq!(
+            McpProvenance::Profile {
+                name: "rust".into()
+            }
+            .label(),
+            "profile:rust"
+        );
+        assert_eq!(McpProvenance::ProjectLocal.label(), "project-local");
+    }
+
+    #[test]
+    fn resolve_higher_layer_wins_and_records_shadow() {
+        let merged = resolve(vec![
+            layer(
+                McpProvenance::AgentNative {
+                    agent: "claude".into(),
+                },
+                standard(r#"{ "mcpServers": { "fs": { "command": "native" } } }"#),
+            ),
+            layer(
+                McpProvenance::Global,
+                standard(r#"{ "mcpServers": { "fs": { "command": "global" } } }"#),
+            ),
+        ]);
+        assert_eq!(resolved_names(&merged), vec!["fs"]);
+        assert_eq!(stdio_command(&merged[0].def), "global");
+        assert_eq!(merged[0].provenance, McpProvenance::Global);
+        assert_eq!(
+            merged[0].shadowed,
+            vec![McpProvenance::AgentNative {
+                agent: "claude".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn resolve_records_full_shadow_chain_in_precedence_order() {
+        let merged = resolve(vec![
+            layer(
+                McpProvenance::AgentNative {
+                    agent: "claude".into(),
+                },
+                standard(r#"{ "mcpServers": { "fs": { "command": "n" } } }"#),
+            ),
+            layer(
+                McpProvenance::Global,
+                standard(r#"{ "mcpServers": { "fs": { "command": "g" } } }"#),
+            ),
+            layer(
+                McpProvenance::Profile {
+                    name: "rust".into(),
+                },
+                standard(r#"{ "mcpServers": { "fs": { "command": "p" } } }"#),
+            ),
+        ]);
+        assert_eq!(stdio_command(&merged[0].def), "p");
+        assert_eq!(
+            merged[0].provenance,
+            McpProvenance::Profile {
+                name: "rust".into()
+            }
+        );
+        assert_eq!(
+            merged[0].shadowed,
+            vec![
+                McpProvenance::AgentNative {
+                    agent: "claude".into()
+                },
+                McpProvenance::Global,
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_unions_distinct_names_sorted() {
+        let merged = resolve(vec![
+            layer(
+                McpProvenance::AgentNative {
+                    agent: "claude".into(),
+                },
+                standard(
+                    r#"{ "mcpServers": { "zebra": { "command": "z" }, "fs": { "command": "n" } } }"#,
+                ),
+            ),
+            layer(
+                McpProvenance::Global,
+                standard(r#"{ "mcpServers": { "alpha": { "command": "a" } } }"#),
+            ),
+        ]);
+        assert_eq!(resolved_names(&merged), vec!["alpha", "fs", "zebra"]);
+    }
+
+    #[test]
+    fn resolve_empty_is_empty() {
+        assert!(resolve(vec![]).is_empty());
+        assert!(resolve(vec![layer(McpProvenance::Global, Vec::new())]).is_empty());
+    }
+
+    #[test]
+    fn summarize_omits_secret_values() {
+        let merged = resolve(vec![layer(
+            McpProvenance::Global,
+            standard(
+                r#"{ "mcpServers": { "fs": { "command": "c", "env": { "TOKEN": "supersecret" } } } }"#,
+            ),
+        )]);
+        let s = summarize(&merged);
+        assert_eq!(s, "fs(stdio)");
+        assert!(!s.contains("supersecret"));
+    }
+
+    #[test]
+    fn global_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_global_mcp_servers(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn global_loads_and_parses_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mcp.json"),
+            r#"{ "mcpServers": { "fs": { "command": "mcp-fs" } } }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            names(&load_global_mcp_servers(dir.path()).unwrap()),
+            vec!["fs"]
+        );
+    }
+
+    #[test]
+    fn global_malformed_file_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("mcp.json"), "{ not json").unwrap();
+        assert!(load_global_mcp_servers(dir.path()).is_err());
+    }
+
+    #[test]
+    fn profile_loads_and_parses_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mcp.json"),
+            r#"{ "mcpServers": { "fs": { "command": "profile-fs" } } }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            names(&load_profile_mcp_servers(dir.path()).unwrap()),
+            vec!["fs"]
+        );
+    }
+
+    #[test]
+    fn native_unknown_agent_is_empty() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(load_native_mcp_servers("opencode", home.path())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn native_missing_file_is_empty() {
+        let home = tempfile::tempdir().unwrap();
+        for agent in ["claude", "gemini", "codex"] {
+            assert!(load_native_mcp_servers(agent, home.path())
+                .unwrap()
+                .is_empty());
+        }
+    }
+
+    #[test]
+    fn native_claude_parses_and_ignores_history() {
+        let home = tempfile::tempdir().unwrap();
+        write(
+            home.path(),
+            ".claude.json",
+            r#"{
+                "projects": { "/some/path": { "lastSessionId": "abc" } },
+                "numStartups": 42,
+                "mcpServers": {
+                    "fs": { "command": "mcp-fs", "args": ["--root", "."] },
+                    "remote": { "type": "http", "url": "https://e/mcp" }
+                }
+            }"#,
+        );
+        let servers = load_native_mcp_servers("claude", home.path()).unwrap();
+        assert_eq!(names(&servers), vec!["fs", "remote"]);
+        // `claude-code` is the legacy alias and resolves to the same reader.
+        let aliased = load_native_mcp_servers("claude-code", home.path()).unwrap();
+        assert_eq!(names(&aliased), vec!["fs", "remote"]);
+    }
+
+    #[test]
+    fn native_claude_skips_bad_entry_keeps_rest() {
+        let home = tempfile::tempdir().unwrap();
+        write(
+            home.path(),
+            ".claude.json",
+            r#"{ "mcpServers": {
+                "broken": { "args": ["--x"] },
+                "ok": { "command": "good" }
+            } }"#,
+        );
+        assert_eq!(
+            names(&load_native_mcp_servers("claude", home.path()).unwrap()),
+            vec!["ok"]
+        );
+    }
+
+    #[test]
+    fn native_claude_malformed_file_is_error() {
+        let home = tempfile::tempdir().unwrap();
+        write(home.path(), ".claude.json", "{ not json");
+        assert!(load_native_mcp_servers("claude", home.path()).is_err());
+    }
+
+    #[test]
+    fn native_gemini_discriminates_transport_by_key() {
+        let home = tempfile::tempdir().unwrap();
+        write(
+            home.path(),
+            ".gemini/settings.json",
+            r#"{
+                "theme": "dark",
+                "mcpServers": {
+                    "local":  { "command": "g", "args": ["--x"] },
+                    "httpish": { "httpUrl": "https://e/mcp", "headers": { "Authorization": "Bearer x" } },
+                    "sseish":  { "url": "https://e/sse" }
+                }
+            }"#,
+        );
+        let servers = load_native_mcp_servers("gemini", home.path()).unwrap();
+        assert_eq!(names(&servers), vec!["httpish", "local", "sseish"]);
+        assert!(matches!(
+            servers[0].transport,
+            ProjectMcpTransport::Http { .. }
+        ));
+        assert!(matches!(
+            servers[1].transport,
+            ProjectMcpTransport::Stdio { .. }
+        ));
+        assert!(matches!(
+            servers[2].transport,
+            ProjectMcpTransport::Sse { .. }
+        ));
+    }
+
+    #[test]
+    fn native_gemini_ambiguous_entry_is_skipped() {
+        let home = tempfile::tempdir().unwrap();
+        write(
+            home.path(),
+            ".gemini/settings.json",
+            r#"{ "mcpServers": {
+                "ambiguous": { "command": "c", "httpUrl": "https://e/mcp" },
+                "ok": { "command": "good" }
+            } }"#,
+        );
+        assert_eq!(
+            names(&load_native_mcp_servers("gemini", home.path()).unwrap()),
+            vec!["ok"]
+        );
+    }
+
+    #[test]
+    fn native_codex_parses_toml() {
+        let home = tempfile::tempdir().unwrap();
+        write(
+            home.path(),
+            ".codex/config.toml",
+            r#"
+model = "gpt-5"
+
+[mcp_servers.fs]
+command = "mcp-fs"
+args = ["--root", "."]
+env = { TOKEN = "secret" }
+
+[mcp_servers.remote]
+url = "https://e/mcp"
+"#,
+        );
+        let servers = load_native_mcp_servers("codex", home.path()).unwrap();
+        assert_eq!(names(&servers), vec!["fs", "remote"]);
+        assert_eq!(stdio_command(&servers[0]), "mcp-fs");
+        assert!(matches!(
+            servers[1].transport,
+            ProjectMcpTransport::Http { .. }
+        ));
+        // Secret env value never appears in the redacted summary.
+        assert!(!servers[0].redacted_summary().contains("secret"));
+    }
+
+    #[test]
+    fn native_codex_malformed_file_is_error() {
+        let home = tempfile::tempdir().unwrap();
+        write(home.path(), ".codex/config.toml", "this = = not toml");
+        assert!(load_native_mcp_servers("codex", home.path()).is_err());
+    }
+}

--- a/src/session/mcp_model.rs
+++ b/src/session/mcp_model.rs
@@ -42,6 +42,11 @@ pub enum McpProvenance {
     Profile { name: String },
     /// The repo's trusted `cwd/.mcp.json`.
     ProjectLocal,
+    /// A server AoE last saw in the named agent's native config that has since
+    /// disappeared from it. Kept in AoE's view (keep-on-removal, feature D) and
+    /// not forwarded until the user keeps it (promoting it to `global`) or drops
+    /// it. `agent` is the native config it last lived in.
+    KeptOnRemoval { agent: String },
 }
 
 impl McpProvenance {
@@ -53,6 +58,7 @@ impl McpProvenance {
             McpProvenance::Global => "global".to_string(),
             McpProvenance::Profile { name } => format!("profile:{name}"),
             McpProvenance::ProjectLocal => "project-local".to_string(),
+            McpProvenance::KeptOnRemoval { agent } => format!("kept-on-removal:{agent}"),
         }
     }
 }
@@ -294,6 +300,82 @@ pub fn resolve_effective(
     ])
 }
 
+/// The full management-surface view for a session context (#1996): the
+/// effective forwarded set, plus servers kept-on-removal, plus the conflicts and
+/// drift-paused state the surfaces render. Built by [`resolve_surface`].
+pub struct McpSurfaceView {
+    /// The merged, trust-gated set that actually forwards to the agent, each
+    /// tagged with its winning provenance and shadow chain. Same set
+    /// [`resolve_effective`] feeds to forwarding.
+    pub effective: Vec<ResolvedMcpServer>,
+    /// Servers that vanished from the active agent's native config since AoE
+    /// last saw them, kept in the view with `KeptOnRemoval` provenance and NOT
+    /// forwarded until the user keeps (promote to global) or drops them.
+    pub kept_on_removal: Vec<ResolvedMcpServer>,
+    /// Servers whose native definition diverged from AoE's snapshot, awaiting a
+    /// which-side-wins decision.
+    pub conflicts: Vec<super::mcp_state::McpConflict>,
+    /// True when drift detection was paused for the active agent because its
+    /// native config has a malformed entry; conflicts and kept-on-removal are
+    /// then empty and the surface should say so rather than imply no drift.
+    pub drift_paused: bool,
+}
+
+/// Resolve the full management-surface view for the active agent and session
+/// context. Combines the forwarded effective set ([`resolve_effective`]) with a
+/// reconcile of the agent's native config against the drift store, so the
+/// surface shows provenance, conflicts, and kept-on-removal in one shot. The
+/// reconcile updates the snapshot (silent adoption of new servers); conflicts
+/// and removals persist until the user resolves them.
+pub fn resolve_surface(agent: &str, profile: Option<&str>, cwd: &Path) -> McpSurfaceView {
+    let effective = resolve_effective(agent, profile, cwd);
+
+    let reconcile = match load_native_mcp_servers_checked_from_home(agent) {
+        Ok(read) => super::mcp_state::reconcile_agent(agent, &read).unwrap_or_else(|e| {
+            warn!(target: "acp.mcp", agent = %agent, error = %e, "failed to reconcile MCP drift store");
+            Default::default()
+        }),
+        Err(e) => {
+            warn!(target: "acp.mcp", agent = %agent, error = %e, "failed to read native MCP config for drift");
+            Default::default()
+        }
+    };
+
+    let kept_on_removal = reconcile
+        .removed
+        .into_iter()
+        .map(|def| ResolvedMcpServer {
+            def,
+            provenance: McpProvenance::KeptOnRemoval {
+                agent: agent.to_string(),
+            },
+            shadowed: Vec::new(),
+        })
+        .collect();
+
+    McpSurfaceView {
+        effective,
+        kept_on_removal,
+        conflicts: reconcile.conflicts,
+        drift_paused: reconcile.paused,
+    }
+}
+
+/// Keep a server that was removed from a native config: promote its last-seen
+/// definition into the global `mcp.json` (where it outranks native and resolves
+/// with provenance `global`), then forget the native snapshot entry so it stops
+/// being reported as kept-on-removal. AoE never writes the native file.
+pub fn keep_removed(agent: &str, server: &ProjectMcpServer) -> Result<()> {
+    super::mcp_overrides::upsert_global_server(server)?;
+    super::mcp_state::forget_native(agent, &server.name)
+}
+
+/// Drop a kept-on-removal server: forget the native snapshot entry without
+/// promoting it, so it disappears from the view entirely.
+pub fn drop_removed(agent: &str, name: &str) -> Result<()> {
+    super::mcp_state::forget_native(agent, name)
+}
+
 // ---------------------------------------------------------------------------
 // Standard `.mcp.json` layers: global and per-profile.
 // ---------------------------------------------------------------------------
@@ -390,6 +472,13 @@ pub fn load_native_mcp_servers(agent_key: &str, home: &Path) -> Result<Vec<Proje
 pub fn load_native_mcp_servers_from_home(agent_key: &str) -> Result<Vec<ProjectMcpServer>> {
     let home = dirs::home_dir().context("could not resolve home dir for native MCP config")?;
     load_native_mcp_servers(agent_key, &home)
+}
+
+/// Like [`load_native_mcp_servers_checked`] but resolves the real home dir. Used
+/// by the management surface, which needs the skipped-entry list to gate drift.
+pub fn load_native_mcp_servers_checked_from_home(agent_key: &str) -> Result<NativeRead> {
+    let home = dirs::home_dir().context("could not resolve home dir for native MCP config")?;
+    load_native_mcp_servers_checked(agent_key, &home)
 }
 
 /// Convert a map of raw server entries, skipping (with a warning) any entry that
@@ -818,6 +907,90 @@ mod tests {
             "header value leaked: {json}"
         );
         assert!(json.contains("TOKEN") && json.contains("Authorization"));
+    }
+
+    fn set_tmp_home() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: serialized by `#[serial]`; matches the existing pattern.
+        unsafe {
+            std::env::set_var("HOME", dir.path());
+            std::env::set_var("XDG_CONFIG_HOME", dir.path().join(".config"));
+        }
+        dir
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn surface_shows_effective_then_keep_on_removal_then_promote() {
+        let home = set_tmp_home();
+        let cwd = home.path().join("repo");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        // Native config (claude) with two servers; first open adopts both.
+        std::fs::write(
+            home.path().join(".claude.json"),
+            r#"{ "mcpServers": { "fs": { "command": "c" }, "gone": { "command": "g" } } }"#,
+        )
+        .unwrap();
+        let view = resolve_surface("claude", None, &cwd);
+        assert_eq!(view.effective.len(), 2);
+        assert!(view.kept_on_removal.is_empty());
+        assert!(view.conflicts.is_empty() && !view.drift_paused);
+
+        // Drop "gone" from native: it must be kept-on-removal, not forwarded.
+        std::fs::write(
+            home.path().join(".claude.json"),
+            r#"{ "mcpServers": { "fs": { "command": "c" } } }"#,
+        )
+        .unwrap();
+        let view = resolve_surface("claude", None, &cwd);
+        assert_eq!(view.effective.len(), 1, "removed server no longer forwards");
+        assert_eq!(view.kept_on_removal.len(), 1);
+        let kept = &view.kept_on_removal[0];
+        assert_eq!(kept.def.name, "gone");
+        assert_eq!(kept.provenance.label(), "kept-on-removal:claude");
+
+        // Keep it: promote to global mcp.json; it now forwards as `global` and is
+        // no longer reported as kept-on-removal.
+        keep_removed("claude", &kept.def).unwrap();
+        let view = resolve_surface("claude", None, &cwd);
+        assert!(
+            view.kept_on_removal.is_empty(),
+            "kept server no longer flagged"
+        );
+        let promoted = view
+            .effective
+            .iter()
+            .find(|s| s.def.name == "gone")
+            .expect("kept server now forwards");
+        assert_eq!(promoted.provenance, McpProvenance::Global);
+        let _ = home;
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn surface_drop_removed_discards_without_promoting() {
+        let home = set_tmp_home();
+        let cwd = home.path().join("repo");
+        std::fs::create_dir_all(&cwd).unwrap();
+        std::fs::write(
+            home.path().join(".claude.json"),
+            r#"{ "mcpServers": { "gone": { "command": "g" } } }"#,
+        )
+        .unwrap();
+        resolve_surface("claude", None, &cwd);
+        std::fs::write(home.path().join(".claude.json"), r#"{ "mcpServers": {} }"#).unwrap();
+        let view = resolve_surface("claude", None, &cwd);
+        assert_eq!(view.kept_on_removal.len(), 1);
+
+        drop_removed("claude", "gone").unwrap();
+        let view = resolve_surface("claude", None, &cwd);
+        assert!(
+            view.kept_on_removal.is_empty(),
+            "dropped server is gone entirely"
+        );
+        assert!(view.effective.is_empty(), "drop must not promote to global");
+        let _ = home;
     }
 
     #[test]

--- a/src/session/mcp_model.rs
+++ b/src/session/mcp_model.rs
@@ -361,21 +361,6 @@ pub fn resolve_surface(agent: &str, profile: Option<&str>, cwd: &Path) -> McpSur
     }
 }
 
-/// Keep a server that was removed from a native config: promote its last-seen
-/// definition into the global `mcp.json` (where it outranks native and resolves
-/// with provenance `global`), then forget the native snapshot entry so it stops
-/// being reported as kept-on-removal. AoE never writes the native file.
-pub fn keep_removed(agent: &str, server: &ProjectMcpServer) -> Result<()> {
-    super::mcp_overrides::upsert_global_server(server)?;
-    super::mcp_state::forget_native(agent, &server.name)
-}
-
-/// Drop a kept-on-removal server: forget the native snapshot entry without
-/// promoting it, so it disappears from the view entirely.
-pub fn drop_removed(agent: &str, name: &str) -> Result<()> {
-    super::mcp_state::forget_native(agent, name)
-}
-
 // ---------------------------------------------------------------------------
 // Standard `.mcp.json` layers: global and per-profile.
 // ---------------------------------------------------------------------------
@@ -952,7 +937,7 @@ mod tests {
 
         // Keep it: promote to global mcp.json; it now forwards as `global` and is
         // no longer reported as kept-on-removal.
-        keep_removed("claude", &kept.def).unwrap();
+        assert!(super::super::mcp_state::keep_removed("claude", &kept.def.name).unwrap());
         let view = resolve_surface("claude", None, &cwd);
         assert!(
             view.kept_on_removal.is_empty(),
@@ -983,7 +968,7 @@ mod tests {
         let view = resolve_surface("claude", None, &cwd);
         assert_eq!(view.kept_on_removal.len(), 1);
 
-        drop_removed("claude", "gone").unwrap();
+        super::super::mcp_state::forget_native("claude", "gone").unwrap();
         let view = resolve_surface("claude", None, &cwd);
         assert!(
             view.kept_on_removal.is_empty(),

--- a/src/session/mcp_model.rs
+++ b/src/session/mcp_model.rs
@@ -340,22 +340,49 @@ fn native_config_for(agent_key: &str) -> Option<NativeMcpConfig> {
     }
 }
 
+/// A native config read: the converted servers plus the names of any entries
+/// that were skipped because they failed to convert. The skipped list gates
+/// drift detection (#1996): a native file with a malformed entry must not make
+/// the drift detector report that entry as "removed" (it is still there, just
+/// unparseable), so callers pause drift for that agent when `skipped` is
+/// non-empty.
+pub struct NativeRead {
+    pub servers: Vec<ProjectMcpServer>,
+    pub skipped: Vec<String>,
+}
+
+impl NativeRead {
+    fn empty() -> Self {
+        NativeRead {
+            servers: Vec::new(),
+            skipped: Vec::new(),
+        }
+    }
+}
+
 /// Read the active agent's own MCP config (the file its CLI reads) and convert
-/// it to neutral servers. Live read-through: called once per spawn, no caching,
-/// so edits are picked up on the next session. Returns an empty list for an
-/// agent with no known native reader and for a missing file. A
-/// present-but-unparseable file is an error the caller downgrades to a warning,
-/// so a broken native file (which AoE does not own) never blocks a spawn.
-/// Individual malformed server entries are skipped with a warning.
-pub fn load_native_mcp_servers(agent_key: &str, home: &Path) -> Result<Vec<ProjectMcpServer>> {
+/// it to neutral servers, reporting any skipped malformed entries. Live
+/// read-through: called once per spawn, no caching, so edits are picked up on
+/// the next session. Returns an empty read for an agent with no known native
+/// reader and for a missing file. A present-but-unparseable file is an error the
+/// caller downgrades to a warning, so a broken native file (which AoE does not
+/// own) never blocks a spawn. Individual malformed server entries are skipped
+/// with a warning and recorded in `skipped`.
+pub fn load_native_mcp_servers_checked(agent_key: &str, home: &Path) -> Result<NativeRead> {
     let Some(config) = native_config_for(agent_key) else {
-        return Ok(Vec::new());
+        return Ok(NativeRead::empty());
     };
     match config {
         NativeMcpConfig::StandardJson(rel) => read_standard_json(&home.join(rel)),
         NativeMcpConfig::GeminiJson(rel) => read_gemini_json(&home.join(rel)),
         NativeMcpConfig::CodexToml(rel) => read_codex_toml(&home.join(rel)),
     }
+}
+
+/// Like [`load_native_mcp_servers_checked`] but discards the skipped-entry list.
+/// Used by forwarding, which only needs the parseable servers.
+pub fn load_native_mcp_servers(agent_key: &str, home: &Path) -> Result<Vec<ProjectMcpServer>> {
+    Ok(load_native_mcp_servers_checked(agent_key, home)?.servers)
 }
 
 /// Convenience wrapper that resolves the real home dir. Kept separate from
@@ -368,15 +395,17 @@ pub fn load_native_mcp_servers_from_home(agent_key: &str) -> Result<Vec<ProjectM
 /// Convert a map of raw server entries, skipping (with a warning) any entry that
 /// fails to convert rather than failing the whole file. Native configs are owned
 /// by other tools, so one bad entry must not discard the user's other servers.
+/// Returns the converted servers and the names of the skipped entries.
 fn convert_tolerant<R>(
     servers: BTreeMap<String, R>,
     path: &Path,
     convert: impl Fn(String, R) -> Result<ProjectMcpServer>,
-) -> Vec<ProjectMcpServer> {
-    servers
-        .into_iter()
-        .filter_map(|(name, raw)| match convert(name.clone(), raw) {
-            Ok(server) => Some(server),
+) -> NativeRead {
+    let mut out = Vec::new();
+    let mut skipped = Vec::new();
+    for (name, raw) in servers {
+        match convert(name.clone(), raw) {
+            Ok(server) => out.push(server),
             Err(e) => {
                 warn!(
                     target: "acp.mcp",
@@ -385,10 +414,14 @@ fn convert_tolerant<R>(
                     error = %e,
                     "skipping malformed MCP server in native config"
                 );
-                None
+                skipped.push(name);
             }
-        })
-        .collect()
+        }
+    }
+    NativeRead {
+        servers: out,
+        skipped,
+    }
 }
 
 /// Open a config file, mapping "not found" to `None` (the user does not use that
@@ -456,9 +489,9 @@ fn convert_standard(name: String, raw: StandardRawServer) -> Result<ProjectMcpSe
 /// Read a standard `mcpServers` JSON config, streaming so a large host file
 /// (e.g. `~/.claude.json`, which also holds project history) is parsed without
 /// materializing the unrelated keys.
-fn read_standard_json(path: &Path) -> Result<Vec<ProjectMcpServer>> {
+fn read_standard_json(path: &Path) -> Result<NativeRead> {
     let Some(file) = open_optional(path)? else {
-        return Ok(Vec::new());
+        return Ok(NativeRead::empty());
     };
     let parsed: StandardConfigFile = serde_json::from_reader(BufReader::new(file))
         .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
@@ -511,9 +544,9 @@ fn convert_gemini(name: String, raw: GeminiRawServer) -> Result<ProjectMcpServer
     Ok(ProjectMcpServer { name, transport })
 }
 
-fn read_gemini_json(path: &Path) -> Result<Vec<ProjectMcpServer>> {
+fn read_gemini_json(path: &Path) -> Result<NativeRead> {
     let Some(file) = open_optional(path)? else {
-        return Ok(Vec::new());
+        return Ok(NativeRead::empty());
     };
     let parsed: GeminiConfigFile = serde_json::from_reader(BufReader::new(file))
         .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
@@ -560,10 +593,10 @@ fn convert_codex(name: String, raw: CodexRawServer) -> Result<ProjectMcpServer> 
 
 /// Codex config files are small (no embedded history), so a whole-string read is
 /// fine; `toml` has no streaming reader.
-fn read_codex_toml(path: &Path) -> Result<Vec<ProjectMcpServer>> {
+fn read_codex_toml(path: &Path) -> Result<NativeRead> {
     let text = match std::fs::read_to_string(path) {
         Ok(t) => t,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(NativeRead::empty()),
         Err(e) => {
             return Err(e)
                 .with_context(|| format!("reading native MCP config at {}", path.display()))

--- a/src/session/mcp_model.rs
+++ b/src/session/mcp_model.rs
@@ -24,7 +24,7 @@ use std::io::BufReader;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use super::project_mcp::{ProjectMcpServer, ProjectMcpTransport};
@@ -76,6 +76,78 @@ pub struct ResolvedMcpServer {
     pub shadowed: Vec<McpProvenance>,
 }
 
+impl ResolvedMcpServer {
+    /// The redaction-safe, serializable view shared by every surface (web JSON,
+    /// CLI `--json`, TUI rows). This is the single chokepoint: the connection
+    /// detail the user needs to identify a server (command/args/url) is kept, but
+    /// env and header VALUES never leave [`ResolvedMcpServer`]; only their names
+    /// do. The unredacted [`def`](Self::def) is reachable only for forwarding and
+    /// the drift store, never for display.
+    pub fn redacted(&self) -> RedactedMcpServer {
+        let (transport, command, args, url, env_names, header_names) = match &self.def.transport {
+            ProjectMcpTransport::Stdio { command, args, env } => (
+                "stdio",
+                Some(command.clone()),
+                args.clone(),
+                None,
+                env.keys().cloned().collect(),
+                Vec::new(),
+            ),
+            ProjectMcpTransport::Http { url, headers } => (
+                "http",
+                None,
+                Vec::new(),
+                Some(url.clone()),
+                Vec::new(),
+                headers.keys().cloned().collect(),
+            ),
+            ProjectMcpTransport::Sse { url, headers } => (
+                "sse",
+                None,
+                Vec::new(),
+                Some(url.clone()),
+                Vec::new(),
+                headers.keys().cloned().collect(),
+            ),
+        };
+        RedactedMcpServer {
+            name: self.def.name.clone(),
+            transport,
+            command,
+            args,
+            url,
+            env_names,
+            header_names,
+            provenance: self.provenance.label(),
+            shadowed: self.shadowed.iter().map(McpProvenance::label).collect(),
+        }
+    }
+}
+
+/// Redaction-safe view of a resolved server for all surfaces. `command`, `args`,
+/// and `url` identify the server and are not secret; env and header VALUES are
+/// secret and are reduced to their NAMES (`env_names` / `header_names`). Built
+/// only via [`ResolvedMcpServer::redacted`].
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RedactedMcpServer {
+    pub name: String,
+    pub transport: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub env_names: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub header_names: Vec<String>,
+    pub provenance: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub shadowed: Vec<String>,
+}
+
 /// Merge layers by precedence. `layers` are ordered lowest first; a server in a
 /// later layer overrides one of the same name in an earlier layer (per server,
 /// not whole layer). The shadowed provenances accumulate in precedence order so
@@ -116,6 +188,110 @@ pub fn summarize(servers: &[ResolvedMcpServer]) -> String {
         .map(|s| format!("{}({})", s.def.name, s.def.kind()))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// Resolve the effective MCP server set for a session context, applying the
+/// full precedence stack: agent-native -> global -> per-profile ->
+/// project-local (trust-gated), higher wins per name. This is the single source
+/// of truth for BOTH forwarding (the supervisor converts the winning set to ACP)
+/// and the management surfaces (#1996), so what the user sees equals what the
+/// agent receives.
+///
+/// Each layer is isolated: a missing, unreadable, or malformed source warns and
+/// contributes nothing rather than aborting, so a single broken file never
+/// blocks a spawn. `profile` is the session's source profile; an empty/`None`
+/// value resolves to the default. `cwd` is the session working directory, from
+/// which the project-local repo (and its `.mcp.json`) is resolved. The
+/// project-local layer is forwarded ONLY when the repo is trusted at the file's
+/// current fingerprint; an untrusted (or changed) file is skipped and logged,
+/// exactly like the create-time trust gate refuses untrusted hooks.
+pub fn resolve_effective(
+    agent_key: &str,
+    profile: Option<&str>,
+    cwd: &Path,
+) -> Vec<ResolvedMcpServer> {
+    let native = load_native_mcp_servers_from_home(agent_key).unwrap_or_else(|e| {
+        warn!(
+            target: "acp.mcp",
+            agent = %agent_key,
+            error = %e,
+            "failed to load native MCP config; contributing none from it"
+        );
+        Vec::new()
+    });
+
+    let global = match super::get_app_dir() {
+        Ok(app_dir) => load_global_mcp_servers(&app_dir).unwrap_or_else(|e| {
+            warn!(target: "acp.mcp", error = %e, "failed to load global MCP config; contributing none from it");
+            Vec::new()
+        }),
+        Err(e) => {
+            warn!(target: "acp.mcp", error = %e, "could not resolve app dir for MCP config; contributing none from it");
+            Vec::new()
+        }
+    };
+
+    let per_profile = match super::get_profile_dir_path(profile.unwrap_or_default()) {
+        Ok(profile_dir) => load_profile_mcp_servers(&profile_dir).unwrap_or_else(|e| {
+            warn!(target: "acp.mcp", error = %e, "failed to load per-profile MCP config; contributing none from it");
+            Vec::new()
+        }),
+        Err(e) => {
+            warn!(target: "acp.mcp", error = %e, "could not resolve profile dir for MCP config; contributing none from it");
+            Vec::new()
+        }
+    };
+
+    let source = super::repo_config::repo_config_source_path(cwd);
+    let project_local = match super::project_mcp::load_project_mcp_servers(&source) {
+        Ok(servers) if servers.is_empty() => Vec::new(),
+        Ok(servers) => {
+            let hash = super::project_mcp::fingerprint(&servers);
+            match super::repo_config::is_repo_trusted(&source, None, Some(&hash)) {
+                Ok(true) => servers,
+                Ok(false) => {
+                    warn!(
+                        target: "acp.mcp",
+                        repo = %source.display(),
+                        count = servers.len(),
+                        "skipping project-local MCP servers: repo not trusted at this .mcp.json fingerprint; review and approve by creating a session for this repo in the TUI or CLI"
+                    );
+                    Vec::new()
+                }
+                Err(e) => {
+                    warn!(target: "acp.mcp", repo = %source.display(), error = %e, "could not check project-local MCP trust; contributing none from it");
+                    Vec::new()
+                }
+            }
+        }
+        Err(e) => {
+            warn!(target: "acp.mcp", repo = %source.display(), error = %e, "failed to load project-local MCP config; contributing none from it");
+            Vec::new()
+        }
+    };
+
+    resolve(vec![
+        McpLayer {
+            provenance: McpProvenance::AgentNative {
+                agent: agent_key.to_string(),
+            },
+            servers: native,
+        },
+        McpLayer {
+            provenance: McpProvenance::Global,
+            servers: global,
+        },
+        McpLayer {
+            provenance: McpProvenance::Profile {
+                name: profile.unwrap_or_default().to_string(),
+            },
+            servers: per_profile,
+        },
+        McpLayer {
+            provenance: McpProvenance::ProjectLocal,
+            servers: project_local,
+        },
+    ])
 }
 
 // ---------------------------------------------------------------------------
@@ -553,6 +729,62 @@ mod tests {
         let s = summarize(&merged);
         assert_eq!(s, "fs(stdio)");
         assert!(!s.contains("supersecret"));
+    }
+
+    #[test]
+    fn redacted_view_keeps_names_drops_secret_values() {
+        let merged = resolve(vec![
+            layer(
+                McpProvenance::AgentNative {
+                    agent: "claude".into(),
+                },
+                standard(r#"{ "mcpServers": { "fs": { "command": "fs-old" } } }"#),
+            ),
+            layer(
+                McpProvenance::Global,
+                standard(
+                    r#"{ "mcpServers": {
+                        "fs": { "command": "mcp-fs", "args": ["--root", "."], "env": { "TOKEN": "SUPER_SECRET_DO_NOT_LEAK" } },
+                        "remote": { "type": "http", "url": "https://e/mcp", "headers": { "Authorization": "Bearer HEADER_SECRET_DO_NOT_LEAK" } }
+                    } }"#,
+                ),
+            ),
+        ]);
+
+        let stdio = merged
+            .iter()
+            .find(|s| s.def.name == "fs")
+            .unwrap()
+            .redacted();
+        assert_eq!(stdio.transport, "stdio");
+        assert_eq!(stdio.command.as_deref(), Some("mcp-fs"));
+        assert_eq!(stdio.args, vec!["--root", "."]);
+        assert_eq!(stdio.env_names, vec!["TOKEN"]);
+        assert_eq!(stdio.provenance, "global");
+        assert_eq!(stdio.shadowed, vec!["agent-native:claude"]);
+
+        let remote = merged
+            .iter()
+            .find(|s| s.def.name == "remote")
+            .unwrap()
+            .redacted();
+        assert_eq!(remote.transport, "http");
+        assert_eq!(remote.url.as_deref(), Some("https://e/mcp"));
+        assert_eq!(remote.header_names, vec!["Authorization"]);
+
+        // The single chokepoint must never serialize a secret VALUE on any
+        // surface (web JSON, CLI --json, TUI rows all go through this).
+        let json = serde_json::to_string(&merged.iter().map(|s| s.redacted()).collect::<Vec<_>>())
+            .unwrap();
+        assert!(
+            !json.contains("SUPER_SECRET_DO_NOT_LEAK"),
+            "env value leaked: {json}"
+        );
+        assert!(
+            !json.contains("HEADER_SECRET_DO_NOT_LEAK"),
+            "header value leaked: {json}"
+        );
+        assert!(json.contains("TOKEN") && json.contains("Authorization"));
     }
 
     #[test]

--- a/src/session/mcp_overrides.rs
+++ b/src/session/mcp_overrides.rs
@@ -1,0 +1,265 @@
+//! Writer for the AoE-owned global `<app_dir>/mcp.json` (#1996).
+//!
+//! The unified MCP surface resolves conflicts (feature C) and keep-on-removal
+//! (feature D) by writing the server's definition into the global `mcp.json`,
+//! never into an agent-native config. Because the global layer outranks
+//! agent-native in the precedence stack, a server promoted here shadows the
+//! native one and resolves with provenance `global`, so no bespoke "aoe-added"
+//! layer is needed.
+//!
+//! The file is the ecosystem-standard `{ "mcpServers": { ... } }` shape that
+//! users also hand-edit, so mutations go through a `serde_json::Value` that
+//! preserves every other server and any unknown keys, rather than round-tripping
+//! through the typed model (which would drop fields AoE does not model). Writes
+//! serialize through an exclusive file lock so a concurrent surface write cannot
+//! clobber another.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde_json::{Map, Value};
+
+use super::project_mcp::{ProjectMcpServer, ProjectMcpTransport};
+
+/// Path to the global `mcp.json` AoE owns and may write.
+fn global_mcp_path() -> Result<PathBuf> {
+    Ok(super::get_app_dir()?.join("mcp.json"))
+}
+
+/// The standard `.mcp.json` entry object for a server: stdio carries
+/// command/args/env; remote transports carry a `type` plus url/headers. Empty
+/// maps and arg lists are omitted so the file stays clean.
+fn server_to_entry(server: &ProjectMcpServer) -> Value {
+    let mut entry = Map::new();
+    match &server.transport {
+        ProjectMcpTransport::Stdio { command, args, env } => {
+            entry.insert("command".into(), Value::String(command.clone()));
+            if !args.is_empty() {
+                entry.insert(
+                    "args".into(),
+                    Value::Array(args.iter().cloned().map(Value::String).collect()),
+                );
+            }
+            if !env.is_empty() {
+                entry.insert("env".into(), to_object(env));
+            }
+        }
+        ProjectMcpTransport::Http { url, headers } => {
+            entry.insert("type".into(), Value::String("http".into()));
+            entry.insert("url".into(), Value::String(url.clone()));
+            if !headers.is_empty() {
+                entry.insert("headers".into(), to_object(headers));
+            }
+        }
+        ProjectMcpTransport::Sse { url, headers } => {
+            entry.insert("type".into(), Value::String("sse".into()));
+            entry.insert("url".into(), Value::String(url.clone()));
+            if !headers.is_empty() {
+                entry.insert("headers".into(), to_object(headers));
+            }
+        }
+    }
+    Value::Object(entry)
+}
+
+fn to_object(map: &std::collections::BTreeMap<String, String>) -> Value {
+    Value::Object(
+        map.iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect(),
+    )
+}
+
+/// Read the current global `mcp.json` as a JSON object, treating a missing or
+/// empty file as `{}`.
+fn read_root(content: &str) -> Result<Map<String, Value>> {
+    if content.trim().is_empty() {
+        return Ok(Map::new());
+    }
+    match serde_json::from_str::<Value>(content).context("parsing global mcp.json")? {
+        Value::Object(m) => Ok(m),
+        _ => anyhow::bail!("global mcp.json is not a JSON object"),
+    }
+}
+
+/// Apply a mutation to the `mcpServers` object of the global `mcp.json` under an
+/// exclusive lock, preserving every other server and any unknown top-level keys.
+fn mutate_servers(mutate: impl FnOnce(&mut Map<String, Value>)) -> Result<()> {
+    use fs2::FileExt;
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    let path = global_mcp_path()?;
+    if !path.exists() {
+        std::fs::write(&path, "").with_context(|| format!("creating {}", path.display()))?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    file.lock_exclusive().context("locking global mcp.json")?;
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)?;
+    let mut root = read_root(&content)?;
+
+    let mut servers = match root.remove("mcpServers") {
+        Some(Value::Object(m)) => m,
+        Some(_) => anyhow::bail!("mcpServers in global mcp.json is not an object"),
+        None => Map::new(),
+    };
+    mutate(&mut servers);
+    root.insert("mcpServers".into(), Value::Object(servers));
+
+    let new_content = serde_json::to_string_pretty(&Value::Object(root))?;
+    file.seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
+    file.write_all(new_content.as_bytes())?;
+    Ok(())
+}
+
+/// Insert or replace a server in the global `mcp.json` by name. Used by both
+/// keep-on-removal ("keep") and conflict resolution ("AoE wins"): the promoted
+/// definition then resolves with provenance `global` and shadows any
+/// same-named agent-native server.
+pub fn upsert_global_server(server: &ProjectMcpServer) -> Result<()> {
+    let entry = server_to_entry(server);
+    let name = server.name.clone();
+    mutate_servers(move |servers| {
+        servers.insert(name, entry);
+    })
+}
+
+/// Remove a server from the global `mcp.json` by name. A no-op if it is not
+/// present. Used by the surface to delete a `global`-provenance entry.
+pub fn remove_global_server(name: &str) -> Result<()> {
+    let name = name.to_string();
+    mutate_servers(move |servers| {
+        servers.remove(&name);
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::mcp_model::load_global_mcp_servers;
+    use crate::session::project_mcp::ProjectMcpTransport;
+
+    /// Serialized across the suite by `#[serial_test::serial]`; the returned
+    /// `TempDir` must outlive the test body.
+    fn set_tmp_home() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: serialized by `#[serial]`; matches the existing pattern.
+        unsafe {
+            std::env::set_var("HOME", dir.path());
+            std::env::set_var("XDG_CONFIG_HOME", dir.path().join(".config"));
+        }
+        dir
+    }
+
+    fn stdio(name: &str, command: &str) -> ProjectMcpServer {
+        ProjectMcpServer {
+            name: name.into(),
+            transport: ProjectMcpTransport::Stdio {
+                command: command.into(),
+                args: vec![],
+                env: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_creates_then_replaces_and_round_trips() {
+        let home = set_tmp_home();
+        let app_dir = crate::session::get_app_dir().unwrap();
+
+        upsert_global_server(&stdio("fs", "first")).unwrap();
+        let servers = load_global_mcp_servers(&app_dir).unwrap();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "fs");
+
+        // Replace same name.
+        upsert_global_server(&stdio("fs", "second")).unwrap();
+        let servers = load_global_mcp_servers(&app_dir).unwrap();
+        assert_eq!(servers.len(), 1);
+        match &servers[0].transport {
+            ProjectMcpTransport::Stdio { command, .. } => assert_eq!(command, "second"),
+            other => panic!("expected stdio, got {other:?}"),
+        }
+        let _ = home;
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_preserves_other_servers_and_unknown_keys() {
+        let _home = set_tmp_home();
+        let app_dir = crate::session::get_app_dir().unwrap();
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(
+            app_dir.join("mcp.json"),
+            r#"{ "someOtherKey": 7, "mcpServers": { "keepme": { "command": "k" } } }"#,
+        )
+        .unwrap();
+
+        upsert_global_server(&stdio("added", "a")).unwrap();
+
+        let raw = std::fs::read_to_string(app_dir.join("mcp.json")).unwrap();
+        let val: Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            val["someOtherKey"],
+            serde_json::json!(7),
+            "unknown key dropped"
+        );
+        let servers = load_global_mcp_servers(&app_dir).unwrap();
+        let names: Vec<_> = servers.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["added", "keepme"]);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_deletes_by_name() {
+        let _home = set_tmp_home();
+        let app_dir = crate::session::get_app_dir().unwrap();
+        upsert_global_server(&stdio("a", "x")).unwrap();
+        upsert_global_server(&stdio("b", "y")).unwrap();
+        remove_global_server("a").unwrap();
+        let servers = load_global_mcp_servers(&app_dir).unwrap();
+        let names: Vec<_> = servers.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["b"]);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remote_round_trips_with_type_and_headers() {
+        let _home = set_tmp_home();
+        let app_dir = crate::session::get_app_dir().unwrap();
+        let mut headers = std::collections::BTreeMap::new();
+        headers.insert("Authorization".to_string(), "Bearer secret".to_string());
+        upsert_global_server(&ProjectMcpServer {
+            name: "remote".into(),
+            transport: ProjectMcpTransport::Http {
+                url: "https://e/mcp".into(),
+                headers,
+            },
+        })
+        .unwrap();
+        let servers = load_global_mcp_servers(&app_dir).unwrap();
+        match &servers[0].transport {
+            ProjectMcpTransport::Http { url, headers } => {
+                assert_eq!(url, "https://e/mcp");
+                assert_eq!(
+                    headers.get("Authorization").map(String::as_str),
+                    Some("Bearer secret")
+                );
+            }
+            other => panic!("expected http, got {other:?}"),
+        }
+    }
+}

--- a/src/session/mcp_state.rs
+++ b/src/session/mcp_state.rs
@@ -93,9 +93,6 @@ fn mcp_state_path() -> Result<PathBuf> {
 /// The whole read-modify-write runs under an exclusive lock so concurrent
 /// surface opens (e.g. web and TUI) cannot clobber each other's snapshot.
 pub fn reconcile_agent(agent: &str, read: &NativeRead) -> Result<McpReconcile> {
-    use fs2::FileExt;
-    use std::io::{Read, Seek, SeekFrom, Write};
-
     if !read.skipped.is_empty() {
         tracing::warn!(
             target: "acp.mcp",
@@ -109,6 +106,73 @@ pub fn reconcile_agent(agent: &str, read: &NativeRead) -> Result<McpReconcile> {
         });
     }
 
+    let current: BTreeMap<String, ProjectMcpServer> = read
+        .servers
+        .iter()
+        .map(|s| (s.name.clone(), s.clone()))
+        .collect();
+
+    with_locked_state(|state| {
+        let snapshot = state.native_snapshots.entry(agent.to_string()).or_default();
+
+        let mut conflicts = Vec::new();
+        for (name, cur) in &current {
+            if let Some(prev) = snapshot.get(name) {
+                if prev != cur {
+                    conflicts.push(McpConflict {
+                        agent: agent.to_string(),
+                        previous: prev.clone(),
+                        current: cur.clone(),
+                    });
+                }
+            }
+        }
+
+        let removed: Vec<ProjectMcpServer> = snapshot
+            .iter()
+            .filter(|(name, _)| !current.contains_key(*name))
+            .map(|(_, def)| def.clone())
+            .collect();
+
+        // Adopt new servers (present in native, absent from snapshot). Unchanged
+        // servers already match. Conflicts and removals deliberately keep their
+        // old snapshot value until the user resolves them.
+        for (name, cur) in &current {
+            snapshot.entry(name.clone()).or_insert_with(|| cur.clone());
+        }
+
+        McpReconcile {
+            conflicts,
+            removed,
+            paused: false,
+        }
+    })
+}
+
+/// Drop a server from an agent's snapshot. Used to finalize a keep-on-removal
+/// decision: "keep" promotes the server into the global `mcp.json` and then
+/// forgets the native snapshot entry; "drop" just forgets it. Either way the
+/// server stops being reported as kept-on-removal on the next open. A no-op if
+/// the entry is already gone.
+pub fn forget_native(agent: &str, name: &str) -> Result<()> {
+    with_locked_state(|state| {
+        if let Some(snapshot) = state.native_snapshots.get_mut(agent) {
+            snapshot.remove(name);
+            if snapshot.is_empty() {
+                state.native_snapshots.remove(agent);
+            }
+        }
+    })
+}
+
+/// Open the drift store, lock it exclusively, hand the parsed state to `f`, then
+/// write the (possibly mutated) state back through the same locked handle. The
+/// lock serializes concurrent surface opens (web and TUI) so neither clobbers
+/// the other's snapshot.
+fn with_locked_state<R>(f: impl FnOnce(&mut McpState) -> R) -> Result<R> {
+    use fs2::FileExt;
+    use std::io::{Read, Seek, SeekFrom, Write};
+
     let path = mcp_state_path()?;
     if !path.exists() {
         std::fs::write(&path, "").with_context(|| format!("creating {}", path.display()))?;
@@ -121,94 +185,47 @@ pub fn reconcile_agent(agent: &str, read: &NativeRead) -> Result<McpReconcile> {
         let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
     }
 
-    let mut lock_file = std::fs::OpenOptions::new()
+    let mut file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .open(&path)
         .with_context(|| format!("opening {}", path.display()))?;
-    lock_file
-        .lock_exclusive()
-        .context("locking mcp_state.json")?;
+    file.lock_exclusive().context("locking mcp_state.json")?;
 
     let mut content = String::new();
-    lock_file.read_to_string(&mut content)?;
+    file.read_to_string(&mut content)?;
     let mut state: McpState = if content.trim().is_empty() {
         McpState::default()
     } else {
         serde_json::from_str(&content).context("parsing mcp_state.json")?
     };
 
-    let current: BTreeMap<String, ProjectMcpServer> = read
-        .servers
-        .iter()
-        .map(|s| (s.name.clone(), s.clone()))
-        .collect();
-    let snapshot = state.native_snapshots.entry(agent.to_string()).or_default();
-
-    let mut conflicts = Vec::new();
-    for (name, cur) in &current {
-        if let Some(prev) = snapshot.get(name) {
-            if prev != cur {
-                conflicts.push(McpConflict {
-                    agent: agent.to_string(),
-                    previous: prev.clone(),
-                    current: cur.clone(),
-                });
-            }
-        }
-    }
-
-    let removed: Vec<ProjectMcpServer> = snapshot
-        .iter()
-        .filter(|(name, _)| !current.contains_key(*name))
-        .map(|(_, def)| def.clone())
-        .collect();
-
-    // Adopt new servers (present in native, absent from snapshot). Unchanged
-    // servers already match. Conflicts and removals deliberately keep their old
-    // snapshot value until the user resolves them.
-    for (name, cur) in &current {
-        snapshot.entry(name.clone()).or_insert_with(|| cur.clone());
-    }
+    let result = f(&mut state);
 
     let new_content = serde_json::to_string_pretty(&state)?;
-    lock_file.seek(SeekFrom::Start(0))?;
-    lock_file.set_len(0)?;
-    lock_file.write_all(new_content.as_bytes())?;
-
-    Ok(McpReconcile {
-        conflicts,
-        removed,
-        paused: false,
-    })
+    file.seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
+    file.write_all(new_content.as_bytes())?;
+    Ok(result)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::session::project_mcp::parse_standard_mcp_servers;
-    use std::sync::{Mutex, MutexGuard};
 
-    // The drift store lives at a HOME-derived path; serialize the env mutation.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct TmpHome {
-        _guard: MutexGuard<'static, ()>,
-        _dir: tempfile::TempDir,
-    }
-
-    fn with_tmp_home() -> TmpHome {
-        let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    /// The drift store path derives from HOME; the env mutation is serialized
+    /// across the whole suite by `#[serial_test::serial]` on each test (the same
+    /// global lock the supervisor's HOME-touching tests use), and the returned
+    /// `TempDir` must be kept alive for the test body.
+    fn set_tmp_home() -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
-        // SAFETY: serialized by ENV_LOCK for the duration of the returned guard.
+        // SAFETY: serialized by `#[serial]`; matches the existing pattern.
         unsafe {
             std::env::set_var("HOME", dir.path());
             std::env::set_var("XDG_CONFIG_HOME", dir.path().join(".config"));
         }
-        TmpHome {
-            _guard: guard,
-            _dir: dir,
-        }
+        dir
     }
 
     fn read(json: &str) -> NativeRead {
@@ -219,8 +236,9 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn first_open_adopts_silently_no_conflicts() {
-        let _home = with_tmp_home();
+        let _home = set_tmp_home();
         let r = reconcile_agent(
             "claude",
             &read(r#"{ "mcpServers": { "fs": { "command": "c" }, "remote": { "type": "http", "url": "u" } } }"#),
@@ -240,8 +258,9 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn changed_definition_is_conflict_and_snapshot_holds_old() {
-        let _home = with_tmp_home();
+        let _home = set_tmp_home();
         reconcile_agent(
             "claude",
             &read(r#"{ "mcpServers": { "fs": { "command": "old" } } }"#),
@@ -271,8 +290,9 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn disappeared_server_is_kept_on_removal() {
-        let _home = with_tmp_home();
+        let _home = set_tmp_home();
         reconcile_agent(
             "claude",
             &read(r#"{ "mcpServers": { "fs": { "command": "c" }, "gone": { "command": "g" } } }"#),
@@ -296,8 +316,9 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn skipped_entry_pauses_drift_detection() {
-        let _home = with_tmp_home();
+        let _home = set_tmp_home();
         reconcile_agent(
             "claude",
             &read(r#"{ "mcpServers": { "fs": { "command": "c" } } }"#),

--- a/src/session/mcp_state.rs
+++ b/src/session/mcp_state.rs
@@ -182,11 +182,33 @@ pub fn reconcile_agent(agent: &str, read: &NativeRead) -> Result<McpReconcile> {
     })
 }
 
-/// Drop a server from an agent's snapshot. Used to finalize a keep-on-removal
-/// decision: "keep" promotes the server into the global `mcp.json` and then
-/// forgets the native snapshot entry; "drop" just forgets it. Either way the
-/// server stops being reported as kept-on-removal on the next open. A no-op if
-/// the entry is already gone.
+/// Keep a server that was removed from a native config (feature D): promote its
+/// last-seen definition (held in the snapshot) into the global `mcp.json` so it
+/// keeps forwarding as `global`, then forget the snapshot entry so it stops
+/// being reported as kept-on-removal. By NAME so every surface can call it
+/// (the web client never holds the unredacted definition). Returns `false` if
+/// no such kept entry exists (already kept or dropped by another surface).
+/// Reads the definition, promotes, then forgets, so a failed global write
+/// leaves the entry intact and still keepable.
+pub fn keep_removed(agent: &str, name: &str) -> Result<bool> {
+    let def = with_locked_state(|state| {
+        state
+            .native_snapshots
+            .get(agent)
+            .and_then(|m| m.get(name))
+            .cloned()
+    })?;
+    let Some(def) = def else {
+        return Ok(false);
+    };
+    super::mcp_overrides::upsert_global_server(&def)?;
+    forget_native(agent, name)?;
+    Ok(true)
+}
+
+/// Drop a server from an agent's snapshot. Finalizes a keep-on-removal "drop"
+/// decision (or the second half of [`keep_removed`]). The server stops being
+/// reported as kept-on-removal on the next open. A no-op if already gone.
 pub fn forget_native(agent: &str, name: &str) -> Result<()> {
     with_locked_state(|state| {
         if let Some(snapshot) = state.native_snapshots.get_mut(agent) {

--- a/src/session/mcp_state.rs
+++ b/src/session/mcp_state.rs
@@ -1,0 +1,319 @@
+//! Drift store for the unified MCP surface (#1996).
+//!
+//! AoE keeps no live daemon state for MCP servers, so "what AoE last knew about
+//! a server" must be persisted. `<app_dir>/mcp_state.json` records, per agent,
+//! the last-seen definition of every server read from that agent's native
+//! config. On each surface open, the current native config is reconciled against
+//! this snapshot to detect drift:
+//!
+//! - a server whose definition CHANGED since the snapshot is a conflict the user
+//!   resolves (feature C);
+//! - a server that DISAPPEARED from the native config is kept in AoE's view and
+//!   flagged (keep-on-removal, feature D), rather than silently dropped;
+//! - a server that is NEW (present in native, absent from the snapshot) is
+//!   adopted silently and recorded, so a first-ever open raises zero conflicts.
+//!
+//! The store holds the FULL, unredacted definition (env and header values
+//! included): keep-on-removal and "AoE wins" must be able to reconstruct a
+//! working server, which a redacted snapshot or a bare fingerprint cannot. The
+//! file therefore carries the same secrets the user already keeps in plaintext
+//! in `mcp.json` and the agents' own configs; it is written owner-only and
+//! redacted at every DISPLAY edge (see [`super::mcp_model::RedactedMcpServer`]),
+//! never on disk. AoE writes only this store and its own `mcp.json`; it never
+//! writes back to an agent-native config (sync is native -> AoE only).
+//!
+//! Concurrent surface opens serialize through an exclusive file lock, mirroring
+//! the repo trust store (`repo_config::trust_repo`).
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::mcp_model::NativeRead;
+use super::project_mcp::ProjectMcpServer;
+
+/// On-disk shape of `<app_dir>/mcp_state.json`. A missing file is an empty
+/// state. New optional file (no existing data shape changes), so no migration:
+/// absence is the default and older binaries simply never read it.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct McpState {
+    /// Per-agent last-seen native snapshot: agent key -> (server name -> def).
+    #[serde(default)]
+    native_snapshots: BTreeMap<String, BTreeMap<String, ProjectMcpServer>>,
+}
+
+/// A server whose agent-native definition diverged from AoE's last-seen
+/// snapshot. The user resolves which side wins (feature C); AoE never writes the
+/// native file, so resolving "AoE wins" persists into the global `mcp.json`
+/// instead (via the override writer added for keep/resolve actions).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpConflict {
+    pub agent: String,
+    /// AoE's last-seen definition (the snapshot side).
+    pub previous: ProjectMcpServer,
+    /// What the native config holds right now (the native side).
+    pub current: ProjectMcpServer,
+}
+
+/// Outcome of reconciling one agent's native config against the snapshot.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct McpReconcile {
+    /// Servers whose definition changed since the snapshot: conflicts (C).
+    pub conflicts: Vec<McpConflict>,
+    /// Servers gone from the native config since the snapshot, kept in AoE's
+    /// view rather than silently dropped (keep-on-removal, D). The full last-seen
+    /// definition, so the surface can still show (and the user can still keep)
+    /// the server.
+    pub removed: Vec<ProjectMcpServer>,
+    /// True when drift detection was PAUSED for this agent because the native
+    /// read skipped a malformed entry: a server that failed to parse must not be
+    /// reported as "removed" (it is still in the file, just unreadable), so the
+    /// snapshot is left untouched and no conflicts/removals are reported.
+    pub paused: bool,
+}
+
+/// Path to the drift store, shared across all profiles (a server's drift is a
+/// property of the host config, not of a session profile).
+fn mcp_state_path() -> Result<PathBuf> {
+    Ok(super::get_app_dir()?.join("mcp_state.json"))
+}
+
+/// Reconcile one agent's CURRENT native read against the stored snapshot,
+/// updating the snapshot and returning the drift the surface must show.
+///
+/// Write policy: NEW servers are adopted into the snapshot immediately (so the
+/// next open does not re-report them), and unchanged servers stay. Conflicting
+/// and removed servers KEEP their old snapshot value (the AoE side), pending an
+/// explicit user resolution, so the same drift surfaces on every open until the
+/// user acts. If the native read skipped a malformed entry, drift detection is
+/// paused and the snapshot is left completely untouched.
+///
+/// The whole read-modify-write runs under an exclusive lock so concurrent
+/// surface opens (e.g. web and TUI) cannot clobber each other's snapshot.
+pub fn reconcile_agent(agent: &str, read: &NativeRead) -> Result<McpReconcile> {
+    use fs2::FileExt;
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    if !read.skipped.is_empty() {
+        tracing::warn!(
+            target: "acp.mcp",
+            agent = %agent,
+            skipped = read.skipped.len(),
+            "native MCP config has malformed entries; pausing drift detection for this agent"
+        );
+        return Ok(McpReconcile {
+            paused: true,
+            ..Default::default()
+        });
+    }
+
+    let path = mcp_state_path()?;
+    if !path.exists() {
+        std::fs::write(&path, "").with_context(|| format!("creating {}", path.display()))?;
+    }
+    // Owner-only: the store holds the same plaintext secrets as the user's
+    // mcp.json and native configs, so it must never widen beyond the owner.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    let mut lock_file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    lock_file
+        .lock_exclusive()
+        .context("locking mcp_state.json")?;
+
+    let mut content = String::new();
+    lock_file.read_to_string(&mut content)?;
+    let mut state: McpState = if content.trim().is_empty() {
+        McpState::default()
+    } else {
+        serde_json::from_str(&content).context("parsing mcp_state.json")?
+    };
+
+    let current: BTreeMap<String, ProjectMcpServer> = read
+        .servers
+        .iter()
+        .map(|s| (s.name.clone(), s.clone()))
+        .collect();
+    let snapshot = state.native_snapshots.entry(agent.to_string()).or_default();
+
+    let mut conflicts = Vec::new();
+    for (name, cur) in &current {
+        if let Some(prev) = snapshot.get(name) {
+            if prev != cur {
+                conflicts.push(McpConflict {
+                    agent: agent.to_string(),
+                    previous: prev.clone(),
+                    current: cur.clone(),
+                });
+            }
+        }
+    }
+
+    let removed: Vec<ProjectMcpServer> = snapshot
+        .iter()
+        .filter(|(name, _)| !current.contains_key(*name))
+        .map(|(_, def)| def.clone())
+        .collect();
+
+    // Adopt new servers (present in native, absent from snapshot). Unchanged
+    // servers already match. Conflicts and removals deliberately keep their old
+    // snapshot value until the user resolves them.
+    for (name, cur) in &current {
+        snapshot.entry(name.clone()).or_insert_with(|| cur.clone());
+    }
+
+    let new_content = serde_json::to_string_pretty(&state)?;
+    lock_file.seek(SeekFrom::Start(0))?;
+    lock_file.set_len(0)?;
+    lock_file.write_all(new_content.as_bytes())?;
+
+    Ok(McpReconcile {
+        conflicts,
+        removed,
+        paused: false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::project_mcp::parse_standard_mcp_servers;
+    use std::sync::{Mutex, MutexGuard};
+
+    // The drift store lives at a HOME-derived path; serialize the env mutation.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct TmpHome {
+        _guard: MutexGuard<'static, ()>,
+        _dir: tempfile::TempDir,
+    }
+
+    fn with_tmp_home() -> TmpHome {
+        let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: serialized by ENV_LOCK for the duration of the returned guard.
+        unsafe {
+            std::env::set_var("HOME", dir.path());
+            std::env::set_var("XDG_CONFIG_HOME", dir.path().join(".config"));
+        }
+        TmpHome {
+            _guard: guard,
+            _dir: dir,
+        }
+    }
+
+    fn read(json: &str) -> NativeRead {
+        NativeRead {
+            servers: parse_standard_mcp_servers(json).unwrap(),
+            skipped: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn first_open_adopts_silently_no_conflicts() {
+        let _home = with_tmp_home();
+        let r = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "c" }, "remote": { "type": "http", "url": "u" } } }"#),
+        )
+        .unwrap();
+        assert!(r.conflicts.is_empty());
+        assert!(r.removed.is_empty());
+        assert!(!r.paused);
+
+        // Second open against the same native set sees no drift (adopted).
+        let r2 = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "c" }, "remote": { "type": "http", "url": "u" } } }"#),
+        )
+        .unwrap();
+        assert!(r2.conflicts.is_empty() && r2.removed.is_empty());
+    }
+
+    #[test]
+    fn changed_definition_is_conflict_and_snapshot_holds_old() {
+        let _home = with_tmp_home();
+        reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "old" } } }"#),
+        )
+        .unwrap();
+        let r = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "new" } } }"#),
+        )
+        .unwrap();
+        assert_eq!(r.conflicts.len(), 1);
+        let c = &r.conflicts[0];
+        assert_eq!(c.agent, "claude");
+        // previous = snapshot (old), current = native (new).
+        assert!(matches!(&c.previous.transport,
+            crate::session::project_mcp::ProjectMcpTransport::Stdio { command, .. } if command == "old"));
+        assert!(matches!(&c.current.transport,
+            crate::session::project_mcp::ProjectMcpTransport::Stdio { command, .. } if command == "new"));
+
+        // Unresolved conflict re-surfaces on the next open (snapshot kept old).
+        let r2 = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "new" } } }"#),
+        )
+        .unwrap();
+        assert_eq!(r2.conflicts.len(), 1, "conflict persists until resolved");
+    }
+
+    #[test]
+    fn disappeared_server_is_kept_on_removal() {
+        let _home = with_tmp_home();
+        reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "c" }, "gone": { "command": "g" } } }"#),
+        )
+        .unwrap();
+        let r = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "c" } } }"#),
+        )
+        .unwrap();
+        assert_eq!(r.removed.len(), 1);
+        assert_eq!(r.removed[0].name, "gone");
+
+        // Still flagged on the next open (snapshot keeps the removed entry).
+        let r2 = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "c" } } }"#),
+        )
+        .unwrap();
+        assert_eq!(r2.removed.len(), 1, "removal persists until dropped");
+    }
+
+    #[test]
+    fn skipped_entry_pauses_drift_detection() {
+        let _home = with_tmp_home();
+        reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "c" } } }"#),
+        )
+        .unwrap();
+        // A read with a skipped (malformed) entry must not report "fs" removed.
+        let poisoned = NativeRead {
+            servers: Vec::new(),
+            skipped: vec!["fs".to_string()],
+        };
+        let r = reconcile_agent("claude", &poisoned).unwrap();
+        assert!(r.paused);
+        assert!(
+            r.removed.is_empty(),
+            "paused detection must not report removals"
+        );
+        assert!(r.conflicts.is_empty());
+    }
+}

--- a/src/session/mcp_state.rs
+++ b/src/session/mcp_state.rs
@@ -57,6 +57,39 @@ pub struct McpConflict {
     pub current: ProjectMcpServer,
 }
 
+impl McpConflict {
+    /// Optimistic-concurrency token: the fingerprint of the AoE (snapshot) side
+    /// as this surface saw it when it opened the conflict modal. [`resolve_conflict`]
+    /// rejects the resolution as stale if the on-disk snapshot no longer matches
+    /// this token, i.e. another surface (web vs TUI) resolved the same conflict
+    /// first.
+    pub fn fingerprint(&self) -> String {
+        super::project_mcp::fingerprint(std::slice::from_ref(&self.previous))
+    }
+}
+
+/// Which side wins a conflict resolution (feature C).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictWinner {
+    /// Keep AoE's last-seen definition: promote it into the global `mcp.json`
+    /// (where it outranks native) so it keeps forwarding unchanged.
+    Aoe,
+    /// Accept the native config's current definition: just re-baseline the
+    /// snapshot to it. The native definition then forwards on its own.
+    Native,
+}
+
+/// Outcome of a conflict resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveStatus {
+    /// The resolution was applied.
+    Applied,
+    /// The on-disk snapshot changed since the surface opened the modal (another
+    /// surface resolved this conflict first); nothing was changed. The caller
+    /// should refetch and re-prompt rather than blindly overwrite.
+    Stale,
+}
+
 /// Outcome of reconciling one agent's native config against the snapshot.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct McpReconcile {
@@ -163,6 +196,68 @@ pub fn forget_native(agent: &str, name: &str) -> Result<()> {
             }
         }
     })
+}
+
+/// Resolve a conflict between AoE's snapshot and the native config (feature C).
+///
+/// `expected_fingerprint` is the optimistic-concurrency token the surface
+/// captured when it opened the modal ([`McpConflict::fingerprint`]). Under the
+/// store lock, if the snapshot entry is gone or no longer matches that token
+/// (another surface already resolved it), nothing changes and [`ResolveStatus::Stale`]
+/// is returned. Otherwise the snapshot is re-baselined to the native definition
+/// (so the conflict does not re-surface), and for [`ConflictWinner::Aoe`] the
+/// AoE-side definition is additionally promoted into the global `mcp.json` so it
+/// keeps forwarding. AoE never writes the native config either way.
+pub fn resolve_conflict(
+    conflict: &McpConflict,
+    winner: ConflictWinner,
+    expected_fingerprint: &str,
+) -> Result<ResolveStatus> {
+    let name = conflict.current.name.clone();
+
+    // Phase 1, under the store lock: verify the token, re-baseline the snapshot,
+    // and report whether the AoE side must still be promoted to global.
+    enum Decision {
+        Stale,
+        Applied { promote: Option<ProjectMcpServer> },
+    }
+    let decision = with_locked_state(|state| {
+        let Some(snap) = state
+            .native_snapshots
+            .get(&conflict.agent)
+            .and_then(|m| m.get(&name))
+        else {
+            return Decision::Stale;
+        };
+        if super::project_mcp::fingerprint(std::slice::from_ref(snap)) != expected_fingerprint {
+            return Decision::Stale;
+        }
+        let promote = match winner {
+            ConflictWinner::Aoe => Some(snap.clone()),
+            ConflictWinner::Native => None,
+        };
+        // Re-baseline to the native definition so subsequent diffs compare
+        // against the now-known state and the conflict does not re-surface.
+        state
+            .native_snapshots
+            .get_mut(&conflict.agent)
+            .expect("snapshot present: looked up above under the same lock")
+            .insert(name.clone(), conflict.current.clone());
+        Decision::Applied { promote }
+    })?;
+
+    match decision {
+        Decision::Stale => Ok(ResolveStatus::Stale),
+        Decision::Applied { promote } => {
+            // Promote AoE's definition into the global mcp.json (a separate
+            // locked file) only after the snapshot re-baseline committed, so a
+            // stale resolution never writes global.
+            if let Some(def) = promote {
+                super::mcp_overrides::upsert_global_server(&def)?;
+            }
+            Ok(ResolveStatus::Applied)
+        }
+    }
 }
 
 /// Open the drift store, lock it exclusively, hand the parsed state to `f`, then
@@ -313,6 +408,93 @@ mod tests {
         )
         .unwrap();
         assert_eq!(r2.removed.len(), 1, "removal persists until dropped");
+    }
+
+    fn make_conflict(agent: &str) -> McpConflict {
+        reconcile_agent(
+            agent,
+            &read(r#"{ "mcpServers": { "fs": { "command": "old" } } }"#),
+        )
+        .unwrap();
+        let r = reconcile_agent(
+            agent,
+            &read(r#"{ "mcpServers": { "fs": { "command": "new" } } }"#),
+        )
+        .unwrap();
+        assert_eq!(r.conflicts.len(), 1);
+        r.conflicts.into_iter().next().unwrap()
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_conflict_aoe_wins_promotes_to_global_and_clears() {
+        let _home = set_tmp_home();
+        let conflict = make_conflict("claude");
+        let fp = conflict.fingerprint();
+        let status = resolve_conflict(&conflict, ConflictWinner::Aoe, &fp).unwrap();
+        assert_eq!(status, ResolveStatus::Applied);
+
+        // AoE's old definition is promoted into global mcp.json.
+        let app_dir = crate::session::get_app_dir().unwrap();
+        let global = crate::session::mcp_model::load_global_mcp_servers(&app_dir).unwrap();
+        assert_eq!(global.len(), 1);
+        assert!(matches!(&global[0].transport,
+            crate::session::project_mcp::ProjectMcpTransport::Stdio { command, .. } if command == "old"));
+
+        // Conflict no longer surfaces (snapshot re-baselined to native).
+        let r = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "new" } } }"#),
+        )
+        .unwrap();
+        assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_conflict_native_wins_clears_without_global_write() {
+        let _home = set_tmp_home();
+        let conflict = make_conflict("claude");
+        let fp = conflict.fingerprint();
+        assert_eq!(
+            resolve_conflict(&conflict, ConflictWinner::Native, &fp).unwrap(),
+            ResolveStatus::Applied
+        );
+        let app_dir = crate::session::get_app_dir().unwrap();
+        let global = crate::session::mcp_model::load_global_mcp_servers(&app_dir).unwrap();
+        assert!(global.is_empty(), "native wins must not write global");
+        let r = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "new" } } }"#),
+        )
+        .unwrap();
+        assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_conflict_stale_token_is_rejected() {
+        let _home = set_tmp_home();
+        let conflict = make_conflict("claude");
+        let status =
+            resolve_conflict(&conflict, ConflictWinner::Aoe, "not-the-real-fingerprint").unwrap();
+        assert_eq!(status, ResolveStatus::Stale);
+
+        // Nothing changed: conflict still surfaces, global untouched.
+        let app_dir = crate::session::get_app_dir().unwrap();
+        assert!(crate::session::mcp_model::load_global_mcp_servers(&app_dir)
+            .unwrap()
+            .is_empty());
+        let r = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "new" } } }"#),
+        )
+        .unwrap();
+        assert_eq!(
+            r.conflicts.len(),
+            1,
+            "stale resolution must not clear the conflict"
+        );
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -11,6 +11,7 @@ mod groups;
 pub mod idle_reap;
 mod instance;
 pub mod mcp_model;
+pub mod mcp_overrides;
 pub mod mcp_state;
 pub mod poller;
 pub mod profile_config;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -11,6 +11,7 @@ mod groups;
 pub mod idle_reap;
 mod instance;
 pub mod mcp_model;
+pub mod mcp_state;
 pub mod poller;
 pub mod profile_config;
 pub mod project_mcp;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod environment;
 mod groups;
 pub mod idle_reap;
 mod instance;
+pub mod mcp_model;
 pub mod poller;
 pub mod profile_config;
 pub mod project_mcp;

--- a/src/session/project_mcp.rs
+++ b/src/session/project_mcp.rs
@@ -138,22 +138,31 @@ fn redacted_remote(
 /// agent configs, a project file is small and fully under review, so a single
 /// bad entry fails the whole parse rather than being silently dropped.
 pub fn load_project_mcp_servers(repo_path: &Path) -> Result<Vec<ProjectMcpServer>> {
-    let path = repo_path.join(PROJECT_MCP_FILE);
-    let text = match std::fs::read_to_string(&path) {
+    load_standard_mcp_servers(&repo_path.join(PROJECT_MCP_FILE))
+}
+
+/// Read and parse a standard `.mcp.json`-shaped file at `path` into
+/// transport-resolved servers. A missing file yields an empty list; a
+/// present-but-malformed file is an error the caller surfaces. Shared by the
+/// project-local layer and the AoE-owned global/per-profile `mcp.json` layers
+/// (`session::mcp_model`), which all use this exact on-disk shape.
+pub(crate) fn load_standard_mcp_servers(path: &Path) -> Result<Vec<ProjectMcpServer>> {
+    let text = match std::fs::read_to_string(path) {
         Ok(t) => t,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => {
-            return Err(e)
-                .with_context(|| format!("reading project MCP config at {}", path.display()))
+            return Err(e).with_context(|| format!("reading MCP config at {}", path.display()))
         }
     };
-    parse_project_mcp_servers(&text)
-        .with_context(|| format!("parsing project MCP config at {}", path.display()))
+    parse_standard_mcp_servers(&text)
+        .with_context(|| format!("parsing MCP config at {}", path.display()))
 }
 
-/// Parse `.mcp.json` text into transport-resolved servers. Split from the file
-/// read so the conversion rules are unit-testable without touching disk.
-fn parse_project_mcp_servers(text: &str) -> Result<Vec<ProjectMcpServer>> {
+/// Parse standard `.mcp.json` text into transport-resolved servers. Split from
+/// the file read so the conversion rules are unit-testable without touching
+/// disk. Public so `session::mcp_model` reuses the exact same standard-shape
+/// parse for the global and per-profile layers.
+pub fn parse_standard_mcp_servers(text: &str) -> Result<Vec<ProjectMcpServer>> {
     let parsed: ProjectMcpFile = serde_json::from_str(text)?;
     parsed
         .mcp_servers
@@ -268,27 +277,28 @@ mod tests {
             "alpha": { "command": "a", "args": ["--x"], "env": { "TOKEN": "secret" } },
             "remote": { "type": "http", "url": "https://e/mcp", "headers": { "Authorization": "Bearer x" } }
         } }"#;
-        let servers = parse_project_mcp_servers(text).unwrap();
+        let servers = parse_standard_mcp_servers(text).unwrap();
         assert_eq!(names(&servers), vec!["alpha", "remote", "zebra"]);
     }
 
     #[test]
     fn stdio_without_command_is_error() {
         assert!(
-            parse_project_mcp_servers(r#"{ "mcpServers": { "x": { "args": ["--y"] } } }"#).is_err()
+            parse_standard_mcp_servers(r#"{ "mcpServers": { "x": { "args": ["--y"] } } }"#)
+                .is_err()
         );
     }
 
     #[test]
     fn remote_without_url_is_error() {
         assert!(
-            parse_project_mcp_servers(r#"{ "mcpServers": { "x": { "type": "http" } } }"#).is_err()
+            parse_standard_mcp_servers(r#"{ "mcpServers": { "x": { "type": "http" } } }"#).is_err()
         );
     }
 
     #[test]
     fn unknown_type_is_error() {
-        assert!(parse_project_mcp_servers(
+        assert!(parse_standard_mcp_servers(
             r#"{ "mcpServers": { "x": { "type": "pigeon", "url": "u" } } }"#
         )
         .is_err());
@@ -303,11 +313,11 @@ mod tests {
 
     #[test]
     fn fingerprint_is_deterministic_and_order_independent() {
-        let a = parse_project_mcp_servers(
+        let a = parse_standard_mcp_servers(
             r#"{ "mcpServers": { "fs": { "command": "c", "env": { "A": "1", "B": "2" } } } }"#,
         )
         .unwrap();
-        let b = parse_project_mcp_servers(
+        let b = parse_standard_mcp_servers(
             r#"{ "mcpServers": { "fs": { "command": "c", "env": { "B": "2", "A": "1" } } } }"#,
         )
         .unwrap();
@@ -316,11 +326,11 @@ mod tests {
 
     #[test]
     fn fingerprint_changes_when_secret_value_changes() {
-        let a = parse_project_mcp_servers(
+        let a = parse_standard_mcp_servers(
             r#"{ "mcpServers": { "fs": { "command": "c", "env": { "TOKEN": "old" } } } }"#,
         )
         .unwrap();
-        let b = parse_project_mcp_servers(
+        let b = parse_standard_mcp_servers(
             r#"{ "mcpServers": { "fs": { "command": "c", "env": { "TOKEN": "new" } } } }"#,
         )
         .unwrap();
@@ -333,7 +343,7 @@ mod tests {
 
     #[test]
     fn redacted_summary_hides_values_shows_names() {
-        let servers = parse_project_mcp_servers(
+        let servers = parse_standard_mcp_servers(
             r#"{ "mcpServers": {
                 "fs": { "command": "mcp-fs", "args": ["--root", "."], "env": { "TOKEN": "supersecret" } },
                 "remote": { "type": "http", "url": "https://e/mcp", "headers": { "Authorization": "Bearer hunter2" } }

--- a/src/session/project_mcp.rs
+++ b/src/session/project_mcp.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 /// Project-local MCP config filename, read from the repository root.
@@ -54,13 +54,13 @@ struct RawServer {
 /// so the fingerprint is order-independent. Values are kept in memory for the
 /// fingerprint (a changed token is an effective config change), but the display
 /// helpers redact them so secrets never reach a screen or log.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProjectMcpServer {
     pub name: String,
     pub transport: ProjectMcpTransport,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProjectMcpTransport {
     Stdio {
         command: String,

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -69,6 +69,76 @@ fn test_cli_add_next_steps_uses_aoe_binary_name() {
     );
 }
 
+/// #1996: `aoe mcp list --json` shows the merged effective MCP set with
+/// per-server provenance and redacts every secret value (env/header values
+/// reduced to names). Native (claude) + global mcp.json are merged; global wins
+/// a name collision. The native config also carries a secret that must never
+/// reach stdout.
+#[test]
+#[serial]
+fn test_cli_mcp_list_provenance_and_redaction() {
+    let h = TuiTestHarness::new("cli_mcp_list");
+    let home = h.home_path();
+
+    // Native (claude) layer: defines "shared" and "native-only", plus a secret.
+    std::fs::write(
+        home.join(".claude.json"),
+        r#"{ "mcpServers": {
+            "shared": { "command": "from-native" },
+            "native-only": { "command": "n", "env": { "TOKEN": "SUPER_SECRET_DO_NOT_LEAK" } }
+        } }"#,
+    )
+    .expect("write .claude.json");
+
+    // Global layer: overrides "shared" and adds "global-only".
+    let app_dir = crate::harness::app_dir_in(home);
+    std::fs::create_dir_all(&app_dir).expect("create app dir");
+    std::fs::write(
+        app_dir.join("mcp.json"),
+        r#"{ "mcpServers": {
+            "shared": { "command": "from-global" },
+            "global-only": { "command": "g" }
+        } }"#,
+    )
+    .expect("write mcp.json");
+
+    let out = h.run_cli(&["mcp", "list", "--agent", "claude", "--json"]);
+    assert!(
+        out.status.success(),
+        "aoe mcp list failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // No secret value may ever reach stdout.
+    assert!(
+        !stdout.contains("SUPER_SECRET_DO_NOT_LEAK"),
+        "secret env value leaked to CLI output:\n{stdout}"
+    );
+
+    let val: serde_json::Value = serde_json::from_str(&stdout).expect("output is JSON");
+    let effective = val["effective"].as_array().expect("effective array");
+    assert_eq!(effective.len(), 3, "native + global union, got {stdout}");
+
+    let shared = effective
+        .iter()
+        .find(|s| s["name"] == "shared")
+        .expect("shared present");
+    assert_eq!(
+        shared["command"], "from-global",
+        "global must win the name collision"
+    );
+    assert_eq!(shared["provenance"], "global");
+
+    let native_only = effective
+        .iter()
+        .find(|s| s["name"] == "native-only")
+        .expect("native-only present");
+    assert_eq!(native_only["provenance"], "agent-native:claude");
+    // The secret env var is reported by NAME only.
+    assert_eq!(native_only["envNames"], serde_json::json!(["TOKEN"]));
+}
+
 /// #1909: `aoe add --interactive` must fail loudly when stdin is not a
 /// terminal instead of hanging on the name prompt. `run_cli` runs the
 /// binary as a plain subprocess with no controlling TTY, which is the

--- a/tests/integration/acp_mcp.rs
+++ b/tests/integration/acp_mcp.rs
@@ -13,6 +13,7 @@ use agent_of_empires::acp::acp_client::{AcpClient, SpawnConfig};
 use agent_of_empires::acp::agent_registry::AgentSpec;
 use agent_of_empires::acp::mcp_config;
 use agent_of_empires::acp::state::AcpSessionId;
+use agent_of_empires::session::mcp_model::{self, McpLayer, McpProvenance};
 
 use crate::common::{shim_path, shim_ready};
 
@@ -72,7 +73,7 @@ async fn configured_mcp_servers_reach_new_session() {
         r#"{ "mcpServers": { "probe": { "command": "echo", "args": ["hi"] } } }"#,
     )
     .unwrap();
-    let servers = mcp_config::load_global_mcp_servers(app_dir.path()).unwrap();
+    let servers = mcp_model::load_global_mcp_servers(app_dir.path()).unwrap();
     assert_eq!(servers.len(), 1, "fixture should parse one server");
 
     // A tempdir + plain path, not NamedTempFile: the shim writes this file from
@@ -80,7 +81,7 @@ async fn configured_mcp_servers_reach_new_session() {
     let record_dir = tempfile::tempdir().unwrap();
     let record_path = record_dir.path().join("record.json");
     let mut config = base_config(std::env::temp_dir(), &record_path);
-    config.mcp_servers = servers;
+    config.mcp_servers = mcp_config::project_servers_to_acp(servers);
 
     let client = AcpClient::spawn(config, AcpSessionId("mcp-forward".into()))
         .await
@@ -114,7 +115,7 @@ async fn native_and_global_merge_reaches_new_session() {
         } }"#,
     )
     .unwrap();
-    let native = mcp_config::load_native_mcp_servers("claude", home.path()).unwrap();
+    let native = mcp_model::load_native_mcp_servers("claude", home.path()).unwrap();
 
     // Global layer (higher precedence): `<app_dir>/mcp.json`. It overrides
     // "shared" and adds "global-only".
@@ -127,15 +128,17 @@ async fn native_and_global_merge_reaches_new_session() {
         } }"#,
     )
     .unwrap();
-    let global = mcp_config::load_global_mcp_servers(app_dir.path()).unwrap();
+    let global = mcp_model::load_global_mcp_servers(app_dir.path()).unwrap();
 
-    let merged = mcp_config::merge_by_precedence(vec![
-        mcp_config::McpLayer {
-            label: "agent-native",
+    let merged = mcp_model::resolve(vec![
+        McpLayer {
+            provenance: McpProvenance::AgentNative {
+                agent: "claude".into(),
+            },
             servers: native,
         },
-        mcp_config::McpLayer {
-            label: "global",
+        McpLayer {
+            provenance: McpProvenance::Global,
             servers: global,
         },
     ]);
@@ -143,7 +146,8 @@ async fn native_and_global_merge_reaches_new_session() {
     let record_dir = tempfile::tempdir().unwrap();
     let record_path = record_dir.path().join("record.json");
     let mut config = base_config(std::env::temp_dir(), &record_path);
-    config.mcp_servers = merged;
+    config.mcp_servers =
+        mcp_config::project_servers_to_acp(merged.into_iter().map(|s| s.def).collect());
 
     let client = AcpClient::spawn(config, AcpSessionId("mcp-native-merge".into()))
         .await
@@ -187,13 +191,13 @@ async fn no_config_forwards_empty_list() {
 
     // No mcp.json in the app dir => empty list, unchanged from pre-feature.
     let app_dir = tempfile::tempdir().unwrap();
-    let servers = mcp_config::load_global_mcp_servers(app_dir.path()).unwrap();
+    let servers = mcp_model::load_global_mcp_servers(app_dir.path()).unwrap();
     assert!(servers.is_empty());
 
     let record_dir = tempfile::tempdir().unwrap();
     let record_path = record_dir.path().join("record.json");
     let mut config = base_config(std::env::temp_dir(), &record_path);
-    config.mcp_servers = servers;
+    config.mcp_servers = mcp_config::project_servers_to_acp(servers);
 
     let client = AcpClient::spawn(config, AcpSessionId("mcp-empty".into()))
         .await

--- a/web/src/components/McpServers.tsx
+++ b/web/src/components/McpServers.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  fetchMcpServers,
+  resolveMcpConflict,
+  keepMcpServer,
+  dropMcpServer,
+  type McpServersResponse,
+  type McpServerView,
+  type McpConflictView,
+} from "../lib/api";
+
+/** One-line redacted connection detail: command/args or url, plus secret NAMES. */
+function detail(s: McpServerView): string {
+  let base = s.command
+    ? `${s.command}${s.args && s.args.length ? " " + s.args.join(" ") : ""}`
+    : (s.url ?? "");
+  const tags: string[] = [];
+  if (s.envNames && s.envNames.length) tags.push(`env: ${s.envNames.join(", ")}`);
+  if (s.headerNames && s.headerNames.length) tags.push(`headers: ${s.headerNames.join(", ")}`);
+  if (tags.length) base += `  [${tags.join("; ")}]`;
+  return base;
+}
+
+function ProvenanceBadge({ label }: { label: string }) {
+  return (
+    <span className="font-mono text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-700 text-text-secondary">
+      {label}
+    </span>
+  );
+}
+
+function ServerRow({ s }: { s: McpServerView }) {
+  return (
+    <div className="py-2 border-b border-surface-700">
+      <div className="flex items-center gap-2">
+        <span className="font-body text-[13px] font-medium text-text-primary">{s.name}</span>
+        <span className="font-mono text-[10px] text-text-muted">({s.transport})</span>
+        <ProvenanceBadge label={s.provenance} />
+      </div>
+      <p className="font-mono text-[11px] text-text-secondary ml-1">{detail(s)}</p>
+      {s.shadowed && s.shadowed.length > 0 && (
+        <p className="font-body text-[11px] text-text-muted ml-1">
+          shadows: {s.shadowed.join(", ")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ConflictModal({
+  conflict,
+  busy,
+  onResolve,
+  onClose,
+}: {
+  conflict: McpConflictView;
+  busy: boolean;
+  onResolve: (winner: "aoe" | "native") => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Resolve MCP conflict for ${conflict.name}`}
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in"
+    >
+      <div className="bg-surface-800 border border-surface-700/50 rounded-lg p-5 w-[min(36rem,90vw)]">
+        <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-2">
+          Conflict: {conflict.name}
+        </h3>
+        <p className="font-body text-[13px] text-text-secondary mb-3">
+          This server's definition in the agent's native config changed since AoE last saw it.
+          Pick which side wins. AoE never writes back to the native config; keeping AoE's version
+          stores it in the global mcp.json.
+        </p>
+        <div className="space-y-2 mb-4">
+          <div>
+            <span className="font-mono text-[11px] text-text-muted">AoE (last seen):</span>
+            <p className="font-mono text-[12px] text-text-primary">{conflict.previous}</p>
+          </div>
+          <div>
+            <span className="font-mono text-[11px] text-text-muted">native (now):</span>
+            <p className="font-mono text-[12px] text-text-primary">{conflict.current}</p>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onClose}
+            className="px-3 py-1.5 text-[13px] rounded border border-surface-700 text-text-secondary hover:bg-surface-700 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onResolve("native")}
+            className="px-3 py-1.5 text-[13px] rounded border border-surface-700 text-text-primary hover:bg-surface-700 disabled:opacity-50"
+          >
+            Use native
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onResolve("aoe")}
+            className="px-3 py-1.5 text-[13px] rounded bg-brand-600 text-white hover:bg-brand-500 disabled:opacity-50"
+          >
+            Keep AoE version
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function McpServers() {
+  const [data, setData] = useState<McpServersResponse | null>(null);
+  const [error, setError] = useState(false);
+  const [active, setActive] = useState<McpConflictView | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const result = await fetchMcpServers();
+    if (result === null) {
+      setError(true);
+    } else {
+      setError(false);
+      setData(result);
+    }
+  }, []);
+
+  useEffect(() => {
+    const first = setTimeout(load, 0);
+    return () => clearTimeout(first);
+  }, [load]);
+
+  const agent = data?.agent ?? "";
+
+  const onResolve = async (winner: "aoe" | "native") => {
+    if (!active) return;
+    setBusy(true);
+    const result = await resolveMcpConflict(active.name, agent, winner, active.fingerprint);
+    setBusy(false);
+    setActive(null);
+    if (result === "stale") {
+      setNotice(`"${active.name}" was already resolved by another surface; refreshed.`);
+    } else if (result === "error") {
+      setNotice(`Could not resolve "${active.name}".`);
+    } else {
+      setNotice(null);
+    }
+    await load();
+  };
+
+  const onKeep = async (name: string) => {
+    setBusy(true);
+    await keepMcpServer(name, agent);
+    setBusy(false);
+    await load();
+  };
+
+  const onDrop = async (name: string) => {
+    setBusy(true);
+    await dropMcpServer(name, agent);
+    setBusy(false);
+    await load();
+  };
+
+  if (error) {
+    return (
+      <div>
+        <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
+          MCP Servers
+        </h3>
+        <p className="font-body text-[13px] text-status-error">Could not load MCP servers</p>
+      </div>
+    );
+  }
+
+  if (data === null) {
+    return (
+      <div>
+        <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
+          MCP Servers
+        </h3>
+        <p className="font-mono text-[11px] text-text-muted">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="mcp-panel">
+      <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-1">
+        MCP Servers
+      </h3>
+      <p className="font-body text-[12px] text-text-muted mb-4">
+        Effective set forwarded to <span className="font-mono">{agent}</span>, with provenance.
+        Values are redacted; only env and header names are shown.
+      </p>
+
+      {notice && (
+        <p className="font-body text-[12px] text-status-waiting mb-3" role="status">
+          {notice}
+        </p>
+      )}
+
+      {data.conflicts.length > 0 && (
+        <div className="mb-5" data-testid="mcp-conflicts">
+          <h4 className="font-mono text-[11px] uppercase tracking-wider text-status-error mb-2">
+            Conflicts
+          </h4>
+          {data.conflicts.map((c) => (
+            <div
+              key={c.name}
+              className="flex items-center justify-between py-2 border-b border-surface-700"
+            >
+              <span className="font-body text-[13px] text-text-primary">{c.name}</span>
+              <button
+                type="button"
+                onClick={() => setActive(c)}
+                aria-label={`resolve ${c.name}`}
+                className="px-2.5 py-1 text-[12px] rounded border border-status-error/50 text-status-error hover:bg-status-error/10"
+              >
+                Resolve
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {data.driftPaused && (
+        <p className="font-body text-[12px] text-status-waiting mb-4">
+          Drift detection is paused: the native config for {agent} has a malformed entry.
+        </p>
+      )}
+
+      {data.effective.length === 0 ? (
+        <p className="font-body text-[13px] text-text-muted">No servers forwarded.</p>
+      ) : (
+        <div className="mb-5">
+          {data.effective.map((s) => (
+            <ServerRow key={s.name} s={s} />
+          ))}
+        </div>
+      )}
+
+      {data.keptOnRemoval.length > 0 && (
+        <div data-testid="mcp-kept">
+          <h4 className="font-mono text-[11px] uppercase tracking-wider text-status-waiting mb-2">
+            Kept after removal from the native config
+          </h4>
+          <p className="font-body text-[12px] text-text-muted mb-2">
+            These are no longer in the native config and are not forwarded. Keep promotes them to
+            the global mcp.json; drop discards them.
+          </p>
+          {data.keptOnRemoval.map((s) => (
+            <div
+              key={s.name}
+              className="flex items-center justify-between py-2 border-b border-surface-700"
+            >
+              <div>
+                <span className="font-body text-[13px] text-text-primary">{s.name}</span>
+                <p className="font-mono text-[11px] text-text-secondary">{detail(s)}</p>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => onKeep(s.name)}
+                  aria-label={`keep ${s.name}`}
+                  className="px-2.5 py-1 text-[12px] rounded bg-brand-600 text-white hover:bg-brand-500 disabled:opacity-50"
+                >
+                  Keep
+                </button>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => onDrop(s.name)}
+                  aria-label={`drop ${s.name}`}
+                  className="px-2.5 py-1 text-[12px] rounded border border-surface-700 text-text-secondary hover:bg-surface-700 disabled:opacity-50"
+                >
+                  Drop
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {active && (
+        <ConflictModal
+          conflict={active}
+          busy={busy}
+          onResolve={onResolve}
+          onClose={() => setActive(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/McpServers.tsx
+++ b/web/src/components/McpServers.tsx
@@ -23,7 +23,7 @@ function detail(s: McpServerView): string {
 
 function ProvenanceBadge({ label }: { label: string }) {
   return (
-    <span className="font-mono text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-700 text-text-secondary">
+    <span className="font-mono text-[11px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-700 text-text-secondary">
       {label}
     </span>
   );
@@ -34,7 +34,7 @@ function ServerRow({ s }: { s: McpServerView }) {
     <div className="py-2 border-b border-surface-700">
       <div className="flex items-center gap-2">
         <span className="font-body text-[13px] font-medium text-text-primary">{s.name}</span>
-        <span className="font-mono text-[10px] text-text-muted">({s.transport})</span>
+        <span className="font-mono text-[11px] text-text-muted">({s.transport})</span>
         <ProvenanceBadge label={s.provenance} />
       </div>
       <p className="font-mono text-[11px] text-text-secondary ml-1">{detail(s)}</p>

--- a/web/src/components/McpServers.tsx
+++ b/web/src/components/McpServers.tsx
@@ -157,15 +157,25 @@ export function McpServers() {
 
   const onKeep = async (name: string) => {
     setBusy(true);
-    await keepMcpServer(name, agent);
+    const ok = await keepMcpServer(name, agent);
     setBusy(false);
+    if (!ok) {
+      setNotice(`Could not keep "${name}".`);
+      return;
+    }
+    setNotice(null);
     await load();
   };
 
   const onDrop = async (name: string) => {
     setBusy(true);
-    await dropMcpServer(name, agent);
+    const ok = await dropMcpServer(name, agent);
     setBusy(false);
+    if (!ok) {
+      setNotice(`Could not drop "${name}".`);
+      return;
+    }
+    setNotice(null);
     await load();
   };
 

--- a/web/src/components/McpServers.tsx
+++ b/web/src/components/McpServers.tsx
@@ -15,8 +15,10 @@ function detail(s: McpServerView): string {
     ? `${s.command}${s.args && s.args.length ? " " + s.args.join(" ") : ""}`
     : (s.url ?? "");
   const tags: string[] = [];
-  if (s.envNames && s.envNames.length) tags.push(`env: ${s.envNames.join(", ")}`);
-  if (s.headerNames && s.headerNames.length) tags.push(`headers: ${s.headerNames.join(", ")}`);
+  if (s.envNames && s.envNames.length)
+    tags.push(`env: ${s.envNames.join(", ")}`);
+  if (s.headerNames && s.headerNames.length)
+    tags.push(`headers: ${s.headerNames.join(", ")}`);
   if (tags.length) base += `  [${tags.join("; ")}]`;
   return base;
 }
@@ -33,11 +35,17 @@ function ServerRow({ s }: { s: McpServerView }) {
   return (
     <div className="py-2 border-b border-surface-700">
       <div className="flex items-center gap-2">
-        <span className="font-body text-[13px] font-medium text-text-primary">{s.name}</span>
-        <span className="font-mono text-[11px] text-text-muted">({s.transport})</span>
+        <span className="font-body text-[13px] font-medium text-text-primary">
+          {s.name}
+        </span>
+        <span className="font-mono text-[11px] text-text-muted">
+          ({s.transport})
+        </span>
         <ProvenanceBadge label={s.provenance} />
       </div>
-      <p className="font-mono text-[11px] text-text-secondary ml-1">{detail(s)}</p>
+      <p className="font-mono text-[11px] text-text-secondary ml-1">
+        {detail(s)}
+      </p>
       {s.shadowed && s.shadowed.length > 0 && (
         <p className="font-body text-[11px] text-text-muted ml-1">
           shadows: {s.shadowed.join(", ")}
@@ -70,18 +78,26 @@ function ConflictModal({
           Conflict: {conflict.name}
         </h3>
         <p className="font-body text-[13px] text-text-secondary mb-3">
-          This server's definition in the agent's native config changed since AoE last saw it.
-          Pick which side wins. AoE never writes back to the native config; keeping AoE's version
-          stores it in the global mcp.json.
+          This server's definition in the agent's native config changed since
+          AoE last saw it. Pick which side wins. AoE never writes back to the
+          native config; keeping AoE's version stores it in the global mcp.json.
         </p>
         <div className="space-y-2 mb-4">
           <div>
-            <span className="font-mono text-[11px] text-text-muted">AoE (last seen):</span>
-            <p className="font-mono text-[12px] text-text-primary">{conflict.previous}</p>
+            <span className="font-mono text-[11px] text-text-muted">
+              AoE (last seen):
+            </span>
+            <p className="font-mono text-[12px] text-text-primary">
+              {conflict.previous}
+            </p>
           </div>
           <div>
-            <span className="font-mono text-[11px] text-text-muted">native (now):</span>
-            <p className="font-mono text-[12px] text-text-primary">{conflict.current}</p>
+            <span className="font-mono text-[11px] text-text-muted">
+              native (now):
+            </span>
+            <p className="font-mono text-[12px] text-text-primary">
+              {conflict.current}
+            </p>
           </div>
         </div>
         <div className="flex justify-end gap-2">
@@ -142,11 +158,18 @@ export function McpServers() {
   const onResolve = async (winner: "aoe" | "native") => {
     if (!active) return;
     setBusy(true);
-    const result = await resolveMcpConflict(active.name, agent, winner, active.fingerprint);
+    const result = await resolveMcpConflict(
+      active.name,
+      agent,
+      winner,
+      active.fingerprint,
+    );
     setBusy(false);
     setActive(null);
     if (result === "stale") {
-      setNotice(`"${active.name}" was already resolved by another surface; refreshed.`);
+      setNotice(
+        `"${active.name}" was already resolved by another surface; refreshed.`,
+      );
     } else if (result === "error") {
       setNotice(`Could not resolve "${active.name}".`);
     } else {
@@ -185,7 +208,9 @@ export function McpServers() {
         <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
           MCP Servers
         </h3>
-        <p className="font-body text-[13px] text-status-error">Could not load MCP servers</p>
+        <p className="font-body text-[13px] text-status-error">
+          Could not load MCP servers
+        </p>
       </div>
     );
   }
@@ -207,12 +232,16 @@ export function McpServers() {
         MCP Servers
       </h3>
       <p className="font-body text-[12px] text-text-muted mb-4">
-        Effective set forwarded to <span className="font-mono">{agent}</span>, with provenance.
-        Values are redacted; only env and header names are shown.
+        Effective set forwarded to <span className="font-mono">{agent}</span>,
+        with provenance. Values are redacted; only env and header names are
+        shown.
       </p>
 
       {notice && (
-        <p className="font-body text-[12px] text-status-waiting mb-3" role="status">
+        <p
+          className="font-body text-[12px] text-status-waiting mb-3"
+          role="status"
+        >
           {notice}
         </p>
       )}
@@ -227,7 +256,9 @@ export function McpServers() {
               key={c.name}
               className="flex items-center justify-between py-2 border-b border-surface-700"
             >
-              <span className="font-body text-[13px] text-text-primary">{c.name}</span>
+              <span className="font-body text-[13px] text-text-primary">
+                {c.name}
+              </span>
               <button
                 type="button"
                 onClick={() => setActive(c)}
@@ -243,12 +274,15 @@ export function McpServers() {
 
       {data.driftPaused && (
         <p className="font-body text-[12px] text-status-waiting mb-4">
-          Drift detection is paused: the native config for {agent} has a malformed entry.
+          Drift detection is paused: the native config for {agent} has a
+          malformed entry.
         </p>
       )}
 
       {data.effective.length === 0 ? (
-        <p className="font-body text-[13px] text-text-muted">No servers forwarded.</p>
+        <p className="font-body text-[13px] text-text-muted">
+          No servers forwarded.
+        </p>
       ) : (
         <div className="mb-5">
           {data.effective.map((s) => (
@@ -263,8 +297,8 @@ export function McpServers() {
             Kept after removal from the native config
           </h4>
           <p className="font-body text-[12px] text-text-muted mb-2">
-            These are no longer in the native config and are not forwarded. Keep promotes them to
-            the global mcp.json; drop discards them.
+            These are no longer in the native config and are not forwarded. Keep
+            promotes them to the global mcp.json; drop discards them.
           </p>
           {data.keptOnRemoval.map((s) => (
             <div
@@ -272,8 +306,12 @@ export function McpServers() {
               className="flex items-center justify-between py-2 border-b border-surface-700"
             >
               <div>
-                <span className="font-body text-[13px] text-text-primary">{s.name}</span>
-                <p className="font-mono text-[11px] text-text-secondary">{detail(s)}</p>
+                <span className="font-body text-[13px] text-text-primary">
+                  {s.name}
+                </span>
+                <p className="font-mono text-[11px] text-text-secondary">
+                  {detail(s)}
+                </p>
               </div>
               <div className="flex gap-2">
                 <button

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { ConnectedDevices } from "./ConnectedDevices";
+import { McpServers } from "./McpServers";
 import { NotificationSettings } from "./NotificationSettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { TerminalSettings } from "./TerminalSettings";
@@ -34,6 +35,7 @@ type TabId =
   | "security"
   | "devices"
   | "structured-view"
+  | "mcp"
   | "logging";
 
 type SidebarItem =
@@ -57,6 +59,7 @@ export function buildSidebar(): SidebarItem[] {
     { kind: "divider", label: "Sessions" },
     { kind: "tab", id: "session", label: "Session" },
     { kind: "tab", id: "structured-view", label: "Structured view" },
+    { kind: "tab", id: "mcp", label: "MCP servers" },
     { kind: "divider", label: "Environment" },
     { kind: "tab", id: "sandbox", label: "Sandbox" },
     { kind: "tab", id: "worktree", label: "Worktree" },
@@ -103,6 +106,7 @@ const ALL_TAB_IDS = new Set<TabId>([
   "security",
   "devices",
   "structured-view",
+  "mcp",
   "logging",
 ]);
 
@@ -331,6 +335,7 @@ export function SettingsView({
       activeTab !== "security" &&
       activeTab !== "devices" &&
       activeTab !== "structured-view" &&
+      activeTab !== "mcp" &&
       activeTab !== "telemetry"
     ) {
       return <div className="text-sm text-text-dim">Loading settings...</div>;
@@ -511,6 +516,8 @@ export function SettingsView({
         return <SecuritySettings />;
       case "devices":
         return <ConnectedDevices />;
+      case "mcp":
+        return <McpServers />;
       case "structured-view": {
         if (!settings) {
           return (

--- a/web/src/components/__tests__/McpServers.test.tsx
+++ b/web/src/components/__tests__/McpServers.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+//
+// Contract test for the MCP servers settings panel (#1996). The live
+// Playwright spec covers the read/provenance/redaction happy path against a
+// real backend; this locks in the mutation handlers (conflict resolve, keep,
+// drop) and their notice branches, which the live coverage does not feed into
+// the Vitest patch lane. The api module is mocked so each handler's
+// success / stale / failure path is driven deterministically.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+
+import type { McpServersResponse, McpResolveResult } from "../../lib/api";
+
+const fetchMcpServers = vi.fn<[string?], Promise<McpServersResponse | null>>();
+const resolveMcpConflict = vi.fn<
+  [string, string, "aoe" | "native", string],
+  Promise<McpResolveResult>
+>();
+const keepMcpServer = vi.fn<[string, string], Promise<boolean>>();
+const dropMcpServer = vi.fn<[string, string], Promise<boolean>>();
+
+vi.mock("../../lib/api", () => ({
+  fetchMcpServers: (agent?: string) => fetchMcpServers(agent),
+  resolveMcpConflict: (
+    name: string,
+    agent: string,
+    winner: "aoe" | "native",
+    fingerprint: string,
+  ) => resolveMcpConflict(name, agent, winner, fingerprint),
+  keepMcpServer: (name: string, agent: string) => keepMcpServer(name, agent),
+  dropMcpServer: (name: string, agent: string) => dropMcpServer(name, agent),
+}));
+
+// Imported after the mock is registered.
+import { McpServers } from "../McpServers";
+
+function response(
+  overrides: Partial<McpServersResponse> = {},
+): McpServersResponse {
+  return {
+    agent: "claude",
+    effective: [],
+    keptOnRemoval: [],
+    conflicts: [],
+    driftPaused: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fetchMcpServers.mockReset();
+  resolveMcpConflict.mockReset();
+  keepMcpServer.mockReset();
+  dropMcpServer.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("McpServers read view", () => {
+  it("shows an error when the surface fails to load", async () => {
+    fetchMcpServers.mockResolvedValue(null);
+    render(<McpServers />);
+    expect(await screen.findByText("Could not load MCP servers")).toBeTruthy();
+  });
+
+  it("renders the effective set with provenance, redacted detail, and shadows", async () => {
+    fetchMcpServers.mockResolvedValue(
+      response({
+        effective: [
+          {
+            name: "fs",
+            transport: "stdio",
+            command: "mcp-fs",
+            args: ["--root", "."],
+            envNames: ["TOKEN"],
+            provenance: "global",
+            shadowed: ["agent-native:claude"],
+          },
+          {
+            name: "remote",
+            transport: "http",
+            url: "https://example/mcp",
+            headerNames: ["Authorization"],
+            provenance: "agent-native:claude",
+          },
+        ],
+      }),
+    );
+    render(<McpServers />);
+    const panel = await screen.findByTestId("mcp-panel");
+    expect(within(panel).getByText("fs")).toBeTruthy();
+    expect(within(panel).getByText("global")).toBeTruthy();
+    // Redacted detail: command/args plus the env NAME, never a value.
+    expect(panel.textContent).toContain("mcp-fs --root .");
+    expect(panel.textContent).toContain("env: TOKEN");
+    expect(panel.textContent).toContain("shadows: agent-native:claude");
+    // Remote transport renders its url and the header NAME only.
+    expect(panel.textContent).toContain("https://example/mcp");
+    expect(panel.textContent).toContain("headers: Authorization");
+  });
+
+  it("surfaces the drift-paused note", async () => {
+    fetchMcpServers.mockResolvedValue(response({ driftPaused: true }));
+    render(<McpServers />);
+    expect(await screen.findByText(/Drift detection is paused/)).toBeTruthy();
+  });
+});
+
+const CONFLICT = {
+  name: "fs",
+  agent: "claude",
+  previous: "fs (stdio): old",
+  current: "fs (stdio): new",
+  fingerprint: "fp-123",
+};
+
+async function openConflictModal() {
+  fetchMcpServers.mockResolvedValue(response({ conflicts: [CONFLICT] }));
+  render(<McpServers />);
+  const resolveBtn = await screen.findByLabelText("resolve fs");
+  fireEvent.click(resolveBtn);
+  return screen.findByRole("dialog");
+}
+
+describe("McpServers conflict resolution", () => {
+  it("resolving 'Keep AoE version' posts the winner + fingerprint and reloads", async () => {
+    resolveMcpConflict.mockResolvedValue("applied");
+    const dialog = await openConflictModal();
+    // After an applied resolution the surface reloads with no conflict.
+    fetchMcpServers.mockResolvedValue(response());
+    fireEvent.click(within(dialog).getByText("Keep AoE version"));
+    await waitFor(() =>
+      expect(resolveMcpConflict).toHaveBeenCalledWith(
+        "fs",
+        "claude",
+        "aoe",
+        "fp-123",
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.queryByLabelText("resolve fs")).toBeNull(),
+    );
+  });
+
+  it("'Use native' resolves with the native winner", async () => {
+    resolveMcpConflict.mockResolvedValue("applied");
+    const dialog = await openConflictModal();
+    fetchMcpServers.mockResolvedValue(response());
+    fireEvent.click(within(dialog).getByText("Use native"));
+    await waitFor(() =>
+      expect(resolveMcpConflict).toHaveBeenCalledWith(
+        "fs",
+        "claude",
+        "native",
+        "fp-123",
+      ),
+    );
+  });
+
+  it("a stale result shows the 'already resolved' notice", async () => {
+    resolveMcpConflict.mockResolvedValue("stale");
+    const dialog = await openConflictModal();
+    fireEvent.click(within(dialog).getByText("Keep AoE version"));
+    expect(
+      await screen.findByText(/already resolved by another surface/),
+    ).toBeTruthy();
+  });
+
+  it("an error result shows the failure notice", async () => {
+    resolveMcpConflict.mockResolvedValue("error");
+    const dialog = await openConflictModal();
+    fireEvent.click(within(dialog).getByText("Keep AoE version"));
+    expect(await screen.findByText(/Could not resolve "fs"/)).toBeTruthy();
+  });
+
+  it("cancel closes the modal without resolving", async () => {
+    const dialog = await openConflictModal();
+    fireEvent.click(within(dialog).getByText("Cancel"));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(resolveMcpConflict).not.toHaveBeenCalled();
+  });
+});
+
+describe("McpServers keep / drop", () => {
+  function keptResponse() {
+    return response({
+      keptOnRemoval: [
+        {
+          name: "gone",
+          transport: "stdio",
+          command: "g",
+          provenance: "kept-on-removal:claude",
+        },
+      ],
+    });
+  }
+
+  it("keep promotes the server and reloads on success", async () => {
+    fetchMcpServers.mockResolvedValue(keptResponse());
+    keepMcpServer.mockResolvedValue(true);
+    render(<McpServers />);
+    const keepBtn = await screen.findByLabelText("keep gone");
+    fetchMcpServers.mockResolvedValue(response());
+    fireEvent.click(keepBtn);
+    await waitFor(() =>
+      expect(keepMcpServer).toHaveBeenCalledWith("gone", "claude"),
+    );
+    await waitFor(() =>
+      expect(screen.queryByLabelText("keep gone")).toBeNull(),
+    );
+  });
+
+  it("keep failure shows a notice and does not clear the row", async () => {
+    fetchMcpServers.mockResolvedValue(keptResponse());
+    keepMcpServer.mockResolvedValue(false);
+    render(<McpServers />);
+    fireEvent.click(await screen.findByLabelText("keep gone"));
+    expect(await screen.findByText(/Could not keep "gone"/)).toBeTruthy();
+    expect(screen.getByLabelText("keep gone")).toBeTruthy();
+  });
+
+  it("drop discards the server on success", async () => {
+    fetchMcpServers.mockResolvedValue(keptResponse());
+    dropMcpServer.mockResolvedValue(true);
+    render(<McpServers />);
+    const dropBtn = await screen.findByLabelText("drop gone");
+    fetchMcpServers.mockResolvedValue(response());
+    fireEvent.click(dropBtn);
+    await waitFor(() =>
+      expect(dropMcpServer).toHaveBeenCalledWith("gone", "claude"),
+    );
+  });
+
+  it("drop failure shows a notice", async () => {
+    fetchMcpServers.mockResolvedValue(keptResponse());
+    dropMcpServer.mockResolvedValue(false);
+    render(<McpServers />);
+    fireEvent.click(await screen.findByLabelText("drop gone"));
+    expect(await screen.findByText(/Could not drop "gone"/)).toBeTruthy();
+  });
+});

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -25,6 +25,7 @@ describe("buildSidebar", () => {
       { kind: "divider", label: "Sessions" },
       { kind: "tab", id: "session", label: "Session" },
       { kind: "tab", id: "structured-view", label: "Structured view" },
+      { kind: "tab", id: "mcp", label: "MCP servers" },
       { kind: "divider", label: "Environment" },
       { kind: "tab", id: "sandbox", label: "Sandbox" },
       { kind: "tab", id: "worktree", label: "Worktree" },

--- a/web/src/lib/api.mcp.test.ts
+++ b/web/src/lib/api.mcp.test.ts
@@ -1,0 +1,143 @@
+// Contract test for the MCP api-client wrappers (#1996). These mutation
+// helpers are otherwise only exercised by the live Playwright panel, whose
+// coverage does not feed the Vitest patch lane, so the status-to-result
+// mapping (`applied` / `stale` / `error`), the request payloads, and the
+// network-failure fallbacks are locked in here at the api-client layer.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchMcpServers,
+  resolveMcpConflict,
+  keepMcpServer,
+  dropMcpServer,
+  type McpServersResponse,
+} from "./api";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makeResponse(
+  overrides: Partial<McpServersResponse> = {},
+): McpServersResponse {
+  return {
+    agent: "claude",
+    effective: [],
+    keptOnRemoval: [],
+    conflicts: [],
+    driftPaused: false,
+    ...overrides,
+  };
+}
+
+const fetchSpy = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchMcpServers", () => {
+  it("returns the parsed payload and omits the query when no agent is given", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(makeResponse({ agent: "claude" })),
+    );
+    const res = await fetchMcpServers();
+    expect(res?.agent).toBe("claude");
+    expect(fetchSpy).toHaveBeenCalledWith("/api/mcp/servers", undefined);
+  });
+
+  it("encodes the agent into the query string", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeResponse()));
+    await fetchMcpServers("claude code");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/mcp/servers?agent=claude%20code",
+      undefined,
+    );
+  });
+
+  it("returns null on non-2xx and on network failure", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 500 }));
+    expect(await fetchMcpServers()).toBeNull();
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    expect(await fetchMcpServers()).toBeNull();
+  });
+});
+
+describe("resolveMcpConflict", () => {
+  it("POSTs the winner + fingerprint and maps 2xx to `applied`", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ status: "applied" }));
+    const result = await resolveMcpConflict("fs", "claude", "aoe", "fp-123");
+    expect(result).toBe("applied");
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/mcp/servers/fs/resolve");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(init!.body as string)).toEqual({
+      agent: "claude",
+      winner: "aoe",
+      fingerprint: "fp-123",
+    });
+  });
+
+  it("maps 409 to `stale` and other non-2xx to `error`", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 409 }));
+    expect(await resolveMcpConflict("fs", "claude", "native", "fp")).toBe(
+      "stale",
+    );
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 500 }));
+    expect(await resolveMcpConflict("fs", "claude", "native", "fp")).toBe(
+      "error",
+    );
+  });
+
+  it("maps a network failure to `error`", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    expect(await resolveMcpConflict("fs", "claude", "aoe", "fp")).toBe("error");
+  });
+
+  it("percent-encodes the server name in the path", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ status: "applied" }));
+    await resolveMcpConflict("a/b", "claude", "aoe", "fp");
+    expect(fetchSpy.mock.calls[0]![0]).toBe("/api/mcp/servers/a%2Fb/resolve");
+  });
+});
+
+describe("keepMcpServer / dropMcpServer", () => {
+  it("keep POSTs the agent and returns true on 2xx", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ status: "kept" }));
+    expect(await keepMcpServer("fs", "claude")).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/mcp/servers/fs/keep");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(init!.body as string)).toEqual({ agent: "claude" });
+  });
+
+  it("drop POSTs the agent and returns true on 2xx", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ status: "dropped" }));
+    expect(await dropMcpServer("fs", "claude")).toBe(true);
+    expect(fetchSpy.mock.calls[0]![0]).toBe("/api/mcp/servers/fs/drop");
+    expect(JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string)).toEqual({
+      agent: "claude",
+    });
+  });
+
+  it("both return false on a non-2xx response and on a network failure", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 403 }));
+    expect(await keepMcpServer("fs", "claude")).toBe(false);
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    expect(await keepMcpServer("fs", "claude")).toBe(false);
+
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 403 }));
+    expect(await dropMcpServer("fs", "claude")).toBe(false);
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    expect(await dropMcpServer("fs", "claude")).toBe(false);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1287,7 +1287,9 @@ export interface McpServersResponse {
   driftPaused: boolean;
 }
 
-export function fetchMcpServers(agent?: string): Promise<McpServersResponse | null> {
+export function fetchMcpServers(
+  agent?: string,
+): Promise<McpServersResponse | null> {
   const q = agent ? `?agent=${encodeURIComponent(agent)}` : "";
   return fetchJson<McpServersResponse>(`/api/mcp/servers${q}`);
 }
@@ -1312,23 +1314,38 @@ export async function resolveMcpConflict(
   winner: "aoe" | "native",
   fingerprint: string,
 ): Promise<McpResolveResult> {
-  const res = await postMcp(`/api/mcp/servers/${encodeURIComponent(name)}/resolve`, {
-    agent,
-    winner,
-    fingerprint,
-  });
+  const res = await postMcp(
+    `/api/mcp/servers/${encodeURIComponent(name)}/resolve`,
+    {
+      agent,
+      winner,
+      fingerprint,
+    },
+  );
   if (!res) return "error";
   if (res.ok) return "applied";
   if (res.status === 409) return "stale";
   return "error";
 }
 
-export async function keepMcpServer(name: string, agent: string): Promise<boolean> {
-  const res = await postMcp(`/api/mcp/servers/${encodeURIComponent(name)}/keep`, { agent });
+export async function keepMcpServer(
+  name: string,
+  agent: string,
+): Promise<boolean> {
+  const res = await postMcp(
+    `/api/mcp/servers/${encodeURIComponent(name)}/keep`,
+    { agent },
+  );
   return !!res && res.ok;
 }
 
-export async function dropMcpServer(name: string, agent: string): Promise<boolean> {
-  const res = await postMcp(`/api/mcp/servers/${encodeURIComponent(name)}/drop`, { agent });
+export async function dropMcpServer(
+  name: string,
+  agent: string,
+): Promise<boolean> {
+  const res = await postMcp(
+    `/api/mcp/servers/${encodeURIComponent(name)}/drop`,
+    { agent },
+  );
   return !!res && res.ok;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1256,3 +1256,79 @@ export async function deleteSession(
     };
   }
 }
+
+// --- MCP servers (#1996) ---
+
+export interface McpServerView {
+  name: string;
+  transport: string;
+  command?: string;
+  args?: string[];
+  url?: string;
+  envNames?: string[];
+  headerNames?: string[];
+  provenance: string;
+  shadowed?: string[];
+}
+
+export interface McpConflictView {
+  name: string;
+  agent: string;
+  previous: string;
+  current: string;
+  fingerprint: string;
+}
+
+export interface McpServersResponse {
+  agent: string;
+  effective: McpServerView[];
+  keptOnRemoval: McpServerView[];
+  conflicts: McpConflictView[];
+  driftPaused: boolean;
+}
+
+export function fetchMcpServers(agent?: string): Promise<McpServersResponse | null> {
+  const q = agent ? `?agent=${encodeURIComponent(agent)}` : "";
+  return fetchJson<McpServersResponse>(`/api/mcp/servers${q}`);
+}
+
+async function postMcp(url: string, body: unknown): Promise<Response | null> {
+  try {
+    return await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return null;
+  }
+}
+
+export type McpResolveResult = "applied" | "stale" | "error";
+
+export async function resolveMcpConflict(
+  name: string,
+  agent: string,
+  winner: "aoe" | "native",
+  fingerprint: string,
+): Promise<McpResolveResult> {
+  const res = await postMcp(`/api/mcp/servers/${encodeURIComponent(name)}/resolve`, {
+    agent,
+    winner,
+    fingerprint,
+  });
+  if (!res) return "error";
+  if (res.ok) return "applied";
+  if (res.status === 409) return "stale";
+  return "error";
+}
+
+export async function keepMcpServer(name: string, agent: string): Promise<boolean> {
+  const res = await postMcp(`/api/mcp/servers/${encodeURIComponent(name)}/keep`, { agent });
+  return !!res && res.ok;
+}
+
+export async function dropMcpServer(name: string, agent: string): Promise<boolean> {
+  const res = await postMcp(`/api/mcp/servers/${encodeURIComponent(name)}/drop`, { agent });
+  return !!res && res.ok;
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -10,6 +10,16 @@
       "components": ["web/src/components/McpServers.tsx"]
     },
     {
+      "id": "settings.mcp-servers.handlers",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": [
+        "src/components/__tests__/McpServers.test.tsx",
+        "src/lib/api.mcp.test.ts"
+      ],
+      "components": ["web/src/components/McpServers.tsx"]
+    },
+    {
       "id": "dashboard.golden-path",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -3,6 +3,17 @@
   "description": "Surface/flow coverage matrix for the agent-of-empires web dashboard. Every component file under web/src/components/** must appear in at least one entry's `components` list (covered, deferred, or out-of-scope), or in coverage-matrix.exempt.json. CI validates this on every PR via tests/validate-coverage-matrix.mjs.",
   "surfaces": [
     {
+      "id": "settings.mcp-servers",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/mcp-servers.spec.ts"
+      ],
+      "components": [
+        "web/src/components/McpServers.tsx"
+      ]
+    },
+    {
       "id": "dashboard.golden-path",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -6,12 +6,8 @@
       "id": "settings.mcp-servers",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": [
-        "tests/live/mcp-servers.spec.ts"
-      ],
-      "components": [
-        "web/src/components/McpServers.tsx"
-      ]
+      "specs": ["tests/live/mcp-servers.spec.ts"],
+      "components": ["web/src/components/McpServers.tsx"]
     },
     {
       "id": "dashboard.golden-path",

--- a/web/tests/live/mcp-servers.spec.ts
+++ b/web/tests/live/mcp-servers.spec.ts
@@ -1,0 +1,60 @@
+// Live: the MCP servers settings panel (#1996) renders the effective set
+// resolved from a real `aoe serve` backend, tags each server with its
+// provenance, and never leaks a secret value to the DOM.
+
+import { test as base, expect } from "@playwright/test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+base("MCP panel shows native servers with provenance and redacts secrets", async ({
+  page,
+}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    // Seed the agent-native config (~/.claude.json) the resolver reads. It
+    // carries a secret in both an env value and a header value, neither of
+    // which may ever reach the rendered panel.
+    seedFn: ({ home }) => {
+      writeFileSync(
+        join(home, ".claude.json"),
+        JSON.stringify({
+          mcpServers: {
+            fs: {
+              command: "mcp-fs",
+              args: ["--root", "."],
+              env: { TOKEN: "SUPER_SECRET_DO_NOT_LEAK" },
+            },
+            remote: {
+              type: "http",
+              url: "https://example/mcp",
+              headers: { Authorization: "Bearer HEADER_SECRET_DO_NOT_LEAK" },
+            },
+          },
+        }),
+      );
+    },
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings/mcp`);
+
+    const panel = page.getByTestId("mcp-panel");
+    await expect(panel).toBeVisible();
+
+    // Both native servers render, tagged with their provenance.
+    await expect(panel.getByText("fs", { exact: true })).toBeVisible();
+    await expect(panel.getByText("remote", { exact: true })).toBeVisible();
+    await expect(panel.getByText("agent-native:claude").first()).toBeVisible();
+
+    // Secret values never reach the DOM; only the names do.
+    await expect(panel).not.toContainText("SUPER_SECRET_DO_NOT_LEAK");
+    await expect(panel).not.toContainText("HEADER_SECRET_DO_NOT_LEAK");
+    await expect(panel).toContainText("TOKEN");
+    await expect(panel).toContainText("Authorization");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/mcp-servers.spec.ts
+++ b/web/tests/live/mcp-servers.spec.ts
@@ -49,11 +49,13 @@ base("MCP panel shows native servers with provenance and redacts secrets", async
     await expect(panel.getByText("remote", { exact: true })).toBeVisible();
     await expect(panel.getByText("agent-native:claude").first()).toBeVisible();
 
-    // Secret values never reach the DOM; only the names do.
+    // Secret values never reach the DOM; only the names do. The negative
+    // assertions prove the env value (TOKEN) and header value (Authorization)
+    // are redacted; the positive assertions prove their NAMES still render.
     await expect(panel).not.toContainText("SUPER_SECRET_DO_NOT_LEAK");
     await expect(panel).not.toContainText("HEADER_SECRET_DO_NOT_LEAK");
-    await expect(panel).toContainText("TOKEN");
-    await expect(panel).toContainText("Authorization");
+    await expect(panel).toContainText("TOKEN"); // env var name
+    await expect(panel).toContainText("Authorization"); // header name
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/mcp-servers.spec.ts
+++ b/web/tests/live/mcp-servers.spec.ts
@@ -7,56 +7,59 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnAoeServe } from "../helpers/aoeServe";
 
-base("MCP panel shows native servers with provenance and redacts secrets", async ({
-  page,
-}, testInfo) => {
-  const serve = await spawnAoeServe({
-    authMode: "none",
-    workerIndex: testInfo.workerIndex,
-    parallelIndex: testInfo.parallelIndex,
-    // Seed the agent-native config (~/.claude.json) the resolver reads. It
-    // carries a secret in both an env value and a header value, neither of
-    // which may ever reach the rendered panel.
-    seedFn: ({ home }) => {
-      writeFileSync(
-        join(home, ".claude.json"),
-        JSON.stringify({
-          mcpServers: {
-            fs: {
-              command: "mcp-fs",
-              args: ["--root", "."],
-              env: { TOKEN: "SUPER_SECRET_DO_NOT_LEAK" },
+base(
+  "MCP panel shows native servers with provenance and redacts secrets",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      // Seed the agent-native config (~/.claude.json) the resolver reads. It
+      // carries a secret in both an env value and a header value, neither of
+      // which may ever reach the rendered panel.
+      seedFn: ({ home }) => {
+        writeFileSync(
+          join(home, ".claude.json"),
+          JSON.stringify({
+            mcpServers: {
+              fs: {
+                command: "mcp-fs",
+                args: ["--root", "."],
+                env: { TOKEN: "SUPER_SECRET_DO_NOT_LEAK" },
+              },
+              remote: {
+                type: "http",
+                url: "https://example/mcp",
+                headers: { Authorization: "Bearer HEADER_SECRET_DO_NOT_LEAK" },
+              },
             },
-            remote: {
-              type: "http",
-              url: "https://example/mcp",
-              headers: { Authorization: "Bearer HEADER_SECRET_DO_NOT_LEAK" },
-            },
-          },
-        }),
-      );
-    },
-  });
+          }),
+        );
+      },
+    });
 
-  try {
-    await page.goto(`${serve.baseUrl}/settings/mcp`);
+    try {
+      await page.goto(`${serve.baseUrl}/settings/mcp`);
 
-    const panel = page.getByTestId("mcp-panel");
-    await expect(panel).toBeVisible();
+      const panel = page.getByTestId("mcp-panel");
+      await expect(panel).toBeVisible();
 
-    // Both native servers render, tagged with their provenance.
-    await expect(panel.getByText("fs", { exact: true })).toBeVisible();
-    await expect(panel.getByText("remote", { exact: true })).toBeVisible();
-    await expect(panel.getByText("agent-native:claude").first()).toBeVisible();
+      // Both native servers render, tagged with their provenance.
+      await expect(panel.getByText("fs", { exact: true })).toBeVisible();
+      await expect(panel.getByText("remote", { exact: true })).toBeVisible();
+      await expect(
+        panel.getByText("agent-native:claude").first(),
+      ).toBeVisible();
 
-    // Secret values never reach the DOM; only the names do. The negative
-    // assertions prove the env value (TOKEN) and header value (Authorization)
-    // are redacted; the positive assertions prove their NAMES still render.
-    await expect(panel).not.toContainText("SUPER_SECRET_DO_NOT_LEAK");
-    await expect(panel).not.toContainText("HEADER_SECRET_DO_NOT_LEAK");
-    await expect(panel).toContainText("TOKEN"); // env var name
-    await expect(panel).toContainText("Authorization"); // header name
-  } finally {
-    await serve.stop();
-  }
-});
+      // Secret values never reach the DOM; only the names do. The negative
+      // assertions prove the env value (TOKEN) and header value (Authorization)
+      // are redacted; the positive assertions prove their NAMES still render.
+      await expect(panel).not.toContainText("SUPER_SECRET_DO_NOT_LEAK");
+      await expect(panel).not.toContainText("HEADER_SECRET_DO_NOT_LEAK");
+      await expect(panel).toContainText("TOKEN"); // env var name
+      await expect(panel).toContainText("Authorization"); // header name
+    } finally {
+      await serve.stop();
+    }
+  },
+);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

This builds the unified MCP server management surface (#1996) on top of the four-layer MCP resolver landed by the config-source trio (#1994 / agent-of-empires/agent-of-empires#1986 / agent-of-empires/agent-of-empires#1985). It gives a user one redaction-safe view of which MCP servers an agent will actually reach, where each came from, and what to do when an agent's native config drifts.

What changed:

- **Read model with provenance (A).** Parsing, layering, and the precedence merge move out of the serve-gated `acp::mcp_config` (which returned ACP wire types and dropped the layer label) into a new always-compiled `session::mcp_model`. The resolver now returns a neutral `ResolvedMcpServer` carrying typed provenance (`agent-native:<agent>`, `global`, `profile:<name>`, `project-local`) and the full shadow chain. Forwarding consumes the same resolver and converts only the winning set to ACP just before sending, so what the user sees can never diverge from what the agent receives.
- **Drift store + conflict (C) and keep-on-removal (D).** A new owner-only `mcp_state.json` records the last-seen definition of each agent-native server. On open, the current native config is reconciled: a changed definition is a conflict the user resolves (which-side-wins; "AoE wins" promotes the definition into the global `mcp.json`, which outranks native), and a server that disappeared is kept in view and flagged rather than silently dropped. AoE never writes back to an agent-native config. A malformed native entry pauses drift detection for that agent so a parse failure is never mistaken for a removal. Conflict resolution carries an optimistic-concurrency fingerprint so concurrent web and TUI resolutions cannot clobber each other.
- **CLI (E).** `aoe mcp list [--agent <a>] [--json]`, top-level and always compiled, renders the same model so terminal users can debug config without a serve build.
- **Web.** A "MCP servers" settings tab with provenance badges, a conflict modal, and keep/drop, backed by `GET /api/mcp/servers` plus `POST .../resolve|keep|drop` (read-only guarded, lazy body extraction, redacted on the wire).

Every surface redacts secrets: command/args/url identify a server, env and header values are reduced to their names, and a sentinel test asserts no secret value reaches any serialized output.

Closes agent-of-empires/agent-of-empires#1996

Deferred to follow-ups (both already noted as out of scope in agent-of-empires/agent-of-empires#1996):
- agent-of-empires/plugin-mcp#3: live per-server status + connect / reconnect / authenticate (the ACP protocol exposes no per-server status today).
- agent-of-empires/plugin-mcp#2: native in-TUI management panel (`aoe mcp list` already gives TUI users the same inspection; the interactive overlay touches the hottest TUI paths and is better as its own PR).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Put two servers in `~/.claude.json` under `mcpServers` (one stdio with an `env` secret, one `http` with a header), then run `aoe mcp list --agent claude`. Confirm both appear with provenance `agent-native:claude` and that env/header values are shown as names only.
- [ ] Add a same-named server to `<app_dir>/mcp.json`. Re-run `aoe mcp list` and confirm the global one wins with `provenance: global` and lists the native one under `shadows`.
- [ ] `aoe mcp list --json` and confirm no secret value appears anywhere in the output.
- [ ] In `aoe serve`, open Settings -> MCP servers; confirm the list renders with provenance badges.
- [ ] Edit a server's definition in `~/.claude.json`, reopen the MCP tab, and confirm a Conflict appears; resolve it "Keep AoE version" and confirm the server now resolves as `global`.
- [ ] Remove a server from `~/.claude.json`, reopen the tab, confirm it appears under "Kept after removal"; use Drop and confirm it disappears.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, multi-LLM design debate, plan, and implementation drafted by Claude under my direction. I made the design calls (scope cut to A/C/D/E, store-unredacted-redact-at-edge, no bespoke aoe-added layer, defer B and the TUI panel), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR adds a unified, redaction-safe MCP server management surface and centralizes MCP resolution into a reusable session layer. Users now get one view of the effective MCP server set (agent-native, global, profile, project-local) with provenance and full shadow chains, plus drift detection, conflict detection/resolution, and keep-on-removal promotion — across CLI, web, API, and TUI surfaces.

What changed / moved / added / removed (plain language)
- Added a single read model that merges servers from all layers and records each entry’s provenance and shadowed sources.
- Added an on-disk drift store that remembers last-seen native definitions and classifies entries as NEW, UNCHANGED, CHANGED (conflict), or DISAPPEARED (kept-on-removal).
- Added flows to promote removed native servers into the global mcp.json (keep) or drop them.
- Added CLI command: aoe mcp list [--agent] [--json].
- Added Web UI: “MCP servers” settings tab with a conflict modal and keep/drop actions.
- Added REST API: GET /api/mcp/servers and POST endpoints to resolve/keep/drop servers.
- Centralized secret redaction behind a single serialization point so secret values never appear in CLI, web, API JSON, or DOM outputs.
- Moved config-loading, parsing, layering, and precedence merging out of the ACP serve layer into session; acp::mcp_config now only converts resolved servers into ACP and filters by agent capabilities.
- Removed the old inline parsing/merge utilities from the ACP layer.

Benefits
- Single, provenance-aware surface across interfaces improves visibility and consistency.
- Central redaction reduces risk of secret leakage.
- Deterministic conflict detection with optimistic-concurrency fingerprints reduces stale or conflicting user actions.
- Atomic, permissioned on-disk writes (exclusive locks) protect state integrity.
- Reusable resolver shared by serve, CLI, web, and tests.

## Technical Summary

Key new/changed modules
- src/session/mcp_model.rs
  - New resolver producing ResolvedMcpServer with provenance + shadow chain.
  - RedactedMcpServer as the single serialization/redaction chokepoint (exports only non-secret identifiers: command/args/url and env/header names).
  - Parsers for native agent formats (Claude, Gemini, Codex) with tolerant conversion and skipped-entry reporting.
  - resolve_effective / resolve_surface produce effective servers, kept_on_removal, conflicts, and drift_paused.

- src/session/mcp_state.rs
  - On-disk drift store (mcp_state.json) with reconcile_agent() returning conflicts/removed/paused.
  - resolve_conflict() uses optimistic-concurrency fingerprints; can rebaseline or promote AoE definitions into global mcp.json.
  - keep_removed(), forget_native() manage kept-on-removal lifecycle.
  - Read-modify-write protected by fs2 exclusive file locks and owner-only perms on Unix.

- src/session/mcp_overrides.rs
  - Upsert/remove AoE-managed entries into global <app_dir>/mcp.json, preserving unrelated keys.
  - Uses exclusive lock + truncate-and-rewrite; unit-tested for correct round-trip and preservation.

API / CLI / Web
- CLI: aoe mcp list [--agent] [--json] prints the redacted McpSurfaceView.
- API: GET /api/mcp/servers and POST /api/mcp/servers/{name}/resolve|keep|drop with status mappings (applied/stale/errors) and read-only guarding.
- Web: McpServers React component, Settings tab, client helpers for fetch/resolve/keep/drop; Playwright and unit tests for UI flows.

Other notable changes
- src/acp/mcp_config.rs now only converts ProjectMcpServer -> ACP McpServer and filters by capabilities; prior parsing/merge utilities removed.
- Project .mcp.json parsing refactored into parse_standard_mcp_servers and shared loaders.
- Tests: Playwright live test, e2e CLI test, unit/integration tests covering parsing, reconciliation, conflict lifecycle, locking, and overrides.

Review focus / follow-ups
- Ensure secret redaction across all surfaces (including on-disk mcp_state.json is owner-only but contains secrets).
- Validate optimistic-concurrency fingerprint correctness and race behavior between concurrent UI/TUI/web actions.
- Confirm fs2 exclusive lock coverage and robust error handling for read-modify-write cycles.
- Drift detection behavior for malformed native entries (pausing) and kept-on-removal semantics.
- Deferred work: per-server live status and a native-management TUI panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->