### PR TITLE
fix(acp): re-adopt live orphan runners so a failed handshake self-heals

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,35 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo test --features serve --lib --bins
 
+  macos-acp-e2e:
+    # The acp live-daemon e2e tests exercise the structured-view
+    # daemon -> runner -> ACP-handshake -> prompt path, which has genuinely
+    # OS-divergent behavior: unix-socket sun_path limits (104 on macOS vs
+    # 108 on Linux), /tmp vs /private/tmp resolution, and setsid /
+    # detached-spawn plus node cold-start timing. The `cargo` job above runs
+    # only --lib --bins on macOS, so a macOS-only failure that lives in the
+    # e2e crate (e.g. #1890) was structurally outside CI's reach. This job
+    # closes that gap by running just the acp e2e modules on macOS. The fake
+    # ACP agent is self-contained (web/tests/helpers/fakeAcpAgent.mjs uses
+    # only `node:` builtins), so no npm install is needed beyond the web
+    # bundle build.rs builds for --features serve.
+    name: macOS acp e2e
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "true"
+          save-if: true
+      - name: Install tmux
+        run: brew install tmux
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+      - name: Cargo test (macOS, acp live-daemon e2e)
+        run: cargo test --features serve --test e2e -- acp_ --test-threads=1 --nocapture
+
   vitest:
     name: Vitest
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   cargo:
     name: Cargo Test

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -963,6 +963,35 @@ fn runner_socket_deadline() -> std::time::Duration {
     std::time::Duration::from_secs(10)
 }
 
+/// Test-only fault injection for the #1890 regression e2e. When
+/// `AOE_ACP_TEST_FAIL_FIRST_HANDSHAKES=N` is set, the first N *fresh*-spawn
+/// ACP handshakes fail right after the runner has come up, before the daemon
+/// records an in-memory worker. The runner keeps its agent alive and its
+/// on-disk registry entry, so the daemon is left with a live, registered
+/// runner it never adopted: the exact orphan state #1890 got permanently
+/// stuck in, reproduced deterministically without depending on host timing.
+/// Each call consumes one budgeted failure; `0` (the default, var unset) is a
+/// no-op. Debug builds only, so release can never trip it. Mirrors the
+/// `AOE_ACP_RUNNER_SOCKET_TIMEOUT_MS` debug knob above.
+#[cfg(debug_assertions)]
+fn take_injected_fresh_handshake_failure() -> bool {
+    use std::sync::atomic::{AtomicI64, Ordering};
+    use std::sync::OnceLock;
+    static REMAINING: OnceLock<AtomicI64> = OnceLock::new();
+    let remaining = REMAINING.get_or_init(|| {
+        let n = std::env::var("AOE_ACP_TEST_FAIL_FIRST_HANDSHAKES")
+            .ok()
+            .and_then(|v| v.trim().parse::<i64>().ok())
+            .unwrap_or(0);
+        AtomicI64::new(n)
+    });
+    remaining
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+            (n > 0).then_some(n - 1)
+        })
+        .is_ok()
+}
+
 /// Read the silent-orphan watchdog grace for the given source profile.
 /// In debug builds, honors `AOE_SILENT_ORPHAN_GRACE_MS` so the
 /// integration test can drive a sub-second cadence without making
