### PR TITLE
feat(cli): profile lock/unlock/status commands

### DIFF
--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -6,6 +6,8 @@ use std::io::{self, Write};
 
 use crate::session;
 
+// Note: serde_json and dirs crates used for manifest handling; ensure they're in Cargo.toml
+
 #[derive(Subcommand)]
 pub enum ProfileCommands {
     /// List all profiles
@@ -40,6 +42,24 @@ pub enum ProfileCommands {
         /// Profile name (optional, shows current if not provided)
         name: Option<String>,
     },
+
+    /// Lock a profile to prevent account binding changes
+    Lock {
+        /// Profile name, or --all for all profiles
+        name: Option<String>,
+        /// Lock all profiles
+        #[arg(long)]
+        all: bool,
+    },
+
+    /// Unlock a profile
+    Unlock {
+        /// Profile name
+        name: String,
+    },
+
+    /// Show profile lock status and bound account
+    Status,
 }
 
 #[tracing::instrument(target = "cli.session", skip_all)]
@@ -58,6 +78,17 @@ pub async fn run(command: Option<ProfileCommands>) -> Result<()> {
                 show_default_profile().await
             }
         }
+        Some(ProfileCommands::Lock { name, all }) => {
+            if all {
+                lock_all_profiles().await
+            } else if let Some(n) = name {
+                lock_profile(&n).await
+            } else {
+                bail!("profile lock requires a name or --all")
+            }
+        }
+        Some(ProfileCommands::Unlock { name }) => unlock_profile(&name).await,
+        Some(ProfileCommands::Status) => show_profile_status().await,
     }
 }
 
@@ -136,4 +167,109 @@ async fn set_default_profile(name: &str) -> Result<()> {
     session::set_default_profile(name)?;
     println!("✓ Default profile set to: {}", name);
     Ok(())
+}
+
+async fn lock_profile(name: &str) -> Result<()> {
+    // Read manifest, validate profile exists, update lock status
+    let manifest = load_profile_lock_manifest()?;
+    if !manifest.bindings.contains_key(name) {
+        bail!("Profile '{}' not found in manifest", name);
+    }
+    update_profile_lock(name, true)?;
+    println!("✓ Locked profile: {}", name);
+    Ok(())
+}
+
+async fn lock_all_profiles() -> Result<()> {
+    // Read manifest and lock all profiles
+    let manifest = load_profile_lock_manifest()?;
+    for profile in manifest.bindings.keys() {
+        update_profile_lock(profile, true)?;
+    }
+    println!("✓ Locked all profiles");
+    Ok(())
+}
+
+async fn unlock_profile(name: &str) -> Result<()> {
+    // Unlock a specific profile
+    let manifest = load_profile_lock_manifest()?;
+    if !manifest.bindings.contains_key(name) {
+        bail!("Profile '{}' not found in manifest", name);
+    }
+    update_profile_lock(name, false)?;
+    println!("✓ Unlocked profile: {}", name);
+    Ok(())
+}
+
+async fn show_profile_status() -> Result<()> {
+    // Show lock status for all profiles with their bound accounts
+    let manifest = load_profile_lock_manifest()?;
+    println!(
+        "Profile Lock Status (manifest: locked = {}):",
+        manifest.locked
+    );
+    println!();
+    for (name, binding) in &manifest.bindings {
+        let locked_indicator = if binding.locked { "🔒" } else { "🔓" };
+        let collision_marker = if binding.collision.is_some() {
+            " ⚠️"
+        } else {
+            ""
+        };
+        println!(
+            "  {} {:<20} account={}{}",
+            locked_indicator, name, binding.account, collision_marker
+        );
+    }
+    Ok(())
+}
+
+// Helper: load profile-lock.json manifest
+fn load_profile_lock_manifest() -> Result<ProfileLockManifest> {
+    let manifest_path = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?
+        .join(".claude-accounts/profile-lock.json");
+
+    if !manifest_path.exists() {
+        bail!("Profile lock manifest not found: {:?}", manifest_path);
+    }
+
+    let content = std::fs::read_to_string(&manifest_path)?;
+    let manifest: ProfileLockManifest = serde_json::from_str(&content)?;
+    Ok(manifest)
+}
+
+// Helper: update profile lock status in manifest
+fn update_profile_lock(profile: &str, locked: bool) -> Result<()> {
+    let manifest_path = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?
+        .join(".claude-accounts/profile-lock.json");
+
+    let mut manifest = load_profile_lock_manifest()?;
+    if let Some(binding) = manifest.bindings.get_mut(profile) {
+        binding.locked = locked;
+    }
+
+    let content = serde_json::to_string_pretty(&manifest)?;
+    std::fs::write(&manifest_path, content)?;
+    Ok(())
+}
+
+// Manifest types (mirror from cx-scripts spec)
+#[derive(serde::Deserialize, serde::Serialize)]
+struct ProfileLockManifest {
+    version: u32,
+    locked: bool,
+    bindings: std::collections::HashMap<String, ProfileBinding>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct ProfileBinding {
+    account: String,
+    billing: String,
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    collision: Option<String>,
+    #[serde(default)]
+    locked: bool,
 }


### PR DESCRIPTION
Implements Layer 2 of the profile-lock design. Adds three new aoe profile subcommands for profile locking via manifest. See companion Layer 1 PR in per-dev. ⏳ Needs: lock enforcement on aoe add, session-move enforcement, e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Profile Lock Management Commands

## Overview
This PR implements Layer 2 of the profile-lock feature by adding three new CLI subcommands for managing profile access control: `aoe profile lock`, `aoe profile unlock`, and `aoe profile status`.

## What Changed

**Added Commands:**
- **`aoe profile lock <name> | --all`**: Lock a specific profile by name or lock all profiles at once using the `--all` flag. Validates that the profile exists before locking.
- **`aoe profile unlock <name>`**: Unlock a specific profile by name. Validates that the profile exists before unlocking.
- **`aoe profile status`**: Display the lock state of all profiles along with bound account information and collision markers.

**Implementation Details:**
- Lock state is persisted in a JSON manifest file at `~/.claude-accounts/profile-lock.json`
- Each profile binding tracks its lock state (`locked` boolean flag)
- Manifest is loaded before lock/unlock operations to validate profile existence
- Lock state changes are immediately written back to disk
- Proper error handling that prevents users from locking/unlocking non-existent profiles

**Code Additions:**
- Three new enum variants in `ProfileCommands`: `Lock`, `Unlock`, and `Status`
- New helper functions: `lock_profile()`, `lock_all_profiles()`, `unlock_profile()`, `show_profile_status()`, `load_profile_lock_manifest()`, and `update_profile_lock()`
- Serde-backed data structures for manifest serialization/deserialization
- **Lines changed**: +136 additions

## Benefits
- **Access Control**: Users can prevent accidental or unauthorized account binding changes to important profiles
- **Persistence**: Lock state survives across CLI sessions via JSON manifest storage
- **Visibility**: Status command provides clear overview of which profiles are locked and their bound accounts
- **Flexibility**: Both single-profile and bulk-locking options available
- **Validation**: Built-in checks prevent operations on non-existent profiles

## Remaining Work (As Noted in PR)
- Integration of lock enforcement into `aoe add -p <name>` to reject additions to locked profiles
- Session move enforcement to block account binding changes when a profile is locked
- End-to-end tests covering the complete lock/unlock cycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->