### PR TITLE
feat(tui): pin a project so it persists without sessions

### DIFF
--- a/docs/guides/multi-repo-workspaces.md
+++ b/docs/guides/multi-repo-workspaces.md
@@ -76,6 +76,10 @@ aoe project add /repo/foo                              # global
 aoe -p other project add /repo/foo --allow-override    # profile shadows global
 ```
 
+### Pinning a project from the TUI
+
+In the TUI's project view (press `g` and pick Project grouping), a project header normally disappears once its last session is gone. Press `p` on a project header, or pick "Pin project" from its right-click menu, to register that repo in the global registry. A pinned project keeps its header (marked with a `◆`) even with zero sessions, so you can launch new work under it later, mirroring the web dashboard, where a project is a registry entry independent of any session. Press `p` again to unpin; an unpinned project drops from the view once it has no sessions.
+
 ## CLI Reference
 
 ```bash

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -172,6 +173,66 @@ pub(crate) fn canonical_key(path: &str) -> String {
         .canonicalize()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| path.to_string())
+}
+
+/// Display label for a repo path: its final path segment, with readable
+/// fallbacks for the root and empty cases. This is the header a project
+/// renders under in the project-grouped view, so a registered project and
+/// the sessions living in the same repo collapse under one header.
+///
+/// Shared so the TUI's session-derived grouping and the empty-project
+/// injection below agree on the label, and so a future server endpoint can
+/// reuse the same derivation instead of re-implementing it in TypeScript.
+pub fn repo_label(path: &str) -> String {
+    let p = Path::new(path);
+    p.file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| {
+            if path == "/" || path.is_empty() {
+                "(root)".to_string()
+            } else {
+                path.to_string()
+            }
+        })
+}
+
+/// A registered project that has no live session keeping its header alive in
+/// the project-grouped view, so a surface can render it as an empty header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnpopulatedProject {
+    /// Header label (the repo basename), matching [`repo_label`].
+    pub label: String,
+    /// Canonical repo path, used to unpin the entry and to launch new
+    /// sessions under it.
+    pub path: String,
+}
+
+/// Given the set of project-header labels that already have at least one live
+/// session and the registered projects, return the registered projects whose
+/// header would otherwise be invisible. Deduped by label; the first registered
+/// entry for a label wins. A registered project whose label collides with a
+/// populated header is omitted, the populated header already carries it (and
+/// the pin indicator is derived separately from the registry).
+///
+/// Pure and side-effect free so it can be unit-tested directly and reused by
+/// any surface that wants to show pinned-but-empty projects.
+pub fn unpopulated_projects(
+    populated_labels: &HashSet<String>,
+    registered: &[Project],
+) -> Vec<UnpopulatedProject> {
+    let mut out = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for p in registered {
+        let label = repo_label(&p.path);
+        if populated_labels.contains(&label) || !seen.insert(label.clone()) {
+            continue;
+        }
+        out.push(UnpopulatedProject {
+            label,
+            path: p.path.clone(),
+        });
+    }
+    out
 }
 
 /// Replace the contents of one scope's registry file.
