### PR TITLE
fix(build): resolve git HEAD/index via rev-parse so worktree builds cache

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,8 @@
+// Git path-resolution shared with the regression test in
+// `tests/build_version_rerun.rs` so the test exercises the real watch-path
+// logic against a temporary worktree.
+include!("build_git_watch.rs");
+
 fn main() {
     check_stale_build_cache();
     emit_build_version();
@@ -30,9 +35,16 @@ fn emit_build_version() {
     use std::process::Command;
 
     // Re-run when the committed revision changes or an override toggles.
-    // `.git/HEAD` moves on checkout/commit; `.git/index` moves on stage.
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    println!("cargo:rerun-if-changed=.git/index");
+    // HEAD moves on checkout/commit; index moves on stage. Resolve the real
+    // paths via `git rev-parse --git-path` rather than hardcoding `.git/HEAD`:
+    // in a git worktree `.git` is a file pointing at
+    // `<main>/.git/worktrees/<name>/`, so the literal `.git/HEAD` path does not
+    // exist. Cargo treats a missing `rerun-if-changed` input as perpetually
+    // stale, which reran this script (and recompiled the lib + binary that read
+    // AOE_BUILD_VERSION) on every build inside a worktree (issue #1962).
+    for path in git_watch_paths(std::path::Path::new(".")) {
+        println!("cargo:rerun-if-changed={path}");
+    }
     println!("cargo:rerun-if-env-changed=AOE_BUILD_VERSION");
     println!("cargo:rerun-if-env-changed=GITHUB_SHA");
 

--- a/build_git_watch.rs
+++ b/build_git_watch.rs
@@ -1,0 +1,43 @@
+// Shared between `build.rs` (via `include!`) and the regression test in
+// `tests/build_version_rerun.rs` (via `#[path] mod`). Keep it free of
+// dependencies on the rest of the crate: build scripts compile in isolation.
+
+/// The git files cargo should watch so `AOE_BUILD_VERSION` is recomputed when
+/// the checkout's revision or staged state changes: `HEAD` moves on
+/// checkout/commit, `index` moves on stage.
+///
+/// Paths are resolved for the repository rooted at `dir` via
+/// `git rev-parse --git-path`, which is correct for both a normal checkout
+/// (`.git/HEAD`) and a git worktree, where `.git` is a file pointing at
+/// `<main>/.git/worktrees/<name>/` and the literal `.git/HEAD` path does not
+/// exist. Hardcoding `.git/HEAD` made cargo treat the missing input as
+/// perpetually stale, rebuilding on every invocation inside a worktree
+/// (issue #1962). Returns an empty vec when git is unavailable or `dir` is not
+/// a git checkout (e.g. a source tarball), leaving the build version pinned to
+/// `CARGO_PKG_VERSION` with no spurious rerun trigger.
+pub fn git_watch_paths(dir: &std::path::Path) -> Vec<String> {
+    ["HEAD", "index"]
+        .iter()
+        .filter_map(|file| git_path(dir, file))
+        .collect()
+}
+
+/// Resolve a single per-worktree git file path via `git rev-parse --git-path`,
+/// run inside `dir`. `None` when git fails or the output is empty.
+pub fn git_path(dir: &std::path::Path, file: &str) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--git-path", file])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(path)
+    }
+}

--- a/build_git_watch.rs
+++ b/build_git_watch.rs
@@ -10,21 +10,26 @@
 /// `git rev-parse --git-path`, which is correct for both a normal checkout
 /// (`.git/HEAD`) and a git worktree, where `.git` is a file pointing at
 /// `<main>/.git/worktrees/<name>/` and the literal `.git/HEAD` path does not
-/// exist. Hardcoding `.git/HEAD` made cargo treat the missing input as
-/// perpetually stale, rebuilding on every invocation inside a worktree
-/// (issue #1962). Returns an empty vec when git is unavailable or `dir` is not
-/// a git checkout (e.g. a source tarball), leaving the build version pinned to
+/// exist.
+///
+/// Only paths that exist on disk are returned. Cargo treats a missing
+/// `rerun-if-changed` input as perpetually stale, so handing it a path that
+/// does not exist rebuilds the lib + binary on every invocation; that is the
+/// exact failure that hardcoding `.git/HEAD` caused in a worktree (issue
+/// #1962). Returns an empty vec when git is unavailable or `dir` is not a git
+/// checkout (e.g. a source tarball), leaving the build version pinned to
 /// `CARGO_PKG_VERSION` with no spurious rerun trigger.
 pub fn git_watch_paths(dir: &std::path::Path) -> Vec<String> {
     ["HEAD", "index"]
         .iter()
         .filter_map(|file| git_path(dir, file))
+        .filter(|path| watched_path_exists(dir, path))
         .collect()
 }
 
 /// Resolve a single per-worktree git file path via `git rev-parse --git-path`,
 /// run inside `dir`. `None` when git fails or the output is empty.
