### PR TITLE
feat(archive): archive an entire project at once

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -778,12 +778,19 @@ impl HomeView {
         if count == 0 {
             return;
         }
-        let name = group_path.rsplit('/').next().unwrap_or(&group_path);
+        // Project mode groups by repo, Manual mode by user-assigned path; name
+        // the scope accordingly and show the full path so nested groups that
+        // share a leaf segment aren't ambiguous.
+        let (title, scope) = if self.group_by == crate::session::config::GroupByMode::Project {
+            ("Archive project", "project")
+        } else {
+            ("Archive group", "group")
+        };
         let noun = if count == 1 { "session" } else { "sessions" };
         self.confirm_dialog = Some(
             ConfirmDialog::new(
-                "Archive project",
-                &format!("Archive all {count} {noun} in \"{name}\"?"),
+                title,
+                &format!("Archive all {count} {noun} in {scope} \"{group_path}\"?"),
                 "archive_group",
             )
             .neutral(),

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -744,6 +744,12 @@ impl HomeView {
                 }
                 None
             }
+            "archive_group" => {
+                if let Err(e) = self.archive_selected_group() {
+                    tracing::error!(target: "tui.input", "Failed to archive group: {}", e);
+                }
+                None
+            }
             "stop_session" => self.pending_stop_session.take().map(Action::StopSession),
             "force_remove_session" => {
                 if let Some(session_id) = self.pending_force_remove_session.take() {
@@ -757,6 +763,31 @@ impl HomeView {
             "quit" => Some(Action::Quit),
             _ => None,
         }
+    }
+
+    /// Confirm before archiving every active session under the focused group.
+    /// Archiving a whole project at once is a bigger hammer than the single-row
+    /// `z`, so it routes through a prompt. Archiving is reversible, hence the
+    /// calmer neutral tone rather than the destructive red. No-ops silently
+    /// (no prompt) when the group has no active sessions left to archive.
+    pub(super) fn prompt_archive_selected_group(&mut self) {
+        let Some(group_path) = self.selected_group.clone() else {
+            return;
+        };
+        let count = self.active_sessions_in_selected_group().len();
+        if count == 0 {
+            return;
+        }
+        let name = group_path.rsplit('/').next().unwrap_or(&group_path);
+        let noun = if count == 1 { "session" } else { "sessions" };
+        self.confirm_dialog = Some(
+            ConfirmDialog::new(
+                "Archive project",
+                &format!("Archive all {count} {noun} in \"{name}\"?"),
+                "archive_group",
+            )
+            .neutral(),
+        );
     }
 
     /// Discard unsaved Settings changes: force-close the view, clear the
@@ -2163,7 +2194,9 @@ impl HomeView {
             ActionId::Restart => self.open_restart_dialog(),
             ActionId::Update => return self.run_update(update_info),
             ActionId::ToggleArchive => {
-                if let Err(e) = self.toggle_archive_at_cursor() {
+                if self.selected_group.is_some() {
+                    self.prompt_archive_selected_group();
+                } else if let Err(e) = self.toggle_archive_at_cursor() {
                     tracing::error!("toggle_archive_at_cursor failed: {}", e);
                 }
             }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1060,4 +1060,77 @@ impl HomeView {
         }
         Ok(())
     }
+
+    /// Collect the active (non-archived) session ids under the currently
+    /// selected group header, honoring the active group-by mode. Archived
+    /// sessions are excluded: they already live under the synthetic Archived
+    /// section, and re-archiving them is a no-op. Returns empty when no group
+    /// is selected.
+    pub(super) fn active_sessions_in_selected_group(&self) -> Vec<String> {
+        let Some(group_path) = self.selected_group.as_deref() else {
+            return Vec::new();
+        };
+        match self.group_by {
+            // Project headers are derived from each session's repo name and
+            // unified across profiles, narrowed only by the active profile
+            // filter, exactly as `build_flat_items_by_project` builds them.
+            crate::session::config::GroupByMode::Project => self
+                .instances
+                .iter()
+                .filter(|i| !i.is_archived())
+                .filter(|i| {
+                    self.active_profile
+                        .as_ref()
+                        .is_none_or(|p| &i.source_profile == p)
+                })
+                .filter(|i| super::project_group_name(i) == group_path)
+                .map(|i| i.id.clone())
+                .collect(),
+            // Manual groups can nest, so a session belongs when its path
+            // matches exactly or sits beneath the group. Scope to the group's
+            // owning profile the same way `delete_selected_group` does.
+            crate::session::config::GroupByMode::Manual => {
+                let prefix = format!("{}/", group_path);
+                self.instances
+                    .iter()
+                    .filter(|i| !i.is_archived())
+                    .filter(|i| i.group_path == group_path || i.group_path.starts_with(&prefix))
+                    .filter(|i| {
+                        self.selected_group_profile
+                            .as_ref()
+                            .is_none_or(|p| p == &i.source_profile)
+                    })
+                    .map(|i| i.id.clone())
+                    .collect()
+            }
+        }
+    }
+
+    /// Archive every active session under the selected group. Mirrors the
+    /// single-row archive path in `toggle_archive_at_cursor`: kill each pane
+    /// before flipping the archived bit, then reveal the Archived section so
+    /// the rows stay visible. Triggered behind a confirmation prompt, so there
+    /// is no further guard here.
+    pub(super) fn archive_selected_group(&mut self) -> anyhow::Result<()> {
+        let ids = self.active_sessions_in_selected_group();
+        if ids.is_empty() {
+            return Ok(());
+        }
+        for inst in self.instances.iter().filter(|i| ids.contains(&i.id)) {
+            if let Err(e) = inst.kill() {
+                tracing::warn!("archive_selected_group: kill failed (continuing): {}", e);
+            }
+        }
+        self.bulk_apply_user_action(&ids, |inst| inst.archive())?;
+        self.reveal_archived_section();
+        self.flat_items = self.build_flat_items();
+        // The project header vanishes once its last active member is archived
+        // (project headers are seeded from live sessions only), so the cursor's
+        // old index may now point past the list end; clamp and re-resolve.
+        if !self.flat_items.is_empty() && self.cursor >= self.flat_items.len() {
+            self.cursor = self.flat_items.len() - 1;
+        }
+        self.update_selected();
+        Ok(())
+    }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1614,6 +1614,135 @@ fn test_delete_selected_group_updates_groups_field() {
     assert!(!group_paths.contains(&"work/projects"));
 }
 
+/// Archiving a manual group archives every session under it, including
+/// nested subgroups, and leaves sessions outside the group untouched.
+#[test]
+#[serial]
+fn test_archive_selected_group_archives_all_members() {
+    let mut env = create_test_env_with_group_sessions();
+
+    // Select the "work" group.
+    for (i, item) in env.view.flat_items.iter().enumerate() {
+        if let Item::Group { path, .. } = item {
+            if path == "work" {
+                env.view.cursor = i;
+                env.view.update_selected();
+                break;
+            }
+        }
+    }
+    assert_eq!(env.view.selected_group.as_deref(), Some("work"));
+
+    // "work" holds two direct sessions plus one in the nested "work/projects".
+    assert_eq!(env.view.active_sessions_in_selected_group().len(), 3);
+
+    env.view.archive_selected_group().unwrap();
+
+    for inst in env.view.instances() {
+        let in_work = inst.group_path == "work" || inst.group_path.starts_with("work/");
+        assert_eq!(
+            inst.is_archived(),
+            in_work,
+            "session {} (group {:?}) archived state should match group membership",
+            inst.title,
+            inst.group_path
+        );
+    }
+}
+
+/// In project group-by mode, archiving a project header archives every live
+/// session that maps to that repo, even though their stored `group_path`
+/// values differ from the synthetic project name.
+#[test]
+#[serial]
+fn test_archive_selected_group_project_mode() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new_unwatched("test").unwrap();
+
+    // Two sessions sharing one repo, one session in a different repo.
+    let a1 = Instance::new("alpha-1", "/tmp/alpha");
+    let a2 = Instance::new("alpha-2", "/tmp/alpha");
+    let b1 = Instance::new("beta-1", "/tmp/beta");
+    let instances = vec![a1, a2, b1];
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        tools,
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    view.group_by = crate::session::config::GroupByMode::Project;
+    view.flat_items = view.build_flat_items();
+
+    // Select the "alpha" project header.
+    for (i, item) in view.flat_items.iter().enumerate() {
+        if let Item::Group { path, .. } = item {
+            if path == "alpha" {
+                view.cursor = i;
+                view.update_selected();
+                break;
+            }
+        }
+    }
+    assert_eq!(view.selected_group.as_deref(), Some("alpha"));
+    assert_eq!(view.active_sessions_in_selected_group().len(), 2);
+
+    view.archive_selected_group().unwrap();
+
+    for inst in view.instances() {
+        let in_alpha = inst.project_path == "/tmp/alpha";
+        assert_eq!(
+            inst.is_archived(),
+            in_alpha,
+            "session {} (repo {}) archived state should match project membership",
+            inst.title,
+            inst.project_path
+        );
+    }
+}
+
+/// The group-level prompt opens a confirmation carrying the `archive_group`
+/// action and counts only the active members, and no-ops without a prompt when
+/// the group has nothing left to archive.
+#[test]
+#[serial]
+fn test_prompt_archive_selected_group() {
+    let mut env = create_test_env_with_group_sessions();
+
+    for (i, item) in env.view.flat_items.iter().enumerate() {
+        if let Item::Group { path, .. } = item {
+            if path == "work" {
+                env.view.cursor = i;
+                env.view.update_selected();
+                break;
+            }
+        }
+    }
+
+    env.view.prompt_archive_selected_group();
+    assert_eq!(
+        env.view.confirm_dialog.as_ref().map(|d| d.action()),
+        Some("archive_group")
+    );
+
+    // Confirm, which archives the group and clears the prompt.
+    env.view.confirm_dialog = None;
+    env.view.archive_selected_group().unwrap();
+
+    // With every member archived, a second prompt is a silent no-op.
+    env.view.prompt_archive_selected_group();
+    assert!(env.view.confirm_dialog.is_none());
+}
+
 #[test]
 #[serial]
 fn test_delete_group_with_sessions_updates_groups_field() {

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -28,6 +28,7 @@ import { CSS } from "@dnd-kit/utilities";
 import type { SessionResponse, SessionStatus, Workspace } from "../lib/types";
 import type { SidebarAxis } from "../lib/sidebarAxis";
 import {
+  archivableWorkspaces,
   nestedSidebarGroupHasLiveWorkspace,
   sidebarGroupHasLiveWorkspace,
   type NestedSidebarGroup,
@@ -1529,6 +1530,7 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
   onClick,
   onNewSession,
   onUpdateAppearance,
+  onArchiveAll,
   offline,
   dragHandle,
 }: {
@@ -1537,6 +1539,9 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
   onClick: () => void;
   onNewSession: () => void;
   onUpdateAppearance: (repoId: string, update: RepoAppearanceUpdate) => void;
+  /** Archive every active session under this group. Omitted (read-only /
+   *  offline) hides the action; the parent owns the confirmation. */
+  onArchiveAll?: () => void;
   offline: boolean;
   dragHandle?: DragHandleProps;
 }) {
@@ -1544,6 +1549,13 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
   // only. The user-group axis has no per-group appearance in v1, so the
   // menu trigger and rename input are gated off rather than rendered inert.
   const canAppearance = group.capabilities.appearance;
+  // "Archive all in group" works on every axis (a project or a manual
+  // group), so it can light up the context menu even where appearance is
+  // off. Count only the still-active members so the label is honest and the
+  // action hides once everything is already archived.
+  const archivableCount = onArchiveAll ? archivableWorkspaces(group).length : 0;
+  const canArchiveAll = archivableCount > 0;
+  const hasMenu = canAppearance || canArchiveAll;
   const headerTitle = group.groupPath ?? group.repoPath;
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -1633,18 +1645,18 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
       <div
         data-testid="sidebar-group-header"
         data-group-id={group.id}
-        tabIndex={canAppearance ? 0 : undefined}
-        aria-haspopup={canAppearance ? "menu" : undefined}
-        aria-label={canAppearance ? `Project actions for ${group.displayName}` : undefined}
+        tabIndex={hasMenu ? 0 : undefined}
+        aria-haspopup={hasMenu ? "menu" : undefined}
+        aria-label={hasMenu ? `Project actions for ${group.displayName}` : undefined}
         onContextMenu={
-          canAppearance
+          hasMenu
             ? (e) => {
                 e.preventDefault();
                 openMenuAt(e.clientX, e.clientY);
               }
             : undefined
         }
-        onKeyDown={canAppearance ? handleHeaderKeyDown : undefined}
+        onKeyDown={hasMenu ? handleHeaderKeyDown : undefined}
         className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary focus:outline-none focus:ring-2 focus:ring-brand-600 ${headerHoverClass} ${
           hasActiveChild ? "border-l-2 border-brand-600" : ""
         }`}
@@ -1718,7 +1730,7 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
           </button>
         </Tooltip>
       </div>
-      {canAppearance &&
+      {hasMenu &&
         contextMenu &&
         createPortal(
           <div
@@ -1731,61 +1743,80 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
               maxHeight: "calc(100vh - 16px)",
             }}
           >
-            <button
-              onClick={() => {
-                setContextMenu(null);
-                setRenameValue(group.alias ?? group.defaultDisplayName);
-                setRenaming(true);
-                requestAnimationFrame(() => renameRef.current?.select());
-              }}
-              data-testid="sidebar-group-context-menu-rename"
-              className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
-            >
-              Rename
-            </button>
-            {group.alias && (
+            {canArchiveAll && (
               <button
                 onClick={() => {
                   setContextMenu(null);
-                  onUpdateAppearance(group.id, { alias: null });
+                  onArchiveAll?.();
                 }}
+                data-testid="sidebar-group-context-menu-archive-all"
                 className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
               >
-                Clear alias
+                {`Archive all (${archivableCount})`}
               </button>
             )}
-            <div className="border-t border-surface-700/20 my-1" />
-            <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">Background</div>
-            <div className="grid grid-cols-4 gap-1 px-3 py-1.5">
-              {REPO_COLOR_OPTIONS.map((option) => (
+            {canArchiveAll && canAppearance && <div className="border-t border-surface-700/20 my-1" />}
+            {canAppearance && (
+              <>
                 <button
-                  key={option.id}
-                  type="button"
                   onClick={() => {
                     setContextMenu(null);
-                    onUpdateAppearance(group.id, { color: option.id });
+                    setRenameValue(group.alias ?? group.defaultDisplayName);
+                    setRenaming(true);
+                    requestAnimationFrame(() => renameRef.current?.select());
                   }}
-                  data-testid={`sidebar-group-color-${option.id}`}
-                  aria-label={`Set ${option.label} background`}
-                  className={`h-8 rounded-md border cursor-pointer transition-colors ${
-                    group.color === option.id ? "border-text-primary" : "border-surface-700"
-                  }`}
-                  style={repoSwatchStyle(option.id)}
-                />
-              ))}
-              <button
-                type="button"
-                onClick={() => {
-                  setContextMenu(null);
-                  onUpdateAppearance(group.id, { color: null });
-                }}
-                data-testid="sidebar-group-color-clear"
-                aria-label="Clear background"
-                className="h-8 rounded-md border border-surface-700 bg-surface-900 text-[10px] font-mono text-text-dim cursor-pointer hover:bg-surface-700/40"
-              >
-                None
-              </button>
-            </div>
+                  data-testid="sidebar-group-context-menu-rename"
+                  className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+                >
+                  Rename
+                </button>
+                {group.alias && (
+                  <button
+                    onClick={() => {
+                      setContextMenu(null);
+                      onUpdateAppearance(group.id, { alias: null });
+                    }}
+                    className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+                  >
+                    Clear alias
+                  </button>
+                )}
+                <div className="border-t border-surface-700/20 my-1" />
+                <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">
+                  Background
+                </div>
+                <div className="grid grid-cols-4 gap-1 px-3 py-1.5">
+                  {REPO_COLOR_OPTIONS.map((option) => (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => {
+                        setContextMenu(null);
+                        onUpdateAppearance(group.id, { color: option.id });
+                      }}
+                      data-testid={`sidebar-group-color-${option.id}`}
+                      aria-label={`Set ${option.label} background`}
+                      className={`h-8 rounded-md border cursor-pointer transition-colors ${
+                        group.color === option.id ? "border-text-primary" : "border-surface-700"
+                      }`}
+                      style={repoSwatchStyle(option.id)}
+                    />
+                  ))}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setContextMenu(null);
+                      onUpdateAppearance(group.id, { color: null });
+                    }}
+                    data-testid="sidebar-group-color-clear"
+                    aria-label="Clear background"
+                    className="h-8 rounded-md border border-surface-700 bg-surface-900 text-[10px] font-mono text-text-dim cursor-pointer hover:bg-surface-700/40"
+                  >
+                    None
+                  </button>
+                </div>
+              </>
+            )}
           </div>,
           document.body,
         )}
@@ -2109,6 +2140,22 @@ export function WorkspaceSidebar({
     [runBulkAction, triage],
   );
 
+  // Archive every active session under a group at once. Archiving a whole
+  // project is a bigger hammer than a single row, so it confirms first
+  // (matching the TUI's `z`-over-a-project prompt). Reversible, so a plain
+  // confirm rather than a destructive warning; the bulk fan-out reuses the
+  // same per-session path as multi-select archive.
+  const onArchiveGroup = useCallback(
+    (group: SidebarGroup) => {
+      const wss = archivableWorkspaces(group);
+      if (wss.length === 0) return;
+      const noun = wss.length === 1 ? "session" : "sessions";
+      if (!window.confirm(`Archive all ${wss.length} ${noun} in "${group.displayName}"?`)) return;
+      onBulkArchive(wss, true);
+    },
+    [onBulkArchive],
+  );
+
   // Interpret a row click: plain click clears the selection and navigates
   // (today's behavior), modifier clicks build the selection instead. The row
   // has already guarded button / deleting / drag, and called preventDefault.
@@ -2340,6 +2387,7 @@ export function WorkspaceSidebar({
                           hasActiveChild={!showExpanded && hasActiveChild}
                           onClick={() => !q && onToggleGroup(group.id)}
                           onUpdateAppearance={onUpdateRepoAppearance}
+                          onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(group)}
                           onNewSession={() =>
                             group.capabilities.create === "repo" && group.repoPath
                               ? onCreateSession(group.repoPath)
@@ -2426,6 +2474,7 @@ export function WorkspaceSidebar({
                     hasActiveChild={!repoExpanded && repoHasActiveChild}
                     onClick={() => !q && onToggleGroup(repo.id)}
                     onUpdateAppearance={onUpdateRepoAppearance}
+                    onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(repo)}
                     onNewSession={() =>
                       repo.capabilities.create === "repo" && repo.repoPath ? onCreateSession(repo.repoPath) : onNew()
                     }
@@ -2452,6 +2501,7 @@ export function WorkspaceSidebar({
                             hasActiveChild={!subExpanded && subHasActiveChild}
                             onClick={() => !q && onToggleSubgroup(repo.id, groupPath)}
                             onUpdateAppearance={onUpdateRepoAppearance}
+                            onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(sg)}
                             onNewSession={onNew}
                             offline={offline}
                           />

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2146,7 +2146,9 @@ export function WorkspaceSidebar({
   // project is a bigger hammer than a single row, so it confirms first
   // (matching the TUI's `z`-over-a-project prompt). Reversible, so a plain
   // confirm rather than a destructive warning; the bulk fan-out reuses the
-  // same per-session path as multi-select archive.
+  // same per-session path as multi-select archive. The caller must pass the
+  // unfiltered group (see `fullGroup`/`fullSubgroup` below) so an active
+  // search filter doesn't shrink "archive all" to the visible matches.
   const onArchiveGroup = useCallback(
     (group: SidebarGroup) => {
       const wss = archivableWorkspaces(group);
@@ -2157,6 +2159,13 @@ export function WorkspaceSidebar({
     },
     [onBulkArchive],
   );
+
+  // Unfiltered flat-axis groups keyed by id, so the group header's
+  // "Archive all" count and action can resolve full project membership even
+  // while a search filter has sliced the rendered `workspaces`. The nested
+  // repo header already carries full membership (`filteredNested` copies
+  // `ng.repo` unchanged); only the flat header and nested subgroups need it.
+  const groupById = useMemo(() => new Map(groups.map((g) => [g.id, g])), [groups]);
 
   // Interpret a row click: plain click clears the selection and navigates
   // (today's behavior), modifier clicks build the selection instead. The row
@@ -2382,14 +2391,18 @@ export function WorkspaceSidebar({
                   const renderGroupBody = (group: SidebarGroup, dragHandle?: DragHandleProps) => {
                     const showExpanded = q ? true : !group.collapsed;
                     const hasActiveChild = group.workspaces.some((v) => v.workspace.id === displayedActiveId);
+                    // Header archive count + action operate on the full group,
+                    // not the filter-sliced one, so "Archive all" never silently
+                    // skips hidden members. Rows below still render `group`.
+                    const fullGroup = groupById.get(group.id) ?? group;
                     return (
                       <>
                         <SidebarGroupHeader
-                          group={{ ...group, collapsed: !showExpanded }}
+                          group={{ ...fullGroup, collapsed: !showExpanded }}
                           hasActiveChild={!showExpanded && hasActiveChild}
                           onClick={() => !q && onToggleGroup(group.id)}
                           onUpdateAppearance={onUpdateRepoAppearance}
-                          onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(group)}
+                          onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(fullGroup)}
                           onNewSession={() =>
                             group.capabilities.create === "repo" && group.repoPath
                               ? onCreateSession(group.repoPath)
@@ -2491,6 +2504,12 @@ export function WorkspaceSidebar({
                       // footer below, exactly like the flat axes, so
                       // each subgroup renders only its live tier.
                       const liveWorkspaces = sg.workspaces.filter((v) => !workspaceIsSunk(v.workspace));
+                      // Resolve the unfiltered subgroup so "Archive all"
+                      // covers the whole subgroup, not just filter matches.
+                      const fullSubgroup =
+                        nestedGroups
+                          .find((n) => n.repo.id === repo.id)
+                          ?.subgroups.find((s) => (s.groupPath ?? "") === groupPath) ?? sg;
                       return (
                         <div
                           key={`${repo.id}::${groupPath}`}
@@ -2499,11 +2518,11 @@ export function WorkspaceSidebar({
                           data-repo-id={repo.id}
                         >
                           <SidebarGroupHeader
-                            group={{ ...sg, collapsed: !subExpanded }}
+                            group={{ ...fullSubgroup, collapsed: !subExpanded }}
                             hasActiveChild={!subExpanded && subHasActiveChild}
                             onClick={() => !q && onToggleSubgroup(repo.id, groupPath)}
                             onUpdateAppearance={onUpdateRepoAppearance}
-                            onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(sg)}
+                            onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(fullSubgroup)}
                             onNewSession={onNew}
                             offline={offline}
                           />

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1647,7 +1647,9 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
         data-group-id={group.id}
         tabIndex={hasMenu ? 0 : undefined}
         aria-haspopup={hasMenu ? "menu" : undefined}
-        aria-label={hasMenu ? `Project actions for ${group.displayName}` : undefined}
+        aria-label={
+          hasMenu ? `${group.kind === "repo" ? "Project" : "Group"} actions for ${group.displayName}` : undefined
+        }
         onContextMenu={
           hasMenu
             ? (e) => {

--- a/web/src/lib/__tests__/sidebarGroups.test.ts
+++ b/web/src/lib/__tests__/sidebarGroups.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  archivableWorkspaces,
   buildNestedSidebarGroups,
   buildSessionGroups,
   nestedSidebarGroupHasLiveWorkspace,
@@ -368,5 +369,45 @@ describe("sidebarGroupHasLiveWorkspace", () => {
   it("is true when at least one workspace is live", () => {
     const groups = build([workspace("w1", [session({ id: "s1", group_path: "feature" })])]);
     expect(sidebarGroupHasLiveWorkspace(groups[0]!)).toBe(true);
+  });
+});
+
+describe("archivableWorkspaces", () => {
+  it("returns members whose primary session is not archived", () => {
+    const groups = build([
+      workspace("w-live", [session({ id: "a", group_path: "feature" })]),
+      workspace("w-archived", [session({ id: "b", group_path: "feature", archived_at: "2025-01-02T00:00:00Z" })]),
+    ]);
+    const feature = groups.find((g) => g.id === "feature")!;
+    expect(archivableWorkspaces(feature).map((ws) => ws.id)).toEqual(["w-live"]);
+  });
+
+  it("includes snoozed-but-not-archived members (archive sweeps them in)", () => {
+    const groups = build([
+      workspace("w-snoozed", [session({ id: "a", group_path: "feature", snoozed_until: "2999-01-01T00:00:00Z" })]),
+    ]);
+    const feature = groups.find((g) => g.id === "feature")!;
+    expect(archivableWorkspaces(feature).map((ws) => ws.id)).toEqual(["w-snoozed"]);
+  });
+
+  it("is empty once every member is archived", () => {
+    const groups = build([
+      workspace("w1", [session({ id: "a", group_path: "feature", archived_at: "2025-01-02T00:00:00Z" })]),
+    ]);
+    const feature = groups.find((g) => g.id === "feature")!;
+    expect(archivableWorkspaces(feature)).toHaveLength(0);
+  });
+
+  it("keys off the primary session, ignoring archived siblings", () => {
+    // A workspace whose primary session is live is archivable even if a
+    // later session is already archived; triage acts on sessions[0].
+    const groups = build([
+      workspace("w1", [
+        session({ id: "a", group_path: "feature" }),
+        session({ id: "b", group_path: "feature", archived_at: "2025-01-02T00:00:00Z" }),
+      ]),
+    ]);
+    const feature = groups.find((g) => g.id === "feature")!;
+    expect(archivableWorkspaces(feature).map((ws) => ws.id)).toEqual(["w1"]);
   });
 });

--- a/web/src/lib/sidebarGroups.ts
+++ b/web/src/lib/sidebarGroups.ts
@@ -193,6 +193,21 @@ export function sidebarGroupHasLiveWorkspace(group: SidebarGroup): boolean {
   return group.workspaces.some((v) => !workspaceIsSunk(v.workspace));
 }
 
+// The workspaces an "archive all in group" action would act on: every member
+// whose primary session is not already archived. Triage targets each
+// workspace's primary session (`sessions[0]`), matching the single-row and
+// bulk archive paths, so the predicate keys off that session rather than any
+// sibling. Snoozed-but-not-archived members are included (archiving the whole
+// project should still sweep them in); members with no session are skipped.
+export function archivableWorkspaces(group: SidebarGroup): Workspace[] {
+  return group.workspaces
+    .map((v) => v.workspace)
+    .filter((ws) => {
+      const primary = ws.sessions[0];
+      return primary != null && primary.archived_at == null;
+    });
+}
+
 // The nested `repo+group` axis (#1720). A repository header keeps its full
 // repo-axis identity (`repo`), and inside it the same `group_path` buckets
 // the user-group axis already computes show up as `subgroups`. This is a

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2155,6 +2155,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx", "web/src/components/BulkActionBar.tsx"]
     },
     {
+      "id": "sidebar.archive-group",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["tests/sidebar-multi-session.spec.ts", "src/lib/__tests__/sidebarGroups.test.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "triage.acp-banners",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/sidebar-multi-session.spec.ts
+++ b/web/tests/sidebar-multi-session.spec.ts
@@ -274,6 +274,55 @@ test.describe("Sidebar multi-session (#956)", () => {
     await expect(restoredHeader).toHaveAttribute("style", /color-mix/);
   });
 
+  test("project group context menu archives every active session", async ({ page }) => {
+    await mockApis(page, [
+      {
+        id: "sess-a",
+        title: "Ethiopians",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+      },
+      {
+        id: "sess-b",
+        title: "Celts",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+      },
+    ]);
+
+    const archived: string[] = [];
+    await page.route("**/api/sessions/*/archive", async (r) => {
+      const url = new URL(r.request().url());
+      const id = url.pathname.split("/")[3];
+      const body = r.request().postDataJSON() as { archived: boolean };
+      if (body.archived) archived.push(id);
+      await r.fulfill({ json: { id, archived_at: new Date().toISOString() } });
+    });
+
+    // The "archive all in project" action confirms first; accept it.
+    let confirmText = "";
+    page.on("dialog", (dialog) => {
+      confirmText = dialog.message();
+      void dialog.accept();
+    });
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const projectHeader = page.locator('[data-testid="sidebar-group-header"][data-group-id="/tmp/agent-of-empires"]');
+    await projectHeader.click({ button: "right" });
+    const menu = page.locator("[data-testid='sidebar-group-context-menu']");
+    await expect(menu).toBeVisible();
+
+    const archiveAll = menu.locator("[data-testid='sidebar-group-context-menu-archive-all']");
+    await expect(archiveAll).toHaveText("Archive all (2)");
+    await archiveAll.click();
+
+    await expect.poll(() => archived.slice().sort()).toEqual(["sess-a", "sess-b"]);
+    expect(confirmText).toContain("Archive all 2 sessions");
+  });
+
   test("project group appearance menu opens from keyboard", async ({ page }) => {
     await mockApis(page, [
       {


### PR DESCRIPTION
## Description

Backburning an entire project used to mean selecting each session in it and hitting `z` one at a time. This adds a project-level "archive all" so pressing `z` over a project (or group) archives every active session in it at once, behind a confirmation. Implemented for both the TUI and the web dashboard, per #2046.

**TUI:** `z` on a project/group header opens a confirmation prompt, then kills each pane and archives every active member. Membership is resolved mode-aware (by repo name in Project mode, by `group_path` + nested prefix in Manual mode), so it works in both grouping modes and respects the active/owning profile. Single-session `z` is unchanged.

**Web:** the sidebar group-header context menu gains an "Archive all (N)" action, available on every axis (repo / group / nested), hidden in read-only or offline and once nothing is archivable. It confirms first, then reuses the existing serial bulk-archive fan-out and summary toast.

Fixes #2046

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs needed; behavior is discoverable via the prompt/menu)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added a mocked-Playwright test (`tests/sidebar-multi-session.spec.ts`) for the menu, confirmation, and archive PATCH fan-out, plus Vitest cases for the new pure `archivableWorkspaces` helper; new matrix entry `sidebar.archive-group`.

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Covered with in-module unit tests in `src/tui/home/tests.rs` (manual mode incl. nested groups, Project mode, and the prompt/no-op path) rather than a full tmux e2e, since the behavior is pure list/selection logic that the harness can exercise directly.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**

Implemented via Claude Code with @njbrake reviewing. Note: the mocked-Playwright spec could not be run in the dev sandbox (Playwright has no prebuilt browser for the sandbox platform), so it was validated by type-check/lint and is expected to run in CI; the Vitest and Rust suites were run locally and pass.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds a project-/group-level "archive all" action that archives every active session in a project or group after confirmation. Implemented consistently for the TUI and web sidebar, respects grouping modes (Project vs Manual), and preserves single-session behavior.

## High-Level Changes

- TUI: Pressing `z` on a project/group header opens a confirmation prompt and then kills panes and archives all active members in that group. Single-session `z` is unchanged.
- Web: Sidebar group-header context menu gains an "Archive all (N)" item that shows the count of archivable workspaces, asks for confirmation, and reuses the existing bulk-archive flow and summary toast. Disabled when read-only or offline and hidden when nothing is archivable.
- Helper: New archivableWorkspaces helper returns workspaces whose primary session is not already archived.
- Tests & CI: New unit tests for TUI group archiving (including nested manual groups and project mode), a Playwright spec for the web sidebar, Vitest coverage for the helper, and a new coverage-matrix entry. Existing tests updated/extended; local checks pass.
- Safety & UX tweaks: Confirmation prompts and messaging adjusted to show full group paths and mode-aware text. The web count/action operates over unfiltered canonical group membership so filtering doesn't hide members that should be archived.
- Attribution: AI assistance (Claude Code) is acknowledged in commit metadata.

## Technical Details

TUI (src/tui/home):
- Added prompt_archive_selected_group() and a dispatch_confirm_submit branch for "archive_group".
- Added active_sessions_in_selected_group() to compute non-archived session IDs according to current group_by mode.
- Added archive_selected_group() to kill panes, bulk-archive sessions, reveal the Archived section, rebuild the list, and clamp cursor/selection.
- Tests: three new HomeView tests covering manual nested groups, project mode, and prompt/no-op behavior.

Web (web/src):
- WorkspaceSidebar.tsx: SidebarGroupHeader accepts an optional onArchiveAll; menu shows "Archive all (N)" when applicable and wires into onBulkArchive with confirmation.
- sidebarGroups.ts: archivableWorkspaces(group) returns workspaces whose primary session exists and is not archived.
- Tests: unit tests for archivableWorkspaces and a Playwright spec verifying end-to-end archive-all behavior.
- coverage-matrix.json: new sidebar.archive-group entry for CI coverage.

Other notes:
- Fixes review feedback ensuring the web action counts full unfiltered membership and improving TUI prompt text.
- No removals; primarily additive changes.

## Benefits

- Big time-saver: archive an entire project/group in one action instead of repeating single-session archives.
- Consistent UX across TUI and web.
- Safer bulk operations via confirmation and accurate counts.
- Handles both Project and Manual grouping modes correctly.
- Covered by unit, integration, and end-to-end tests to reduce regressions.

## Potential areas for further enhancement

- Replace window.confirm in the web UI with a styled modal for consistent UX and richer messaging.
- Add an undo mechanism or a short grace period to recover accidental bulk-archives.
- Expand telemetry/logging for bulk-archive operations to aid debugging and auditability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->