### PR TITLE
fix(server): refresh recovery suppression marks so queued candidates don't age out

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -303,6 +303,13 @@ pub struct AppState {
     /// transitions to `Status::Error` for up to 8 seconds while the agent
     /// is still settling. Periodically GC'd by a background task.
     pub recently_restarted: crate::session::recovery::RecentlyRestarted,
+    /// Ids whose startup-recovery cascade is scheduled but not yet complete.
+    /// Phase A seeds it; each Phase B worker drains its id on completion. The
+    /// background refresher walks it to keep queued candidates' marks in
+    /// `recently_restarted` fresh past `RECENTLY_RESTARTED_TTL`, closing the
+    /// race where a candidate waiting on a `STARTUP_RECOVERY_CONCURRENCY`
+    /// permit ages out of suppression and trips a phantom `Status::Error`.
+    pub recovery_pending: crate::session::recovery::RecoveryPending,
     /// Cached per-profile cleanup defaults for the delete dialog, with a
     /// timestamp so we re-resolve after config changes (see
     /// `CLEANUP_DEFAULTS_TTL`).
@@ -948,6 +955,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         serve_mode,
         instance_locks: RwLock::new(std::collections::HashMap::new()),
         recently_restarted: crate::session::recovery::new_recently_restarted(),
+        recovery_pending: crate::session::recovery::new_recovery_pending(),
         cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
             // Seed with an already-stale timestamp so the first request
             // forces a fresh resolve instead of handing out an empty map.
@@ -1039,6 +1047,42 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     }
 
     if let Some((lock, candidates)) = recovery_inputs {
+        // Background mark-refresher (#1264). Re-stamps every still-pending
+        // candidate in `recently_restarted` every RECENTLY_RESTARTED_TTL / 2
+        // so a candidate queued past the TTL behind a
+        // STARTUP_RECOVERY_CONCURRENCY permit does not age out of suppression
+        // and trip a phantom Status::Error in status_poll_loop. Exits once the
+        // pending set drains (every worker finished) or on shutdown.
+        {
+            let pending = state.recovery_pending.clone();
+            let recently = state.recently_restarted.clone();
+            let shutdown = state.shutdown.clone();
+            crate::task_util::spawn_supervised(
+                "server.startup_recovery_refresher",
+                crate::task_util::PanicPolicy::Log,
+                async move {
+                    let mut interval =
+                        tokio::time::interval(crate::session::recovery::RECENTLY_RESTARTED_TTL / 2);
+                    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                    // First tick fires immediately; skip past it so we don't
+                    // redundantly re-stamp the marks Phase A just wrote.
+                    interval.tick().await;
+                    loop {
+                        tokio::select! {
+                            _ = interval.tick() => {
+                                if !crate::session::recovery::refresh_recovery_pending(
+                                    &pending, &recently,
+                                ) {
+                                    break;
+                                }
+                            }
+                            _ = shutdown.cancelled() => break,
+                        }
+                    }
+                },
+            );
+        }
+
         let cascade_state = state.clone();
         crate::task_util::spawn_supervised(
             "server.startup_recovery_cascade",
@@ -2969,6 +3013,14 @@ async fn daemon_startup_recovery_mark(
     for inst in &candidates {
         crate::session::recovery::mark_recently_restarted(&state.recently_restarted, &inst.id);
     }
+    // Seed the pending set so the refresher (spawned between Phase A and
+    // Phase B) keeps these marks fresh while candidates wait on a
+    // STARTUP_RECOVERY_CONCURRENCY permit. Each worker drains its own id on
+    // completion.
+    crate::session::recovery::seed_recovery_pending(
+        &state.recovery_pending,
+        candidates.iter().map(|i| i.id.clone()),
+    );
 
     tracing::info!(
         target: "session.startup_recovery",
@@ -3023,7 +3075,8 @@ async fn daemon_startup_recovery_cascade(
                         error = %e,
                         "tmux probe failed during recovery re-check; skipping cascade",
                     );
-                    crate::session::recovery::unmark_recently_restarted(
+                    crate::session::recovery::drain_recovery_pending(
+                        &inst_state.recovery_pending,
                         &inst_state.recently_restarted,
                         &id,
                     );
@@ -3046,10 +3099,12 @@ async fn daemon_startup_recovery_cascade(
                     .unwrap_or(false)
             };
             if !still_candidate {
-                // Phase A pre-marked this id; without unmarking, the
-                // status_poll_loop would suppress the real status for
-                // the full TTL even though we are not running a cascade.
-                crate::session::recovery::unmark_recently_restarted(
+                // Phase A pre-marked this id and seeded recovery_pending;
+                // without draining, the refresher would keep re-stamping the
+                // mark and status_poll_loop would suppress the real status
+                // even though we are not running a cascade.
+                crate::session::recovery::drain_recovery_pending(
+                    &inst_state.recovery_pending,
                     &inst_state.recently_restarted,
                     &id,
                 );
@@ -3108,7 +3163,8 @@ async fn daemon_startup_recovery_cascade(
                     // reload; once the cascade has finished the on-disk
                     // status is current and the poll path resolves to the
                     // correct status without help.
-                    crate::session::recovery::unmark_recently_restarted(
+                    crate::session::recovery::drain_recovery_pending(
+                        &inst_state.recovery_pending,
                         &inst_state.recently_restarted,
                         &id,
                     );
@@ -3151,7 +3207,8 @@ async fn daemon_startup_recovery_cascade(
                     // Release the suppression so the next poll respects the
                     // Error state instead of forcing Status::Starting for
                     // the rest of the TTL window.
-                    crate::session::recovery::unmark_recently_restarted(
+                    crate::session::recovery::drain_recovery_pending(
+                        &inst_state.recovery_pending,
                         &inst_state.recently_restarted,
                         &id,
                     );
@@ -3175,7 +3232,8 @@ async fn daemon_startup_recovery_cascade(
                     // Same suppression release as above: without unmarking,
                     // the next poll forces Status::Starting and wipes the
                     // panic-specific last_error written above.
-                    crate::session::recovery::unmark_recently_restarted(
+                    crate::session::recovery::drain_recovery_pending(
+                        &inst_state.recovery_pending,
                         &inst_state.recently_restarted,
                         &id,
                     );
@@ -3593,6 +3651,7 @@ pub mod test_support {
             serve_mode: "local",
             instance_locks: RwLock::new(HashMap::new()),
             recently_restarted: crate::session::recovery::new_recently_restarted(),
+            recovery_pending: crate::session::recovery::new_recovery_pending(),
             cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
                 refreshed_at: std::time::Instant::now(),
                 entries: HashMap::new(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3040,6 +3040,9 @@ async fn daemon_startup_recovery_cascade(
     let semaphore = Arc::new(tokio::sync::Semaphore::new(
         crate::session::recovery::STARTUP_RECOVERY_CONCURRENCY,
     ));
+    // Captured up front for the completion sweep below; the worker loop
+    // consumes `candidates`.
+    let all_ids: Vec<String> = candidates.iter().map(|i| i.id.clone()).collect();
     let mut tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
 
     for inst in candidates {
@@ -3243,6 +3246,21 @@ async fn daemon_startup_recovery_cascade(
     }
 
     while tasks.join_next().await.is_some() {}
+
+    // Completion sweep: every worker drains its own id on each exit arm
+    // (including the spawn_blocking panic arm), but a panic in a worker's
+    // async body *outside* that match would skip its drain and leave the id
+    // pending, so the refresher would re-stamp it until daemon shutdown. By
+    // the time the JoinSet is fully drained every worker has terminated, so
+    // sweeping all ids guarantees `recovery_pending` is empty and the
+    // refresher exits on its next tick. Idempotent for ids already drained.
+    for id in &all_ids {
+        crate::session::recovery::drain_recovery_pending(
+            &state.recovery_pending,
+            &state.recently_restarted,
+            id,
+        );
+    }
     drop(lock);
 }
 

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -244,6 +244,80 @@ pub fn gc_recently_restarted(map: &RecentlyRestarted) {
     }
 }
 
+/// Set of instance ids whose startup-recovery cascade has been scheduled
+/// but not yet completed. Populated by Phase A (`daemon_startup_recovery_mark`)
+/// for every candidate; each Phase B worker drains its own id when its
+/// cascade terminates (success, skip, error, or panic). The background
+/// refresher walks this set every `RECENTLY_RESTARTED_TTL / 2` and re-stamps
+/// each member in `recently_restarted`, so a candidate that sits in the
+/// `STARTUP_RECOVERY_CONCURRENCY` semaphore queue past the TTL does not age
+/// out of suppression and trip a phantom `Status::Error` before its worker
+/// even begins.
+#[cfg(feature = "serve")]
+pub type RecoveryPending = Arc<std::sync::RwLock<std::collections::HashSet<String>>>;
+
+/// Construct an empty `recovery_pending` set.
+#[cfg(feature = "serve")]
+pub fn new_recovery_pending() -> RecoveryPending {
+    Arc::new(std::sync::RwLock::new(std::collections::HashSet::new()))
+}
+
+/// Seed the pending set with every scheduled candidate id. Called by Phase A
+/// alongside the initial `mark_recently_restarted` so the refresher has the
+/// full work set before the cascade (and the refresher) start.
+#[cfg(feature = "serve")]
+pub fn seed_recovery_pending(pending: &RecoveryPending, ids: impl IntoIterator<Item = String>) {
+    if let Ok(mut guard) = pending.write() {
+        guard.extend(ids);
+    }
+}
+
+/// One refresher tick: re-stamp every still-pending id in `recently_restarted`.
+/// Returns `false` once the pending set is empty so the caller can stop
+/// ticking (the cascade is done).
+///
+/// Lock order is `R(pending)` → `W(recently_restarted)`, with the marking
+/// performed *inside* the `pending` read-lock scope. That is the load-bearing
+/// detail: a concurrent [`drain_recovery_pending`] takes `W(pending)` first,
+/// so it cannot interleave between this function observing an id and stamping
+/// it. Either the drain wins the write lock before this read (the id is gone,
+/// never re-stamped) or it blocks until this read releases (its later unmark
+/// strictly succeeds this stamp). No mark-after-unmark resurrection is
+/// possible. See [`drain_recovery_pending`].
+#[cfg(feature = "serve")]
+pub fn refresh_recovery_pending(
+    pending: &RecoveryPending,
+    recently_restarted: &RecentlyRestarted,
+) -> bool {
+    let guard = match pending.read() {
+        Ok(g) => g,
+        Err(_) => return false,
+    };
+    if guard.is_empty() {
+        return false;
+    }
+    for id in guard.iter() {
+        mark_recently_restarted(recently_restarted, id);
+    }
+    true
+}
+
+/// Worker-completion drain: remove `id` from the pending set so the refresher
+/// stops re-stamping it, *then* clear its suppression mark. The ordering
+/// (`W(pending)` before unmarking `recently_restarted`) is what makes the
+/// unmark stick against a racing refresher; see [`refresh_recovery_pending`].
+#[cfg(feature = "serve")]
+pub fn drain_recovery_pending(
+    pending: &RecoveryPending,
+    recently_restarted: &RecentlyRestarted,
+    id: &str,
+) {
+    if let Ok(mut guard) = pending.write() {
+        guard.remove(id);
+    }
+    unmark_recently_restarted(recently_restarted, id);
+}
+
 /// Run the recovery cascade for one instance. Wraps
 /// `restart_with_size_opts(None, false)` in a [`HookTimeoutScope`] so a
 /// hung `on_launch` hook cannot pin the recovery lock (#1265).
@@ -364,6 +438,78 @@ mod tests {
         let g = map.read().unwrap();
         assert!(!g.contains_key("stale"));
         assert!(g.contains_key("fresh"));
+    }
+
+    /// Regression for the queued-candidate TTL race (#1264): the background
+    /// refresher must not resurrect a mark that a completed worker has just
+    /// cleared. The worker drains its id from `recovery_pending` *before*
+    /// unmarking; a subsequent refresher tick sees an empty (for that id)
+    /// pending set and leaves `recently_restarted` clear. Without the drain,
+    /// the refresher would re-stamp the id forever and suppress its real
+    /// status for the rest of the cascade.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn refresher_does_not_resurrect_drained_worker_mark() {
+        let recently = new_recently_restarted();
+        let pending = new_recovery_pending();
+
+        // Phase A: schedule the candidate and stamp its initial mark.
+        seed_recovery_pending(&pending, ["abc".to_string()]);
+        mark_recently_restarted(&recently, "abc");
+
+        // A refresher tick while the worker is still queued keeps it fresh.
+        assert!(
+            refresh_recovery_pending(&pending, &recently),
+            "non-empty pending set should keep ticking",
+        );
+        assert!(
+            recently.read().unwrap().contains_key("abc"),
+            "refresher must keep a queued candidate's mark fresh",
+        );
+
+        // Worker completes: drain from pending, then unmark.
+        drain_recovery_pending(&pending, &recently, "abc");
+        assert!(
+            !recently.read().unwrap().contains_key("abc"),
+            "drain must clear the suppression mark",
+        );
+
+        // A later refresher tick must not bring the mark back, and reports
+        // the set as drained so the loop can exit.
+        assert!(
+            !refresh_recovery_pending(&pending, &recently),
+            "empty pending set signals the refresher to stop",
+        );
+        assert!(
+            !recently.read().unwrap().contains_key("abc"),
+            "refresher must not resurrect a drained worker's mark",
+        );
+    }
+
+    /// The refresher keeps a still-queued candidate marked while a *different*
+    /// candidate finishes. Draining one id must not stop refreshing the rest.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn refresher_keeps_remaining_candidates_after_partial_drain() {
+        let recently = new_recently_restarted();
+        let pending = new_recovery_pending();
+        seed_recovery_pending(&pending, ["done".to_string(), "queued".to_string()]);
+
+        // First worker finishes; the second is still waiting on a permit.
+        drain_recovery_pending(&pending, &recently, "done");
+
+        assert!(
+            refresh_recovery_pending(&pending, &recently),
+            "the queued candidate keeps the refresher alive",
+        );
+        assert!(
+            recently.read().unwrap().contains_key("queued"),
+            "still-queued candidate must stay suppressed",
+        );
+        assert!(
+            !recently.read().unwrap().contains_key("done"),
+            "drained candidate must not be re-stamped",
+        );
     }
 
     /// Regression: archiving a session kills its tmux pane, so the next

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -512,6 +512,64 @@ mod tests {
         );
     }
 
+    /// The two tests above are sequential, so they would still pass even if
+    /// [`refresh_recovery_pending`] snapshotted the ids and *released* the
+    /// `pending` read lock before stamping. That ordering is the whole point
+    /// of the fix, so prove it under a real lock overlap: hold the `pending`
+    /// read lock (standing in for a refresher mid-tick), start a concurrent
+    /// drain that blocks on the write lock, stamp the mark at the last
+    /// possible moment while still holding the read lock, then release and
+    /// let the drain finish. The drain's unmark must win.
+    ///
+    /// This fails if [`drain_recovery_pending`] is reordered to unmark before
+    /// taking `W(pending)`: the premature unmark would race ahead of the
+    /// stamp and the id would be resurrected.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn refresher_mark_loses_to_concurrent_drain_under_lock_overlap() {
+        use std::thread;
+        use std::time::Duration;
+
+        let recently = new_recently_restarted();
+        let pending = new_recovery_pending();
+        seed_recovery_pending(&pending, ["x".to_string()]);
+        mark_recently_restarted(&recently, "x");
+
+        // Stand in for a refresher tick that is *inside* its `pending`
+        // read-lock scope and has not yet stamped.
+        let read_guard = pending.read().unwrap();
+
+        // A worker completes concurrently. `drain_recovery_pending` takes
+        // `W(pending)` first, which blocks behind our read lock, so its
+        // unmark is forced to serialize after we release.
+        let drain_pending = pending.clone();
+        let drain_recently = recently.clone();
+        let drainer = thread::spawn(move || {
+            drain_recovery_pending(&drain_pending, &drain_recently, "x");
+        });
+
+        // Give the drainer time to reach (and block on) the write lock, or,
+        // if drain were buggily reordered to unmark first, to perform that
+        // premature unmark. Then stamp at the latest possible moment, exactly
+        // as the refresher would just before releasing its read lock.
+        thread::sleep(Duration::from_millis(100));
+        mark_recently_restarted(&recently, "x");
+
+        // Release: the blocked drain now removes the id and unmarks.
+        drop(read_guard);
+        drainer.join().unwrap();
+
+        assert!(
+            !pending.read().unwrap().contains("x"),
+            "drain must remove the id from the pending set",
+        );
+        assert!(
+            !recently.read().unwrap().contains_key("x"),
+            "the worker's unmark must win over the refresher's last mark; \
+             no mark-after-unmark resurrection",
+        );
+    }
+
     /// Regression: archiving a session kills its tmux pane, so the next
     /// startup observes a dead pane on a resume-capable agent. Without an
     /// archive guard on `is_recovery_candidate`, the cascade respawns the


### PR DESCRIPTION
## Description

Fixes a race in daemon startup recovery where a queued candidate can age out of the `recently_restarted` suppression window before its worker runs, producing a phantom `Status::Error` chip.

Phase A (`daemon_startup_recovery_mark`) marks all N candidates synchronously at t=0 with an 8s TTL. Phase B spawns N workers that each `acquire_owned().await` a permit from `Semaphore::new(STARTUP_RECOVERY_CONCURRENCY = 3)` and only then re-mark. A candidate sitting in the permit queue has nothing refreshing its mark. If the first cascade batch runs to its ~7s worst case, the 4th+ candidate's t=0 mark can cross the 8s TTL before its worker re-marks; `status_poll_loop` (2s cadence) reads the now-expired mark, sees the still-missing tmux pane, and broadcasts a phantom `Status::Error` before the cascade even begins.

This implements the issue's prescribed background mark-refresher:

- New `recovery_pending` set on `AppState`, seeded by Phase A alongside `recently_restarted`.
- A refresher task spawned between Phase A and Phase B re-stamps every still-pending id every `RECENTLY_RESTARTED_TTL / 2`, and exits once the set drains or on shutdown.
- Each Phase B worker drains its id from `recovery_pending` (W-lock) before unmarking `recently_restarted`, on every exit path (skip, success, error, panic).

Lock order is deadlock-free and resurrection-free: the refresher takes `R(recovery_pending)` then `W(recently_restarted)` with the mark performed inside the read-lock scope, while a worker takes `W(recovery_pending)` before the unmark. A worker drain therefore cannot interleave between the refresher observing an id and stamping it, so a completed worker's unmark strictly succeeds any racing refresher mark.

As a side benefit, the refresher also covers the single-cascade case that exceeds the TTL (the ~10s absolute worst case noted in `RECENTLY_RESTARTED_TTL`'s own doc comment): the mark now stays fresh until the worker actually drains.

Out of scope (unchanged): the TUI path uses event-driven `recovery_in_flight` suppression with no TTL, so it was never affected; cockpit/structured-view sessions are excluded upstream by `is_recovery_candidate`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the bug is a sub-second timing window (a candidate aging past an 8s TTL while queued behind a concurrency permit). The correctness guarantee is the refresher/worker lock ordering, which two new deterministic unit tests in `src/session/recovery.rs` cover directly (`refresher_does_not_resurrect_drained_worker_mark`, `refresher_keeps_remaining_candidates_after_partial_drain`). An e2e reproducing the >TTL queue-aging would require contrived cascade timing and would be inherently flaky.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation and implementation done with Claude Code; the design follows the background mark-refresher specified in the issue. Reasoning and decisions are mine; the prose was drafted by Claude.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #1264


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
High-Level Summary

This PR fixes a startup recovery race that could let queued recovery candidates’ suppression marks expire while waiting for a concurrency permit, producing phantom Status::Error broadcasts. Changes:

- Added recovery_pending to AppState to track instance IDs scheduled for startup recovery.
- Phase A now seeds recovery_pending alongside recently_restarted.
- A supervised background refresher (ticks at RECENTLY_RESTARTED_TTL/2) re-stamps recently_restarted for IDs still in recovery_pending and exits once the set is empty or on shutdown.
- Phase B workers drain their ID from recovery_pending (write-lock) before unmarking recently_restarted, on every exit path (skip, success, error, panic).
- Deterministic unit tests added to validate refresher/worker interaction and the lock-ordering contract.

Benefits

- Prevents phantom Error status broadcasts by ensuring suppression marks do not age out while candidates queue for a worker.
- Preserves correct suppression semantics across semaphore queuing and panics.
- Tests enforce and protect the concurrency contract, reducing regression risk.
- Scope is limited to recovery logic; TUI/cockpit exclusions unchanged.

Technical Details

- New exported type (feature-gated): RecoveryPending = Arc<RwLock<HashSet<String>>> with helpers: new_recovery_pending, seed_recovery_pending, refresh_recovery_pending, drain_recovery_pending.
- AppState now contains pub recovery_pending: RecoveryPending.
- Locking protocol to avoid deadlock and prevent mark-after-unmark resurrection:
  - Refresher: R(recovery_pending) → W(recently_restarted) with marking performed while holding the read-lock on pending.
  - Workers: W(recovery_pending) → W(recently_restarted); workers remove their pending entry before unmarking.
- Refresher tick frequency: RECENTLY_RESTARTED_TTL / 2; GC behavior and final sweep ensure timely refresher exit.
- New deterministic tests cover refresher not resurrecting a drained mark, partial-drain behavior, and a lock-overlap regression ensuring drain wins over a concurrent refresher stamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->