### PR TITLE
feat(acp): bump claude-agent-acp floor to 0.44.0 for upstream #641 fix and fable model

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN npm install -g @qwen-code/qwen-code
 # `gemini --acp`, `vibe-acp`) are already provided by their respective
 # CLIs above.
 RUN npm install -g \
-    @agentclientprotocol/claude-agent-acp@^0.39.0 \
+    @agentclientprotocol/claude-agent-acp@^0.44.0 \
     @zed-industries/codex-acp \
     pi-acp
 

--- a/docs/development/internals/sandbox.md
+++ b/docs/development/internals/sandbox.md
@@ -56,7 +56,7 @@ docker volume rm aoe-claude-auth aoe-opencode-auth aoe-codex-auth aoe-gemini-aut
 
 Agent-view sessions can run inside the container. When both are enabled, the structured view runner wraps the ACP agent in `docker exec`, so the adapter binary must exist inside the container. The published `aoe-sandbox` image bundles the npm-distributed ACP adapters:
 
-- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@^0.41.0`, floor pin)
+- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@^0.44.0`, floor pin)
 - `codex-acp` (`@zed-industries/codex-acp`)
 - `pi-acp`
 

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -20,7 +20,7 @@ aoe ships an ACP registry entry for each tool whose ACP server we've verified. F
 
 | Agent | ACP adapter | Install | Auth |
 |-------|-------------|---------|------|
