### PR TITLE
fix(server): drop stale last_error on healthy instance after recovery

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1873,7 +1873,14 @@ fn load_all_instances(file_watch: &Arc<FileWatchService>) -> anyhow::Result<Vec<
 fn merge_runtime_fields(prior: Instance, mut fresh: Instance) -> Instance {
     fresh.last_error_check = prior.last_error_check;
     fresh.last_start_time = prior.last_start_time;
-    fresh.last_error = prior.last_error;
+    // Only preserve `last_error` while the session is still in Error. A healthy
+    // `fresh` clears it in `update_status_with_metadata_inner`; carrying the
+    // prior string over unconditionally would re-stick a stale error on a now-green
+    // session every poll tick when a healthy transition happened through a path that
+    // did not explicitly null `last_error` in-memory (issue #1271).
+    if fresh.status == Status::Error {
+        fresh.last_error = prior.last_error;
+    }
     fresh.session_id_poller = prior.session_id_poller;
     fresh.retroactive_capture_excludes = prior.retroactive_capture_excludes;
     fresh
@@ -3673,6 +3680,54 @@ pub mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn merge_runtime_fields_preserves_last_error_while_still_in_error() {
+        // Cascade-Err preservation: prior held the error string, fresh re-derived
+        // Error from a still-dead pane without re-attaching the message. Carry it.
+        let mut prior = Instance::new("seed", "/tmp/seed");
+        prior.status = Status::Error;
+        prior.last_error = Some("recovery cascade: foo".to_string());
+
+        let mut fresh = Instance::new("seed", "/tmp/seed");
+        fresh.status = Status::Error;
+        fresh.last_error = None;
+
+        let merged = merge_runtime_fields(prior, fresh);
+        assert_eq!(merged.last_error.as_deref(), Some("recovery cascade: foo"));
+    }
+
+    #[test]
+    fn merge_runtime_fields_drops_stale_last_error_on_healthy_transition() {
+        // Issue #1271: prior errored in-memory, the session recovered to Idle
+        // through a path that never nulled `last_error`. The fresh poll must not
+        // re-stick the stale string on a now-green session.
+        let mut prior = Instance::new("seed", "/tmp/seed");
+        prior.status = Status::Error;
+        prior.last_error = Some("recovery cascade: foo".to_string());
+
+        let mut fresh = Instance::new("seed", "/tmp/seed");
+        fresh.status = Status::Idle;
+        fresh.last_error = None;
+
+        let merged = merge_runtime_fields(prior, fresh);
+        assert_eq!(merged.last_error, None);
+    }
+
+    #[test]
+    fn merge_runtime_fields_drops_stale_last_error_idle_to_idle() {
+        // Both ends healthy but prior still carried a stale string: don't propagate.
+        let mut prior = Instance::new("seed", "/tmp/seed");
+        prior.status = Status::Idle;
+        prior.last_error = Some("stale".to_string());
+
+        let mut fresh = Instance::new("seed", "/tmp/seed");
+        fresh.status = Status::Idle;
+        fresh.last_error = None;
+
+        let merged = merge_runtime_fields(prior, fresh);
+        assert_eq!(merged.last_error, None);
+    }
 
     #[tokio::test]
     #[serial_test::serial]

--- a/tests/serve_disk_reload_helper_equivalence.rs
+++ b/tests/serve_disk_reload_helper_equivalence.rs
@@ -5,7 +5,11 @@
 //! `StatusSource` variants: `DiskOnly` keeps the prior in-memory `status` and
 //! `idle_entered_at` while `TmuxApplied` trusts the caller-applied scrape.
 //! Both paths must take the monotonic-max `last_accessed_at` and carry the
-//! five `#[serde(skip)]` runtime fields preserved by `merge_runtime_fields`.
+//! `#[serde(skip)]` runtime fields preserved by `merge_runtime_fields`.
+//! `last_error` is the exception: it is preserved only while the merged status
+//! is still `Error`, so a session that recovered to a healthy state drops the
+//! stale string (issue #1271). The other runtime fields (here `last_error_check`)
+//! carry over unconditionally.
 //!
 //! Drives the helper directly via the `crate::server::test_support` surface
 //! exposed for this test (the merge invariants live below the HTTP API and
@@ -22,8 +26,10 @@ use chrono::TimeZone;
 
 #[tokio::test]
 async fn reload_state_instances_from_disk_disk_only_preserves_prior_status() {
+    let probe = std::time::Instant::now();
     let mut prior = Instance::new("seed", "/tmp/seed");
     prior.status = Status::Running;
+    prior.last_error_check = Some(probe);
     prior.last_error = Some("boom".to_string());
     prior.last_accessed_at = Some(chrono::Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap());
     let prior_id = prior.id.clone();
@@ -46,9 +52,13 @@ async fn reload_state_instances_from_disk_disk_only_preserves_prior_status() {
         "DiskOnly: prior in-memory status must win"
     );
     assert_eq!(
-        row.last_error.as_deref(),
-        Some("boom"),
-        "runtime field preserved"
+        row.last_error_check,
+        Some(probe),
+        "runtime field preserved unconditionally"
+    );
+    assert_eq!(
+        row.last_error, None,
+        "healthy merged status drops the stale last_error (#1271)"
     );
     assert_eq!(
         row.last_accessed_at.unwrap().timestamp(),
@@ -62,8 +72,10 @@ async fn reload_state_instances_from_disk_disk_only_preserves_prior_status() {
 
 #[tokio::test]
 async fn reload_state_instances_from_disk_tmux_applied_takes_fresh_status() {
+    let probe = std::time::Instant::now();
     let mut prior = Instance::new("seed", "/tmp/seed");
     prior.status = Status::Idle;
+    prior.last_error_check = Some(probe);
     prior.last_error = Some("prev".to_string());
     prior.last_accessed_at = Some(chrono::Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap());
     let prior_id = prior.id.clone();
@@ -85,9 +97,13 @@ async fn reload_state_instances_from_disk_tmux_applied_takes_fresh_status() {
         "TmuxApplied: fresh status must win",
     );
     assert_eq!(
-        row.last_error.as_deref(),
-        Some("prev"),
-        "runtime field preserved"
+        row.last_error_check,
+        Some(probe),
+        "runtime field preserved unconditionally"
+    );
+    assert_eq!(
+        row.last_error, None,
+        "healthy merged status drops the stale last_error (#1271)"
     );
     assert_eq!(
         row.last_accessed_at.unwrap().timestamp(),


### PR DESCRIPTION
## Description

`merge_runtime_fields` in `src/server/mod.rs` carried `prior.last_error` onto the freshly disk-loaded `Instance` unconditionally. When a session recovered to a healthy state through a path that did not explicitly null `last_error` in-memory (for example, a manual tmux recovery picked up by the next `status_poll` tick), every subsequent poll re-installed the stale error string on a now-green session. The effect is cosmetic (the dashboard "Last Error" column on an Idle/Running session) but wrong, and it never self-heals while the process is up.

The fix gates the carry-over on `fresh.status == Status::Error`, mirroring the `status==Error` filter from the per-status overlay block that #1251 dropped (commit `406f05f`), without the 30s clamp since the underlying preservation is needed unbounded. The cascade-Err trace is unaffected: `update_status_with_metadata_inner` independently re-derives `status=Error` from a still-dead pane, so `fresh.status` is still `Error` when the string genuinely needs to survive.

```rust
if fresh.status == Status::Error {
    fresh.last_error = prior.last_error;
}
```

Fixes #1271

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

Three unit tests added in `src/server/mod.rs` covering the three cases from the issue:
- `merge_runtime_fields_preserves_last_error_while_still_in_error` (cascade-Err preservation still works)
- `merge_runtime_fields_drops_stale_last_error_on_healthy_transition` (the bug: Error to Idle clears)
- `merge_runtime_fields_drops_stale_last_error_idle_to_idle` (Idle to Idle clears)

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause investigation and the fix were done with Claude Code; the issue itself already proposed the gating approach, which matched the code on inspection.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Problem fixed: stale "last_error" strings could be reattached to sessions that had recovered to a healthy state because merge_runtime_fields unconditionally copied prior.last_error onto disk-loaded instances.

Solution: gate carry-over of last_error in src/server/mod.rs so prior.last_error is only copied when the freshly-loaded instance is actually in Status::Error.

What was added:
- A conditional check in merge_runtime_fields to only preserve last_error when fresh.status == Status::Error.
- Three unit tests covering:
  - Error->Error preservation,
  - Error->Idle clearing,
  - Idle->Idle clearing of stale last_error.

What was removed:
- One unconditional assignment that always copied prior.last_error onto fresh.

## Technical Details

The change replaces the unconditional overwrite with:
if fresh.status == Status::Error {
    fresh.last_error = prior.last_error;
}
Cascade-error detection remains unchanged (status=Error can be re-derived elsewhere), and a separate runtime field last_error_check continues to be preserved unconditionally as before. Tests and a disk-reload equivalence test were updated to assert that last_error is cleared for healthy merged statuses.

## Benefits

- Prevents cosmetic, persistent stale error messages from appearing on recovered sessions.
- Keeps genuine error messages for sessions still in Error.
- Improves dashboard accuracy with minimal risk to existing error-preservation logic.

Lines changed: +56/-1

Fixes: `#1271`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->