### PR TITLE
fix(theme): make the theme a single global preference

### DIFF
--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -20,13 +20,14 @@ mod v009_update_check_mode;
 mod v010_drop_legacy_live_send_exit_chord;
 mod v011_relocate_sandbox_image;
 mod v012_acp_rename;
+mod v013_strip_profile_theme;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 12;
+const CURRENT_VERSION: u32 = 13;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -95,6 +96,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 12,
         name: "acp_rename",
         run: v012_acp_rename::run,
+    },
+    Migration {
+        version: 13,
+        name: "strip_profile_theme",
+        run: v013_strip_profile_theme::run,
     },
 ];
 

--- a/src/migrations/v013_strip_profile_theme.rs
+++ b/src/migrations/v013_strip_profile_theme.rs
@@ -1,0 +1,158 @@
+//! Migration v013: strip per-profile theme overrides.
+//!
+//! The theme became a single global preference: one theme paints every surface
+//! (TUI boot, Settings close, tmux status bar, web `/api/theme/current`)
+//! regardless of which session profile is active. Before that, the web
+//! dashboard's theme picker wrote `name` / `color_mode` into the *active
+//! profile's* `config.toml`, while the TUI wrote them to the global config and
+//! booted from it. A profile-level theme then shadowed the global pick on every
+//! Settings open/close, flipping the theme (e.g. empire -> rose-pine) until the
+//! next restart.
+//!
+//! This removes `name` and `color_mode` from the `[theme]` table of every
+//! `profiles/*/config.toml`, leaving the global `config.toml` (the authoritative
+//! theme) untouched. `idle_decay_minutes` stays profile-overridable, so only
+//! those two keys are pulled. Idempotent: a profile with no theme override is
+//! left alone.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+use tracing::{debug, info};
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    let profiles_dir = app_dir.join("profiles");
+    if !profiles_dir.exists() {
+        debug!("No profiles dir; nothing to strip for v013");
+        return Ok(());
+    }
+    for entry in fs::read_dir(&profiles_dir)? {
+        let entry = entry?;
+        if entry.path().is_dir() {
+            strip_profile_theme(&entry.path().join("config.toml"))?;
+        }
+    }
+    Ok(())
+}
+
+/// Keys pulled from a profile's `[theme]` table. `idle_decay_minutes` stays
+/// profile-overridable and is intentionally not listed.
+const GLOBAL_THEME_KEYS: &[&str] = &["name", "color_mode"];
+
+fn strip_profile_theme(path: &Path) -> Result<()> {
+    if !path.exists() {
+        debug!("Profile config {} does not exist, skipping", path.display());
+        return Ok(());
+    }
+    let content = fs::read_to_string(path)?;
+    let mut doc: toml::Table = content
+        .parse()
+        .with_context(|| format!("Failed to parse {} during v013 migration", path.display()))?;
+
+    let Some(theme) = doc.get_mut("theme").and_then(|t| t.as_table_mut()) else {
+        return Ok(());
+    };
+
+    let mut removed = Vec::new();
+    for key in GLOBAL_THEME_KEYS {
+        if theme.remove(*key).is_some() {
+            removed.push(*key);
+        }
+    }
+    if removed.is_empty() {
+        return Ok(());
+    }
+    // Drop an emptied [theme] table so the file doesn't keep a dangling header.
+    if theme.is_empty() {
+        doc.remove("theme");
+    }
+
+    info!(
+        "Stripping global-only theme keys {:?} from profile config {} (theme is now global)",
+        removed,
+        path.display()
+    );
+    let new_content = toml::to_string_pretty(&doc)?;
+    fs::write(path, new_content)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, content).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn strips_name_and_color_mode_but_keeps_idle_decay() {
+        let (_dir, path) = write(
+            r#"
+[theme]
+name = "rose-pine"
+color_mode = "palette"
+idle_decay_minutes = 5
+"#,
+        );
+        strip_profile_theme(&path).unwrap();
+        let result: toml::Table = fs::read_to_string(&path).unwrap().parse().unwrap();
+        let theme = result.get("theme").and_then(|t| t.as_table()).unwrap();
+        assert!(theme.get("name").is_none(), "name should be stripped");
+        assert!(
+            theme.get("color_mode").is_none(),
+            "color_mode should be stripped"
+        );
+        assert_eq!(
+            theme.get("idle_decay_minutes").and_then(|v| v.as_integer()),
+            Some(5),
+            "idle_decay_minutes stays profile-overridable"
+        );
+    }
+
+    #[test]
+    fn drops_table_when_only_global_keys_present() {
+        let (_dir, path) = write(
+            r#"
+[theme]
+name = "rose-pine"
+
+[session]
+default_tool = "claude"
+"#,
+        );
+        strip_profile_theme(&path).unwrap();
+        let result: toml::Table = fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert!(
+            result.get("theme").is_none(),
+            "an emptied [theme] table is removed"
+        );
+        // Unrelated sections are untouched.
+        assert!(result.get("session").is_some());
+    }
+
+    #[test]
+    fn idempotent_when_no_theme_override() {
+        let (_dir, path) = write(
+            r#"
+[session]
+default_tool = "claude"
+"#,
+        );
+        let before = fs::read_to_string(&path).unwrap();
+        strip_profile_theme(&path).unwrap();
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after, "no theme override means no rewrite");
+    }
+
+    #[test]
+    fn missing_file_is_a_noop() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("nope.toml");
+        assert!(strip_profile_theme(&path).is_ok());
+    }
+}

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -48,7 +48,7 @@ pub use system::{
     filesystem_home, get_about, get_current_theme, get_profile_settings, get_resolved_theme,
     get_settings, get_settings_schema, get_update_status, list_agents, list_groups, list_profiles,
     list_sounds, list_themes, mark_web_tour_seen, rename_profile, serve_sound_file,
-    update_profile_settings, update_settings,
+    update_profile_settings, update_settings, update_theme,
 };
 pub use telemetry::{
     get_telemetry_status, post_telemetry_seen, post_telemetry_structured_interaction,

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -283,6 +283,107 @@ pub async fn get_settings_schema() -> Json<Vec<crate::session::settings_schema::
     Json(crate::session::settings_schema::schema())
 }
 