@@ -364,6 +425,40 @@ mod tests {
         std::env::set_var("HOME", temp);
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
+    }
+
+    #[test]
+    fn repo_label_uses_basename_with_root_fallbacks() {
+        assert_eq!(repo_label("/home/me/myrepo"), "myrepo");
+        assert_eq!(repo_label("/home/me/myrepo/"), "myrepo");
+        assert_eq!(repo_label("/"), "(root)");
+        assert_eq!(repo_label(""), "(root)");
+    }
+
+    #[test]
+    fn unpopulated_projects_skips_populated_and_dedupes_by_label() {
+        let registered = vec![
+            Project::new("alpha", "/work/alpha", ProjectScope::Global),
+            Project::new("beta", "/work/beta", ProjectScope::Global),
+            // Same basename as the first beta entry: a second registration
+            // under a different parent must not double up the empty header.
+            Project::new("beta-dup", "/other/beta", ProjectScope::Profile),
+        ];
+        // `alpha` has a live session keeping its header alive; only the
+        // beta projects should surface as empty headers, deduped to one.
+        let populated: HashSet<String> = ["alpha".to_string()].into_iter().collect();
+
+        let empties = unpopulated_projects(&populated, &registered);
+        assert_eq!(empties.len(), 1);
+        assert_eq!(empties[0].label, "beta");
+        assert_eq!(empties[0].path, "/work/beta");
+    }
+
+    #[test]
+    fn unpopulated_projects_empty_when_all_populated() {
+        let registered = vec![Project::new("alpha", "/work/alpha", ProjectScope::Global)];
+        let populated: HashSet<String> = ["alpha".to_string()].into_iter().collect();
+        assert!(unpopulated_projects(&populated, &registered).is_empty());
     }
 
     #[test]

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -209,10 +209,11 @@ pub struct UnpopulatedProject {
 
 /// Given the set of project-header labels that already have at least one live
 /// session and the registered projects, return the registered projects whose
-/// header would otherwise be invisible. Deduped by label; the first registered
-/// entry for a label wins. A registered project whose label collides with a
-/// populated header is omitted, the populated header already carries it (and
-/// the pin indicator is derived separately from the registry).
+/// header would otherwise be invisible. Deduped by canonical path (the stable
+/// repo identity), so two repos that merely share a basename are not folded
+/// into one entry. A registered project whose label collides with a populated
+/// header is omitted, the populated header already carries it (and the pin
+/// indicator is derived separately, against the header's own repo path).
 ///
 /// Pure and side-effect free so it can be unit-tested directly and reused by
 /// any surface that wants to show pinned-but-empty projects.
@@ -224,7 +225,7 @@ pub fn unpopulated_projects(
     let mut seen: HashSet<String> = HashSet::new();
     for p in registered {
         let label = repo_label(&p.path);
-        if populated_labels.contains(&label) || !seen.insert(label.clone()) {
+        if populated_labels.contains(&label) || !seen.insert(canonical_key(&p.path)) {
             continue;
         }
         out.push(UnpopulatedProject {
@@ -436,21 +437,36 @@ mod tests {
     }
 
     #[test]
-    fn unpopulated_projects_skips_populated_and_dedupes_by_label() {
+    fn unpopulated_projects_skips_populated_and_keys_on_path() {
         let registered = vec![
             Project::new("alpha", "/work/alpha", ProjectScope::Global),
             Project::new("beta", "/work/beta", ProjectScope::Global),
-            // Same basename as the first beta entry: a second registration
-            // under a different parent must not double up the empty header.
-            Project::new("beta-dup", "/other/beta", ProjectScope::Profile),
+            // Same basename as the first beta entry but a distinct repo: it
+            // must NOT be folded away by the shared basename, the identity is
+            // the path.
+            Project::new("beta-other", "/other/beta", ProjectScope::Profile),
         ];
-        // `alpha` has a live session keeping its header alive; only the
-        // beta projects should surface as empty headers, deduped to one.
+        // `alpha` has a live session keeping its header alive, so only the
+        // two distinct beta repos surface as empty headers.
         let populated: HashSet<String> = ["alpha".to_string()].into_iter().collect();
 
         let empties = unpopulated_projects(&populated, &registered);
+        let paths: Vec<&str> = empties.iter().map(|p| p.path.as_str()).collect();
+        assert_eq!(paths, vec!["/work/beta", "/other/beta"]);
+        assert!(empties.iter().all(|p| p.label == "beta"));
+    }
+
+    #[test]
+    fn unpopulated_projects_dedupes_same_path() {
+        let registered = vec![
+            Project::new("beta", "/work/beta", ProjectScope::Global),
+            // Same canonical path registered again (e.g. global + profile
+            // shadow): collapse to a single header.
+            Project::new("beta", "/work/beta", ProjectScope::Profile),
+        ];
+        let populated: HashSet<String> = HashSet::new();
+        let empties = unpopulated_projects(&populated, &registered);
         assert_eq!(empties.len(), 1);
-        assert_eq!(empties[0].label, "beta");
         assert_eq!(empties[0].path, "/work/beta");
     }
 

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -722,6 +722,10 @@ mod tests {
             ActionId::SearchPrev,
             "search-cycle; only meaningful while a search is active",
         ),
+        (
+            ActionId::ToggleProjectPin,
+            "only valid on a project header in project view; reached via the header context menu and `p`",
+        ),
     ];
 
     /// Drift guard. The palette is generated from `bindings::BINDINGS`, so a

--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -21,6 +21,9 @@ pub enum ContextMenuAction {
     OpenSortPicker,
     /// Open the group-by mode picker (mirrors `'g'`).
     OpenGroupPicker,
+    /// Pin or unpin the project header (project view only; mirrors `'p'`). The
+    /// menu label flips to "Unpin project" when the project is already pinned.
+    TogglePin,
 }
 
 pub struct ContextMenuDialog {
@@ -81,6 +84,20 @@ impl ContextMenuDialog {
                 (ContextMenuAction::Delete, "Delete Group"),
             ],
         )
+    }
+
+    /// Menu for a project header in project view. Project groups are
+    /// automatic, so Rename/Delete don't apply (they'd only show the
+    /// "Project groups are automatic" info dialog). The one meaningful action
+    /// is pinning the project so it persists without any sessions. The label
+    /// flips based on the current pinned state.
+    pub fn for_project_group(anchor: (u16, u16), is_pinned: bool) -> Self {
+        let pin_label = if is_pinned {
+            "Unpin project"
+        } else {
+            "Pin project"
+        };
+        Self::new(anchor, vec![(ContextMenuAction::TogglePin, pin_label)])
     }
 
     /// Menu shown when the user right-clicks the empty area of the
@@ -208,6 +225,7 @@ impl ContextMenuDialog {
                     'n' | 'N' => Some(ContextMenuAction::NewSession),
                     'o' | 'O' => Some(ContextMenuAction::OpenSortPicker),
                     'g' | 'G' => Some(ContextMenuAction::OpenGroupPicker),
+                    'p' | 'P' => Some(ContextMenuAction::TogglePin),
                     _ => None,
                 };
                 match action {
@@ -404,6 +422,35 @@ mod tests {
             result,
             DialogResult::Submit(ContextMenuAction::Delete)
         ));
+    }
+
+    #[test]
+    fn project_group_menu_labels_flip_on_pin_state() {
+        let unpinned = ContextMenuDialog::for_project_group((0, 0), false);
+        let labels: Vec<&str> = unpinned.items_for_test().iter().map(|(_, l)| *l).collect();
+        assert_eq!(labels, vec!["Pin project"]);
+
+        let pinned = ContextMenuDialog::for_project_group((0, 0), true);
+        let labels: Vec<&str> = pinned.items_for_test().iter().map(|(_, l)| *l).collect();
+        assert_eq!(labels, vec!["Unpin project"]);
+    }
+
+    #[test]
+    fn p_hotkey_submits_toggle_pin() {
+        let mut menu = ContextMenuDialog::for_project_group((0, 0), false);
+        let result = menu.handle_key(key(KeyCode::Char('p')));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::TogglePin)
+        ));
+    }
+
+    #[test]
+    fn p_hotkey_inert_on_session_menu() {
+        // The session menu has no pin entry, so `p` must not fire it.
+        let mut menu = ContextMenuDialog::for_session((0, 0), false);
+        let result = menu.handle_key(key(KeyCode::Char('p')));
+        assert!(matches!(result, DialogResult::Continue));
     }
 
     #[test]

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -61,6 +61,10 @@ pub enum ActionId {
     SortPicker,
     GroupBy,
     NextWaiting,
+    /// Pin or unpin the selected project header (project view only). Pinning
+    /// registers the repo so the project persists in the view without any
+    /// sessions; unpinning removes the registry entry.
+    ToggleProjectPin,
 }
 
 /// A single chord. `ctrl` requires the Control modifier; Shift is implicit in
@@ -101,6 +105,8 @@ pub enum Context {
     TerminalView,
     AttentionSort,
     SearchActive,
+    /// The cursor is on a real (non-synthetic) project header in project view.
+    ProjectGroupSelected,
 }
 
 /// Help-overlay section. Ordering mirrors `components/help.rs`.
@@ -139,6 +145,9 @@ pub struct Ctx {
     pub view_mode: ViewMode,
     pub sort_order: SortOrder,
     pub has_search: bool,
+    /// True when the cursor sits on a real project header in project view, so
+    /// the pin toggle can claim its chord ahead of the projects-dialog binding.
+    pub project_group_selected: bool,
 }
 
 fn chord_matches(c: &Chord, key: &KeyEvent) -> bool {
@@ -155,6 +164,7 @@ fn context_holds(context: Context, ctx: &Ctx) -> bool {
         Context::TerminalView => ctx.view_mode == ViewMode::Terminal,
         Context::AttentionSort => ctx.sort_order == SortOrder::Attention,
         Context::SearchActive => ctx.has_search,
+        Context::ProjectGroupSelected => ctx.project_group_selected,
     }
 }
 
@@ -516,6 +526,21 @@ pub static BINDINGS: &[Binding] = &[
             serve_only: false,
         }),
     },
