### PR TITLE
Add Telegram bridge and improve mobile input

### DIFF
--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -34,9 +34,10 @@ pub use log_level::{get_log_level, patch_log_level};
 pub use projects::{create_project, delete_project, list_projects};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
-    list_sessions, read_output, rename_session, send_message, session_diff_file,
-    session_diff_files, update_session_diff_base, update_session_notifications,
-    update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
+    list_sessions, read_output, rename_session, send_message, send_text_to_tmux_session,
+    session_diff_file, session_diff_files, update_session_diff_base, update_session_notifications,
+    update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SendTextError,
+    SendTextOutcome, SessionResponse,
 };
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, docker_status,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3143,38 +3143,40 @@ enum SendKeysError {
 type SendKeysResult =
     Result<(EnsureReadyOutcome, Instance), Box<(Instance, EnsureReadyOutcome, SendKeysError)>>;
 
-pub async fn send_message(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-    req: Result<Json<SendMessageRequest>, axum::extract::rejection::JsonRejection>,
-) -> impl IntoResponse {
-    if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({"error": "read_only"})),
-        )
-            .into_response();
-    }
-    let Json(req) = match req {
-        Ok(j) => j,
-        Err(rej) => return rej.into_response(),
-    };
+#[derive(Debug, Clone)]
+pub struct SendTextOutcome {
+    pub stale_session_id: Option<String>,
+}
 
-    if req.message.trim().is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "message_empty"})),
-        )
-            .into_response();
+#[derive(Debug)]
+pub enum SendTextError {
+    ReadOnly,
+    MessageEmpty,
+    NotFound,
+    NotRunning,
+    Transient(Status),
+    CockpitModeUnsupported,
+    Tmux(String),
+    Internal,
+}
+
+pub async fn send_text_to_tmux_session(
+    state: Arc<AppState>,
+    id: &str,
+    message: String,
+    revive: bool,
+) -> Result<SendTextOutcome, SendTextError> {
+    if state.read_only {
+        return Err(SendTextError::ReadOnly);
+    }
+
+    if message.trim().is_empty() {
+        return Err(SendTextError::MessageEmpty);
     }
 
     let instances = state.instances.read().await;
     let Some(instance) = instances.iter().find(|i| i.id == id).cloned() else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": "not_found"})),
-        )
-            .into_response();
+        return Err(SendTextError::NotFound);
     };
     drop(instances);
 
@@ -3182,12 +3184,10 @@ pub async fn send_message(
     // Without this, two POSTs racing against the same session would issue
     // overlapping `tmux send-keys -l` invocations and the bytes can interleave
     // inside the pane.
-    let inst_lock = state.instance_lock(&id).await;
+    let inst_lock = state.instance_lock(id).await;
     let _guard = inst_lock.lock().await;
 
     let tool = instance.tool.clone();
-    let message = req.message;
-    let revive = req.revive;
     let send_result = tokio::task::spawn_blocking(move || -> SendKeysResult {
         // Revive the pane before sending. Without this, a send to a dead
         // pane silently writes keystrokes to a corpse with no agent.
@@ -3269,10 +3269,12 @@ pub async fn send_message(
             } else {
                 // Session was deleted between the send and the stamp; nothing
                 // left to persist.
-                return (StatusCode::OK, Json(serde_json::json!({"sent": true}))).into_response();
+                return Ok(SendTextOutcome {
+                    stale_session_id: None,
+                });
             };
             drop(instances);
-            let id_for_save = id.clone();
+            let id_for_save = id.to_string();
             let started_for_save = started.clone();
             let outcome_already_alive = matches!(outcome, EnsureReadyOutcome::AlreadyAlive);
             tokio::task::spawn_blocking(move || {
@@ -3290,7 +3292,6 @@ pub async fn send_message(
                     }
                 }
             });
-            let mut body = serde_json::json!({"sent": true});
             let stale_sid = match &outcome {
                 EnsureReadyOutcome::Respawned {
                     stale_sid: Some(sid),
@@ -3301,9 +3302,14 @@ pub async fn send_message(
                 _ => None,
             };
             if let Some(sid) = stale_sid {
-                body["stale_session_id"] = serde_json::Value::String(sid);
+                Ok(SendTextOutcome {
+                    stale_session_id: Some(sid),
+                })
+            } else {
+                Ok(SendTextOutcome {
+                    stale_session_id: None,
+                })
             }
-            (StatusCode::OK, Json(body)).into_response()
         }
         Ok(Err(boxed)) => {
             let (started, outcome, send_err) = *boxed;
@@ -3334,25 +3340,10 @@ pub async fn send_message(
                             apply_cascade_state_sync(i, &started);
                         }
                     }
-                    (
-                        StatusCode::CONFLICT,
-                        Json(serde_json::json!({"error": "session_not_running"})),
-                    )
-                        .into_response()
+                    Err(SendTextError::NotRunning)
                 }
-                SendKeysError::Transient(status) => (
-                    StatusCode::CONFLICT,
-                    Json(serde_json::json!({
-                        "error": "session_transient",
-                        "status": format!("{status:?}"),
-                    })),
-                )
-                    .into_response(),
-                SendKeysError::CockpitMode => (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({"error": "cockpit_mode_unsupported"})),
-                )
-                    .into_response(),
+                SendKeysError::Transient(status) => Err(SendTextError::Transient(status)),
+                SendKeysError::CockpitMode => Err(SendTextError::CockpitModeUnsupported),
                 SendKeysError::Tmux(e) => {
                     tracing::error!(target: "http.api.sessions", "send_message: tmux error for {id}: {e}");
                     let msg = e.to_string();
@@ -3371,22 +3362,86 @@ pub async fn send_message(
                         i.status = crate::session::Status::Error;
                         i.last_error = Some(msg);
                     }
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(serde_json::json!({"error": "tmux_error"})),
-                    )
-                        .into_response()
+                    Err(SendTextError::Tmux(e.to_string()))
                 }
             }
         }
         Err(e) => {
             tracing::error!(target: "http.api.sessions", "send_message: blocking task panicked for {id}: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "internal"})),
-            )
-                .into_response()
+            Err(SendTextError::Internal)
         }
+    }
+}
+
+pub async fn send_message(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    req: Result<Json<SendMessageRequest>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "read_only"})),
+        )
+            .into_response();
+    }
+
+    let Json(req) = match req {
+        Ok(j) => j,
+        Err(rej) => return rej.into_response(),
+    };
+
+    match send_text_to_tmux_session(state, &id, req.message, req.revive).await {
+        Ok(outcome) => {
+            let mut body = serde_json::json!({"sent": true});
+            if let Some(sid) = outcome.stale_session_id {
+                body["stale_session_id"] = serde_json::Value::String(sid);
+            }
+            (StatusCode::OK, Json(body)).into_response()
+        }
+        Err(SendTextError::ReadOnly) => (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "read_only"})),
+        )
+            .into_response(),
+        Err(SendTextError::MessageEmpty) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "message_empty"})),
+        )
+            .into_response(),
+        Err(SendTextError::NotFound) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not_found"})),
+        )
+            .into_response(),
+        Err(SendTextError::NotRunning) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "session_not_running"})),
+        )
+            .into_response(),
+        Err(SendTextError::Transient(status)) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "session_transient",
+                "status": format!("{status:?}"),
+            })),
+        )
+            .into_response(),
+        Err(SendTextError::CockpitModeUnsupported) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "cockpit_mode_unsupported"})),
+        )
+            .into_response(),
+        Err(SendTextError::Tmux(_)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "tmux_error"})),
+        )
+            .into_response(),
+        Err(SendTextError::Internal) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "internal"})),
+        )
+            .into_response(),
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,6 +13,7 @@ pub mod login;
 pub mod push;
 pub mod push_send;
 pub mod rate_limit;
+pub mod telegram;
 pub mod tunnel;
 pub mod ws;
 
@@ -608,6 +609,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     });
 
     let app = build_router(state.clone());
+    telegram::spawn_if_configured(state.clone()).await;
 
     // Cockpit workers for persisted sessions get auto-spawned by the
     // reconciler in `status_poll_loop`. The poll interval's first tick

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -737,18 +737,40 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             }
         };
 
-        // Collect labeled URLs in preference order (Tailscale > LAN > localhost).
+        // Collect labeled URLs in preference order: Tailscale, LAN, localhost.
         // When bound to 0.0.0.0 we're reachable on all three; on a specific
         // host we just surface that one.
-        let labeled_urls: Vec<(IpKind, String)> = if host == "0.0.0.0" {
-            let mut urls: Vec<(IpKind, String)> = discover_tagged_ips()
-                .into_iter()
-                .map(|(kind, ip)| (kind, make_url(&ip.to_string())))
-                .collect();
-            urls.push((IpKind::Loopback, make_url("localhost")));
+        let labeled_urls: Vec<(String, String)> = if host == "0.0.0.0" {
+            let tagged_ips = discover_tagged_ips();
+            let has_tailscale_ip = tagged_ips
+                .iter()
+                .any(|(kind, _)| *kind == IpKind::Tailscale);
+            let mut urls: Vec<(String, String)> = Vec::new();
+            let mut added_tailscale_dns = false;
+            if has_tailscale_ip {
+                match tunnel::tailscale_dns_name().await {
+                    Ok(dns) => {
+                        urls.push(("tailscale".to_string(), make_url(&dns)));
+                        added_tailscale_dns = true;
+                    }
+                    Err(e) => tracing::debug!(
+                        target: "http.middleware",
+                        "Could not resolve Tailscale DNS name for serve URL list: {e}"
+                    ),
+                }
+            }
+            urls.extend(tagged_ips.into_iter().map(|(kind, ip)| {
+                let label = if kind == IpKind::Tailscale && added_tailscale_dns {
+                    "tailscale-ip"
+                } else {
+                    kind.label()
+                };
+                (label.to_string(), make_url(&ip.to_string()))
+            }));
+            urls.push(("localhost".to_string(), make_url("localhost")));
             urls
         } else {
-            vec![(IpKind::Loopback, make_url(host))]
+            vec![("localhost".to_string(), make_url(host))]
         };
 
         println!("aoe web dashboard running at:");
@@ -778,8 +800,8 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
                 contents.push_str(primary);
                 contents.push('\n');
             }