-| `claude` | `claude-agent-acp` (Zed, requires ≥0.41.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` | `claude login`, or `ANTHROPIC_API_KEY` |
+| `claude` | `claude-agent-acp` (Zed, requires ≥0.44.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` | `claude login`, or `ANTHROPIC_API_KEY` |
 | `codex` | `codex-acp` (Zed) | `npm install -g @zed-industries/codex-acp` | `OPENAI_API_KEY`, or ChatGPT login (local-only) |
 | `opencode` | `opencode acp` (native, ≥1.16.0 recommended) | `curl -fsSL https://opencode.ai/install \| bash` | `opencode auth` / provider env |
 | `gemini` | `gemini --acp` (native) | `npm install -g @google/gemini-cli` | `GEMINI_API_KEY`, OAuth, or Vertex |

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -53,14 +53,14 @@ install is incomplete. Reinstall aoe via your package manager (e.g.,
 
 ### `aoe acp doctor` says claude-code adapter is missing
 
-aoe requires `claude-agent-acp` v0.41.0 or newer. Install the official adapter:
+aoe requires `claude-agent-acp` v0.44.0 or newer. Install the official adapter:
 
 ```bash
 npm install -g @agentclientprotocol/claude-agent-acp@latest
 ```
 
 Then run `claude login` if you haven't already. If an older version is pinned by
-an internal mirror, ship 0.41.0 from the mirror or run the `@latest` install
+an internal mirror, ship 0.44.0 from the mirror or run the `@latest` install
 above before starting `aoe serve`.
 
 ### "Failed to start structured view agent" while the adapter is installed

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -393,7 +393,7 @@ const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from
 /// claude-agent-acp >=0.41.0 (upstream #680) also force-resolves a
 /// prompt loop wedged in a `TaskOutput { block: true }` poll against a
 /// hung background task: ~30s after the first cancel it returns
-/// `cancelled` instead of hanging forever. The 0.41.0 floor (see
+/// `cancelled` instead of hanging forever. The 0.44.0 floor (see
 /// `agent_compat`) guarantees that path, so a cancel during off-protocol
 /// background work no longer rides the 30-minute
 /// `OFF_PROTOCOL_WORK_GRACE_FLOOR` below before recovering.

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -7,11 +7,11 @@
 //! single hook to call after `initialize` succeeds, instead of scattering
 //! ad-hoc semver checks at every spawn site.
 //!
-//! Today only `ClaudeAgentAcp` carries a minimum version (>=0.41.0,
+//! Today only `ClaudeAgentAcp` carries a minimum version (>=0.44.0,
 //! required for `memory_recall` tool-call emission, native `cancelled`
 //! stop reason, force-cancel of a wedged `TaskOutput` block (upstream
-//! #680), Opus 4.8 model availability, and several other behaviors
-//! aoe builds on). Other agents
+//! #680), the upstream #641 fix, the `fable` model, and several other
+//! behaviors aoe builds on). Other agents
 //! get a permissive policy (protocol check only). Long-term aoe should
 //! prefer ACP capability flags over package-version gating; until upstream
 //! exposes those, package versions are the only precise contract.
@@ -49,7 +49,7 @@ impl ExpectedAgent {
     /// separators, and the `.exe` / `.cmd` suffixes Windows shims add.
     /// Without this normalization a wrapped or Windows-installed
     /// `claude-agent-acp` would land in `Other` and silently bypass the
-    /// >=0.41.0 gate.
+    /// >=0.44.0 gate.
     pub fn from_command(command: &str) -> Self {
         // Scan every whitespace-separated token. The actual binary can
         // be the first token (`/usr/local/bin/claude-agent-acp`) but
@@ -57,7 +57,7 @@ impl ExpectedAgent {
         // (`bash claude-agent-acp`, `env -u FOO claude-agent-acp`,
         // `npx claude-agent-acp`, etc.). Match against the first token
         // that classifies as a known adapter so wrappers don't bypass
-        // the >=0.41.0 gate.
+        // the >=0.44.0 gate.
         command
             .split_whitespace()
             .find_map(|token| {
@@ -100,7 +100,7 @@ impl ExpectedAgent {
         match self {
             Self::ClaudeAgentAcp => CompatibilityPolicy {
                 expected_name: Some("@agentclientprotocol/claude-agent-acp"),
-                min_version: Some(semver::Version::new(0, 41, 0)),
+                min_version: Some(semver::Version::new(0, 44, 0)),
                 required_protocol: ProtocolVersion::V1,
                 fail_on_missing_agent_info: true,
             },
@@ -188,7 +188,7 @@ impl StartupError {
                 expected_package,
                 install_command,
             } => format!(
-                "Adapter did not report its package version. aoe requires {expected_package} >=0.41.0. Run: {install_command}",
+                "Adapter did not report its package version. aoe requires {expected_package} >=0.44.0. Run: {install_command}",
             ),
             Self::MismatchedAgentName {
                 expected,
@@ -386,29 +386,29 @@ mod tests {
             panic!()
         };
         assert_eq!(installed, "0.32.0");
-        assert_eq!(required, "0.41.0");
+        assert_eq!(required, "0.44.0");
     }
 
     #[test]
     fn claude_below_new_floor_rejected() {
-        // 0.40.x advertises the model selector and native cancel but lacks
-        // the force-cancel of a wedged TaskOutput block (upstream #680),
-        // which the 0.41.0 floor requires. Pin the boundary so a future
-        // accidental floor downgrade is caught.
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.40.9");
+        // 0.43.x carries the model selector, native cancel, and the
+        // wedged-TaskOutput force-cancel, but lacks the upstream #641 fix
+        // and the `fable` model, which the 0.44.0 floor requires. Pin the
+        // boundary so a future accidental floor downgrade is caught.
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.43.9");
         let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
         assert_eq!(err.kind(), "incompatible_agent_version");
     }
 
     #[test]
     fn claude_at_minimum_accepted() {
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.41.0");
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.44.0");
         validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap();
     }
 
     #[test]
     fn claude_above_minimum_accepted() {
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.41.1");
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.44.1");
         validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap();
     }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Raises the `claude-agent-acp` minimum-version floor from `0.41.0` to `0.44.0`. The bump pulls in the upstream [`claude-agent-acp#641`](https://github.com/agentclientprotocol/claude-agent-acp/issues/641) fix and the new `fable` Claude model.

No model-list code is involved: models and reasoning-effort selectors are advertised dynamically by the adapter over ACP, so once the adapter is at `0.44.0` the `fable` model surfaces on its own. The version floor is the whole change.

This also corrects the Docker sandbox image, which had lagged at `@^0.39.0` (below even the prior `0.41.0` host floor, so sandboxed sessions would have been rejected by the compat gate). It now pins `@^0.44.0` to match.

Touched: the `agent_compat` gate constant and its boundary test fixtures (now reject `0.43.9`, accept `0.44.0` and `0.44.1`), the floor statements in code comments and the version-mismatch error string, the Dockerfile sandbox pin, and the user docs. Historical references to behavior-arrival versions (`v0.37.0`, the `>=0.41.0` upstream #680 force-cancel) are intentionally left intact.

There is no aoe GitHub issue tracking this; it is a routine upstream-floor bump, so no `Closes` line.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] With `claude-agent-acp` `0.43.x` installed, start a structured-view `claude` session and confirm aoe rejects it with a `>=0.44.0` required message.
- [ ] Upgrade to `claude-agent-acp` `>=0.44.0` (`npm install -g @agentclientprotocol/claude-agent-acp@latest`), start a structured-view session, and confirm it initializes.
- [ ] In an initialized session, open the model dropdown in the composer footer and confirm `fable` is listed.
- [ ] Rebuild the sandbox image and run a sandboxed structured-view session, confirming the in-container adapter clears the `0.44.0` floor.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The boundary is covered by the `agent_compat` unit tests (`claude_below_new_floor_rejected`, `claude_at_minimum_accepted`, `claude_above_minimum_accepted`), updated to bracket the new `0.44.0` floor.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls and reviewed the diff.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783628768&installation_id=139138837&pr_number=2077&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2077&signature=d0d31dc0c7d714886f1ae22cddeef1ece6322f6bab6cf5427cd54583b2d6eb22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR raises the minimum required version of the Claude Agent ACP adapter from 0.41.0 to 0.44.0 to incorporate upstream bug fixes and access to the new "fable" Claude model.

## What Changed

**Version Updates:**
- Updated the Docker sandbox image to require ACP adapter v0.44.0 or newer
- Updated all documentation to reflect the new v0.44.0 minimum requirement
- Updated the code-level compatibility gate from 0.41.0 to 0.44.0
- Updated internal test assertions to accept 0.44.0 and reject older versions

**Files Modified:**
- **Docker configuration** - Updated the ACP adapter dependency constraint
- **Documentation** (4 files) - Revised version requirements and prerequisites across sandbox setup, structured view guides, and troubleshooting sections
- **Source code** (2 files) - Updated compatibility checks and version-related comments

## What Was Added/Removed
- No new features or code entities added; this is a version constraint update
- No code removed; only version numbers updated in configuration, comments, and documentation

## Benefits
- **Access to upstream fix**: Incorporates the fix from agentclientprotocol/claude-agent-acp#641 that resolves a cancel-related prompt-loop issue
- **New model availability**: The "fable" Claude model becomes available once the adapter is upgraded
- **Simplified maintenance**: Models and reasoning-effort options are dynamically advertised by the adapter over ACP, so no model-list code changes are needed
- **Consistency**: All documentation and code now align on the same minimum version requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->