### PR TITLE
testing new codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,9 +17,9 @@
 comment:
   layout: "header, diff, files, components, sunburst, uncovered, footer"
   behavior: default
-  require_changes: false
-  require_base: false
-  require_head: false
+  require_changes: true
+  require_base: true
+  require_head: true
   hide_project_coverage: false
 
 codecov:
@@ -32,6 +32,7 @@ codecov:
   # `wait_for_ci: true` additionally holds notifications until GitHub Actions
   # reports the workflow done, so a hung uploader cannot trigger a premature
   # evaluation either.
+  require_ci_to_pass: true
   notify:
     after_n_builds: 3
     wait_for_ci: true

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -187,6 +187,7 @@ function isInsideEditable(target: EventTarget | null): boolean {
     if (tag === "INPUT" || tag === "TEXTAREA" || el.isContentEditable) {
       return true;
     }
+
     el = el.parentElement;
   }
   return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces Codecov configuration to the project and makes a minor formatting change to test the setup.

### What Changed

**codecov.yml** (new file)
- Added comprehensive Codecov configuration for the web frontend (Vitest unit tests + Playwright tests)
- Configured notification gating requirements: Codecov PR comments now require reporting on changes, base, and head coverage (`require_changes`, `require_base`, `require_head` set to `true`)
- Enabled CI status check gating (`require_ci_to_pass: true`) to hold notifications until GitHub Actions completes, preventing premature evaluations when multiple coverage uploads are queued
- Defined coverage status gates: Project-level auto-target (don't drop below main) with 1% threshold, and patch-level 75% target for new/changed code
- Structured coverage components for different parts of the web UI (Diff Viewer, Settings, Auth, Dashboard, Hooks, Lib, etc.) to show granular coverage changes in PR comments
- Set flags for three separate test types (vitest, playwright-mocked, playwright-live) that merge into combined coverage reports

**web/src/App.tsx**
- Added a blank line in the `isInsideEditable()` function to test the Codecov configuration

### Benefits

- Enables automated coverage tracking and reporting on pull requests
- Ensures code changes have sufficient test coverage through gated status checks
- Provides granular visibility into which UI components have coverage changes
- Prevents noisy re-evaluation of coverage reports by waiting for all CI uploads and workflows to complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->