+    // Pin toggle shares `p` (Shift+P in strict) with Projects, but only fires
+    // when a project header is selected, so it must precede the Projects
+    // binding. On a project header `p` pins/unpins; everywhere else `p` still
+    // opens the projects dialog.
+    Binding {
+        id: ActionId::ToggleProjectPin,
+        non_strict: &[k('p')],
+        strict: &[k('P')],
+        context: Context::ProjectGroupSelected,
+        help: Some(HelpMeta {
+            section: HelpSection::Actions,
+            desc: "Pin/unpin project (keep without sessions)",
+        }),
+        palette: None,
+    },
     // P flip: Projects is the primary (bare `p`) action -> Shift+P in strict;
     // Profiles is the secondary (`Shift+P`) action -> Ctrl+P in strict.
     Binding {
@@ -695,6 +720,7 @@ pub fn palette_id(id: ActionId) -> &'static str {
         ActionId::SearchPrev => "search-prev",
         ActionId::Update => "update",
         ActionId::ToggleContainer => "toggle-container",
+        ActionId::ToggleProjectPin => "toggle-project-pin",
     }
 }
 
@@ -707,6 +733,7 @@ mod tests {
             view_mode: ViewMode::Structured,
             sort_order: SortOrder::Newest,
             has_search: false,
+            project_group_selected: false,
         }
     }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1998,6 +1998,7 @@ impl HomeView {
             view_mode: self.view_mode.clone(),
             sort_order: self.sort_order,
             has_search: !self.search_matches.is_empty(),
+            project_group_selected: self.project_group_at_cursor().is_some(),
         };
         if let Some(id) = bindings::resolve(&key, self.strict_hotkeys, &ctx) {
             return self.run_action(id, update_info);
@@ -2181,6 +2182,7 @@ impl HomeView {
             ActionId::TogglePreviewInfo => self.toggle_preview_info(),
             ActionId::SortPicker => self.show_sort_picker(),
             ActionId::GroupBy => self.show_group_picker(),
+            ActionId::ToggleProjectPin => self.toggle_project_pin_at_cursor(),
             ActionId::NextWaiting => self.jump_to_next_waiting(),
         }
         None
@@ -3092,7 +3094,13 @@ impl HomeView {
             // row reads as "Rename Group / Delete Group" instead of bare
             // "Rename / Delete".
             let is_group = matches!(self.flat_items[idx], super::Item::Group { .. });
-            self.context_menu = Some(if is_group {
+            // A real project header in project view gets the pin menu; the
+            // cursor was just moved onto this row, so `project_group_at_cursor`
+            // reflects it. Manual/synthetic group rows keep Rename/Delete.
+            let project_label = self.project_group_at_cursor();
+            self.context_menu = Some(if let Some(label) = project_label {
+                ContextMenuDialog::for_project_group(anchor, self.is_project_label_pinned(&label))
+            } else if is_group {
                 ContextMenuDialog::for_group(anchor)
             } else {
                 let is_archived = match &self.flat_items[idx] {
@@ -3173,6 +3181,12 @@ impl HomeView {
             ContextMenuAction::NewSession => self.open_new_session_dialog(),
             ContextMenuAction::OpenSortPicker => self.show_sort_picker(),
             ContextMenuAction::OpenGroupPicker => self.show_group_picker(),
+            ContextMenuAction::TogglePin => {
+                // The right-click already moved the cursor onto the project
+                // header, so the toggle acts on the same project the menu was
+                // opened for.
+                self.toggle_project_pin_at_cursor();
+            }
         }
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4301,19 +4301,60 @@ impl HomeView {
     /// Reload the merged project registry into `registered_projects`. Called on
     /// every storage reload and after a pin/unpin so the project view's empty
     /// headers and pin indicators track the on-disk registry.
+    ///
+    /// In all-profiles mode `build_flat_items_by_project` merges sessions from
+    /// every loaded profile, so the registry must too: a profile-scoped pin
+    /// would otherwise lose its header (and glyph) the moment its sessions are
+    /// gone. Dedupe across profiles by canonical path since each
+    /// `load_merged` repeats the global entries.
     pub(super) fn refresh_registered_projects(&mut self) {
-        let profile = self.config_profile();
-        self.registered_projects =
-            crate::session::projects::load_merged(&profile).unwrap_or_default();
+        use crate::session::projects::{canonical_key, load_merged};
+        if self.active_profile.is_some() {
+            self.registered_projects = load_merged(&self.config_profile()).unwrap_or_default();
+            return;
+        }
+        let profiles: Vec<String> = self.storages.keys().cloned().collect();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut merged = Vec::new();
+        for profile in &profiles {
+            for p in load_merged(profile).unwrap_or_default() {
+                if seen.insert(canonical_key(&p.path)) {
+                    merged.push(p);
+                }
+            }
+        }
+        self.registered_projects = merged;
     }
 
-    /// Whether a project-view header `label` is backed by a registered
-    /// (pinned) project. Used for the pin indicator and to decide whether the
-    /// pin toggle adds or removes the registry entry.
-    pub(super) fn is_project_label_pinned(&self, label: &str) -> bool {
-        self.registered_projects
+    /// The canonical repo path of the first live session under project header
+    /// `label`, or `None` when the header has no sessions (an empty pinned
+    /// header). This is the header's stable repo identity, so two repos that
+    /// merely share a basename are judged against their own paths rather than
+    /// the shared display label.
+    pub(super) fn project_header_repo_path(&self, label: &str) -> Option<String> {
+        self.instances
             .iter()
-            .any(|p| crate::session::projects::repo_label(&p.path) == label)
+            .find(|i| project_group_name(i) == label)
+            .map(|i| crate::session::projects::canonical_key(project_repo_path(i)))
+    }
+
+    /// Whether the project-view header `label` is backed by a registered
+    /// (pinned) project. A header with live sessions is pinned iff its own repo
+    /// path is in the registry, so two repos sharing a basename are judged
+    /// independently. An empty header exists only because a registered project
+    /// carries that basename, so it is pinned by construction (matched by
+    /// label). Used for the pin indicator and the pin toggle.
+    pub(super) fn is_project_label_pinned(&self, label: &str) -> bool {
+        match self.project_header_repo_path(label) {
+            Some(path) => self
+                .registered_projects
+                .iter()
+                .any(|p| crate::session::projects::canonical_key(&p.path) == path),
+            None => self
+                .registered_projects
+                .iter()
+                .any(|p| crate::session::projects::repo_label(&p.path) == label),
+        }
     }
 
     /// The project-view header label under the cursor when it is a real,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -57,23 +57,18 @@ fn project_group_name(inst: &Instance) -> String {
         return "scratch".to_string();
     }
 
-    let base_path = inst
-        .worktree_info
+    crate::session::projects::repo_label(project_repo_path(inst))
+}
+
+/// The repo path a session groups under in project view: its worktree's main
+/// repo when present, else its launch path. Shared by the group label and the
+/// pin action so a pinned project registers the same path the header derives
+/// from.
+fn project_repo_path(inst: &Instance) -> &str {
+    inst.worktree_info
         .as_ref()
         .map(|wt| wt.main_repo_path.as_str())
-        .unwrap_or(&inst.project_path);
-
-    let path = std::path::Path::new(base_path);
-    path.file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| {
-            // For root paths like "/", use a readable fallback
-            if base_path == "/" || base_path.is_empty() {
-                "(root)".to_string()
-            } else {
-                base_path.to_string()
-            }
-        })
+        .unwrap_or(&inst.project_path)
 }
 
 /// Kinds of in-progress mouse drags. Today only the list/preview divider
@@ -394,6 +389,9 @@ pub(super) const ICON_STOPPED: &str = "⠒";
 pub(super) const ICON_DELETING: &str = "✕";
 pub(super) const ICON_COLLAPSED: &str = "▶";
 pub(super) const ICON_EXPANDED: &str = "▼";
+/// Marks a pinned project header in project view. Geometric per DESIGN.md
+/// (clean readable glyphs, not emoji).
+pub(super) const ICON_PINNED: &str = "◆";
 
 /// Hook progress for a session being created in the background
 pub(super) struct CreatingHookProgress {
@@ -454,6 +452,12 @@ pub struct HomeView {
     pub(super) profile_default_attach_mode: crate::session::NewSessionAttachMode,
     /// Collapsed state for project-mode groups (persists across rebuilds)
     pub(super) project_group_collapsed: HashMap<String, bool>,
+    /// Merged project registry (global + active profile), refreshed on reload
+    /// and after a pin/unpin. Project view injects the registered projects
+    /// with no live sessions as empty "pinned" headers, and the renderer reads
+    /// it to mark pinned headers. Mirrors the WebUI, where an empty project is
+    /// just a registry entry decoupled from any session.
+    pub(super) registered_projects: Vec<crate::session::Project>,
 
     // Dialogs
     pub(super) show_help: bool,
@@ -1086,6 +1090,7 @@ impl HomeView {
             row_tag_mode: resolved.session.row_tag,
             profile_default_attach_mode: resolved.session.default_attach_mode,
             project_group_collapsed: HashMap::new(),
+            registered_projects: Vec::new(),
             show_help: false,
             help_scroll: 0,
             new_dialog: None,
@@ -1316,6 +1321,7 @@ impl HomeView {
             .map(|i| (i.id.clone(), i.clone()))
             .collect();
 
+        view.refresh_registered_projects();
         view.flat_items = view.build_flat_items();
         view.update_selected();
         let initial_profiles: Vec<String> = view.storages.keys().cloned().collect();
@@ -1416,6 +1422,10 @@ impl HomeView {
             .iter()
             .map(|i| (i.id.clone(), i.clone()))
             .collect();
+        // Refresh the project registry so project view's empty pinned headers
+        // and pin indicators reflect the current on-disk registry.
+        self.refresh_registered_projects();
+
         // Remember what the cursor was pointing at so we can follow it
         let prev_selected_session = self.selected_session.clone();
         let prev_selected_group = self.selected_group.clone();
@@ -3085,7 +3095,27 @@ impl HomeView {
             .filter(|i| !i.is_archived())
             .cloned()
             .collect();
-        let mut tree = GroupTree::new_with_groups(&tree_seed, &[]);
+
+        // Surface registered projects with no live session as empty "pinned"
+        // headers, so a project can persist in the view without any sessions,
+        // matching the WebUI where an empty project is just a registry entry.
+        // Seed them as empty groups; their headers render even with zero
+        // members (the phantom-header guard above only excludes archived-only
+        // session groups, not deliberately pinned ones).
+        let populated_labels: std::collections::HashSet<String> = tree_seed
+            .iter()
+            .map(|i| i.group_path.clone())
+            .filter(|p| !p.is_empty())
+            .collect();
+        let empty_pinned: Vec<crate::session::Group> =
+            crate::session::projects::unpopulated_projects(
+                &populated_labels,
+                &self.registered_projects,
+            )
+            .into_iter()
+            .map(|p| crate::session::Group::new(&p.label, &p.label))
+            .collect();
+        let mut tree = GroupTree::new_with_groups(&tree_seed, &empty_pinned);
         for (path, &collapsed) in &self.project_group_collapsed {
             if collapsed {
                 tree.set_collapsed(path, true);
@@ -4266,6 +4296,42 @@ impl HomeView {
         self.active_profile
             .clone()
             .unwrap_or_else(crate::session::config::resolve_default_profile)
+    }
+
+    /// Reload the merged project registry into `registered_projects`. Called on
+    /// every storage reload and after a pin/unpin so the project view's empty
+    /// headers and pin indicators track the on-disk registry.
+    pub(super) fn refresh_registered_projects(&mut self) {
+        let profile = self.config_profile();
+        self.registered_projects =
+            crate::session::projects::load_merged(&profile).unwrap_or_default();
+    }
+
+    /// Whether a project-view header `label` is backed by a registered
+    /// (pinned) project. Used for the pin indicator and to decide whether the
+    /// pin toggle adds or removes the registry entry.
+    pub(super) fn is_project_label_pinned(&self, label: &str) -> bool {
+        self.registered_projects
+            .iter()
+            .any(|p| crate::session::projects::repo_label(&p.path) == label)
+    }
+
+    /// The project-view header label under the cursor when it is a real,
+    /// pinnable project: project grouping is active, the cursor is on a group
+    /// header, and that header is neither the synthetic Archived section nor
+    /// the `scratch` bucket (scratch sessions have no backing repo to pin).
+    pub(super) fn project_group_at_cursor(&self) -> Option<String> {
+        if self.group_by != GroupByMode::Project {
+            return None;
+        }
+        match self.flat_items.get(self.cursor) {
+            Some(Item::Group { path, name, .. })
+                if !crate::session::is_within_archived_section(path) && name != "scratch" =>
+            {
+                Some(name.clone())
+            }
+            _ => None,
+        }
     }
 
     /// Resolve the effective `SessionConfig` for an existing session

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -40,17 +40,29 @@ impl HomeView {
             return;
         };
         let profile = self.config_profile();
+        // The header's own repo path (canonical), or None for an empty pinned
+        // header. Keying on the path keeps two repos that share a basename
+        // independent, so the toggle acts on the repo the user is looking at.
+        let header_path = self.project_header_repo_path(&label);
 
         if self.is_project_label_pinned(&label) {
-            // Unpin: remove the matching registry entry in its own scope. The
-            // merged registry holds one entry per canonical path, so the first
-            // label match is the one backing this header.
-            let Some(existing) = self
-                .registered_projects
-                .iter()
-                .find(|p| projects::repo_label(&p.path) == label)
-                .cloned()
-            else {
+            // Unpin. Prefer the registry entry whose canonical path matches the
+            // header's own repo. An empty header has no session path, so fall
+            // back to the basename match (it exists only because a registered
+            // project carries that basename; two such empties share one header
+            // and clear one per press).
+            let existing = match &header_path {
+                Some(path) => self
+                    .registered_projects
+                    .iter()
+                    .find(|p| projects::canonical_key(&p.path) == *path),
+                None => self
+                    .registered_projects
+                    .iter()
+                    .find(|p| projects::repo_label(&p.path) == label),
+            }
+            .cloned();
+            let Some(existing) = existing else {
                 return;
             };
             match projects::remove(&profile, existing.scope, &existing.path) {
@@ -71,16 +83,10 @@ impl HomeView {
                 }
             }
         } else {
-            // Pin: register the repo backing this header. The repo path comes
-            // from a live session in the group (an unpinned header always has
-            // at least one), using the same path the header label derives from.
-            let Some(repo_path) = self
-                .instances
-                .iter()
-                .filter(|i| super::project_group_name(i) == label)
-                .map(|i| super::project_repo_path(i).to_string())
-                .next()
-            else {
+            // Pin the repo backing this header. An unpinned header always has at
+            // least one live session (an empty header is pinned by
+            // construction), so its repo path is known.
+            let Some(repo_path) = header_path else {
                 return;
             };
             let project = Project::new(label.clone(), repo_path, ProjectScope::Global);

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -22,6 +22,92 @@ fn humanize_minutes(m: u32) -> String {
 }
 
 impl HomeView {
+    /// Pin or unpin the project header under the cursor (project view only).
+    ///
+    /// Pinning registers the repo in the global project registry (the same
+    /// store the WebUI writes), so the project keeps its header in project
+    /// view even after its last session is deleted. Unpinning removes the
+    /// registry entry; a project with no remaining sessions then disappears.
+    ///
+    /// The registry is the shared persistence layer: this goes through the
+    /// same `projects::add` / `projects::remove` the web API and the projects
+    /// dialog use, so canonicalization and conflict rules stay in one place.
+    pub(super) fn toggle_project_pin_at_cursor(&mut self) {
+        use crate::session::{projects, Project, ProjectScope};
+        use crate::tui::dialogs::InfoDialog;
+
+        let Some(label) = self.project_group_at_cursor() else {
+            return;
+        };
+        let profile = self.config_profile();
+
+        if self.is_project_label_pinned(&label) {
+            // Unpin: remove the matching registry entry in its own scope. The
+            // merged registry holds one entry per canonical path, so the first
+            // label match is the one backing this header.
+            let Some(existing) = self
+                .registered_projects
+                .iter()
+                .find(|p| projects::repo_label(&p.path) == label)
+                .cloned()
+            else {
+                return;
+            };
+            match projects::remove(&profile, existing.scope, &existing.path) {
+                Ok(_) => {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Project Unpinned",
+                        &format!(
+                            "'{}' is no longer pinned. It will drop from project view once it has no sessions.",
+                            label
+                        ),
+                    ));
+                }
+                Err(e) => {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Unpin Failed",
+                        &format!("Could not unpin: {}", e),
+                    ));
+                }
+            }
+        } else {
+            // Pin: register the repo backing this header. The repo path comes
+            // from a live session in the group (an unpinned header always has
+            // at least one), using the same path the header label derives from.
+            let Some(repo_path) = self
+                .instances
+                .iter()
+                .filter(|i| super::project_group_name(i) == label)
+                .map(|i| super::project_repo_path(i).to_string())
+                .next()
+            else {
+                return;
+            };
+            let project = Project::new(label.clone(), repo_path, ProjectScope::Global);
+            match projects::add(&profile, ProjectScope::Global, project, false) {
+                Ok(_) => {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Project Pinned",
+                        &format!(
+                            "'{}' is pinned. It will stay in project view even with no sessions.",
+                            label
+                        ),
+                    ));
+                }
+                Err(e) => {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Pin Failed",
+                        &format!("Could not pin: {}", e),
+                    ));
+                }
+            }
+        }
+
+        self.refresh_registered_projects();
+        self.flat_items = self.build_flat_items();
+        self.update_selected();
+    }
+
     pub(super) fn create_session(&mut self, data: NewSessionData) -> anyhow::Result<String> {
         let target_profile = data.profile.clone();
 

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -9,7 +9,7 @@ use rattles::presets::prelude as spinners;
 
 use super::{
     get_indent, live_send, HomeView, TerminalMode, ViewMode, ICON_COLLAPSED, ICON_DELETING,
-    ICON_ERROR, ICON_EXPANDED, ICON_IDLE, ICON_STOPPED, ICON_UNKNOWN,
+    ICON_ERROR, ICON_EXPANDED, ICON_IDLE, ICON_PINNED, ICON_STOPPED, ICON_UNKNOWN,
 };
 use crate::session::config::{GroupByMode, SortOrder};
 use crate::session::{Item, Status};
@@ -918,7 +918,18 @@ impl HomeView {
                 } else {
                     ICON_EXPANDED
                 };
-                let text = Cow::Owned(format!("{} ({})", name, session_count));
+                // Mark pinned project headers with a trailing pin glyph so an
+                // empty (sessionless) pinned project still reads as deliberate
+                // rather than stale. Project view only; the registry lookup is
+                // keyed by the header label.
+                let pinned = self.group_by == GroupByMode::Project
+                    && !crate::session::is_within_archived_section(path)
+                    && self.is_project_label_pinned(name);
+                let text = if pinned {
+                    Cow::Owned(format!("{} ({}) {}", name, session_count, ICON_PINNED))
+                } else {
+                    Cow::Owned(format!("{} ({})", name, session_count))
+                };
                 let mut style = Style::default().fg(theme.group).bold();
                 if crate::session::is_within_archived_section(path) {
                     // Synthetic Archived section header (and any

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5470,6 +5470,119 @@ fn pinned_project_survives_losing_last_session() {
     );
 }
 
+/// Two repos that share a basename are judged independently for pinning: a
+/// header whose own repo is not registered must read as unpinned even when a
+/// different same-basename repo is in the registry. Guards the path-keyed pin
+/// identity (CodeRabbit #2055).
+#[test]
+#[serial]
+fn same_basename_repos_pin_independently() {
+    use crate::session::config::GroupByMode;
+    use crate::session::projects::{self, Project, ProjectScope};
+
+    let mut env = create_test_env_empty();
+    // Register `/work/api`, but the visible header's repo is `/other/api`.
+    projects::add(
+        "test",
+        ProjectScope::Global,
+        Project::new("api", "/work/api", ProjectScope::Global),
+        false,
+    )
+    .unwrap();
+    let mut sess = Instance::new("api-sess", "/other/api");
+    sess.source_profile = "test".to_string();
+    env.view.instances.push(sess);
+
+    env.view.group_by = GroupByMode::Project;
+    env.view.refresh_registered_projects();
+    env.view.flat_items = env.view.build_flat_items();
+
+    let api_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|i| matches!(i, Item::Group { name, .. } if name == "api"))
+        .expect("api header present");
+    // The header's repo (/other/api) is not registered, so it is NOT pinned,
+    // even though a same-basename repo (/work/api) is. The old basename match
+    // would have reported pinned here.
+    assert!(!env.view.is_project_label_pinned("api"));
+
+    // Pinning this header would register under the basename "api", which the
+    // registry already holds for /work/api, so the registry's name-uniqueness
+    // surfaces a conflict rather than silently toggling the unrelated entry.
+    env.view.cursor = api_idx;
+    env.view.update_selected();
+    env.view.toggle_project_pin_at_cursor();
+    assert!(
+        !env.view.is_project_label_pinned("api"),
+        "the unrelated /work/api entry must not make this header read as pinned"
+    );
+    // The conflicting pin did not register the header's repo.
+    let paths: Vec<String> = projects::load_global()
+        .unwrap()
+        .into_iter()
+        .map(|p| p.path)
+        .collect();
+    assert_eq!(paths, vec!["/work/api".to_string()]);
+}
+
+/// In all-profiles mode the pin registry must include every loaded profile's
+/// projects, not just the default profile's, so a profile-scoped pin keeps its
+/// empty header (CodeRabbit #2055).
+#[test]
+#[serial]
+fn all_profiles_view_includes_profile_scoped_pins() {
+    use crate::session::config::GroupByMode;
+    use crate::session::projects::{self, Project, ProjectScope};
+
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    // Two discoverable profiles, each with a session.
+    for (profile, title, path) in [
+        ("alpha", "Alpha Session", "/tmp/a"),
+        ("beta", "Beta Session", "/tmp/b"),
+    ] {
+        let storage = Storage::new_unwatched(profile).unwrap();
+        let xs = vec![Instance::new(title, path)];
+        storage
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
+            .unwrap();
+    }
+    // A profile-scoped pin in `beta` with no sessions of its own.
+    projects::add(
+        "beta",
+        ProjectScope::Profile,
+        Project::new("lonely", "/repos/lonely", ProjectScope::Profile),
+        false,
+    )
+    .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools, crate::file_watch::FileWatchService::noop()).unwrap();
+    view.group_by = GroupByMode::Project;
+    view.flat_items = view.build_flat_items();
+
+    let names: Vec<String> = view
+        .flat_items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Group { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "lonely"),
+        "beta's profile-scoped pin must show in all-profiles project view, got {names:?}"
+    );
+    assert!(view.is_project_label_pinned("lonely"));
+}
+
 /// Pressing `g` to flip `group_by` keeps the cursor on the previously
 /// selected session, even when the list reshapes (Manual flat list →
 /// Project grouped list). Previously `apply_group_by` clamped by index,

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5329,6 +5329,147 @@ fn project_groups_sort_by_top_attention_member() {
     );
 }
 
+/// A registered (pinned) project with no sessions surfaces as an empty
+/// header in project view, mirroring the WebUI where an empty project is just
+/// a registry entry decoupled from sessions. This is the core of #2047.
+#[test]
+#[serial]
+fn pinned_project_without_sessions_shows_empty_header() {
+    use crate::session::config::GroupByMode;
+    use crate::session::projects::{self, Project, ProjectScope};
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    // Register a project that has no sessions at all. The path need not exist;
+    // `add` falls back to the literal path when canonicalization fails.
+    projects::add(
+        "test",
+        ProjectScope::Global,
+        Project::new("gamma", "/repos/gamma", ProjectScope::Global),
+        false,
+    )
+    .unwrap();
+
+    env.view.group_by = GroupByMode::Project;
+    env.view.refresh_registered_projects();
+    env.view.flat_items = env.view.build_flat_items();
+
+    let group_names: Vec<String> = env
+        .view
+        .flat_items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Group { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        group_names.iter().any(|n| n == "gamma"),
+        "pinned empty project gamma must show as a header, got {group_names:?}"
+    );
+    assert!(env.view.is_project_label_pinned("gamma"));
+}
+
+/// Pressing `p` on a project header pins it (registers the repo) instead of
+/// opening the projects dialog; the pin toggle binding wins the shared chord
+/// because a project header is selected.
+#[test]
+#[serial]
+fn p_key_pins_project_on_header() {
+    use crate::session::config::GroupByMode;
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    env.view.flat_items = env.view.build_flat_items();
+
+    let alpha_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|i| matches!(i, Item::Group { name, .. } if name == "alpha"))
+        .expect("alpha header present");
+    env.view.cursor = alpha_idx;
+    env.view.update_selected();
+
+    assert!(!env.view.is_project_label_pinned("alpha"));
+    env.view.handle_key(key(KeyCode::Char('p')), None);
+    assert!(
+        env.view.is_project_label_pinned("alpha"),
+        "p on a project header should pin it"
+    );
+    // The pin path must not open the projects dialog (the chord is shared).
+    assert!(env.view.projects_dialog.is_none());
+
+    // Unpinning (a second toggle) drops the registry entry.
+    env.view.toggle_project_pin_at_cursor();
+    assert!(!env.view.is_project_label_pinned("alpha"));
+}
+
+/// Off a project header (here: in Manual grouping), `p` keeps its original
+/// meaning and opens the projects dialog, so the overload doesn't shadow the
+/// global binding.
+#[test]
+#[serial]
+fn p_key_opens_projects_dialog_off_project_header() {
+    use crate::session::config::GroupByMode;
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Manual;
+    env.view.flat_items = env.view.build_flat_items();
+    env.view.cursor = 0;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('p')), None);
+    assert!(
+        env.view.projects_dialog.is_some(),
+        "p off a project header should open the projects dialog"
+    );
+}
+
+/// The pin must persist a project across its last session leaving the view:
+/// once pinned, the header remains even when no sessions reference it. This
+/// is the user-visible promise of #2047.
+#[test]
+#[serial]
+fn pinned_project_survives_losing_last_session() {
+    use crate::session::config::GroupByMode;
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    env.view.flat_items = env.view.build_flat_items();
+
+    let alpha_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|i| matches!(i, Item::Group { name, .. } if name == "alpha"))
+        .expect("alpha header present");
+    env.view.cursor = alpha_idx;
+    env.view.update_selected();
+    env.view.toggle_project_pin_at_cursor();
+    assert!(env.view.is_project_label_pinned("alpha"));
+
+    // Drop every alpha session, then rebuild as a reload would. The registry
+    // entry keeps the header alive even with zero members.
+    env.view
+        .instances
+        .retain(|i| super::project_group_name(i) != "alpha");
+    env.view.flat_items = env.view.build_flat_items();
+
+    let alpha_header = env.view.flat_items.iter().find_map(|i| match i {
+        Item::Group {
+            name,
+            session_count,
+            ..
+        } if name == "alpha" => Some(*session_count),
+        _ => None,
+    });
+    assert_eq!(
+        alpha_header,
+        Some(0),
+        "pinned alpha must remain as an empty (0) header after losing its sessions"
+    );
+}
+
 /// Pressing `g` to flip `group_by` keeps the cursor on the previously
 /// selected session, even when the list reshapes (Manual flat list →
 /// Project grouped list). Previously `apply_group_by` clamped by index,


### PR DESCRIPTION
## Description

Fixes #2047.

In the TUI's project view, a project header was derived purely from live sessions, so it vanished the moment its last session was deleted (#2033 made empty project headers undeletable, so they had to be dropped). The WebUI has no such gap: an empty project is just an entry in the project registry, decoupled from sessions.

This mirrors that design in the TUI. In project view (`g` -> Project grouping):

- Press `p` on a project header, or pick "Pin project" from its right-click menu, to register that repo in the global project registry.
- A pinned project keeps its header (marked with `◆`) even with zero sessions, so you can launch new work under it later. Press `p` again (or "Unpin project") to remove it; an unpinned project drops from the view once it has no sessions.

### Code sharing

Persistence reuses the shared registry layer rather than a new TUI-only store: pin/unpin go through `projects::add` / `projects::remove`, the same path the web API (`src/server/api/projects.rs`) and `aoe project add` use, so canonicalization, conflict detection, and scope rules stay in one place. The new "which registered projects have no live sessions" derivation lands as a pure, unit-tested helper in `src/session/projects.rs` (`unpopulated_projects` + a shared `repo_label`), positioned so a future server endpoint can reuse it instead of the TypeScript grouping in `web/src/hooks/useRepoGroups.ts`. (A follow-up to track moving that grouping into the backend can be filed separately.)

The pin chord shares `p` with the projects dialog but is gated by a new `ProjectGroupSelected` context, so on a project header `p` pins, and everywhere else `p` still opens the projects dialog.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test: unit tests for the shared `unpopulated_projects` / `repo_label` helpers in `src/session/projects.rs`, and TUI tests in `src/tui/home/tests.rs` (empty pinned project shows as a header, `p` pins a header without shadowing the projects dialog, a pinned project survives losing its last session) plus context-menu tests for the new Pin/Unpin entry.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Design choices (registry-backed persistence, global scope, both keybinding and context-menu affordances) were decided by @njbrake; the implementation and prose were drafted by Claude under his direction.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds persistent "pinned" projects to the TUI project view so project headers can remain visible even when they have no sessions, bringing TUI behavior in line with the WebUI and addressing `#2047`.

## What changed (high-level)

- Documentation: added guidance for pinning projects from the TUI.
- Registry integration: Home view now reads the global project registry and injects registered projects with zero sessions into the project list so empty headers render and persist.
- Pin/unpin UI: pressing `p` on a project header or choosing "Pin project"/"Unpin project" in the header context menu toggles pin state; pinned headers show a ◆ glyph and remain visible without sessions.
- Keybinding/context: introduced a ProjectGroupSelected context so `p` pins only when a project header is selected (avoids conflicting with the projects dialog).
- Operations: added a cursor-driven toggle that uses shared registry APIs to add/remove canonicalized project entries.
- Rendering: group headers render a pinned glyph when applicable.
- Tests: unit and TUI tests covering label canonicalization, empty pinned headers, pin/unpin behavior, survival after session deletion, profile-scoped pins, and hotkey/context-menu interactions.

## Notable implementation details (technical)

- New session helpers (src/session/projects.rs):
  - repo_label(path): consistent header label computation (handles "/" and empty).
  - UnpopulatedProject + unpopulated_projects(...): compute registered projects that should render as empty headers, deduped by canonical repo path.
- HomeView changes (src/tui/home/*):
  - Caches merged registered_projects and refreshes on load and storage-only reloads.
  - build_flat_items_by_project seeds empty pinned groups from registered_projects.
  - Added ICON_PINNED ("◆") and methods: refresh_registered_projects, project_header_repo_path, is_project_label_pinned, project_group_at_cursor.
  - Added toggle_project_pin_at_cursor which resolves canonical repo identity then calls projects::add / projects::remove and updates the view and selection.
- Input & bindings:
  - New ActionId::ToggleProjectPin, Context::ProjectGroupSelected, and a `p` binding scoped to project headers (placed before the projects-dialog binding).
  - Palette ID stable mapping for toggle action; updated palette allowlist for tests.
- Context menu:
  - ContextMenuAction::TogglePin and a project-group-specific menu with Pin/Unpin label switching and `'p'` hotkey support.
- Tests:
  - Added/extended tests in src/session/projects.rs and src/tui/home/tests.rs for deduplication, canonical matching, empty pinned headers, pin/unpin behavior without opening the projects dialog, survival after session deletion, and all-profiles pin visibility.

## Benefits

- Restores parity with WebUI: projects persist independent of live sessions.
- Improves UX for workflows that rely on persistent project headers (e.g., launching new sessions).
- Maintains consistent semantics by reusing existing registry APIs (canonicalization, conflict detection, scope/profile rules).
- Covered by unit and UI tests to prevent regressions.

## Potential follow-ups

- Consider an in-UI hint or brief onboarding to surface the pin feature more clearly.
- Monitor registry refresh performance/scalability if large numbers of registered projects are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->