### PR TITLE
fix(test): gate harness helpers behind serve feature

### DIFF
--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -11,6 +11,7 @@
 //! convert it to a GIF via `agg`. Recordings are saved to
 //! `target/e2e-recordings/`. Both `asciinema` and `agg` must be on `$PATH`.
 
+#[cfg(feature = "serve")]
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -57,6 +58,7 @@ macro_rules! require_tmux {
 }
 pub(crate) use require_tmux;
 
+#[cfg(feature = "serve")]
 pub fn node_available() -> bool {
     Command::new("node")
         .arg("--version")
@@ -68,6 +70,7 @@ pub fn node_available() -> bool {
 /// Skip the calling test if Node.js is not installed. Acp e2e tests
 /// drive the shared `web/tests/helpers/fakeAcpAgent.mjs` fake agent, which
 /// is a Node script; without Node the worker can't speak ACP.
+#[cfg(feature = "serve")]
 macro_rules! require_node {
     () => {
         if !$crate::harness::node_available() {
@@ -76,6 +79,7 @@ macro_rules! require_node {
         }
     };
 }
+#[cfg(feature = "serve")]
 pub(crate) use require_node;
 
 // ---------------------------------------------------------------------------
@@ -85,6 +89,7 @@ pub(crate) use require_node;
 /// Bind a TCP listener to an ephemeral port, drop it, and return the port.
 /// Tiny TOCTOU window before the daemon binds, but acceptable for a serial
 /// test.
+#[cfg(feature = "serve")]
 pub fn pick_free_port() -> u16 {
     let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
     l.local_addr().expect("local_addr").port()
@@ -94,6 +99,7 @@ pub fn pick_free_port() -> u16 {
 /// `aoe serve --daemon` returns as soon as it has spawned the child, so a
 /// successful exit doesn't prove the child bound the port; this is the
 /// real signal that the daemon is up.
+#[cfg(feature = "serve")]
 pub fn wait_for_port(port: u16, timeout: Duration) -> bool {
     let start = Instant::now();
     while start.elapsed() < timeout {


### PR DESCRIPTION
## Description

`cargo test --no-run` (no features) emits 5 unused-symbol warnings plus the rustc summary line in `tests/e2e/harness.rs`:

- `node_available`
- `require_node` (macro definition + the `pub(crate) use` re-export)
- `pick_free_port`
- `wait_for_port`

All four helpers are consumed only by ACP and serve-gated e2e tests (e.g. `tests/e2e/acp_focus_isolation_e2e.rs`), so the default-features build never sees a caller. The serve-features build is already clean.

This change gates each definition with `#[cfg(feature = "serve")]` at the symbol site (and the `TcpListener` / `TcpStream` imports those helpers depend on), so the symbols and their imports vanish from the default-features build. No `#[allow(dead_code)]`. No behavior change.

After the fix:

- `cargo test --no-run`: 0 warnings (was 5).
- `cargo test --features serve --no-run`: 0 warnings.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The change is a build-only gate on test-harness helpers; runtime behavior of every existing e2e test is unchanged, and `cargo test --features serve --no-run` continues to compile every consumer of the gated helpers.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** claude-opus-4-7

**Any Additional AI Details you'd like to share:**

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes compilation warnings in the test suite by conditionally including test helpers that are only used when the `serve` feature is enabled.

**What changed:**
- Four test helper functions/macros (`node_available()`, `require_node`, `pick_free_port()`, and `wait_for_port()`) in the e2e test harness are now only included in builds with the `serve` feature enabled
- The TCP networking imports these helpers depend on are similarly gated

**What was added:**
- Conditional compilation attributes (`#[cfg(feature = "serve")]`) around the helper definitions

**Results:**
- Eliminated 5 unused-symbol compiler warnings in default-features builds
- Maintained 0 warnings in serve-feature builds
- No functional changes or runtime behavior modifications

**Benefits:**
- Cleaner compilation output with no false-positive warnings
- More accurate reflection of code dependencies (helpers only compile when actually used)
- Better code organization by coupling feature-dependent code with the feature itself

<!-- end of auto-generated comment: release notes by coderabbit.ai -->