-pub fn git_path(dir: &std::path::Path, file: &str) -> Option<String> {
+fn git_path(dir: &std::path::Path, file: &str) -> Option<String> {
     let out = std::process::Command::new("git")
         .arg("-C")
         .arg(dir)
@@ -39,5 +44,19 @@ pub fn git_path(dir: &std::path::Path, file: &str) -> Option<String> {
         None
     } else {
         Some(path)
+    }
+}
+
+/// True when `path` points at an existing file. `git rev-parse --git-path`
+/// returns an absolute path in a worktree and a path relative to `dir` (e.g.
+/// `.git/HEAD`) in a normal checkout, so relative paths are resolved against
+/// `dir`. `build.rs` runs with `dir = "."` and cargo's cwd at the package
+/// root, so the relative path it emits resolves identically there.
+fn watched_path_exists(dir: &std::path::Path, path: &str) -> bool {
+    let p = std::path::Path::new(path);
+    if p.is_absolute() {
+        p.exists()
+    } else {
+        dir.join(p).exists()
     }
 }

--- a/tests/build_version_rerun.rs
+++ b/tests/build_version_rerun.rs
@@ -133,13 +133,17 @@ fn watch_paths_resolve_in_a_normal_checkout() {
 }
 
 #[test]
-fn git_watch_paths_empty_outside_a_repo() {
+fn git_watch_paths_empty_when_git_cannot_resolve() {
     if !git_available() {
         eprintln!("skipping: git not available");
         return;
     }
+    // Point at a path with no repository so `git -C` fails: resolution yields
+    // nothing and the build version stays pinned to CARGO_PKG_VERSION with no
+    // rerun trigger (the source-tarball / no-VCS fallback). Using a
+    // nonexistent directory keeps this deterministic regardless of whether the
+    // system temp dir happens to sit inside a git repository.
     let tmp = tempfile::tempdir().expect("tempdir");
-    // A bare directory with no git repository: resolution yields nothing, so
-    // the build version stays pinned to CARGO_PKG_VERSION with no rerun trigger.
-    assert!(build_git_watch::git_watch_paths(tmp.path()).is_empty());
+    let no_repo = tmp.path().join("nonexistent");
+    assert!(build_git_watch::git_watch_paths(&no_repo).is_empty());
 }

--- a/tests/build_version_rerun.rs
+++ b/tests/build_version_rerun.rs
@@ -1,0 +1,145 @@
+//! Regression test for issue #1962: inside a git worktree the build script
+//! must watch the *real* per-worktree `HEAD`/`index`, not the literal
+//! `.git/HEAD` (which does not exist there). A missing `rerun-if-changed`
+//! input makes cargo treat the build script as perpetually stale, recompiling
+//! the lib + binary on every build.
+//!
+//! The test drives the actual watch-path logic used by `build.rs`
+//! (`build_git_watch.rs`, shared via `include!`) against a temporary git
+//! worktree and asserts every watched path exists on disk.
+
+#[path = "../build_git_watch.rs"]
+mod build_git_watch;
+
+use std::path::Path;
+use std::process::Command;
+
+fn git(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .expect("failed to run git")
+}
+
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Resolve a watch path (absolute as-is, relative against `base`) and check it
+/// points at an existing file.
+fn watch_path_exists(base: &Path, watched: &str) -> bool {
+    let p = Path::new(watched);
+    let resolved = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        base.join(p)
+    };
+    resolved.exists()
+}
+
+#[test]
+fn watch_paths_resolve_in_a_git_worktree() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let main_repo = tmp.path().join("main");
+    std::fs::create_dir(&main_repo).expect("create main repo dir");
+
+    assert!(git(&main_repo, &["init", "-q"]).status.success());
+    // Identity + a commit so HEAD points at something and a worktree can branch.
+    git(&main_repo, &["config", "user.email", "test@example.com"]);
+    git(&main_repo, &["config", "user.name", "Test"]);
+    assert!(git(&main_repo, &["commit", "--allow-empty", "-qm", "init"])
+        .status
+        .success());
+
+    let worktree = tmp.path().join("wt");
+    assert!(
+        git(
+            &main_repo,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                worktree.to_str().unwrap(),
+                "-b",
+                "wt-branch",
+            ],
+        )
+        .status
+        .success(),
+        "failed to create worktree"
+    );
+
+    // Sanity: in a worktree `.git` is a file, so the naive hardcoded path the
+    // bug used does not exist. This is precisely why hardcoding broke caching.
+    assert!(
+        !worktree.join(".git/HEAD").exists(),
+        "expected `.git/HEAD` to be absent in a worktree"
+    );
+
+    let paths = build_git_watch::git_watch_paths(&worktree);
+    assert_eq!(
+        paths.len(),
+        2,
+        "expected HEAD and index watch paths, got {paths:?}"
+    );
+    for watched in &paths {
+        assert!(
+            watch_path_exists(&worktree, watched),
+            "watched path does not exist: {watched}"
+        );
+    }
+}
+
+#[test]
+fn watch_paths_resolve_in_a_normal_checkout() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo dir");
+
+    assert!(git(&repo, &["init", "-q"]).status.success());
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "user.name", "Test"]);
+    assert!(git(&repo, &["commit", "--allow-empty", "-qm", "init"])
+        .status
+        .success());
+
+    let paths = build_git_watch::git_watch_paths(&repo);
+    assert!(
+        paths.iter().any(|p| p.ends_with("HEAD")),
+        "expected a HEAD watch path, got {paths:?}"
+    );
+    for watched in &paths {
+        assert!(
+            watch_path_exists(&repo, watched),
+            "watched path does not exist: {watched}"
+        );
+    }
+}
+
+#[test]
+fn git_watch_paths_empty_outside_a_repo() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // A bare directory with no git repository: resolution yields nothing, so
+    // the build version stays pinned to CARGO_PKG_VERSION with no rerun trigger.
+    assert!(build_git_watch::git_watch_paths(tmp.path()).is_empty());
+}


