### PR TITLE
feat(tui): add "New Session" to the project/group right-click menu

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1288,6 +1288,18 @@ impl Instance {
         self.sandbox_info.as_ref().is_some_and(|s| s.enabled)
     }
 
+    /// The repo this session groups under: the worktree's main repo when
+    /// present (so all branches of a repo group together), else the project
+    /// path. Shared by sidebar project grouping and new-session prefill so
+    /// the "which directory does this session belong to" rule lives in one
+    /// place.
+    pub fn repo_path(&self) -> &str {
+        self.worktree_info
+            .as_ref()
+            .map(|w| w.main_repo_path.as_str())
+            .unwrap_or(&self.project_path)
+    }
+
     pub fn is_yolo_mode(&self) -> bool {
         self.yolo_mode
     }
@@ -4918,6 +4930,24 @@ mod tests {
         let wt = deserialized.worktree_info.unwrap();
         assert_eq!(wt.branch, "feature/abc");
         assert!(wt.managed_by_aoe);
+    }
+
+    #[test]
+    fn test_repo_path_prefers_worktree_main_repo() {
+        let mut inst = Instance::new("Test", "/tmp/worktrees/feature");
+        assert_eq!(inst.repo_path(), "/tmp/worktrees/feature");
+        inst.worktree_info = Some(WorktreeInfo {
+            branch: "feature".to_string(),
+            main_repo_path: "/tmp/main-repo".to_string(),
+            managed_by_aoe: true,
+            created_at: Utc::now(),
+            base_branch: None,
+        });
+        assert_eq!(
+            inst.repo_path(),
+            "/tmp/main-repo",
+            "worktree sessions group under the main repo, not the worktree dir"
+        );
     }
 
     // Test generate_id function properties

--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -17,6 +17,10 @@ pub enum ContextMenuAction {
     ToggleArchive,
     /// Open the new-session dialog (mirrors the `'n'` hotkey).
     NewSession,
+    /// Open the new-session dialog prefilled from the right-clicked
+    /// project/group (mirrors `'N'` "new from selection" on a group),
+    /// so the mouse path matches the web sidebar's per-project "+".
+    NewFromGroup,
     /// Open the sort-order picker (mirrors `'o'`).
     OpenSortPicker,
     /// Open the group-by mode picker (mirrors `'g'`).
@@ -77,6 +81,7 @@ impl ContextMenuDialog {
         Self::new(
             anchor,
             vec![
+                (ContextMenuAction::NewFromGroup, "New Session"),
                 (ContextMenuAction::Rename, "Rename Group"),
                 (ContextMenuAction::Delete, "Delete Group"),
             ],
@@ -205,7 +210,21 @@ impl ContextMenuDialog {
                     'r' | 'R' => Some(ContextMenuAction::Rename),
                     'd' | 'D' => Some(ContextMenuAction::Delete),
                     'z' | 'Z' => Some(ContextMenuAction::ToggleArchive),
-                    'n' | 'N' => Some(ContextMenuAction::NewSession),
+                    // `n` opens a new session from whichever new-session entry
+                    // the current menu carries: the group/project menu prefills
+                    // from the row (NewFromGroup), the empty-sidebar menu opens
+                    // a blank one (NewSession).
+                    'n' | 'N' => {
+                        if self
+                            .items
+                            .iter()
+                            .any(|(item, _)| *item == ContextMenuAction::NewFromGroup)
+                        {
+                            Some(ContextMenuAction::NewFromGroup)
+                        } else {
+                            Some(ContextMenuAction::NewSession)
+                        }
+                    }
                     'o' | 'O' => Some(ContextMenuAction::OpenSortPicker),
                     'g' | 'G' => Some(ContextMenuAction::OpenGroupPicker),
                     _ => None,
@@ -322,6 +341,48 @@ mod tests {
         assert!(matches!(
             result,
             DialogResult::Submit(ContextMenuAction::Delete)
+        ));
+    }
+
+    #[test]
+    fn group_menu_offers_new_session_first() {
+        let menu = ContextMenuDialog::for_group((0, 0));
+        let items: Vec<(ContextMenuAction, &str)> = menu
+            .items_for_test()
+            .iter()
+            .map(|(a, l)| (*a, *l))
+            .collect();
+        assert_eq!(
+            items,
+            vec![
+                (ContextMenuAction::NewFromGroup, "New Session"),
+                (ContextMenuAction::Rename, "Rename Group"),
+                (ContextMenuAction::Delete, "Delete Group"),
+            ]
+        );
+    }
+
+    #[test]
+    fn n_hotkey_in_group_menu_submits_new_from_group() {
+        let mut menu = ContextMenuDialog::for_group((0, 0));
+        // Pre-select Delete to prove the hotkey wins over the cursor.
+        menu.handle_key(key(KeyCode::Up));
+        let result = menu.handle_key(key(KeyCode::Char('n')));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::NewFromGroup)
+        ));
+    }
+
+    #[test]
+    fn n_hotkey_in_empty_sidebar_menu_submits_new_session() {
+        // The empty-sidebar menu carries the blank NewSession entry, so `n`
+        // must resolve there and never to the group-scoped NewFromGroup.
+        let mut menu = ContextMenuDialog::for_empty_sidebar((0, 0));
+        let result = menu.handle_key(key(KeyCode::Char('n')));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::NewSession)
         ));
     }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2194,6 +2194,14 @@ impl HomeView {
             ));
             return;
         }
