### PR TITLE
feat(sandbox): expand glob volume_ignores at create time with a confirm gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.4.2",
  "git2",
+ "glob",
  "hkdf 0.13.0",
  "jsonwebtoken",
  "mime_guess",
@@ -1426,6 +1427,12 @@ dependencies = [
  "log",
  "openssl-sys",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,9 @@ rand = "0.10"
 # Directory utilities
 dirs = "6.0"
 
+# Glob expansion for sandbox volume_ignores patterns (e.g. `**/bin`, `**/obj`)
+glob = "0.3"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -71,7 +71,7 @@ environment = ["ANTHROPIC_API_KEY"]
 | `cpu_limit` | (none) | CPU limit (e.g., "4") |
 | `memory_limit` | (none) | Memory limit (e.g., "8g") |
 | `environment` | `[]` | Env vars for containers (bare KEY or KEY=VALUE, see below) |
-| `volume_ignores` | `[]` | Literal directory paths to exclude from the project mount via anonymous volumes (no glob expansion, see below) |
+| `volume_ignores` | `[]` | Directory paths to exclude from the project mount via anonymous volumes. Literal paths or glob patterns expanded at create time (see below) |
 | `volume_ignores_strategy` | `"anonymous"` | How `volume_ignores` are mounted: `"anonymous"` (default) or `"named"` (required on macOS/VirtioFS, see below) |
 | `extra_volumes` | `[]` | Additional volume mounts |
 | `mount_ssh` | `false` | Mount `~/.ssh/` read-only into containers |
@@ -79,20 +79,19 @@ environment = ["ANTHROPIC_API_KEY"]
 
 ## Volume Mounts
 
-### Volume Ignores Are Literal Paths
+### Volume Ignores: Literal Paths and Glob Patterns
 
-`volume_ignores` entries are literal directory paths, each resolved relative to the mounted workspace roots. Glob patterns are **not** expanded: Docker needs concrete mount paths at container-create time. An entry like `**/bin` or `target/*` is skipped with a warning rather than mounted, since concatenating it literally would create a real `**` directory inside the bind-mounted repo and leak it back onto the host.
+`volume_ignores` entries can be literal directory paths or glob patterns:
 
-List each generated directory explicitly:
+- A **literal path** (e.g. `node_modules`, `target`, `src/MyApp/bin`) is resolved relative to each mounted workspace root and mounted unconditionally. It need not exist yet; the anonymous volume shadows it once the directory is created.
+- A **glob pattern** (containing `*`, `?`, `[`, or `]`, e.g. `**/bin`, `**/obj`) is expanded against the workspace filesystem when the session is created, and one ignore mount is created per matching directory.
 
 ```toml
 [sandbox]
-# Good: literal paths
-volume_ignores = ["node_modules", "target", "src/MyApp/bin", "src/MyApp/obj"]
-
-# Skipped with a warning: glob metacharacters (* ? [ ])
-# volume_ignores = ["**/bin", "**/obj"]
+volume_ignores = ["node_modules", "target", "**/bin", "**/obj"]
 ```
+
+> **Glob expansion is a point-in-time snapshot.** Docker needs concrete mount paths when the container starts, so a glob is expanded only against the directories that exist at create time. A `bin/` that a build creates *later*, inside the container, is **not** shadowed. Re-create the session to pick up new matches, or list the path literally if you know it ahead of time. The native TUI and the web dashboard show a one-time confirmation explaining this before creating a sandbox session whose config has a glob entry.
 
 ### Volume Ignores Strategy (macOS/VirtioFS)
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -38,17 +38,18 @@ pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_con
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
-    list_sessions, read_output, rename_session, send_message, session_diff_file,
-    session_diff_files, set_worktree_name, update_session_archive, update_session_diff_base,
-    update_session_group, update_session_notifications, update_session_pin, update_session_snooze,
-    update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
+    list_sessions, preview_volume_ignores_globs, read_output, rename_session, send_message,
+    session_diff_file, session_diff_files, set_worktree_name, update_session_archive,
+    update_session_diff_base, update_session_group, update_session_notifications,
+    update_session_pin, update_session_snooze, update_workspace_ordering, CleanupDefaults,
+    OutputQuery, SendMessageRequest, SessionResponse,
 };
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, docker_status,
     filesystem_home, get_about, get_current_theme, get_profile_settings, get_resolved_theme,
     get_settings, get_settings_schema, get_update_status, list_agents, list_groups, list_profiles,