### PR DESCRIPTION
## Description

Inside a git worktree, `cargo build` (and `cargo run --features serve --profile dev-release`) recompiled and relinked `agent-of-empires` on **every** invocation, even with no source changes (issue #1962).

**Root cause:** In a git worktree `.git` is a *file* pointing at `<main>/.git/worktrees/<name>/`, not a directory, so `build.rs`'s hardcoded `cargo:rerun-if-changed=.git/HEAD` and `.git/index` reference paths that do not exist. Cargo treats a missing `rerun-if-changed` input as perpetually stale, so it reran the build script every time, re-emitted `AOE_BUILD_VERSION`, and forced the lib + binary to recompile. Fingerprint logging confirmed it:

```
dirty: FsStatusOutdated(StaleItem(MissingFile { path: ".../.git/HEAD" }))
```

A normal clone has a real `.git/HEAD`, so the bug only bites worktree-based workflows. Introduced in #1786 (the `AOE_BUILD_VERSION` stamp for #1754).

**Fix:** Resolve the real paths with `git rev-parse --git-path HEAD`/`index`, which returns `.git/HEAD` in a normal checkout and the linked-worktree path otherwise. The watch-path logic is factored into `build_git_watch.rs`, shared with `build.rs` via `include!` and with a new regression test via `#[path] mod` so the test exercises the real code against a temporary worktree.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

New regression test `tests/build_version_rerun.rs` drives the real watch-path logic against a temporary git worktree and a normal checkout, asserting every watched path exists on disk. Verified it fails (`watched path does not exist: .git/HEAD`) when the logic is reverted to the old hardcoded behavior, and passes with the fix. Manually confirmed: before, every `cargo build` recompiled; after, three consecutive builds are no-ops.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude investigated the cache breakage via cargo fingerprint logging, identified the worktree path-resolution issue, and drafted the fix and regression test through back-and-forth with @njbrake. The reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #1962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary

This PR fixes a build-cache regression that caused unnecessary recompilation when the repository was used as a git worktree.

## What changed (high-level)
- build.rs: stopped using hardcoded `.git/HEAD` and `.git/index` watch paths; now emits cargo:rerun-if-changed for paths returned by shared git-watch logic.
- build_git_watch.rs (new): extracted logic that resolves git paths via `git rev-parse --git-path <file>`, filters out non-existent paths, and returns the concrete paths Cargo should watch.
- tests/build_version_rerun.rs (new): regression tests that exercise the behavior against a real worktree, a normal checkout, and a non-repo path.

## Why this matters (benefits)
- Restores correct incremental build caching: builds no longer force recompilation/relink when nothing changed.
- Worktree-safe: handles `.git` being a file that points to worktree metadata, avoiding perpetually-stale rerun inputs.
- Prevents wasted developer time and CPU from unnecessary rebuilds.
- Regression tests reduce risk of recurrence.

## Technical notes (concise)
- Uses `git -C <dir> rev-parse --git-path HEAD/index` to resolve repository-rooted paths.
- Filters resolved paths to only include existing filesystem entries so `rerun-if-changed` does not receive missing inputs.
- `git_watch_paths(dir) -> Vec<String>` is the exported helper; `git_path` is internal/private.
- Tests ensure deterministic behavior (including making the no-repo case point at a nonexistent directory to avoid flakiness).

## Potential follow-ups / enhancements
- Consider logging or a verbose mode in build diagnostics to surface which git paths were discovered during build script runs.
- Expand tests to cover additional git configurations (e.g., submodules, alternate object directories) if relevant.

Fixes `#1962`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->