+        // Same gate as `open_new_session_dialog`: with no agent available the
+        // dialog has nothing to create, so point the user at setup instead of
+        // opening an unusable form. Keeps `'N'` and the group menu's New
+        // Session in step with `'n'` and the empty-sidebar menu.
+        if !self.available_tools.any_available() {
+            self.show_no_agents();
+            return;
+        }
         let prefill_path = self
             .selected_session
             .as_ref()

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2198,11 +2198,15 @@ impl HomeView {
             .selected_session
             .as_ref()
             .and_then(|id| self.get_instance(id))
-            .map(|inst| {
-                inst.worktree_info
+            .map(|inst| inst.repo_path().to_string())
+            .or_else(|| {
+                // No session selected (the project/group right-click menu, or
+                // `'N'` on a group header): borrow a member's repo path so the
+                // new session lands in the same project, matching the web
+                // sidebar's per-project "+".
+                self.selected_group
                     .as_ref()
-                    .map(|wt| wt.main_repo_path.clone())
-                    .unwrap_or_else(|| inst.project_path.clone())
+                    .and_then(|g| self.group_repo_path(g))
             });
         let prefill_group = self
             .selected_session
@@ -2237,14 +2241,35 @@ impl HomeView {
             if let Some(group) = prefill_group {
                 dialog.set_group(group);
             }
-            // Only skip to the title when the path was inherited from a
-            // session. In the group-only fallback the path is still the
-            // default cwd, so leaving focus there lets the user confirm it.
+            // Skip to the title whenever the path is genuinely prefilled,
+            // whether inherited from a session or borrowed from a project/group
+            // member, so the user lands directly on naming. Only an empty group
+            // (no member to borrow a path from) leaves focus on the default cwd
+            // so the user can confirm it.
             if has_prefilled_path {
                 dialog.focus_title();
             }
             self.new_dialog = Some(dialog);
         }
+    }
+
+    /// Pick a representative repo path for a selected group so "New Session"
+    /// from a project/group can prefill the working directory. In project mode
+    /// the group label is a derived basename, so match members by
+    /// `project_group_name`; in manual mode match by the stored `group_path`,
+    /// including nested subgroups. Returns `None` for an empty group (no member
+    /// to borrow a path from), leaving the dialog on the default cwd.
+    fn group_repo_path(&self, group_path: &str) -> Option<String> {
+        self.instances
+            .iter()
+            .find(|inst| match self.group_by {
+                GroupByMode::Project => super::project_group_name(inst) == group_path,
+                _ => {
+                    inst.group_path == group_path
+                        || inst.group_path.starts_with(&format!("{group_path}/"))
+                }
+            })
+            .map(|inst| inst.repo_path().to_string())
     }
 
     fn attach_terminal_for_selected(&mut self) -> Option<Action> {
@@ -3171,6 +3196,11 @@ impl HomeView {
                 }
             }
             ContextMenuAction::NewSession => self.open_new_session_dialog(),
+            // The right-click already moved the cursor onto the group row, so
+            // reuse the "new from selection" path: with a group selected it
+            // prefills the project's repo path (and group) the same way `'N'`
+            // does on a session.
+            ContextMenuAction::NewFromGroup => self.open_new_from_selection(),
             ContextMenuAction::OpenSortPicker => self.show_sort_picker(),
             ContextMenuAction::OpenGroupPicker => self.show_group_picker(),
         }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -57,11 +57,7 @@ fn project_group_name(inst: &Instance) -> String {
         return "scratch".to_string();
     }
 
-    let base_path = inst
-        .worktree_info
-        .as_ref()
-        .map(|wt| wt.main_repo_path.as_str())
-        .unwrap_or(&inst.project_path);
+    let base_path = inst.repo_path();
 
     let path = std::path::Path::new(base_path);
     path.file_name()

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -3634,6 +3634,73 @@ fn test_shift_n_opens_prefilled_dialog_from_group() {
     env.view.handle_key(key(KeyCode::Char('N')), None);
     let dialog = env.view.new_dialog.as_ref().expect("N should open dialog");
     assert_eq!(dialog.group_value(), "work");
+    // The group has a member at "/tmp/work", so the path is borrowed from it
+    // instead of being left on the default cwd (issue #2023).
+    assert_eq!(dialog.path_value(), "/tmp/work");
+}
+
+#[test]
+#[serial]
+fn test_group_context_menu_new_session_prefills_path() {
+    use crate::tui::dialogs::ContextMenuAction;
+
+    let mut env = create_test_env_with_groups();
+
+    // Move cursor to the "work" group row, as a right-click would.
+    let group_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Group { path, .. } if path == "work"))
+        .expect("work group should exist in flat_items");
+    env.view.cursor = group_idx;
+    env.view.update_selected();
+
+    // The group right-click menu's "New Session" routes here.
+    env.view
+        .dispatch_context_menu_action(ContextMenuAction::NewFromGroup);
+    let dialog = env
+        .view
+        .new_dialog
+        .as_ref()
+        .expect("NewFromGroup should open the new-session dialog");
+    assert_eq!(dialog.path_value(), "/tmp/work");
+    assert_eq!(dialog.group_value(), "work");
+}
+
+#[test]
+#[serial]
+fn test_group_context_menu_new_session_prefills_path_in_project_mode() {
+    use crate::session::config::GroupByMode;
+    use crate::tui::dialogs::ContextMenuAction;
+
+    let mut env = create_test_env_with_groups();
+    env.view.group_by = GroupByMode::Project;
+    env.view.flat_items = env.view.build_flat_items();
+
+    // In project mode the group label is the repo basename ("work" from
+    // "/tmp/work"), not the stored group_path.
+    let group_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Group { name, .. } if name == "work"))
+        .expect("work project group should exist in flat_items");
+    env.view.cursor = group_idx;
+    env.view.update_selected();
+
+    env.view
+        .dispatch_context_menu_action(ContextMenuAction::NewFromGroup);
+    let dialog = env
+        .view
+        .new_dialog
+        .as_ref()
+        .expect("NewFromGroup should open the new-session dialog");
+    assert_eq!(
+        dialog.path_value(),
+        "/tmp/work",
+        "project-mode prefill should borrow the member repo path"
+    );
 }
 
 #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -3670,6 +3670,35 @@ fn test_group_context_menu_new_session_prefills_path() {
 
 #[test]
 #[serial]
