### PR TITLE
feat(tui): offer to pull a newer sandbox image when one is available

### DIFF
--- a/src/containers/container_interface.rs
+++ b/src/containers/container_interface.rs
@@ -123,6 +123,13 @@ pub trait ContainerRuntimeInterface {
 
     fn image_exists_locally(&self, image: &str) -> bool;
 
+    /// The manifest digest (`sha256:...`) of the locally-stored image, read
+    /// from its repo digest. `None` when the image isn't present locally, was
+    /// built rather than pulled (no repo digest), or the runtime can't report
+    /// one. Used to compare against the registry to detect a stale sandbox
+    /// image; never pulls.
+    fn local_image_digest(&self, image: &str) -> Option<String>;
+
     // container management
     fn does_container_exist(&self, name: &str) -> Result<bool>;
 

--- a/src/containers/image_update.rs
+++ b/src/containers/image_update.rs
@@ -1,0 +1,416 @@
+//! Detect when the configured sandbox image has a newer build in its registry.
+//!
+//! The TUI surfaces a "sandbox image update available" banner so users on the
+//! `:latest` tag (the default) learn that `ghcr.io/.../aoe-sandbox` moved on
+//! and can pull the refresh without leaving the app. The check compares the
+//! digest of the locally-stored image against the registry's current digest
+//! for the same tag; it never pulls and degrades to "no update" whenever the
+//! runtime, image, or network is unavailable.
+
+use anyhow::{anyhow, Result};
+
+/// A detected sandbox-image update: the configured image plus the registry
+/// digest it now resolves to. The digest doubles as the snooze key so a
+/// dismissal sticks until the registry moves again.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageUpdate {
+    pub image: String,
+    pub remote_digest: String,
+}
+
+/// Default Accept header advertising every manifest media type a tag might
+/// resolve to (single image or multi-arch index, Docker or OCI), so the
+/// registry returns a `Docker-Content-Digest` for whichever it serves.
+const MANIFEST_ACCEPT: &str = "application/vnd.oci.image.index.v1+json, \
+     application/vnd.docker.distribution.manifest.list.v2+json, \
+     application/vnd.docker.distribution.manifest.v2+json, \
+     application/vnd.oci.image.manifest.v1+json";
+
+/// A parsed image reference, split into the registry coordinates needed to
+/// query the registry HTTP API.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryRef {
+    /// Registry host (e.g. `ghcr.io`, `registry-1.docker.io`).
+    pub host: String,
+    /// Repository path (e.g. `agent-of-empires/aoe-sandbox`, `library/ubuntu`).
+    pub repository: String,
+    /// Tag or digest reference (e.g. `latest`, `sha256:...`).
+    pub reference: String,
+    /// True when `reference` is a content digest rather than a tag. A
+    /// digest-pinned image can't go stale, so the staleness check is skipped.
+    pub pinned: bool,
+}
+
+impl RegistryRef {
+    /// Parse a Docker/OCI image reference into registry coordinates, applying
+    /// the same defaults the docker CLI uses: a first path segment that looks
+    /// like a hostname (contains `.`/`:` or is `localhost`) is the registry,
+    /// otherwise the image lives on Docker Hub and a single-segment name gets
+    /// the implicit `library/` namespace. Returns `None` for an empty name.
+    pub fn parse(image: &str) -> Option<Self> {
+        let image = image.trim();
+        if image.is_empty() {
+            return None;
+        }
+
+        // Peel a trailing `@sha256:...` digest first; whatever precedes it is
+        // the name (and possibly a tag we then ignore for the request).
+        let (name_and_tag, digest) = match image.split_once('@') {
+            Some((lhs, rhs)) => (lhs, Some(rhs.to_string())),
+            None => (image, None),
+        };
+
+        // Split host from the remaining path. Only the first segment can be a
+        // registry host, and only if it carries a `.`/`:` or is `localhost`.
+        let (host, remainder) = match name_and_tag.split_once('/') {
+            Some((first, rest))
+                if first == "localhost" || first.contains('.') || first.contains(':') =>
+            {
+                (first.to_string(), rest.to_string())
+            }
+            _ => ("registry-1.docker.io".to_string(), name_and_tag.to_string()),
+        };
+
+        // The tag is the part after the final `:` in the path remainder; a
+        // colon only counts when it isn't inside a path segment boundary.
+        let (mut repository, tag) = match remainder.rsplit_once(':') {
+            Some((repo, tag)) if !tag.contains('/') => (repo.to_string(), Some(tag.to_string())),
+            _ => (remainder, None),
+        };
+
+        if repository.is_empty() {
+            return None;
+        }
+
+        // Docker Hub's library namespace is implicit for single-segment names.
+        if host == "registry-1.docker.io" && !repository.contains('/') {
+            repository = format!("library/{repository}");
+        }
+
+        let (reference, pinned) = match digest {
+            Some(d) => (d, true),
+            None => (tag.unwrap_or_else(|| "latest".to_string()), false),
+        };
+
+        Some(Self {
+            host,
+            repository,
+            reference,
+            pinned,
+        })
+    }
+
+    fn manifest_url(&self) -> String {
+        format!(
+            "https://{}/v2/{}/manifests/{}",
+            self.host, self.repository, self.reference
+        )
+    }
+
+    /// Fetch the registry digest for this reference, performing the standard
+    /// token handshake when the registry answers the first request with a
+    /// `401 WWW-Authenticate: Bearer` challenge (ghcr.io and Docker Hub both
+    /// do for anonymous pulls of public images).
+    async fn fetch_remote_digest(&self, client: &reqwest::Client) -> Result<String> {
+        let url = self.manifest_url();
+        let resp = client
+            .get(&url)
+            .header(reqwest::header::ACCEPT, MANIFEST_ACCEPT)
+            .send()
+            .await?;
+
+        let resp = if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+            let token = self.obtain_token(client, &resp).await?;
+            client
+                .get(&url)
+                .header(reqwest::header::ACCEPT, MANIFEST_ACCEPT)
+                .bearer_auth(token)
+                .send()
+                .await?
+        } else {
+            resp
+        };
+
+        let resp = resp.error_for_status()?;
+        resp.headers()
+            .get("docker-content-digest")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| anyhow!("registry response missing Docker-Content-Digest header"))
+    }
+
+    /// Resolve a bearer token from a `401`'s `WWW-Authenticate: Bearer` header
+    /// by calling the advertised `realm` with its `service`/`scope` params.
+    async fn obtain_token(
+        &self,
+        client: &reqwest::Client,
+        challenge: &reqwest::Response,
+    ) -> Result<String> {
+        let header = challenge
+            .headers()
+            .get(reqwest::header::WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| anyhow!("registry 401 without WWW-Authenticate header"))?;
+
+        let params = parse_bearer_challenge(header)
+            .ok_or_else(|| anyhow!("unsupported WWW-Authenticate challenge: {header}"))?;
+
+        let mut url = reqwest::Url::parse(&params.realm)?;
+        {
+            let mut qp = url.query_pairs_mut();
+            if let Some(service) = &params.service {
+                qp.append_pair("service", service);
+            }
+            if let Some(scope) = &params.scope {
+                qp.append_pair("scope", scope);
+            }
+        }
+
+        let token: TokenResponse = client
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        token
+            .token
+            .or(token.access_token)
+            .ok_or_else(|| anyhow!("registry token endpoint returned no token"))
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct TokenResponse {
+    token: Option<String>,
+    access_token: Option<String>,
+}
+
+struct BearerChallenge {
+    realm: String,
+    service: Option<String>,
+    scope: Option<String>,
+}
+
+/// Parse a `Bearer realm="...",service="...",scope="..."` challenge into its
+/// parts. Returns `None` when the scheme isn't `Bearer` or `realm` is absent.
+fn parse_bearer_challenge(header: &str) -> Option<BearerChallenge> {
+    let rest = header.strip_prefix("Bearer ").or_else(|| {
+        header
+            .strip_prefix("bearer ")
+            .or_else(|| header.strip_prefix("BEARER "))
+    })?;
+
+    let mut realm = None;
+    let mut service = None;
+    let mut scope = None;
+    for part in rest.split(',') {
+        let Some((key, value)) = part.split_once('=') else {
+            continue;
+        };
+        let value = value.trim().trim_matches('"').to_string();
+        match key.trim() {
+            "realm" => realm = Some(value),
+            "service" => service = Some(value),
+            "scope" => scope = Some(value),
+            _ => {}
+        }
+    }
+
+    Some(BearerChallenge {
+        realm: realm?,
+        service,
+        scope,
+    })
+}
+
+/// Pick the `sha256:...` digest matching `image`'s repository out of docker's
+/// newline-separated `RepoDigests` (`repo@sha256:...` per line). Falls back to
+/// the first entry's digest when none matches the parsed repository, and
+/// returns `None` when there are no usable entries (e.g. a locally-built image
+/// with an empty `RepoDigests`).
+pub fn pick_repo_digest(image: &str, repo_digests: &str) -> Option<String> {
+    let wanted = RegistryRef::parse(image).map(|r| r.repository);
+
+    let mut first = None;
+    for line in repo_digests.lines() {
+        let line = line.trim();
+        let Some((repo, digest)) = line.split_once("@") else {
+            continue;
+        };
+        if digest.is_empty() {
+            continue;
+        }
+        if first.is_none() {
+            first = Some(digest.to_string());
+        }
+        // `repo` carries the registry-qualified path; match on a suffix so a
+        // `ghcr.io/owner/img@...` entry still matches the parsed `owner/img`.
+        if let Some(wanted) = &wanted {
+            if repo == wanted || repo.ends_with(&format!("/{wanted}")) {
+                return Some(digest.to_string());
+            }
+        }
+    }
+    first
+}
+
+/// Check whether the configured sandbox `image` has a newer digest in its
+/// registry than the copy stored locally. Returns:
+/// - `Ok(Some(_))` when a different digest is available to pull,
+/// - `Ok(None)` when up to date, not locally present, digest-pinned, or the
+///   runtime can't report a local digest (nothing actionable to surface),
+/// - `Err(_)` when the registry query itself fails (caller logs and stays quiet).
+pub async fn check_for_image_update(image: &str) -> Result<Option<ImageUpdate>> {
+    let Some(reference) = RegistryRef::parse(image) else {
+        return Ok(None);
+    };
+    // A digest-pinned image is already exact; it can't drift.
+    if reference.pinned {
+        return Ok(None);
+    }
+
+    // Reading the local digest shells out to the runtime; keep it off the
+    // async worker threads.
+    let image_owned = image.to_string();
+    let local = tokio::task::spawn_blocking(move || {
+        use crate::containers::ContainerRuntimeInterface;
+        crate::containers::get_container_runtime().local_image_digest(&image_owned)
+    })
+    .await
+    .ok()
+    .flatten();
+
+    // No local copy (or no reportable digest) means there's nothing to update
+    // in place; the first sandbox launch pulls it via `ensure_image`.
+    let Some(local) = local else {
+        return Ok(None);
+    };
+
+    let client = reqwest::Client::builder()
+        .user_agent(crate::github::DEFAULT_USER_AGENT)
+        .timeout(std::time::Duration::from_secs(8))
+        .build()?;
+
+    let remote = reference.fetch_remote_digest(&client).await?;
+
+    if remote != local {
+        tracing::info!(
+            target: "containers.image_update",
+            %image,
+            local = %local,
+            remote = %remote,
+            "sandbox image update available"
+        );
+        Ok(Some(ImageUpdate {
+            image: image.to_string(),
+            remote_digest: remote,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ghcr_reference_with_tag() {
+        let r = RegistryRef::parse("ghcr.io/agent-of-empires/aoe-sandbox:latest").unwrap();
+        assert_eq!(r.host, "ghcr.io");
+        assert_eq!(r.repository, "agent-of-empires/aoe-sandbox");
+        assert_eq!(r.reference, "latest");
+        assert!(!r.pinned);
+    }
+
+    #[test]
+    fn defaults_tag_to_latest() {
+        let r = RegistryRef::parse("ghcr.io/agent-of-empires/aoe-sandbox").unwrap();
+        assert_eq!(r.reference, "latest");
+        assert!(!r.pinned);
+    }
+
+    #[test]
+    fn applies_docker_hub_library_namespace() {
+        let r = RegistryRef::parse("ubuntu:22.04").unwrap();
+        assert_eq!(r.host, "registry-1.docker.io");
+        assert_eq!(r.repository, "library/ubuntu");
+        assert_eq!(r.reference, "22.04");
+    }
+
+    #[test]
+    fn keeps_namespaced_docker_hub_repository() {
+        let r = RegistryRef::parse("mozillaai/foo").unwrap();
+        assert_eq!(r.host, "registry-1.docker.io");
+        assert_eq!(r.repository, "mozillaai/foo");
+        assert_eq!(r.reference, "latest");
+    }
+
+    #[test]
+    fn parses_registry_with_port() {
+        let r = RegistryRef::parse("localhost:5000/team/img:dev").unwrap();
+        assert_eq!(r.host, "localhost:5000");
+        assert_eq!(r.repository, "team/img");
+        assert_eq!(r.reference, "dev");
+    }
+
+    #[test]
+    fn marks_digest_pinned_references() {
+        let r = RegistryRef::parse("ghcr.io/agent-of-empires/aoe-sandbox@sha256:abc123def4567890")
+            .unwrap();
+        assert!(r.pinned);
+        assert_eq!(r.reference, "sha256:abc123def4567890");
+    }
+
+    #[test]
+    fn rejects_empty_reference() {
+        assert!(RegistryRef::parse("").is_none());
+        assert!(RegistryRef::parse("   ").is_none());
+    }
+
+    #[test]
+    fn picks_matching_repo_digest() {
+        let repo_digests = "\
+ghcr.io/agent-of-empires/aoe-sandbox@sha256:aaa\n\
+docker.io/library/ubuntu@sha256:bbb\n";
+        let digest =
+            pick_repo_digest("ghcr.io/agent-of-empires/aoe-sandbox:latest", repo_digests).unwrap();
+        assert_eq!(digest, "sha256:aaa");
+    }
+
+    #[test]
+    fn falls_back_to_first_repo_digest_when_none_match() {
+        let repo_digests = "registry.example.com/other/img@sha256:ccc\n";
+        let digest =
+            pick_repo_digest("ghcr.io/agent-of-empires/aoe-sandbox:latest", repo_digests).unwrap();
+        assert_eq!(digest, "sha256:ccc");
+    }
+
+    #[test]
+    fn returns_none_for_empty_repo_digests() {
+        assert!(pick_repo_digest("ghcr.io/agent-of-empires/aoe-sandbox:latest", "").is_none());
+        assert!(
+            pick_repo_digest("ghcr.io/agent-of-empires/aoe-sandbox:latest", "\n  \n").is_none()
+        );
+    }
+
+    #[test]
+    fn parses_bearer_challenge_fields() {
+        let header = "Bearer realm=\"https://ghcr.io/token\",service=\"ghcr.io\",scope=\"repository:agent-of-empires/aoe-sandbox:pull\"";
+        let c = parse_bearer_challenge(header).unwrap();
+        assert_eq!(c.realm, "https://ghcr.io/token");
+        assert_eq!(c.service.as_deref(), Some("ghcr.io"));
+        assert_eq!(
+            c.scope.as_deref(),
+            Some("repository:agent-of-empires/aoe-sandbox:pull")
+        );
+    }
+
+    #[test]
+    fn rejects_non_bearer_challenge() {
+        assert!(parse_bearer_challenge("Basic realm=\"x\"").is_none());
+    }
+}

--- a/src/containers/image_update.rs
+++ b/src/containers/image_update.rs
@@ -210,7 +210,14 @@ fn parse_bearer_challenge(header: &str) -> Option<BearerChallenge> {
         let Some((key, value)) = part.split_once('=') else {
             continue;
         };
-        let value = value.trim().trim_matches('"').to_string();
+        // Strip only a single outer pair of quotes, not every quote, so a
+        // value that legitimately contains a `"` survives intact.
+        let value = value.trim();
+        let value = value
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .unwrap_or(value)
+            .to_string();
         match key.trim() {
             "realm" => realm = Some(value),
             "service" => service = Some(value),
@@ -412,5 +419,18 @@ docker.io/library/ubuntu@sha256:bbb\n";
     #[test]
     fn rejects_non_bearer_challenge() {
         assert!(parse_bearer_challenge("Basic realm=\"x\"").is_none());
+    }
+
+    #[test]
+    fn strips_only_the_outer_quote_pair() {
+        // An unquoted value passes through; only a single surrounding pair is
+        // removed, so an embedded quote is preserved rather than stripped.
+        let c = parse_bearer_challenge(
+            "Bearer realm=https://r.example/token,service=svc,scope=\"a\"b\"",
+        )
+        .unwrap();
+        assert_eq!(c.realm, "https://r.example/token");
+        assert_eq!(c.service.as_deref(), Some("svc"));
+        assert_eq!(c.scope.as_deref(), Some("a\"b"));
     }
 }

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -1,5 +1,6 @@
 pub mod container_interface;
 pub mod error;
+pub mod image_update;
 mod runtime;
 pub(crate) mod runtime_base;
 

--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -69,6 +69,36 @@ impl ContainerRuntimeInterface for ContainerRuntime {
         self.base.image_exists_locally(image)
     }
 
+    fn local_image_digest(&self, image: &str) -> Option<String> {
+        match self.kind {
+            RuntimeKind::Docker | RuntimeKind::Podman => {
+                // `RepoDigests` holds `repo@sha256:...` entries for the pulled
+                // manifest. One subprocess, newline-joined so a multi-registry
+                // image still lets us pick the entry matching this reference.
+                let output = self
+                    .base
+                    .command()
+                    .args([
+                        "image",
+                        "inspect",
+                        "--format",
+                        "{{range .RepoDigests}}{{println .}}{{end}}",
+                        image,
+                    ])
+                    .output()
+                    .ok()?;
+                if !output.status.success() {
+                    return None;
+                }
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                super::image_update::pick_repo_digest(image, &stdout)
+            }
+            // Apple Container's `image inspect` doesn't expose a Docker-style
+            // repo digest; skip the staleness check there rather than guess.
+            RuntimeKind::AppleContainer => None,
+        }
+    }
+
     fn pull_image(&self, image: &str) -> Result<()> {
         self.base.pull_image(image)
     }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -634,6 +634,13 @@ pub struct AppStateConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dismissed_update_version: Option<String>,
 
+    /// Registry digest of the sandbox image the user dismissed the
+    /// "image update available" banner for. The banner stays hidden while the
+    /// registry still resolves to this digest and returns automatically once a
+    /// newer image is published (the digest no longer matches).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dismissed_image_digest: Option<String>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub home_list_width: Option<u16>,
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -14,6 +14,7 @@ use super::attached_status_hooks::AttachedStatusHookWatcher;
 use super::home::{HomeView, TerminalMode};
 use super::status_poller::StatusUpdate;
 use super::styles::Theme;
+use crate::containers::image_update::ImageUpdate;
 use crate::session::{get_update_settings, save_config, Config};
 use crate::tmux::AvailableTools;
 use crate::update::{check_for_update, UpdateInfo};
@@ -92,6 +93,18 @@ pub struct App {
     /// fetched latest_version equals this value, and returns
     /// automatically when a newer release ships.
     dismissed_update_version: Option<String>,
+    /// A newer sandbox image detected in its registry, surfaced as the
+    /// lowest-priority bottom banner (below app-update and transient status).
+    /// `None` until the background check finds a drift the user hasn't snoozed.
+    image_update: Option<ImageUpdate>,
+    image_update_rx: Option<tokio::sync::oneshot::Receiver<anyhow::Result<Option<ImageUpdate>>>>,
+    /// In-flight `docker pull` of the sandbox image, kicked off when the user
+    /// accepts the banner's confirm. Result promotes into a transient toast.
+    image_pull_rx: Option<tokio::sync::oneshot::Receiver<anyhow::Result<()>>>,
+    /// Registry digest the user dismissed via Ctrl+x on the image banner.
+    /// Persisted to `app_state.dismissed_image_digest`; the banner stays hidden
+    /// while the registry still resolves to this digest.
+    dismissed_image_digest: Option<String>,
     /// Held in an Option so `with_raw_mode_disabled` can drop it before
     /// spawning child processes. Crossterm's EventStream runs a background
     /// reader thread on stdin; if it's alive when tmux attach-session starts,
@@ -280,6 +293,7 @@ impl App {
         }
 
         let dismissed_update_version = config.app_state.dismissed_update_version.clone();
+        let dismissed_image_digest = config.app_state.dismissed_image_digest.clone();
 
         Ok(Self {
             home,
@@ -291,6 +305,10 @@ impl App {
             update_status: None,
             update_status_rx: None,
             dismissed_update_version,
+            image_update: None,
+            image_update_rx: None,
+            image_pull_rx: None,
+            dismissed_image_digest,
             event_stream: Some(EventStream::new()),
             // Initial state matches whatever `tui::run` did at startup: capture
             // is requested by default, but Mosh suppresses the actual escape, so
@@ -495,6 +513,14 @@ impl App {
             } else {
                 None
             };
+
+        // Check the sandbox image for a newer registry build, once at startup.
+        // Gated on the same network-checks toggle as app updates, and only for
+        // users who actually run sandboxed sessions (so non-sandbox users never
+        // see a docker banner).
+        if settings.update_check_mode.is_enabled() && self.sandbox_in_use() {
+            self.spawn_image_update_check();
+        }
 
         // SIGHUP/SIGTERM futures so we exit cleanly when the terminal
         // emulator is force-quit, preventing PTY slot leaks (#541).
@@ -1136,6 +1162,19 @@ impl App {
                 refresh_needed = true;
                 needs_full_refresh = true;
             }
+            // The sandbox-image banner and its pull toast share the same
+            // bottom-row layout slot, so treat their changes as full-refresh
+            // work too.
+            if self.poll_image_update_check() {
+                self.needs_redraw = true;
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
+            if self.poll_image_pull_status() {
+                self.needs_redraw = true;
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
 
             if last_status_refresh.elapsed() >= STATUS_REFRESH_INTERVAL {
                 self.home.request_status_refresh();
@@ -1430,6 +1469,7 @@ impl App {
             &self.theme,
             self.update_info.as_ref(),
             status_text,
+            self.image_update.as_ref(),
         );
         // Sampled trace for frame-budget diagnostics. A full-frame trace on
         // every paint would dominate the log at `default_level = trace`, so
@@ -1546,6 +1586,120 @@ impl App {
         }
 
         true
+    }
+
+    /// Whether the user runs sandboxed sessions, so a docker-image banner is
+    /// worth surfacing. True when sandbox is on by default or any current
+    /// session is sandboxed; otherwise we skip the registry check entirely.
+    fn sandbox_in_use(&self) -> bool {
+        if Config::load_or_warn().sandbox.enabled_by_default {
+            return true;
+        }
+        self.home.instances().iter().any(|i| i.is_sandboxed())
+    }
+
+    /// Is the sandbox-image banner the one currently shown? It sits below the
+    /// app-update banner and transient toast, so it only owns the `u`/Ctrl+x
+    /// keys when neither of those is up.
+    fn image_banner_active(&self) -> bool {
+        self.image_update.is_some() && self.update_info.is_none() && self.update_status.is_none()
+    }
+
+    /// Spawn the background sandbox-image staleness check. Mirrors
+    /// `spawn_update_check`: the result lands on `image_update_rx` for the
+    /// main loop's `poll_image_update_check` to pick up.
+    fn spawn_image_update_check(&mut self) {
+        if self.image_update_rx.is_some() {
+            return;
+        }
+        let image = Config::load_or_warn().sandbox.default_image.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.image_update_rx = Some(rx);
+        tokio::spawn(async move {
+            let result = crate::containers::image_update::check_for_image_update(&image).await;
+            let _ = tx.send(result);
+        });
+    }
+
+    /// Poll the image-update check (non-blocking). Returns true when a fresh,
+    /// non-snoozed update just arrived and the banner should show.
+    fn poll_image_update_check(&mut self) -> bool {
+        let Some(mut rx) = self.image_update_rx.take() else {
+            return false;
+        };
+        match rx.try_recv() {
+            Ok(Ok(Some(update))) => {
+                // Honor the per-digest snooze; a newer image clears it
+                // automatically because its digest no longer matches.
+                if self.dismissed_image_digest.as_deref() == Some(update.remote_digest.as_str()) {
+                    return false;
+                }
+                self.image_update = Some(update);
+                true
+            }
+            Ok(Ok(None)) => false,
+            Ok(Err(e)) => {
+                tracing::debug!(target: "containers.image_update", error = %e, "image update check failed");
+                false
+            }
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                self.image_update_rx = Some(rx);
+                false
+            }
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => false,
+        }
+    }
+
+    /// Kick off a `docker pull` of the sandbox image after the user accepts the
+    /// banner's confirm dialog. The blocking pull runs on a std thread (the
+    /// runtime call shells out); the result promotes into a transient toast.
+    fn spawn_image_pull(&mut self, image: String) {
+        if self.image_pull_rx.is_some() {
+            return;
+        }
+        self.update_status = Some(UpdateStatus::transient(format!("pulling {image}…")));
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.image_pull_rx = Some(rx);
+        std::thread::spawn(move || {
+            use crate::containers::ContainerRuntimeInterface;
+            let result = crate::containers::get_container_runtime()
+                .pull_image(&image)
+                .map_err(anyhow::Error::from);
+            let _ = tx.send(result);
+        });
+    }
+
+    /// Poll the in-progress image pull. On success the banner clears (the local
+    /// copy now matches the registry) and a confirmation toast shows. Returns
+    /// true when the status line changed.
+    fn poll_image_pull_status(&mut self) -> bool {
+        let Some(mut rx) = self.image_pull_rx.take() else {
+            return false;
+        };
+        match rx.try_recv() {
+            Ok(Ok(())) => {
+                self.image_update = None;
+                self.update_status = Some(UpdateStatus::transient(
+                    "sandbox image updated. New sessions will use it.".into(),
+                ));
+                true
+            }
+            Ok(Err(e)) => {
+                self.update_status =
+                    Some(UpdateStatus::transient(format!("image pull failed: {e}")));
+                true
+            }
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                self.image_pull_rx = Some(rx);
+                false
+            }
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                self.update_status = Some(UpdateStatus::transient(
+                    "image pull ended unexpectedly".into(),
+                ));
+                true
+            }
+        }
     }
 
     /// Kick off a background install when `update_check_mode = "auto"` and a
@@ -1726,6 +1880,21 @@ fn persist_dismissed_update_version(version: Option<String>) {
             target: "update.snooze",
             error = %e,
             "failed to persist dismissed_update_version"
+        );
+    }
+}
+
+/// Persist `app_state.dismissed_image_digest` so dismissing the sandbox-image
+/// banner (Ctrl+x) survives restarts. Like the update snooze, failures are
+/// logged but never surfaced.
+fn persist_dismissed_image_digest(digest: Option<String>) {
+    let mut config = Config::load_or_warn();
+    config.app_state.dismissed_image_digest = digest;
+    if let Err(e) = save_config(&config) {
+        tracing::warn!(
+            target: "containers.image_update",
+            error = %e,
+            "failed to persist dismissed_image_digest"
         );
     }
 }
@@ -1917,9 +2086,24 @@ impl App {
             // a beat (visible flash). Ratatui's diff renderer handles the
             // 1-row layout shrink on the next normal draw.
             (KeyCode::Char('x'), KeyModifiers::CONTROL)
-                if (self.update_info.is_some() || self.update_status.is_some())
+                if (self.update_info.is_some()
+                    || self.update_status.is_some()
+                    || self.image_update.is_some())
                     && !self.home.has_dialog() =>
             {
+                // The image banner is lowest priority, so Ctrl+x only dismisses
+                // it when it's the one actually showing. Otherwise it targets
+                // the app update / toast as before, leaving any pending image
+                // update to surface once those clear.
+                if self.image_banner_active() {
+                    if let Some(update) = self.image_update.as_ref() {
+                        let digest = update.remote_digest.clone();
+                        self.dismissed_image_digest = Some(digest.clone());
+                        persist_dismissed_image_digest(Some(digest));
+                    }
+                    self.image_update = None;
+                    return Ok(());
+                }
                 if let Some(info) = self.update_info.as_ref() {
                     let v = info.latest_version.clone();
                     self.dismissed_update_version = Some(v.clone());
@@ -1927,6 +2111,19 @@ impl App {
                 }
                 self.update_info = None;
                 self.update_status = None;
+                return Ok(());
+            }
+            // `u` on the sandbox-image banner opens the pull confirm. The app
+            // update owns `u` via the home bindings, but the image banner only
+            // shows when no app update is up (see `image_banner_active`), so
+            // there's no collision.
+            (KeyCode::Char('u'), KeyModifiers::NONE)
+                if self.image_banner_active() && !self.home.has_dialog() =>
+            {
+                if let Some(update) = self.image_update.as_ref() {
+                    let image = update.image.clone();
+                    self.home.prompt_pull_sandbox_image(image);
+                }
                 return Ok(());
             }
             _ => {}
@@ -2093,6 +2290,15 @@ impl App {
             }
             Action::SetTransientStatus(text) => {
                 self.update_status = Some(UpdateStatus::transient(text));
+            }
+            Action::SpawnImagePull(image) => {
+                if self.image_pull_rx.is_some() {
+                    self.update_status = Some(UpdateStatus::transient(
+                        "image pull already in progress".into(),
+                    ));
+                    return Ok(());
+                }
+                self.spawn_image_pull(image);
             }
             Action::SendMessage(id, message) => {
                 // Flip the row to Starting and show a toast so the user has
@@ -2584,6 +2790,10 @@ pub enum Action {
     SetTheme(String),
     SpawnUpdate(crate::update::install::InstallMethod, String),
     SetTransientStatus(String),
+    /// Pull the sandbox image after the user accepts the "image update
+    /// available" banner's confirm. Deferred to `execute_action` so the loop
+    /// can show a "pulling…" status before the blocking pull starts.
+    SpawnImagePull(String),
     /// Send a message to a session. Deferred to `execute_action` (rather
     /// than handled inline in the dialog Submit branch) so the app loop
     /// can render a "Reviving..." status before the potentially-slow

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -759,10 +759,32 @@ impl HomeView {
                 }
                 None
             }
+            "pull_sandbox_image" => self.pending_image_pull.take().map(Action::SpawnImagePull),
             "quit_during_creation" => Some(Action::Quit),
             "quit" => Some(Action::Quit),
             _ => None,
         }
+    }
+
+    /// Open a neutral confirm dialog offering to pull the newer sandbox image
+    /// the registry check surfaced. The image is stashed in
+    /// `pending_image_pull` because the generic `ConfirmDialog` only carries an
+    /// action string; the Submit handler reads it back to emit the pull.
+    pub(crate) fn prompt_pull_sandbox_image(&mut self, image: String) {
+        if self.confirm_dialog.is_some() {
+            return;
+        }
+        self.pending_image_pull = Some(image.clone());
+        self.confirm_dialog = Some(
+            ConfirmDialog::new(
+                "Update sandbox image",
+                &format!(
+                    "Pull the latest {image}? This downloads the new image and uses it for new sandbox sessions."
+                ),
+                "pull_sandbox_image",
+            )
+            .neutral(),
+        );
     }
 
     /// Confirm before archiving every active session under the focused group.
@@ -901,6 +923,7 @@ impl HomeView {
                         self.confirm_dialog = None;
                         self.pending_stop_session = None;
                         self.pending_force_remove_session = None;
+                        self.pending_image_pull = None;
                         // The settings close path mirrors the keyboard
                         // route: Cancel here means "don't discard," so
                         // settings stays open and `settings_close_confirm`
@@ -1693,6 +1716,7 @@ impl HomeView {
                     self.confirm_dialog = None;
                     self.pending_stop_session = None;
                     self.pending_force_remove_session = None;
+                    self.pending_image_pull = None;
                 }
                 DialogResult::Submit(_) => {
                     let action = dialog.action().to_string();

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -578,6 +578,10 @@ pub struct HomeView {
     pub(super) pending_attach_after_warning: Option<String>,
     /// Session to stop after the confirmation dialog is accepted
     pub(super) pending_stop_session: Option<String>,
+    /// Sandbox image to pull after the "image update available" confirm dialog
+    /// is accepted. Carries the image through the generic `ConfirmDialog`,
+    /// which only knows its action string.
+    pub(super) pending_image_pull: Option<String>,
     /// Session to force-remove after the confirmation dialog is accepted
     pub(super) pending_force_remove_session: Option<String>,
     /// Action emitted by a mouse-click on a modal dialog (e.g. clicking
@@ -1137,6 +1141,7 @@ impl HomeView {
             pending_paste: None,
             pending_attach_after_warning: None,
             pending_stop_session: None,
+            pending_image_pull: None,
             pending_force_remove_session: None,
             pending_dialog_click_action: None,
             search_active: false,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -11,6 +11,7 @@ use super::{
     get_indent, live_send, HomeView, TerminalMode, ViewMode, ICON_COLLAPSED, ICON_DELETING,
     ICON_ERROR, ICON_EXPANDED, ICON_IDLE, ICON_PINNED, ICON_STOPPED, ICON_UNKNOWN,
 };
+use crate::containers::image_update::ImageUpdate;
 use crate::session::config::{GroupByMode, SortOrder};
 use crate::session::{Item, Status};
 use crate::tui::components::preview::{self, CachedPreview};
@@ -452,6 +453,7 @@ impl HomeView {
         theme: &Theme,
         update_info: Option<&UpdateInfo>,
         update_status: Option<&str>,
+        image_update: Option<&ImageUpdate>,
     ) {
         // Settings view takes over the whole screen
         if let Some(ref mut settings) = self.settings_view {
@@ -502,7 +504,8 @@ impl HomeView {
         // (update_info) and transient toasts (update_status); we need a row
         // for it whenever either is present, otherwise toasts fired without
         // a pending update would never reach the screen.
-        let has_update_bar = update_info.is_some() || update_status.is_some();
+        let has_update_bar =
+            update_info.is_some() || update_status.is_some() || image_update.is_some();
         let constraints = if has_update_bar {
             vec![
                 Constraint::Min(0),
@@ -581,7 +584,14 @@ impl HomeView {
         self.render_status_bar(frame, main_chunks[1], theme);
 
         if has_update_bar {
-            self.render_update_bar(frame, main_chunks[2], theme, update_info, update_status);
+            self.render_update_bar(
+                frame,
+                main_chunks[2],
+                theme,
+                update_info,
+                update_status,
+                image_update,
+            );
         }
 
         // Render dialogs on top
@@ -2799,11 +2809,13 @@ impl HomeView {
         theme: &Theme,
         info: Option<&UpdateInfo>,
         status: Option<&str>,
+        image_update: Option<&ImageUpdate>,
     ) {
         let update_style = Style::default().fg(theme.waiting).bold();
-        // Transient status takes precedence over the persistent update banner
-        // so users see the latest signal (e.g. "restart failed: ...") even
-        // when an update banner is also up.
+        // Precedence (highest first): transient status, app update, then the
+        // sandbox-image update. Only one banner shows at a time, so its keys
+        // ([u]/[Ctrl+x]) are unambiguous; a lower-priority banner surfaces once
+        // the ones above it clear.
         let text = if let Some(s) = status {
             format!(" {s}  [Ctrl+x] dismiss")
         } else if let Some(info) = info {
@@ -2811,6 +2823,8 @@ impl HomeView {
                 " update available {} → {}  [u] update  [Ctrl+x] dismiss",
                 info.current_version, info.latest_version
             )
+        } else if image_update.is_some() {
+            " sandbox image update available  [u] pull  [Ctrl+x] dismiss".to_string()
         } else {
             return;
         };

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -221,7 +221,7 @@ fn preview_info_follows_flag_and_never_auto_shows_in_live() {
         terminal
             .draw(|f| {
                 let area = f.area();
-                view.render(f, area, &theme, None, None);
+                view.render(f, area, &theme, None, None, None);
             })
             .unwrap();
         let buf = terminal.backend().buffer().clone();
@@ -300,7 +300,7 @@ fn preview_visible_rows_equal_output_area_with_info_shown() {
     terminal
         .draw(|f| {
             let area = f.area();
-            env.view.render(f, area, &theme, None, None);
+            env.view.render(f, area, &theme, None, None, None);
         })
         .unwrap();
 
@@ -5060,7 +5060,7 @@ fn update_bar_renders_status_toast_without_update_info() {
     terminal
         .draw(|f| {
             let area = f.area();
-            env.view.render(f, area, &theme, None, Some(toast));
+            env.view.render(f, area, &theme, None, Some(toast), None);
         })
         .unwrap();
 
@@ -5081,6 +5081,116 @@ fn update_bar_renders_status_toast_without_update_info() {
     assert!(
         out.contains("[Ctrl+x] dismiss"),
         "expected the dismiss hint alongside the toast.\nFull buffer:\n{out}"
+    );
+}
+
+/// The sandbox-image update banner renders (with its `[u] pull` /
+/// `[Ctrl+x] dismiss` hints) when an `ImageUpdate` is present and no
+/// higher-priority banner is up. Guards the lowest-priority slot in
+/// `render_update_bar`.
+#[test]
+#[serial]
+fn update_bar_renders_sandbox_image_banner() {
+    use crate::containers::image_update::ImageUpdate;
+    use crate::tui::styles::load_theme;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let mut env = create_test_env_empty();
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let theme = load_theme("empire");
+
+    let image_update = ImageUpdate {
+        image: "ghcr.io/agent-of-empires/aoe-sandbox:latest".to_string(),
+        remote_digest: "sha256:abc".to_string(),
+    };
+
+    terminal
+        .draw(|f| {
+            let area = f.area();
+            env.view
+                .render(f, area, &theme, None, None, Some(&image_update));
+        })
+        .unwrap();
+
+    let buf = terminal.backend().buffer();
+    let mut out = String::new();
+    for y in 0..buf.area.height {
+        for x in 0..buf.area.width {
+            out.push_str(buf[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+
+    assert!(
+        out.contains("sandbox image update available"),
+        "expected the sandbox image banner to render.\nFull buffer:\n{out}"
+    );
+    assert!(
+        out.contains("[u] pull") && out.contains("[Ctrl+x] dismiss"),
+        "expected the pull/dismiss hints alongside the image banner.\nFull buffer:\n{out}"
+    );
+}
+
+/// The app-update banner wins the shared bottom row over a pending
+/// sandbox-image update: only one shows at a time, so the lower-priority
+/// image banner must stay hidden (and its `[u] pull` hint absent) while an
+/// app update is up. This is what keeps the `u` / Ctrl+x keys unambiguous.
+#[test]
+#[serial]
+fn app_update_banner_takes_precedence_over_image_banner() {
+    use crate::containers::image_update::ImageUpdate;
+    use crate::tui::styles::load_theme;
+    use crate::update::UpdateInfo;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let mut env = create_test_env_empty();
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let theme = load_theme("empire");
+
+    let update_info = UpdateInfo {
+        available: true,
+        current_version: "1.0.0".to_string(),
+        latest_version: "1.1.0".to_string(),
+    };
+    let image_update = ImageUpdate {
+        image: "ghcr.io/agent-of-empires/aoe-sandbox:latest".to_string(),
+        remote_digest: "sha256:abc".to_string(),
+    };
+
+    terminal
+        .draw(|f| {
+            let area = f.area();
+            env.view.render(
+                f,
+                area,
+                &theme,
+                Some(&update_info),
+                None,
+                Some(&image_update),
+            );
+        })
+        .unwrap();
+
+    let buf = terminal.backend().buffer();
+    let mut out = String::new();
+    for y in 0..buf.area.height {
+        for x in 0..buf.area.width {
+            out.push_str(buf[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+
+    assert!(
+        out.contains("update available 1.0.0"),
+        "expected the app update banner to win the row.\nFull buffer:\n{out}"
+    );
+    assert!(
+        !out.contains("sandbox image update available"),
+        "image banner must stay hidden while an app update is shown.\nFull buffer:\n{out}"
     );
 }
 
@@ -5171,7 +5281,7 @@ fn footer_hides_attention_workflow_hints_outside_attention_sort() {
         terminal
             .draw(|f| {
                 let area = f.area();
-                env.view.render(f, area, &theme, None, None);
+                env.view.render(f, area, &theme, None, None, None);
             })
             .unwrap();
         let buf = terminal.backend().buffer();
@@ -7409,7 +7519,7 @@ mod scroll_pane_isolation {
             terminal
                 .draw(|f| {
                     let area = f.area();
-                    env.view.render(f, area, &theme, None, None);
+                    env.view.render(f, area, &theme, None, None, None);
                 })
                 .unwrap();
             env.view.preview_pane_area.width
@@ -9048,7 +9158,7 @@ mod preview_drag_select {
         terminal
             .draw(|f| {
                 let area = f.area();
-                env.view.render(f, area, &theme, None, None);
+                env.view.render(f, area, &theme, None, None, None);
             })
             .unwrap();
 
@@ -9099,7 +9209,7 @@ mod preview_drag_select {
         terminal
             .draw(|f| {
                 let area = f.area();
-                env.view.render(f, area, &theme, None, None);
+                env.view.render(f, area, &theme, None, None, None);
             })
             .unwrap();
 
@@ -11502,7 +11612,7 @@ mod apply_session_id_updates {
         terminal
             .draw(|f| {
                 let area = f.area();
-                view.render(f, area, &theme, None, None);
+                view.render(f, area, &theme, None, None, None);
             })
             .unwrap();
 


### PR DESCRIPTION
## Description

Fixes #576.

Users on the default \`:latest\` sandbox image (\`ghcr.io/agent-of-empires/aoe-sandbox:latest\`) had no in-app signal when the image moved on in its registry, so they kept running a stale copy until they happened to re-pull by hand.

This adds a background registry check that compares the locally stored image digest against the registry's current digest for the configured tag. When they differ, the home screen surfaces a dismissible bottom banner offering to pull the refresh:

\`\`\`
 sandbox image update available  [u] pull  [Ctrl+x] dismiss
\`\`\`

Design and behavior:

- **Check**: runs once at startup, off the UI thread. Gated on the same network checks toggle as app updates (\`update_check_mode.is_enabled()\`) and only for users who actually run sandboxed sessions (sandbox enabled by default, or any current session is sandboxed), so non sandbox users never see a docker banner. Reads the local digest via \`docker image inspect\` (RepoDigests) and the remote digest via the registry manifest API, performing the standard \`WWW-Authenticate: Bearer\` token handshake (works for ghcr.io and Docker Hub). It never pulls, and degrades to "no update" whenever the runtime, image, or network is unavailable; digest pinned images are skipped.
- **Surface**: occupies the lowest priority slot in the existing single banner row (precedence: transient toast, then app update, then image update), so only one banner shows at a time and its keys stay unambiguous. Mirrors the existing app update banner UX.
- **Pull**: \`[u]\` opens a neutral confirm dialog; on accept, the image is pulled on a background thread with a progress toast, then the banner clears.
- **Snooze**: \`[Ctrl+x]\` persists the registry digest to \`app_state.dismissed_image_digest\`; the banner stays hidden while the registry still resolves to that digest and returns automatically once a newer image ships.

Scope note: this reuses \`update_check_mode\` as the on/off gate rather than introducing a dedicated setting, to avoid the settings schema and web coverage matrix surface for a P2. It can be split into its own toggle later if preferred.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none required; no user facing docs cover the update banners)
- [ ] For UI changes: included screenshot or recording

UI note: this is a TUI banner that only appears when the local sandbox image is genuinely behind its registry, which needs a real digest mismatch to reproduce. Rendering is covered by unit render tests instead; happy to add a recording via the needs-recording label if reviewers want one.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under \`tests/e2e/\`
- [x] Skipped a test, because: the new rendering path is covered by unit render tests in \`src/tui/home/tests.rs\` (banner shows when an \`ImageUpdate\` is present; app update banner takes precedence over it), and the reference parsing, repo digest selection, and bearer challenge parsing are unit tested in \`src/containers/image_update.rs\`. The async registry round trip isn't practical to exercise in the tmux e2e harness without standing up a fake registry.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:** Claude drafted the implementation and this PR description through back and forth with @njbrake; the design decisions (home banner surfacing, gating on sandbox usage, reusing the update check toggle) are his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783615469&installation_id=139138837&pr_number=2065&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2065&signature=ceb83cee03491c8e64da2605346d98b1acd96bb22ee25be369c89f52a5ff80fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a background sandbox Docker image update check and a TUI banner that offers to pull a newer sandbox image from the registry when one is available. It notifies users non-intrusively, lets them pull the image from inside the app, and supports a snooze/dismiss option that persists across sessions.

## What changed (high-level)

- New background check that compares the local sandbox image digest with the registry’s current digest for the configured tag.
- Dismissible bottom-banner on the home screen that appears when a newer image exists.
- Keyboard flows: press [u] to confirm and pull the image; press Ctrl+x to snooze/dismiss until the registry digest changes.
- Pull runs on a background thread with a progress toast; banner clears after successful pull.
- Snooze persists the dismissed registry digest to app state so the banner stays hidden until a newer digest appears.
- Reuses existing update_check_mode gate and only runs when sandboxed sessions are used; degrades gracefully when runtime/image/network are unavailable and skips digest-pinned images.
- Unit tests added for parsing, manifest handling, and TUI banner rendering; e2e does not exercise async registry round-trip.

## Key code additions & movement

- New module: src/containers/image_update.rs
  - RegistryRef parsing, registry manifest queries, Bearer token handshake, check_for_image_update(), ImageUpdate struct, pick_repo_digest(), and tests.
- Container runtime interface:
  - Added fn local_image_digest(&self, image: &str) -> Option<String>; implemented for Docker/Podman (inspects RepoDigests), no-op on AppleContainer.
- TUI integration:
  - App state fields for image_update, image_update_rx, image_pull_rx, and dismissed_image_digest; SpawnImagePull action and background pull handling.
  - Home view rendering updated to include image_update and to render the new banner with correct precedence (transient status > app update > image update).
  - Input handling updated to prompt/confirm image pulls and to persist snooze.
- Config persistence:
  - New AppStateConfig field dismissed_image_digest: Option<String>.
- Tests:
  - Render tests for the update banner and unit tests for reference/digest parsing and Bearer challenge parsing.
- Minor refactor:
  - Tightened Bearer challenge parsing (fixes mangling of quoted values) with a regression test.

## Benefits

- Proactively informs users when sandbox images are outdated.
- Simple, non-intrusive UX with in-app pull and persistent snooze.
- Avoids unnecessary pulls and respects digest-pinned images.
- Uses existing update-check toggle (no new settings).
- Graceful behavior when runtime or network is unavailable.

## Technical details (brief)

- Queries registry manifest endpoint with appropriate Accept headers and extracts Docker-Content-Digest; performs OAuth Bearer flow when challenged via WWW-Authenticate.
- Compares remote digest to local RepoDigests returned by docker/podman image inspect; pick_repo_digest matches repository names robustly.
- Long-running operations (check/pull) are off the UI thread and coordinated via oneshot receivers; UI updates rendered in the home view’s update bar.
- Snooze persists the registry digest so the banner stays hidden until a newer digest appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->