### PR TITLE
fix(tui): boot live-send agent pane at the visible size to kill the resize race

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3046,6 +3046,28 @@ impl Instance {
     /// `finalize_launch` writes those fields and they would otherwise be
     /// dropped with the clone. See `apply_post_restart_sync`.
     pub fn ensure_pane_ready(&mut self) -> Result<EnsureReadyOutcome, EnsureReadyError> {
+        self.ensure_pane_ready_with_size(None)
+    }
+
+    /// Like [`ensure_pane_ready`](Self::ensure_pane_ready), but seeds a
+    /// freshly created or respawned pane at `size` (cols, rows) instead of
+    /// letting tmux fall back to its 80x24 default.
+    ///
+    /// Live-send entry passes the visible preview-pane size here so the agent
+    /// boots at the width it will be shown at. Without it the agent boots
+    /// narrow (80 cols) and depends on a single post-boot `resize-window`
+    /// SIGWINCH to grow into the live area. That SIGWINCH races the agent's
+    /// startup: if it lands before the agent installs its resize handler the
+    /// reflow is lost, and because the per-frame resize loop is deduped on the
+    /// (already-correct) tmux window size, nothing re-issues it. The pane then
+    /// stays pinned at ~80 cols (≈50% of a wide live area) until live mode is
+    /// exited and re-entered. Booting at the right size sidesteps the race.
+    ///
+    /// `None` keeps tmux's default for callers with no target geometry.
+    pub fn ensure_pane_ready_with_size(
+        &mut self,
+        size: Option<(u16, u16)>,
+    ) -> Result<EnsureReadyOutcome, EnsureReadyError> {
         if matches!(self.status, Status::Creating | Status::Deleting) {
             return Err(EnsureReadyError::Transient(self.status));
         }
@@ -3061,7 +3083,7 @@ impl Instance {
             // server kill or reboot resurrects the same bad sid the
             // restart paths exist to recover from.
             let outcome = self
-                .start_with_resume_fallback(None, false)
+                .start_with_resume_fallback(size, false)
                 .map_err(EnsureReadyError::Tmux)?;
             self.wait_for_pane_ready(&session);
             let stale_sid = match outcome {
@@ -3072,7 +3094,7 @@ impl Instance {
         }
         if session.is_pane_dead() {
             let outcome = self
-                .restart_with_size(None)
+                .restart_with_size(size)
                 .map_err(EnsureReadyError::Tmux)?;
             self.wait_for_pane_ready(&session);
             let stale_sid = match outcome {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3300,11 +3300,15 @@ impl HomeView {
         let size = crate::terminal::get_size();
         // Same pane-readiness cascades as live-send: agent runs the
         // full `ensure_pane_ready` (Docker, splash, resume); terminals
-        // just need their tmux session to exist with a live pane.
+        // just need their tmux session to exist with a live pane. Seed a
+        // cold/dead agent pane at the terminal size for the same reason
+        // live-send does (see `ensure_pane_ready_with_size`): otherwise it
+        // boots at tmux's 80x24 default and runs narrow until something
+        // resizes it.
         let stale_sid = match target {
             live_send::LiveSendTarget::Agent => {
                 let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
-                    inst.ensure_pane_ready().map_err(Into::into)
+                    inst.ensure_pane_ready_with_size(size).map_err(Into::into)
                 });
                 match outcome {
                     Ok(Some(EnsureReadyOutcome::Respawned {
@@ -3411,6 +3415,22 @@ impl HomeView {
     /// fired during respawn, `Ok(None)` on a clean ready, and `Err(())`
     /// if the pane could not be readied (`info_dialog` is set with the
     /// underlying error so the caller only has to clear its toast).
+    /// Size to boot a cold/dead agent pane at on live-send entry: the visible
+    /// preview output rect when known, else the full terminal. `preview_pane_area`
+    /// is the exact rect `finalize_live_send_resize` resizes to, so seeding the
+    /// boot here makes the post-boot resize a no-op for cold starts (no reflow,
+    /// no SIGWINCH race). Falls back to the terminal size for the rare entry
+    /// with no prior preview frame (e.g. attach-on-create), and to `None` if
+    /// neither is available so tmux keeps its default.
+    fn live_send_boot_size(&self) -> Option<(u16, u16)> {
+        let pane = self.preview_pane_area;
+        if pane.width > 0 && pane.height > 0 {
+            Some((pane.width, pane.height))
+        } else {
+            crate::terminal::get_size()
+        }
+    }
+
     pub fn prepare_live_send(&mut self, session_id: &str) -> Result<Option<String>, ()> {
         let target = self.pending_live_send_target;
         self.pending_live_send_target = live_send::LiveSendTarget::Agent;
@@ -3420,10 +3440,19 @@ impl HomeView {
         // targets are simpler: the paired terminal is a plain shell,
         // so we just ensure the tmux session exists and re-spawn it if
         // the pane has died (matches `attach_terminal`).
+        //
+        // Boot the agent at the size it will be shown at, not tmux's 80x24
+        // default. A cold-started agent that boots narrow relies on
+        // `finalize_live_send_resize`'s single post-boot SIGWINCH to grow into
+        // the live area, a resize that races the agent's startup and, when
+        // lost, leaves the pane pinned at ~50% width until live mode is
+        // re-entered. See `Instance::ensure_pane_ready_with_size`.
+        let agent_boot_size = self.live_send_boot_size();
         let stale_sid = match target {
             live_send::LiveSendTarget::Agent => {
                 let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
-                    inst.ensure_pane_ready().map_err(Into::into)
+                    inst.ensure_pane_ready_with_size(agent_boot_size)
+                        .map_err(Into::into)
                 });
                 match outcome {
                     Ok(Some(EnsureReadyOutcome::Respawned {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3406,7 +3406,10 @@ impl HomeView {
         if pane.width > 0 && pane.height > 0 {
             Some((pane.width, pane.height))
         } else {
-            crate::terminal::get_size()
+            // A zero-dimension terminal size is as unusable as no size at all;
+            // drop it so the start path keeps tmux's default instead of being
+            // handed `-x 0`/`-y 0`.
+            crate::terminal::get_size().filter(|(cols, rows)| *cols > 0 && *rows > 0)
         }
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3394,6 +3394,22 @@ impl HomeView {
         stale_sid
     }
 
+    /// Size to boot a cold/dead agent pane at on live-send entry: the visible
+    /// preview output rect when known, else the full terminal. `preview_pane_area`
+    /// is the exact rect `finalize_live_send_resize` resizes to, so seeding the
+    /// boot here makes the post-boot resize a no-op for cold starts (no reflow,
+    /// no SIGWINCH race). Falls back to the terminal size for the rare entry
+    /// with no prior preview frame (e.g. attach-on-create), and to `None` if
+    /// neither is available so tmux keeps its default.
+    fn live_send_boot_size(&self) -> Option<(u16, u16)> {
+        let pane = self.preview_pane_area;
+        if pane.width > 0 && pane.height > 0 {
+            Some((pane.width, pane.height))
+        } else {
+            crate::terminal::get_size()
+        }
+    }
+
     /// Stage live-send mode against `session_id`. Mirrors
     /// `execute_send_message`'s revive cascade so a cold-start (Docker
     /// pull, agent splash) is handled before the user starts typing,
@@ -3415,22 +3431,6 @@ impl HomeView {
     /// fired during respawn, `Ok(None)` on a clean ready, and `Err(())`
     /// if the pane could not be readied (`info_dialog` is set with the
     /// underlying error so the caller only has to clear its toast).
-    /// Size to boot a cold/dead agent pane at on live-send entry: the visible
-    /// preview output rect when known, else the full terminal. `preview_pane_area`
-    /// is the exact rect `finalize_live_send_resize` resizes to, so seeding the
-    /// boot here makes the post-boot resize a no-op for cold starts (no reflow,
-    /// no SIGWINCH race). Falls back to the terminal size for the rare entry
-    /// with no prior preview frame (e.g. attach-on-create), and to `None` if
-    /// neither is available so tmux keeps its default.
-    fn live_send_boot_size(&self) -> Option<(u16, u16)> {
-        let pane = self.preview_pane_area;
-        if pane.width > 0 && pane.height > 0 {
-            Some((pane.width, pane.height))
-        } else {
-            crate::terminal::get_size()
-        }
-    }
-
     pub fn prepare_live_send(&mut self, session_id: &str) -> Result<Option<String>, ()> {
         let target = self.pending_live_send_target;
         self.pending_live_send_target = live_send::LiveSendTarget::Agent;

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -11527,3 +11527,43 @@ mod apply_session_id_updates {
         assert!(!view.settings_close_confirm, "confirm flag should reset");
     }
 }
+
+/// Live-send must boot a cold/dead agent pane at the visible preview size so it
+/// does not start at tmux's 80x24 default and then depend on a single,
+/// race-prone post-boot `resize-window` SIGWINCH to grow into the live area.
+/// Regression guard for the "live mode opens at ~50% width" race: if this seed
+/// regresses back to `None`/default, the agent boots narrow again.
+mod live_send_boot_size_tests {
+    use super::create_test_env_empty;
+    use ratatui::layout::Rect;
+
+    #[test]
+    #[serial_test::serial]
+    fn boots_agent_at_visible_preview_size() {
+        let mut env = create_test_env_empty();
+        // The rect `finalize_live_send_resize` would resize the pane to.
+        env.view.preview_pane_area = Rect::new(35, 1, 123, 38);
+
+        assert_eq!(
+            env.view.live_send_boot_size(),
+            Some((123, 38)),
+            "cold agent must boot at the preview pane's visible size, not tmux's 80x24 default"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn never_seeds_a_zero_sized_pane() {
+        let mut env = create_test_env_empty();
+        // No preview has been drawn yet (attach-on-create style entry): the
+        // cached rect is empty. The seed must fall back, never hand tmux a
+        // degenerate 0x0 boot size.
+        env.view.preview_pane_area = Rect::default();
+
+        let seed = env.view.live_send_boot_size();
+        assert!(
+            !matches!(seed, Some((0, _)) | Some((_, 0))),
+            "empty preview rect must fall back, not seed a 0-dimension size; got {seed:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Description

Entering live mode sometimes opened the agent pane at ~50% of the live area instead of full width; exiting and re-entering fixed it. Classic timing race.

**Root cause.** A cold or dead agent pane was created with no size, so tmux fell back to its 80x24 default. `finalize_live_send_resize` then issued a single `resize-window` to the real live-area width, delivering one SIGWINCH. When that lands before the agent (e.g. claude-code) installs its resize handler, the reflow is lost. Nothing re-issues it: the per-frame resize loop (`resize_live_pane_if_target`) is deduped on the already-correct tmux window size (`live_send_last_resize`), so the pane stays pinned at ~80 cols (≈50% of a wide live area) until live mode is re-entered, which clears the dedup and resizes the now-settled agent.

The terminal targets in `prepare_live_send` were already seeded with `crate::terminal::get_size()`; the Agent branch was the only one left on the tmux default (the asymmetry dates to #1561). Terminal panes hide it because shells don't visibly reflow; the agent TUI does.

**Fix.** Boot the cold/dead agent pane at the size it will be shown at:

- Split `Instance::ensure_pane_ready` into a thin wrapper plus `ensure_pane_ready_with_size(size)`, threading the size into the start/restart calls. Non-live callers (server, CLI) keep `None`, so their behavior is unchanged.
- Add `HomeView::live_send_boot_size`, which returns `preview_pane_area` (the exact rect `finalize_live_send_resize` targets) when known, else the terminal size. The live-send Agent branch passes it through, so finalize becomes a no-op for cold starts and the SIGWINCH race never bites.
- Seed `execute_send_message`'s agent cold-start the same way, so `aoe send` no longer leaves the agent running at 80 cols.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A: no user-facing docs affected)
- [x] For UI changes: included screenshot or recording (N/A: not a visual/layout change, this is pane geometry sizing; the behavior is intermittent tmux/agent timing and not capturable as a deterministic screenshot)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test: `src/tui/home/tests.rs::live_send_boot_size_tests` (`boots_agent_at_visible_preview_size`, `never_seeds_a_zero_sized_pane`) locks in the load-bearing change: the agent boots at the visible preview size instead of tmux's 80x24 default. The intermittent SIGWINCH race itself needs a live tmux + agent process and can't be reproduced deterministically, so the regression guard targets the seed decision that removes the race.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-caused and drafted via Claude Code in back-and-forth with @njbrake. The diagnosis (cold boot at 80 cols + a single non-retried grow-SIGWINCH + a dedup that suppresses self-healing) explains both the ~50% width and the "re-enter fixes it" behavior; the reasoning and decisions are mine.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783615137&installation_id=139138837&pr_number=2064&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2064&signature=e43dd4d089143f56804ef40959071bbc49bd37aba113b4596b552d1af9fb5723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a TUI sizing bug where newly created agent panes could open at tmux's 80×24 default (visually too narrow in wide live-preview areas). Agent panes now boot at the visible preview size when available, avoiding a resize-race that previously left panes at the wrong width until re-entering live mode.

## What changed (high-level)

- Pane readiness split into a size-aware path:
  - Added Instance::ensure_pane_ready_with_size(size) and made ensure_pane_ready() delegate to it.
  - Start/restart flows now accept an explicit boot size instead of implicitly using tmux defaults.
- Live-send boot sizing:
  - Added HomeView::live_send_boot_size() which returns the preview pane rectangle when available, otherwise falls back to terminal size. Zero-dimension results are filtered out so callers receive None when no usable size is known.
  - Live-send initialization and the general send-message path pass that boot size to instance readiness so cold agent panes start at the visible preview dimensions.
- Tests:
  - Added unit tests verifying live_send_boot_size() returns the preview dimensions when set and avoids seeding zero-width/height sizes.

## Benefits

- Eliminates the SIGWINCH/resize race that caused incorrect initial pane widths.
- Agents boot at the visible size immediately, improving UX and avoiding manual re-entry to correct layout.
- Backwards compatible: callers that don't supply a size still get previous behavior.

## Technical details (concise)

- New public API: pub fn ensure_pane_ready_with_size(&mut self, size: Option<(u16, u16)>) -> Result<EnsureReadyOutcome, EnsureReadyError>.
- ensure_pane_ready() now calls ensure_pane_ready_with_size(None).
- Fresh-start and respawn paths route through start_with_resume_fallback(size, false) and restart_with_size(size), seeding tmux with the intended geometry.
- HomeView::live_send_boot_size() prefers cached preview_pane_area (the exact rect finalize_live_send_resize targets), then falls back to crate::terminal::get_size(); it filters out zero width/height so None is returned when no usable size exists.
- execute_send_message and prepare_live_send now pass the boot size into instance readiness (including aoe send cold-starts), preventing 80-column defaults.
- Added TUI unit tests (src/tui/home/tests.rs::live_send_boot_size_tests) to assert correct boot-size selection and zero-dimension filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->