+fn test_group_context_menu_new_session_shows_no_agents_without_tools() {
+    use crate::tui::dialogs::ContextMenuAction;
+
+    let mut env = create_test_env_with_groups();
+    env.view.available_tools = AvailableTools::with_tools(&[]);
+
+    let group_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Group { path, .. } if path == "work"))
+        .expect("work group should exist in flat_items");
+    env.view.cursor = group_idx;
+    env.view.update_selected();
+
+    env.view
+        .dispatch_context_menu_action(ContextMenuAction::NewFromGroup);
+    assert!(
+        env.view.new_dialog.is_none(),
+        "no agents means the new-session form must not open"
+    );
+    assert!(
+        env.view.no_agents_dialog.is_some(),
+        "should point the user at agent setup instead, like 'n'"
+    );
+}
+
+#[test]
+#[serial]
 fn test_group_context_menu_new_session_prefills_path_in_project_mode() {
     use crate::session::config::GroupByMode;
     use crate::tui::dialogs::ContextMenuAction;


### PR DESCRIPTION
## Description

Right-clicking a project (group) in the TUI sidebar only offered Rename and Delete. The web sidebar exposes a per-project "+" to spin up a new session in that project, so the mouse-only TUI path lagged behind.

This adds a **"New Session"** entry to the group right-click context menu that opens the new-session dialog prefilled with the project's repo path, bringing the TUI in line with the web UX (per @njbrake's direction on the issue: surface this on the project/group, not on individual sessions).

