### PR TITLE
fix(session): keep wrapped-agent idle status instead of masking to Unknown

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3539,11 +3539,18 @@ fn resolve_detected_status(
     match detected {
         Status::Idle if has_command_override => {
             // Custom commands run agents through wrapper scripts that appear
-            // as shell processes to tmux. Only declare Error when the pane is
-            // actually dead; don't use shell-stale since the shell IS the
-            // expected wrapper process.
+            // as shell processes to tmux, so we can't trust the pane's current
+            // command here; decide from pane *content* instead. A pane that is
+            // still rendering the agent TUI is genuinely parked at its prompt,
+            // so a detected Idle is real and we keep it (otherwise on_idle /
+            // on_waiting status hooks never fire for wrapped agents, e.g. an
+            // opencode session launched via agent_command_override, see #2022).
+            // Only declare Error when the pane is actually dead; a live pane
+            // without recognizable agent content stays Unknown.
             if is_dead {
                 Status::Error
+            } else if pane_has_agent_content(pane_content, tool) {
+                Status::Idle
             } else {
                 Status::Unknown
             }
@@ -5407,6 +5414,19 @@ mod tests {
         assert_eq!(
             resolve_detected_status(Status::Idle, false, true, true, "$ ", "opencode"),
             Status::Unknown
+        );
+    }
+
+    #[test]
+    fn test_resolve_detected_status_command_override_agent_content_stays_idle() {
+        // A wrapped agent (agent_command_override) whose pane still renders the
+        // agent TUI must keep its detected Idle so on_idle / on_waiting status
+        // hooks fire; previously the override masked every Idle to Unknown and
+        // those hooks never ran (#2022).
+        let content = "ctrl+p commands \u{2022} OpenCode 1.16.2";
+        assert_eq!(
+            resolve_detected_status(Status::Idle, false, false, true, content, "opencode"),
+            Status::Idle
         );
     }
 


### PR DESCRIPTION
## Description

A session launched via `agent_command_override` (e.g. an `opencode` wrapper script) reported `running` <-> `unknown` forever and never fired `on_idle` / `on_waiting` status hooks. See #2022.

The root cause is not WSL-specific (the issue surfaced there, but the trigger is the command override). `resolve_detected_status` blanket-mapped every detected `Idle` to `Unknown` whenever `has_command_override` was true, on the theory that wrapper scripts appear as shell processes to tmux. OpenCode is pane-polled (no status hooks), and its resting input prompt correctly detects as `Idle`; the override branch then rewrote that `Idle` to `Unknown`. That is the exact `running` <-> `unknown` oscillation in the reporter's diagnostic log: `Running` while generating, `Idle`->`Unknown` while parked at the prompt, so no idle/waiting transition ever fired.

The fix decides from pane *content* instead, which is robust against wrapper scripts that show up as shells:

- pane still rendering the agent TUI (`pane_has_agent_content`) -> keep `Idle`, so hooks fire
- bare shell or unrecognizable pane -> stays `Unknown`, unchanged from before
- dead pane -> `Error`, unchanged

Note on semantics for the reporter: a finished turn parked at the prompt is `idle`, not `waiting` (every hook agent maps end-of-turn `Stop` to `idle`; `waiting` is reserved for blocking permission prompts). So the hook to wire for "turn done, your input needed" is `on_idle`. OpenCode permission prompts already classified as `Waiting` and passed through the override branch unaffected; only `Idle` was being lost.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A)
- [x] For UI changes: included screenshot or recording (N/A, no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this is pure status-classification logic; covered by a unit test (`test_resolve_detected_status_command_override_agent_content_stays_idle`) alongside the existing `resolve_detected_status` suite, which is the right altitude for this change.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8, 1M context)

**Any Additional AI Details you'd like to share:** Claude diagnosed the root cause and drafted the fix and this PR text via back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixed a bug where sessions launched through wrapper scripts (like opencode) would oscillate between Running and Unknown states and never trigger idle/waiting hooks. 

**What Changed:**
The fix modifies how the session status is determined when a command override is present. Instead of automatically treating wrapped agents as in an Unknown state, the code now checks the actual pane content:
- If the pane still shows the agent's UI and the detected status is Idle, it keeps Idle (allowing hooks to fire properly)
- If the pane shows a bare shell or is unrecognizable, it remains Unknown
- If the pane is dead, it remains Error

A new unit test was added to verify this behavior works correctly.

**What Moved/Added/Removed:**
- Modified: `src/session/instance.rs` (23 lines added, 3 lines removed)
- Added: Unit test `test_resolve_detected_status_command_override_agent_content_stays_idle`
- Removed: Logic that unconditionally marked idle states as unknown for wrapped agents

**Benefits:**
- Sessions with wrapped agents now properly fire `on_idle` and `on_waiting` hooks when the turn completes
- Eliminates status oscillation between Running and Unknown
- Maintains correct status tracking by checking actual pane content rather than making assumptions about wrapper script behavior

**Technical Details:**
The `resolve_detected_status` function now uses pane content analysis (`pane_has_agent_content`) as the determining factor rather than just the presence of a command override flag. This means wrapped agents that still render the agent TUI will properly report Idle status (mapped from agent Stop), while bare shells without agent UI will default to Unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->