-    list_sounds, list_themes, mark_web_tour_seen, rename_profile, serve_sound_file,
-    update_profile_settings, update_settings, update_theme,
+    list_sounds, list_themes, mark_volume_ignores_globs_acknowledged, mark_web_tour_seen,
+    rename_profile, serve_sound_file, update_profile_settings, update_settings, update_theme,
 };
 pub use telemetry::{
     get_telemetry_status, post_telemetry_seen, post_telemetry_structured_interaction,
@@ -183,6 +184,7 @@ mod tests {
                 &[
                     "update_settings",
                     "mark_web_tour_seen",
+                    "mark_volume_ignores_globs_acknowledged",
                     "create_profile",
                     "delete_profile",
                     "rename_profile",

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3797,6 +3797,91 @@ pub async fn session_diff_file(
     }
 }
 
+#[derive(Deserialize)]
+pub struct VolumeIgnoresPreviewQuery {
+    pub path: String,
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct VolumeIgnoresGlobPreview {
+    pub pattern: String,
+    pub matched_paths: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct VolumeIgnoresPreviewResponse {
+    /// True once the user has acknowledged the snapshot-expansion behavior, so
+    /// the wizard can skip the confirm modal without another round trip.
+    pub acknowledged: bool,
+    /// One entry per glob `volume_ignores` pattern with the directories it
+    /// currently matches (container-side paths). Empty when none are configured.
+    pub globs: Vec<VolumeIgnoresGlobPreview>,
+}
+
+/// Dry-run how glob `volume_ignores` entries would expand for a session rooted at
+/// `path`, without creating anything. The wizard calls this before a sandbox
+/// create to decide whether to show the snapshot-expansion confirm modal (#2045).
+/// Read-only: no `read_only` guard needed.
+pub async fn preview_volume_ignores_globs(
+    axum::extract::Query(query): axum::extract::Query<VolumeIgnoresPreviewQuery>,
+) -> impl IntoResponse {
+    let result = tokio::task::spawn_blocking(move || {
+        let profile = query.profile.unwrap_or_default();
+        let config = crate::session::repo_config::resolve_config_with_repo(
+            &profile,
+            std::path::Path::new(&query.path),
+        )?;
+        let expansions = crate::session::container_config::preview_glob_volume_ignores(
+            &query.path,
+            None,
+            &config.sandbox.volume_ignores,
+        )?;
+        let acknowledged = crate::session::Config::load()
+            .map(|c| c.app_state.has_acknowledged_volume_ignores_globs)
+            .unwrap_or(false);
+        Ok::<_, anyhow::Error>((acknowledged, expansions))
+    })
+    .await;
+
+    match result {
+        Ok(Ok((acknowledged, expansions))) => {
+            let globs = expansions
+                .into_iter()
+                .map(|e| VolumeIgnoresGlobPreview {
+                    pattern: e.pattern,
+                    matched_paths: e.matched_container_paths,
+                })
+                .collect();
+            (
+                StatusCode::OK,
+                Json(VolumeIgnoresPreviewResponse {
+                    acknowledged,
+                    globs,
+                }),
+            )
+                .into_response()
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(target: "http.api.sessions", "volume_ignores glob preview failed: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "preview_failed", "message": "Failed to preview volume_ignores"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(target: "http.api.sessions", "volume_ignores glob preview panicked: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -442,6 +442,58 @@ pub async fn mark_web_tour_seen(State(state): State<Arc<AppState>>) -> impl Into
     }
 }
 
+/// Records that the user has acknowledged glob `volume_ignores` snapshot
+/// expansion (#2045), so the new-session wizard's confirm modal is shown once
+/// and never again. Single-purpose write mirroring [`mark_web_tour_seen`]: it
+/// flips one bool, grants no capability, stays exempt from the elevation wall,
+/// and `read_only` still blocks it. `Config::load()` (not `load_or_warn`) keeps
+/// a corrupt config from being silently overwritten.
+pub async fn mark_volume_ignores_globs_acknowledged(
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+
+    let result = tokio::task::spawn_blocking(|| {
+        let mut config = crate::session::Config::load()?;
+        config.app_state.has_acknowledged_volume_ignores_globs = true;
+        crate::session::save_config(&config)?;
+        Ok::<_, anyhow::Error>(())
+    })
+    .await;
+
+    match result {
+        Ok(Ok(())) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"has_acknowledged_volume_ignores_globs": true})),
+        )
+            .into_response(),
+        Ok(Err(e)) => {
+            tracing::warn!(target: "http.api.system", "Marking volume_ignores globs acknowledged failed: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "save_failed", "message": "Failed to persist acknowledgment"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(target: "http.api.system", "Marking volume_ignores globs acknowledged panicked: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 // --- Themes ---
 
 pub async fn list_themes() -> Json<Vec<String>> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1335,6 +1335,14 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/app-state/web-tour-seen",
             post(api::mark_web_tour_seen),
         )
+        .route(
+            "/api/app-state/volume-ignores-globs-acknowledged",
+            post(api::mark_volume_ignores_globs_acknowledged),
+        )
+        .route(
+            "/api/sandbox/volume-ignores-preview",
+            get(api::preview_volume_ignores_globs),
+        )
         .route("/api/themes", get(api::list_themes))
         .route("/api/themes/{name}", get(api::get_resolved_theme))
         .route("/api/theme/current", get(api::get_current_theme))

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -692,13 +692,6 @@ pub fn build_instance(
         };
         warnings.extend(crate::session::validate_env_entries(effective_env));
 
-        // Glob patterns in volume_ignores are skipped at mount time (they would
-        // materialize a literal `**` dir inside the bind mount, #2036). Surface
-        // the skip here so it isn't silent, matching the env-var warning above.
-        warnings.extend(crate::session::container_config::validate_volume_ignores(
-            &config.sandbox.volume_ignores,
-        ));
-
         instance.sandbox_info = Some(SandboxInfo {
             enabled: true,
             container_id: None,

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -659,6 +659,14 @@ pub struct AppStateConfig {
     #[serde(default)]
     pub has_acknowledged_agent_hooks: bool,
 
+    /// True once the user has acknowledged that glob `volume_ignores` entries
+    /// (e.g. `**/bin`) are expanded against the workspace at session-create time,
+    /// a point-in-time snapshot that won't shadow directories created later by an
+    /// in-container build (#2045). Gates the one-time confirm dialog shown before a
+    /// sandbox session whose resolved config contains a glob ignore.
+    #[serde(default)]
+    pub has_acknowledged_volume_ignores_globs: bool,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sort_order: Option<SortOrder>,
 

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -963,35 +963,121 @@ impl<'a> ContainerAgentSelection<'a> {
     }
 }
 
-/// `volume_ignores` entries are treated as literal directory paths and concatenated
-/// onto each mount base. Glob patterns are not expanded (Docker needs concrete mount
-/// paths at container-create time), so an entry like `**/bin` would materialize a
-/// literal `**` directory inside the bind-mounted repo, leaking onto the host (#2036).
-/// Detect such entries so we can skip and warn instead of creating junk mount targets.
-fn has_glob_metachars(entry: &str) -> bool {
+/// A `volume_ignores` entry containing glob metacharacters is expanded against the
+/// mounted workspace roots at container-create time (#2045); a literal entry is
+/// concatenated onto each mount base unconditionally. This distinguishes the two.
+pub(crate) fn has_glob_metachars(entry: &str) -> bool {
     entry.contains(['*', '?', '[', ']'])
 }
 
-/// Produce user-facing warnings for `volume_ignores` entries that `build_container_config`
-/// will skip because they contain glob metacharacters. Mirrors that skip so session
-/// creation can surface the same information in the TUI warnings dialog (#2036), the way
-/// [`validate_env_entries`](crate::session::validate_env_entries) surfaces unset env vars.
-pub(crate) fn validate_volume_ignores<I, S>(entries: I) -> Vec<String>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<str>,
-{
-    entries
+/// Expand one glob `volume_ignores` entry against the host filesystem under each
+/// mounted workspace root, returning the container-side mount paths for every
+/// directory that matches right now.
+///
+/// `roots` is `(host_path, container_path)` for each project mount. Expansion is a
+/// point-in-time snapshot: Docker needs concrete mount paths when the container
+/// starts, so a directory created later by an in-container build is not shadowed.
+/// Only directories are returned; files can't be ignore mounts. The glob's leading
+/// host prefix is escaped so a literal `[` in the real path isn't treated as a
+/// character class.
+fn expand_glob_ignore(entry: &str, roots: &[(String, String)]) -> Vec<String> {
+    let mut out = Vec::new();
+    for (host_base, container_base) in roots {
+        let host_trimmed = host_base.trim_end_matches('/');
+        let pattern = format!("{}/{}", glob::Pattern::escape(host_trimmed), entry);
+        let matches = match glob::glob(&pattern) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(
+                    target: "session.profile",
+                    "Skipping volume_ignores glob '{}': invalid pattern: {}",
+                    entry, e
+                );
+                continue;
+            }
+        };
+        for matched in matches {
+            let path = match matched {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::debug!(target: "session.profile", "glob walk error for '{}': {}", entry, e);
+                    continue;
+                }
+            };
+            if !path.is_dir() {
+                continue;
+            }
+            let Ok(rel) = path.strip_prefix(host_trimmed) else {
+                continue;
+            };
+            let rel = rel.to_string_lossy();
+            if rel.is_empty() {
+                continue;
+            }
+            out.push(format!("{}/{}", container_base, rel));
+        }
+    }
+    out
+}
+
+/// One glob `volume_ignores` entry paired with the directories it currently
+/// matches, expressed as container-side mount paths. The empty-`matches` case is
+/// kept (rather than dropped) so callers can tell "configured but matched nothing"
+/// from "no glob configured".
+#[derive(Debug, Clone)]
+pub(crate) struct GlobIgnoreExpansion {
+    pub pattern: String,
+    pub matched_container_paths: Vec<String>,
+}
+
+/// Compute how glob `volume_ignores` entries would expand for a session rooted at
+/// `project_path_str`, without creating any container. The TUI confirm gate and the
+/// web preview endpoint both call this so they describe the exact snapshot
+/// [`build_container_config`] will materialize. Literal (non-glob) entries are
+/// excluded; an `Ok(vec![])` means nothing needs confirming.
+pub(crate) fn preview_glob_volume_ignores(
+    project_path_str: &str,
+    workspace_info: Option<&super::WorkspaceInfo>,
+    volume_ignores: &[String],
+) -> Result<Vec<GlobIgnoreExpansion>> {
+    // An empty project path (scratch session) has no workspace to expand
+    // against; globbing it would resolve to filesystem-root patterns. Nothing
+    // to preview.
+    if project_path_str.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let glob_entries: Vec<&String> = volume_ignores
+        .iter()
+        .filter(|e| has_glob_metachars(e))
+        .collect();
+    if glob_entries.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let project_path = Path::new(project_path_str);
+    let (project_volumes, _workspace_path) = if let Some(ws_info) = workspace_info {
+        compute_workspace_volume_paths(project_path, ws_info)?
+    } else {
+        compute_volume_paths(project_path, project_path_str)?
+    };
+    let roots = glob_roots(&project_volumes);
+
+    Ok(glob_entries
         .into_iter()
-        .filter_map(|e| {
-            let s = e.as_ref();
-            has_glob_metachars(s).then(|| {
-                format!(
-                    "Warning: volume_ignores entry '{}' was skipped; glob patterns are not supported, list literal directory paths instead",
-                    s
-                )
-            })
+        .map(|pattern| GlobIgnoreExpansion {
+            pattern: pattern.clone(),
+            matched_container_paths: expand_glob_ignore(pattern, &roots),
         })
+        .collect())
+}
+
+/// `(host_path, container_path)` pairs for the project mounts, the roots glob
+/// `volume_ignores` are expanded against.
+fn glob_roots(project_volumes: &[VolumeMount]) -> Vec<(String, String)> {
+    project_volumes
+        .iter()
+        .map(|v| (v.host_path.clone(), v.container_path.clone()))
         .collect()
 }
 
@@ -1070,6 +1156,10 @@ pub(crate) fn build_container_config(
     if !volume_ignore_bases.contains(&workspace_path) {
         volume_ignore_bases.push(workspace_path.clone());
     }
+
+    // (host, container) roots for expanding glob volume_ignores against the live
+    // filesystem. Captured before `project_volumes` is moved into `volumes`.
+    let glob_roots = glob_roots(&project_volumes);
 
     let mut volumes = project_volumes;
 
@@ -1314,36 +1404,30 @@ pub(crate) fn build_container_config(
         }
     }
 
-    // Glob patterns are not supported: they would be concatenated literally and create
-    // a real `**`/`*` directory inside the bind-mounted repo, leaking onto the host (#2036).
-    // Skip glob-like entries with a warning rather than mounting a bogus path.
-    let literal_ignores: Vec<&String> = sandbox_config
-        .volume_ignores
-        .iter()
-        .filter(|ignore| {
-            if has_glob_metachars(ignore) {
-                tracing::warn!(
-                    target: "session.profile",
-                    "Ignoring volume_ignores entry '{}': glob patterns are not supported, entries must be literal directory paths",
-                    ignore
-                );
-                false
-            } else {
-                true
+    // Resolve volume_ignores into concrete container mount paths. Literal entries
+    // mount unconditionally at every workspace base (the path need not exist yet,
+    // since the anonymous/named volume shadows it once created). Glob entries are
+    // expanded against the host filesystem now (#2045): a point-in-time snapshot,
+    // since Docker needs concrete mount paths when the container starts.
+    let mut resolved_ignore_paths: Vec<String> = Vec::new();
+    for ignore in &sandbox_config.volume_ignores {
+        if has_glob_metachars(ignore) {
+            resolved_ignore_paths.extend(expand_glob_ignore(ignore, &glob_roots));
+        } else {
+            for base_path in &volume_ignore_bases {
+                resolved_ignore_paths.push(format!("{}/{}", base_path, ignore));
             }
-        })
-        .collect();
+        }
+    }
 
-    // Expand all volume_ignores paths and filter conflicts with extra_volumes.
-    // (extra_volumes take precedence over volume_ignores)
-    // Conflicts: exact match, anonymous is a parent of extra, or inside extra.
-    let expanded_ignore_paths: Vec<String> = volume_ignore_bases
-        .iter()
-        .flat_map(|base_path| {
-            literal_ignores
-                .iter()
-                .map(move |ignore| format!("{}/{}", base_path, ignore))
-        })
+    // Drop duplicates (a glob can match the same dir under overlapping bases) and
+    // filter conflicts with extra_volumes, which take precedence over
+    // volume_ignores. Conflicts: exact match, ignore is a parent of an extra, or
+    // ignore sits inside an extra.
+    let mut seen_ignore = std::collections::HashSet::new();
+    let expanded_ignore_paths: Vec<String> = resolved_ignore_paths
+        .into_iter()
+        .filter(|path| seen_ignore.insert(path.clone()))
         .filter(|path| {
             !extra_volume_container_paths.iter().any(|extra_path| {
                 path == extra_path
@@ -2671,34 +2755,31 @@ extra_volumes = ["/host/data:/container/data:ro"]
         assert!(!has_glob_metachars(".venv"));
     }
 
-    #[test]
-    fn test_validate_volume_ignores_warns_only_on_globs() {
-        let warnings = validate_volume_ignores(["**/bin/", "target", "**/obj/", "node_modules"]);
-        assert_eq!(warnings.len(), 2, "got: {:?}", warnings);
-        assert!(warnings[0].contains("**/bin/"));
-        assert!(warnings[1].contains("**/obj/"));
-        assert!(validate_volume_ignores(["target", ".venv"]).is_empty());
-    }
-
-    /// Regression test for #2036: glob-like volume_ignores entries must be skipped
-    /// rather than concatenated into literal mount targets (which leaked a `**`
-    /// directory onto the host through the bind mount). Literal entries still mount.
+    /// Feature test for #2045: glob volume_ignores entries are expanded against the
+    /// live workspace at build time, emitting one mount per matched directory, while
+    /// literal entries still mount unconditionally and no `*` ever reaches a mount
+    /// path (the #2036 host-littering regression must not return).
     #[test]
     #[serial_test::serial]
-    fn test_volume_ignores_skips_glob_entries() {
+    fn test_volume_ignores_expands_glob_entries() {
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         let project_dir = TempDir::new().unwrap();
+        // Nested generated dirs the .NET-style globs should find.
+        fs::create_dir_all(project_dir.path().join("src/App/bin")).unwrap();
+        fs::create_dir_all(project_dir.path().join("src/App/obj")).unwrap();
+        fs::create_dir_all(project_dir.path().join("tests/Lib/bin")).unwrap();
+
         let config_dir = project_dir.path().join(".agent-of-empires");
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(
             config_dir.join("config.toml"),
             r#"
 [sandbox]
-volume_ignores = ["**/bin/", "**/obj/", "target"]
+volume_ignores = ["**/bin", "**/obj", "target"]
 "#,
         )
         .unwrap();
@@ -2727,9 +2808,18 @@ volume_ignores = ["**/bin/", "**/obj/", "target"]
         .unwrap();
 
         let dir_name = project_dir.path().file_name().unwrap().to_string_lossy();
-        let expected_target = format!("/workspace/{}/target", dir_name);
+        let expect = |p: &str| format!("/workspace/{}/{}", dir_name, p);
+
+        for matched in ["src/App/bin", "tests/Lib/bin", "src/App/obj"] {
+            assert!(
+                config.anonymous_volumes.contains(&expect(matched)),
+                "glob should have expanded to {}, got: {:?}",
+                matched,
+                config.anonymous_volumes
+            );
+        }
         assert!(
-            config.anonymous_volumes.contains(&expected_target),
+            config.anonymous_volumes.contains(&expect("target")),
             "literal 'target' entry should still mount, got: {:?}",
             config.anonymous_volumes
         );
@@ -2738,9 +2828,56 @@ volume_ignores = ["**/bin/", "**/obj/", "target"]
                 .anonymous_volumes
                 .iter()
                 .any(|p| p.contains('*') || p.contains('?')),
-            "glob-like entries must not produce literal mount targets, got: {:?}",
+            "no glob metachar may reach a mount path, got: {:?}",
             config.anonymous_volumes
         );
+    }
+
+    /// `preview_glob_volume_ignores` reports the same expansion the build performs,
+    /// keeps a configured-but-unmatched pattern with an empty match list, and ignores
+    /// literal entries entirely.
+    #[test]
+    #[serial_test::serial]
+    fn test_preview_glob_volume_ignores() {
+        let project_dir = TempDir::new().unwrap();
+        fs::create_dir_all(project_dir.path().join("src/App/bin")).unwrap();
+        // A file (not a dir) named like a match must be ignored.
+        fs::write(project_dir.path().join("notes.bin"), "x").unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+        let project_path_str = project_dir.path().to_str().unwrap();
+
+        let ignores = vec![
+            "**/bin".to_string(),
+            "**/missing".to_string(),
+            "target".to_string(),
+        ];
+        let expansions = preview_glob_volume_ignores(project_path_str, None, &ignores).unwrap();
+
+        // Two glob entries (literal "target" excluded); order preserved.
+        assert_eq!(expansions.len(), 2);
+        assert_eq!(expansions[0].pattern, "**/bin");
+        let dir_name = project_dir.path().file_name().unwrap().to_string_lossy();
+        assert_eq!(
+            expansions[0].matched_container_paths,
+            vec![format!("/workspace/{}/src/App/bin", dir_name)],
+            "only the directory should match, not notes.bin"
+        );
+        assert_eq!(expansions[1].pattern, "**/missing");
+        assert!(
+            expansions[1].matched_container_paths.is_empty(),
+            "an unmatched glob is kept with no matches"
+        );
+    }
+
+    #[test]
+    fn test_preview_glob_volume_ignores_empty_without_globs() {
+        let project_dir = TempDir::new().unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+        let ignores = vec!["target".to_string(), ".venv".to_string()];
+        let expansions =
+            preview_glob_volume_ignores(project_dir.path().to_str().unwrap(), None, &ignores)
+                .unwrap();
+        assert!(expansions.is_empty());
     }
 
     /// Regression: when project_path is a sibling worktree, `.agent-of-empires/config.toml`

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1109,6 +1109,29 @@ impl HomeView {
                             }
                         }
                         if let Some(data) = self.pending_hooks_install_data.take() {
+                            self.pending_dialog_click_action =
+                                self.maybe_confirm_volume_ignores_globs(data);
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+        if let Some(dialog) = &self.volume_ignores_glob_dialog {
+            if let Some(result) = dialog.handle_click(col, row) {
+                let dont_ask_again = dialog.dont_ask_again();
+                match result {
+                    DialogResult::Continue => {}
+                    DialogResult::Cancel => {
+                        self.volume_ignores_glob_dialog = None;
+                        self.pending_volume_ignores_glob_data = None;
+                    }
+                    DialogResult::Submit(_) => {
+                        self.volume_ignores_glob_dialog = None;
+                        if dont_ask_again {
+                            self.persist_volume_ignores_globs_ack();
+                        }
+                        if let Some(data) = self.pending_volume_ignores_glob_data.take() {
                             self.pending_dialog_click_action = self.continue_session_creation(data);
                         }
                     }
@@ -1506,6 +1529,27 @@ impl HomeView {
                     }
                     // Resume session creation
                     if let Some(data) = self.pending_hooks_install_data.take() {
+                        return self.maybe_confirm_volume_ignores_globs(data);
+                    }
+                }
+            }
+            return None;
+        }
+
+        if let Some(dialog) = &mut self.volume_ignores_glob_dialog {
+            match dialog.handle_key(key) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel => {
+                    self.volume_ignores_glob_dialog = None;
+                    self.pending_volume_ignores_glob_data = None;
+                }
+                DialogResult::Submit(_) => {
+                    let dont_ask_again = dialog.dont_ask_again();
+                    self.volume_ignores_glob_dialog = None;
+                    if dont_ask_again {
+                        self.persist_volume_ignores_globs_ack();
+                    }
+                    if let Some(data) = self.pending_volume_ignores_glob_data.take() {
                         return self.continue_session_creation(data);
                     }
                 }
@@ -1598,7 +1642,7 @@ impl HomeView {
                         }
                     }
 
-                    return self.continue_session_creation(data);
+                    return self.maybe_confirm_volume_ignores_globs(data);
                 }
             }
             return None;
@@ -4273,6 +4317,85 @@ impl HomeView {
         }
     }
 
+    /// Gate sandbox session creation on a one-time confirmation when the resolved
+    /// config has glob `volume_ignores` (e.g. `**/bin`). Those entries are expanded
+    /// against the workspace at create time, a point-in-time snapshot that won't
+    /// shadow directories a build creates later inside the container (#2045). Shows
+    /// the dialog once (unless already acknowledged or no glob is configured),
+    /// otherwise proceeds straight to creation.
+    fn maybe_confirm_volume_ignores_globs(&mut self, data: NewSessionData) -> Option<Action> {
+        if data.sandbox && !Self::volume_ignores_globs_acknowledged() {
+            if let Some(message) = Self::volume_ignores_glob_confirm_message(&data) {
+                self.volume_ignores_glob_dialog = Some(
+                    crate::tui::dialogs::ConfirmDialog::new(
+                        "Glob volume_ignores",
+                        &message,
+                        "volume_ignores_globs",
+                    )
+                    .neutral()
+                    .offering_dont_ask_again(),
+                );
+                self.pending_volume_ignores_glob_data = Some(data);
+                return None;
+            }
+        }
+        self.continue_session_creation(data)
+    }
+
+    fn volume_ignores_globs_acknowledged() -> bool {
+        load_config()
+            .ok()
+            .flatten()
+            .map(|c| c.app_state.has_acknowledged_volume_ignores_globs)
+            .unwrap_or(false)
+    }
+
+    fn persist_volume_ignores_globs_ack(&self) {
+        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
+            config.app_state.has_acknowledged_volume_ignores_globs = true;
+            if let Err(e) = save_config(&config) {
+                tracing::warn!(target: "tui.input", "Failed to save volume_ignores ack: {e}");
+            }
+        }
+    }
+
+    /// Build the confirm message describing how this session's glob volume_ignores
+    /// will expand, or `None` when there is no glob entry (nothing to confirm).
+    fn volume_ignores_glob_confirm_message(data: &NewSessionData) -> Option<String> {
+        let config =
+            repo_config::resolve_config_with_repo(&data.profile, std::path::Path::new(&data.path))
+                .ok()?;
+        let expansions = crate::session::container_config::preview_glob_volume_ignores(
+            &data.path,
+            None,
+            &config.sandbox.volume_ignores,
+        )
+        .ok()?;
+        if expansions.is_empty() {
+            return None;
+        }
+        let match_count: usize = expansions
+            .iter()
+            .map(|e| e.matched_container_paths.len())
+            .sum();
+        // Name the patterns (capped) so the user sees what will expand.
+        let mut patterns: Vec<&str> = expansions.iter().map(|e| e.pattern.as_str()).collect();
+        let pattern_list = if patterns.len() > 3 {
+            patterns.truncate(3);
+            format!("{}, ...", patterns.join(", "))
+        } else {
+            patterns.join(", ")
+        };
+        Some(format!(
+            "volume_ignores globs ({}) match {} director{} in the workspace right now. Each \
+             becomes an ignore mount at create time; directories a build creates later inside the \
+             container are not hidden. Proceed?",
+            pattern_list,
+            match_count,
+            if match_count == 1 { "y" } else { "ies" },
+        ))
+    }
+
     /// Continue session creation after agent hooks acknowledgment.
     /// Runs the repo hook trust check and then creates the session.
     fn continue_session_creation(&mut self, data: NewSessionData) -> Option<Action> {
@@ -4604,5 +4727,65 @@ mod tests {
         let cache = build_tool_hotkey_cache(&tools);
         assert_eq!(cache[0].0, "alpha");
         assert_eq!(cache[1].0, "beta");
+    }
+
+    fn glob_session_data(path: &str) -> NewSessionData {
+        NewSessionData {
+            profile: String::new(),
+            title: String::new(),
+            path: path.to_string(),
+            group: String::new(),
+            tool: "claude".to_string(),
+            worktree_enabled: false,
+            worktree_branch: None,
+            create_new_branch: false,
+            base_branch: None,
+            extra_repo_paths: Vec::new(),
+            sandbox: true,
+            sandbox_image: "ubuntu:latest".to_string(),
+            yolo_mode: false,
+            extra_env: Vec::new(),
+            extra_args: String::new(),
+            command_override: String::new(),
+            scratch: false,
+        }
+    }
+
+    /// The confirm gate only fires when the resolved config has a glob ignore
+    /// that the message can name; literal-only ignores produce no dialog.
+    #[test]
+    #[serial_test::serial]
+    fn volume_ignores_glob_confirm_message_fires_only_on_globs() {
+        let temp_home = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let project = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(project.path().join("src/App/bin")).unwrap();
+        git2::Repository::init(project.path()).unwrap();
+        let cfg = project.path().join(".agent-of-empires");
+        std::fs::create_dir_all(&cfg).unwrap();
+        let path = project.path().to_str().unwrap();
+
+        std::fs::write(
+            cfg.join("config.toml"),
+            "[sandbox]\nvolume_ignores = [\"**/bin\", \"target\"]\n",
+        )
+        .unwrap();
+        let msg = HomeView::volume_ignores_glob_confirm_message(&glob_session_data(path))
+            .expect("glob ignore should produce a confirm message");
+        assert!(msg.contains("**/bin"), "message names the pattern: {msg}");
+        assert!(msg.contains("1 directory"), "one match counted: {msg}");
+
+        std::fs::write(
+            cfg.join("config.toml"),
+            "[sandbox]\nvolume_ignores = [\"target\", \".venv\"]\n",
+        )
+        .unwrap();
+        assert!(
+            HomeView::volume_ignores_glob_confirm_message(&glob_session_data(path)).is_none(),
+            "literal-only ignores must not trigger the gate"
+        );
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -475,6 +475,13 @@ pub struct HomeView {
     pub(super) hooks_install_dialog: Option<HooksInstallDialog>,
     /// Session data pending agent hooks acknowledgment
     pub(super) pending_hooks_install_data: Option<NewSessionData>,
+    /// One-time confirm shown before a sandbox session whose resolved config
+    /// has glob `volume_ignores` (e.g. `**/bin`), explaining the create-time
+    /// snapshot expansion (#2045). Reuses [`ConfirmDialog`] with a
+    /// "don't warn me again" checkbox persisted to app_state.
+    pub(super) volume_ignores_glob_dialog: Option<ConfirmDialog>,
+    /// Session data pending the volume_ignores glob expansion acknowledgment.
+    pub(super) pending_volume_ignores_glob_data: Option<NewSessionData>,
     pub(super) intro_dialog: Option<IntroDialog>,
     /// Theme name queued by a click on the intro dialog (live preview or
     /// final pick). Drained by the `App` mouse handler after
@@ -1101,6 +1108,8 @@ impl HomeView {
             pending_repo_trust_data: None,
             hooks_install_dialog: None,
             pending_hooks_install_data: None,
+            volume_ignores_glob_dialog: None,
+            pending_volume_ignores_glob_data: None,
             intro_dialog: None,
             pending_intro_theme: None,
             no_agents_dialog: None,
@@ -2764,6 +2773,7 @@ impl HomeView {
             || self.context_menu.is_some()
             || self.repo_trust_dialog.is_some()
             || self.hooks_install_dialog.is_some()
+            || self.volume_ignores_glob_dialog.is_some()
             || self.intro_dialog.is_some()
             || self.no_agents_dialog.is_some()
             || self.changelog_dialog.is_some()
@@ -2801,6 +2811,7 @@ impl HomeView {
             || self.context_menu.is_some()
             || self.repo_trust_dialog.is_some()
             || self.hooks_install_dialog.is_some()
+            || self.volume_ignores_glob_dialog.is_some()
             || self.intro_dialog.is_some()
             || self.no_agents_dialog.is_some()
             || self.changelog_dialog.is_some()

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -630,6 +630,7 @@ impl HomeView {
             worktree_name_dialog,
             restart_dialog,
             hooks_install_dialog,
+            volume_ignores_glob_dialog,
             repo_trust_dialog,
             intro_dialog,
             no_agents_dialog,
@@ -867,6 +868,7 @@ impl HomeView {
             || self.worktree_name_dialog.is_some()
             || self.repo_trust_dialog.is_some()
             || self.hooks_install_dialog.is_some()
+            || self.volume_ignores_glob_dialog.is_some()
             || self.intro_dialog.is_some()
             || self.no_agents_dialog.is_some()
             || self.changelog_dialog.is_some()

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -7,7 +7,11 @@ import {
   fetchProfiles,
   fetchSettings,
   createSession,
+  fetchVolumeIgnoresPreview,
+  markVolumeIgnoresGlobsAcknowledged,
+  type VolumeIgnoresGlobPreview,
 } from "../../lib/api";
+import { VolumeIgnoresGlobDialog } from "./VolumeIgnoresGlobDialog";
 import { ACP_CAPABLE_TOOLS, isAcpCapable } from "../../lib/acpCapableTools";
 import { safeGetItem, safeSetItem } from "../../lib/safeStorage";
 import { toastBus } from "../../lib/toastBus";
@@ -134,6 +138,13 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
   // and on a profile switch, so the preview adds no extra request. See
   // #1911.
   const [commandMaps, setCommandMaps] = useState<CommandMaps>(EMPTY_COMMAND_MAPS);
+  // Pending sandbox create paused on the glob volume_ignores confirm modal
+  // (#2045). Holds the matched patterns to explain and the request to replay
+  // once the user proceeds.
+  const [globConfirm, setGlobConfirm] = useState<{
+    globs: VolumeIgnoresGlobPreview[];
+    body: CreateSessionRequest;
+  } | null>(null);
 
   const steps = useMemo(() => computeSteps(state.data), [state.data]);
 
@@ -264,10 +275,27 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
       agent_effort: selectedAgentAcpCapable && d.useStructuredView && d.agentEffort ? d.agentEffort : undefined,
       scratch: d.scratch || undefined,
     };
+
+    // Sandbox sessions whose resolved config has glob volume_ignores get a
+    // one-time snapshot-expansion confirmation before we create (#2045). Skip
+    // for scratch (no project path to expand against) and treat any preview
+    // failure as "nothing to confirm" so it never blocks creation.
+    if (d.sandboxEnabled && !d.scratch && d.path) {
+      const preview = await fetchVolumeIgnoresPreview(d.path, d.profile || undefined);
+      if (preview && !preview.acknowledged && preview.globs.length > 0) {
+        setGlobConfirm({ globs: preview.globs, body });
+        return;
+      }
+    }
+
+    await runCreate(body, d.tool);
+  };
+
+  const runCreate = async (body: CreateSessionRequest, tool: string) => {
     const result = await createSession(body);
     if (result.ok) {
       dispatch({ type: "SUBMIT_SUCCESS" });
-      saveLastUsedTool(d.tool);
+      saveLastUsedTool(tool);
       const warnings = result.session?.warnings;
       if (warnings && warnings.length > 0) {
         for (const w of warnings) toastBus.handler?.error(w);
@@ -278,6 +306,19 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
         type: "SUBMIT_ERROR",
         error: result.error || "Unknown error",
       });
+  };
+
+  const handleGlobConfirm = async (dontShowAgain: boolean) => {
+    const pending = globConfirm;
+    if (!pending) return;
+    if (dontShowAgain) await markVolumeIgnoresGlobsAcknowledged();
+    setGlobConfirm(null);
+    await runCreate(pending.body, state.data.tool);
+  };
+
+  const handleGlobCancel = () => {
+    setGlobConfirm(null);
+    dispatch({ type: "SUBMIT_CANCEL" });
   };
 
   useEffect(() => {
@@ -366,6 +407,13 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
           </div>
         )}
       </div>
+      {globConfirm && (
+        <VolumeIgnoresGlobDialog
+          globs={globConfirm.globs}
+          onConfirm={handleGlobConfirm}
+          onCancel={handleGlobCancel}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -408,11 +408,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
         )}
       </div>
       {globConfirm && (
-        <VolumeIgnoresGlobDialog
-          globs={globConfirm.globs}
-          onConfirm={handleGlobConfirm}
-          onCancel={handleGlobCancel}
-        />
+        <VolumeIgnoresGlobDialog globs={globConfirm.globs} onConfirm={handleGlobConfirm} onCancel={handleGlobCancel} />
       )}
     </div>
   );

--- a/web/src/components/session-wizard/VolumeIgnoresGlobDialog.tsx
+++ b/web/src/components/session-wizard/VolumeIgnoresGlobDialog.tsx
@@ -22,10 +22,7 @@ export function VolumeIgnoresGlobDialog({ globs, onConfirm, onCancel }: Props) {
   const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  const matchCount = useMemo(
-    () => globs.reduce((sum, g) => sum + g.matched_paths.length, 0),
-    [globs],
-  );
+  const matchCount = useMemo(() => globs.reduce((sum, g) => sum + g.matched_paths.length, 0), [globs]);
 
   const handleConfirm = useCallback(async () => {
     setConfirming(true);
@@ -89,26 +86,24 @@ export function VolumeIgnoresGlobDialog({ globs, onConfirm, onCancel }: Props) {
         {/* Body */}
         <div className="px-5 py-4 space-y-3">
           <p className="text-[13px] text-text-secondary">
-            This session's <span className="font-mono text-text-primary">volume_ignores</span> include glob
-            patterns. They are expanded against the workspace now, matching{" "}
-            <span className="text-text-primary">{matchCount}</span> director{matchCount === 1 ? "y" : "ies"}, and
-            one ignore mount is created per match.
+            This session's <span className="font-mono text-text-primary">volume_ignores</span> include glob patterns.
+            They are expanded against the workspace now, matching{" "}
+            <span className="text-text-primary">{matchCount}</span> director{matchCount === 1 ? "y" : "ies"}, and one
+            ignore mount is created per match.
           </p>
 
           <ul className="space-y-1 max-h-40 overflow-y-auto" data-testid="volume-ignores-glob-list">
             {globs.map((g) => (
               <li key={g.pattern} className="text-[13px] text-text-secondary flex items-baseline justify-between gap-3">
                 <span className="font-mono text-text-primary truncate">{g.pattern}</span>
-                <span className="text-text-dim whitespace-nowrap">
-                  {g.matched_paths.length} matched
-                </span>
+                <span className="text-text-dim whitespace-nowrap">{g.matched_paths.length} matched</span>
               </li>
             ))}
           </ul>
 
           <p className="text-[12px] text-text-dim">
-            This is a point-in-time snapshot. Directories a build creates later inside the container are not
-            hidden; re-create the session to pick up new matches.
+            This is a point-in-time snapshot. Directories a build creates later inside the container are not hidden;
+            re-create the session to pick up new matches.
           </p>
 
           <Checkbox
@@ -137,7 +132,15 @@ export function VolumeIgnoresGlobDialog({ globs, onConfirm, onCancel }: Props) {
           >
             {confirming && (
               <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                  fill="none"
+                />
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
             )}

--- a/web/src/components/session-wizard/VolumeIgnoresGlobDialog.tsx
+++ b/web/src/components/session-wizard/VolumeIgnoresGlobDialog.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { VolumeIgnoresGlobPreview } from "../../lib/api";
+
+interface Props {
+  globs: VolumeIgnoresGlobPreview[];
+  /** Resolves with whether the user ticked "Don't show this again". */
+  onConfirm: (dontShowAgain: boolean) => Promise<void> | void;
+  onCancel: () => void;
+}
+
+/**
+ * One-time confirmation shown before creating a sandbox session whose resolved
+ * config has glob `volume_ignores` (recursive `**` patterns). Those are expanded
+ * against the workspace now, a point-in-time snapshot that won't shadow
+ * directories a build creates later inside the container (#2045). Mirrors the
+ * native TUI confirm gate; the "Don't show again" checkbox writes the same
+ * server-side app_state flag.
+ */
+export function VolumeIgnoresGlobDialog({ globs, onConfirm, onCancel }: Props) {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const matchCount = useMemo(
+    () => globs.reduce((sum, g) => sum + g.matched_paths.length, 0),
+    [globs],
+  );
+
+  const handleConfirm = useCallback(async () => {
+    setConfirming(true);
+    try {
+      await onConfirm(dontShowAgain);
+    } catch {
+      setConfirming(false);
+    }
+  }, [onConfirm, dontShowAgain]);
+
+  // Restore focus to the trigger on unmount, matching DeleteSessionDialog.
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    confirmButtonRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+        return;
+      }
+      if (e.key === "Enter") {
+        const target = e.target as HTMLElement | null;
+        if (target) {
+          const tag = target.tagName;
+          if (tag === "INPUT" || tag === "TEXTAREA" || tag === "BUTTON") return;
+        }
+        if (confirming) return;
+        e.preventDefault();
+        void handleConfirm();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onCancel, handleConfirm, confirming]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="volume-ignores-glob-dialog-title"
+      data-testid="volume-ignores-glob-dialog"
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-surface-800 border border-surface-700/50 rounded-lg w-[460px] max-w-[90vw] shadow-2xl animate-slide-up"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="px-5 py-4 border-b border-surface-700">
+          <h2 id="volume-ignores-glob-dialog-title" className="text-sm font-semibold text-status-warning">
+            Glob volume_ignores
+          </h2>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-3">
+          <p className="text-[13px] text-text-secondary">
+            This session's <span className="font-mono text-text-primary">volume_ignores</span> include glob
+            patterns. They are expanded against the workspace now, matching{" "}
+            <span className="text-text-primary">{matchCount}</span> director{matchCount === 1 ? "y" : "ies"}, and
+            one ignore mount is created per match.
+          </p>
+
+          <ul className="space-y-1 max-h-40 overflow-y-auto" data-testid="volume-ignores-glob-list">
+            {globs.map((g) => (
+              <li key={g.pattern} className="text-[13px] text-text-secondary flex items-baseline justify-between gap-3">
+                <span className="font-mono text-text-primary truncate">{g.pattern}</span>
+                <span className="text-text-dim whitespace-nowrap">
+                  {g.matched_paths.length} matched
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <p className="text-[12px] text-text-dim">
+            This is a point-in-time snapshot. Directories a build creates later inside the container are not
+            hidden; re-create the session to pick up new matches.
+          </p>
+
+          <Checkbox
+            checked={dontShowAgain}
+            onChange={setDontShowAgain}
+            label="Don't show this again"
+            testId="volume-ignores-glob-dont-show-again"
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-5 py-3 border-t border-surface-700">
+          <button
+            onClick={onCancel}
+            disabled={confirming}
+            className="px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary rounded-md hover:bg-surface-700/50 cursor-pointer transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            ref={confirmButtonRef}
+            onClick={handleConfirm}
+            disabled={confirming}
+            data-testid="volume-ignores-glob-proceed"
+            className="px-3 py-1.5 text-sm text-surface-900 bg-green-500 hover:bg-green-600 active:bg-green-700 rounded-md cursor-pointer transition-colors disabled:opacity-50 flex items-center gap-2"
+          >
+            {confirming && (
+              <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+            )}
+            {confirming ? "Creating..." : "Proceed"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Checkbox({
+  checked,
+  onChange,
+  label,
+  testId,
+}: {
+  checked: boolean;
+  onChange: (val: boolean) => void;
+  label: string;
+  testId?: string;
+}) {
+  return (
+    <label
+      className="flex items-start gap-2.5 cursor-pointer group"
+      data-testid={testId}
+      data-checked={checked ? "true" : "false"}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        aria-label={label}
+        className="peer sr-only"
+      />
+      <span
+        aria-hidden="true"
+        className={`mt-0.5 w-4 h-4 rounded border flex items-center justify-center shrink-0 transition-colors peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-green-500 ${
+          checked ? "bg-green-500 border-green-500" : "border-surface-600 group-hover:border-surface-500"
+        }`}
+      >
+        {checked && (
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+            <path d="M2 5L4 7L8 3" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </span>
+      <span className="text-[13px] text-text-secondary group-hover:text-text-primary transition-colors">{label}</span>
+    </label>
+  );
+}

--- a/web/src/components/session-wizard/__tests__/VolumeIgnoresGlobDialog.test.tsx
+++ b/web/src/components/session-wizard/__tests__/VolumeIgnoresGlobDialog.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// Vitest coverage for the glob volume_ignores confirm dialog (#2045). The
+// mocked Playwright spec exercises the wizard wiring end to end, but the
+// component's own render + handlers (pattern list, match-count pluralization,
+// checkbox, Proceed/Cancel, overlay + keyboard handling, and the confirm
+// catch branch) are covered directly here.
+//
+// Note: this project does not register @testing-library/jest-dom, so
+// assertions use plain DOM properties (textContent, getAttribute, disabled).
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import { VolumeIgnoresGlobDialog } from "../VolumeIgnoresGlobDialog";
+import type { VolumeIgnoresGlobPreview } from "../../../lib/api";
+
+afterEach(() => {
+  cleanup();
+});
+
+const TWO_PATTERNS: VolumeIgnoresGlobPreview[] = [
+  { pattern: "**/bin", matched_paths: ["/workspace/x/src/bin", "/workspace/x/tests/bin"] },
+  { pattern: "**/obj", matched_paths: ["/workspace/x/src/obj"] },
+];
+
+function setup(
+  overrides: { globs?: VolumeIgnoresGlobPreview[]; onConfirm?: (d: boolean) => Promise<void> | void } = {},
+) {
+  const onConfirm = overrides.onConfirm ?? vi.fn();
+  const onCancel = vi.fn();
+  const utils = render(
+    <VolumeIgnoresGlobDialog globs={overrides.globs ?? TWO_PATTERNS} onConfirm={onConfirm} onCancel={onCancel} />,
+  );
+  return { onConfirm, onCancel, ...utils };
+}
+
+describe("VolumeIgnoresGlobDialog (#2045)", () => {
+  it("lists each pattern with its match count and the plural total", () => {
+    const { getByTestId } = setup();
+    const list = getByTestId("volume-ignores-glob-list");
+    expect(list.textContent).toContain("**/bin");
+    expect(list.textContent).toContain("**/obj");
+    // Three matched dirs total -> plural "directories".
+    const dialog = getByTestId("volume-ignores-glob-dialog");
+    expect(dialog.textContent).toContain("3");
+    expect(dialog.textContent).toContain("directories");
+  });
+
+  it("uses the singular when exactly one directory matches", () => {
+    const { getByTestId } = setup({
+      globs: [{ pattern: "**/bin", matched_paths: ["/workspace/x/bin"] }],
+    });
+    const dialog = getByTestId("volume-ignores-glob-dialog");
+    expect(dialog.textContent).toContain("director");
+    expect(dialog.textContent).not.toContain("directories");
+  });
+
+  it("Proceed without the checkbox confirms with dontShowAgain=false", () => {
+    const { getByTestId, onConfirm } = setup();
+    fireEvent.click(getByTestId("volume-ignores-glob-proceed"));
+    expect(onConfirm).toHaveBeenCalledWith(false);
+  });
+
+  it("toggling the checkbox then Proceed confirms with dontShowAgain=true", () => {
+    const { getByTestId, onConfirm } = setup();
+    const checkbox = getByTestId("volume-ignores-glob-dont-show-again");
+    expect(checkbox.getAttribute("data-checked")).toBe("false");
+    fireEvent.click(checkbox);
+    expect(checkbox.getAttribute("data-checked")).toBe("true");
+    fireEvent.click(getByTestId("volume-ignores-glob-proceed"));
+    expect(onConfirm).toHaveBeenCalledWith(true);
+  });
+
+  it("Cancel and the overlay backdrop both cancel; an inner click does not", () => {
+    const { getByText, getByTestId, onCancel } = setup();
+    fireEvent.click(getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    // Backdrop click cancels; clicking inside the panel is stopped.
+    fireEvent.click(getByTestId("volume-ignores-glob-dialog"));
+    expect(onCancel).toHaveBeenCalledTimes(2);
+    fireEvent.click(getByTestId("volume-ignores-glob-list"));
+    expect(onCancel).toHaveBeenCalledTimes(2);
+  });
+
+  it("Escape cancels and Enter confirms from the document body", () => {
+    const { onConfirm, onCancel } = setup();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(document.body, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-enables Proceed when onConfirm rejects", async () => {
+    const onConfirm = vi.fn().mockRejectedValue(new Error("create failed"));
+    const { getByTestId } = setup({ onConfirm });
+    const proceed = getByTestId("volume-ignores-glob-proceed") as HTMLButtonElement;
+    fireEvent.click(proceed);
+    // The catch branch clears the in-flight state so the user can retry.
+    await waitFor(() => expect(proceed.disabled).toBe(false));
+  });
+});

--- a/web/src/components/session-wizard/wizardReducer.test.ts
+++ b/web/src/components/session-wizard/wizardReducer.test.ts
@@ -266,3 +266,16 @@ describe("SessionWizard reducer / useStructuredView (#1580)", () => {
     expect(next.data.useStructuredView).toBe(false);
   });
 });
+
+describe("SessionWizard reducer / SUBMIT_CANCEL (#2045)", () => {
+  it("re-enables submit without an error when a pre-create confirm is cancelled", () => {
+    // SUBMIT_START disables the button; backing out of the glob volume_ignores
+    // confirm modal must restore the interactive state and leave no error.
+    const submitting = reducer(makeState(), { type: "SUBMIT_START" });
+    expect(submitting.isSubmitting).toBe(true);
+
+    const cancelled = reducer(submitting, { type: "SUBMIT_CANCEL" });
+    expect(cancelled.isSubmitting).toBe(false);
+    expect(cancelled.error).toBeNull();
+  });
+});

--- a/web/src/components/session-wizard/wizardReducer.ts
+++ b/web/src/components/session-wizard/wizardReducer.ts
@@ -79,6 +79,7 @@ export type Action =
   | { type: "SUBMIT_START" }
   | { type: "SUBMIT_ERROR"; error: string }
   | { type: "SUBMIT_SUCCESS" }
+  | { type: "SUBMIT_CANCEL" }
   | { type: "SET_AGENTS"; agents: AgentInfo[] }
   | { type: "SET_GROUPS"; groups: GroupInfo[] }
   | { type: "SET_PROFILES"; profiles: ProfileInfo[] }
@@ -175,6 +176,10 @@ export function reducer(state: WizardState, action: Action): WizardState {
       return { ...state, isSubmitting: false, error: action.error };
     case "SUBMIT_SUCCESS":
       return { ...state, isSubmitting: false };
+    case "SUBMIT_CANCEL":
+      // User backed out of a pre-create confirmation (e.g. the glob
+      // volume_ignores modal); re-enable the submit button without an error.
+      return { ...state, isSubmitting: false, error: null };
     case "SET_AGENTS":
       return { ...state, agents: action.agents };
     case "SET_GROUPS":

--- a/web/src/lib/__tests__/volumeIgnoresApi.test.ts
+++ b/web/src/lib/__tests__/volumeIgnoresApi.test.ts
@@ -1,0 +1,77 @@
+// Vitest coverage for the sandbox volume_ignores glob API client (#2045):
+// the dry-run preview fetch and the acknowledge POST. Both swallow network
+// and non-OK responses so the wizard treats a failure as "nothing to confirm"
+// rather than blocking session creation.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchVolumeIgnoresPreview, markVolumeIgnoresGlobsAcknowledged } from "../api";
+
+const fetchSpy = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchVolumeIgnoresPreview (#2045)", () => {
+  it("returns the parsed preview and encodes path + profile in the query", async () => {
+    const payload = {
+      acknowledged: false,
+      globs: [{ pattern: "**/bin", matched_paths: ["/workspace/x/src/bin"] }],
+    };
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+
+    const result = await fetchVolumeIgnoresPreview("/repo/with space", "prof");
+
+    expect(result).toEqual(payload);
+    const url = new URL(fetchSpy.mock.calls[0][0] as string, "http://localhost");
+    expect(url.pathname).toBe("/api/sandbox/volume-ignores-preview");
+    expect(url.searchParams.get("path")).toBe("/repo/with space");
+    expect(url.searchParams.get("profile")).toBe("prof");
+  });
+
+  it("omits the profile param when none is given", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ acknowledged: true, globs: [] }), { status: 200 }));
+
+    await fetchVolumeIgnoresPreview("/repo");
+
+    const url = new URL(fetchSpy.mock.calls[0][0] as string, "http://localhost");
+    expect(url.searchParams.has("profile")).toBe(false);
+  });
+
+  it("returns null on a non-OK response", async () => {
+    fetchSpy.mockResolvedValue(new Response("nope", { status: 500 }));
+    expect(await fetchVolumeIgnoresPreview("/repo")).toBeNull();
+  });
+
+  it("returns null when the request throws", async () => {
+    fetchSpy.mockRejectedValue(new Error("network down"));
+    expect(await fetchVolumeIgnoresPreview("/repo")).toBeNull();
+  });
+});
+
+describe("markVolumeIgnoresGlobsAcknowledged (#2045)", () => {
+  it("POSTs to the acknowledge endpoint and returns true on success", async () => {
+    fetchSpy.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    expect(await markVolumeIgnoresGlobsAcknowledged()).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/app-state/volume-ignores-globs-acknowledged");
+    expect(init?.method).toBe("POST");
+  });
+
+  it("returns false on a non-OK response (e.g. read-only 403)", async () => {
+    fetchSpy.mockResolvedValue(new Response("forbidden", { status: 403 }));
+    expect(await markVolumeIgnoresGlobsAcknowledged()).toBe(false);
+  });
+
+  it("returns false when the request throws", async () => {
+    fetchSpy.mockRejectedValue(new Error("network down"));
+    expect(await markVolumeIgnoresGlobsAcknowledged()).toBe(false);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -191,6 +191,59 @@ export async function markWebTourSeen(): Promise<boolean> {
   }
 }
 
+// --- Sandbox volume_ignores glob expansion (#2045) ---
+
+export interface VolumeIgnoresGlobPreview {
+  pattern: string;
+  /** Container-side paths the pattern matches in the workspace right now. */
+  matched_paths: string[];
+}
+
+export interface VolumeIgnoresPreviewResponse {
+  /** True once the snapshot-expansion behavior has been acknowledged. */
+  acknowledged: boolean;
+  /** One entry per configured glob pattern; empty when none are configured. */
+  globs: VolumeIgnoresGlobPreview[];
+}
+
+/**
+ * Dry-run how glob `volume_ignores` entries (recursive `**` patterns) expand for a
+ * sandbox session rooted at `path`. The wizard calls this before creating to
+ * decide whether to show the one-time snapshot-expansion confirm modal (#2045).
+ * Returns null on failure; callers treat that as "nothing to confirm".
+ */
+export async function fetchVolumeIgnoresPreview(
+  path: string,
+  profile?: string,
+): Promise<VolumeIgnoresPreviewResponse | null> {
+  try {
+    const params = new URLSearchParams({ path });
+    if (profile) params.set("profile", profile);
+    const res = await fetch(`/api/sandbox/volume-ignores-preview?${params.toString()}`);
+    if (!res.ok) return null;
+    return (await res.json()) as VolumeIgnoresPreviewResponse;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Records that the user acknowledged glob `volume_ignores` snapshot expansion,
+ * so the confirm modal shows once and never again. Single-purpose endpoint
+ * (not PATCH /api/settings) so the flag stays off the passphrase/elevation
+ * wall. Returns false on read-only servers (403) or network failure.
+ */
+export async function markVolumeIgnoresGlobsAcknowledged(): Promise<boolean> {
+  try {
+    const res = await fetch("/api/app-state/volume-ignores-globs-acknowledged", {
+      method: "POST",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 // --- Profile management ---
 
 export async function createProfile(name: string): Promise<boolean> {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -372,6 +372,18 @@
       ]
     },
     {
+      "id": "wizard.volume-ignores-globs",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/wizard-volume-ignores-globs.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/VolumeIgnoresGlobDialog.tsx"
+      ]
+    },
+    {
       "id": "wizard.acp-opt-out",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -375,13 +375,21 @@
       "id": "wizard.volume-ignores-globs",
       "kind": "mocked-playwright",
       "risk": "medium",
-      "specs": [
-        "tests/wizard-volume-ignores-globs.spec.ts"
-      ],
+      "specs": ["tests/wizard-volume-ignores-globs.spec.ts"],
       "components": [
         "web/src/components/session-wizard/SessionWizard.tsx",
         "web/src/components/session-wizard/VolumeIgnoresGlobDialog.tsx"
       ]
+    },
+    {
+      "id": "wizard.volume-ignores-globs.unit",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/session-wizard/__tests__/VolumeIgnoresGlobDialog.test.tsx",
+        "src/lib/__tests__/volumeIgnoresApi.test.ts"
+      ],
+      "components": ["web/src/components/session-wizard/VolumeIgnoresGlobDialog.tsx"]
     },
     {
       "id": "wizard.acp-opt-out",

--- a/web/tests/wizard-volume-ignores-globs.spec.ts
+++ b/web/tests/wizard-volume-ignores-globs.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+
+// Wizard glob volume_ignores confirmation modal (#2045). A sandbox session
+// whose resolved config has glob volume_ignores (e.g. `**/bin`) must surface a
+// one-time snapshot-expansion confirm modal before creating: the patterns are
+// expanded against the workspace at create time, a snapshot that won't shadow
+// directories a build creates later inside the container. Covers: modal shows
+// with patterns + match count, Cancel aborts the create, Proceed creates, and
+// "Don't show this again" hits the acknowledge endpoint.
+
+interface Calls {
+  createSession: number;
+  acknowledge: number;
+}
+
+async function mockApis(page: Page, calls: Calls) {
+  await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  for (const path of ["themes", "groups", "devices", "about", "system/update-status"]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: path === "about" || path === "system/update-status" ? {} : [] }),
+    );
+  }
+  await page.route("**/api/settings**", (r) => r.fulfill({ json: {} }));
+  await page.route("**/api/profiles", (r) => r.fulfill({ json: [] }));
+  await page.route("**/api/docker/status", (r) => r.fulfill({ json: { available: true, runtime: "docker" } }));
+  await page.route("**/api/agents", (r) =>
+    r.fulfill({
+      json: [{ name: "claude", binary: "claude", host_only: false, installed: true, install_hint: "" }],
+    }),
+  );
+  // Glob preview: two patterns, three matched dirs, not yet acknowledged.
+  await page.route("**/api/sandbox/volume-ignores-preview**", (r) =>
+    r.fulfill({
+      json: {
+        acknowledged: false,
+        globs: [
+          { pattern: "**/bin", matched_paths: ["/workspace/example/src/App/bin", "/workspace/example/tests/Lib/bin"] },
+          { pattern: "**/obj", matched_paths: ["/workspace/example/src/App/obj"] },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/app-state/volume-ignores-globs-acknowledged", (r) => {
+    if (r.request().method() === "POST") calls.acknowledge += 1;
+    return r.fulfill({ json: { has_acknowledged_volume_ignores_globs: true } });
+  });
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "GET") {
+      return r.fulfill({
+        json: {
+          sessions: [
+            {
+              id: "seed-session",
+              title: "seed",
+              project_path: "/tmp/example",
+              group_path: "/tmp",
+              tool: "claude",
+              status: "Idle",
+              yolo_mode: false,
+              created_at: new Date().toISOString(),
+              last_accessed_at: null,
+              last_error: null,
+              branch: null,
+              main_repo_path: null,
+              is_sandboxed: false,
+              has_terminal: true,
+              profile: "default",
+              workspace_repos: [],
+            },
+          ],
+          workspace_ordering: [],
+        },
+      });
+    }
+    calls.createSession += 1;
+    return r.fulfill({ json: { session: { id: "new-session" } } });
+  });
+}
+
+// Walk project -> session -> agent, enable the sandbox toggle, then advance to
+// Review and click Launch. Lands with the create paused on the glob modal.
+async function launchSandboxSession(page: Page) {
+  await page.locator("body").click();
+  await page.keyboard.press("n");
+  await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
+  const recent = page.getByRole("button").filter({ hasText: "/tmp/example" }).first();
+  await recent.waitFor({ state: "visible", timeout: 5000 });
+  await recent.click();
+  await page.getByRole("button", { name: "Next" }).click();
+  await expect(page.getByText("Name your session")).toBeVisible();
+  await page.getByRole("button", { name: "Next" }).click();
+  await expect(page.getByRole("heading", { name: "Which AI agent?" })).toBeVisible();
+  const sandboxToggle = page.locator("label", { hasText: "Run in a safe container" }).locator("role=switch");
+  await sandboxToggle.click();
+  await expect(sandboxToggle).toHaveAttribute("aria-checked", "true");
+  await page.getByRole("button", { name: "Next" }).click();
+  await expect(page.getByRole("heading", { name: "Review & Launch" })).toBeVisible();
+  await page.getByRole("button", { name: /Launch session/ }).click();
+}
+
+test.describe("Wizard glob volume_ignores confirmation (#2045)", () => {
+  test("modal shows the patterns and match count before creating", async ({ page }) => {
+    const calls: Calls = { createSession: 0, acknowledge: 0 };
+    await mockApis(page, calls);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await launchSandboxSession(page);
+
+    const dialog = page.getByTestId("volume-ignores-glob-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("**/bin");
+    await expect(dialog).toContainText("**/obj");
+    await expect(dialog).toContainText("3 directories");
+    // The session is not created until the user proceeds.
+    expect(calls.createSession).toBe(0);
+  });
+
+  test("Cancel aborts the create and returns to the wizard", async ({ page }) => {
+    const calls: Calls = { createSession: 0, acknowledge: 0 };
+    await mockApis(page, calls);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await launchSandboxSession(page);
+
+    await expect(page.getByTestId("volume-ignores-glob-dialog")).toBeVisible();
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByTestId("volume-ignores-glob-dialog")).toHaveCount(0);
+    expect(calls.createSession).toBe(0);
+    expect(calls.acknowledge).toBe(0);
+    // Wizard is still open and the Launch button is interactive again.
+    await expect(page.getByRole("button", { name: /Launch session/ })).toBeEnabled();
+  });
+
+  test("Proceed without the checkbox creates the session and does not acknowledge", async ({ page }) => {
+    const calls: Calls = { createSession: 0, acknowledge: 0 };
+    await mockApis(page, calls);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await launchSandboxSession(page);
+
+    await expect(page.getByTestId("volume-ignores-glob-dialog")).toBeVisible();
+    await page.getByTestId("volume-ignores-glob-proceed").click();
+    await expect.poll(() => calls.createSession).toBe(1);
+    expect(calls.acknowledge).toBe(0);
+  });
+
+  test("'Don't show again' + Proceed persists the acknowledgment and creates", async ({ page }) => {
+    const calls: Calls = { createSession: 0, acknowledge: 0 };
+    await mockApis(page, calls);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await launchSandboxSession(page);
+
+    await expect(page.getByTestId("volume-ignores-glob-dialog")).toBeVisible();
+    await page.getByTestId("volume-ignores-glob-dont-show-again").click();
+    await page.getByTestId("volume-ignores-glob-proceed").click();
+    await expect.poll(() => calls.acknowledge).toBe(1);
+    await expect.poll(() => calls.createSession).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

Follow-up to #2037. That PR addressed the host-littering half of #2036 by skipping glob-like `volume_ignores` entries with a warning. This PR ships the remaining half tracked by #2045: actually **expanding** glob patterns.

When a `volume_ignores` entry contains glob metacharacters (e.g. `**/bin`, `**/obj`), it is now matched against the host filesystem under each mounted workspace root at container-create time, and one ignore mount is emitted per matching directory. Literal entries still mount unconditionally as before.

**Snapshot semantics + confirmation.** Docker needs concrete mount paths when the container starts, so expansion is a point-in-time snapshot: a directory a build creates *later* inside the container is not shadowed. To make that explicit, a sandbox session whose resolved config has a glob entry shows a one-time confirmation before creating, with a "don't warn me again" / "don't show again" opt-out persisted to `app_state`. This was the design decision called out in the issue; we chose snapshot expansion (option 1) plus the confirm gate.

The expansion logic lives in one place (`preview_glob_volume_ignores` / `expand_glob_ignore` in `container_config.rs`) shared by the real build, the native TUI gate, and the web preview endpoint, so all three describe the identical snapshot.

### What changed

- **Core** (`src/session/container_config.rs`): glob expansion against the workspace roots, dedup, and the existing `extra_volumes` conflict filter. New `glob` dependency. Replaces the skip-with-warning path.
- **TUI** (`src/tui/home/`): a new confirm gate slotted into the existing create chain (hooks → globs → repo-trust), reusing `ConfirmDialog` with the "don't warn me again" checkbox; persists `app_state.has_acknowledged_volume_ignores_globs`.
- **Web backend** (`src/server/`): `GET /api/sandbox/volume-ignores-preview` (dry-run) and `POST /api/app-state/volume-ignores-globs-acknowledged` (mirrors `mark_web_tour_seen`, added to the read-only-guard audit).
- **Web frontend**: `VolumeIgnoresGlobDialog` (mirrors `DeleteSessionDialog`'s modal + checkbox), wired into the wizard submit via a preview call and a new `SUBMIT_CANCEL` reducer action.
- **Docs**: `docs/guides/sandbox.md` rewritten to describe expansion and the snapshot caveat.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

New Rust unit tests in `container_config.rs` (glob expansion end-to-end, `preview_glob_volume_ignores` matches / empty / no-glob) and a TUI gate test in `tui/home/input.rs` (confirm message fires only on globs). New Vitest case for the `SUBMIT_CANCEL` reducer action.

Verified locally: `cargo fmt --check`, `cargo clippy --features serve --all-targets` clean; `cargo test --features serve --lib` green except one pre-existing root-only environmental failure (`storage::tests::test_update_write_failure_emits_no_notify`, which expects a write under a `0o500` dir to fail; uid 0 bypasses it, so it fails identically on main in a root sandbox). Web: `eslint .` clean, full Vitest suite (1755) green.

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added `web/tests/wizard-volume-ignores-globs.spec.ts` (modal shows patterns + match count; Cancel aborts the create; Proceed creates; "Don't show again" hits the acknowledge endpoint) and a `wizard.volume-ignores-globs` coverage-matrix surface. Note: the Playwright browser could not be installed in my dev sandbox (`ubuntu26.04-arm64` is unsupported by Playwright's browser builds), so I validated the spec via lint + tsc and am relying on CI to run it in a browser.

**TUI / CLI (e2e test)**
- [x] N/A: covered by unit tests for the gate logic; no new TUI rendering or CLI subcommand surface beyond the confirm dialog, which reuses the existing `ConfirmDialog` widget (already e2e-covered).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Design decision (snapshot expansion + confirm gate, full TUI/web parity), implementation, and tests drafted by Claude via back-and-forth with @njbrake; the decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sandbox `volume_ignores` now accepts and expands glob patterns (e.g., **/bin, **/obj) at session-create time — each matching host directory becomes a concrete ignore mount. Literal entries still mount unconditionally.
  * One-time confirmation dialog added for sessions whose resolved config contains glob entries. The dialog shows matched directories and includes a “Don’t show this again” opt-out persisted to app state.
  * Dry-run preview endpoint and client added so UI can show how globs would expand before creation.

* **User-facing Changes**
  * TUI: New confirm-gate integrated into session creation, reusing existing ConfirmDialog and persisting acknowledgment.
  * Web: Session wizard pauses on preview results and shows VolumeIgnoresGlobDialog; users can proceed or cancel and optionally persist the acknowledgement.
  * Docs: sandbox guide rewritten to document glob support, snapshot caveat (expansion is point-in-time), and behavior expectations.

* **APIs & Backend**
  * Added GET /api/sandbox/volume-ignores-preview to return previewed expansions and acknowledged state.
  * Added POST /api/app-state/volume-ignores-globs-acknowledged to persist the “don’t warn me” setting.
  * Server-side expansion logic centralized and shared across build, TUI gate, and web preview.

* **Tests & CI**
  * New Rust unit tests for glob expansion and TUI gate behavior.
  * Playwright spec for end-to-end wizard flow and Vitest + RTL unit tests for the dialog and API client.
  * Coverage matrix updated to include the new surfaces.

## Technical notes (short)
* Core expansion implemented in src/session/container_config.rs (preview_glob_volume_ignores / expand_glob_ignore); uses the glob crate (added to Cargo.toml).
* build_container_config now expands globs against mounted workspace roots, dedups resolved paths, and filters conflicts with extra_volumes.
* App state now includes has_acknowledged_volume_ignores_globs (persisted boolean).
* New server handlers in src/server/api/{sessions.rs,system.rs} and router wiring in src/server/mod.rs.
* Web client additions in web/src/lib/api.ts, SessionWizard.tsx, VolumeIgnoresGlobDialog.tsx, and reducer support for SUBMIT_CANCEL.
* Documentation updated at docs/guides/sandbox.md.

## Benefits
* Makes sandbox ignore behavior more flexible and intuitive by supporting globs and surfacing exact mounts before creation.
* Avoids surprising missing mounts later by taking a point-in-time snapshot and asking for confirmation.
* Single centralized expansion implementation ensures consistent behavior across TUI, web preview, and actual container creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->