### PR TITLE
chore: add .git-blame-ignore-revs for oxfmt reformats

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,5 @@
-# Revs ignored by git blame.
+# Revs ignored by git blame, such as large reformatting diffs.
+# Docs: https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
 # Enable with: git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 # oxfmt

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
-# Bulk reformatting commits, ignored by git blame.
+# Revs ignored by git blame.
 # Enable with: git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 # oxfmt

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Bulk reformatting commits, ignored by git blame.
+# Enable with: git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# oxfmt
+9f9414197e890eda18b9d914b9c6d9406f8c0fda
+
+# oxfmt 80 -> 120 line width
+1f1a33396d189a596d29404df074b22e11646721


### PR DESCRIPTION
## Description

Adds a `.git-blame-ignore-revs` file listing the two large oxfmt reformatting commits so `git blame` skips them. Enable locally with `git config blame.ignoreRevsFile .git-blame-ignore-revs`; GitHub picks it up automatically.

Ignored revs:
- `9f941419` — initial oxfmt reformat
- `1f1a3339` — oxfmt 80 → 120 line width

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**
Used to identify the bulk-format commits and author the file.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

A new `.git-blame-ignore-revs` file was added to the repository to configure Git's blame feature to skip over large formatting commits that don't represent meaningful code logic changes.

## What Was Added

- **One new file** with 9 lines of configuration
- Instructions for developers to enable the ignore list locally via `git config blame.ignoreRevsFile .git-blame-ignore-revs`
- Two commit hashes marked for git blame to skip:
  - `9f941419` — initial oxfmt reformat
  - `1f1a3339` — oxfmt line width change (80 → 120 characters)

## Benefits

**Developer Experience:**
- When developers run `git blame` on code, they'll see the actual functional changes instead of being pointed to large formatting commits
- GitHub automatically recognizes the file, so no manual configuration is needed on GitHub's web interface
- Developers can opt-in locally to get the same behavior in their command-line tools

**Code Review & History:**
- Keeps commit history clean from formatting noise
- Makes it easier to track the real authorship and intent behind code changes
- Reduces confusion when investigating when a piece of code was last meaningfully modified

---

**Technical Details:** Infrastructure/CI change. The file uses Git's standard `blame.ignoreRevsFile` configuration mechanism as documented in Git documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->