### PR TITLE
feat(cli): native bulk fleet ops — TargetFilter for send/restart/status

### DIFF
--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -38,6 +38,18 @@ struct SessionJson {
     workspace_repos: Vec<WorkspaceRepoJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
     worktree: Option<WorktreeJson>,
+    /// Seconds since the session's last hook activity (`now - since`). `None`
+    /// when the session isn't tracked by the attention hook.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_activity_age_secs: Option<i64>,
+    /// Tool name on the most recent Pre/PostToolUse event. See the `last_tool`
+    /// caveat on `HookAttention`: after a toolless turn-complete this reflects
+    /// the prior tool; the age above is always the true last-activity time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_tool: Option<String>,
+    /// Kind of the most recent hook event: `turn_complete`/`tool_invoke`/`tool_error`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_reason: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -131,17 +143,24 @@ pub async fn run(profile: &str, args: ListArgs) -> Result<()> {
     if args.json {
         let sessions: Vec<SessionJson> = instances
             .iter()
-            .map(|inst| SessionJson {
-                id: inst.id.clone(),
-                title: inst.title.clone(),
-                path: inst.project_path.clone(),
-                group: inst.group_path.clone(),
-                tool: inst.tool.clone(),
-                command: inst.command.clone(),
-                profile: storage.profile().to_string(),
-                created_at: inst.created_at,
-                workspace_repos: workspace_repos_for(inst),
-                worktree: worktree_for(inst),
+            .map(|inst| {
+                let (last_activity_age_secs, last_tool, last_reason, _urgent) =
+                    super::session_activity(&inst.id);
+                SessionJson {
+                    id: inst.id.clone(),
+                    title: inst.title.clone(),
+                    path: inst.project_path.clone(),
+                    group: inst.group_path.clone(),
+                    tool: inst.tool.clone(),
+                    command: inst.command.clone(),
+                    profile: storage.profile().to_string(),
+                    created_at: inst.created_at,
+                    workspace_repos: workspace_repos_for(inst),
+                    worktree: worktree_for(inst),
+                    last_activity_age_secs,
+                    last_tool,
+                    last_reason,
+                }
             })
             .collect();
         super::output::print_json(&sessions)?;
@@ -176,6 +195,8 @@ async fn run_all_profiles(json: bool) -> Result<()> {
                     for inst in instances {
                         let workspace_repos = workspace_repos_for(&inst);
                         let worktree = worktree_for(&inst);
+                        let (last_activity_age_secs, last_tool, last_reason, _urgent) =
+                            super::session_activity(&inst.id);
                         all_sessions.push(SessionJson {
                             id: inst.id,
                             title: inst.title,
@@ -187,6 +208,9 @@ async fn run_all_profiles(json: bool) -> Result<()> {
                             created_at: inst.created_at,
                             workspace_repos,
                             worktree,
+                            last_activity_age_secs,
+                            last_tool,
+                            last_reason,
                         });
                     }
                 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,6 +22,7 @@ pub mod serve;
 pub mod session;
 pub mod sounds;
 pub mod status;
+pub mod target;
 pub mod telemetry;
 pub mod theme;
 pub mod tmux;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -101,6 +101,28 @@ pub fn truncate_id(id: &str, max_len: usize) -> &str {
     }
 }
 
+/// Per-session activity fields derived from the agent attention hook, shared by
+/// `list --json` and `status --json` so both surface identical semantics.
+/// Returns `(last_activity_age_secs, last_tool, last_reason, urgent)`:
+/// - age is `now - since` clamped at 0 (`None` when the session isn't tracked);
+/// - `last_tool`/`last_reason` come straight from the hook record;
+/// - `urgent` honors `urgent_expires_at`, matching the TUI.
+pub(crate) fn session_activity(
+    instance_id: &str,
+) -> (Option<i64>, Option<String>, Option<String>, bool) {
+    let Some(att) = crate::hooks::read_hook_attention(instance_id) else {
+        return (None, None, None, false);
+    };
+    let age = att.since.map(|since| {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        (now - since).max(0)
+    });
+    (age, att.tool, att.reason, att.urgent)
+}
+
 /// Resolve `identifier` and run `f` on the matching instance. Designed for
 /// use inside `Storage::update`'s closure: find + mutate is atomic under
 /// both lock layers. Delegates to `resolve_session`, so ambiguous prefixes

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -1,18 +1,39 @@
 //! `agent-of-empires send` subcommand implementation
+//!
+//! Two modes share one entry point:
+//! - **single target** — `aoe send <id> "msg"` (unchanged, backward-compatible);
+//! - **bulk** — `aoe send [FILTER] "msg"` selects a set via [`TargetFilter`] and,
+//!   by default, PREVIEWS it (prints matched targets, sends nothing). Only
+//!   `--yes` actually delivers. This preview gate is the whole reason bulk send
+//!   is safe: a blind `send` appends + submits, clobbering any input the agent
+//!   has staged at its prompt, so we never fan out keystrokes the operator
+//!   hasn't seen the blast radius of first.
 
 use anyhow::{bail, Result};
 use clap::Args;
 
 use crate::cli::session::stale_history_suffix;
-use crate::session::{EnsureReadyError, EnsureReadyOutcome, Storage};
+use crate::cli::target::{self, ResolvedTarget, TargetFilter};
+use crate::session::{EnsureReadyError, EnsureReadyOutcome, Status, Storage};
 
 #[derive(Args)]
 pub struct SendArgs {
-    /// Session ID or title
-    identifier: String,
+    /// In single-target mode: the session id or title. In bulk mode (a filter
+    /// is present): omit this and pass only the message. Positional parsing:
+    /// when two positionals are given they are `<identifier> <message>`; when
+    /// one is given it is the `<message>` and targets come from the filter.
+    arg1: Option<String>,
 
-    /// Message to send to the agent
-    message: String,
+    /// Second positional; present only in `<identifier> <message>` form.
+    arg2: Option<String>,
+
+    #[command(flatten)]
+    filter: TargetFilter,
+
+    /// Actually deliver in bulk mode. Without it, bulk send only previews the
+    /// matched targets. No effect on single-target sends (those always send).
+    #[arg(long, short = 'y')]
+    yes: bool,
 
     /// Fail loud on dead/stopped sessions instead of auto-respawning. Default
     /// behavior is to revive the session so a `send` after a crash or stop
@@ -23,14 +44,38 @@ pub struct SendArgs {
 
 #[tracing::instrument(target = "cli.send", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
-    let storage = Storage::new(profile)?;
-    let (mut instances, _) = storage.load_with_groups()?;
+    // Disambiguate positionals: `<id> <msg>` vs filter-mode `<msg>`.
+    let (identifier, message) = match (args.arg1, args.arg2) {
+        (Some(id), Some(msg)) => (Some(id), msg),
+        (Some(msg), None) => (None, msg),
+        (None, _) => bail!("a message is required"),
+    };
 
-    if args.message.trim().is_empty() {
+    if message.trim().is_empty() {
         bail!("Message cannot be empty");
     }
 
-    let inst = super::resolve_session(&args.identifier, &instances)?;
+    // Bulk when any filter selector is present, or when no identifier was
+    // given at all (a filter-less, identifier-less send is a no-op guard, not
+    // a whole-fleet blast).
+    if args.filter.has_selector() || identifier.is_none() {
+        return bulk_send(profile, &args.filter, &message, args.yes, args.no_revive).await;
+    }
+
+    let identifier = identifier.expect("checked: Some in single-target branch");
+    let title = deliver_send(profile, &identifier, &message, args.no_revive)?;
+    println!("Sent message to '{}'", title);
+    Ok(())
+}
+
+/// Deliver one message to one session in one profile: revive the pane if
+/// needed, send keystrokes, then stamp `last_accessed`/`Running`. Returns the
+/// session title on success. Shared by the single-target and bulk paths.
+fn deliver_send(profile: &str, identifier: &str, message: &str, no_revive: bool) -> Result<String> {
+    let storage = Storage::new(profile)?;
+    let (mut instances, _) = storage.load_with_groups()?;
+
+    let inst = super::resolve_session(identifier, &instances)?;
     let session_id = inst.id.clone();
     let session_title = inst.title.clone();
     let tool = inst.tool.clone();
@@ -38,7 +83,7 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     // Revive the pane if needed before delivering keystrokes. Without this,
     // a send to a dead pane silently writes to a corpse with no agent to
     // respond to it.
-    if !args.no_revive {
+    if !no_revive {
         if let Some(target) = instances.iter_mut().find(|i| i.id == session_id) {
             match target.ensure_pane_ready() {
                 Ok(EnsureReadyOutcome::Respawned { stale_sid: None }) => {
@@ -79,12 +124,12 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     if !tmux_session.exists() {
         bail!(
             "Session is not running. Start it first with: aoe session start {}",
-            args.identifier
+            identifier
         );
     }
 
     let delay = crate::agents::send_keys_enter_delay(&tool);
-    tmux_session.send_keys_with_delay(&args.message, delay)?;
+    tmux_session.send_keys_with_delay(message, delay)?;
 
     // Stamp last_accessed_at so the "last activity" column reflects user
     // interaction, and remap the status to Running. The agent has just been
@@ -113,6 +158,93 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
         );
     }
 
-    println!("Sent message to '{}'", session_title);
+    Ok(session_title)
+}
+
+/// Bulk send: resolve the matched set across profiles, PREVIEW by default,
+/// deliver only on `--yes`. Excludes the invoking session so the operator
+/// never messages themselves; warns on `waiting`/`idle` targets that may hold
+/// input staged at the prompt (a send appends + submits, mixing the two).
+async fn bulk_send(
+    ambient_profile: &str,
+    filter: &TargetFilter,
+    message: &str,
+    yes: bool,
+    no_revive: bool,
+) -> Result<()> {
+    let self_id = target::self_instance_id();
+    let targets = target::resolve_targets(ambient_profile, filter, self_id.as_deref(), true)?;
+
+    if targets.is_empty() {
+        println!("No sessions match the filter (nothing to send).");
+        return Ok(());
+    }
+
+    let staged: Vec<&ResolvedTarget> = targets
+        .iter()
+        .filter(|t| matches!(t.instance.status, Status::Waiting | Status::Idle))
+        .collect();
+
+    println!(
+        "{} session(s) match{}:",
+        targets.len(),
+        if yes { "" } else { " (preview)" }
+    );
+    for t in &targets {
+        println!(
+            "  · [{}] {:<20} {:<8} {}",
+            t.profile,
+            super::truncate(&t.instance.title, 20),
+            t.instance.status.as_str(),
+            t.instance.id,
+        );
+    }
+    if self_id.is_some() {
+        println!("  (excluding this session)");
+    }
+    if !staged.is_empty() {
+        println!(
+            "⚠ {} target(s) are waiting/idle and may hold input staged at the prompt; \
+             a send appends + submits, mixing your message with theirs:",
+            staged.len()
+        );
+        for t in &staged {
+            println!("    · [{}] {}", t.profile, t.instance.title);
+        }
+    }
+
+    if !yes {
+        println!(
+            "\nPreview only — nothing sent. Re-run with --yes to deliver to the {} matched session(s).",
+            targets.len()
+        );
+        return Ok(());
+    }
+
+    println!("\nMessage: {message:?}\n");
+    let mut sent: Vec<String> = Vec::new();
+    let mut failed: Vec<(String, String)> = Vec::new();
+    for t in &targets {
+        match deliver_send(&t.profile, &t.instance.id, message, no_revive) {
+            Ok(title) => sent.push(format!("[{}] {}", t.profile, title)),
+            Err(e) => failed.push((
+                format!("[{}] {}", t.profile, t.instance.title),
+                e.to_string(),
+            )),
+        }
+    }
+
+    println!("✓ Sent to {}/{} sessions:", sent.len(), targets.len());
+    for s in &sent {
+        println!("  · {s}");
+    }
+    if !failed.is_empty() {
+        println!("✗ {} failed:", failed.len());
+        for (label, err) in &failed {
+            println!("  · {label}: {err}");
+        }
+        bail!("{} session(s) failed to receive the message", failed.len());
+    }
+
     Ok(())
 }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -112,21 +112,30 @@ pub struct SessionIdArgs {
 
 #[derive(Args)]
 pub struct RestartArgs {
-    /// Session ID or title (required unless `--all` is passed)
+    /// Session ID or title. Required unless a fleet filter (`--all`,
+    /// `--state`, `--errors`, `--group`, `--ids`, `--path`, `--profiles`)
+    /// is passed. Mutually exclusive with every filter selector.
+    #[arg(conflicts_with_all = ["all", "profiles", "groups", "states", "errors", "ids", "path"])]
     pub identifier: Option<String>,
 
-    /// Restart every session in the active profile. Useful after
-    /// `aoe update`, after editing `sandbox.environment`, after a
-    /// Docker hiccup, or after changing a hook. Mutually exclusive
-    /// with `identifier`.
-    #[arg(long, conflicts_with = "identifier")]
-    pub all: bool,
+    /// Fleet selector. With no narrowing, `--all` restarts every session
+    /// across every profile (consistent with `send`/`status`); add
+    /// `--state error`, `--group`, etc. to narrow. Useful after
+    /// `aoe update`, editing `sandbox.environment`, a Docker hiccup, or
+    /// changing a hook.
+    #[command(flatten)]
+    pub filter: crate::cli::target::TargetFilter,
 
-    /// Concurrency cap for `--all`. Restarting many sandboxed
+    /// Concurrency cap for bulk restart. Restarting many sandboxed
     /// sessions in parallel pressures dockerd, so the default is
-    /// intentionally modest. Ignored when `--all` is not set.
+    /// intentionally modest. Ignored for a single-identifier restart.
     #[arg(long, default_value_t = 3)]
     pub parallel: usize,
+
+    /// Print the resolved target set (grouped by profile) and exit without
+    /// restarting anything. The safety valve for the no-preview bulk path.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Args)]
@@ -507,45 +516,46 @@ async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 }
 
 async fn restart_session_dispatch(profile: &str, args: RestartArgs) -> Result<()> {
-    if args.all {
-        return restart_all_sessions(profile, args.parallel).await;
+    if let Some(identifier) = args.identifier {
+        // `conflicts_with_all` on `identifier` guarantees no filter selector
+        // is present here, so a single-identifier restart is unambiguous.
+        return restart_session(profile, SessionIdArgs { identifier }).await;
     }
-    let identifier = args
-        .identifier
-        .ok_or_else(|| anyhow::anyhow!("session identifier required (or pass --all)"))?;
-    restart_session(profile, SessionIdArgs { identifier }).await
+    if args.filter.has_selector() {
+        return restart_targets(profile, &args.filter, args.parallel, args.dry_run).await;
+    }
+    bail!("session identifier required (or pass a fleet filter such as --all / --state error)")
 }
 
-async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
+/// Outcome of one profile's restart fan-out, aggregated by the caller so a
+/// cross-profile bulk restart prints a single summary.
+#[derive(Default)]
+struct RestartReport {
+    total: usize,
+    /// `(title, stale_sid)` per restarted session; `stale_sid` is `Some` when
+    /// the resume cascade had to start fresh.
+    succeeded: Vec<(String, Option<String>)>,
+    failed: Vec<(String, String)>,
+    orphaned: Vec<(String, String)>,
+}
+
+/// Restart an explicit set of already-cloned target instances within one
+/// profile, using the same three-phase (snapshot → unlocked parallel tmux
+/// restart → locked merge-by-id) protocol as the legacy `--all`. `targets`
+/// must already carry `source_profile` so start-time config resolution honors
+/// the right profile's overrides.
+async fn restart_fanout(
+    profile: &str,
+    targets: Vec<crate::session::Instance>,
+    parallel: usize,
+) -> Result<RestartReport> {
     let storage = Storage::new(profile)?;
-
-    // Phase 1 (unlocked): snapshot the targets. We don't hold the flock
-    // across the parallel restart fan-out below; phase 3 re-loads under
-    // the lock and merges by id.
-    let (instances, _groups) = storage.load_with_groups()?;
-    let target_ids = pick_targets_for_restart_all(&instances);
-    if target_ids.is_empty() {
-        println!("No sessions to restart in profile '{}'.", profile);
-        return Ok(());
+    let total = targets.len();
+    if total == 0 {
+        return Ok(RestartReport::default());
     }
-
-    let total = target_ids.len();
     let size = crate::terminal::get_size();
     let parallel = parallel.max(1);
-
-    // Clone each target into its worker. `source_profile` is runtime-only
-    // (skip_serializing) so storage-loaded instances always come back
-    // blank; rehydrate it from the storage profile so start-time config
-    // resolution honors the right profile's overrides (sandbox.environment,
-    // on_launch hooks, etc.).
-    let mut targets: Vec<crate::session::Instance> = Vec::with_capacity(total);
-    for id in &target_ids {
-        if let Some(inst) = instances.iter().find(|i| &i.id == id) {
-            let mut clone = inst.clone();
-            clone.source_profile = profile.to_string();
-            targets.push(clone);
-        }
-    }
 
     let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(parallel));
     let mut join_set: tokio::task::JoinSet<(
@@ -615,7 +625,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
                 tracing::warn!(
                     target: "session.cli",
                     session_id = %restarted_inst.id,
-                    "session row removed by peer between phase 1 and phase 3 of restart --all; tmux session is now orphan"
+                    "session row removed by peer between phase 1 and phase 3 of bulk restart; tmux session is now orphan"
                 );
                 orphaned.push((restarted_inst.id.clone(), restarted_inst.title.clone()));
             }
@@ -627,67 +637,135 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let orphaned_ids: HashSet<&String> = orphaned.iter().map(|(id, _)| id).collect();
     succeeded.retain(|(id, _, _)| !orphaned_ids.contains(id));
 
-    let stale_count = succeeded.iter().filter(|(_, _, s)| s.is_some()).count();
+    Ok(RestartReport {
+        total,
+        succeeded: succeeded
+            .into_iter()
+            .map(|(_id, title, stale)| (title, stale))
+            .collect(),
+        failed,
+        orphaned,
+    })
+}
+
+/// Bulk restart across the filtered target set (possibly spanning profiles).
+/// Excludes the invoking session, prints the resolved plan grouped by profile,
+/// and — unless `--dry-run` — fans out per profile via [`restart_fanout`],
+/// then prints one aggregated summary.
+async fn restart_targets(
+    ambient_profile: &str,
+    filter: &crate::cli::target::TargetFilter,
+    parallel: usize,
+    dry_run: bool,
+) -> Result<()> {
+    use crate::cli::target;
+    use std::collections::BTreeMap;
+
+    let self_id = target::self_instance_id();
+    let resolved = target::resolve_targets(ambient_profile, filter, self_id.as_deref(), true)?;
+    if resolved.is_empty() {
+        println!("No sessions match the filter (nothing to restart).");
+        return Ok(());
+    }
+
+    // Group by (canonical) profile so each fan-out opens the right Storage and
+    // the plan reads profile-by-profile. Stamp source_profile for config
+    // resolution at restart time.
+    let mut by_profile: BTreeMap<String, Vec<crate::session::Instance>> = BTreeMap::new();
+    for t in resolved {
+        let mut inst = t.instance;
+        inst.source_profile = t.profile.clone();
+        by_profile.entry(t.profile).or_default().push(inst);
+    }
+    let total: usize = by_profile.values().map(|v| v.len()).sum();
+
+    println!(
+        "Restarting {} session(s) across {} profile(s){}:",
+        total,
+        by_profile.len(),
+        if dry_run { " [dry run]" } else { "" }
+    );
+    for (prof, insts) in &by_profile {
+        println!("  ═ {} ({}):", prof, insts.len());
+        for inst in insts {
+            println!(
+                "    · {:<20} {:<8} {}",
+                super::truncate(&inst.title, 20),
+                inst.status.as_str(),
+                inst.id,
+            );
+        }
+    }
+    if self_id.is_some() {
+        println!("  (excluding this session)");
+    }
+    if dry_run {
+        println!("\nDry run — nothing restarted.");
+        return Ok(());
+    }
+
+    // Fan out per profile. Each profile's fan-out is independent (separate
+    // Storage lock); run them sequentially so the dockerd-pressure cap stays
+    // honored per profile rather than multiplying across profiles.
+    let mut agg = RestartReport {
+        total,
+        ..Default::default()
+    };
+    for (prof, insts) in by_profile {
+        match restart_fanout(&prof, insts, parallel).await {
+            Ok(report) => {
+                agg.succeeded.extend(report.succeeded);
+                agg.failed.extend(report.failed);
+                agg.orphaned.extend(report.orphaned);
+            }
+            Err(e) => {
+                // A whole-profile failure (e.g. Storage open) shouldn't abort
+                // the other profiles; record it and continue.
+                agg.failed
+                    .push((format!("[{prof}] <profile>"), e.to_string()));
+            }
+        }
+    }
+
+    let stale_count = agg.succeeded.iter().filter(|(_, s)| s.is_some()).count();
     if stale_count == 0 {
-        println!("✓ Restarted {}/{} sessions:", succeeded.len(), total);
+        println!(
+            "✓ Restarted {}/{} sessions:",
+            agg.succeeded.len(),
+            agg.total
+        );
     } else {
         println!(
             "✓ Restarted {}/{} sessions ({} without prior history):",
-            succeeded.len(),
-            total,
+            agg.succeeded.len(),
+            agg.total,
             stale_count,
         );
     }
-    for (_id, title, stale) in &succeeded {
+    for (title, stale) in &agg.succeeded {
         match stale {
             Some(sid) => println!("  · {}{}", title, stale_history_suffix(sid)),
             None => println!("  · {}", title),
         }
     }
-    if !orphaned.is_empty() {
+    if !agg.orphaned.is_empty() {
         println!(
             "⚠ {} orphaned (row removed by peer mid-flight; tmux running but unrooted):",
-            orphaned.len()
+            agg.orphaned.len()
         );
-        for (_, title) in &orphaned {
+        for (_, title) in &agg.orphaned {
             println!("  · {}", title);
         }
     }
-    if !failed.is_empty() {
-        println!("✗ {} failed:", failed.len());
-        for (title, err) in &failed {
+    if !agg.failed.is_empty() {
+        println!("✗ {} failed:", agg.failed.len());
+        for (title, err) in &agg.failed {
             println!("  · {}: {}", title, err);
         }
-        bail!("{} session(s) failed to restart", failed.len());
+        bail!("{} session(s) failed to restart", agg.failed.len());
     }
 
     Ok(())
-}
-
-/// Sessions in `Deleting` or `Creating` are mid-transition; restarting them
-/// would race the deletion/boot path. Cockpit-mode sessions are skipped
-/// because their lifecycle is owned by `aoe serve`'s supervisor, not
-/// tmux: a CLI-side restart would no-op silently and (with the explicit
-/// bail in `restart_session`) flood `--all` with per-session errors.
-/// Everything else is fair game; agents have their own resume-or-restart
-/// logic on the next start.
-fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<String> {
-    use crate::session::Status;
-    instances
-        .iter()
-        .filter(|i| !matches!(i.status, Status::Deleting | Status::Creating))
-        .filter(|_i| {
-            #[cfg(feature = "serve")]
-            {
-                !_i.cockpit_mode
-            }
-            #[cfg(not(feature = "serve"))]
-            {
-                true
-            }
-        })
-        .map(|i| i.id.clone())
-        .collect()
 }
 
 async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
@@ -1308,7 +1386,7 @@ mod restart_args_tests {
             .expect("identifier-only must parse");
         match cli.cmd {
             SessionCommands::Restart(args) => {
-                assert!(!args.all);
+                assert!(!args.filter.all);
                 assert_eq!(args.identifier.as_deref(), Some("claude-3"));
                 assert_eq!(args.parallel, 3);
             }
@@ -1321,7 +1399,7 @@ mod restart_args_tests {
         let cli = Cli::try_parse_from(["aoe", "restart", "--all"]).expect("--all alone must parse");
         match cli.cmd {
             SessionCommands::Restart(args) => {
-                assert!(args.all);
+                assert!(args.filter.all);
                 assert!(args.identifier.is_none());
                 assert_eq!(args.parallel, 3);
             }
@@ -1335,7 +1413,7 @@ mod restart_args_tests {
             .expect("--all --parallel must parse");
         match cli.cmd {
             SessionCommands::Restart(args) => {
-                assert!(args.all);
+                assert!(args.filter.all);
                 assert_eq!(args.parallel, 5);
             }
             _ => panic!("wrong subcommand"),
@@ -1390,48 +1468,63 @@ mod restart_args_tests {
 }
 
 #[cfg(test)]
-mod target_filter_tests {
-    use super::pick_targets_for_restart_all;
-    use crate::session::{Instance, Status};
+mod restart_filter_dispatch_tests {
+    use super::SessionCommands;
+    use clap::Parser;
 
-    fn instance_with_status(id: &str, status: Status) -> Instance {
-        let mut inst = Instance::new(id, "/tmp");
-        inst.id = id.to_string();
-        inst.status = status;
-        inst
+    #[derive(Parser)]
+    struct Cli {
+        #[command(subcommand)]
+        cmd: SessionCommands,
     }
 
     #[test]
-    fn skips_deleting_and_creating() {
-        let instances = vec![
-            instance_with_status("running", Status::Running),
-            instance_with_status("idle", Status::Idle),
-            instance_with_status("stopped", Status::Stopped),
-            instance_with_status("error", Status::Error),
-            instance_with_status("waiting", Status::Waiting),
-            instance_with_status("starting", Status::Starting),
-            instance_with_status("unknown", Status::Unknown),
-            instance_with_status("deleting", Status::Deleting),
-            instance_with_status("creating", Status::Creating),
-        ];
-        let mut picked = pick_targets_for_restart_all(&instances);
-        picked.sort();
-        let mut expected = vec![
-            "error".to_string(),
-            "idle".to_string(),
-            "running".to_string(),
-            "starting".to_string(),
-            "stopped".to_string(),
-            "unknown".to_string(),
-            "waiting".to_string(),
-        ];
-        expected.sort();
-        assert_eq!(picked, expected);
+    fn restart_state_filter_parses_without_identifier() {
+        let cli = Cli::try_parse_from(["aoe", "restart", "--state", "error"])
+            .expect("a state filter alone must parse");
+        match cli.cmd {
+            SessionCommands::Restart(args) => {
+                assert!(args.identifier.is_none());
+                assert_eq!(args.filter.states.len(), 1);
+                assert!(args.filter.has_selector());
+            }
+            _ => panic!("wrong subcommand"),
+        }
     }
 
     #[test]
-    fn empty_input_yields_empty_targets() {
-        assert!(pick_targets_for_restart_all(&[]).is_empty());
+    fn restart_errors_shorthand_and_dry_run_parse() {
+        let cli = Cli::try_parse_from(["aoe", "restart", "--errors", "--dry-run"])
+            .expect("--errors --dry-run must parse");
+        match cli.cmd {
+            SessionCommands::Restart(args) => {
+                assert!(args.filter.errors);
+                assert!(args.dry_run);
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+
+    #[test]
+    fn restart_identifier_conflicts_with_any_filter_selector() {
+        // identifier + --state, --errors, --group, --ids, --path, --profiles
+        // all conflict at parse time (mirrors the historical --all conflict).
+        for sel in [
+            vec!["--state", "error"],
+            vec!["--errors"],
+            vec!["--group", "fleet"],
+            vec!["--ids", "abc"],
+            vec!["--path", "/tmp"],
+            vec!["--profiles", "main"],
+        ] {
+            let mut argv = vec!["aoe", "restart", "claude-3"];
+            argv.extend(sel.iter().copied());
+            assert!(
+                Cli::try_parse_from(&argv).is_err(),
+                "identifier + {:?} should conflict",
+                sel
+            );
+        }
     }
 }
 

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -39,6 +39,62 @@ struct StatusJson {
     stopped: usize,
     error: usize,
     total: usize,
+    /// Complete per-session rows. Additive: the count fields above are kept
+    /// for existing consumers, and each row carries the identity fields
+    /// (`id/title/path/group/profile`) ALONGSIDE `state` and the activity
+    /// metadata, so one `status --json` call replaces the old
+    /// `list --json` ⋈ `status -v` join on path.
+    sessions: Vec<StatusSessionJson>,
+}
+
+/// A complete per-session row in `status --json`: identity + live state +
+/// activity metadata. This is the shape the fleet consumer keys on to address
+/// matched sessions (send/restart) without a second call.
+#[derive(Serialize)]
+struct StatusSessionJson {
+    id: String,
+    title: String,
+    path: String,
+    group: String,
+    profile: String,
+    /// Live status word: `running`/`waiting`/`idle`/`stopped`/`error`/etc.
+    state: String,
+    /// Seconds since the session's last hook activity (`now - since`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_activity_age_secs: Option<i64>,
+    /// Tool name on the most recent Pre/PostToolUse event (see `HookAttention`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_tool: Option<String>,
+    /// Kind of the most recent hook event: `turn_complete`/`tool_invoke`/`tool_error`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_reason: Option<String>,
+    /// Honored urgent flag (respects `urgent_expires_at`).
+    urgent: bool,
+}
+
+fn build_session_rows(
+    profile: &str,
+    instances: &[crate::session::Instance],
+) -> Vec<StatusSessionJson> {
+    instances
+        .iter()
+        .map(|inst| {
+            let (last_activity_age_secs, last_tool, last_reason, urgent) =
+                super::session_activity(&inst.id);
+            StatusSessionJson {
+                id: inst.id.clone(),
+                title: inst.title.clone(),
+                path: inst.project_path.clone(),
+                group: inst.group_path.clone(),
+                profile: profile.to_string(),
+                state: inst.status.as_str().to_string(),
+                last_activity_age_secs,
+                last_tool,
+                last_reason,
+                urgent,
+            }
+        })
+        .collect()
 }
 
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
@@ -48,9 +104,16 @@ pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
 
     if instances.is_empty() {
         if args.json {
-            println!(
-                r#"{{"waiting": 0, "running": 0, "idle": 0, "stopped": 0, "error": 0, "total": 0}}"#
-            );
+            let empty = StatusJson {
+                waiting: 0,
+                running: 0,
+                idle: 0,
+                stopped: 0,
+                error: 0,
+                total: 0,
+                sessions: Vec::new(),
+            };
+            println!("{}", serde_json::to_string(&empty)?);
         } else if args.quiet {
             println!("0");
         } else {
@@ -77,6 +140,7 @@ pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
             stopped: counts.stopped,
             error: counts.error,
             total: counts.total,
+            sessions: build_session_rows(storage.profile(), &instances),
         };
         println!("{}", serde_json::to_string(&status_json)?);
     } else if args.quiet {

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::Args;
 use serde::Serialize;
 
+use crate::cli::target::{self, TargetFilter};
 use crate::session::{Status, Storage};
 
 #[derive(Args)]
@@ -19,6 +20,15 @@ pub struct StatusArgs {
     /// Output as JSON
     #[arg(long)]
     json: bool,
+
+    /// Fleet selector. When any of `--all`, `--state`, `--errors`, `--group`,
+    /// `--ids`, `--path`, or `--profiles` is present, status resolves the
+    /// matched set (possibly across profiles), emits one row per session, and
+    /// recomputes counts over exactly that set — the read-only counterpart to
+    /// the bulk `send`/`restart` selectors. Unlike the mutating verbs, this
+    /// includes archived/snoozed sessions and the invoking session.
+    #[command(flatten)]
+    filter: TargetFilter,
 }
 
 #[derive(Default)]
@@ -72,33 +82,56 @@ struct StatusSessionJson {
     urgent: bool,
 }
 
+fn session_row(profile: &str, inst: &crate::session::Instance) -> StatusSessionJson {
+    let (last_activity_age_secs, last_tool, last_reason, urgent) =
+        super::session_activity(&inst.id);
+    StatusSessionJson {
+        id: inst.id.clone(),
+        title: inst.title.clone(),
+        path: inst.project_path.clone(),
+        group: inst.group_path.clone(),
+        profile: profile.to_string(),
+        state: inst.status.as_str().to_string(),
+        last_activity_age_secs,
+        last_tool,
+        last_reason,
+        urgent,
+    }
+}
+
 fn build_session_rows(
     profile: &str,
     instances: &[crate::session::Instance],
 ) -> Vec<StatusSessionJson> {
     instances
         .iter()
-        .map(|inst| {
-            let (last_activity_age_secs, last_tool, last_reason, urgent) =
-                super::session_activity(&inst.id);
-            StatusSessionJson {
-                id: inst.id.clone(),
-                title: inst.title.clone(),
-                path: inst.project_path.clone(),
-                group: inst.group_path.clone(),
-                profile: profile.to_string(),
-                state: inst.status.as_str().to_string(),
-                last_activity_age_secs,
-                last_tool,
-                last_reason,
-                urgent,
-            }
-        })
+        .map(|inst| session_row(profile, inst))
         .collect()
+}
+
+fn tally(counts: &mut StatusCounts, status: Status) {
+    match status {
+        Status::Running => counts.running += 1,
+        Status::Waiting => counts.waiting += 1,
+        Status::Idle => counts.idle += 1,
+        Status::Unknown => counts.idle += 1,
+        Status::Stopped => counts.stopped += 1,
+        Status::Error => counts.error += 1,
+        Status::Starting => counts.idle += 1,
+        Status::Deleting => {}
+        Status::Creating => {}
+    }
+    counts.total += 1;
 }
 
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
+    // Fleet-selector path: resolve the matched set (possibly cross-profile),
+    // including archived/snoozed and the invoking session (read-only verb).
+    if args.filter.has_selector() {
+        return run_filtered(profile, args).await;
+    }
+
     let storage = Storage::new(profile)?;
     let (mut instances, _) = storage.load_with_groups()?;
 
@@ -179,20 +212,116 @@ pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
 fn count_by_status(instances: &[crate::session::Instance]) -> StatusCounts {
     let mut counts = StatusCounts::default();
     for inst in instances {
-        match inst.status {
-            Status::Running => counts.running += 1,
-            Status::Waiting => counts.waiting += 1,
-            Status::Idle => counts.idle += 1,
-            Status::Unknown => counts.idle += 1,
-            Status::Stopped => counts.stopped += 1,
-            Status::Error => counts.error += 1,
-            Status::Starting => counts.idle += 1,
-            Status::Deleting => {}
-            Status::Creating => {}
-        }
-        counts.total += 1;
+        tally(&mut counts, inst.status);
     }
     counts
+}
+
+/// Sort priority for the filtered human table: most-actionable first
+/// (running, then error, then waiting), idle/stopped last. Mirrors the
+/// `fleet status` ordering so the native command reads the same.
+fn state_order(status: Status) -> u8 {
+    match status {
+        Status::Running => 0,
+        Status::Error => 1,
+        Status::Waiting => 2,
+        Status::Starting => 3,
+        Status::Idle | Status::Unknown => 4,
+        Status::Stopped => 5,
+        Status::Deleting | Status::Creating => 8,
+    }
+}
+
+/// Compact human age: `42s`, `7m`, `3h`, `5d`. `None` → `-`.
+fn fmt_age(secs: Option<i64>) -> String {
+    let Some(s) = secs else {
+        return "-".to_string();
+    };
+    if s < 60 {
+        format!("{s}s")
+    } else if s < 3600 {
+        format!("{}m", s / 60)
+    } else if s < 86_400 {
+        format!("{}h", s / 3600)
+    } else {
+        format!("{}d", s / 86_400)
+    }
+}
+
+/// Read-only fleet-selector status: resolve the matched set (possibly across
+/// profiles), then render JSON / quiet / human exactly like the unfiltered
+/// path but scoped to that set with recomputed counts. `resolve_targets`
+/// already refreshes the tmux cache and runs `update_status`, so states are
+/// live without the extra pass the unfiltered path does.
+async fn run_filtered(profile: &str, args: StatusArgs) -> Result<()> {
+    // exclude_id = None (show self), mutating = false (include archived/snoozed).
+    let targets = target::resolve_targets(profile, &args.filter, None, false)?;
+
+    let mut counts = StatusCounts::default();
+    for t in &targets {
+        tally(&mut counts, t.instance.status);
+    }
+
+    if args.json {
+        let sessions: Vec<StatusSessionJson> = targets
+            .iter()
+            .map(|t| session_row(&t.profile, &t.instance))
+            .collect();
+        let status_json = StatusJson {
+            waiting: counts.waiting,
+            running: counts.running,
+            idle: counts.idle,
+            stopped: counts.stopped,
+            error: counts.error,
+            total: counts.total,
+            sessions,
+        };
+        println!("{}", serde_json::to_string(&status_json)?);
+        return Ok(());
+    }
+
+    if args.quiet {
+        println!("{}", counts.waiting);
+        return Ok(());
+    }
+
+    if targets.is_empty() {
+        println!("No sessions match the filter.");
+        return Ok(());
+    }
+
+    let mut rows: Vec<&target::ResolvedTarget> = targets.iter().collect();
+    rows.sort_by(|a, b| {
+        state_order(a.instance.status)
+            .cmp(&state_order(b.instance.status))
+            .then_with(|| a.profile.cmp(&b.profile))
+            .then_with(|| a.instance.title.cmp(&b.instance.title))
+    });
+
+    println!(
+        "{} waiting • {} running • {} idle • {} stopped • {} error   (total {})",
+        counts.waiting, counts.running, counts.idle, counts.stopped, counts.error, counts.total
+    );
+    for t in rows {
+        let (age, _tool, _reason, urgent) = super::session_activity(&t.instance.id);
+        let group = if t.instance.group_path.is_empty() {
+            "-".to_string()
+        } else {
+            super::truncate(&t.instance.group_path, 14)
+        };
+        println!(
+            "  {:<8} {:<13} {:<16} {:<14} {:>5} {}{}",
+            t.instance.status.as_str(),
+            t.profile,
+            super::truncate_id(&t.instance.id, 16),
+            group,
+            fmt_age(age),
+            t.instance.title,
+            if urgent { "  !urgent" } else { "" },
+        );
+    }
+
+    Ok(())
 }
 
 fn print_status_group(

--- a/src/cli/target.rs
+++ b/src/cli/target.rs
@@ -1,0 +1,409 @@
+//! Shared multi-profile target selection for bulk fleet operations.
+//!
+//! `send`, `session restart`, and `status` all need the same question
+//! answered: "given these filters, which sessions am I acting on, and in which
+//! profile does each live?" This module is the single answer. It generalizes
+//! the per-profile `pick_targets_for_restart_all` into an AND-combined filter
+//! that can span every profile, mirroring the `scripts/fleet` join semantics
+//! (`list --all --json` ⋈ `status -v` on path) so one native primitive retires
+//! that stopgap.
+//!
+//! Safety invariants baked in here so no caller can forget them:
+//! - transitional states (`Deleting`/`Creating`) are never selected;
+//! - cockpit-mode sessions (lifecycle owned by `aoe serve`, not tmux) are
+//!   never selected;
+//! - the invoking session can be excluded (so a bulk `send`/`restart` never
+//!   clobbers or kills the operator's own pane);
+//! - for mutating verbs, archived/snoozed sessions are excluded unless the
+//!   caller opts in with `--include-archived`.
+
+use anyhow::Result;
+use clap::Args;
+
+use crate::session::{Instance, Status, Storage};
+
+/// AND-combined fleet selector, flattened into the bulk verbs' arg structs.
+///
+/// An empty filter selects every (non-transitional, non-cockpit) session in
+/// the active profile; each populated field narrows the set further. The verbs
+/// layer their own safety on top — notably `send` previews unless `--yes`.
+///
+/// Profile selection note: aoe's global `-p/--profile` already names the
+/// *ambient* profile, so the multi-profile subset selector here is spelled
+/// `--profiles a,b,c` (comma list) to avoid colliding with it; `--all` spans
+/// every profile.
+#[derive(Args, Debug, Default, Clone)]
+pub struct TargetFilter {
+    /// Operate across every profile, not just the active one.
+    #[arg(long)]
+    pub all: bool,
+
+    /// Restrict to these profiles (comma-separated). Implies cross-profile
+    /// scanning. Ignored when `--all` is set (which already spans all).
+    #[arg(long, value_delimiter = ',')]
+    pub profiles: Vec<String>,
+
+    /// Keep only sessions whose group path starts with one of these prefixes
+    /// (repeatable). Matches the fleet script's prefix semantics.
+    #[arg(long = "group")]
+    pub groups: Vec<String>,
+
+    /// Keep only sessions in one of these live states (repeatable):
+    /// running|waiting|idle|stopped|error|starting|unknown.
+    #[arg(long = "state", value_parser = parse_status_filter)]
+    pub states: Vec<Status>,
+
+    /// Shorthand for `--state error` — the highest-frequency fleet filter.
+    #[arg(long)]
+    pub errors: bool,
+
+    /// Keep only these session ids (comma-separated). Exact id or unique
+    /// id-prefix; non-matching ids are silently ignored (they may live in a
+    /// profile outside the scanned set).
+    #[arg(long, value_delimiter = ',')]
+    pub ids: Vec<String>,
+
+    /// Keep only sessions whose project path contains this substring.
+    #[arg(long)]
+    pub path: Option<String>,
+
+    /// Include archived/snoozed sessions in mutating verbs. Off by default so
+    /// a bulk op never wakes a parked session. No effect on `status`, which
+    /// always lists them.
+    #[arg(long = "include-archived")]
+    pub include_archived: bool,
+}
+
+fn parse_status_filter(s: &str) -> Result<Status, String> {
+    match s.to_ascii_lowercase().as_str() {
+        "running" => Ok(Status::Running),
+        "waiting" => Ok(Status::Waiting),
+        "idle" => Ok(Status::Idle),
+        "stopped" => Ok(Status::Stopped),
+        "error" => Ok(Status::Error),
+        "starting" => Ok(Status::Starting),
+        "unknown" => Ok(Status::Unknown),
+        other => Err(format!(
+            "unknown state '{other}' (expected running|waiting|idle|stopped|error|starting|unknown)"
+        )),
+    }
+}
+
+impl TargetFilter {
+    /// Whether the user supplied any selector. Callers use this to decide
+    /// bulk-vs-single dispatch: `send`/`restart` treat "filter present" as
+    /// "operate on the matched set" and "no filter + no identifier" as a
+    /// no-op guard rather than an accidental whole-fleet blast.
+    pub fn has_selector(&self) -> bool {
+        self.all
+            || !self.profiles.is_empty()
+            || !self.groups.is_empty()
+            || !self.states.is_empty()
+            || self.errors
+            || !self.ids.is_empty()
+            || self.path.is_some()
+    }
+
+    /// Effective state set, folding the `--errors` shorthand into `--state`.
+    fn effective_states(&self) -> Vec<Status> {
+        let mut states = self.states.clone();
+        if self.errors && !states.contains(&Status::Error) {
+            states.push(Status::Error);
+        }
+        states
+    }
+}
+
+/// A selected session plus the profile it was loaded from. Bulk verbs key on
+/// `profile` to open the right `Storage` for the follow-up mutation.
+pub struct ResolvedTarget {
+    pub profile: String,
+    pub instance: Instance,
+}
+
+/// Resolve the profile set to scan from the ambient profile + filter. `--all`
+/// wins; otherwise an explicit `--profiles` subset; otherwise just the ambient
+/// profile (empty string resolves to the configured default downstream in
+/// `Storage::new`).
+fn profiles_to_scan(ambient_profile: &str, filter: &TargetFilter) -> Result<Vec<String>> {
+    if filter.all {
+        return crate::session::list_profiles();
+    }
+    if !filter.profiles.is_empty() {
+        return Ok(filter.profiles.clone());
+    }
+    Ok(vec![ambient_profile.to_string()])
+}
+
+/// Resolve the full target set across all in-scope profiles.
+///
+/// `exclude_id` drops the invoking session (pass `Some(self_id)` for mutating
+/// verbs, `None` for `status` where the operator wants to see their own row).
+/// `mutating` gates the archived/snoozed exclusion: `true` for `send`/`restart`
+/// (respecting `--include-archived`), `false` for `status`.
+///
+/// Live status is refreshed before filtering so `--state`/`--errors` match the
+/// real current state, not the last persisted value.
+pub fn resolve_targets(
+    ambient_profile: &str,
+    filter: &TargetFilter,
+    exclude_id: Option<&str>,
+    mutating: bool,
+) -> Result<Vec<ResolvedTarget>> {
+    // One tmux cache refresh for the whole sweep; update_status reads from it.
+    crate::tmux::refresh_session_cache();
+
+    let states = filter.effective_states();
+    let profiles = profiles_to_scan(ambient_profile, filter)?;
+    let mut out = Vec::new();
+
+    for profile in &profiles {
+        let Ok(storage) = Storage::new(profile) else {
+            continue;
+        };
+        let Ok((mut instances, _groups)) = storage.load_with_groups() else {
+            continue;
+        };
+        // Resolve to the canonical profile name (handles ambient "").
+        let resolved_profile = storage.profile().to_string();
+
+        for inst in &mut instances {
+            inst.update_status();
+        }
+
+        for inst in instances {
+            if instance_passes(&inst, filter, &states, exclude_id, mutating) {
+                out.push(ResolvedTarget {
+                    profile: resolved_profile.clone(),
+                    instance: inst,
+                });
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// AND-combined acceptance test for one instance against the filter, plus the
+/// non-negotiable safety skips (transitional/cockpit states, self-exclusion,
+/// archived/snoozed for mutating verbs). Pure and side-effect-free so it is
+/// unit-testable without touching storage; `resolve_targets` is the I/O shell
+/// around it. `states` is the caller's `effective_states()` (errors folded in).
+fn instance_passes(
+    inst: &Instance,
+    filter: &TargetFilter,
+    states: &[Status],
+    exclude_id: Option<&str>,
+    mutating: bool,
+) -> bool {
+    if matches!(inst.status, Status::Deleting | Status::Creating) {
+        return false;
+    }
+    #[cfg(feature = "serve")]
+    if inst.cockpit_mode {
+        return false;
+    }
+    if let Some(skip) = exclude_id {
+        if inst.id == skip {
+            return false;
+        }
+    }
+    if mutating && !filter.include_archived && (inst.is_archived() || inst.is_snoozed()) {
+        return false;
+    }
+    if !filter.groups.is_empty()
+        && !filter
+            .groups
+            .iter()
+            .any(|g| inst.group_path.starts_with(g.as_str()))
+    {
+        return false;
+    }
+    if !states.is_empty() && !states.contains(&inst.status) {
+        return false;
+    }
+    if !filter.ids.is_empty()
+        && !filter
+            .ids
+            .iter()
+            .any(|id| inst.id == *id || inst.id.starts_with(id.as_str()))
+    {
+        return false;
+    }
+    if let Some(sub) = &filter.path {
+        if !inst.project_path.contains(sub.as_str()) {
+            return false;
+        }
+    }
+    true
+}
+
+/// The invoking session's own instance id, from the `AOE_INSTANCE_ID` env var
+/// aoe exports into every pane. `None` when not running under aoe (e.g. a bare
+/// CLI invocation), in which case there is no self to exclude.
+pub fn self_instance_id() -> Option<String> {
+    std::env::var("AOE_INSTANCE_ID")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inst(id: &str, status: Status) -> Instance {
+        let mut i = Instance::new(id, "/tmp/proj");
+        i.id = id.to_string();
+        i.status = status;
+        i
+    }
+
+    fn empty() -> TargetFilter {
+        TargetFilter::default()
+    }
+
+    // Mutating, empty filter: every live state passes; transitional states are
+    // always skipped. Mirrors the old `pick_targets_for_restart_all` invariant.
+    #[test]
+    fn empty_mutating_filter_skips_only_transitional() {
+        let f = empty();
+        let states = f.effective_states();
+        for (status, expect) in [
+            (Status::Running, true),
+            (Status::Waiting, true),
+            (Status::Idle, true),
+            (Status::Stopped, true),
+            (Status::Error, true),
+            (Status::Starting, true),
+            (Status::Unknown, true),
+            (Status::Deleting, false),
+            (Status::Creating, false),
+        ] {
+            assert_eq!(
+                instance_passes(&inst("x", status), &f, &states, None, true),
+                expect,
+                "status {status:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn exclude_id_drops_self() {
+        let f = empty();
+        let states = f.effective_states();
+        let me = inst("self-1", Status::Running);
+        assert!(!instance_passes(&me, &f, &states, Some("self-1"), true));
+        assert!(instance_passes(&me, &f, &states, Some("other"), true));
+    }
+
+    #[test]
+    fn errors_shorthand_folds_into_state_filter() {
+        let mut f = empty();
+        f.errors = true;
+        let states = f.effective_states();
+        assert!(instance_passes(
+            &inst("e", Status::Error),
+            &f,
+            &states,
+            None,
+            true
+        ));
+        assert!(!instance_passes(
+            &inst("r", Status::Running),
+            &f,
+            &states,
+            None,
+            true
+        ));
+    }
+
+    #[test]
+    fn state_filter_is_membership() {
+        let mut f = empty();
+        f.states = vec![Status::Waiting, Status::Idle];
+        let states = f.effective_states();
+        assert!(instance_passes(
+            &inst("w", Status::Waiting),
+            &f,
+            &states,
+            None,
+            true
+        ));
+        assert!(instance_passes(
+            &inst("i", Status::Idle),
+            &f,
+            &states,
+            None,
+            true
+        ));
+        assert!(!instance_passes(
+            &inst("r", Status::Running),
+            &f,
+            &states,
+            None,
+            true
+        ));
+    }
+
+    #[test]
+    fn id_filter_accepts_exact_and_prefix() {
+        let mut f = empty();
+        f.ids = vec!["abc".to_string()];
+        let states = f.effective_states();
+        assert!(instance_passes(
+            &inst("abc", Status::Running),
+            &f,
+            &states,
+            None,
+            true
+        ));
+        assert!(instance_passes(
+            &inst("abcdef", Status::Running),
+            &f,
+            &states,
+            None,
+            true
+        ));
+        assert!(!instance_passes(
+            &inst("xyz", Status::Running),
+            &f,
+            &states,
+            None,
+            true
+        ));
+    }
+
+    #[test]
+    fn group_filter_is_prefix_match() {
+        let mut f = empty();
+        f.groups = vec!["fleet".to_string()];
+        let states = f.effective_states();
+        let mut in_group = inst("a", Status::Running);
+        in_group.group_path = "fleet/sub".to_string();
+        let mut other = inst("b", Status::Running);
+        other.group_path = "other".to_string();
+        assert!(instance_passes(&in_group, &f, &states, None, true));
+        assert!(!instance_passes(&other, &f, &states, None, true));
+    }
+
+    #[test]
+    fn path_filter_is_substring() {
+        let mut f = empty();
+        f.path = Some("per-dev".to_string());
+        let states = f.effective_states();
+        let mut hit = inst("a", Status::Running);
+        hit.project_path = "/Users/x/GitProjects/per-dev".to_string();
+        let mut miss = inst("b", Status::Running);
+        miss.project_path = "/Users/x/GitProjects/other".to_string();
+        assert!(instance_passes(&hit, &f, &states, None, true));
+        assert!(!instance_passes(&miss, &f, &states, None, true));
+    }
+
+    #[test]
+    fn has_selector_reflects_populated_fields() {
+        assert!(!empty().has_selector());
+        let mut f = empty();
+        f.all = true;
+        assert!(f.has_selector());
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -16,8 +16,8 @@ use fs2::FileExt as _;
 use serde_json::Value;
 
 pub use status_file::{
-    cleanup_hook_status_dir, hook_status_dir, read_hook_session_id, read_hook_status,
-    read_hook_urgent,
+    cleanup_hook_status_dir, hook_status_dir, read_hook_attention, read_hook_session_id,
+    read_hook_status, read_hook_urgent, HookAttention,
 };
 
 /// Base directory for all AoE hook status files.

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -67,6 +67,22 @@ pub fn read_hook_session_id(instance_id: &str) -> Option<String> {
     }
 }
 
+/// Whether an `urgent` record's explicit `urgent_expires_at` (if present) has
+/// already passed. A record with no expiry never expires here — the producer
+/// (`attention-urgent`) always writes one, so legacy/expiry-less records stay
+/// honored by design. Shared by [`read_hook_urgent`] and
+/// [`read_hook_attention`] so the auto-expiry rule has a single source of truth.
+fn urgent_expired(value: &serde_json::Value) -> bool {
+    let Some(exp) = value.get("urgent_expires_at").and_then(|v| v.as_i64()) else {
+        return false;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    now > exp
+}
+
 /// Read the urgent flag from the hook-written `attention.json` for the given
 /// instance. Set by the `attention-urgent` script (cx-scripts) when the agent
 /// surfaces something genuinely time-sensitive (expiring device code, hard
@@ -92,16 +108,68 @@ pub fn read_hook_urgent(instance_id: &str) -> bool {
     {
         return false;
     }
-    if let Some(exp) = value.get("urgent_expires_at").and_then(|v| v.as_i64()) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
-        if now > exp {
-            return false;
-        }
-    }
-    true
+    !urgent_expired(&value)
+}
+
+/// Per-session activity/attention metadata parsed from `attention.json`, which
+/// the Claude attention-signal hook rewrites every turn. Powers the
+/// `last_activity_*` fields in `aoe list`/`status --json` so consumers can see
+/// how long ago a session was active and what it last did without scraping
+/// panes. Every field is optional: a session not running under the hook (or
+/// whose file predates a field) simply omits it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HookAttention {
+    /// Attention tier (0 = most urgent). From `tier`.
+    pub tier: Option<i64>,
+    /// What kind of event last fired: `turn_complete`, `tool_invoke`, or
+    /// `tool_error`. From `reason`.
+    pub reason: Option<String>,
+    /// Unix seconds of the most recent hook event = last activity. From `since`.
+    pub since: Option<i64>,
+    /// Tool name on the last Pre/PostToolUse event. From `tool`. After a
+    /// toolless turn-complete this reflects the *prior* tool; `since` is always
+    /// the true last-activity time.
+    pub tool: Option<String>,
+    /// Unix seconds when this attention record expires. From `expires_at`.
+    pub expires_at: Option<i64>,
+    /// Honored `urgent` flag — true only when set AND `urgent_expires_at` (if
+    /// present) has not passed, matching [`read_hook_urgent`].
+    pub urgent: bool,
+}
+
+/// Read the full attention record for an instance from `attention.json`.
+///
+/// Returns `None` when the file is absent or unparseable; individual fields are
+/// `None`/false when their key is missing. Shares the read path and urgent
+/// auto-expiry rule with [`read_hook_urgent`] — callers that need only the
+/// urgent bool should keep using that lighter function (it is on the polling
+/// hot path), while list/status JSON uses this to emit the richer row.
+pub fn read_hook_attention(instance_id: &str) -> Option<HookAttention> {
+    let dir = hook_status_dir(instance_id).ok()?;
+    let path = dir.join("attention.json");
+    let content = std::fs::read_to_string(&path).ok()?;
+    let value = serde_json::from_str::<serde_json::Value>(&content).ok()?;
+
+    let urgent = value
+        .get("urgent")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+        && !urgent_expired(&value);
+
+    Some(HookAttention {
+        tier: value.get("tier").and_then(|v| v.as_i64()),
+        reason: value
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        since: value.get("since").and_then(|v| v.as_i64()),
+        tool: value
+            .get("tool")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        expires_at: value.get("expires_at").and_then(|v| v.as_i64()),
+        urgent,
+    })
 }
 
 /// Remove the hook status directory for a given instance (cleanup on stop/delete).
@@ -359,6 +427,70 @@ mod tests {
     #[test]
     fn read_hook_urgent_returns_false_for_unsafe_id() {
         assert!(!read_hook_urgent("../etc"));
+    }
+
+    #[test]
+    fn test_read_hook_attention_full_record() {
+        let id = "test_attention_full";
+        let future = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        let body = format!(
+            r#"{{"tier":0,"reason":"tool_invoke","since":1700000000,"tool":"Bash","expires_at":{future},"urgent":true,"urgent_expires_at":{future}}}"#
+        );
+        let dir = write_attention_json(id, &body);
+        let att = read_hook_attention(id).expect("record should parse");
+        assert_eq!(att.tier, Some(0));
+        assert_eq!(att.reason.as_deref(), Some("tool_invoke"));
+        assert_eq!(att.since, Some(1_700_000_000));
+        assert_eq!(att.tool.as_deref(), Some("Bash"));
+        assert_eq!(att.expires_at, Some(future as i64));
+        assert!(att.urgent);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_hook_attention_none_when_absent() {
+        assert_eq!(read_hook_attention("test_attention_no_file"), None);
+    }
+
+    #[test]
+    fn test_read_hook_attention_partial_record() {
+        // turn_complete with no tool: tool is None, since/reason present.
+        let id = "test_attention_partial";
+        let dir = write_attention_json(id, r#"{"reason":"turn_complete","since":1700000123}"#);
+        let att = read_hook_attention(id).expect("record should parse");
+        assert_eq!(att.reason.as_deref(), Some("turn_complete"));
+        assert_eq!(att.since, Some(1_700_000_123));
+        assert_eq!(att.tool, None);
+        assert_eq!(att.tier, None);
+        assert!(!att.urgent);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_hook_attention_urgent_respects_expiry() {
+        // urgent flag set but past its expiry => urgent must be false, while
+        // the rest of the record still parses.
+        let id = "test_attention_urgent_expired";
+        let dir = write_attention_json(
+            id,
+            r#"{"urgent":true,"urgent_expires_at":1,"since":1700000000}"#,
+        );
+        let att = read_hook_attention(id).expect("record should parse");
+        assert!(!att.urgent);
+        assert_eq!(att.since, Some(1_700_000_000));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_hook_attention_none_when_malformed() {
+        let id = "test_attention_bad_json";
+        let dir = write_attention_json(id, "{ not json");
+        assert_eq!(read_hook_attention(id), None);
+        fs::remove_dir_all(dir).ok();
     }
 
     #[test]


### PR DESCRIPTION
Adds a `TargetFilter` selector to `send`, `restart`, and `status` so one invocation can act on many sessions instead of one id at a time.

## What
New composable selectors for `send` / `restart` / `status`:
- `--all`, `--group <g>`, `--profiles <p,...>`, `--state <s>`, `--errors`, `--ids <id,...>`, `--path <glob>`

## Why
Fleet operations (broadcast a message, restart every errored session, status a group) currently require scripting a loop over ids. A native filter makes bulk ops first-class and consistent across the three verbs.

## Stacking
> Draft until #2012 merges. This branch currently contains the activity-metadata commit from #2012 as its base; once that merges I will rebase so this PR shows only the bulk-ops commit (`86b60f41`).