@@ -1440,6 +1469,20 @@ impl AcpClient {
         // few ms) but bound the wait so a wedged runner returns a typed
         // error instead of parking the supervisor.
         let stream = wait_for_socket(&socket_path, runner_socket_deadline()).await?;
+        // #1890 regression hook (debug-only): simulate a fresh-spawn whose
+        // daemon-side handshake fails after the runner is already up and
+        // registered. Dropping the socket closes the daemon's end cleanly; the
+        // runner keeps its agent alive and its registry entry, leaving the
+        // orphaned-but-live-runner state the readopt pass must recover from.
+        // Gated on `Fresh` so the recovery reattach/respawn is never failed,
+        // and budgeted by the env var so only the first spawn trips.
+        #[cfg(debug_assertions)]
+        if matches!(mode, ConnectMode::Fresh { .. }) && take_injected_fresh_handshake_failure() {
+            drop(stream);
+            return Err(AcpError::Spawn(
+                "injected fresh-handshake failure (AOE_ACP_TEST_FAIL_FIRST_HANDSHAKES)".into(),
+            ));
+        }
         let (read_half, write_half) = stream.into_split();
         let transport = ByteStreams::new(write_half.compat_write(), read_half.compat());
 

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -234,6 +234,10 @@ pub async fn reconcile_acp_workers(
     // block legitimate spawns until the next tick. Do not reorder.
     sweep_orphan_workers(state, &live).await;
 
+    // Re-adopt live orphan runners (#1890) before the work-list loop, which
+    // skips every `attempted` id. See `readopt_orphan_runners`.
+    readopt_orphan_runners(state, attempted).await;
+
     // Build the work list. Skip ids already in `attempted` (a
     // permanently-failing spawn shouldn't loop every tick) and ids the
     // supervisor already knows about (REST-triggered spawn or
@@ -703,6 +707,20 @@ enum AdoptDecision {
     /// Live worker on an older binary mid-turn: adopt to keep the turn
     /// streaming, then respawn at the next idle boundary.
     AdoptStaleForDrain,
+}
+
+/// Decide whether a session currently pinned in the reconciler's
+/// `attempted` set should be dropped so the resume pass can re-adopt its
+/// live on-disk runner. `running` folds the in-memory worker AND any
+/// in-flight resume reservation (`Supervisor::is_running`); `has_live_runner`
+/// is a live registry record (PID alive + socket present). A session with a
+/// live runner but no in-memory presence is the orphan-after-failed-handshake
+/// state (#1890): the runner is serving on its socket but the daemon never
+/// reattached, so every prompt 404s. A running session (healthy or mid-spawn)
+/// is left alone. Pure so the policy is unit-testable without a daemon,
+/// mirroring `adopt_decision`.
+fn should_readopt_orphan_runner(running: bool, has_live_runner: bool) -> bool {
+    !running && has_live_runner
 }
 
 fn adopt_decision(live: bool, build_current: bool, in_flight_turn: bool) -> AdoptDecision {
@@ -1287,6 +1305,46 @@ pub(crate) async fn trigger_resume_background(
     Ok(ResumeTrigger::Started)
 }
 
+/// Re-adopt live orphan runners. A fresh spawn whose in-memory handshake
+/// fails or times out can leave its DETACHED runner alive and registered on
+/// disk: the runner binds its socket and writes its registry entry BEFORE the
+/// handshake completes, and `connect_via_socket`'s error/timeout path does not
+/// kill it (the runner owns the agent and survives daemon death by design).
+/// Such a session is left in `attempted` with no in-memory worker, so the
+/// reconciler's work-list loop skips it forever and the live runner is never
+/// reattached, so every prompt 404s even though `aoe acp ps` shows the worker
+/// alive.
+///
+/// This is the live-session mirror of `sweep_orphan_workers`, which only reaps
+/// runners whose session is GONE; here the session IS live, so clear it from
+/// `attempted` and let the same tick's resume pass adopt the runner over its
+/// socket. The respawn budget still bounds a genuinely-wedged runner: a record
+/// that can't be reattached burns a budget slot per tick and parks after the
+/// cap rather than looping. A worker that is in-memory or mid-spawn reports
+/// `is_running`, so the healthy and in-flight cases are left untouched. See
+/// #1890.
+async fn readopt_orphan_runners(state: &Arc<AppState>, attempted: &mut HashSet<String>) {
+    let mut readopt: Vec<String> = Vec::new();
+    for id in attempted.iter() {
+        let running = state.acp_supervisor.is_running(id).await;
+        // Skip the registry disk read on the hot path: only a non-running
+        // session can possibly be a readopt candidate.
+        if running {
+            continue;
+        }
+        let has_live_runner = matches!(
+            crate::acp::worker_registry::load(id),
+            Ok(Some(record)) if crate::acp::worker_registry::is_record_live(&record)
+        );
+        if should_readopt_orphan_runner(running, has_live_runner) {
+            readopt.push(id.clone());
+        }
+    }
+    for id in readopt {
+        attempted.remove(&id);
+    }
+}
+
 async fn sweep_orphan_workers(state: &Arc<AppState>, live: &HashSet<&String>) {
     // Sweep registry entries whose session no longer exists (deleted
     // while serve was down) and SIGTERM the orphan runner so the user
@@ -1330,8 +1388,8 @@ async fn sweep_orphan_workers(state: &Arc<AppState>, live: &HashSet<&String>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        adopt_decision, rate_limit_resume_at, should_auto_stop, AdoptDecision,
-        RATE_LIMIT_MIN_PARK_SECS,
+        adopt_decision, rate_limit_resume_at, should_auto_stop, should_readopt_orphan_runner,
+        AdoptDecision, RATE_LIMIT_MIN_PARK_SECS,
     };
     use chrono::{Duration, TimeZone, Utc};
 
@@ -1385,6 +1443,26 @@ mod tests {
             "other-sess",
             now
         ));
+    }
+
+    // --- live orphan runner re-adoption (#1890) ---
+
+    /// The only state that should drop a session from `attempted` for
+    /// re-adoption is "no in-memory worker / reservation, but a live runner
+    /// on disk": a fresh spawn whose handshake failed while the detached
+    /// runner stayed up. A running session (healthy or mid-spawn) is never
+    /// disturbed, and a session with no live runner stays parked under the
+    /// respawn budget instead of being poked every tick.
+    #[test]
+    fn readopt_only_when_runner_live_and_not_running() {
+        // Orphan: live runner, nothing in memory -> re-adopt.
+        assert!(should_readopt_orphan_runner(false, true));
+        // Healthy / mid-spawn: an in-memory worker or reservation wins, even
+        // if a registry record exists.
+        assert!(!should_readopt_orphan_runner(true, true));
+        // No live runner: leave the respawn budget to govern; do not clear.
+        assert!(!should_readopt_orphan_runner(false, false));
+        assert!(!should_readopt_orphan_runner(true, false));
     }
 
     // --- build-version respawn policy (#1754) ---

--- a/tests/e2e/acp_orphan_runner_recovery_e2e.rs
+++ b/tests/e2e/acp_orphan_runner_recovery_e2e.rs
@@ -1,0 +1,168 @@
+//! Full-stack regression for #1890: the daemon must recover a structured-view
+//! session whose first fresh-spawn handshake fails while the detached runner
+//! stays alive and registered on disk.
+//!
+//! The original symptom only reproduced on slow/contended macOS hardware: the
+//! runner subprocess bound its socket and wrote its registry entry before the
+//! daemon-side ACP handshake completed, the handshake then lost the race, and
+//! the reconciler pinned the session in its `attempted` set forever. `aoe acp
+//! ps` showed the worker alive, but every prompt 404'd ("session not found on
+//! the daemon"). Stock CI runners win the handshake race, so this drives the
+//! failure deterministically instead: `AOE_ACP_TEST_FAIL_FIRST_HANDSHAKES=1`
+//! makes the daemon fail exactly the first fresh-spawn handshake (debug-only
+//! hook in `acp_client::connect_via_socket`), leaving the orphaned-but-live
+//! runner. The reconciler's readopt pass must then clear `attempted` and bring
+//! the session back, so the prompt is eventually accepted.
+//!
+//! Without the fix this test hangs until the 45s prompt deadline and panics;
+//! with it, the prompt is accepted once the worker is recovered.
+//!
+//! Compiled only with `--features serve`. Run via:
+//!
+//! ```sh
+//! cargo test --test e2e --features serve -- acp_orphan_runner_recovery
+//! ```
+#![cfg(feature = "serve")]
+
+use std::time::{Duration, Instant};
+
+use serial_test::serial;
+
+use crate::harness::{pick_free_port, require_node, require_tmux, wait_for_port, TuiTestHarness};
+
+/// Minimal one-turn fake-ACP script: accept the prompt and end the turn
+/// immediately. The test only cares that the prompt POST is accepted (the
+/// readiness oracle for "worker live + handshake done"), not what the agent
+/// renders.
+const NOOP_SCRIPT: &str = r#"{
+  "turns": [
+    { "updates": [], "stopReason": "end_turn" }
+  ]
+}"#;
+
+/// Parse the `  ID:      <id>` line that `aoe add` prints on success.
+fn parse_session_id(add_stdout: &str) -> String {
+    add_stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("ID:"))
+        .map(|rest| rest.trim().to_string())
+        .unwrap_or_else(|| panic!("could not find session ID in `aoe add` output:\n{add_stdout}"))
+}
+
+/// Retry `aoe acp prompt` until accepted. The prompt POST 404s while no worker
+/// is live; a successful call proves the reconciler recovered the orphaned
+/// runner. With the bug present this never succeeds and the loop panics at the
+/// deadline, which is the regression oracle.
+fn prompt_until_accepted(h: &TuiTestHarness, session_id: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let out = h.run_cli(&["acp", "prompt", session_id, "please proceed"]);
+        if out.status.success() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            let ps = h.run_cli(&["acp", "ps", "--json"]);
+            panic!(
+                "structured view worker never recovered after an injected fresh-handshake \
+                 failure within {:?}.\n last prompt stdout: {}\n last prompt stderr: {}\n \
+                 acp ps: {}",
+                timeout,
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr),
+                String::from_utf8_lossy(&ps.stdout),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// Stand up a live daemon with the first fresh-spawn handshake rigged to fail,
+/// create a structured-view session, and assert the daemon recovers the
+/// orphaned runner so a prompt is eventually accepted.
+#[test]
+#[serial]
+fn acp_recovers_orphaned_runner_after_failed_first_handshake() {
+    require_tmux!();
+    require_node!();
+
+    // HOME under /tmp: structured view workers bind a unix socket under the app
+    // dir, and a deep tempdir overflows the macOS sun_path limit.
+    let mut h = TuiTestHarness::new_in_tmp("acp_orphan_recovery");
+
+    // Shared Node fake-ACP agent, scripted to accept one no-op turn.
+    let script_path = h.home_path().join("noop-script.json");
+    std::fs::write(&script_path, NOOP_SCRIPT).expect("write fake-acp script");
+    h.install_acp_shim(&script_path);
+
+    // The fault hook: fail exactly the first fresh-spawn ACP handshake in the
+    // daemon, reproducing the #1890 orphaned-but-live-runner state. Set before
+    // the daemon starts so it inherits the var.
+    h.set_env("AOE_ACP_TEST_FAIL_FIRST_HANDSHAKES", "1");
+
+    // Tear down the worker + daemon on Drop so a panicking assertion can't
+    // leak a daemon onto the test port between serial tests.
+    h.stop_daemon_on_drop();
+
+    // A structured view session needs a git repo as its workspace; create one.
+    let project = h.project_path();
+    for args in [
+        vec!["init", "-q"],
+        vec!["commit", "--allow-empty", "-q", "-m", "init"],
+    ] {
+        let out = std::process::Command::new("git")
+            .args(&args)
+            .current_dir(&project)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("run git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    // Start the daemon.
+    let port = pick_free_port();
+    let port_s = port.to_string();
+    let start = h.run_cli(&["serve", "--daemon", "--port", &port_s, "--no-auth"]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {}",
+        port
+    );
+
+    // Create the structured view session. The reconciler auto-spawns the
+    // worker; its first handshake is rigged to fail, orphaning the runner.
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "orphan-recovery",
+        "-c",
+        "claude",
+        "--structured-view",
+    ]);
+    assert!(
+        add.status.success(),
+        "aoe add --structured-view failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&add.stdout),
+        String::from_utf8_lossy(&add.stderr),
+    );
+    let session_id = parse_session_id(&String::from_utf8_lossy(&add.stdout));
+
+    // The readopt pass must clear `attempted` and respawn/reattach so the
+    // worker comes back. Allow extra slack over the happy path for the failed
+    // first handshake plus the reconciler tick that recovers it.
+    prompt_until_accepted(&h, &session_id, Duration::from_secs(45));
+}

--- a/tests/e2e/acp_orphan_runner_recovery_e2e.rs
+++ b/tests/e2e/acp_orphan_runner_recovery_e2e.rs
@@ -60,6 +60,20 @@ fn prompt_until_accepted(h: &TuiTestHarness, session_id: &str, timeout: Duration
         if out.status.success() {
             return;
         }
+        // Only the "no live worker yet" 404 is an expected transient while the
+        // reconciler recovers the orphaned runner; the client renders every
+        // such 404 as "... not found on the daemon". Any other failure (a 500,
+        // a transport error, a real regression) should fail fast instead of
+        // being masked as a 45s timeout.
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if !stderr.contains("not found on the daemon") {
+            panic!(
+                "acp prompt failed with an unexpected error before recovery.\n\
+                 stdout: {}\n stderr: {}",
+                String::from_utf8_lossy(&out.stdout),
+                stderr,
+            );
+        }
         if Instant::now() >= deadline {
             let ps = h.run_cli(&["acp", "ps", "--json"]);
             panic!(

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -18,6 +18,7 @@
 mod harness;
 
 mod acp_focus_isolation_e2e;
+mod acp_orphan_runner_recovery_e2e;
 mod acp_session_log_tee_e2e;
 mod acp_tool_cards_e2e;
 mod archive_restore;


### PR DESCRIPTION
## Description

Fixes #1890.

The cockpit/structured-view live-daemon e2e suite (`acp_focus_isolation_e2e`, `acp_tool_cards_e2e`) fails 100% on macOS with `cockpit/structured view session <id> not found on the daemon`, while `aoe acp ps` shows the worker subprocess alive and registered on disk. It passes on Linux.

### Root cause

When the reconciler fresh-spawns a structured-view worker, the runner subprocess (`aoe __acp-runner`) binds its socket and writes its registry entry BEFORE the daemon-side ACP handshake completes (it binds first so the daemon's post-spawn connect does not race the listener). If that handshake then fails or times out, `connect_via_socket`'s error/timeout path does not kill the detached runner, because the runner owns the agent and is designed to survive daemon death.

The result is a stuck session:

- `aoe acp ps` shows the worker alive and registered (it is a live, detached runner).
- The daemon has no in-memory worker, and the session is pinned in the reconciler's `attempted` set.
- The work-list loop skips every `attempted` id, and `sweep_orphan_workers` only reaps runners whose session is gone. A live session whose runner is live-but-orphaned is never reattached.
- Every prompt 404s indefinitely.

On a loaded macOS box the first handshake is slow or flaky enough to trip this deterministically; Linux wins the handshake race, which is why it was green there.

### Fix

Add `readopt_orphan_runners`, the live-session mirror of `sweep_orphan_workers`. Before the work-list loop, it drops from `attempted` any session that has no in-memory worker (and no in-flight resume reservation) but does have a live registry record, so the same tick's resume pass reattaches over the existing socket. Existing safety still holds: the respawn budget bounds a genuinely wedged runner (it parks after the cap rather than looping), and the loop's own parked and rate-limit guards re-apply, so nothing that was intentionally stopped gets respawned. A pure helper `should_readopt_orphan_runner` carries the policy with a unit test, matching the file's existing `adopt_decision` convention.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --features serve --all-targets`, and `cargo test --features serve --lib server::` (297 passed) are clean. The new `readopt_only_when_runner_live_and_not_running` unit test passes, and both acp live-daemon e2e tests still pass on Linux. I could not reproduce on macOS (Linux-only environment), so the fix is reasoned from the code path and verified not to regress the Linux leg.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

This change is exercised by the existing `tests/e2e/acp_focus_isolation_e2e.rs` and `acp_tool_cards_e2e.rs`, which drive the full daemon -> runner -> handshake -> prompt path that this bug lives in. The reconciler decision is also covered by a new in-module unit test. Note: these e2e tests run only on the Linux CI leg today (see the note below), so the new unit test is what gives both CI legs regression coverage.

A note on why CI did not catch this: `tests.yml` runs `cargo test --features serve` (full suite incl. integration + e2e) only on `ubuntu-latest`. The `macos-latest` leg runs `cargo test --features serve --lib --bins` only, deliberately skipping the integration and e2e crates. So a macOS-only failure that lives in the e2e crate is structurally outside CI's reach. The new unit test lives in `--lib`, so it runs on both legs.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation, root-cause analysis, and the patch were produced by Claude Code via back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Concise summary (non-technical)
This PR fixes a race that allowed freshly spawned ACP runner subprocesses to become "live orphans" when the daemon-side handshake failed: the runner would register on disk but the daemon would not record the in-memory worker, leaving the reconciler to skip reattaching that session. The change re-adopts those live orphan runners so a failed handshake can self-heal, adds targeted unit and e2e tests that reproduce the issue via a debug fault-injection, and expands CI to run the ACP live-daemon e2e tests on macOS.

What changed, added, removed
- Re-adoption logic:
  - Added should_readopt_orphan_runner helper and readopt_orphan_runners pass inside reconcile_acp_workers to remove eligible session IDs from the reconciler’s attempted set so resume can reattach to live runners.
- Fault-injection:
  - Debug-only environment-hook (AOE_ACP_TEST_FAIL_FIRST_HANDSHAKES) to force the first N fresh handshakes to fail, enabling deterministic reproduction of the race.
- Tests:
  - New unit test for should_readopt_orphan_runner.
  - New e2e regression test acp_orphan_runner_recovery_e2e that simulates the failure and verifies recovery.
- CI:
  - New GitHub Actions job macos-acp-e2e to run ACP live-daemon e2e tests on macOS.
- Minor:
  - No public API changes; linting/formatting clean.

Technical details
- Root cause: the reconciler’s attempted set caused the resume work-list loop to permanently skip sessions where the runner wrote its on-disk registry entry before the daemon’s handshake completed. sweep_orphan_workers only reaped sessions whose registry entry had been removed, so live-but-orphaned runners were never reattached.
- Fix: readopt_orphan_runners scans attempted; for session IDs with no in-memory worker and no in-flight resume reservation but with a live registry record (worker_registry::load + is_record_live), it clears them from attempted so the same tick’s resume pass can attach to the existing socket. Existing safety measures (respawn budgets, parked/rate-limit guards) remain unchanged.
- Testing hook: connect_via_socket includes a test-only atomic counter to fail the first N fresh handshakes and reproduce the scenario in tests/CI.

Benefits
- Eliminates a deterministic cause of intermittent macOS e2e failures by allowing live runners to be reattached instead of left orphaned.
- Improves robustness of the live-daemon to transient handshake failures without weakening existing safety/rate-limit protections.
- Adds deterministic test coverage and macOS CI to catch platform-specific regressions earlier.

Potential areas for further improvement
- Broaden stress and platform coverage to validate re-adoption under heavier load or resource constraints.
- Audit other supervisor/registration code paths for similar registration-vs-in-memory races and add targeted telemetry/logging to simplify future diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->