### PR TITLE
feat: add bare repository clone option to web dashboard

### DIFF
--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -17,6 +17,12 @@ my-project/
 
 ### Initial Setup
 
+**From the web dashboard:**
+
+When creating a new session, go to the "Clone URL" tab, enter the repository URL, expand "Advanced", and check "Clone as bare repository". This performs the setup automatically and returns the path to the main worktree.
+
+**From the command line:**
+
 ```bash
 git clone --bare git@github.com:user/repo.git my-project/.bare
 cd my-project

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -23,7 +23,7 @@ mod remote;
 pub mod template;
 mod worktree;
 
-pub use remote::{clone_repo, get_remote_owner};
+pub use remote::{clone_bare_repo, clone_repo, get_remote_owner};
 pub use worktree::{GitWorktree, WorktreeEntry};
 
 /// Open a git repository at the given path without searching parent directories.

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -371,4 +371,67 @@ mod tests {
     fn test_parse_owner_empty_url() {
         assert_eq!(parse_owner_from_remote_url(""), None);
     }
+
+    #[test]
+    fn test_clone_bare_repo_creates_structure() {
+        use tempfile::TempDir;
+
+        // Create a source repo to clone from
+        let source_dir = TempDir::new().unwrap();
+        let source_repo = git2::Repository::init(source_dir.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let mut index = source_repo.index().unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = source_repo.find_tree(tree_id).unwrap();
+        source_repo
+            .commit(Some("HEAD"), &sig, &sig, "Initial", &tree, &[])
+            .unwrap();
+
+        // Clone as bare repo
+        let dest_dir = TempDir::new().unwrap();
+        let dest_path = dest_dir.path().join("test-bare-clone");
+        let url = format!("file://{}", source_dir.path().display());
+
+        let result = clone_bare_repo(&url, &dest_path);
+        assert!(result.is_ok(), "clone_bare_repo failed: {:?}", result.err());
+
+        let worktree_path = result.unwrap();
+        assert!(
+            worktree_path.ends_with("/main"),
+            "Expected path ending with /main"
+        );
+
+        // Verify structure
+        assert!(dest_path.join(".bare").exists(), ".bare directory missing");
+        assert!(dest_path.join(".git").exists(), ".git file missing");
+        assert!(dest_path.join("main").exists(), "main worktree missing");
+
+        // Verify .git file content
+        let gitfile = std::fs::read_to_string(dest_path.join(".git")).unwrap();
+        assert_eq!(gitfile.trim(), "gitdir: ./.bare");
+
+        // Verify main is a valid worktree
+        let main_path = dest_path.join("main");
+        assert!(main_path.join(".git").exists(), "worktree .git missing");
+    }
+
+    #[test]
+    fn test_clone_bare_repo_destination_exists() {
+        use tempfile::TempDir;
+
+        let dest_dir = TempDir::new().unwrap();
+        let dest_path = dest_dir.path().join("existing");
+        std::fs::create_dir(&dest_path).unwrap();
+
+        let result = clone_bare_repo("https://example.com/repo.git", &dest_path);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "Expected 'already exists' error, got: {}",
+            err
+        );
+    }
 }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -5,6 +5,185 @@ use std::path::Path;
 use super::error::{GitError, Result};
 use super::open_repo_at;
 
+/// Clone a git repository as a bare repo with worktree setup, following the
+/// workflow-guide structure. Returns the path to the created worktree
+/// (`<destination>/main`). Cleans up `<destination>` on failure.
+#[tracing::instrument(target = "git.fetch", skip_all, fields(url = %redact_url(url)))]
+pub fn clone_bare_repo(url: &str, destination: &Path) -> Result<String> {
+    if destination.exists() {
+        return Err(GitError::CloneFailed(format!(
+            "Destination already exists: {}",
+            destination.display()
+        )));
+    }
+
+    let bare_dir = destination.join(".bare");
+    let bare_str = bare_dir
+        .to_str()
+        .ok_or_else(|| GitError::CloneFailed("Invalid bare directory path".to_string()))?;
+
+    let redacted_url = redact_url(url);
+
+    tracing::debug!(
+        target: "git.command",
+        args = ?["clone", "--bare", &redacted_url, bare_str],
+        "spawning git clone --bare"
+    );
+    let mut child = std::process::Command::new("git")
+        .args(["clone", "--bare", url, bare_str])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| GitError::CloneFailed(format!("Failed to run git clone --bare: {e}")))?;
+
+    let timeout = std::time::Duration::from_secs(300);
+    let poll_interval = std::time::Duration::from_millis(200);
+    let start = std::time::Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => break,
+            Ok(Some(_)) => {
+                let stderr = child
+                    .stderr
+                    .take()
+                    .and_then(|mut s| {
+                        let mut buf = String::new();
+                        std::io::Read::read_to_string(&mut s, &mut buf).ok()?;
+                        Some(buf)
+                    })
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                let _ = std::fs::remove_dir_all(destination);
+                return Err(GitError::CloneFailed(stderr));
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = std::fs::remove_dir_all(destination);
+                    return Err(GitError::CloneFailed(
+                        "Bare clone timed out after 5 minutes".to_string(),
+                    ));
+                }
+                std::thread::sleep(poll_interval);
+            }
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(destination);
+                return Err(GitError::CloneFailed(format!(
+                    "Failed waiting for git clone --bare: {e}"
+                )));
+            }
+        }
+    }
+
+    let run_in_bare = |args: &[&str]| -> Result<std::process::Output> {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&bare_dir)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .map_err(|e| GitError::CloneFailed(format!("Git command failed: {e}")))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let _ = std::fs::remove_dir_all(destination);
+            return Err(GitError::CloneFailed(stderr));
+        }
+        Ok(output)
+    };
+
+    let gitfile_path = destination.join(".git");
+    if let Err(e) = std::fs::write(&gitfile_path, "gitdir: ./.bare\n") {
+        let _ = std::fs::remove_dir_all(destination);
+        return Err(GitError::CloneFailed(format!(
+            "Failed to create .git file: {e}"
+        )));
+    }
+
+    run_in_bare(&[
+        "config",
+        "remote.origin.fetch",
+        "+refs/heads/*:refs/remotes/origin/*",
+    ])?;
+
+    run_in_bare(&["fetch", "origin"])?;
+
+    let default_branch = {
+        let output = run_in_bare(&["symbolic-ref", "refs/remotes/origin/HEAD"])?;
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        stdout
+            .rsplit_once('/')
+            .map(|(_, name)| name.to_string())
+            .filter(|s| !s.is_empty())
+    };
+
+    let default_branch = match default_branch {
+        Some(b) => b,
+        None => {
+            let try_branch = |branch: &str| -> bool {
+                std::process::Command::new("git")
+                    .args([
+                        "show-ref",
+                        "--verify",
+                        &format!("refs/remotes/origin/{branch}"),
+                    ])
+                    .current_dir(&bare_dir)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status()
+                    .map(|s| s.success())
+                    .unwrap_or(false)
+            };
+            if try_branch("main") {
+                "main".to_string()
+            } else if try_branch("master") {
+                "master".to_string()
+            } else {
+                let _ = std::fs::remove_dir_all(destination);
+                return Err(GitError::CloneFailed(
+                    "Could not detect default branch (tried main, master)".to_string(),
+                ));
+            }
+        }
+    };
+
+    let worktree_path = destination.join("main");
+    let worktree_str = worktree_path
+        .to_str()
+        .ok_or_else(|| GitError::CloneFailed("Invalid worktree path".to_string()))?;
+
+    let output = std::process::Command::new("git")
+        .args(["worktree", "add", worktree_str, &default_branch])
+        .current_dir(destination)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .map_err(|e| GitError::CloneFailed(format!("Git worktree add failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let _ = std::fs::remove_dir_all(destination);
+        return Err(GitError::CloneFailed(format!(
+            "Failed to create worktree: {stderr}"
+        )));
+    }
+
+    tracing::info!(
+        target: "git.fetch",
+        "Bare clone complete: {} -> {}",
+        redacted_url,
+        worktree_path.display()
+    );
+
+    Ok(worktree_path.display().to_string())
+}
+
 /// Clone a git repository from a URL into the given destination directory.
 ///
 /// The destination must not already exist. If `shallow` is true, only the

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -112,43 +112,51 @@ pub fn clone_bare_repo(url: &str, destination: &Path) -> Result<String> {
 
     run_in_bare(&["fetch", "origin"])?;
 
-    let default_branch = {
-        let output = run_in_bare(&["symbolic-ref", "refs/remotes/origin/HEAD"])?;
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        stdout
-            .rsplit_once('/')
-            .map(|(_, name)| name.to_string())
-            .filter(|s| !s.is_empty())
+    // Detect the default branch. `git clone --bare` points the bare repo's
+    // own HEAD at the remote's default branch, which works on every git
+    // version. `refs/remotes/origin/HEAD` is only populated by `git fetch`
+    // on git >= 2.45 (followRemoteHEAD), so it can't be relied on; try it
+    // and then main/master as fallbacks. These probes must tolerate a
+    // non-zero exit (the ref simply not existing), so they don't go through
+    // `run_in_bare`, which treats failure as fatal and wipes the clone.
+    let probe = |args: &[&str]| -> Option<String> {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&bare_dir)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let out = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!out.is_empty()).then_some(out)
     };
+    let branch_from_ref = |full: &str| full.rsplit_once('/').map(|(_, name)| name.to_string());
+
+    let default_branch = probe(&["symbolic-ref", "--short", "HEAD"])
+        .or_else(|| {
+            probe(&["symbolic-ref", "refs/remotes/origin/HEAD"])
+                .as_deref()
+                .and_then(branch_from_ref)
+        })
+        .or_else(|| {
+            probe(&["show-ref", "--verify", "refs/remotes/origin/main"]).map(|_| "main".into())
+        })
+        .or_else(|| {
+            probe(&["show-ref", "--verify", "refs/remotes/origin/master"]).map(|_| "master".into())
+        });
 
     let default_branch = match default_branch {
         Some(b) => b,
         None => {
-            let try_branch = |branch: &str| -> bool {
-                std::process::Command::new("git")
-                    .args([
-                        "show-ref",
-                        "--verify",
-                        &format!("refs/remotes/origin/{branch}"),
-                    ])
-                    .current_dir(&bare_dir)
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .status()
-                    .map(|s| s.success())
-                    .unwrap_or(false)
-            };
-            if try_branch("main") {
-                "main".to_string()
-            } else if try_branch("master") {
-                "master".to_string()
-            } else {
-                let _ = std::fs::remove_dir_all(destination);
-                return Err(GitError::CloneFailed(
-                    "Could not detect default branch (tried main, master)".to_string(),
-                ));
-            }
+            let _ = std::fs::remove_dir_all(destination);
+            return Err(GitError::CloneFailed(
+                "Could not detect default branch (tried HEAD, origin/HEAD, main, master)"
+                    .to_string(),
+            ));
         }
     };
 

--- a/src/server/api/git.rs
+++ b/src/server/api/git.rs
@@ -15,6 +15,8 @@ pub struct CloneRepoBody {
     pub destination: Option<String>,
     #[serde(default)]
     pub shallow: bool,
+    #[serde(default)]
+    pub bare: bool,
 }
 
 /// Returns true if `url` looks like a git clone URL accepted by this
@@ -93,6 +95,14 @@ pub async fn clone_repo(
             .into_response();
     }
 
+    if body.bare && body.shallow {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "validation_failed", "message": "Cannot use both bare and shallow options"})),
+        )
+            .into_response();
+    }
+
     // Resolve destination path
     let destination = if let Some(ref dest) = body.destination {
         let dest = dest.trim();
@@ -156,9 +166,14 @@ pub async fn clone_repo(
     }
 
     let shallow = body.shallow;
+    let bare = body.bare;
     let result = tokio::task::spawn_blocking(move || {
-        crate::git::clone_repo(&url, &destination, shallow)?;
-        Ok::<String, crate::git::error::GitError>(destination.display().to_string())
+        if bare {
+            crate::git::clone_bare_repo(&url, &destination)
+        } else {
+            crate::git::clone_repo(&url, &destination, shallow)?;
+            Ok(destination.display().to_string())
+        }
     })
     .await;
 

--- a/src/server/api/git.rs
+++ b/src/server/api/git.rs
@@ -32,6 +32,21 @@ fn looks_like_git_url(url: &str) -> bool {
         || (url.contains('@') && url.contains(':') && !url.contains(' '))
 }
 
+/// Expand a leading `~` or `~/` to the user's home directory.
+/// Leaves the path unchanged when no home dir is available.
+fn expand_tilde(path: &str) -> std::path::PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    } else if path == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    std::path::PathBuf::from(path)
+}
+
 /// Extract a repository name from a git URL.
 ///
 /// Handles HTTPS, SSH, and scp-style URLs:
@@ -109,7 +124,7 @@ pub async fn clone_repo(
         if dest.is_empty() {
             None
         } else {
-            Some(std::path::PathBuf::from(dest))
+            Some(expand_tilde(dest))
         }
     } else {
         None
@@ -379,5 +394,21 @@ mod tests {
     #[test]
     fn looks_like_git_url_rejects_scp_style_with_space() {
         assert!(!looks_like_git_url("git@host: /path"));
+    }
+
+    #[test]
+    fn expand_tilde_expands_home() {
+        let home = dirs::home_dir().expect("home dir");
+        assert_eq!(expand_tilde("~/foo"), home.join("foo"));
+        assert_eq!(expand_tilde("~"), home);
+    }
+
+    #[test]
+    fn expand_tilde_leaves_absolute_paths_alone() {
+        assert_eq!(
+            expand_tilde("/tmp/foo"),
+            std::path::PathBuf::from("/tmp/foo")
+        );
+        assert_eq!(expand_tilde("foo/bar"), std::path::PathBuf::from("foo/bar"));
     }
 }

--- a/web/src/components/session-wizard/steps/ProjectStep.tsx
+++ b/web/src/components/session-wizard/steps/ProjectStep.tsx
@@ -125,6 +125,7 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
   const [cloneUrl, setCloneUrl] = useState("");
   const [cloneDestination, setCloneDestination] = useState("");
   const [shallowClone, setShallowClone] = useState(false);
+  const [bareClone, setBareClone] = useState(false);
   const [cloning, setCloning] = useState(false);
   const [cloneError, setCloneError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -164,6 +165,7 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
     const result = await cloneRepo(url, {
       destination: dest,
       shallow: shallowClone,
+      bare: bareClone,
     });
     setCloning(false);
     if (result.ok && result.path) {
@@ -358,10 +360,26 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
                       checked={shallowClone}
                       onChange={(e) => setShallowClone(e.target.checked)}
                       className="accent-brand-600"
+                      disabled={cloning || bareClone}
+                    />
+                    <span className={`text-sm ${bareClone ? "text-text-dim" : "text-text-secondary"}`}>
+                      Shallow clone (--depth 1)
+                    </span>
+                    <span className="text-[10px] text-text-dim">faster for large repos</span>
+                  </label>
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={bareClone}
+                      onChange={(e) => {
+                        setBareClone(e.target.checked);
+                        if (e.target.checked) setShallowClone(false);
+                      }}
+                      className="accent-brand-600"
                       disabled={cloning}
                     />
-                    <span className="text-sm text-text-secondary">Shallow clone (--depth 1)</span>
-                    <span className="text-[10px] text-text-dim">faster for large repos</span>
+                    <span className="text-sm text-text-secondary">Clone as bare repository</span>
+                    <span className="text-[10px] text-text-dim">recommended for worktrees</span>
                   </label>
                 </div>
               )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -887,12 +887,13 @@ export async function createSession(body: CreateSessionRequest): Promise<{
 
 export async function cloneRepo(
   url: string,
-  opts?: { destination?: string; shallow?: boolean },
+  opts?: { destination?: string; shallow?: boolean; bare?: boolean },
 ): Promise<{ ok: boolean; path?: string; error?: string }> {
   try {
     const body: Record<string, unknown> = { url };
     if (opts?.destination) body.destination = opts.destination;
     if (opts?.shallow) body.shallow = true;
+    if (opts?.bare) body.bare = true;
     const res = await fetch("/api/git/clone", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/web/tests/helpers/gitFixture.ts
+++ b/web/tests/helpers/gitFixture.ts
@@ -74,6 +74,34 @@ export function initWorkingRepo(repoPath: string, opts: { defaultBranch?: string
 }
 
 /**
+ * Create a throwaway bare repo that already contains one commit on
+ * `defaultBranch`. Unlike {@link createBareRepo}, this one has a branch to
+ * check out, so it can be cloned as a bare repo + worktree (cloning an
+ * empty bare repo leaves `git worktree add` with no reference to resolve).
+ * Built by committing into a temporary working repo, then cloning it bare.
+ *
+ * Returns the absolute path and the `file://` URL.
+ */
+export function createSeededBareRepo(
+  parentDir: string,
+  opts: { name?: string; defaultBranch?: string } = {},
+): BareRepoFixture {
+  const name = opts.name ?? "seeded-bare.git";
+  const branch = opts.defaultBranch ?? "main";
+  mkdirSync(parentDir, { recursive: true });
+  const path = join(parentDir, name);
+  const workdir = join(parentDir, `${name}.src`);
+  initWorkingRepo(workdir, { defaultBranch: branch });
+  const res = spawnSync("git", ["clone", "--bare", "--quiet", workdir, path], {
+    env: { ...process.env, ...GIT_ENV },
+  });
+  if (res.status !== 0) {
+    throw new Error(`git clone --bare failed: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`);
+  }
+  return { path, url: `file://${path}` };
+}
+
+/**
  * Write a set of files into a repo (uncommitted). Paths are joined onto
  * `repoPath`; nested directories are created automatically. Use to
  * stage uncommitted modifications visible to the diff endpoint, or as

--- a/web/tests/live/git-clone.spec.ts
+++ b/web/tests/live/git-clone.spec.ts
@@ -11,7 +11,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { test as base, expect } from "@playwright/test";
 import { spawnAoeServe } from "../helpers/aoeServe";
-import { createBareRepo } from "../helpers/gitFixture";
+import { createBareRepo, createSeededBareRepo } from "../helpers/gitFixture";
 
 base("clone happy path: file:// URL clones into HOME and the wizard advances", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
@@ -70,7 +70,9 @@ base("bare clone: creates worktree structure and returns main path", async ({ pa
   });
 
   try {
-    const bare = createBareRepo(serve.home);
+    // A bare clone checks out a worktree, so the source must have a commit
+    // on its default branch; an empty bare repo has no reference to resolve.
+    const bare = createSeededBareRepo(serve.home);
 
     await page.goto(serve.baseUrl);
     await page.locator("body").click();

--- a/web/tests/live/git-clone.spec.ts
+++ b/web/tests/live/git-clone.spec.ts
@@ -62,6 +62,58 @@ base("clone happy path: file:// URL clones into HOME and the wizard advances", a
   }
 });
 
+base("bare clone: creates worktree structure and returns main path", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    const bare = createBareRepo(serve.home);
+
+    await page.goto(serve.baseUrl);
+    await page.locator("body").click();
+    await page.keyboard.press("n");
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole("button", { name: "Clone URL", exact: true }).click();
+    await page.locator("#clone-url").fill(bare.url);
+
+    await page.getByRole("button", { name: /Advanced/ }).click();
+    const dest = join(serve.home, "bare-clone-test");
+    await page.locator("#clone-dest").fill(dest);
+
+    // Check the bare clone checkbox
+    await page.getByText("Clone as bare repository").click();
+
+    // Shallow clone should be disabled when bare is checked
+    const shallowCheckbox = page.locator('input[type="checkbox"]').first();
+    await expect(shallowCheckbox).toBeDisabled();
+
+    await page.getByRole("button", { name: "Clone repository" }).click();
+
+    // The wizard shows the worktree path (dest/main)
+    await expect(page.getByText("Selected project")).toBeVisible({
+      timeout: 30_000,
+    });
+    const mainPath = join(dest, "main");
+    await expect(page.getByText(mainPath, { exact: false })).toBeVisible();
+
+    // Verify bare repo structure on disk
+    expect(existsSync(join(dest, ".bare"))).toBe(true);
+    expect(existsSync(join(dest, ".git"))).toBe(true);
+    expect(existsSync(mainPath)).toBe(true);
+    expect(existsSync(join(mainPath, ".git"))).toBe(true);
+
+    await expect(page.getByRole("button", { name: "Next" })).toBeEnabled();
+  } finally {
+    await serve.stop();
+  }
+});
+
 base("clone failure path: unrecognised URL scheme surfaces a server error", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
     authMode: "none",


### PR DESCRIPTION
## Description

Adds a "Clone as bare repository" option to the web dashboard's session creation wizard, implementing the bare-repo + worktree structure recommended in `docs/guides/workflow.md`.

When checked, the clone produces:

```
<destination>/
  .bare/   # Bare git repository
  .git     # File pointing to .bare
  main/    # Worktree for the default branch
```

Previously this setup was only possible via the CLI commands documented in the workflow guide. The web dashboard's "Clone URL" tab now performs the same setup with a single checkbox under Advanced options.

Also fixes a pre-existing bug where the clone destination field did not expand a leading `~/`, causing valid home-relative paths to be rejected by the "must be within home directory" validation.

**Note:** This PR was drafted with the assistance of an LLM, in discussion with the author. All reasoning, decisions, and judgment expressed here are the author's own.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added `bare clone` live test case to `web/tests/live/git-clone.spec.ts`, reusing the existing `git-clone` matrix entry which already lists `ProjectStep.tsx` as the covered component.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Backend logic is covered by unit tests in `src/git/remote.rs` (`test_clone_bare_repo_creates_structure`, `test_clone_bare_repo_destination_exists`) and `src/server/api/git.rs` (`expand_tilde_*`).

## What changed

- **`src/git/remote.rs`**: new `clone_bare_repo()` function that runs `git clone --bare`, creates the `.git` gitdir pointer, sets the fetch refspec, fetches origin, detects the default branch (via `symbolic-ref refs/remotes/origin/HEAD`, falling back to `main`/`master`), and creates the `main` worktree. Cleans up `<destination>` on any failure.
- **`src/server/api/git.rs`**: extended `CloneRepoBody` with a `bare` flag; mutually exclusive with `shallow` (rejected with 400). Added `expand_tilde()` so `~/foo` destinations resolve under the home directory before the security check.
- **`web/src/lib/api.ts`**: `cloneRepo()` accepts `bare?: boolean`.
- **`web/src/components/session-wizard/steps/ProjectStep.tsx`**: new "Clone as bare repository" checkbox under Advanced. Checking it disables the shallow checkbox.
- **`docs/guides/workflow.md`**: notes that the bare-repo setup is available from the web dashboard.

## Design decisions

- `bare` and `shallow` are mutually exclusive (shallow makes no sense for a bare repo backing worktrees).
- The handler returns the path to `<destination>/main`, so the wizard treats the worktree as the project path and can proceed directly.
- Default branch detection prefers `origin/HEAD`, then falls back to `main`, then `master`. Anything else fails with a clear error rather than guessing.
- Failures at any step remove the entire `<destination>` directory so no partial state is left behind.
- Same home-directory security constraint as the existing clone path.

## How I tested

- `cargo fmt`, `cargo clippy --features serve -- -D warnings`, `cargo test clone_bare_repo`, `cargo test --lib --features serve server::api::git` all clean.
- Manual: built `cargo build --release --features serve`, ran `aoe serve --no-auth`, walked through the wizard with the GitHub `octocat/Hello-World` repo against `~/test-bare-clone`. Verified `.bare/`, `.git` (file with `gitdir: ./.bare`), and `main/` worktree all exist; wizard advances to the next step with the `main` path selected.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenCode CLI (Anthropic Claude Opus 4.7)

**Any Additional AI Details you'd like to share:**
The AI assisted with code drafting, test scaffolding, and PR description structure. All design decisions, file routing, and manual validation were performed by me.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783661589&installation_id=139138837&pr_number=2081&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2081&signature=fa16f6658fc5dea677c03123f7936d5f7856714acf9fa05bcd7d50f1954e8333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds a "Clone as bare repository" option to the web dashboard session creation wizard. When selected, the server creates a bare repository at <destination>/.bare, writes a .git pointer to that gitdir, and checks out a worktree at <destination>/main.

## What changed (high-level)
- Backend: new clone_bare_repo() implements a safe git clone --bare flow that fetches refs, determines the default branch, creates a worktree for the default branch, enforces a 5-minute timeout, redacts credentials in logs, and cleans up the destination on failure.
- API: CloneRepoBody gains a bare flag (mutually exclusive with shallow; request rejected with 400 if both set). Added expand_tilde() to resolve leading ~ in destination paths before home-directory security checks.
- Frontend: session wizard adds a "Clone as bare repository" checkbox; selecting it disables/clears shallow clone. Client API (cloneRepo) sends the bare flag.
- Docs & tests: workflow docs updated; Playwright live test added to exercise the full bare-clone wizard flow (uses a seeded bare repo); backend unit tests added for clone_bare_repo behavior and expand_tilde.

## Benefits
- Enables creating a predictable bare-repo + worktree layout from the dashboard without CLI steps.
- Reduces risk of partial or hung operations via timeouts and cleanup.
- UI prevents conflicting clone options, improving UX.
- Tests and docs improve reliability and discoverability.

## Technical notes (concise)
- clone_bare_repo(url, destination) performs git clone --bare into a .bare directory, writes a gitdir pointer file at <destination>/.git referencing ./.bare, sets fetch refspec and fetches origin, detects default branch (prefer origin/HEAD, then main/master), then creates a worktree at <destination>/main and returns that path. It enforces a 5-minute clone timeout and removes the destination on failure.
- Server API rejects simultaneous bare+shallow, and expand_tilde resolves leading ~ before security checks.
- Frontend ProjectStep toggles bareClone state and updates cloneRepo call; web API client accepts an optional bare flag.
- Tests: backend unit tests for clone_bare_repo and expand_tilde; Playwright e2e test that uses a seeded bare repo fixture to ensure default-branch worktree creation succeeds.

## Areas for further improvement
- Allow configurable worktree name or explicit branch selection when creating the worktree.
- Add more granular telemetry/logging on failures to aid debugging.
- Document behavior with older Git versions and edge cases (e.g., repositories without a clear default branch).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->