+/// Body of `PATCH /api/theme`. Either field may be omitted to leave it
+/// unchanged.
+#[derive(serde::Deserialize)]
+pub struct ThemePatch {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub color_mode: Option<crate::session::config::ColorMode>,
+}
+
+/// `PATCH /api/theme` sets the global theme name and/or color mode and returns
+/// the freshly resolved theme so the caller can repaint.
+///
+/// The theme is a global preference (see `config::resolve_theme_name`): it
+/// lives in the global config, never a profile, so one theme paints every
+/// surface. This is a dedicated, non-elevated write (like the web-tour flag)
+/// rather than routing through `PATCH /api/settings`: a cosmetic theme change
+/// must not trip the passphrase wall that guards the general settings surface
+/// (`requires_elevation` keeps profile-settings preference writes off that wall
+/// for the same reason). `read_only` still blocks it.
+pub async fn update_theme(
+    State(state): State<Arc<AppState>>,
+    body: Result<Json<ThemePatch>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    let Json(patch) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+    // Reject an unknown theme name so a typo can't repaint to the `default`
+    // fallback. Empty is allowed (clears back to the default builtin).
+    if let Some(name) = &patch.name {
+        if !name.is_empty()
+            && !crate::tui::styles::available_themes()
+                .iter()
+                .any(|t| t == name)
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "unknown_theme",
+                    "message": format!("Unknown theme '{name}'"),
+                })),
+            )
+                .into_response();
+        }
+    }
+    let result = tokio::task::spawn_blocking(move || {
+        let mut config = crate::session::Config::load_or_warn();
+        if let Some(name) = patch.name {
+            config.theme.name = name;
+        }
+        if let Some(mode) = patch.color_mode {
+            config.theme.color_mode = mode;
+        }
+        crate::session::save_config(&config)?;
+        Ok::<_, anyhow::Error>(crate::tui::styles::resolve_theme(
+            &config.effective_theme_name(),
+        ))
+    })
+    .await;
+
+    match result {
+        Ok(Ok(resolved)) => match serde_json::to_value(&resolved) {
+            Ok(val) => (StatusCode::OK, Json(val)).into_response(),
+            Err(e) => {
+                tracing::error!(target: "http.api.system", "theme serialization failed: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "serialize_failed", "message": "Failed to serialize theme"})),
+                )
+                    .into_response()
+            }
+        },
+        Ok(Err(e)) => {
+            tracing::warn!(target: "http.api.system", "theme update failed: {}", e);
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "update_failed", "message": "Failed to update theme"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(target: "http.api.system", "theme update panicked: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 /// Marks the web dashboard's first-run tour as seen for this server.
 ///
 /// Single-purpose write so the cosmetic flag never widens the
@@ -385,10 +486,10 @@ pub async fn get_resolved_theme(
     Json(resolved)
 }
 
-/// `GET /api/theme/current` returns the resolved theme for the active
-/// profile (the picker's current selection). Resolved through
-/// `profile_config::resolve_config_or_warn` so per-profile theme
-/// overrides land in the right place. Sync work runs in
+/// `GET /api/theme/current` returns the resolved theme to paint. Theme is a
+/// global preference, not profile-merged, so this reads the global config
+/// (see `config::resolve_theme_name`); every surface paints the same theme
+/// regardless of the active session profile. Sync work runs in
 /// `spawn_blocking`.
 pub async fn get_current_theme(
     State(state): State<Arc<AppState>>,
@@ -396,12 +497,7 @@ pub async fn get_current_theme(
     let profile = state.profile.clone();
     tracing::debug!(profile = %profile, "GET /api/theme/current");
     let resolved = tokio::task::spawn_blocking(move || {
-        let cfg = crate::session::profile_config::resolve_config_or_warn(&profile);
-        let name = if cfg.theme.name.is_empty() {
-            "default".to_string()
-        } else {
-            cfg.theme.name
-        };
+        let name = crate::session::config::resolve_theme_name();
         crate::tui::styles::resolve_theme(&name)
     })
     .await

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -339,7 +339,11 @@ pub async fn update_theme(
         }
     }
     let result = tokio::task::spawn_blocking(move || {
-        let mut config = crate::session::Config::load_or_warn();
+        // `Config::load()` (not `load_or_warn`) so a corrupt config.toml is not
+        // silently replaced with defaults, wiping every other setting, just to
+        // change a theme. Mirrors `mark_web_tour_seen`. A parse error surfaces
+        // as a 400 below.
+        let mut config = crate::session::Config::load()?;
         if let Some(name) = patch.name {
             config.theme.name = name;
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1262,6 +1262,9 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/themes", get(api::list_themes))
         .route("/api/themes/{name}", get(api::get_resolved_theme))
         .route("/api/theme/current", get(api::get_current_theme))
+        // Dedicated, non-elevated global-theme write: a cosmetic theme change
+        // must not trip the passphrase wall on `PATCH /api/settings`.
+        .route("/api/theme", patch(api::update_theme))
         .route("/api/sounds", get(api::list_sounds))
         .route("/api/sounds/file/{name}", get(api::serve_sound_file))
         // Push notifications

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1351,17 +1351,20 @@ pub enum ColorMode {
 #[derive(Debug, Clone, Serialize, Deserialize, SettingsSection)]
 #[setting_section(name = "theme", category = "Theme")]
 pub struct ThemeConfig {
-    /// Color theme for the TUI.
+    /// Color theme for the TUI. A global preference: one theme paints every
+    /// surface regardless of the active session profile (see
+    /// `config::resolve_theme_name`), so it is not profile-overridable.
     #[serde(default)]
-    #[setting(label = "Theme", widget = "custom:theme-name")]
+    #[setting(label = "Theme", widget = "custom:theme-name", global_only)]
     pub name: String,
     /// Truecolor (24-bit RGB) or palette (xterm-256). Use palette if your
-    /// terminal mangles RGB escapes.
+    /// terminal mangles RGB escapes. Global, like the theme itself.
     #[serde(default)]
     #[setting(
         label = "Color Mode",
         widget = "select",
-        options = "truecolor:truecolor,palette:palette"
+        options = "truecolor:truecolor,palette:palette",
+        global_only
     )]
     pub color_mode: ColorMode,
     /// Off by default (0). Set a positive value to opt in: a freshly-stopped
@@ -2036,6 +2039,23 @@ impl Config {
             self.session.session_id_poller_max_threads = 1;
         }
     }
+
+    /// Effective theme name to paint, mapping the empty default to the
+    /// `default` builtin. Theme is a global preference (see
+    /// [`resolve_theme_name`]); callers read it from the global config, never
+    /// the profile-merged config.
+    pub fn effective_theme_name(&self) -> String {
+        if self.theme.name.is_empty() {
+            "default".to_string()
+        } else {
+            self.theme.name.clone()
+        }
+    }
+
+    /// Whether the theme requests xterm-256 palette downsampling.
+    pub fn theme_palette_mode(&self) -> bool {
+        matches!(self.theme.color_mode, ColorMode::Palette)
+    }
 }
 
 pub fn load_config() -> Result<Option<Config>> {
@@ -2051,6 +2071,26 @@ pub fn save_config(config: &Config) -> Result<()> {
     let content = toml::to_string_pretty(config)?;
     super::atomic_write(&path, content.as_bytes())?;
     Ok(())
+}
+
+/// Theme name to paint, read from the **global** config only.
+///
+/// The theme is a global preference: it is never profile-merged, so the TUI
+/// boot, the Settings-close repaint, the tmux status bar, and the web
+/// `/api/theme/current` all paint the same theme regardless of which session
+/// profile is active. Reading the profile-merged theme on some surfaces but
+/// the global theme on others let a per-profile override (which the web theme
+/// picker used to write) shadow the global pick on every Settings open/close,
+/// flipping the theme until the next restart. An empty name maps to the
+/// `default` builtin, matching the web dashboard's empty-name fallback.
+pub fn resolve_theme_name() -> String {
+    Config::load_or_warn().effective_theme_name()
+}
+
+/// Whether the global theme requests xterm-256 palette downsampling. Reads the
+/// global config only, for the same reason as [`resolve_theme_name`].
+pub fn resolve_theme_palette_mode() -> bool {
+    Config::load_or_warn().theme_palette_mode()
 }
 
 /// Resolve the active profile name.

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -110,16 +110,13 @@ pub fn apply_all_tmux_options(
     use crate::tui::styles::load_theme;
 
     if should_apply_tmux_status_bar() {
-        let config = crate::session::config::Config::load_or_warn();
-        let theme_name = if config.theme.name.is_empty() {
-            "empire"
-        } else {
-            &config.theme.name
-        };
+        // Theme is a global preference; match the TUI's empty-name fallback
+        // (`default`) so the status bar can't paint a different theme.
+        let theme_name = crate::session::config::resolve_theme_name();
         // Always use truecolor here: tmux receives hex color values (#rrggbb)
         // and manages its own escape-sequence rendering via TERM/terminfo.
         // Palette mode only affects the TUI's direct terminal output.
-        let theme = load_theme(theme_name);
+        let theme = load_theme(&theme_name);
 
         if let Err(e) = apply_status_bar(session_name, title, branch, sandbox, &theme) {
             tracing::debug!(target: "tmux.status", "Failed to apply tmux status bar: {}", e);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -242,18 +242,12 @@ impl App {
         // Check if we need to show welcome or changelog dialogs
         let mut config = Config::load_or_warn();
 
-        // Load theme from config, defaulting to the `default` builtin if
-        // empty so the TUI matches the web dashboard's empty-name fallback.
-        let theme_name = if config.theme.name.is_empty() {
-            "default"
-        } else {
-            &config.theme.name
-        };
-        let palette_mode = matches!(
-            config.theme.color_mode,
-            crate::session::config::ColorMode::Palette
-        );
-        let theme = crate::tui::styles::load_theme_with_mode(theme_name, palette_mode);
+        // Theme is a global preference: read it from the global config, never
+        // profile-merged, so boot matches Settings-close and the web dashboard
+        // (see config::resolve_theme_name). Empty maps to the `default` builtin.
+        let theme_name = config.effective_theme_name();
+        let palette_mode = config.theme_palette_mode();
+        let theme = crate::tui::styles::load_theme_with_mode(&theme_name, palette_mode);
         let current_version = env!("CARGO_PKG_VERSION").to_string();
 
         if no_agents {
@@ -264,7 +258,7 @@ impl App {
             // changelog so the warning is what the user sees first, and avoid
             // overwriting a malformed config.toml with defaults via save_config.
         } else if !config.app_state.has_seen_welcome {
-            home.show_intro(theme_name);
+            home.show_intro(&theme_name);
             config.app_state.has_seen_welcome = true;
             config.app_state.last_seen_version = Some(current_version);
             save_config(&config)?;
@@ -488,17 +482,10 @@ impl App {
         // SetTheme dispatched from the Settings view preview/apply flow will
         // re-load the theme with raw RGB colors, "breaking the coloration"
         // on terminals that were working with the user's palette preference
-        // (Termius/mosh edge cases, 8-bit-only TTYs, etc.).
-        let palette_mode = crate::session::resolve_config(
-            self.home.active_profile.as_deref().unwrap_or("default"),
-        )
-        .map(|c| {
-            matches!(
-                c.theme.color_mode,
-                crate::session::config::ColorMode::Palette
-            )
-        })
-        .unwrap_or(false);
+        // (Termius/mosh edge cases, 8-bit-only TTYs, etc.). Read from the
+        // global config: theme (and its color_mode) is a global preference,
+        // not profile-merged.
+        let palette_mode = crate::session::config::resolve_theme_palette_mode();
         self.theme = crate::tui::styles::load_theme_with_mode(name, palette_mode);
         self.needs_redraw = true;
     }

--- a/src/tui/dialogs/confirm.rs
+++ b/src/tui/dialogs/confirm.rs
@@ -102,6 +102,13 @@ impl ConfirmDialog {
         &self.action
     }
 
+    /// The `[Yes]` button hit-rect, populated on `render`. Test-only so a
+    /// click path can be exercised at the exact coordinates the dialog draws.
+    #[cfg(test)]
+    pub(crate) fn yes_button_area_for_test(&self) -> ratatui::layout::Rect {
+        self.yes_button_area
+    }
+
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
         match key.code {
             KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => DialogResult::Cancel,

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -759,6 +759,24 @@ impl HomeView {
         }
     }
 
+    /// Discard unsaved Settings changes: force-close the view, clear the
+    /// confirm state, and revert any live theme preview back to the saved
+    /// config theme. Shared by the keyboard (Esc/q -> confirm) and mouse
+    /// (click [Yes]) discard paths so the two can't drift. The mouse path
+    /// previously skipped the theme revert, so discarding via a click left a
+    /// previewed theme applied until the next restart.
+    pub(super) fn discard_settings_changes(&mut self) -> Action {
+        if let Some(ref mut settings) = self.settings_view {
+            settings.force_close();
+        }
+        self.settings_view = None;
+        self.confirm_dialog = None;
+        self.settings_close_confirm = false;
+        // Theme is a global preference, not profile-merged: revert any live
+        // preview to the saved global theme so boot and Settings agree.
+        Action::SetTheme(crate::session::config::resolve_theme_name())
+    }
+
     pub fn handle_dialog_click(&mut self, col: u16, row: u16) -> bool {
         if let Some(dialog) = &mut self.intro_dialog {
             let click = dialog.handle_click(col, row);
@@ -855,18 +873,19 @@ impl HomeView {
                         let dont_ask_again = dialog.dont_ask_again();
                         self.confirm_dialog = None;
                         if self.settings_close_confirm {
-                            // Discard branch: force-close settings (the
-                            // keyboard path runs the same sequence).
-                            if let Some(ref mut settings) = self.settings_view {
-                                settings.force_close();
+                            // Discard branch: run the exact same sequence as the
+                            // keyboard path, including the theme revert. Omitting
+                            // it here stranded a live theme preview until the next
+                            // restart when the user discarded via a mouse click.
+                            self.pending_dialog_click_action =
+                                Some(self.discard_settings_changes());
+                        } else {
+                            if action == "quit" && dont_ask_again {
+                                self.disable_confirm_before_quit();
                             }
-                            self.settings_view = None;
-                            self.settings_close_confirm = false;
+                            self.pending_dialog_click_action =
+                                self.dispatch_confirm_submit(&action);
                         }
-                        if action == "quit" && dont_ask_again {
-                            self.disable_confirm_before_quit();
-                        }
-                        self.pending_dialog_click_action = self.dispatch_confirm_submit(&action);
                     }
                 }
             }
@@ -1192,19 +1211,7 @@ impl HomeView {
                     }
                     DialogResult::Submit(_) => {
                         // User chose to discard changes
-                        if let Some(ref mut settings) = self.settings_view {
-                            settings.force_close();
-                        }
-                        self.settings_view = None;
-                        self.confirm_dialog = None;
-                        self.settings_close_confirm = false;
-                        let config = resolve_config_or_warn(&self.config_profile());
-                        let theme_name = if config.theme.name.is_empty() {
-                            "default".to_string()
-                        } else {
-                            config.theme.name
-                        };
-                        return Some(Action::SetTheme(theme_name));
+                        return Some(self.discard_settings_changes());
                     }
                 }
             }
@@ -1220,14 +1227,11 @@ impl HomeView {
                     self.settings_view = None;
                     // Refresh config-dependent state in case settings changed
                     self.refresh_from_config();
-                    // Reload theme from saved config
-                    let config = resolve_config_or_warn(&self.config_profile());
-                    let theme_name = if config.theme.name.is_empty() {
-                        "default".to_string()
-                    } else {
-                        config.theme.name
-                    };
-                    return Some(Action::SetTheme(theme_name));
+                    // Reload the theme from the global config (theme is a global
+                    // preference, not profile-merged) so the repaint matches boot.
+                    return Some(Action::SetTheme(
+                        crate::session::config::resolve_theme_name(),
+                    ));
                 }
                 SettingsAction::UnsavedChangesWarning => {
                     // Show confirmation dialog
@@ -2338,7 +2342,7 @@ impl HomeView {
         }
     }
 
-    fn open_settings(&mut self) {
+    pub(super) fn open_settings(&mut self) {
         let project_path = self
             .selected_session
             .as_ref()

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10122,4 +10122,65 @@ mod apply_session_id_updates {
             "no tmux session means no publish target"
         );
     }
+
+    /// Discarding unsaved Settings changes via a mouse click on the
+    /// confirmation dialog's [Yes] button must revert a live theme preview,
+    /// exactly like the keyboard discard path. Regression for the
+    /// empire -> rose-pine flip where the click path closed Settings but
+    /// never dispatched `SetTheme`, leaving the previewed theme applied until
+    /// the next restart.
+    #[test]
+    #[serial]
+    fn settings_mouse_discard_reverts_theme_preview() {
+        use crate::tui::dialogs::ConfirmDialog;
+        use crate::tui::styles::load_theme;
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut env = create_test_env_empty();
+        let view = &mut env.view;
+        view.open_settings();
+        assert!(view.settings_view.is_some(), "settings view should open");
+
+        // Stand in the state reached after the user previewed a theme (so the
+        // view has unsaved changes) and pressed Esc to close: the unsaved-
+        // changes confirm dialog floats over the settings takeover.
+        view.settings_close_confirm = true;
+        view.confirm_dialog = Some(ConfirmDialog::new(
+            "Unsaved Changes",
+            "You have unsaved changes. Discard them?",
+            "discard_settings",
+        ));
+
+        // Render once so the dialog's [Yes] button hit-rect is populated at the
+        // exact coordinates it draws.
+        let theme = load_theme("empire");
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                view.render(f, area, &theme, None, None);
+            })
+            .unwrap();
+
+        let yes = view
+            .confirm_dialog
+            .as_ref()
+            .unwrap()
+            .yes_button_area_for_test();
+        assert!(yes.width > 0, "render should populate the [Yes] hit-rect");
+
+        // Click the center of [Yes] to discard.
+        view.handle_dialog_click(yes.x + yes.width / 2, yes.y + yes.height / 2);
+
+        // The click path must queue the same theme revert the keyboard path
+        // returns. Before the fix this was `None` and the previewed theme stuck.
+        assert!(
+            matches!(view.pending_dialog_click_action, Some(Action::SetTheme(_))),
+            "mouse discard should queue a SetTheme revert, got {:?}",
+            view.pending_dialog_click_action
+        );
+        assert!(view.settings_view.is_none(), "settings should be closed");
+        assert!(!view.settings_close_confirm, "confirm flag should reset");
+    }
 }

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -643,6 +643,12 @@ pub fn build_fields_for_category(
     for desc in schema()
         .into_iter()
         .filter(|d| d.category == category.schema_name())
+        // Global-only fields (e.g. the theme) are not profile-overridable, so
+        // only surface them under Global scope. Otherwise a Profile/Repo edit
+        // would write an override the read path ignores, stranding the value
+        // (the empire->rose-pine flip). Enforces the documented `global_only`
+        // semantics that nothing else was checking.
+        .filter(|d| scope == SettingsScope::Global || d.profile_overridable)
     {
         // The per-target logging matrix expands one descriptor into N rows.
         if matches!(&desc.widget, WidgetKind::Custom { id } if id == "logging-targets") {

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -12,6 +12,7 @@ import {
   getSettingsSchema,
   setDefaultProfile,
   updateProfileSettings,
+  updateTheme,
 } from "../lib/api";
 import type { ProfileInfo, SettingsFieldDescriptor } from "../lib/types";
 import { SchemaSection } from "./settings/SchemaSection";
@@ -327,6 +328,38 @@ export function SettingsView({
     [settings, saveField],
   );
 
+  // The theme name and color mode are global preferences, not
+  // profile-overridable: write them through the dedicated non-elevated
+  // /api/theme endpoint instead of the profile settings PATCH. Writing the
+  // theme into a profile let a stale override shadow the global pick on every
+  // Settings open/close (the empire->rose-pine flip). Profile-overridable rows
+  // in the same tab (e.g. idle decay) still write to the selected profile.
+  const saveThemeField = useCallback(
+    async (
+      section: string,
+      field: string,
+      value: unknown,
+    ): Promise<boolean> => {
+      const overridable = schema.some(
+        (d) =>
+          d.section === section && d.field === field && d.profile_overridable,
+      );
+      if (overridable) return saveSubField(section, field, value);
+      const sectionData = (settings?.theme ?? {}) as Record<string, unknown>;
+      updateLocal({ theme: { ...sectionData, [field]: value } });
+      setSaving(true);
+      setSaveError(null);
+      const ok = await updateTheme({ [field]: value });
+      setSaving(false);
+      if (!ok) {
+        setSaveError("Failed to save, please try again");
+        loadSettings();
+      }
+      return ok;
+    },
+    [schema, settings, updateLocal, loadSettings, saveSubField],
+  );
+
   const renderTabContent = () => {
     if (
       !settings &&
@@ -439,7 +472,7 @@ export function SettingsView({
             section="theme"
             schema={schema}
             values={(settings?.theme ?? {}) as Record<string, unknown>}
-            onSaveField={saveSubField}
+            onSaveField={saveThemeField}
           />
         );
       case "diff":

--- a/web/src/components/__tests__/SettingsView.themeSave.test.tsx
+++ b/web/src/components/__tests__/SettingsView.themeSave.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+//
+// The theme is a global preference: the Settings theme tab must route the
+// global-only fields (theme name, color mode) to the dedicated PATCH /api/theme
+// endpoint, while a profile-overridable row in the same tab (idle decay) still
+// writes the selected profile. Pins `saveThemeField`'s per-field routing so a
+// regression can't quietly send the theme back into a profile (the
+// empire->rose-pine flip). The end-to-end persist path lives in
+// web/tests/live/settings-persistence-theme.spec.ts.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { SettingsView } from "../SettingsView";
+
+const PROFILES = [{ name: "main", is_default: true }];
+
+const THEME_SCHEMA = [
+  {
+    section: "theme",
+    field: "name",
+    category: "Theme",
+    label: "Theme",
+    description: "",
+    widget: { kind: "custom", id: "theme-name" },
+    web_write: { policy: "allow" },
+    profile_overridable: false,
+    validation: { rule: "none" },
+    advanced: false,
+  },
+  {
+    section: "theme",
+    field: "color_mode",
+    category: "Theme",
+    label: "Color Mode",
+    description: "",
+    widget: {
+      kind: "select",
+      options: [
+        { value: "truecolor", label: "truecolor" },
+        { value: "palette", label: "palette" },
+      ],
+    },
+    web_write: { policy: "allow" },
+    profile_overridable: false,
+    validation: { rule: "none" },
+    advanced: false,
+  },
+  {
+    section: "theme",
+    field: "idle_decay_minutes",
+    category: "Theme",
+    label: "Idle Decay (minutes)",
+    description: "",
+    widget: { kind: "number", min: 0 },
+    web_write: { policy: "allow" },
+    profile_overridable: true,
+    validation: { rule: "none" },
+    advanced: false,
+  },
+];
+
+const updateTheme = vi.fn(() => Promise.resolve(true));
+const updateProfileSettings = vi.fn(() => Promise.resolve(true));
+
+vi.mock("../../lib/api", () => ({
+  fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchSettings: vi.fn(() =>
+    Promise.resolve({ theme: { name: "empire", idle_decay_minutes: 0 } }),
+  ),
+  getSettingsSchema: vi.fn(() => Promise.resolve(THEME_SCHEMA)),
+  setDefaultProfile: vi.fn(() => Promise.resolve(true)),
+  createProfile: vi.fn(() => Promise.resolve(true)),
+  renameProfile: vi.fn(() => Promise.resolve(true)),
+  deleteProfile: vi.fn(() => Promise.resolve(true)),
+  updateProfileSettings: (name: string, updates: Record<string, unknown>) =>
+    updateProfileSettings(name, updates),
+  updateTheme: (patch: Record<string, unknown>) => updateTheme(patch),
+  fetchThemes: vi.fn(() => Promise.resolve(["empire", "dracula"])),
+}));
+
+vi.mock("../../hooks/useResolvedTheme", () => ({
+  dispatchThemePickerChanged: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  updateTheme.mockClear();
+  updateProfileSettings.mockClear();
+});
+
+function renderThemeTab() {
+  return render(
+    <SettingsView
+      onClose={() => {}}
+      tab="theme"
+      onSelectTab={vi.fn()}
+      onServerAboutRefresh={() => {}}
+    />,
+  );
+}
+
+/** A <select> that carries an <option> with this value. Labels in FormFields
+ *  are not wired to their controls, so we locate by option value rather than
+ *  accessible name (and dodge the duplicated mobile/desktop tab strips). */
+function selectWithOption(value: string): HTMLSelectElement {
+  const found = Array.from(
+    document.querySelectorAll<HTMLSelectElement>("select"),
+  ).find((s) => Array.from(s.options).some((o) => o.value === value));
+  if (!found) throw new Error(`no <select> has an option "${value}"`);
+  return found;
+}
+
+/** The <input> rendered next to a unique field label. */
+function inputByLabel(text: string): HTMLInputElement {
+  const input = screen.getByText(text).closest("div")?.querySelector("input");
+  if (!input) throw new Error(`no <input> under label "${text}"`);
+  return input;
+}
+
+describe("SettingsView theme tab save routing", () => {
+  it("writes the theme name to /api/theme, not the profile", async () => {
+    renderThemeTab();
+    // The theme dropdown is populated asynchronously from fetchThemes.
+    await waitFor(() => selectWithOption("dracula"));
+    fireEvent.change(selectWithOption("dracula"), {
+      target: { value: "dracula" },
+    });
+    await waitFor(() =>
+      expect(updateTheme).toHaveBeenCalledWith({ name: "dracula" }),
+    );
+    expect(updateProfileSettings).not.toHaveBeenCalled();
+  });
+
+  it("writes color mode to /api/theme too", async () => {
+    renderThemeTab();
+    await waitFor(() => selectWithOption("palette"));
+    fireEvent.change(selectWithOption("palette"), {
+      target: { value: "palette" },
+    });
+    await waitFor(() =>
+      expect(updateTheme).toHaveBeenCalledWith({ color_mode: "palette" }),
+    );
+    expect(updateProfileSettings).not.toHaveBeenCalled();
+  });
+
+  it("routes a profile-overridable row (idle decay) to the profile, not /api/theme", async () => {
+    renderThemeTab();
+    await screen.findByText("Idle Decay (minutes)");
+    const idle = inputByLabel("Idle Decay (minutes)");
+    // NumberField re-syncs from its prop unless focused, so focus before typing.
+    fireEvent.focus(idle);
+    fireEvent.change(idle, { target: { value: "5" } });
+    fireEvent.blur(idle);
+    await waitFor(() =>
+      expect(updateProfileSettings).toHaveBeenCalledWith("main", {
+        theme: { idle_decay_minutes: 5 },
+      }),
+    );
+    expect(updateTheme).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/onboarding/__tests__/ThemeIntro.test.tsx
+++ b/web/src/components/onboarding/__tests__/ThemeIntro.test.tsx
@@ -14,19 +14,14 @@ import {
   waitFor,
 } from "@testing-library/react";
 
-const updateProfileSettings = vi.fn(() => Promise.resolve(true));
+const updateTheme = vi.fn(() => Promise.resolve(true));
 vi.mock("../../../lib/api", () => ({
   fetchThemes: vi.fn(() =>
     Promise.resolve(["default", "modus-vivendi", "empire"]),
   ),
-  fetchProfiles: vi.fn(() =>
-    Promise.resolve([
-      { name: "work", is_default: false },
-      { name: "default", is_default: true },
-    ]),
-  ),
-  updateProfileSettings: (name: string, updates: Record<string, unknown>) =>
-    updateProfileSettings(name, updates),
+  // The theme is a global preference, written via the dedicated /api/theme
+  // endpoint (not a profile settings PATCH).
+  updateTheme: (patch: { name?: string }) => updateTheme(patch),
 }));
 
 const dispatchSpy = vi.fn();
@@ -39,8 +34,8 @@ import { ThemeIntro } from "../ThemeIntro";
 afterEach(() => {
   cleanup();
   dispatchSpy.mockClear();
-  updateProfileSettings.mockClear();
-  updateProfileSettings.mockImplementation(() => Promise.resolve(true));
+  updateTheme.mockClear();
+  updateTheme.mockImplementation(() => Promise.resolve(true));
 });
 
 async function mount() {
@@ -58,13 +53,11 @@ describe("ThemeIntro", () => {
     expect(screen.getAllByRole("option")).toHaveLength(3);
   });
 
-  it("persists the picked theme to the default profile and repaints", async () => {
+  it("persists the picked theme globally and repaints", async () => {
     await mount();
     fireEvent.click(screen.getByRole("option", { name: "modus-vivendi" }));
     await waitFor(() =>
-      expect(updateProfileSettings).toHaveBeenCalledWith("default", {
-        theme: { name: "modus-vivendi" },
-      }),
+      expect(updateTheme).toHaveBeenCalledWith({ name: "modus-vivendi" }),
     );
     expect(dispatchSpy).toHaveBeenCalledWith("modus-vivendi");
     expect(
@@ -82,11 +75,11 @@ describe("ThemeIntro", () => {
     );
     fireEvent.click(screen.getByRole("option", { name: "empire" }));
     await waitFor(() => expect(dispatchSpy).toHaveBeenCalledWith("empire"));
-    expect(updateProfileSettings).toHaveBeenCalledTimes(2);
+    expect(updateTheme).toHaveBeenCalledTimes(2);
   });
 
   it("shows an error and does not repaint when the save fails", async () => {
-    updateProfileSettings.mockImplementation(() => Promise.resolve(false));
+    updateTheme.mockImplementation(() => Promise.resolve(false));
     await mount();
     fireEvent.click(screen.getByRole("option", { name: "empire" }));
     await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());

--- a/web/src/hooks/useThemeMutation.ts
+++ b/web/src/hooks/useThemeMutation.ts
@@ -1,24 +1,20 @@
 import { useCallback, useState } from "react";
-import { fetchProfiles, updateProfileSettings } from "../lib/api";
+import { updateTheme } from "../lib/api";
 import { dispatchThemePickerChanged } from "./useResolvedTheme";
 
 export type ThemeSelectResult = { ok: true } | { ok: false; error: string };
 
 const SAVE_ERROR = "Could not save theme. Please try again.";
 
-/** The profile a first-run user has no reason to pick yet: the default one,
- *  matching how the settings profile picker resolves the active profile. */
-async function resolveDefaultProfile(): Promise<string> {
-  const profiles = await fetchProfiles();
-  return profiles.find((p) => p.is_default)?.name ?? "default";
-}
-
 /**
- * Persist a theme selection to the default profile and repaint, used by the
- * first-run theme welcome modal. Persist-then-paint: the dashboard only
- * repaints after the PATCH lands (via dispatchThemePickerChanged, which routes
- * through useResolvedTheme's single apply path), so a failed save never leaves
- * the applied/cached theme ahead of what is on disk (the #1510 bug class).
+ * Persist a theme selection and repaint, used by the first-run theme welcome
+ * modal. The theme is a global preference, so this writes the global config
+ * (PATCH /api/theme), not a profile override; writing it per-profile let a
+ * stale override shadow the TUI's global pick and flip the theme on every
+ * Settings open/close. Persist-then-paint: the dashboard only repaints after
+ * the PATCH lands (via dispatchThemePickerChanged, which routes through
+ * useResolvedTheme's single apply path), so a failed save never leaves the
+ * applied/cached theme ahead of what is on disk (the #1510 bug class).
  */
 export function useThemeMutation(): {
   select: (name: string) => Promise<ThemeSelectResult>;
@@ -30,8 +26,7 @@ export function useThemeMutation(): {
     async (name: string): Promise<ThemeSelectResult> => {
       setPending(true);
       try {
-        const profile = await resolveDefaultProfile();
-        const ok = await updateProfileSettings(profile, { theme: { name } });
+        const ok = await updateTheme({ name });
         if (!ok) return { ok: false, error: SAVE_ERROR };
         dispatchThemePickerChanged(name);
         return { ok: true };

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -24,6 +24,7 @@ import {
   setSessionPin,
   setSessionSnooze,
   updateProfileSettings,
+  updateTheme,
   PROFILE_WRITABLE_SECTIONS,
   updateSessionGroup,
   type ServerAbout,
@@ -320,5 +321,39 @@ describe("isDebugBuild", () => {
 
   it("returns false when the about payload is undefined", () => {
     expect(isDebugBuild(undefined)).toBe(false);
+  });
+});
+
+// The theme is a global preference written through the dedicated, non-elevated
+// PATCH /api/theme endpoint (not the profile settings PATCH that the picker used
+// to hit). These pin the request shape and the boolean result contract so the
+// api-client surface stays covered when Playwright is gated off.
+describe("updateTheme", () => {
+  it("PATCHes /api/theme with the name and returns true on ok", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ name: "dracula" }));
+    const ok = await updateTheme({ name: "dracula" });
+    expect(ok).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/theme");
+    expect(init!.method).toBe("PATCH");
+    expect(JSON.parse(init!.body as string)).toEqual({ name: "dracula" });
+  });
+
+  it("forwards a color_mode-only patch", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+    await updateTheme({ color_mode: "palette" });
+    expect(JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string)).toEqual({
+      color_mode: "palette",
+    });
+  });
+
+  it("returns false on a non-ok response", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 403 }));
+    expect(await updateTheme({ name: "dracula" })).toBe(false);
+  });
+
+  it("returns false on a network error", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    expect(await updateTheme({ name: "dracula" })).toBe(false);
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -180,6 +180,27 @@ export async function updateSettings(
 }
 
 /**
+ * Sets the global theme (name and/or color mode). Dedicated endpoint, not
+ * `PATCH /api/settings`: the theme is a global preference but cosmetic, so it
+ * must not trip the passphrase/elevation wall the general settings surface
+ * carries. Returns false on read-only servers (403) or network failure.
+ */
+export async function updateTheme(
+  patch: { name?: string; color_mode?: string },
+): Promise<boolean> {
+  try {
+    const res = await fetch("/api/theme", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Marks the first-run dashboard tour as seen for this server. Single-purpose
  * endpoint (not PATCH /api/settings) so the cosmetic flag stays off the
  * passphrase/elevation wall. Returns false on read-only servers (403) or

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -185,9 +185,10 @@ export async function updateSettings(
  * must not trip the passphrase/elevation wall the general settings surface
  * carries. Returns false on read-only servers (403) or network failure.
  */
-export async function updateTheme(
-  patch: { name?: string; color_mode?: string },
-): Promise<boolean> {
+export async function updateTheme(patch: {
+  name?: string;
+  color_mode?: string;
+}): Promise<boolean> {
   try {
     const res = await fetch("/api/theme", {
       method: "PATCH",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -103,7 +103,8 @@
       "specs": ["tests/live/settings-persistence-theme.spec.ts"],
       "components": [
         "web/src/components/SettingsView.tsx",
-        "web/src/components/settings/SchemaSection.tsx"
+        "web/src/components/settings/SchemaSection.tsx",
+        "web/src/lib/api.ts"
       ]
     },
     {
@@ -2432,7 +2433,11 @@
       "kind": "live-playwright",
       "risk": "medium",
       "specs": ["tests/live/theme-onboarding.spec.ts"],
-      "components": ["web/src/components/onboarding/ThemeIntro.tsx"]
+      "components": [
+        "web/src/components/onboarding/ThemeIntro.tsx",
+        "web/src/hooks/useThemeMutation.ts",
+        "web/src/lib/api.ts"
+      ]
     },
     {
       "id": "onboarding.theme-welcome-unit",
@@ -2442,7 +2447,10 @@
         "src/components/onboarding/__tests__/ThemeIntro.test.tsx",
         "src/lib/__tests__/onboarding.test.ts"
       ],
-      "components": ["web/src/components/onboarding/ThemeIntro.tsx"]
+      "components": [
+        "web/src/components/onboarding/ThemeIntro.tsx",
+        "web/src/hooks/useThemeMutation.ts"
+      ]
     },
     {
       "id": "shortcuts.single-source",

--- a/web/tests/live/acp-stories/settings-theme-color-mode.spec.ts
+++ b/web/tests/live/acp-stories/settings-theme-color-mode.spec.ts
@@ -83,15 +83,14 @@ base(
       await expect(colorMode).toHaveValue(nextMode);
 
       // The PATCH lands; this poll reads the persisted value back via
-      // GET /api/profiles/<name>/settings so a regression that drops the
-      // write surfaces here, not as a missing event later.
-      const profiles: Array<{ name: string; is_default?: boolean }> =
-        await fetch(`${serve.baseUrl}/api/profiles`).then((r) => r.json());
-      const defaultProfile =
-        profiles.find((p) => p.is_default)?.name ?? profiles[0]?.name ?? "main";
-      const profileUrl = `${serve.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
+      // GET /api/settings so a regression that drops the write surfaces
+      // here, not as a missing event later. Color mode is a global
+      // preference (like the theme), so it persists to the global config,
+      // not a profile.
       await expect(async () => {
-        const after = await fetch(profileUrl).then((r) => r.json());
+        const after = await fetch(`${serve.baseUrl}/api/settings`).then((r) =>
+          r.json(),
+        );
         expect(after?.theme?.color_mode).toBe(nextMode);
       }).toPass({ timeout: 5_000 });
 

--- a/web/tests/live/acp-stories/settings-theme-failure-revert.spec.ts
+++ b/web/tests/live/acp-stories/settings-theme-failure-revert.spec.ts
@@ -36,11 +36,12 @@ base(
         });
       });
 
-      // Reject the settings PATCH at the browser boundary. The rest of
-      // the surface (themes list, current theme, GETs against the
-      // profile) stays on the real serve so the rendering paths behave
-      // like production. Only the write path 500s.
-      await page.route(/.*\/api\/profiles\/[^/]+\/settings$/, (route) => {
+      // Reject the theme PATCH at the browser boundary. The rest of the
+      // surface (themes list, current theme) stays on the real serve so
+      // the rendering paths behave like production. The theme is a global
+      // preference, so the picker writes the dedicated /api/theme endpoint;
+      // only that write path 500s.
+      await page.route(/.*\/api\/theme$/, (route) => {
         if (route.request().method() === "PATCH") {
           return route.fulfill({ status: 500, body: "boom" });
         }

--- a/web/tests/live/settings-persistence-theme-passphrase.spec.ts
+++ b/web/tests/live/settings-persistence-theme-passphrase.spec.ts
@@ -140,8 +140,11 @@ test("theme picker persists across reload + restart without passphrase prompt", 
   servePreauthed,
   page,
 }) => {
-  const defaultProfile = await resolveDefaultProfile(servePreauthed);
-  const profileUrl = `${servePreauthed.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
+  // The theme is a global preference written via the dedicated,
+  // non-elevated /api/theme endpoint, so persistence is read back from the
+  // global settings, not a profile config. The point of this test is that a
+  // passphrase user can change a cosmetic theme without an elevation prompt.
+  const globalUrl = `${servePreauthed.baseUrl}/api/settings`;
 
   await bootDashboardAndNavigate(page, servePreauthed, "/settings/theme");
 
@@ -176,7 +179,7 @@ test("theme picker persists across reload + restart without passphrase prompt", 
   await themeSelect.selectOption(SWITCH_TO);
 
   await expect(async () => {
-    const after = await fetch(profileUrl, {
+    const after = await fetch(globalUrl, {
       headers: authHeaders(servePreauthed),
     }).then((r) => r.json());
     expect(after?.theme?.name).toBe(SWITCH_TO);
@@ -217,14 +220,14 @@ test("theme picker persists across reload + restart without passphrase prompt", 
     ),
     page.reload(),
   ]);
-  const afterReload = await fetch(profileUrl, {
+  const afterReload = await fetch(globalUrl, {
     headers: authHeaders(servePreauthed),
   }).then((r) => r.json());
   expect(afterReload?.theme?.name).toBe(SWITCH_TO);
 
   await servePreauthed.restart();
   await reLogin(servePreauthed);
-  const afterRestart = await fetch(profileUrl, {
+  const afterRestart = await fetch(globalUrl, {
     headers: authHeaders(servePreauthed),
   }).then((r) => r.json());
   expect(afterRestart?.theme?.name).toBe(SWITCH_TO);

--- a/web/tests/live/settings-persistence-theme.spec.ts
+++ b/web/tests/live/settings-persistence-theme.spec.ts
@@ -56,17 +56,10 @@ test("theme picker repaints, persists across reload and serve restart (#1510)", 
   serve,
   page,
 }) => {
-  // The dashboard's `selectedProfile` resolves to whichever profile
-  // GET /api/profiles flags `is_default`. On a fresh `aoe serve` that
-  // is "main" (bootstrap profile), not "default", so we cannot
-  // hard-code the path; query the server and use whatever name it
-  // hands back.
-  const profiles: Array<{ name: string; is_default?: boolean }> = await fetch(
-    `${serve.baseUrl}/api/profiles`,
-  ).then((r) => r.json());
-  const defaultProfile =
-    profiles.find((p) => p.is_default)?.name ?? profiles[0]?.name ?? "main";
-  const profileUrl = `${serve.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
+  // The theme is a global preference: the picker writes the dedicated
+  // /api/theme endpoint, so persistence is read back from the global
+  // settings (GET /api/settings), not a profile config.
+  const globalUrl = `${serve.baseUrl}/api/settings`;
 
   // Drive the picker through the actual settings UI, not the REST
   // endpoint, so the regression that landed the dispatch-before-PATCH
@@ -95,9 +88,9 @@ test("theme picker repaints, persists across reload and serve restart (#1510)", 
 
   await themeSelect.selectOption(SWITCH_TO);
 
-  // Server-side: PATCH landed and the profile config reflects the pick.
+  // Server-side: PATCH landed and the global config reflects the pick.
   await expect(async () => {
-    const after = await fetch(profileUrl).then((r) => r.json());
+    const after = await fetch(globalUrl).then((r) => r.json());
     expect(after?.theme?.name).toBe(SWITCH_TO);
   }).toPass({ timeout: 5_000 });
 
@@ -129,12 +122,12 @@ test("theme picker repaints, persists across reload and serve restart (#1510)", 
   const afterReload = await page.evaluate(async (url) => {
     const r = await fetch(url);
     return r.json();
-  }, profileUrl);
+  }, globalUrl);
   expect(afterReload?.theme?.name).toBe(SWITCH_TO);
 
   // Persistence across `aoe serve` restart (process exits, config.toml
   // is what survives). The restart() helper reuses the same port.
   await serve.restart();
-  const afterRestart = await fetch(profileUrl).then((r) => r.json());
+  const afterRestart = await fetch(globalUrl).then((r) => r.json());
   expect(afterRestart?.theme?.name).toBe(SWITCH_TO);
 });

--- a/web/tests/live/theme-switch-live.spec.ts
+++ b/web/tests/live/theme-switch-live.spec.ts
@@ -99,15 +99,12 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
       )
       .toBe(true);
 
-    // Drive a theme switch by patching the profile-scoped settings
+    // Drive a theme switch by patching the dedicated global theme
     // endpoint the picker uses, then firing the same event the
-    // ThemeSettings.tsx save() handler dispatches.
-    const patch = await page.request.patch(
-      `${handle.baseUrl}/api/profiles/default/settings`,
-      {
-        data: { theme: { name: SWITCH_TO } },
-      },
-    );
+    // theme widget's save() handler dispatches.
+    const patch = await page.request.patch(`${handle.baseUrl}/api/theme`, {
+      data: { name: SWITCH_TO },
+    });
     expect(patch.ok()).toBe(true);
 
     await page.evaluate((name) => {


### PR DESCRIPTION
> _Note: this PR description was drafted by Claude (Claude Code, Opus 4.8) via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes the bug where the TUI theme flips (e.g. empire to rose-pine) whenever you open and close Settings, then reverts on restart.

**Root cause.** The theme was read from two different config layers. Boot read the global config; Settings-close, `set_theme`'s palette lookup, the tmux status bar, and the web `/api/theme/current` all read the profile-merged config. The web dashboard's theme picker wrote the theme into the active profile, so a profile-level theme shadowed the global pick on every profile-merged read. Boot showed the global theme; the first Settings open/close "corrected" it to the profile theme; a restart re-read global and reverted. `global_only` turned out to be a display hint only: it is not enforced by `validate_patch`, the TUI apply path, or the config merge.

**Fix: the theme is now a single global preference.**

- Reads go through `config::resolve_theme_name()` (global only). Repointed boot, `set_theme`, Settings-close plus the discard helper, the tmux status bar, and the web `/api/theme/current`.
- `theme.name` and `color_mode` are tagged `global_only`; the TUI now surfaces global-only fields under Global scope only (enforcing the documented semantics that nothing was checking).
- The web writes the theme through a dedicated, non-elevated `PATCH /api/theme` (first-run modal and Settings theme tab). `auth.rs` deliberately keeps cosmetic preference writes off the passphrase wall, so routing through the elevation-gated `PATCH /api/settings` would have forced remote users to elevate just to change a theme.
- Migration `v013` strips `[theme]` `name`/`color_mode` from every `profiles/*/config.toml`; `idle_decay_minutes` stays profile-overridable.

Also fixes a secondary bug found along the way: the mouse-click "discard" path of the Settings unsaved-changes dialog closed the view without reverting a live theme preview, while the keyboard discard path did. Both now route through one `discard_settings_changes()` helper.

**Breaking change.** Per-profile theme overrides are removed; the theme is global. The TUI scope filter also makes every `global_only` field (push notifications, etc.) Global-scope-only, which is the correct enforcement but a behavior change beyond the theme.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

(Also a breaking change, noted above.)

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (code comments; no user-facing docs affected)
- [ ] For UI changes: included screenshot or recording (N/A: behavior fix, no visual change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Updated the live theme specs (persistence, passphrase, color-mode, failure-revert, theme-switch) to assert the new global write path, and the `ThemeIntro` Vitest to the `updateTheme` endpoint.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the global-theme read change is already exercised by `tests/e2e/intro.rs` (theme pick persists to the global config, still green), and the mouse-discard revert has a focused regression test in `src/tui/home/tests.rs` (`settings_mouse_discard_reverts_theme_preview`, which fails without the fix). Migration `v013` has unit tests.

## Verifications

- `cargo fmt`, `cargo clippy --features serve`, `cargo test --features serve --lib` (3705 passed), integration (154 passed): all green.
- Web: `tsc`, `eslint`, Vitest (1746 passed), `npm run build`, coverage-matrix validator: all green.
- The live Playwright suite was not run locally (it spawns a real `aoe serve` plus browsers); it needs a CI run.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Opus 4.8, 1M context)

**Any Additional AI Details you'd like to share:** Root-caused and implemented by Claude via back-and-forth with @njbrake; the design decision (theme is a single global preference, written through a dedicated non-elevated endpoint) and the overall direction are his.

- [ ] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