-            for (kind, url) in labeled_urls.iter().skip(1) {
-                contents.push_str(kind.label());
+            for (label, url) in labeled_urls.iter().skip(1) {
+                contents.push_str(label);
                 contents.push('\t');
                 contents.push_str(url);
                 contents.push('\n');

--- a/src/server/telegram.rs
+++ b/src/server/telegram.rs
@@ -1371,10 +1371,11 @@ fn output_after_baseline(baseline: &str, latest: &str) -> String {
 
 fn clean_agent_reply(raw: &str, prompt: &str) -> String {
     let turn = reply_turn_after_prompt(raw, prompt);
-    let without_footer = strip_terminal_footer(&turn);
-    let without_chrome = strip_terminal_chrome_lines(&without_footer);
+    let without_chrome = strip_terminal_chrome_lines(&turn);
     let without_tools = strip_pi_tool_blocks(&without_chrome);
-    normalize_reply_text(&without_tools)
+    let without_footer = strip_terminal_footer(&without_tools);
+    let without_meta = strip_pi_meta_lines(&without_footer);
+    normalize_reply_text(&without_meta)
 }
 
 fn reply_turn_after_prompt(raw: &str, prompt: &str) -> String {
@@ -1401,6 +1402,10 @@ fn reply_turn_after_prompt(raw: &str, prompt: &str) -> String {
         }
     }
 
+    if let Some(after_wrapped_prompt) = reply_turn_after_wrapped_prompt(raw, prompt) {
+        return after_wrapped_prompt;
+    }
+
     let compact_prompt = prompt.trim();
     if compact_prompt.chars().count() >= 12 {
         if let Some(pos) = raw.rfind(compact_prompt) {
@@ -1410,6 +1415,44 @@ fn reply_turn_after_prompt(raw: &str, prompt: &str) -> String {
     }
 
     raw.to_string()
+}
+
+fn reply_turn_after_wrapped_prompt(raw: &str, prompt: &str) -> Option<String> {
+    let target = collapse_whitespace(prompt);
+    if target.chars().count() < 12 {
+        return None;
+    }
+
+    let lines: Vec<&str> = raw.lines().collect();
+    let max_span = ((target.chars().count() / 48) + 4).clamp(2, 24);
+    for start in (0..lines.len()).rev() {
+        let mut joined = String::new();
+        let end_limit = (start + max_span).min(lines.len());
+        for end in start..end_limit {
+            let trimmed = lines[end].trim();
+            if trimmed.is_empty() && joined.is_empty() {
+                continue;
+            }
+            if !joined.is_empty() {
+                joined.push(' ');
+            }
+            joined.push_str(trimmed);
+
+            let candidate = collapse_whitespace(&joined);
+            if candidate == target {
+                return Some(lines[end + 1..].join("\n"));
+            }
+            if candidate.chars().count() > target.chars().count() + 80 {
+                break;
+            }
+        }
+    }
+
+    None
+}
+
+fn collapse_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn strip_terminal_footer(text: &str) -> String {
@@ -1511,7 +1554,28 @@ fn strip_pi_tool_blocks(text: &str) -> String {
 }
 
 fn is_pi_tool_block_end(trimmed: &str) -> bool {
-    trimmed.starts_with("Took ") || trimmed.starts_with("Tool failed after ")
+    trimmed.starts_with("Took ")
+        || trimmed.starts_with("Tool failed after ")
+        || trimmed.starts_with("Command exited with code ")
+}
+
+fn strip_pi_meta_lines(text: &str) -> String {
+    text.lines()
+        .filter(|line| !is_pi_meta_line(line.trim()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn is_pi_meta_line(trimmed: &str) -> bool {
+    trimmed.starts_with("[skill] ")
+        || is_folded_output_marker(trimmed)
+        || trimmed.starts_with("Took ")
+        || trimmed.starts_with("Command exited with code ")
+        || trimmed == "(no output)"
+}
+
+fn is_folded_output_marker(trimmed: &str) -> bool {
+    trimmed.starts_with("... (") && trimmed.contains(" earlier lines") && trimmed.contains("ctrl+o")
 }
 
 fn normalize_reply_text(text: &str) -> String {
@@ -1539,6 +1603,8 @@ fn normalize_reply_text(text: &str) -> String {
         }
     }
 
+    lines = reflow_wrapped_lines(lines);
+
     let mut collapsed = Vec::new();
     let mut previous_blank = false;
     for line in lines {
@@ -1551,6 +1617,84 @@ fn normalize_reply_text(text: &str) -> String {
     }
 
     collapsed.join("\n").trim().to_string()
+}
+
+fn reflow_wrapped_lines(lines: Vec<String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut in_code_fence = false;
+
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            out.push(line);
+            continue;
+        }
+
+        if in_code_fence || trimmed.is_empty() {
+            out.push(line);
+            continue;
+        }
+
+        if let Some(last) = out.last_mut() {
+            if should_join_wrapped_line(last, &line) {
+                last.push(' ');
+                last.push_str(trimmed);
+                continue;
+            }
+        }
+
+        out.push(line);
+    }
+
+    out
+}
+
+fn should_join_wrapped_line(previous: &str, current: &str) -> bool {
+    let prev = previous.trim_end();
+    let cur = current.trim_start();
+    if prev.is_empty() || cur.is_empty() {
+        return false;
+    }
+    if is_list_start(cur) || is_hard_break_line(prev) || is_hard_break_line(cur) {
+        return false;
+    }
+    true
+}
+
+fn is_hard_break_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.ends_with(':')
+        || trimmed.starts_with("```")
+        || trimmed.starts_with('|')
+        || trimmed.starts_with("$ ")
+        || trimmed.starts_with('>')
+        || is_terminal_rule_line(trimmed)
+}
+
+fn is_list_start(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("- ")
+        || trimmed.starts_with("* ")
+        || trimmed.starts_with("+ ")
+        || is_numbered_list_start(trimmed)
+}
+
+fn is_numbered_list_start(trimmed: &str) -> bool {
+    let mut chars = trimmed.chars().peekable();
+    let mut saw_digit = false;
+    while let Some(ch) = chars.peek().copied() {
+        if ch.is_ascii_digit() {
+            saw_digit = true;
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    if !saw_digit {
+        return false;
+    }
+    matches!(chars.next(), Some('.') | Some(')')) && matches!(chars.next(), Some(' '))
 }
 
 fn resolve_selector(
@@ -1846,7 +1990,7 @@ Model scope: gpt-5.3-codex-spark:high, nvidia/nemotron-3-super-120b-a12b:low
 
         assert_eq!(
             clean_agent_reply(raw, "What agents are running"),
-            "I don't see any separate background agents running in this environment right\nnow (no pi/coding-agent processes detected).\nI can help you launch or inspect a specific agent workflow if you want."
+            "I don't see any separate background agents running in this environment right now (no pi/coding-agent processes detected). I can help you launch or inspect a specific agent workflow if you want."
         );
     }
 
@@ -1876,6 +2020,85 @@ Model scope: gpt-5.3-codex-spark:high, nvidia/nemotron-3-super-120b-a12b:low
         assert_eq!(
             clean_agent_reply(raw, "Reply with exactly: TELEGRAM_PI_ROUTE_OK"),
             "TELEGRAM_PI_ROUTE_OK"
+        );
+    }
+
+    #[test]
+    fn clean_agent_reply_strips_folded_tool_chatter_and_reflows_answer() {
+        let raw = "\
+ $ TOKEN=\"$(cat ~/.agent-of-empires/serve.token)\";
+ BASE=\"http://100.75.37.105:8765\"; curl -fsS
+ \"${BASE}/api/sessions/2c746b74296b49dc/output?token=${TOKEN}&lines=180&format=
+ text\" | jq -r '.content' | tail -n 120
+
+ ... (123 earlier lines, ctrl+o to expand)
+ \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+ ~/Python_local_Mac
+ \u{2191}24k \u{2193}4.5k R33k CH67.4% $0.110 17.9%/128k (auto) gpt-5.3-codex-spark high
+
+ Took 0.0s
+
+
+ $ aoe-agent-control running
+
+ ... (20 earlier lines, ctrl+o to expand)
+ 2c746b74296b49dc   Running   pi   Telegram Pi Agent
+ /Users/williamsmith/Python_local_Mac
+
+ Took 0.0s
+
+
+ Running AOE sessions now (via aoe-agent-control running):
+
+ - 6bfb2b8ece5f4b92 - codex - Sicilians -
+   ~/Python_local_Mac/02_ml_research/Research (Running)
+ - 2c746b74296b49dc - pi - Telegram Pi Agent -
+   ~/Python_local_Mac (Running)
+
+ Also active but idle: fc01df9321ad4b27 (codex pi) and 10 others idle.
+
+\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+~/Python_local_Mac
+\u{2191}36k \u{2193}7.5k R137k CH87.4% $0.193 27.0%/128k (auto) gpt-5.3-codex-spark high";
+
+        assert_eq!(
+            clean_agent_reply(raw, "plan deep make it work great test it"),
+            "Running AOE sessions now (via aoe-agent-control running):\n\n- 6bfb2b8ece5f4b92 - codex - Sicilians - ~/Python_local_Mac/02_ml_research/Research (Running)\n- 2c746b74296b49dc - pi - Telegram Pi Agent - ~/Python_local_Mac (Running)\n\nAlso active but idle: fc01df9321ad4b27 (codex pi) and 10 others idle."
+        );
+    }
+
+    #[test]
+    fn clean_agent_reply_removes_terminal_wrapped_prompt() {
+        let prompt = "Use aoe-agent-control running, then answer in two concise bullet points: which AOE sessions are running and confirm Telegram replies should be clean. Do not include raw command output in your final answer.";
+        let raw = "\
+ Use aoe-agent-control running, then answer in two concise bullet points: which
+ AOE sessions are running and confirm Telegram replies should be clean. Do not
+ include raw command output in your final answer.
+
+
+ $ aoe-agent-control running
+
+ ... (20 earlier lines, ctrl+o to expand)
+ 2c746b74296b49dc   Running   pi   Telegram Pi Agent
+ /Users/williamsmith/Python_local_Mac
+
+ Took 0.1s
+
+
+ - Running AOE sessions: 6bfb2b8 (codex, Sicilians,
+   ~/Python_local_Mac/02_ml_research/Research), fc01df9 (codex, pi,
+   ~/Python_local_Mac), and 2c746b7 (pi, Telegram Pi Agent,
+   ~/Python_local_Mac).
+ - Telegram reply status: confirmed clean - replies are now expected to be
+   AoE-aware via aoe-agent-control.
+
+\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+~/Python_local_Mac
+\u{2191}63k \u{2193}8.2k R169k CH97.0% $0.254 23.8%/128k (auto)";
+
+        assert_eq!(
+            clean_agent_reply(raw, prompt),
+            "- Running AOE sessions: 6bfb2b8 (codex, Sicilians, ~/Python_local_Mac/02_ml_research/Research), fc01df9 (codex, pi, ~/Python_local_Mac), and 2c746b7 (pi, Telegram Pi Agent, ~/Python_local_Mac).\n- Telegram reply status: confirmed clean - replies are now expected to be AoE-aware via aoe-agent-control."
         );
     }
 

--- a/src/server/telegram.rs
+++ b/src/server/telegram.rs
@@ -33,6 +33,8 @@ const DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_SECS: u64 = 600;
 const DEFAULT_PARAKEET_MODEL: &str = "mlx-community/parakeet-tdt-0.6b-v2";
 const MAX_TELEGRAM_TEXT_CHARS: usize = 3900;
 const MAX_TAIL_LINES: usize = 200;
+const TELEGRAM_REPLY_START: &str = "<telegram_reply>";
+const TELEGRAM_REPLY_END: &str = "</telegram_reply>";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -738,7 +740,8 @@ impl TelegramBridge {
             String::new()
         };
 
-        match send_text_to_tmux_session(self.state.clone(), session_id, text.to_string(), true)
+        let outbound_text = prompt_with_telegram_reply_contract(&instance, text);
+        match send_text_to_tmux_session(self.state.clone(), session_id, outbound_text.clone(), true)
             .await
         {
             Ok(_) => {
@@ -758,7 +761,7 @@ impl TelegramBridge {
                     .await
                 {
                     Ok(Some(output)) => {
-                        let cleaned = clean_agent_reply(&output, text);
+                        let cleaned = clean_agent_reply(&output, &outbound_text);
                         let output = if cleaned.is_empty() {
                             output.trim().to_string()
                         } else {
@@ -1369,13 +1372,75 @@ fn output_after_baseline(baseline: &str, latest: &str) -> String {
         .to_string()
 }
 
+fn prompt_with_telegram_reply_contract(instance: &Instance, text: &str) -> String {
+    if !should_request_telegram_reply_contract(instance, text) {
+        return text.to_string();
+    }
+
+    format!(
+        "{text}\n\n\
+<telegram_bridge_instructions>\n\
+You are replying through Telegram. Do any needed tool use first. When finished, end with exactly one {TELEGRAM_REPLY_START}...{TELEGRAM_REPLY_END} block.\n\
+Inside {TELEGRAM_REPLY_START}, write only the clean human-readable answer for the user. Do not include raw shell commands, logs, terminal status bars, token values, or huge pasted output unless the user explicitly asked for raw output.\n\
+If a command fails or returns noisy permission errors, summarize the issue and the next useful action instead of pasting the raw output.\n\
+Keep the final Telegram reply concise, legible, and useful. Bullets are good when they help.\n\
+</telegram_bridge_instructions>"
+    )
+}
+
+fn should_request_telegram_reply_contract(instance: &Instance, text: &str) -> bool {
+    instance.tool == "pi" && !text.trim_start().starts_with('/')
+}
+
 fn clean_agent_reply(raw: &str, prompt: &str) -> String {
+    if let Some(reply) = extract_tagged_telegram_reply(raw) {
+        return normalize_reply_text(&reply);
+    }
+
     let turn = reply_turn_after_prompt(raw, prompt);
     let without_chrome = strip_terminal_chrome_lines(&turn);
     let without_tools = strip_pi_tool_blocks(&without_chrome);
     let without_footer = strip_terminal_footer(&without_tools);
     let without_meta = strip_pi_meta_lines(&without_footer);
     normalize_reply_text(&without_meta)
+}
+
+fn extract_tagged_telegram_reply(raw: &str) -> Option<String> {
+    let end = raw.rfind(TELEGRAM_REPLY_END)?;
+    let before_end = &raw[..end];
+    let start = before_end.rfind(TELEGRAM_REPLY_START)?;
+    let reply_start = start + TELEGRAM_REPLY_START.len();
+    let reply = dedent_text_block(before_end[reply_start..].trim_matches(['\r', '\n']));
+    let reply = reply.trim();
+    if reply.is_empty() {
+        None
+    } else {
+        Some(reply.to_string())
+    }
+}
+
+fn dedent_text_block(text: &str) -> String {
+    let min_indent = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.chars().take_while(|ch| *ch == ' ').count())
+        .min()
+        .unwrap_or(0);
+
+    if min_indent == 0 {
+        return text.to_string();
+    }
+
+    text.lines()
+        .map(|line| {
+            if line.trim().is_empty() {
+                String::new()
+            } else {
+                line.chars().skip(min_indent).collect()
+            }
+        })
+        .collect::<Vec<String>>()
+        .join("\n")
 }
 
 fn reply_turn_after_prompt(raw: &str, prompt: &str) -> String {
@@ -1938,6 +2003,47 @@ mod tests {
         assert!(is_bridge_command("tail"));
         assert!(!is_bridge_command("login"));
         assert!(!is_bridge_command("model"));
+    }
+
+    #[test]
+    fn telegram_reply_contract_is_added_only_for_pi_non_commands() {
+        let mut pi = Instance::new("pi", "/tmp");
+        pi.tool = "pi".to_string();
+        let wrapped = prompt_with_telegram_reply_contract(&pi, "what agents are running");
+        assert!(wrapped.contains("<telegram_bridge_instructions>"));
+        assert!(wrapped.contains(TELEGRAM_REPLY_START));
+
+        let slash = prompt_with_telegram_reply_contract(&pi, "/model gpt-5.4-mini");
+        assert_eq!(slash, "/model gpt-5.4-mini");
+
+        let mut codex = Instance::new("codex", "/tmp");
+        codex.tool = "codex".to_string();
+        assert_eq!(
+            prompt_with_telegram_reply_contract(&codex, "hello"),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn clean_agent_reply_prefers_tagged_telegram_reply() {
+        let raw = "\
+ $ rg -i exformer /Users/williamsmith
+ rg: /Users/williamsmith/Library/Group Containers/example: Operation not permitted (os error 1)
+ Took 117.2s
+
+ <telegram_reply>
+ I searched the safe workspace paths and hit macOS permission-protected Library folders when the search targeted all of `/Users/williamsmith`.
+
+ Next step: use `aoe-safe-rg exformer /Users/williamsmith/Python_local_Mac` or narrow the target directory.
+ </telegram_reply>
+
+ ~/Python_local_Mac
+ 0.0%/128k (auto)";
+
+        assert_eq!(
+            clean_agent_reply(raw, "find exformer"),
+            "I searched the safe workspace paths and hit macOS permission-protected Library folders when the search targeted all of `/Users/williamsmith`.\n\nNext step: use `aoe-safe-rg exformer /Users/williamsmith/Python_local_Mac` or narrow the target directory."
+        );
     }
 
     #[test]

--- a/src/server/telegram.rs
+++ b/src/server/telegram.rs
@@ -1,0 +1,1493 @@
+//! Optional Telegram bridge for controlling sessions without the mobile web UI.
+
+use std::collections::{BTreeMap, HashMap};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
+
+use crate::server::api::{send_text_to_tmux_session, SendTextError};
+use crate::server::AppState;
+use crate::session::Instance;
+
+const CONFIG_FILE: &str = "telegram.toml";
+const TOKEN_ENV: &str = "AOE_TELEGRAM_BOT_TOKEN";
+const LEGACY_TOKEN_ENV: &str = "TELEGRAM_BOT_TOKEN";
+const ALLOWED_CHATS_ENV: &str = "AOE_TELEGRAM_ALLOWED_CHAT_IDS";
+const DEFAULT_SESSION_ENV: &str = "AOE_TELEGRAM_DEFAULT_SESSION";
+const PARAKEET_MODEL_ENV: &str = "AOE_TELEGRAM_PARAKEET_MODEL";
+const DEFAULT_POLL_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_VOICE_MAX_FILE_SIZE_MB: u64 = 25;
+const DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_SECS: u64 = 600;
+const DEFAULT_PARAKEET_MODEL: &str = "mlx-community/parakeet-tdt-0.6b-v2";
+const MAX_TELEGRAM_TEXT_CHARS: usize = 3900;
+const MAX_TAIL_LINES: usize = 200;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+struct TelegramConfig {
+    enabled: bool,
+    bot_token: String,
+    allowed_chat_ids: Vec<i64>,
+    claim_code: String,
+    default_session: String,
+    chat_sessions: BTreeMap<String, String>,
+    last_update_id: Option<i64>,
+    drop_pending_on_start: bool,
+    poll_timeout_secs: u64,
+    voice_transcription_enabled: bool,
+    voice_max_file_size_mb: u64,
+    voice_transcription_timeout_secs: u64,
+    parakeet_model: String,
+    parakeet_command: Vec<String>,
+}
+
+impl Default for TelegramConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bot_token: String::new(),
+            allowed_chat_ids: Vec::new(),
+            claim_code: String::new(),
+            default_session: String::new(),
+            chat_sessions: BTreeMap::new(),
+            last_update_id: None,
+            drop_pending_on_start: true,
+            poll_timeout_secs: DEFAULT_POLL_TIMEOUT_SECS,
+            voice_transcription_enabled: true,
+            voice_max_file_size_mb: DEFAULT_VOICE_MAX_FILE_SIZE_MB,
+            voice_transcription_timeout_secs: DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_SECS,
+            parakeet_model: DEFAULT_PARAKEET_MODEL.to_string(),
+            parakeet_command: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct ChatRuntime {
+    last_list: Vec<String>,
+}
+
+struct TelegramBridge {
+    state: Arc<AppState>,
+    client: reqwest::Client,
+    config_path: PathBuf,
+    config: Mutex<TelegramConfig>,
+    runtime: Mutex<HashMap<i64, ChatRuntime>>,
+}
+
+struct DownloadedTelegramFile {
+    #[allow(dead_code)]
+    temp_dir: tempfile::TempDir,
+    path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramApiResponse<T> {
+    ok: bool,
+    result: Option<T>,
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramUpdate {
+    update_id: i64,
+    message: Option<TelegramMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramMessage {
+    message_id: i64,
+    chat: TelegramChat,
+    text: Option<String>,
+    voice: Option<TelegramAudioRef>,
+    audio: Option<TelegramAudioRef>,
+    document: Option<TelegramDocumentRef>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramChat {
+    id: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TelegramAudioRef {
+    file_id: String,
+    #[allow(dead_code)]
+    file_unique_id: Option<String>,
+    mime_type: Option<String>,
+    file_size: Option<u64>,
+    duration: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TelegramDocumentRef {
+    file_id: String,
+    #[allow(dead_code)]
+    file_unique_id: Option<String>,
+    file_name: Option<String>,
+    mime_type: Option<String>,
+    file_size: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct VoiceInput {
+    file_id: String,
+    file_size: Option<u64>,
+    duration: Option<u64>,
+    mime_type: Option<String>,
+    label: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramFileInfo {
+    file_id: String,
+    #[allow(dead_code)]
+    file_unique_id: Option<String>,
+    file_size: Option<u64>,
+    file_path: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TelegramGetUpdates {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    offset: Option<i64>,
+    timeout: u64,
+    allowed_updates: [&'static str; 1],
+}
+
+#[derive(Debug, Serialize)]
+struct TelegramGetFile<'a> {
+    file_id: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct TelegramSendMessage<'a> {
+    chat_id: i64,
+    text: &'a str,
+    disable_web_page_preview: bool,
+}
+
+#[derive(Debug)]
+enum TailError {
+    NotFound,
+    NotRunning,
+    Tmux(String),
+    Internal,
+}
+
+/// Start the Telegram bridge if `~/.agent-of-empires/telegram.toml` or
+/// environment variables enable it. Failures are logged and do not stop
+/// the web dashboard from starting.
+pub async fn spawn_if_configured(state: Arc<AppState>) {
+    match TelegramBridge::load(state).await {
+        Ok(Some(bridge)) => {
+            info!(target: "telegram.bridge", "Telegram bridge enabled");
+            tokio::spawn(async move {
+                bridge.run().await;
+            });
+        }
+        Ok(None) => {}
+        Err(e) => {
+            warn!(target: "telegram.bridge", "Telegram bridge disabled: {e}");
+        }
+    }
+}
+
+impl TelegramBridge {
+    async fn load(state: Arc<AppState>) -> Result<Option<Self>> {
+        let app_dir = crate::session::get_app_dir()?;
+        let config_path = app_dir.join(CONFIG_FILE);
+        let config_exists = tokio::fs::try_exists(&config_path).await.unwrap_or(false);
+        let mut config = if config_exists {
+            let raw = tokio::fs::read_to_string(&config_path)
+                .await
+                .with_context(|| format!("read {}", config_path.display()))?;
+            toml::from_str::<TelegramConfig>(&raw)
+                .with_context(|| format!("parse {}", config_path.display()))?
+        } else {
+            TelegramConfig::default()
+        };
+
+        apply_env_overrides(&mut config);
+
+        if !config.enabled && config.bot_token.trim().is_empty() {
+            return Ok(None);
+        }
+        if config.bot_token.trim().is_empty() {
+            warn!(
+                target: "telegram.bridge",
+                "telegram.toml has enabled=true but no bot_token"
+            );
+            return Ok(None);
+        }
+
+        let mut changed = false;
+        if config.allowed_chat_ids.is_empty() && config.claim_code.trim().is_empty() {
+            config.claim_code = generate_claim_code();
+            changed = true;
+        }
+        config.poll_timeout_secs = config.poll_timeout_secs.clamp(5, 50);
+        config.voice_max_file_size_mb = config.voice_max_file_size_mb.clamp(1, 50);
+        config.voice_transcription_timeout_secs =
+            config.voice_transcription_timeout_secs.clamp(30, 1800);
+        if config.parakeet_model.trim().is_empty() {
+            config.parakeet_model = DEFAULT_PARAKEET_MODEL.to_string();
+        }
+
+        if config_exists && changed {
+            save_config(&config_path, &config).await?;
+        } else if !config_exists && config.allowed_chat_ids.is_empty() {
+            warn!(
+                target: "telegram.bridge",
+                "Telegram bridge is using env-only config; claim code will rotate on restart"
+            );
+        }
+
+        Ok(Some(Self {
+            state,
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(config.poll_timeout_secs + 10))
+                .build()
+                .context("build telegram http client")?,
+            config_path,
+            config: Mutex::new(config),
+            runtime: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    async fn run(self) {
+        if let Err(e) = self.drop_pending_if_needed().await {
+            warn!(target: "telegram.bridge", "initial Telegram drain failed: {e}");
+        }
+
+        let mut backoff = Duration::from_secs(1);
+        loop {
+            tokio::select! {
+                _ = self.state.shutdown.cancelled() => {
+                    info!(target: "telegram.bridge", "Telegram bridge stopped");
+                    return;
+                }
+                result = self.poll_once() => {
+                    match result {
+                        Ok(()) => backoff = Duration::from_secs(1),
+                        Err(e) => {
+                            warn!(target: "telegram.bridge", "Telegram poll failed: {e}");
+                            tokio::select! {
+                                _ = self.state.shutdown.cancelled() => return,
+                                _ = tokio::time::sleep(backoff) => {}
+                            }
+                            backoff = (backoff * 2).min(Duration::from_secs(60));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn drop_pending_if_needed(&self) -> Result<()> {
+        let should_drop = {
+            let cfg = self.config.lock().await;
+            cfg.drop_pending_on_start && cfg.last_update_id.is_none()
+        };
+        if !should_drop {
+            return Ok(());
+        }
+
+        let updates = self.fetch_updates(None, 0).await?;
+        let Some(max_id) = updates.iter().map(|u| u.update_id).max() else {
+            let mut cfg = self.config.lock().await;
+            cfg.drop_pending_on_start = false;
+            save_config(&self.config_path, &cfg).await?;
+            return Ok(());
+        };
+
+        let mut cfg = self.config.lock().await;
+        cfg.last_update_id = Some(max_id);
+        cfg.drop_pending_on_start = false;
+        save_config(&self.config_path, &cfg).await?;
+        info!(
+            target: "telegram.bridge",
+            dropped = updates.len(),
+            "Telegram bridge dropped pending updates on first start"
+        );
+        Ok(())
+    }
+
+    async fn poll_once(&self) -> Result<()> {
+        let (offset, timeout) = {
+            let cfg = self.config.lock().await;
+            (
+                cfg.last_update_id.map(|id| id + 1),
+                cfg.poll_timeout_secs.clamp(5, 50),
+            )
+        };
+        let updates = self.fetch_updates(offset, timeout).await?;
+        for update in updates {
+            let update_id = update.update_id;
+            if let Err(e) = self.handle_update(update).await {
+                warn!(target: "telegram.bridge", "Telegram update failed: {e}");
+            }
+            let mut cfg = self.config.lock().await;
+            cfg.last_update_id = Some(update_id);
+            save_config(&self.config_path, &cfg).await?;
+        }
+        Ok(())
+    }
+
+    async fn fetch_updates(
+        &self,
+        offset: Option<i64>,
+        timeout_secs: u64,
+    ) -> Result<Vec<TelegramUpdate>> {
+        let token = self.bot_token().await;
+        let url = telegram_url(&token, "getUpdates");
+        let payload = TelegramGetUpdates {
+            offset,
+            timeout: timeout_secs,
+            allowed_updates: ["message"],
+        };
+        let res = self
+            .client
+            .post(url)
+            .json(&payload)
+            .send()
+            .await
+            .context("getUpdates request failed")?;
+        parse_telegram_response::<Vec<TelegramUpdate>>(res).await
+    }
+
+    async fn handle_update(&self, update: TelegramUpdate) -> Result<()> {
+        let Some(message) = update.message else {
+            return Ok(());
+        };
+        let chat_id = message.chat.id;
+        if let Some(text) = message.text.as_deref() {
+            debug!(
+                target: "telegram.bridge",
+                chat_id,
+                message_id = message.message_id,
+                "handling Telegram text"
+            );
+            return self.handle_text(chat_id, text).await;
+        }
+
+        if let Some(voice) = voice_input_from_message(&message) {
+            debug!(
+                target: "telegram.bridge",
+                chat_id,
+                message_id = message.message_id,
+                kind = voice.label,
+                duration = voice.duration,
+                "handling Telegram voice/audio"
+            );
+            return self.handle_voice(chat_id, voice).await;
+        }
+
+        if self.is_authorized(chat_id).await {
+            self.send_reply(chat_id, "Send text or a voice note.")
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn handle_text(&self, chat_id: i64, text: &str) -> Result<()> {
+        let trimmed = text.trim();
+        if let Some((cmd, rest)) = parse_command(trimmed) {
+            return self.handle_command(chat_id, &cmd, rest).await;
+        }
+
+        if !self.is_authorized(chat_id).await {
+            self.send_reply(
+                chat_id,
+                "This chat is not authorized. Use /claim <code> from the private AoE Telegram config.",
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let Some(session_id) = self.resolve_target_session(chat_id, "").await? else {
+            self.send_reply(
+                chat_id,
+                "No session selected. Use /sessions then /use <number>.",
+            )
+            .await?;
+            return Ok(());
+        };
+        self.send_prompt_to_session(chat_id, &session_id, text)
+            .await
+    }
+
+    async fn handle_voice(&self, chat_id: i64, voice: VoiceInput) -> Result<()> {
+        if !self.is_authorized(chat_id).await {
+            self.send_reply(
+                chat_id,
+                "This chat is not authorized. Use /claim <code> from the private AoE Telegram config.",
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let Some(session_id) = self.resolve_target_session(chat_id, "").await? else {
+            self.send_reply(
+                chat_id,
+                "No session selected. Use /sessions then /use <number> before sending voice notes.",
+            )
+            .await?;
+            return Ok(());
+        };
+
+        let cfg = self.config.lock().await.clone();
+        if !cfg.voice_transcription_enabled {
+            self.send_reply(chat_id, "Voice transcription is disabled in telegram.toml.")
+                .await?;
+            return Ok(());
+        }
+
+        let max_bytes = cfg.voice_max_file_size_mb.saturating_mul(1024 * 1024);
+        if let Some(size) = voice.file_size {
+            if size > max_bytes {
+                self.send_reply(
+                    chat_id,
+                    &format!(
+                        "Voice note is too large ({:.1} MB). Limit is {} MB.",
+                        size as f64 / (1024.0 * 1024.0),
+                        cfg.voice_max_file_size_mb
+                    ),
+                )
+                .await?;
+                return Ok(());
+            }
+        }
+
+        self.send_reply(
+            chat_id,
+            &format!("Transcribing {} with NVIDIA Parakeet v2...", voice.label),
+        )
+        .await?;
+
+        let downloaded = match self.download_telegram_file(&voice, max_bytes).await {
+            Ok(file) => file,
+            Err(e) => {
+                warn!(target: "telegram.bridge", "voice download failed: {e}");
+                self.send_reply(chat_id, "Could not download the voice note from Telegram.")
+                    .await?;
+                return Ok(());
+            }
+        };
+
+        let transcript = match transcribe_with_parakeet(&downloaded.path, &cfg).await {
+            Ok(text) => text,
+            Err(e) => {
+                warn!(target: "telegram.bridge", "voice transcription failed: {e}");
+                self.send_reply(chat_id, &format!("Parakeet transcription failed: {e}"))
+                    .await?;
+                return Ok(());
+            }
+        };
+
+        if transcript.trim().is_empty() {
+            self.send_reply(chat_id, "Parakeet returned an empty transcript.")
+                .await?;
+            return Ok(());
+        }
+
+        self.send_reply(
+            chat_id,
+            &format!(
+                "Transcript:\n{}",
+                truncate_from_end(transcript.trim(), MAX_TELEGRAM_TEXT_CHARS)
+            ),
+        )
+        .await?;
+        self.send_prompt_to_session(chat_id, &session_id, transcript.trim())
+            .await
+    }
+
+    async fn handle_command(&self, chat_id: i64, cmd: &str, rest: &str) -> Result<()> {
+        match cmd {
+            "start" | "help" => {
+                let authorized = self.is_authorized(chat_id).await;
+                self.send_reply(chat_id, help_text(authorized)).await
+            }
+            "claim" => self.handle_claim(chat_id, rest.trim()).await,
+            "whoami" => self.send_reply(chat_id, &format!("chat_id: {chat_id}")).await,
+            _ if !self.is_authorized(chat_id).await => {
+                self.send_reply(
+                    chat_id,
+                    "This chat is not authorized. Use /claim <code> from the private AoE Telegram config.",
+                )
+                .await
+            }
+            "sessions" => self.handle_sessions(chat_id).await,
+            "use" => self.handle_use(chat_id, rest.trim()).await,
+            "tail" | "output" => self.handle_tail(chat_id, rest.trim()).await,
+            "status" => self.handle_status(chat_id).await,
+            _ => {
+                self.send_reply(chat_id, "Unknown command. Use /help.").await
+            }
+        }
+    }
+
+    async fn handle_claim(&self, chat_id: i64, code: &str) -> Result<()> {
+        let mut cfg = self.config.lock().await;
+        if cfg.allowed_chat_ids.contains(&chat_id) {
+            drop(cfg);
+            self.send_reply(chat_id, "This chat is already authorized.")
+                .await?;
+            return Ok(());
+        }
+        if cfg.claim_code.trim().is_empty() || code != cfg.claim_code {
+            drop(cfg);
+            self.send_reply(
+                chat_id,
+                "Claim failed. Check the private claim_code in telegram.toml.",
+            )
+            .await?;
+            return Ok(());
+        }
+        cfg.allowed_chat_ids.push(chat_id);
+        cfg.allowed_chat_ids.sort_unstable();
+        cfg.allowed_chat_ids.dedup();
+        save_config(&self.config_path, &cfg).await?;
+        drop(cfg);
+        self.send_reply(
+            chat_id,
+            "Chat authorized. Use /sessions, then /use <number>.",
+        )
+        .await
+    }
+
+    async fn handle_sessions(&self, chat_id: i64) -> Result<()> {
+        let sessions = self.sessions_snapshot().await;
+        if sessions.is_empty() {
+            self.send_reply(chat_id, "No AoE sessions found.").await?;
+            return Ok(());
+        }
+        {
+            let mut runtime = self.runtime.lock().await;
+            runtime.entry(chat_id).or_default().last_list =
+                sessions.iter().map(|s| s.id.clone()).collect();
+        }
+        self.send_reply(chat_id, &format_sessions(&sessions)).await
+    }
+
+    async fn handle_use(&self, chat_id: i64, selector: &str) -> Result<()> {
+        if selector.is_empty() {
+            self.send_reply(chat_id, "Usage: /use <number, id, or title>")
+                .await?;
+            return Ok(());
+        }
+        let Some(session_id) = self.resolve_target_session(chat_id, selector).await? else {
+            self.send_reply(
+                chat_id,
+                "No matching session. Use /sessions to list choices.",
+            )
+            .await?;
+            return Ok(());
+        };
+        let sessions = self.sessions_snapshot().await;
+        let title = sessions
+            .iter()
+            .find(|s| s.id == session_id)
+            .map(|s| s.title.as_str())
+            .unwrap_or(session_id.as_str())
+            .to_string();
+        {
+            let mut cfg = self.config.lock().await;
+            cfg.chat_sessions
+                .insert(chat_id.to_string(), session_id.clone());
+            save_config(&self.config_path, &cfg).await?;
+        }
+        self.send_reply(chat_id, &format!("Selected: {title}"))
+            .await
+    }
+
+    async fn handle_tail(&self, chat_id: i64, rest: &str) -> Result<()> {
+        let lines = rest
+            .split_whitespace()
+            .next()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(80)
+            .clamp(1, MAX_TAIL_LINES);
+        let Some(session_id) = self.resolve_target_session(chat_id, "").await? else {
+            self.send_reply(
+                chat_id,
+                "No session selected. Use /sessions then /use <number>.",
+            )
+            .await?;
+            return Ok(());
+        };
+        match self.capture_tail(&session_id, lines).await {
+            Ok(content) => {
+                let body = if content.trim().is_empty() {
+                    "(no output)".to_string()
+                } else {
+                    truncate_from_end(&content, MAX_TELEGRAM_TEXT_CHARS)
+                };
+                self.send_reply(chat_id, &body).await
+            }
+            Err(TailError::NotFound) => self.send_reply(chat_id, "Session not found.").await,
+            Err(TailError::NotRunning) => self.send_reply(chat_id, "Session is not running.").await,
+            Err(TailError::Tmux(e)) => {
+                self.send_reply(chat_id, &format!("Could not read tmux output: {e}"))
+                    .await
+            }
+            Err(TailError::Internal) => {
+                self.send_reply(chat_id, "Could not read output due to an internal error.")
+                    .await
+            }
+        }
+    }
+
+    async fn handle_status(&self, chat_id: i64) -> Result<()> {
+        let Some(session_id) = self.resolve_target_session(chat_id, "").await? else {
+            self.send_reply(
+                chat_id,
+                "No session selected. Use /sessions then /use <number>.",
+            )
+            .await?;
+            return Ok(());
+        };
+        let sessions = self.sessions_snapshot().await;
+        let Some(inst) = sessions.iter().find(|s| s.id == session_id) else {
+            self.send_reply(chat_id, "Session not found.").await?;
+            return Ok(());
+        };
+        self.send_reply(
+            chat_id,
+            &format!(
+                "{}\nstatus: {:?}\ntool: {}\nmode: {}",
+                inst.title,
+                inst.status,
+                inst.tool,
+                if inst.is_cockpit_mode() {
+                    "cockpit"
+                } else {
+                    "tmux"
+                }
+            ),
+        )
+        .await
+    }
+
+    async fn send_prompt_to_session(
+        &self,
+        chat_id: i64,
+        session_id: &str,
+        text: &str,
+    ) -> Result<()> {
+        let Some(instance) = self
+            .sessions_snapshot()
+            .await
+            .into_iter()
+            .find(|s| s.id == session_id)
+        else {
+            self.send_reply(chat_id, "Session not found.").await?;
+            return Ok(());
+        };
+
+        if instance.is_cockpit_mode() {
+            return self
+                .send_cockpit_prompt(chat_id, &instance, text.to_string())
+                .await;
+        }
+
+        match send_text_to_tmux_session(self.state.clone(), session_id, text.to_string(), true)
+            .await
+        {
+            Ok(_) => {
+                self.send_reply(chat_id, &format!("Sent to {}.", instance.title))
+                    .await
+            }
+            Err(e) => self.send_reply(chat_id, &format_send_error(&e)).await,
+        }
+    }
+
+    async fn send_cockpit_prompt(
+        &self,
+        chat_id: i64,
+        instance: &Instance,
+        text: String,
+    ) -> Result<()> {
+        self.state
+            .cockpit_supervisor
+            .publish_user_prompt(&instance.id, text.clone())
+            .await;
+        match self
+            .state
+            .cockpit_supervisor
+            .send_prompt(&instance.id, &text)
+            .await
+        {
+            Ok(()) => {
+                self.send_reply(chat_id, &format!("Sent to {}.", instance.title))
+                    .await
+            }
+            Err(crate::cockpit::supervisor::SupervisorError::UnknownSession(_)) => {
+                self.send_reply(
+                    chat_id,
+                    "Cockpit worker is not running for this session. Open it in the dashboard or restart aoe serve.",
+                )
+                .await
+            }
+            Err(e) => {
+                self.send_reply(chat_id, &format!("Cockpit prompt failed: {e}"))
+                    .await
+            }
+        }
+    }
+
+    async fn capture_tail(&self, session_id: &str, lines: usize) -> Result<String, TailError> {
+        let instances = self.state.instances.read().await;
+        let Some(instance) = instances.iter().find(|i| i.id == session_id).cloned() else {
+            return Err(TailError::NotFound);
+        };
+        drop(instances);
+
+        if instance.is_cockpit_mode() {
+            return Err(TailError::Tmux(
+                "tail is only available for tmux sessions".to_string(),
+            ));
+        }
+
+        let capture = tokio::task::spawn_blocking(move || {
+            let session = instance
+                .tmux_session()
+                .map_err(|e| TailError::Tmux(e.to_string()))?;
+            if !session.exists() {
+                return Err(TailError::NotRunning);
+            }
+            let raw = session
+                .capture_pane(lines)
+                .map_err(|e| TailError::Tmux(e.to_string()))?;
+            Ok(crate::tmux::utils::strip_ansi(&raw))
+        })
+        .await;
+        match capture {
+            Ok(result) => result,
+            Err(e) => {
+                warn!(target: "telegram.bridge", "tail task panicked: {e}");
+                Err(TailError::Internal)
+            }
+        }
+    }
+
+    async fn download_telegram_file(
+        &self,
+        voice: &VoiceInput,
+        max_bytes: u64,
+    ) -> Result<DownloadedTelegramFile> {
+        let token = self.bot_token().await;
+        let info = self.get_file_info(&token, &voice.file_id).await?;
+        if info.file_id != voice.file_id {
+            debug!(
+                target: "telegram.bridge",
+                requested = %voice.file_id,
+                returned = %info.file_id,
+                "Telegram getFile returned a canonical file id"
+            );
+        }
+        if let Some(size) = info.file_size.or(voice.file_size) {
+            if size > max_bytes {
+                return Err(anyhow!(
+                    "Telegram file is too large ({size} bytes, limit {max_bytes} bytes)"
+                ));
+            }
+        }
+        let file_path = info
+            .file_path
+            .ok_or_else(|| anyhow!("Telegram getFile did not return file_path"))?;
+        let extension = safe_extension(&file_path).unwrap_or_else(|| {
+            voice
+                .mime_type
+                .as_deref()
+                .and_then(extension_from_mime)
+                .unwrap_or("oga")
+                .to_string()
+        });
+        let temp_dir = tempfile::Builder::new()
+            .prefix("aoe-telegram-voice-")
+            .tempdir()
+            .context("create voice temp dir")?;
+        let path = temp_dir.path().join(format!("voice.{extension}"));
+        let url = format!("https://api.telegram.org/file/bot{token}/{file_path}");
+        let res = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .context("download Telegram file request failed")?;
+        if res.status() != StatusCode::OK {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "Telegram file download HTTP {status}: {}",
+                truncate_log(&body)
+            ));
+        }
+        let bytes = res.bytes().await.context("read Telegram file bytes")?;
+        if bytes.len() as u64 > max_bytes {
+            return Err(anyhow!(
+                "downloaded file is too large ({} bytes, limit {max_bytes} bytes)",
+                bytes.len()
+            ));
+        }
+        tokio::fs::write(&path, &bytes)
+            .await
+            .with_context(|| format!("write {}", path.display()))?;
+        Ok(DownloadedTelegramFile { temp_dir, path })
+    }
+
+    async fn get_file_info(&self, token: &str, file_id: &str) -> Result<TelegramFileInfo> {
+        let url = telegram_url(token, "getFile");
+        let payload = TelegramGetFile { file_id };
+        let res = self
+            .client
+            .post(url)
+            .json(&payload)
+            .send()
+            .await
+            .context("getFile request failed")?;
+        parse_telegram_response(res).await
+    }
+
+    async fn resolve_target_session(&self, chat_id: i64, selector: &str) -> Result<Option<String>> {
+        let sessions = self.sessions_snapshot().await;
+        if sessions.is_empty() {
+            return Ok(None);
+        }
+
+        if selector.trim().is_empty() {
+            if let Some(id) = self.selected_session_for_chat(chat_id).await {
+                if sessions.iter().any(|s| s.id == id) {
+                    return Ok(Some(id));
+                }
+            }
+            let default_session = {
+                let cfg = self.config.lock().await;
+                cfg.default_session.trim().to_string()
+            };
+            if !default_session.is_empty() {
+                if let Some(id) = resolve_selector(&sessions, &default_session, None)? {
+                    return Ok(Some(id));
+                }
+            }
+            let pi_sessions: Vec<&Instance> = sessions.iter().filter(|s| s.tool == "pi").collect();
+            if pi_sessions.len() == 1 {
+                return Ok(Some(pi_sessions[0].id.clone()));
+            }
+            if sessions.len() == 1 {
+                return Ok(Some(sessions[0].id.clone()));
+            }
+            return Ok(None);
+        }
+
+        let last_list = {
+            let runtime = self.runtime.lock().await;
+            runtime
+                .get(&chat_id)
+                .map(|s| s.last_list.clone())
+                .unwrap_or_default()
+        };
+        resolve_selector(&sessions, selector, Some(&last_list))
+    }
+
+    async fn selected_session_for_chat(&self, chat_id: i64) -> Option<String> {
+        let cfg = self.config.lock().await;
+        cfg.chat_sessions.get(&chat_id.to_string()).cloned()
+    }
+
+    async fn sessions_snapshot(&self) -> Vec<Instance> {
+        self.state.instances.read().await.clone()
+    }
+
+    async fn is_authorized(&self, chat_id: i64) -> bool {
+        let cfg = self.config.lock().await;
+        cfg.allowed_chat_ids.contains(&chat_id)
+    }
+
+    async fn bot_token(&self) -> String {
+        self.config.lock().await.bot_token.clone()
+    }
+
+    async fn send_reply(&self, chat_id: i64, text: &str) -> Result<()> {
+        for chunk in split_telegram_text(text) {
+            self.send_message_chunk(chat_id, &chunk).await?;
+        }
+        Ok(())
+    }
+
+    async fn send_message_chunk(&self, chat_id: i64, text: &str) -> Result<()> {
+        let token = self.bot_token().await;
+        let url = telegram_url(&token, "sendMessage");
+        let payload = TelegramSendMessage {
+            chat_id,
+            text,
+            disable_web_page_preview: true,
+        };
+        let res = self
+            .client
+            .post(url)
+            .json(&payload)
+            .send()
+            .await
+            .context("sendMessage request failed")?;
+        let _: serde_json::Value = parse_telegram_response(res).await?;
+        Ok(())
+    }
+}
+
+fn apply_env_overrides(config: &mut TelegramConfig) {
+    if let Some(token) = std::env::var(TOKEN_ENV)
+        .ok()
+        .or_else(|| std::env::var(LEGACY_TOKEN_ENV).ok())
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+    {
+        config.bot_token = token;
+        config.enabled = true;
+    }
+    if let Ok(raw) = std::env::var(ALLOWED_CHATS_ENV) {
+        config.allowed_chat_ids = parse_chat_ids(&raw);
+    }
+    if let Ok(raw) = std::env::var(DEFAULT_SESSION_ENV) {
+        config.default_session = raw.trim().to_string();
+    }
+    if let Ok(raw) = std::env::var(PARAKEET_MODEL_ENV) {
+        let model = raw.trim();
+        if !model.is_empty() {
+            config.parakeet_model = model.to_string();
+        }
+    }
+}
+
+fn voice_input_from_message(message: &TelegramMessage) -> Option<VoiceInput> {
+    if let Some(voice) = &message.voice {
+        return Some(VoiceInput {
+            file_id: voice.file_id.clone(),
+            file_size: voice.file_size,
+            duration: voice.duration,
+            mime_type: voice.mime_type.clone(),
+            label: "voice note",
+        });
+    }
+    if let Some(audio) = &message.audio {
+        return Some(VoiceInput {
+            file_id: audio.file_id.clone(),
+            file_size: audio.file_size,
+            duration: audio.duration,
+            mime_type: audio.mime_type.clone(),
+            label: "audio message",
+        });
+    }
+    let document = message.document.as_ref()?;
+    let mime_is_audio = document
+        .mime_type
+        .as_deref()
+        .is_some_and(|mime| mime.starts_with("audio/"));
+    let name_is_audio = document
+        .file_name
+        .as_deref()
+        .is_some_and(has_audio_extension);
+    if !mime_is_audio && !name_is_audio {
+        return None;
+    }
+    Some(VoiceInput {
+        file_id: document.file_id.clone(),
+        file_size: document.file_size,
+        duration: None,
+        mime_type: document.mime_type.clone(),
+        label: "audio file",
+    })
+}
+
+async fn transcribe_with_parakeet(audio_path: &Path, config: &TelegramConfig) -> Result<String> {
+    let out_dir = tempfile::Builder::new()
+        .prefix("aoe-parakeet-output-")
+        .tempdir()
+        .context("create Parakeet output temp dir")?;
+    let (program, args) = build_parakeet_command(config, audio_path, out_dir.path())?;
+    let timeout = Duration::from_secs(config.voice_transcription_timeout_secs.clamp(30, 1800));
+    let mut cmd = tokio::process::Command::new(&program);
+    cmd.args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let output = tokio::time::timeout(timeout, cmd.output())
+        .await
+        .map_err(|_| anyhow!("Parakeet timed out after {}s", timeout.as_secs()))?
+        .with_context(|| format!("spawn {}", program.to_string_lossy()))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        return Err(anyhow!(
+            "Parakeet exited with {}: {}",
+            output.status,
+            truncate_log(stderr.trim())
+        ));
+    }
+
+    if let Some(path) = find_transcript_file(out_dir.path()).await? {
+        let text = tokio::fs::read_to_string(&path)
+            .await
+            .with_context(|| format!("read {}", path.display()))?;
+        if !text.trim().is_empty() {
+            return Ok(text.trim().to_string());
+        }
+    }
+
+    let fallback = stdout
+        .lines()
+        .map(str::trim)
+        .rfind(|line| !line.is_empty())
+        .unwrap_or_default();
+    if fallback.is_empty() {
+        Err(anyhow!("Parakeet produced no transcript"))
+    } else {
+        Ok(fallback.to_string())
+    }
+}
+
+fn build_parakeet_command(
+    config: &TelegramConfig,
+    audio_path: &Path,
+    out_dir: &Path,
+) -> Result<(OsString, Vec<OsString>)> {
+    let (program, mut args) = if config.parakeet_command.is_empty() {
+        default_parakeet_command()
+    } else {
+        let mut configured = config.parakeet_command.iter();
+        let Some(program) = configured.next() else {
+            return Err(anyhow!("parakeet_command is empty"));
+        };
+        (
+            OsString::from(program),
+            configured.map(OsString::from).collect::<Vec<_>>(),
+        )
+    };
+
+    args.push(audio_path.as_os_str().to_os_string());
+    args.push("--model".into());
+    args.push(config.parakeet_model.as_str().into());
+    args.push("--output-format".into());
+    args.push("txt".into());
+    args.push("--output-dir".into());
+    args.push(out_dir.as_os_str().to_os_string());
+    args.push("--output-template".into());
+    args.push("transcript".into());
+    Ok((program, args))
+}
+
+fn default_parakeet_command() -> (OsString, Vec<OsString>) {
+    if which::which("parakeet-mlx").is_ok() {
+        return ("parakeet-mlx".into(), Vec::new());
+    }
+    if which::which("uvx").is_ok() {
+        return (
+            "uvx".into(),
+            vec![
+                "--from".into(),
+                "parakeet-mlx".into(),
+                "parakeet-mlx".into(),
+            ],
+        );
+    }
+    (
+        "uv".into(),
+        vec![
+            "tool".into(),
+            "run".into(),
+            "--from".into(),
+            "parakeet-mlx".into(),
+            "parakeet-mlx".into(),
+        ],
+    )
+}
+
+async fn find_transcript_file(dir: &Path) -> Result<Option<PathBuf>> {
+    let expected = dir.join("transcript.txt");
+    if tokio::fs::try_exists(&expected).await.unwrap_or(false) {
+        return Ok(Some(expected));
+    }
+    let mut entries = tokio::fs::read_dir(dir)
+        .await
+        .with_context(|| format!("read {}", dir.display()))?;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("txt"))
+        {
+            return Ok(Some(path));
+        }
+    }
+    Ok(None)
+}
+
+fn safe_extension(path: &str) -> Option<String> {
+    let ext = Path::new(path).extension()?.to_str()?;
+    if ext
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() && ext.len() <= 8)
+    {
+        Some(ext.to_ascii_lowercase())
+    } else {
+        None
+    }
+}
+
+fn extension_from_mime(mime: &str) -> Option<&'static str> {
+    match mime {
+        "audio/ogg" | "audio/opus" => Some("oga"),
+        "audio/mpeg" | "audio/mp3" => Some("mp3"),
+        "audio/mp4" | "audio/x-m4a" => Some("m4a"),
+        "audio/wav" | "audio/x-wav" => Some("wav"),
+        "audio/flac" => Some("flac"),
+        _ => None,
+    }
+}
+
+fn has_audio_extension(name: &str) -> bool {
+    let Some(ext) = Path::new(name).extension().and_then(|ext| ext.to_str()) else {
+        return false;
+    };
+    matches!(
+        ext.to_ascii_lowercase().as_str(),
+        "oga" | "ogg" | "opus" | "mp3" | "m4a" | "mp4" | "wav" | "flac" | "aac"
+    )
+}
+
+fn parse_chat_ids(raw: &str) -> Vec<i64> {
+    let mut ids: Vec<i64> = raw
+        .split(|c: char| c == ',' || c == ';' || c.is_whitespace())
+        .filter_map(|part| {
+            let trimmed = part.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                trimmed.parse::<i64>().ok()
+            }
+        })
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
+
+fn parse_command(text: &str) -> Option<(String, &str)> {
+    let text = text.trim_start();
+    let without_slash = text.strip_prefix('/')?;
+    let mut parts = without_slash.splitn(2, char::is_whitespace);
+    let raw = parts.next()?.trim();
+    let rest = parts.next().unwrap_or("").trim_start();
+    let cmd = raw
+        .split_once('@')
+        .map(|(name, _)| name)
+        .unwrap_or(raw)
+        .to_ascii_lowercase();
+    if cmd.is_empty() {
+        None
+    } else {
+        Some((cmd, rest))
+    }
+}
+
+fn resolve_selector(
+    sessions: &[Instance],
+    selector: &str,
+    last_list: Option<&Vec<String>>,
+) -> Result<Option<String>> {
+    let selector = selector.trim();
+    if selector.is_empty() {
+        return Ok(None);
+    }
+
+    if let Ok(index) = selector.parse::<usize>() {
+        if index > 0 {
+            if let Some(list) = last_list {
+                if let Some(id) = list.get(index - 1) {
+                    if sessions.iter().any(|s| s.id == *id) {
+                        return Ok(Some(id.clone()));
+                    }
+                }
+            }
+        }
+    }
+
+    let exact: Vec<&Instance> = sessions
+        .iter()
+        .filter(|s| s.id == selector || s.title.eq_ignore_ascii_case(selector))
+        .collect();
+    if exact.len() == 1 {
+        return Ok(Some(exact[0].id.clone()));
+    }
+    if exact.len() > 1 {
+        return Err(anyhow!("session selector is ambiguous"));
+    }
+
+    let lower = selector.to_ascii_lowercase();
+    let prefix: Vec<&Instance> = sessions
+        .iter()
+        .filter(|s| s.id.starts_with(selector))
+        .collect();
+    if prefix.len() == 1 {
+        return Ok(Some(prefix[0].id.clone()));
+    }
+    if prefix.len() > 1 {
+        return Err(anyhow!("session id prefix is ambiguous"));
+    }
+
+    let title_contains: Vec<&Instance> = sessions
+        .iter()
+        .filter(|s| s.title.to_ascii_lowercase().contains(&lower))
+        .collect();
+    if title_contains.len() == 1 {
+        return Ok(Some(title_contains[0].id.clone()));
+    }
+    if title_contains.len() > 1 {
+        return Err(anyhow!("session title selector is ambiguous"));
+    }
+
+    Ok(None)
+}
+
+fn format_sessions(sessions: &[Instance]) -> String {
+    let mut out = String::from("Sessions:\n");
+    for (i, session) in sessions.iter().take(40).enumerate() {
+        let short_id: String = session.id.chars().take(8).collect();
+        let mode = if session.is_cockpit_mode() {
+            "cockpit"
+        } else {
+            "tmux"
+        };
+        out.push_str(&format!(
+            "{}. {} | {:?} | {} | {} | {}\n",
+            i + 1,
+            short_id,
+            session.status,
+            session.tool,
+            mode,
+            session.title
+        ));
+    }
+    if sessions.len() > 40 {
+        out.push_str(&format!("...and {} more\n", sessions.len() - 40));
+    }
+    out.push_str("Use /use <number> to select.");
+    out
+}
+
+fn format_send_error(error: &SendTextError) -> String {
+    match error {
+        SendTextError::ReadOnly => "AoE serve is in read-only mode.".to_string(),
+        SendTextError::MessageEmpty => "Message cannot be empty.".to_string(),
+        SendTextError::NotFound => "Session not found.".to_string(),
+        SendTextError::NotRunning => "Session is not running.".to_string(),
+        SendTextError::Transient(status) => {
+            format!("Session is mid-lifecycle ({status:?}); try again shortly.")
+        }
+        SendTextError::CockpitModeUnsupported => {
+            "This is a cockpit session, but Telegram could not route it through tmux.".to_string()
+        }
+        SendTextError::Tmux(e) => format!("tmux send failed: {e}"),
+        SendTextError::Internal => "Send failed due to an internal error.".to_string(),
+    }
+}
+
+fn help_text(authorized: bool) -> &'static str {
+    if authorized {
+        "AoE Telegram commands:\n/sessions - list sessions\n/use <number, id, or title> - select a session\n/status - selected session status\n/tail [lines] - show recent tmux output\n/whoami - show this chat id\n\nSend normal text or a voice note to the selected session. Voice notes are transcribed locally with NVIDIA Parakeet v2."
+    } else {
+        "AoE Telegram bridge is locked. Use /claim <code> from the private AoE Telegram config, or /whoami to get this chat id."
+    }
+}
+
+fn generate_claim_code() -> String {
+    crate::server::generate_token().chars().take(10).collect()
+}
+
+fn split_telegram_text(text: &str) -> Vec<String> {
+    if text.is_empty() {
+        return vec![String::new()];
+    }
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    let mut count = 0usize;
+    for ch in text.chars() {
+        if count >= MAX_TELEGRAM_TEXT_CHARS {
+            chunks.push(current);
+            current = String::new();
+            count = 0;
+        }
+        current.push(ch);
+        count += 1;
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+fn truncate_from_end(text: &str, max_chars: usize) -> String {
+    let total = text.chars().count();
+    if total <= max_chars {
+        return text.to_string();
+    }
+    let keep = max_chars.saturating_sub(32);
+    let tail: String = text
+        .chars()
+        .rev()
+        .take(keep)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    format!("[truncated to last {keep} chars]\n{tail}")
+}
+
+fn telegram_url(token: &str, method: &str) -> String {
+    format!("https://api.telegram.org/bot{token}/{method}")
+}
+
+async fn parse_telegram_response<T: for<'de> Deserialize<'de>>(
+    res: reqwest::Response,
+) -> Result<T> {
+    let status = res.status();
+    let body = res.text().await.unwrap_or_default();
+    if status != StatusCode::OK {
+        return Err(anyhow!("Telegram HTTP {status}: {}", truncate_log(&body)));
+    }
+    let parsed: TelegramApiResponse<T> =
+        serde_json::from_str(&body).context("parse Telegram response")?;
+    if !parsed.ok {
+        return Err(anyhow!(
+            "Telegram API error: {}",
+            parsed.description.unwrap_or_else(|| "unknown".to_string())
+        ));
+    }
+    parsed
+        .result
+        .ok_or_else(|| anyhow!("Telegram response missing result"))
+}
+
+fn truncate_log(text: &str) -> String {
+    let max = 240;
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let mut out: String = text.chars().take(max).collect();
+    out.push_str("...");
+    out
+}
+
+async fn save_config(path: &Path, config: &TelegramConfig) -> Result<()> {
+    let body = toml::to_string_pretty(config).context("serialize telegram config")?;
+    let tmp = path.with_extension("toml.tmp");
+    write_secret_file(&tmp, &body)
+        .await
+        .with_context(|| format!("write {}", tmp.display()))?;
+    tokio::fs::rename(&tmp, path)
+        .await
+        .with_context(|| format!("rename {} to {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .await?;
+    file.write_all(contents.as_bytes()).await?;
+    file.flush().await
+}
+
+#[cfg(not(unix))]
+async fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
+    tokio::fs::write(path, contents).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_chat_ids_accepts_common_separators() {
+        assert_eq!(parse_chat_ids("123, 456\n123; -789"), vec![-789, 123, 456]);
+    }
+
+    #[test]
+    fn parse_command_strips_bot_username() {
+        assert_eq!(
+            parse_command("/use@Pi_agent_l337_bot 1"),
+            Some(("use".to_string(), "1"))
+        );
+    }
+
+    #[test]
+    fn split_telegram_text_preserves_text() {
+        let text = "x".repeat(MAX_TELEGRAM_TEXT_CHARS + 12);
+        let chunks = split_telegram_text(&text);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks.concat(), text);
+    }
+
+    #[test]
+    fn truncate_from_end_keeps_short_text() {
+        assert_eq!(truncate_from_end("hello", 10), "hello");
+    }
+
+    #[test]
+    fn voice_input_accepts_voice_note() {
+        let message = TelegramMessage {
+            message_id: 1,
+            chat: TelegramChat { id: 42 },
+            text: None,
+            voice: Some(TelegramAudioRef {
+                file_id: "voice-file".to_string(),
+                file_unique_id: None,
+                mime_type: Some("audio/ogg".to_string()),
+                file_size: Some(123),
+                duration: Some(4),
+            }),
+            audio: None,
+            document: None,
+        };
+
+        let voice = voice_input_from_message(&message).expect("voice input");
+        assert_eq!(voice.file_id, "voice-file");
+        assert_eq!(voice.label, "voice note");
+    }
+
+    #[test]
+    fn build_parakeet_command_uses_v2_model_and_txt_output() {
+        let config = TelegramConfig {
+            parakeet_command: vec!["parakeet-mlx".to_string()],
+            ..TelegramConfig::default()
+        };
+        let (_program, args) =
+            build_parakeet_command(&config, Path::new("/tmp/audio.oga"), Path::new("/tmp/out"))
+                .expect("command");
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+        assert!(rendered.contains(&DEFAULT_PARAKEET_MODEL.to_string()));
+        assert!(rendered.windows(2).any(|w| w == ["--output-format", "txt"]));
+    }
+}

--- a/src/server/telegram.rs
+++ b/src/server/telegram.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, warn};
 
 use crate::server::api::{send_text_to_tmux_session, SendTextError};
 use crate::server::AppState;
-use crate::session::Instance;
+use crate::session::{Instance, Status};
 
 const CONFIG_FILE: &str = "telegram.toml";
 const TOKEN_ENV: &str = "AOE_TELEGRAM_BOT_TOKEN";
@@ -25,6 +25,9 @@ const ALLOWED_CHATS_ENV: &str = "AOE_TELEGRAM_ALLOWED_CHAT_IDS";
 const DEFAULT_SESSION_ENV: &str = "AOE_TELEGRAM_DEFAULT_SESSION";
 const PARAKEET_MODEL_ENV: &str = "AOE_TELEGRAM_PARAKEET_MODEL";
 const DEFAULT_POLL_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_REPLY_TIMEOUT_SECS: u64 = 120;
+const DEFAULT_REPLY_POLL_SECS: u64 = 3;
+const DEFAULT_REPLY_TAIL_LINES: usize = 120;
 const DEFAULT_VOICE_MAX_FILE_SIZE_MB: u64 = 25;
 const DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_SECS: u64 = 600;
 const DEFAULT_PARAKEET_MODEL: &str = "mlx-community/parakeet-tdt-0.6b-v2";
@@ -43,6 +46,10 @@ struct TelegramConfig {
     last_update_id: Option<i64>,
     drop_pending_on_start: bool,
     poll_timeout_secs: u64,
+    reply_relay_enabled: bool,
+    reply_timeout_secs: u64,
+    reply_poll_secs: u64,
+    reply_tail_lines: usize,
     voice_transcription_enabled: bool,
     voice_max_file_size_mb: u64,
     voice_transcription_timeout_secs: u64,
@@ -62,6 +69,10 @@ impl Default for TelegramConfig {
             last_update_id: None,
             drop_pending_on_start: true,
             poll_timeout_secs: DEFAULT_POLL_TIMEOUT_SECS,
+            reply_relay_enabled: true,
+            reply_timeout_secs: DEFAULT_REPLY_TIMEOUT_SECS,
+            reply_poll_secs: DEFAULT_REPLY_POLL_SECS,
+            reply_tail_lines: DEFAULT_REPLY_TAIL_LINES,
             voice_transcription_enabled: true,
             voice_max_file_size_mb: DEFAULT_VOICE_MAX_FILE_SIZE_MB,
             voice_transcription_timeout_secs: DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_SECS,
@@ -236,6 +247,9 @@ impl TelegramBridge {
             changed = true;
         }
         config.poll_timeout_secs = config.poll_timeout_secs.clamp(5, 50);
+        config.reply_timeout_secs = config.reply_timeout_secs.clamp(5, 600);
+        config.reply_poll_secs = config.reply_poll_secs.clamp(1, 30);
+        config.reply_tail_lines = config.reply_tail_lines.clamp(20, MAX_TAIL_LINES);
         config.voice_max_file_size_mb = config.voice_max_file_size_mb.clamp(1, 50);
         config.voice_transcription_timeout_secs =
             config.voice_transcription_timeout_secs.clamp(30, 1800);
@@ -402,7 +416,9 @@ impl TelegramBridge {
     async fn handle_text(&self, chat_id: i64, text: &str) -> Result<()> {
         let trimmed = text.trim();
         if let Some((cmd, rest)) = parse_command(trimmed) {
-            return self.handle_command(chat_id, &cmd, rest).await;
+            if is_bridge_command(&cmd) {
+                return self.handle_command(chat_id, &cmd, rest).await;
+            }
         }
 
         if !self.is_authorized(chat_id).await {
@@ -701,12 +717,78 @@ impl TelegramBridge {
                 .await;
         }
 
+        let relay_config = self.config.lock().await.clone();
+        let baseline = if relay_config.reply_relay_enabled {
+            match self
+                .capture_tail(session_id, relay_config.reply_tail_lines)
+                .await
+            {
+                Ok(content) => content,
+                Err(e) => {
+                    debug!(
+                        target: "telegram.bridge",
+                        session_id,
+                        error = ?e,
+                        "could not capture reply relay baseline"
+                    );
+                    String::new()
+                }
+            }
+        } else {
+            String::new()
+        };
+
         match send_text_to_tmux_session(self.state.clone(), session_id, text.to_string(), true)
             .await
         {
             Ok(_) => {
-                self.send_reply(chat_id, &format!("Sent to {}.", instance.title))
+                if !relay_config.reply_relay_enabled {
+                    return self
+                        .send_reply(chat_id, &format!("Sent to {}.", instance.title))
+                        .await;
+                }
+
+                self.send_reply(
+                    chat_id,
+                    &format!("Sent to {}. Waiting for reply...", instance.title),
+                )
+                .await?;
+                match self
+                    .wait_for_session_reply(session_id, &baseline, &relay_config)
                     .await
+                {
+                    Ok(Some(output)) => {
+                        let output = truncate_from_end(output.trim(), MAX_TELEGRAM_TEXT_CHARS);
+                        self.send_reply(chat_id, &format!("{} output:\n{}", instance.title, output))
+                            .await
+                    }
+                    Ok(None) => {
+                        self.send_reply(
+                            chat_id,
+                            &format!(
+                                "No new output from {} after {}s. Use /tail 80 to check the pane.",
+                                instance.title, relay_config.reply_timeout_secs
+                            ),
+                        )
+                        .await
+                    }
+                    Err(e) => {
+                        debug!(
+                            target: "telegram.bridge",
+                            session_id,
+                            error = ?e,
+                            "reply relay failed"
+                        );
+                        self.send_reply(
+                            chat_id,
+                            &format!(
+                                "Sent to {}, but could not read the reply. Use /tail 80.",
+                                instance.title
+                            ),
+                        )
+                        .await
+                    }
+                }
             }
             Err(e) => self.send_reply(chat_id, &format_send_error(&e)).await,
         }
@@ -779,6 +861,54 @@ impl TelegramBridge {
                 Err(TailError::Internal)
             }
         }
+    }
+
+    async fn wait_for_session_reply(
+        &self,
+        session_id: &str,
+        baseline: &str,
+        config: &TelegramConfig,
+    ) -> Result<Option<String>, TailError> {
+        let timeout = Duration::from_secs(config.reply_timeout_secs.clamp(5, 600));
+        let poll_interval = Duration::from_secs(config.reply_poll_secs.clamp(1, 30));
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut latest_output = None;
+
+        loop {
+            tokio::select! {
+                _ = self.state.shutdown.cancelled() => return Ok(latest_output),
+                _ = tokio::time::sleep(poll_interval) => {}
+            }
+
+            let tail = self
+                .capture_tail(
+                    session_id,
+                    config.reply_tail_lines.clamp(20, MAX_TAIL_LINES),
+                )
+                .await?;
+            let output = output_after_baseline(baseline, &tail);
+            if !output.trim().is_empty() {
+                latest_output = Some(output);
+            }
+
+            if let Some(status) = self.session_status(session_id).await {
+                if latest_output.is_some() && reply_is_ready(status) {
+                    return Ok(latest_output);
+                }
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                return Ok(latest_output);
+            }
+        }
+    }
+
+    async fn session_status(&self, session_id: &str) -> Option<Status> {
+        self.sessions_snapshot()
+            .await
+            .into_iter()
+            .find(|session| session.id == session_id)
+            .map(|session| session.status)
     }
 
     async fn download_telegram_file(
@@ -1204,6 +1334,36 @@ fn parse_command(text: &str) -> Option<(String, &str)> {
     }
 }
 
+fn is_bridge_command(cmd: &str) -> bool {
+    matches!(
+        cmd,
+        "start" | "help" | "claim" | "whoami" | "sessions" | "use" | "tail" | "output" | "status"
+    )
+}
+
+fn reply_is_ready(status: Status) -> bool {
+    matches!(
+        status,
+        Status::Idle | Status::Waiting | Status::Stopped | Status::Error | Status::Unknown
+    )
+}
+
+fn output_after_baseline(baseline: &str, latest: &str) -> String {
+    let baseline = baseline.trim_end();
+    let latest = latest.trim_end();
+    if latest.is_empty() || latest == baseline {
+        return String::new();
+    }
+    if baseline.is_empty() {
+        return latest.trim().to_string();
+    }
+    latest
+        .strip_prefix(baseline)
+        .unwrap_or(latest)
+        .trim()
+        .to_string()
+}
+
 fn resolve_selector(
     sessions: &[Instance],
     selector: &str,
@@ -1308,7 +1468,7 @@ fn format_send_error(error: &SendTextError) -> String {
 
 fn help_text(authorized: bool) -> &'static str {
     if authorized {
-        "AoE Telegram commands:\n/sessions - list sessions\n/use <number, id, or title> - select a session\n/status - selected session status\n/tail [lines] - show recent tmux output\n/whoami - show this chat id\n\nSend normal text or a voice note to the selected session. Voice notes are transcribed locally with NVIDIA Parakeet v2."
+        "AoE Telegram commands:\n/sessions - list sessions\n/use <number, id, or title> - select a session\n/status - selected session status\n/tail [lines] - show recent tmux output\n/whoami - show this chat id\n\nSend normal text or a voice note to the selected session. Voice notes are transcribed locally with NVIDIA Parakeet v2. Other slash commands are forwarded to the agent, and tmux replies are sent back after the turn."
     } else {
         "AoE Telegram bridge is locked. Use /claim <code> from the private AoE Telegram config, or /whoami to get this chat id."
     }
@@ -1436,6 +1596,30 @@ mod tests {
         assert_eq!(
             parse_command("/use@Pi_agent_l337_bot 1"),
             Some(("use".to_string(), "1"))
+        );
+    }
+
+    #[test]
+    fn bridge_command_detection_leaves_agent_slash_commands_for_session() {
+        assert!(is_bridge_command("sessions"));
+        assert!(is_bridge_command("tail"));
+        assert!(!is_bridge_command("login"));
+        assert!(!is_bridge_command("model"));
+    }
+
+    #[test]
+    fn output_after_baseline_returns_only_new_tail() {
+        assert_eq!(
+            output_after_baseline("old line\nprompt", "old line\nprompt\nnew reply\n"),
+            "new reply"
+        );
+    }
+
+    #[test]
+    fn output_after_baseline_falls_back_when_tail_rotated() {
+        assert_eq!(
+            output_after_baseline("old line not present anymore", "prompt\nnew reply"),
+            "prompt\nnew reply"
         );
     }
 

--- a/src/server/telegram.rs
+++ b/src/server/telegram.rs
@@ -758,9 +758,14 @@ impl TelegramBridge {
                     .await
                 {
                     Ok(Some(output)) => {
+                        let cleaned = clean_agent_reply(&output, text);
+                        let output = if cleaned.is_empty() {
+                            output.trim().to_string()
+                        } else {
+                            cleaned
+                        };
                         let output = truncate_from_end(output.trim(), MAX_TELEGRAM_TEXT_CHARS);
-                        self.send_reply(chat_id, &format!("{} output:\n{}", instance.title, output))
-                            .await
+                        self.send_reply(chat_id, &output).await
                     }
                     Ok(None) => {
                         self.send_reply(
@@ -1364,6 +1369,190 @@ fn output_after_baseline(baseline: &str, latest: &str) -> String {
         .to_string()
 }
 
+fn clean_agent_reply(raw: &str, prompt: &str) -> String {
+    let turn = reply_turn_after_prompt(raw, prompt);
+    let without_footer = strip_terminal_footer(&turn);
+    let without_chrome = strip_terminal_chrome_lines(&without_footer);
+    let without_tools = strip_pi_tool_blocks(&without_chrome);
+    normalize_reply_text(&without_tools)
+}
+
+fn reply_turn_after_prompt(raw: &str, prompt: &str) -> String {
+    let prompt_lines: Vec<String> = prompt
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect();
+    if prompt_lines.is_empty() {
+        return raw.to_string();
+    }
+
+    let lines: Vec<&str> = raw.lines().collect();
+    if lines.len() >= prompt_lines.len() {
+        for start in (0..=lines.len() - prompt_lines.len()).rev() {
+            let matches_prompt = prompt_lines
+                .iter()
+                .enumerate()
+                .all(|(offset, prompt_line)| lines[start + offset].trim() == prompt_line);
+            if matches_prompt {
+                return lines[start + prompt_lines.len()..].join("\n");
+            }
+        }
+    }
+
+    let compact_prompt = prompt.trim();
+    if compact_prompt.chars().count() >= 12 {
+        if let Some(pos) = raw.rfind(compact_prompt) {
+            let after = pos + compact_prompt.len();
+            return raw[after..].to_string();
+        }
+    }
+
+    raw.to_string()
+}
+
+fn strip_terminal_footer(text: &str) -> String {
+    let mut kept = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if is_terminal_rule_line(trimmed)
+            || (is_terminal_cwd_footer(trimmed)
+                && kept
+                    .last()
+                    .is_some_and(|line: &&str| line.trim().is_empty()))
+            || is_terminal_status_footer(trimmed)
+        {
+            break;
+        }
+        kept.push(line);
+    }
+    kept.join("\n")
+}
+
+fn is_terminal_rule_line(trimmed: &str) -> bool {
+    trimmed.chars().count() >= 8
+        && trimmed
+            .chars()
+            .all(|ch| ch == '\u{2500}' || ch == '-' || ch.is_whitespace())
+}
+
+fn is_terminal_cwd_footer(trimmed: &str) -> bool {
+    trimmed.starts_with("~/")
+}
+
+fn is_terminal_status_footer(trimmed: &str) -> bool {
+    (trimmed.contains("%/") && trimmed.contains("(auto)"))
+        || trimmed.starts_with('\u{2191}')
+        || trimmed.starts_with("0.0%/")
+}
+
+fn strip_terminal_chrome_lines(text: &str) -> String {
+    let mut lines = Vec::new();
+    let mut skipping_section = false;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            skipping_section = false;
+            lines.push(line);
+            continue;
+        }
+
+        if skipping_section {
+            continue;
+        }
+
+        if is_startup_chrome_line(trimmed) {
+            skipping_section = trimmed == "[Context]" || trimmed == "[Extensions]";
+            continue;
+        }
+
+        lines.push(line);
+    }
+
+    lines.join("\n")
+}
+
+fn is_startup_chrome_line(trimmed: &str) -> bool {
+    trimmed.starts_with("Model scope:")
+        || trimmed.contains("(Ctrl+P to cycle)")
+        || trimmed.starts_with("pi v")
+        || trimmed.starts_with("escape interrupt")
+        || trimmed == "more"
+        || trimmed.starts_with("Press ctrl+o")
+        || trimmed.starts_with("Pi can explain")
+        || trimmed == "[Context]"
+        || trimmed == "[Extensions]"
+        || trimmed.starts_with("Warning: tmux extended-keys")
+        || trimmed.starts_with("-g extended-keys")
+}
+
+fn strip_pi_tool_blocks(text: &str) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+
+    while i < lines.len() {
+        if lines[i].trim_start().starts_with("$ ") {
+            if let Some(end) = lines[i..]
+                .iter()
+                .position(|line| is_pi_tool_block_end(line.trim()))
+            {
+                i += end + 1;
+                continue;
+            }
+        }
+        out.push(lines[i]);
+        i += 1;
+    }
+
+    out.join("\n")
+}
+
+fn is_pi_tool_block_end(trimmed: &str) -> bool {
+    trimmed.starts_with("Took ") || trimmed.starts_with("Tool failed after ")
+}
+
+fn normalize_reply_text(text: &str) -> String {
+    let mut lines: Vec<String> = text
+        .lines()
+        .map(|line| line.trim_end().to_string())
+        .collect();
+
+    while lines.first().is_some_and(|line| line.trim().is_empty()) {
+        lines.remove(0);
+    }
+    while lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.pop();
+    }
+
+    let strip_one_leading_space = lines
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .all(|line| line.starts_with(' '));
+    if strip_one_leading_space {
+        for line in &mut lines {
+            if line.starts_with(' ') {
+                line.remove(0);
+            }
+        }
+    }
+
+    let mut collapsed = Vec::new();
+    let mut previous_blank = false;
+    for line in lines {
+        let blank = line.trim().is_empty();
+        if blank && previous_blank {
+            continue;
+        }
+        collapsed.push(line);
+        previous_blank = blank;
+    }
+
+    collapsed.join("\n").trim().to_string()
+}
+
 fn resolve_selector(
     sessions: &[Instance],
     selector: &str,
@@ -1620,6 +1809,73 @@ mod tests {
         assert_eq!(
             output_after_baseline("old line not present anymore", "prompt\nnew reply"),
             "prompt\nnew reply"
+        );
+    }
+
+    #[test]
+    fn clean_agent_reply_strips_pi_terminal_chrome_and_tool_blocks() {
+        let raw = "\
+Model scope: gpt-5.3-codex-spark:high, nvidia/nemotron-3-super-120b-a12b:low
+
+ pi v0.79.1
+ escape interrupt - ctrl+c/ctrl+d clear/exit - / commands - ! bash - ctrl+o
+ more
+ Press ctrl+o to show full startup help and loaded resources.
+
+ What agents are running
+
+
+ $ ps aux | grep -i 'pi-agent\\|pi-coding-agent\\|coding-agent' | grep -v grep
+
+ (no output)
+
+ Command exited with code 1
+
+ Took 0.1s
+
+
+ I don't see any separate background agents running in this environment right
+ now (no pi/coding-agent processes detected).
+ I can help you launch or inspect a specific agent workflow if you want.
+
+\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+
+\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+~/Python_local_Mac
+\u{2191}1.9k \u{2193}428 1.2%/128k (auto)      gpt-5.3-codex-spark high";
+
+        assert_eq!(
+            clean_agent_reply(raw, "What agents are running"),
+            "I don't see any separate background agents running in this environment right\nnow (no pi/coding-agent processes detected).\nI can help you launch or inspect a specific agent workflow if you want."
+        );
+    }
+
+    #[test]
+    fn clean_agent_reply_uses_exact_prompt_line_for_short_prompts() {
+        let raw = "\
+ Hey
+
+
+ Hey! How can I help?
+
+\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}";
+
+        assert_eq!(clean_agent_reply(raw, "Hey"), "Hey! How can I help?");
+    }
+
+    #[test]
+    fn clean_agent_reply_keeps_simple_exact_reply() {
+        let raw = "\
+ Reply with exactly: TELEGRAM_PI_ROUTE_OK
+
+
+ TELEGRAM_PI_ROUTE_OK
+
+\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}";
+
+        assert_eq!(
+            clean_agent_reply(raw, "Reply with exactly: TELEGRAM_PI_ROUTE_OK"),
+            "TELEGRAM_PI_ROUTE_OK"
         );
     }
 

--- a/src/server/tunnel.rs
+++ b/src/server/tunnel.rs
@@ -742,6 +742,12 @@ async fn check_funnel_capability() -> anyhow::Result<()> {
 }
 
 async fn tailscale_funnel_url() -> anyhow::Result<String> {
+    let host = tailscale_dns_name().await?;
+    debug!(host = %host, "tailscale_funnel_url: resolved stable hostname");
+    Ok(format!("https://{}", host))
+}
+
+pub async fn tailscale_dns_name() -> anyhow::Result<String> {
     let out = Command::new("tailscale")
         .args(["status", "--json"])
         .output()
@@ -767,6 +773,10 @@ async fn tailscale_funnel_url() -> anyhow::Result<String> {
         );
         anyhow::anyhow!("parse tailscale status JSON: {}", e)
     })?;
+    parse_tailscale_dns_name(&parsed)
+}
+
+fn parse_tailscale_dns_name(parsed: &serde_json::Value) -> anyhow::Result<String> {
     let dns = parsed
         .get("Self")
         .and_then(|s| s.get("DNSName"))
@@ -782,8 +792,7 @@ async fn tailscale_funnel_url() -> anyhow::Result<String> {
     if host.is_empty() {
         anyhow::bail!("empty DNSName from tailscale status");
     }
-    debug!(host = %host, "tailscale_funnel_url: resolved stable hostname");
-    Ok(format!("https://{}", host))
+    Ok(host.to_string())
 }
 
 /// Does this ServeConfig proxy URL point at the local machine
@@ -1045,6 +1054,25 @@ mod tests {
         assert!(!proxy_is_loopback("http://100.64.0.1:8080"));
         assert!(!proxy_is_loopback("http://example.com"));
         assert!(!proxy_is_loopback("http://192.168.1.5:8080"));
+    }
+
+    #[test]
+    fn parse_tailscale_dns_name_strips_trailing_dot() {
+        let parsed = serde_json::json!({
+            "Self": {
+                "DNSName": "macbook.tailnet.ts.net."
+            }
+        });
+        assert_eq!(
+            parse_tailscale_dns_name(&parsed).unwrap(),
+            "macbook.tailnet.ts.net"
+        );
+    }
+
+    #[test]
+    fn parse_tailscale_dns_name_rejects_missing_value() {
+        let parsed = serde_json::json!({ "Self": {} });
+        assert!(parse_tailscale_dns_name(&parsed).is_err());
     }
 
     #[test]

--- a/web/src/components/MobileTerminalToolbar.tsx
+++ b/web/src/components/MobileTerminalToolbar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import type { Terminal } from "@xterm/xterm";
 import type { RefObject } from "react";
+import { ClipboardPaste, CornerDownLeft } from "lucide-react";
 import { useLongPressDrag, type DragAxis } from "../hooks/useLongPressDrag";
 import { toastBus } from "../lib/toastBus";
 
@@ -104,10 +105,11 @@ export function MobileTerminalToolbar({
   });
 
   const btnBase =
-    "flex-1 flex items-center justify-center h-11 rounded-md transition-colors duration-75 text-text-secondary select-none touch-manipulation relative active:bg-surface-700/50 active:scale-95";
+    "flex-none min-w-11 flex items-center justify-center h-11 rounded-md transition-colors duration-75 text-text-secondary select-none touch-manipulation relative active:bg-surface-700/50 active:scale-95";
+  const btnWide = `${btnBase} min-w-[58px] gap-1 px-2`;
 
   const strip =
-    "shrink-0 flex items-center gap-1 px-2 py-1.5 bg-surface-850 border-t border-surface-700/20";
+    "shrink-0 flex items-center gap-1 overflow-x-auto px-2 py-1.5 bg-surface-850 border-t border-surface-700/20 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden";
 
   // Parent (TerminalView) reserves paddingBottom for the keyboard
   // (sticky once any keyboard has opened), so once that has happened the
@@ -161,6 +163,10 @@ export function MobileTerminalToolbar({
         onClick={() => send("\x1b")}>
         <span className="font-mono text-sm">Esc</span>
       </button>
+      <button type="button" aria-label="Enter" className={btnBase}
+        onClick={() => send("\r")}>
+        <CornerDownLeft className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
       <button
         type="button"
         aria-label="Ctrl"
@@ -178,7 +184,7 @@ export function MobileTerminalToolbar({
         onClick={() => { send("\x03"); if (ctrlActive) onCtrlToggle(); }}>
         <span className="font-mono text-xs">^C</span>
       </button>
-      <button type="button" aria-label="Paste from clipboard" className={btnBase}
+      <button type="button" aria-label="Paste from clipboard" className={btnWide}
         onClick={async () => {
           haptic();
           const t = toastBus.handler;
@@ -290,20 +296,8 @@ export function MobileTerminalToolbar({
             );
           }
         }}>
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <rect x="9" y="2" width="6" height="4" rx="1" />
-          <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-2" />
-        </svg>
+        <ClipboardPaste className="h-3.5 w-3.5" aria-hidden="true" />
+        <span className="font-mono text-[11px]">Paste</span>
       </button>
     </div>
   );

--- a/web/src/components/cockpit/Composer.insert.test.ts
+++ b/web/src/components/cockpit/Composer.insert.test.ts
@@ -12,7 +12,11 @@
 import { describe, expect, it } from "vitest";
 import { createRef } from "react";
 
-import { insertAtCaret } from "./Composer";
+import {
+  insertAtCaret,
+  insertPlainTextAtCaret,
+  pasteClipboardAtCaret,
+} from "./Composer";
 
 describe("insertAtCaret (#1149)", () => {
   it("dispatches an InputEvent with inputType=insertText and data=text", () => {
@@ -68,6 +72,48 @@ describe("insertAtCaret (#1149)", () => {
     insertAtCaret(ref, "@");
 
     expect(ta.value).toBe("hello @");
+
+    document.body.removeChild(ta);
+  });
+
+  it("inserts pasted text without adding trigger whitespace", () => {
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    ta.value = "run";
+    ta.setSelectionRange(3, 3);
+    const ref = createRef<HTMLTextAreaElement>();
+    (ref as { current: HTMLTextAreaElement }).current = ta;
+
+    const events: InputEvent[] = [];
+    ta.addEventListener("input", (e) => events.push(e as InputEvent));
+
+    insertPlainTextAtCaret(ref, " --help\nnext");
+
+    expect(ta.value).toBe("run --help\nnext");
+    expect(events).toHaveLength(1);
+    expect(events[0].inputType).toBe("insertFromPaste");
+    expect(events[0].data).toBe(" --help\nnext");
+
+    document.body.removeChild(ta);
+  });
+
+  it("reads clipboard text into the composer on secure origins", async () => {
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    const ref = createRef<HTMLTextAreaElement>();
+    (ref as { current: HTMLTextAreaElement }).current = ta;
+
+    Object.defineProperty(window, "isSecureContext", {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { readText: async () => "hello from clipboard" },
+      configurable: true,
+    });
+
+    await expect(pasteClipboardAtCaret(ref)).resolves.toBe(true);
+    expect(ta.value).toBe("hello from clipboard");
 
     document.body.removeChild(ta);
   });

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -22,6 +22,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   AtSign,
   ChevronUp,
+  ClipboardPaste,
+  Send,
   Slash,
   Square,
 } from "lucide-react";
@@ -31,6 +33,7 @@ import type { CockpitState } from "../../lib/cockpitTypes";
 import { getDraft, setDraft } from "../../lib/cockpitDrafts";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { useAgentProfile } from "../../lib/agentProfileContext";
+import { toastBus } from "../../lib/toastBus";
 
 /** Decision returned by {@link decideEnterAction} for an Enter
  *  keystroke on the cockpit composer textarea.
@@ -536,6 +539,8 @@ export function Composer({
                 void sendFromTextarea(taRef, composerRuntime, enqueuePrompt);
               }}
               autoFocus={!isMobile}
+              enterKeyHint={isMobile ? "enter" : undefined}
+              inputMode="text"
               className={[
                 "min-h-[56px] max-h-[200px] resize-none bg-transparent",
                 "px-4 pt-3 pb-1 text-sm leading-6 text-text-primary",
@@ -544,8 +549,8 @@ export function Composer({
             />
 
             {/* Footer strip — affordances on the left, send/stop on the right */}
-            <div className="flex items-center justify-between gap-2 border-t border-surface-800/60 px-2 pb-2 pt-1.5">
-              <div className="flex items-center gap-0.5">
+            <div className="flex flex-wrap items-center justify-between gap-2 border-t border-surface-800/60 px-2 pb-2 pt-1.5">
+              <div className="flex min-w-0 flex-wrap items-center gap-0.5">
                 <ToolbarButton
                   icon={<AtSign className="h-3.5 w-3.5" />}
                   label="Add file context (@)"
@@ -558,6 +563,20 @@ export function Composer({
                   hint="/"
                   onClick={() => insertAtCaret(taRef, "/")}
                 />
+                <ToolbarButton
+                  icon={<ClipboardPaste className="h-3.5 w-3.5" />}
+                  label="Paste from clipboard"
+                  onClick={() => {
+                    void pasteClipboardAtCaret(taRef).then((ok) => {
+                      if (!ok) {
+                        toastBus.handler?.error(
+                          "Couldn't read clipboard. Use HTTPS or paste from the keyboard menu.",
+                        );
+                        taRef.current?.focus();
+                      }
+                    });
+                  }}
+                />
                 <span className="mx-1 h-4 w-px bg-surface-700" aria-hidden />
                 <ModePicker
                   sessionId={sessionId}
@@ -567,7 +586,7 @@ export function Composer({
                 />
               </div>
 
-              <div className="flex items-center gap-2">
+              <div className="ml-auto flex items-center gap-2">
                 <UsageHint usage={sessionUsage} />
                 {turnActive ? (
                   <>
@@ -728,6 +747,54 @@ export function insertAtCaret(
   ta.setSelectionRange(pos, pos);
 }
 
+/** Insert arbitrary pasted text without trigger-specific whitespace
+ *  padding. Kept separate from `insertAtCaret` because @ and / toolbar
+ *  injections need trigger detection, while pasted code or shell
+ *  snippets must stay byte-for-byte as copied. */
+export function insertPlainTextAtCaret(
+  ref: React.RefObject<HTMLTextAreaElement | null>,
+  text: string,
+) {
+  const ta = ref.current;
+  if (!ta || text.length === 0) return;
+  const start = ta.selectionStart ?? ta.value.length;
+  const end = ta.selectionEnd ?? start;
+  const before = ta.value.slice(0, start);
+  const next = before + text + ta.value.slice(end);
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(ta, next);
+  ta.dispatchEvent(
+    new InputEvent("input", {
+      bubbles: true,
+      inputType: "insertFromPaste",
+      data: text,
+    }),
+  );
+  const pos = before.length + text.length;
+  ta.focus();
+  ta.setSelectionRange(pos, pos);
+}
+
+export async function pasteClipboardAtCaret(
+  ref: React.RefObject<HTMLTextAreaElement | null>,
+): Promise<boolean> {
+  if (typeof window === "undefined") return false;
+  if (!window.isSecureContext) return false;
+  const readText = navigator.clipboard?.readText;
+  if (!readText) return false;
+  try {
+    const text = await readText.call(navigator.clipboard);
+    if (!text) return false;
+    insertPlainTextAtCaret(ref, text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function extDescription(path: string): string | undefined {
   const m = path.match(/\.([a-z0-9]+)$/i);
   return m?.[1]?.toLowerCase();
@@ -754,6 +821,7 @@ function ToolbarButton({
       title={label}
       aria-label={label}
       disabled={disabled}
+      onMouseDown={(e) => e.preventDefault()}
       onClick={onClick}
       className={[
         "inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-text-dim",
@@ -1007,7 +1075,7 @@ function SendButton({ connected = true }: { connected?: boolean }) {
           "transition-all duration-100",
         ].join(" ")}
       >
-        <PaperPlaneIcon />
+        <Send className="h-3.5 w-3.5" aria-hidden="true" />
       </button>
     </ComposerPrimitive.Send>
   );
@@ -1072,7 +1140,7 @@ function QueueSendButton({
         "transition-all duration-100",
       ].join(" ")}
     >
-      <PaperPlaneIcon />
+      <Send className="h-3.5 w-3.5" aria-hidden="true" />
       {queuedCount > 0 && (
         <span
           aria-hidden
@@ -1106,23 +1174,4 @@ function sendFromTextarea(
   // and we cleared the value without firing one.
   const el = taRef.current;
   if (el) el.style.height = "auto";
-}
-
-function PaperPlaneIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      width="14"
-      height="14"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M22 2 11 13" />
-      <path d="M22 2 15 22l-4-9-9-4 20-7Z" />
-    </svg>
-  );
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -698,6 +698,21 @@
       ]
     },
     {
+      "id": "mobile.input-controls",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/mobile-keyboard.spec.ts",
+        "tests/mobile-toolbar.spec.ts",
+        "src/components/cockpit/Composer.insert.test.ts"
+      ],
+      "components": [
+        "web/src/components/TerminalView.tsx",
+        "web/src/components/MobileTerminalToolbar.tsx",
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
## Summary
- add an optional Telegram long-poll bridge for controlling AoE sessions
- transcribe Telegram voice/audio messages locally with NVIDIA Parakeet v2 before sending transcript text to the selected agent
- improve mobile paste/keyboard controls in the terminal toolbar and cockpit composer

## Validation
- cargo check --features serve
- cargo clippy --features serve --all-targets -- -D warnings
- cargo test --features serve telegram::tests
- cargo test --features serve --test integration
- npm run test:unit -- src/components/cockpit/Composer.insert.test.ts
- node tests/validate-coverage-matrix.mjs
- npx playwright test tests/mobile-toolbar.spec.ts tests/mobile-keyboard.spec.ts --workers=1
- npm run build
- local Parakeet MLX smoke test with mlx-community/parakeet-tdt-0.6b-v2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783663934&installation_id=139138837&pr_number=2082&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2082&signature=593914d6f9c9ff7a2b48d90e9fa845080d1f765825a5e7b50df055a95c4bb134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds an optional Telegram long-poll bridge with on-host voice transcription and improves mobile input controls in the web UI.

High-level summary
- Telegram bridge: long-polling integration that lets authorized Telegram chats control AoE sessions (commands: /help, /claim, /whoami, /sessions, /use, /tail, /output, /status), forward chat text to sessions, capture session output and reply in chat.
- Local voice transcription: downloads Telegram voice/audio and transcribes locally using NVIDIA Parakeet v2, then forwards transcripts to the selected agent (with size/validation limits).
- Mobile input improvements: adds Enter and Paste controls to the mobile terminal toolbar; clipboard-paste support and caret-aware insertion in the cockpit composer; icon and layout tweaks for better mobile UX.
- Shared plumbing: centralizes send-message logic into a reusable helper so API and the Telegram bridge share robust send-to-session behavior and structured outcome/error handling.

Concrete changes
- New module: src/server/telegram.rs — full Telegram bridge: config load/persist (telegram.toml), claim-code handling, polling loop, per-chat auth, command handlers, file download → Parakeet transcription pipeline, reply capture/cleaning, and spawn_if_configured.
- API helper & reexports: src/server/api/sessions.rs adds SendTextOutcome/SendTextError and send_text_to_tmux_session(...); send_message now delegates to it; src/server/api/mod.rs re-exports send_text_to_tmux_session.
- Startup wiring: src/server/mod.rs exposes pub mod telegram and calls telegram::spawn_if_configured(state.clone()) during server startup.
- Tailscale helper: src/server/tunnel.rs adds tailscale_dns_name() and parsing tests.
- Frontend: web/src/components/cockpit/Composer.tsx adds insertPlainTextAtCaret and pasteClipboardAtCaret, clipboard-paste toolbar button, keyboard/inputMode tweaks; web/src/components/MobileTerminalToolbar.tsx adds Enter and Paste buttons and moves to lucide-react icons.
- Tests/config: unit tests for parsing/Parakeet helpers, updated Composer.insert.test.ts, and web/tests/coverage-matrix.json adds mobile.input-controls entry.

Benefits
- Control AoE sessions remotely via Telegram without opening the web UI.
- Hands-free mobile interaction: voice → local transcription → agent input.
- Improved mobile typing/paste experience and clearer toolbar affordances.
- Less duplicated send-to-session logic and clearer error/outcome semantics.

Potential follow-ups / areas for improvement
- Move the Telegram bridge into the planned plugin system (reviewer-recommended) to keep core lean.
- Add end-to-end tests for Telegram → file download → Parakeet → agent flows and reply-capture timing.
- Harden auth, rate-limiting, input validation, and operational docs for running Parakeet (GPU/CPU, model selection).
- Consider explicit feature flags/runtime guards and resource limits for transcription to reduce attack surface.

Technical notes (concise)
- send_text_to_tmux_session: performs request validation, per-session instance_lock serialization, optional revive, tmux send_keys, and persists cascade-cleared fields; returns SendTextOutcome or detailed SendTextError variants.
- Telegram bridge: long-polls getUpdates with last_update_id tracking and optional initial drain, routes text to sessions (tmux via send_text_to_tmux_session, cockpit via supervisor), downloads media to temp files, invokes Parakeet as an external process with model/timeout settings, enforces file-size limits, chunks/truncates transcripts, captures session tail for replies, and sanitizes agent output before replying.
- Config: telegram.toml persisted with atomic writes and restrictive permissions; spawn_if_configured invoked at server start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->