### PR TITLE
feat(cli): per-session activity metadata in list/status --json

### DIFF
--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -38,6 +38,18 @@ struct SessionJson {
     workspace_repos: Vec<WorkspaceRepoJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
     worktree: Option<WorktreeJson>,
+    /// Seconds since the session's last hook activity (`now - since`). `None`
+    /// when the session isn't tracked by the attention hook.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_activity_age_secs: Option<i64>,
+    /// Tool name on the most recent Pre/PostToolUse event. See the `last_tool`
+    /// caveat on `HookAttention`: after a toolless turn-complete this reflects
+    /// the prior tool; the age above is always the true last-activity time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_tool: Option<String>,
+    /// Kind of the most recent hook event: `turn_complete`/`tool_invoke`/`tool_error`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_reason: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -131,17 +143,24 @@ pub async fn run(profile: &str, args: ListArgs) -> Result<()> {
     if args.json {
         let sessions: Vec<SessionJson> = instances
             .iter()
-            .map(|inst| SessionJson {
-                id: inst.id.clone(),
-                title: inst.title.clone(),
-                path: inst.project_path.clone(),
-                group: inst.group_path.clone(),
-                tool: inst.tool.clone(),
-                command: inst.command.clone(),
-                profile: storage.profile().to_string(),
-                created_at: inst.created_at,
-                workspace_repos: workspace_repos_for(inst),
-                worktree: worktree_for(inst),
+            .map(|inst| {
+                let (last_activity_age_secs, last_tool, last_reason, _urgent) =
+                    super::session_activity(&inst.id);
+                SessionJson {
+                    id: inst.id.clone(),
+                    title: inst.title.clone(),
+                    path: inst.project_path.clone(),
+                    group: inst.group_path.clone(),
+                    tool: inst.tool.clone(),
+                    command: inst.command.clone(),
+                    profile: storage.profile().to_string(),
+                    created_at: inst.created_at,
+                    workspace_repos: workspace_repos_for(inst),
+                    worktree: worktree_for(inst),
+                    last_activity_age_secs,
+                    last_tool,
+                    last_reason,
+                }
             })
             .collect();
         super::output::print_json(&sessions)?;
@@ -176,6 +195,8 @@ async fn run_all_profiles(json: bool) -> Result<()> {
                     for inst in instances {
                         let workspace_repos = workspace_repos_for(&inst);
                         let worktree = worktree_for(&inst);
+                        let (last_activity_age_secs, last_tool, last_reason, _urgent) =
+                            super::session_activity(&inst.id);
                         all_sessions.push(SessionJson {
                             id: inst.id,
                             title: inst.title,
@@ -187,6 +208,9 @@ async fn run_all_profiles(json: bool) -> Result<()> {
                             created_at: inst.created_at,
                             workspace_repos,
                             worktree,
+                            last_activity_age_secs,
+                            last_tool,
+                            last_reason,
                         });
                     }
                 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -101,6 +101,28 @@ pub fn truncate_id(id: &str, max_len: usize) -> &str {
     }
 }
 
+/// Per-session activity fields derived from the agent attention hook, shared by
+/// `list --json` and `status --json` so both surface identical semantics.
+/// Returns `(last_activity_age_secs, last_tool, last_reason, urgent)`:
+/// - age is `now - since` clamped at 0 (`None` when the session isn't tracked);
+/// - `last_tool`/`last_reason` come straight from the hook record;
+/// - `urgent` honors `urgent_expires_at`, matching the TUI.
+pub(crate) fn session_activity(
+    instance_id: &str,
+) -> (Option<i64>, Option<String>, Option<String>, bool) {
+    let Some(att) = crate::hooks::read_hook_attention(instance_id) else {
+        return (None, None, None, false);
+    };
+    let age = att.since.map(|since| {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        (now - since).max(0)
+    });
+    (age, att.tool, att.reason, att.urgent)
+}
+
 /// Resolve `identifier` and run `f` on the matching instance. Designed for
 /// use inside `Storage::update`'s closure: find + mutate is atomic under
 /// both lock layers. Delegates to `resolve_session`, so ambiguous prefixes

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -39,6 +39,62 @@ struct StatusJson {
     stopped: usize,
     error: usize,
     total: usize,
+    /// Complete per-session rows. Additive: the count fields above are kept
+    /// for existing consumers, and each row carries the identity fields
+    /// (`id/title/path/group/profile`) ALONGSIDE `state` and the activity
+    /// metadata, so one `status --json` call replaces the old
+    /// `list --json` ⋈ `status -v` join on path.
+    sessions: Vec<StatusSessionJson>,
+}
+
+/// A complete per-session row in `status --json`: identity + live state +
+/// activity metadata. This is the shape the fleet consumer keys on to address
+/// matched sessions (send/restart) without a second call.
+#[derive(Serialize)]
+struct StatusSessionJson {
+    id: String,
+    title: String,
+    path: String,
+    group: String,
+    profile: String,
+    /// Live status word: `running`/`waiting`/`idle`/`stopped`/`error`/etc.
+    state: String,
+    /// Seconds since the session's last hook activity (`now - since`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_activity_age_secs: Option<i64>,
+    /// Tool name on the most recent Pre/PostToolUse event (see `HookAttention`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_tool: Option<String>,
+    /// Kind of the most recent hook event: `turn_complete`/`tool_invoke`/`tool_error`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_reason: Option<String>,
+    /// Honored urgent flag (respects `urgent_expires_at`).
+    urgent: bool,
+}
+
+fn build_session_rows(
+    profile: &str,
+    instances: &[crate::session::Instance],
+) -> Vec<StatusSessionJson> {
+    instances
+        .iter()
+        .map(|inst| {
+            let (last_activity_age_secs, last_tool, last_reason, urgent) =
+                super::session_activity(&inst.id);
+            StatusSessionJson {
+                id: inst.id.clone(),
+                title: inst.title.clone(),
+                path: inst.project_path.clone(),
+                group: inst.group_path.clone(),
+                profile: profile.to_string(),
+                state: inst.status.as_str().to_string(),
+                last_activity_age_secs,
+                last_tool,
+                last_reason,
+                urgent,
+            }
+        })
+        .collect()
 }
 
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
@@ -48,9 +104,16 @@ pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
 
     if instances.is_empty() {
         if args.json {
-            println!(
-                r#"{{"waiting": 0, "running": 0, "idle": 0, "stopped": 0, "error": 0, "total": 0}}"#
-            );
+            let empty = StatusJson {
+                waiting: 0,
+                running: 0,
+                idle: 0,
+                stopped: 0,
+                error: 0,
+                total: 0,
+                sessions: Vec::new(),
+            };
+            println!("{}", serde_json::to_string(&empty)?);
         } else if args.quiet {
             println!("0");
         } else {
@@ -77,6 +140,7 @@ pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
             stopped: counts.stopped,
             error: counts.error,
             total: counts.total,
+            sessions: build_session_rows(storage.profile(), &instances),
         };
         println!("{}", serde_json::to_string(&status_json)?);
     } else if args.quiet {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -16,8 +16,8 @@ use fs2::FileExt as _;
 use serde_json::Value;
 
 pub use status_file::{
-    cleanup_hook_status_dir, hook_status_dir, read_hook_session_id, read_hook_status,
-    read_hook_urgent,
+    cleanup_hook_status_dir, hook_status_dir, read_hook_attention, read_hook_session_id,
+    read_hook_status, read_hook_urgent, HookAttention,
 };
 
 /// Base directory for all AoE hook status files.

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -67,6 +67,22 @@ pub fn read_hook_session_id(instance_id: &str) -> Option<String> {
     }
 }
 
+/// Whether an `urgent` record's explicit `urgent_expires_at` (if present) has
+/// already passed. A record with no expiry never expires here — the producer
+/// (`attention-urgent`) always writes one, so legacy/expiry-less records stay
+/// honored by design. Shared by [`read_hook_urgent`] and
+/// [`read_hook_attention`] so the auto-expiry rule has a single source of truth.
+fn urgent_expired(value: &serde_json::Value) -> bool {
+    let Some(exp) = value.get("urgent_expires_at").and_then(|v| v.as_i64()) else {
+        return false;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    now > exp
+}
+
 /// Read the urgent flag from the hook-written `attention.json` for the given
 /// instance. Set by the `attention-urgent` script (cx-scripts) when the agent
 /// surfaces something genuinely time-sensitive (expiring device code, hard
@@ -92,16 +108,68 @@ pub fn read_hook_urgent(instance_id: &str) -> bool {
     {
         return false;
     }
-    if let Some(exp) = value.get("urgent_expires_at").and_then(|v| v.as_i64()) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
-        if now > exp {
-            return false;
-        }
-    }
-    true
+    !urgent_expired(&value)
+}
+
+/// Per-session activity/attention metadata parsed from `attention.json`, which
+/// the Claude attention-signal hook rewrites every turn. Powers the
+/// `last_activity_*` fields in `aoe list`/`status --json` so consumers can see
+/// how long ago a session was active and what it last did without scraping
+/// panes. Every field is optional: a session not running under the hook (or
+/// whose file predates a field) simply omits it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HookAttention {
+    /// Attention tier (0 = most urgent). From `tier`.
+    pub tier: Option<i64>,
+    /// What kind of event last fired: `turn_complete`, `tool_invoke`, or
+    /// `tool_error`. From `reason`.
+    pub reason: Option<String>,
+    /// Unix seconds of the most recent hook event = last activity. From `since`.
+    pub since: Option<i64>,
+    /// Tool name on the last Pre/PostToolUse event. From `tool`. After a
+    /// toolless turn-complete this reflects the *prior* tool; `since` is always
+    /// the true last-activity time.
+    pub tool: Option<String>,
+    /// Unix seconds when this attention record expires. From `expires_at`.
+    pub expires_at: Option<i64>,
+    /// Honored `urgent` flag — true only when set AND `urgent_expires_at` (if
+    /// present) has not passed, matching [`read_hook_urgent`].
+    pub urgent: bool,
+}
+
+/// Read the full attention record for an instance from `attention.json`.
+///
+/// Returns `None` when the file is absent or unparseable; individual fields are
+/// `None`/false when their key is missing. Shares the read path and urgent
+/// auto-expiry rule with [`read_hook_urgent`] — callers that need only the
+/// urgent bool should keep using that lighter function (it is on the polling
+/// hot path), while list/status JSON uses this to emit the richer row.
+pub fn read_hook_attention(instance_id: &str) -> Option<HookAttention> {
+    let dir = hook_status_dir(instance_id).ok()?;
+    let path = dir.join("attention.json");
+    let content = std::fs::read_to_string(&path).ok()?;
+    let value = serde_json::from_str::<serde_json::Value>(&content).ok()?;
+
+    let urgent = value
+        .get("urgent")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+        && !urgent_expired(&value);
+
+    Some(HookAttention {
+        tier: value.get("tier").and_then(|v| v.as_i64()),
+        reason: value
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        since: value.get("since").and_then(|v| v.as_i64()),
+        tool: value
+            .get("tool")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        expires_at: value.get("expires_at").and_then(|v| v.as_i64()),
+        urgent,
+    })
 }
 
 /// Remove the hook status directory for a given instance (cleanup on stop/delete).
@@ -359,6 +427,70 @@ mod tests {
     #[test]
     fn read_hook_urgent_returns_false_for_unsafe_id() {
         assert!(!read_hook_urgent("../etc"));
+    }
+
+    #[test]
+    fn test_read_hook_attention_full_record() {
+        let id = "test_attention_full";
+        let future = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        let body = format!(
+            r#"{{"tier":0,"reason":"tool_invoke","since":1700000000,"tool":"Bash","expires_at":{future},"urgent":true,"urgent_expires_at":{future}}}"#
+        );
+        let dir = write_attention_json(id, &body);
+        let att = read_hook_attention(id).expect("record should parse");
+        assert_eq!(att.tier, Some(0));
+        assert_eq!(att.reason.as_deref(), Some("tool_invoke"));
+        assert_eq!(att.since, Some(1_700_000_000));
+        assert_eq!(att.tool.as_deref(), Some("Bash"));
+        assert_eq!(att.expires_at, Some(future as i64));
+        assert!(att.urgent);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_hook_attention_none_when_absent() {
+        assert_eq!(read_hook_attention("test_attention_no_file"), None);
+    }
+
+    #[test]
+    fn test_read_hook_attention_partial_record() {
+        // turn_complete with no tool: tool is None, since/reason present.
+        let id = "test_attention_partial";
+        let dir = write_attention_json(id, r#"{"reason":"turn_complete","since":1700000123}"#);
+        let att = read_hook_attention(id).expect("record should parse");
+        assert_eq!(att.reason.as_deref(), Some("turn_complete"));
+        assert_eq!(att.since, Some(1_700_000_123));
+        assert_eq!(att.tool, None);
+        assert_eq!(att.tier, None);
+        assert!(!att.urgent);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_hook_attention_urgent_respects_expiry() {
+        // urgent flag set but past its expiry => urgent must be false, while
+        // the rest of the record still parses.
+        let id = "test_attention_urgent_expired";
+        let dir = write_attention_json(
+            id,
+            r#"{"urgent":true,"urgent_expires_at":1,"since":1700000000}"#,
+        );
+        let att = read_hook_attention(id).expect("record should parse");
+        assert!(!att.urgent);
+        assert_eq!(att.since, Some(1_700_000_000));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_hook_attention_none_when_malformed() {
+        let id = "test_attention_bad_json";
+        let dir = write_attention_json(id, "{ not json");
+        assert_eq!(read_hook_attention(id), None);
+        fs::remove_dir_all(dir).ok();
     }
 
     #[test]


### PR DESCRIPTION
Adds machine-readable per-session activity fields to the CLI JSON output so external tooling can introspect fleet state without scraping the TUI.

## What
`aoe list --json` and `aoe status --json` now include, per session:
- `last_activity_age_secs` — seconds since last activity
- `last_tool` — most recent tool the agent invoked
- `last_reason` — most recent stop/attention reason

## Why
Scripts that monitor or triage a fleet currently parse human-formatted output. These fields make `list`/`status --json` a stable contract for automation (health checks, audit loops, dashboards).

## Notes
- Single commit, branched off `main` (`3aa42f3f`).
- Purely additive to the JSON surface — no change to human-readable output or existing fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR enhances the CLI's JSON output with machine-readable per-session activity metadata, enabling external tooling to track fleet state without needing to parse the text UI. The changes add three new activity fields and a new sessions array to the JSON output for better observability.

## What Was Added

- **Three new activity fields** to JSON output:
  - `last_activity_age_secs` — how long (in seconds) since the agent last performed an action
  - `last_tool` — the most recent tool the agent used
  - `last_reason` — why the agent last stopped or requested attention

- **New `sessions` array in `status --json`** — a structured list showing detailed status for each active session, including the three activity fields plus session identity (id, title, path, group, profile, state) and urgency flag

- **Activity fields in `list --json`** — both single-profile and multi-profile (`--all`) output now include the same three activity fields in each row

- **New hook reading capability** — added internal infrastructure to parse attention hook metadata from agent records, including functions to read and structure this data

- **5 new unit tests** — covering the new activity reading and JSON generation logic

## What Changed

- `SessionJson` struct was extended with optional activity fields
- `status --json` now includes a top-level `sessions` array alongside existing count summaries
- Both `list` and `status` JSON output paths were updated to populate activity fields when available

## What Was Removed

None — this is a purely additive change with no breaking modifications to existing JSON fields or output formats.

## Benefits

- **Automated monitoring:** External tools can now programmatically check agent activity without UI scraping
- **Fleet observability:** Detailed per-session activity tracking in structured JSON format
- **Non-breaking:** Fully backward compatible; existing JSON consumers are unaffected
- **Flexible:** Fields are omitted when data is unavailable, keeping output clean

## Technical Details

The implementation adds:
- `read_hook_attention()` function to parse per-turn `attention.json` records, returning structured `HookAttention` objects containing activity metadata with proper TTL-based expiry semantics for urgent flags
- `session_activity()` helper that computes activity age as `now − since` (clamped to zero) and bundles this with tool, reason, and urgency data
- `StatusSessionJson` struct and `build_session_rows` helper for structured per-session JSON generation in status output
- Refactored urgent-expiry logic into a shared `urgent_expired()` helper for consistent TTL handling across both hot-polling and rich activity readers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->