It also fixes the `'N'` keybinding on a group header, which previously prefilled the group name but left the working directory on the default cwd.

How it works:
- The group menu's "New Session" routes through the existing "new from selection" handler. Since the right-click already moves the cursor onto the group row, that handler now derives a working directory from a group member when only a group is selected (project mode matches members by the derived basename; manual mode by the stored `group_path`, including nested subgroups). Empty groups (no member to borrow a path from) leave the dialog on the default cwd, as before.
- A dedicated `ContextMenuAction::NewFromGroup` keeps the group menu's prefill distinct from the empty-sidebar menu's blank "New Session", and the in-menu `n` hotkey resolves to whichever entry the open menu carries.

While here, the repeated "repo path of a session" rule (`worktree_info.main_repo_path` else `project_path`), which was copied across `project_group_name` and the new-session prefill paths, is extracted into a shared `Instance::repo_path()` so sidebar project grouping and prefill resolve it the same way in one place.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

<!-- The change is a new entry in an existing terminal popup menu; behavior is covered by unit/integration tests below. Happy to add a recording via the `needs-recording` label if reviewers want one. -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (TUI-only)

**TUI / CLI (e2e test)**
- [x] Added or updated a test

Added/updated regression coverage close to the logic:
- `context_menu.rs`: group menu lists "New Session" first; `n` resolves to `NewFromGroup` in the group menu and `NewSession` in the empty-sidebar menu.
- `home/tests.rs`: group right-click "New Session" prefills the member repo path in both manual and project grouping modes; `'N'` on a group now prefills the path (updated existing test).
- `instance.rs`: `repo_path()` prefers the worktree main repo over the worktree dir.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implemented via Claude Code with back-and-forth review; the shared `Instance::repo_path()` extraction came out of a "could web-only logic move into shared code" review pass.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #2023


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a "New Session" item to the TUI sidebar's project/group right-click context menu and makes new-session creation from selections and groups consistent and reliable.

What changed (high-level)
- Added "New Session" as the first option in project/group right-click menus; it opens the new-session dialog prefilled with a sensible working directory.
- Prefilling logic now borrows a repository path from the selected session or a representative group member (project-mode matches by basename; manual-mode matches by stored group path, including nested subgroups). Empty groups keep the default cwd.
- Introduced a distinct context action for group prefill cases so the in-menu 'n' hotkey resolves to the menu item actually shown.
- Consolidated repository path selection into Instance::repo_path(), preferring a worktree's main_repo_path over project_path.
- Ensured the "new from selection" flow checks agent/tool availability before opening the dialog.

Tests and coverage
- Added/updated tests covering menu ordering and hotkey resolution, group prefill behavior in manual and project grouping, and repo_path precedence.

Benefits
- Faster, more consistent session creation from existing sessions/projects/groups.
- UI parity with the web sidebar quick-create UX.
- Correct and predictable hotkey behavior.
- Centralized repo-path logic reduces duplication and prevents mismatched prefills.

Technical summary (files & key changes)
- src/session/instance.rs: Added pub fn repo_path(&self) -> &str and unit test preferring worktree main_repo_path.
- src/tui/dialogs/context_menu.rs: Added ContextMenuAction::NewFromGroup; inserted "New Session" as first group menu item; updated hotkey handling so 'n' dispatches to the present entry.
- src/tui/home/input.rs: Refactored open_new_from_selection() to use repo_path(); added group_repo_path() helper with project/manual matching; gate on available agents; route NewFromGroup to same handler and focus title when prefilled.
- src/tui/home/mod.rs: Simplified project_group_name() to use inst.repo_path().
- src/tui/home/tests.rs & src/tui/dialogs/context_menu.rs tests: Added/updated tests for prefill behavior, hotkeys, and no-agents gating.

Fixes
- Resolves issue `#2023`. AI-assisted code generation noted in commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->