### PR TITLE
fix(web): keep the agent prompt visible under the mobile keyboard and keep streaming while reading scrollback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@
 - Build: `cargo build --features serve` (build.rs runs `npm install && npm run build` in `web/` when inputs change).
 - Run: `aoe serve --host 0.0.0.0` (token-based auth by default).
 - Frontend dev: `cargo xtask dev` (Unix) builds the serve binary, then runs `aoe serve` (8081) and the Vite dev server (5173, HMR) together, pointing Vite at the backend via `VITE_PROXY` so `/api` and the `/sessions/*/ws` relays resolve; open `:5173`, Ctrl-C stops both. Or run them by hand: `cd web && npm run dev` plus a separate `cargo run --features serve -- serve`.
+- Web checks (CI gates all three on any `web/` change): `cd web && npm run format:check` (oxfmt, NOT prettier; `npm run format` to fix), `npm run lint` (ESLint), and `npx tsc -b` (typecheck, also part of `npm run build`). ESLint and tsc do not catch formatting; run oxfmt explicitly.
 - TUI-only `cargo build` (without `--features serve`) needs no JS tooling.
 
 ## Settings & Configuration
@@ -163,7 +164,7 @@ Full recipe, harness API, and fake-ACP-agent details live in `docs/development/p
 
 Before requesting review, every PR must clear:
 
-1. **`cargo fmt`, `cargo clippy`, `cargo test`** all clean (`--features serve` if the change touches the web dashboard or structured view).
+1. **`cargo fmt`, `cargo clippy`, `cargo test`** all clean (`--features serve` if the change touches the web dashboard or structured view). For any `web/` change, also **`cd web && npm run format:check && npm run lint`** (oxfmt + ESLint; both are CI gates, and neither ESLint nor tsc catches formatting).
 2. **Web tests when applicable.** If the change touches a user-facing dashboard flow listed in the coverage matrix mandate (auth, wizard, settings, profiles, sessions / sidebar, right panel / diff / notifications, directory browser, devices, git clone, connectivity, read-only), update `web/tests/coverage-matrix.json` and add or modify the appropriate Vitest / Playwright test. CI fails on a missing matrix entry.
 3. **Codecov checks.** See below.
 

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -26,13 +26,11 @@
 //!   `{"type":"window","lines":N}`: total capture window (history +
 //!     screen). Clamped to [screen rows, MAX_WINDOW_LINES].
 //!   `{"type":"cadence","fast":bool}`: capture cadence. Fast while the
-//!     client is at the live edge and visible; idle while backgrounded.
-//!   `{"type":"hold","hold":bool}`: freeze pushes while the client reads
-//!     scrollback. While held the loop skips captures entirely (zero
-//!     bandwidth, zero forks) except a single forced capture after a
-//!     window/resize change, so the client's full-history fetch still
-//!     gets its one frame. `hold:false` triggers an immediate fresh
-//!     capture so returning to the live edge repaints at once.
+//!     client is at the live edge and visible; idle while reading
+//!     scrollback or backgrounded. Like the TUI's live mode, the loop
+//!     keeps capturing while the user reads (the agent runs on); a
+//!     scrolled-up client just asks for a bigger window and renders it
+//!     against a stable position via its spacer model.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -80,8 +78,6 @@ enum LiveControlMessage {
     Window { lines: usize },
     #[serde(rename = "cadence")]
     Cadence { fast: bool },
-    #[serde(rename = "hold")]
-    Hold { hold: bool },
 }
 
 /// Shared per-connection knobs the recv loop writes and the capture
@@ -97,10 +93,6 @@ struct LiveSettings {
     /// Set once any resize has been applied; the disconnect path then
     /// restores `window-size latest`.
     resized: AtomicBool,
-    /// Freeze pushes while the client reads scrollback (see module docs).
-    hold: AtomicBool,
-    /// One capture is owed despite `hold` (window/resize changed).
-    force_once: AtomicBool,
 }
 
 pub async fn live_terminal_ws(
@@ -226,8 +218,6 @@ async fn handle_live_ws(
         screen_rows: AtomicU64::new(0),
         screen_cols: AtomicU64::new(0),
         resized: AtomicBool::new(false),
-        hold: AtomicBool::new(false),
-        force_once: AtomicBool::new(false),
     });
     // Wakes the capture loop out of its inter-capture sleep: after
     // dispatched input (echo latency) and after cadence/window changes.
@@ -250,20 +240,6 @@ async fn handle_live_ws(
         let mut dead_probes: u32 = 0;
         let mut last_reassert = std::time::Instant::now() - REASSERT_MIN_INTERVAL;
         loop {
-            // Held: skip the capture (and its tmux fork) entirely unless a
-            // window/resize change owes the client one frame. The
-            // inter-capture wait below still runs, so hold release (which
-            // nudges) is picked up promptly.
-            if capture_settings.hold.load(Ordering::Relaxed)
-                && !capture_settings.force_once.swap(false, Ordering::Acquire)
-            {
-                let ms = CAPTURE_INTERVAL_IDLE_MS;
-                tokio::select! {
-                    _ = tokio::time::sleep(Duration::from_millis(ms)) => {}
-                    _ = capture_nudge.notified() => {}
-                }
-                continue;
-            }
             let lines = capture_settings.window_lines.load(Ordering::Relaxed);
             let name = capture_tmux.clone();
             let captured = tokio::task::spawn_blocking(move || {
@@ -340,7 +316,16 @@ async fn handle_live_ws(
                 _ => break, // join error / capture error: bail quietly
             }
 
-            let ms = if capture_settings.fast.load(Ordering::Relaxed) {
+            // Fast cadence only makes sense for screen-sized windows. A
+            // wide window means a client reading scrollback; the new
+            // client requests idle cadence itself, but cap it here too so
+            // a stale PWA bundle (which spoke the retired hold protocol
+            // and never lowers cadence) cannot keep the server pushing
+            // multi-thousand-line frames at 20/s.
+            let screen = (capture_settings.screen_rows.load(Ordering::Relaxed) as usize)
+                .max(DEFAULT_WINDOW_LINES);
+            let small_window = capture_settings.window_lines.load(Ordering::Relaxed) <= screen * 4;
+            let ms = if capture_settings.fast.load(Ordering::Relaxed) && small_window {
                 CAPTURE_INTERVAL_FAST_MS
             } else {
                 CAPTURE_INTERVAL_IDLE_MS
@@ -432,7 +417,6 @@ async fn handle_live_ws(
                                 })
                                 .await;
                                 settings.resized.store(true, Ordering::Relaxed);
-                                settings.force_once.store(true, Ordering::Release);
                                 nudge.notify_one();
                             }
                             LiveControlMessage::Window { lines } => {
@@ -440,19 +424,11 @@ async fn handle_live_ws(
                                     .max(DEFAULT_WINDOW_LINES);
                                 let clamped = lines.clamp(floor, MAX_WINDOW_LINES);
                                 settings.window_lines.store(clamped, Ordering::Relaxed);
-                                settings.force_once.store(true, Ordering::Release);
                                 nudge.notify_one();
                             }
                             LiveControlMessage::Cadence { fast } => {
                                 settings.fast.store(fast, Ordering::Relaxed);
                                 if fast {
-                                    nudge.notify_one();
-                                }
-                            }
-                            LiveControlMessage::Hold { hold } => {
-                                settings.hold.store(hold, Ordering::Relaxed);
-                                if !hold {
-                                    // Repaint immediately on release.
                                     nudge.notify_one();
                                 }
                             }
@@ -489,8 +465,9 @@ async fn handle_live_ws(
     // `resized` is per-socket, so with two live viewers on one session the
     // first disconnect resets sizing out from under the survivor. That
     // self-heals: the survivor's capture loop re-asserts its grid on the
-    // next drift check (<= REASSERT_MIN_INTERVAL), and a held reader is
-    // rendering a frozen frame anyway and re-asserts on release. Tracking
+    // next drift check (<= REASSERT_MIN_INTERVAL), so the survivor renders
+    // at the wrong wrap width for at most that interval (and the client
+    // hard-wraps drifted frames rather than clipping). Tracking
     // last-resizer-standing across sockets isn't worth that transient.
     if settings.resized.load(Ordering::Relaxed) {
         let name = tmux_name.clone();
@@ -584,7 +561,5 @@ mod tests {
         let m: LiveControlMessage =
             serde_json::from_str(r#"{"type":"cadence","fast":false}"#).unwrap();
         assert!(matches!(m, LiveControlMessage::Cadence { fast: false }));
-        let m: LiveControlMessage = serde_json::from_str(r#"{"type":"hold","hold":true}"#).unwrap();
-        assert!(matches!(m, LiveControlMessage::Hold { hold: true }));
     }
 }

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -238,7 +238,11 @@ export function MobileLiveTerminal({
       // The user is reading scrollback; a keyboard transition there
       // must not yank them later.
       pendingHeightPinRef.current = false;
-    } else if (!movingUp && !touchActiveRef.current && (prev.target < 0 || pendingHeightPinRef.current || target > el.scrollTop)) {
+    } else if (
+      !movingUp &&
+      !touchActiveRef.current &&
+      (prev.target < 0 || pendingHeightPinRef.current || target > el.scrollTop)
+    ) {
       el.scrollTop = target;
       pendingHeightPinRef.current = false;
     }

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -15,27 +15,31 @@ import { useWebSettings } from "../hooks/useWebSettings";
 // Reading model (mirrors the TUI's "capture window follows the scroll
 // offset", adapted for a network hop):
 //
-//   live     — pinned to the bottom. The capture window is just the
-//              screen, so frames are small and fast.
-//   fetching — the user scrolled up. One window request covers the
-//              ENTIRE history; the spacer (sized from tmux's
-//              #{history_size}) already made the area scrollable, so a
-//              flick lands wherever it lands and the content fills in
-//              underneath it in one round trip.
-//   held     — the full-history frame arrived. The client freezes it
-//              and tells the server to stop pushing (`hold`), so the
-//              reading surface cannot move and zero bytes flow while
-//              reading. Returning to the bottom releases the hold; a
-//              fresh frame arrives in ~one capture interval.
+//   live    — pinned to the live edge. The capture window is just the
+//             screen, so frames are small and fast.
+//   reading — the user scrolled up. One window request covers the
+//             ENTIRE history; the spacer (sized from tmux's
+//             #{history_size}) already made the area scrollable, so a
+//             flick lands wherever it lands and the content fills in
+//             underneath it in one round trip. The stream keeps flowing
+//             at idle cadence (the agent runs on, like the TUI); there
+//             is no hold/freeze.
 //
-// Total scroll height is constant across all of this: spacer rows are
-// converted into real rows 1:1 as content arrives, so the browser's
-// preserved scrollTop keeps the same lines in view with no compensation.
+// The reading position is stable without a freeze because above-viewport
+// pixels are invariant by construction: spacer rows convert into real
+// rows 1:1 as content arrives, and when the agent appends k lines the
+// spacer grows by k while the capture window slides down by k, which
+// cancels. The browser-preserved scrollTop keeps the same lines in view
+// with no compensation.
 //
 // The soft keyboard never resizes tmux. Rows are derived from the
 // LARGEST container height seen for the current width (the no-keyboard
-// size); a keyboard cycle only shrinks the visible part of the
-// bottom-pinned scroller, exactly like a chat app.
+// size); a keyboard cycle only shrinks the visible part of the scroller.
+// While the keyboard has the container shrunk below that latched height,
+// the live-edge scroll target anchors the CURSOR near the viewport
+// bottom (see liveScrollTarget) so the agent's prompt stays in view; at
+// full height the target is the literal bottom and the whole screen is
+// visible, exactly like a terminal.
 
 const MIN_FONT_SIZE = 6;
 const MAX_FONT_SIZE = 28;
@@ -47,8 +51,9 @@ export interface MobileLiveTerminalProps {
   frame: LiveFrame | null;
   connected: boolean;
   active: boolean;
-  /** True while the hook's read machine is off the live edge; the frame
-   *  prop is then the frozen full-history snapshot. */
+  /** True while the user reads scrollback (off the live edge); the
+   *  capture window is widened and the jump-to-latest button shows.
+   *  The frame keeps streaming either way. */
   reading: boolean;
   sendResize: (cols: number, rows: number) => void;
   setWindow: (lines: number) => void;
@@ -151,8 +156,8 @@ export function MobileLiveTerminal({
   }, [remeasure]);
 
   // --- frame geometry -------------------------------------------------------
-  // The hook owns the read machine: `frame` is already the frozen
-  // snapshot while reading, the live stream otherwise.
+  // `frame` always tracks the live stream; reading scrollback just widens
+  // the capture window (the hook owns that). Nothing is frozen.
   const rowsRef = useRef(0);
   const readingRef = useRef(reading);
   useEffect(() => {
@@ -177,18 +182,68 @@ export function MobileLiveTerminal({
   // view back AND cancels iOS momentum, making scroll-up nearly
   // impossible to start. Upward motion since the last mutation means
   // the user is heading into scrollback; never pin against it.
-  const geomRef = useRef({ scrollHeight: 0, clientHeight: 0, scrollTop: 0 });
+  //
+  // The live-edge scroll target is the literal bottom, with ONE
+  // exception: while the soft keyboard has the container shrunk below
+  // the latched no-keyboard height, the screen is taller than the
+  // viewport and a fresh agent's literal bottom is blank rows with the
+  // prompt scrolled off the top. The target then anchors the CURSOR
+  // near the viewport bottom instead. The cursor (parked in the agent's
+  // input box) is the stable choice of anchor: pinning to the last
+  // non-blank row was tried and reverted, because capture-pane catches
+  // mid-repaint states whose lowest non-blank row jumps around
+  // (spinner / footer redraws), and every flutter moved the viewport.
+  const latchRef = useRef<{ width: number; maxHeight: number }>({ width: 0, maxHeight: 0 });
+  // Pixel top of the cursor row. Sticky across frames that momentarily
+  // hide the cursor (mid-redraw captures) so the target cannot flap.
+  const cursorAnchorRef = useRef<number | null>(null);
+  // The anchor is in pixels at the current line height; a font-scale
+  // change while the cursor is hidden would leave it in the old scale,
+  // so invalidate and wait for the next cursor-bearing frame.
+  useEffect(() => {
+    cursorAnchorRef.current = null;
+  }, [lineH]);
+  const liveScrollTarget = useCallback(
+    (el: HTMLDivElement) => {
+      const bottom = Math.max(0, el.scrollHeight - el.clientHeight);
+      const shrunken = latchRef.current.maxHeight - el.clientHeight > lineH * 1.5;
+      const anchor = cursorAnchorRef.current;
+      if (!shrunken || anchor == null) return bottom;
+      // One spare line under the cursor row keeps the input box border
+      // visible beneath it.
+      return Math.min(bottom, Math.max(0, anchor + 2 * lineH - el.clientHeight));
+    },
+    [lineH],
+  );
+  const geomRef = useRef({ target: -1, clientHeight: 0, scrollTop: 0 });
+  // A height change observed while pinning was suppressed (finger down,
+  // gesture in flight) would otherwise be consumed without effect and
+  // the cursor anchor never applied; latch it until a pin actually runs.
+  const pendingHeightPinRef = useRef(false);
   const pinIfWasAtBottom = useCallback(() => {
     const el = scrollerRef.current;
     if (!el) return;
     const prev = geomRef.current;
-    const wasAtBottom = prev.scrollHeight === 0 || prev.scrollHeight - el.scrollTop - prev.clientHeight < lineH * 1.5;
-    const movingUp = prev.scrollHeight !== 0 && el.scrollTop < prev.scrollTop - 0.5;
-    if (wasAtBottom && !movingUp && !touchActiveRef.current) {
-      el.scrollTop = el.scrollHeight;
+    const target = liveScrollTarget(el);
+    const wasAtLive = prev.target < 0 || el.scrollTop >= prev.target - lineH * 1.5;
+    const movingUp = prev.target >= 0 && el.scrollTop < prev.scrollTop - 0.5;
+    // Pin downward freely (following appended output); pin upward only
+    // when the viewport height changed (keyboard transition). An upward
+    // pin at constant height would yank a user who deliberately
+    // scrolled below the cursor anchor.
+    if (prev.target >= 0 && Math.abs(el.clientHeight - prev.clientHeight) > 1) {
+      pendingHeightPinRef.current = true;
     }
-    geomRef.current = { scrollHeight: el.scrollHeight, clientHeight: el.clientHeight, scrollTop: el.scrollTop };
-  }, [lineH]);
+    if (!wasAtLive) {
+      // The user is reading scrollback; a keyboard transition there
+      // must not yank them later.
+      pendingHeightPinRef.current = false;
+    } else if (!movingUp && !touchActiveRef.current && (prev.target < 0 || pendingHeightPinRef.current || target > el.scrollTop)) {
+      el.scrollTop = target;
+      pendingHeightPinRef.current = false;
+    }
+    geomRef.current = { target, clientHeight: el.clientHeight, scrollTop: el.scrollTop };
+  }, [lineH, liveScrollTarget]);
   const lines = useMemo(() => (frame ? ansiToLines(frame.content) : []), [frame]);
   // Columns this viewer renders at. Normally the pane is exactly this
   // wide and wrapping is the identity; when another writer resizes the
@@ -214,11 +269,32 @@ export function MobileLiveTerminal({
     rowsRef.current = screenRows || rowsRef.current;
   }, [screenRows]);
 
+  // Cursor cell -> visual overlay position. Shown only at the live edge;
+  // reading scrollback hides it. The pinning layout effect also feeds
+  // this position into cursorAnchorRef for the keyboard-shrunk target.
+  const live = useMemo(() => {
+    const cursor = !reading ? (frame?.cursor ?? null) : null;
+    let cursorTop = 0;
+    let cursorLeft = 0;
+    if (cursor) {
+      const lineIdx = Math.max(0, lines.length - screenRows) + cursor.y;
+      const baseRow = visual.lineStartRow[lineIdx] ?? visual.rows.length;
+      const cols = renderCols > 0 ? renderCols : Number.POSITIVE_INFINITY;
+      const wrapOffset = Number.isFinite(cols) ? Math.floor(cursor.x / cols) : 0;
+      cursorTop = (spacerLines + baseRow + wrapOffset) * lineH;
+      cursorLeft = (Number.isFinite(cols) ? cursor.x % cols : cursor.x) * charW;
+    }
+    return { cursor, cursorTop, cursorLeft };
+  }, [reading, frame, lines.length, screenRows, visual, renderCols, charW, spacerLines, lineH]);
+
   const atBottom = useCallback(() => {
     const el = scrollerRef.current;
     if (!el) return true;
-    return el.scrollHeight - el.scrollTop - el.clientHeight < lineH * 1.5;
-  }, [lineH]);
+    // At (or below) the live-edge target counts as live: scrolling down
+    // past a keyboard-shrunk cursor anchor into the screen's tail must
+    // not enter reading mode.
+    return el.scrollTop >= liveScrollTarget(el) - lineH * 1.5;
+  }, [lineH, liveScrollTarget]);
 
   const onScroll = useCallback(() => {
     if (!atBottom()) {
@@ -233,9 +309,9 @@ export function MobileLiveTerminal({
 
   const jumpToLatest = useCallback(() => {
     const el = scrollerRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (el) el.scrollTop = liveScrollTarget(el);
     returnToLive(rowsRef.current);
-  }, [returnToLive]);
+  }, [returnToLive, liveScrollTarget]);
 
   // --- pinch zoom (two-finger) ---------------------------------------------
   const pinchRef = useRef<{ startDist: number; startSize: number; changed: boolean } | null>(null);
@@ -299,10 +375,12 @@ export function MobileLiveTerminal({
   // --- grid sizing -----------------------------------------------------------
   // Rows come from the LATCHED maximum container height for the current
   // width, so a soft-keyboard cycle (which shrinks the container) never
-  // resizes tmux; the bottom-pinned scroller just shows fewer rows of an
-  // unchanged screen. The latch resets when the width changes
-  // (rotation, sidebar) or the font scale changes the grid anyway.
-  const latchRef = useRef<{ width: number; maxHeight: number }>({ width: 0, maxHeight: 0 });
+  // resizes tmux; the scroller just shows fewer rows of an unchanged
+  // screen, anchored at the cursor (see liveScrollTarget). The latch
+  // resets when the width changes (rotation, sidebar) or the font scale
+  // changes the grid anyway. Resizing tmux on every keyboard cycle was
+  // tried and reverted: on the capture+network path it flashed the pane
+  // (blank-then-redraw) and clipped scrollback.
   useEffect(() => {
     const el = scrollerRef.current;
     if (!el || !active) return;
@@ -344,22 +422,30 @@ export function MobileLiveTerminal({
     };
   }, [active, charW, lineH, sendResize, setWindow, pinIfWasAtBottom]);
 
-  // Cadence: fast only while this pane is the active, visible surface.
+  // Cadence: fast only while this pane is the active, visible surface AND
+  // at the live edge. Reading scrollback drops to idle: the window is
+  // wide (big frames), and the reader is not watching the live tail.
   useEffect(() => {
-    const sync = () => setCadence(active && document.visibilityState === "visible");
+    const sync = () => setCadence(active && document.visibilityState === "visible" && !reading);
     sync();
     document.addEventListener("visibilitychange", sync);
     return () => document.removeEventListener("visibilitychange", sync);
-  }, [active, setCadence]);
+  }, [active, reading, setCadence]);
 
   // --- bottom pinning ---------------------------------------------------------
   useLayoutEffect(() => {
+    // Refresh the cursor anchor before pinning so this commit pins
+    // against the current frame's cursor. Sticky on purpose: a
+    // mid-redraw capture that momentarily hides the cursor keeps the
+    // last known anchor instead of flapping the target to the literal
+    // bottom and back.
+    if (live.cursor) cursorAnchorRef.current = live.cursorTop;
     pinIfWasAtBottom();
     // When not pinned, scrollTop is left alone. Above-viewport height is
     // invariant (spacer rows convert to content rows 1:1; appends only
     // extend the bottom), so the browser-preserved offset keeps the
     // same lines in view.
-  }, [lines, spacerLines, lineH, pinIfWasAtBottom]);
+  }, [lines, spacerLines, lineH, live, pinIfWasAtBottom]);
 
   // --- keyboard input -----------------------------------------------------------
   const composingRef = useRef(false);
@@ -481,18 +567,8 @@ export function MobileLiveTerminal({
     [sendKeys, inputRef],
   );
 
-  // --- cursor overlay (live edge only; a frozen snapshot has no cursor) -------
-  const cursor = !reading ? (frame?.cursor ?? null) : null;
-  let cursorTop = 0;
-  let cursorLeft = 0;
-  if (cursor) {
-    const lineIdx = Math.max(0, lines.length - screenRows) + cursor.y;
-    const baseRow = visual.lineStartRow[lineIdx] ?? visual.rows.length;
-    const cols = renderCols > 0 ? renderCols : Number.POSITIVE_INFINITY;
-    const wrapOffset = Number.isFinite(cols) ? Math.floor(cursor.x / cols) : 0;
-    cursorTop = (spacerLines + baseRow + wrapOffset) * lineH;
-    cursorLeft = (Number.isFinite(cols) ? cursor.x % cols : cursor.x) * charW;
-  }
+  // Cursor overlay geometry (computed in the `live` memo above).
+  const { cursor, cursorTop, cursorLeft } = live;
 
   return (
     <div className="absolute inset-0" data-live-terminal>

--- a/web/src/hooks/useLiveTerminal.ts
+++ b/web/src/hooks/useLiveTerminal.ts
@@ -36,11 +36,13 @@ export interface LiveTerminalState {
   reconnecting: boolean;
   retryCount: number;
   retryCountdown: number;
-  /** Frame to RENDER. While reading scrollback this is the frozen
-   *  full-history snapshot; at the live edge it tracks the stream. */
+  /** Frame to RENDER. Always tracks the stream (the agent keeps running
+   *  while you read, like the TUI's live mode); reading scrollback just
+   *  asks for a bigger capture window. */
   frame: LiveFrame | null;
   /** True from the moment the user leaves the live edge until they
-   *  return: drives the jump-to-latest affordance. */
+   *  return: widens the capture window and drives the jump-to-latest
+   *  affordance. */
   reading: boolean;
 }
 
@@ -52,14 +54,6 @@ const INITIAL_STATE: LiveTerminalState = {
   frame: null,
   reading: false,
 };
-
-/** Cheap line count for the freeze trigger; capture content terminates
- *  every line with `\n`, so count terminators. */
-function contentLineCount(content: string): number {
-  let n = 0;
-  for (let i = 0; i < content.length; i++) if (content.charCodeAt(i) === 10) n++;
-  return n;
-}
 
 export function useLiveTerminal(sessionId: string | null, wsPath: string = "live-ws") {
   const wsRef = useRef<WebSocket | null>(null);
@@ -74,18 +68,10 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
     resize: { cols: number; rows: number } | null;
     window: number | null;
     fast: boolean;
-    hold: boolean;
-  }>({ resize: null, window: null, fast: true, hold: false });
-  // Scrollback read machine (see LiveTerminalState.reading). "fetching"
-  // means the full-history window was requested and the next covering
-  // frame will be frozen; "held" means the server push-freeze is active.
-  const readPhaseRef = useRef<"live" | "fetching" | "held">("live");
-  // Freeze threshold: the requested window, capped by what the pane can
-  // actually provide (rows + history at request time).
-  const fetchTargetRef = useRef(0);
-  // Newest frame from the wire, regardless of freeze state, so returning
-  // to the live edge can repaint instantly while a fresh frame arrives.
-  const latestFrameRef = useRef<LiveFrame | null>(null);
+  }>({ resize: null, window: null, fast: true });
+  // Whether the user is reading scrollback (off the live edge). Guards
+  // enterReading/returnToLive against repeat fires from scroll events.
+  const readingRef = useRef(false);
 
   const storeRef = useRef<{
     snapshot: LiveTerminalState;
@@ -107,6 +93,17 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
   }, []);
   const getSnapshot = useCallback(() => storeRef.current!.snapshot, []);
   const state = useSyncExternalStore(subscribe, getSnapshot);
+
+  // Declared ahead of the connect effect: the onmessage handler widens
+  // the window while reading (see below).
+  const setWindowInternal = (lines: number) => {
+    if (desiredRef.current.window === lines) return;
+    desiredRef.current.window = lines;
+    const ws = wsRef.current;
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "window", lines }));
+    }
+  };
 
   useEffect(() => {
     if (!sessionId) return;
@@ -152,9 +149,6 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
           ws.send(JSON.stringify({ type: "window", lines: desired.window }));
         }
         ws.send(JSON.stringify({ type: "cadence", fast: desired.fast }));
-        if (desired.hold) {
-          ws.send(JSON.stringify({ type: "hold", hold: true }));
-        }
       };
 
       let hasReceivedData = false;
@@ -185,27 +179,19 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
           history: msg.history ?? 0,
           cursor: msg.cursor ?? null,
         };
-        latestFrameRef.current = incoming;
-        if (readPhaseRef.current === "held") {
-          // Frozen: the rendered frame must not move under the reader.
-          // (The server holds pushes anyway; this guards stragglers.)
-          setState((prev) => ({
-            ...prev,
-            retryCount: retryCountRef.current,
-            retryCountdown: 0,
-          }));
-          return;
+        // While reading, keep the capture window covering the FULL
+        // history as the agent appends: the window was sized at entry,
+        // so without this the oldest lines fall out of the capture and
+        // re-render as blank spacer under the reader. Deduped, so it is
+        // one control message per growth step at idle cadence.
+        if (readingRef.current) {
+          const full = Math.min(4000, incoming.rows + incoming.history);
+          if (full > (desiredRef.current.window ?? 0)) setWindowInternal(full);
         }
-        if (
-          readPhaseRef.current === "fetching" &&
-          contentLineCount(incoming.content) >= Math.min(fetchTargetRef.current, incoming.rows + incoming.history)
-        ) {
-          // This frame covers the requested history: freeze it and stop
-          // the server's pushes until the reader returns to the edge.
-          readPhaseRef.current = "held";
-          desiredRef.current.hold = true;
-          ws.send(JSON.stringify({ type: "hold", hold: true }));
-        }
+        // Always render the freshest frame. While reading scrollback the
+        // window is wider, but the component's spacer model keeps the
+        // user's position stable as the agent streams (above-viewport
+        // pixels are invariant), so no freeze is needed.
         setState((prev) => ({
           ...prev,
           retryCount: retryCountRef.current,
@@ -311,14 +297,6 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
     }
   }, []);
 
-  const setWindowInternal = (lines: number) => {
-    if (desiredRef.current.window === lines) return;
-    desiredRef.current.window = lines;
-    const ws = wsRef.current;
-    if (ws?.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "window", lines }));
-    }
-  };
   const setWindow = useCallback((lines: number) => {
     setWindowInternal(lines);
   }, []);
@@ -332,34 +310,30 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
     }
   }, []);
 
-  /** The user left the live edge: request the full history once; the
-   *  covering frame freezes and the server push-freezes (see onmessage). */
+  /** The user left the live edge: widen the capture window to the full
+   *  history once so a flick lands on real content (the spacer is
+   *  already sized for it). The stream keeps flowing; the component's
+   *  spacer keeps the reading position stable. */
   const enterReading = useCallback(
     (rows: number) => {
-      if (readPhaseRef.current !== "live") return;
-      const latest = latestFrameRef.current;
+      if (readingRef.current) return;
+      readingRef.current = true;
+      const latest = storeRef.current!.snapshot.frame;
       const full = Math.min(4000, Math.max(rows, latest ? latest.rows + latest.history : rows));
-      readPhaseRef.current = "fetching";
-      fetchTargetRef.current = full;
       setWindowInternal(full);
       setState((prev) => ({ ...prev, reading: true }));
     },
     [setState],
   );
 
-  /** Back at the live edge: release the hold, shrink the window, and
-   *  resume rendering the freshest frame immediately. */
+  /** Back at the live edge: shrink the window to the live screen so the
+   *  next frame is small again. */
   const returnToLive = useCallback(
     (rows: number) => {
-      if (readPhaseRef.current === "live") return;
-      readPhaseRef.current = "live";
-      desiredRef.current.hold = false;
-      const ws = wsRef.current;
-      if (ws?.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: "hold", hold: false }));
-      }
+      if (!readingRef.current) return;
+      readingRef.current = false;
       if (rows > 0) setWindowInternal(rows);
-      setState((prev) => ({ ...prev, reading: false, frame: latestFrameRef.current ?? prev.frame }));
+      setState((prev) => ({ ...prev, reading: false }));
     },
     [setState],
   );

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -75,7 +75,11 @@
       "id": "terminal.mobile-live-view",
       "kind": "mocked-playwright",
       "risk": "high",
-      "specs": ["tests/mobile-dom-renderer.spec.ts"],
+      "specs": [
+        "tests/mobile-dom-renderer.spec.ts",
+        "tests/keyboard-auto-resize.spec.ts",
+        "tests/mobile-keyboard.spec.ts"
+      ],
       "components": [
         "web/src/components/MobileLiveTerminal.tsx",
         "web/src/components/LiveTerminalView.tsx",

--- a/web/tests/keyboard-auto-resize.spec.ts
+++ b/web/tests/keyboard-auto-resize.spec.ts
@@ -3,20 +3,19 @@ import { devices, type Page } from "@playwright/test";
 import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
 import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
 
-// #1432: the mobile terminal auto-resizes as the soft keyboard opens/closes.
+// #1432: the soft keyboard shrinks the mobile terminal visually but never
+// resizes tmux. Rows are latched to the no-keyboard height, so a keyboard
+// cycle only shrinks the visible part of the scroller; while shrunk, the
+// live-edge scroll target anchors the CURSOR near the viewport bottom, so the
+// agent's prompt stays in view instead of scrolling off the top behind a tail
+// of blank rows.
 //
-// The pane is padded by the LIVE cross-platform keyboard occlusion
-// (stableFullHeight - visualViewport.height), so opening the keyboard shrinks
-// the terminal and closing it grows it back. The previous design latched a
-// fixed reservation and required a manual fullscreen FAB to reclaim space; that
-// reservation, its localStorage seed, and the FAB are gone.
-//
-// The occlusion commit is DEBOUNCED in useMobileKeyboard, so each open/close
-// produces a single PTY resize (a bounded couple, allowing for ResizeObserver
-// noise), not one per animation frame. iOS PWA / iOS 26 Safari shrink
-// innerHeight with the keyboard; App.tsx still pins the root to a measured
-// pixel height so occlusion padding (not a shrinking root) is the one thing
-// that moves the terminal, keeping the behavior identical across platforms.
+// Resizing tmux on every keyboard cycle was tried and reverted: on the
+// capture+network path it flashed the pane (blank-then-redraw) and clipped
+// scrollback. The pane is padded by the LIVE cross-platform keyboard occlusion
+// (stableFullHeight - visualViewport.height) on iOS regular Safari, where the
+// layout viewport does not shrink; on iOS PWA / iOS 26 / Android, 100dvh
+// shrinks natively and the live view adds no inset of its own.
 
 test.use({ ...devices["iPhone 13"] });
 
@@ -110,8 +109,8 @@ test.describe("Keyboard auto-resize (#1432)", () => {
     // iOS regular Safari: the layout viewport does not shrink with the
     // keyboard, so the live view insets itself by the visualViewport
     // delta. The pane shrinks visually, but rows are latched to the
-    // no-keyboard height, so tmux must NOT be resized: the live screen
-    // is bottom-pinned and simply shows fewer rows, like a chat app.
+    // no-keyboard height, so tmux must NOT be resized: the scroller
+    // pins to the live content and simply shows fewer rows.
     await setKeyboard(page, { open: true, px: 320, pwa: false });
     await page.waitForTimeout(800);
 
@@ -126,6 +125,32 @@ test.describe("Keyboard auto-resize (#1432)", () => {
 
     expect(await paneHeight(page)).toBeGreaterThanOrEqual(paneHeightBefore - 2);
     expect(extractResizes(handle).length, "keyboard close must not emit a tmux resize").toBe(baselineCount);
+  });
+
+  test("Safari mode: the prompt cursor stays visible in the keyboard-shrunk viewport", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page, handle);
+    await page.waitForTimeout(1000);
+
+    // The mock screen is a fresh-agent shape: prompt + cursor on the
+    // FIRST screen row, blank rows below. With rows latched, the screen
+    // is now taller than the shrunk viewport; a literal bottom pin would
+    // show only the blank tail and scroll the prompt off the top (the
+    // original bug). The live-edge target must anchor the cursor near
+    // the viewport bottom instead.
+    await setKeyboard(page, { open: true, px: 320, pwa: false });
+    await page.waitForTimeout(800);
+
+    const m = await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>("[data-live-terminal] > div");
+      const cur = el?.querySelector<HTMLElement>("[data-live-cursor]");
+      if (!el || !cur) return null;
+      return { cursorTop: cur.offsetTop, scrollTop: el.scrollTop, clientHeight: el.clientHeight };
+    });
+    expect(m, "live cursor is rendered").not.toBeNull();
+    expect(m!.cursorTop, "cursor is not above the viewport").toBeGreaterThanOrEqual(m!.scrollTop - 2);
+    expect(m!.cursorTop, "cursor is not below the viewport").toBeLessThanOrEqual(m!.scrollTop + m!.clientHeight);
   });
 
   test("PWA mode: dvh shrink owns the layout; no inset, no tmux resize", async ({ page }) => {

--- a/web/tests/scrollback-exit.spec.ts
+++ b/web/tests/scrollback-exit.spec.ts
@@ -147,7 +147,7 @@ test.describe("Mobile live-view scrollback", () => {
     expect(after, "the scroller must not be pinned back to the bottom").toBeLessThanOrEqual(nudged);
   });
 
-  test("reading freezes the stream via hold; returning releases it", async ({ page }) => {
+  test("reading keeps the stream flowing (no hold/freeze)", async ({ page }) => {
     await installTerminalSpies(page);
     const handle = await mockTerminalApis(page);
     await page.goto("/");
@@ -155,23 +155,32 @@ test.describe("Mobile live-view scrollback", () => {
     await page.reload();
     await openSession(page, handle);
 
-    // Scrolling up requests the full history; once the covering frame
-    // arrives the client holds the server's pushes (zero bandwidth, a
-    // perfectly still reading surface, agent untouched).
+    // Scrolling up widens the capture window but never freezes the pane:
+    // mirroring the TUI's live mode, the agent keeps running and frames
+    // keep arriving while the user reads. The client must NOT send a
+    // hold (the whole freeze path is gone); it drops cadence to idle.
     await scroller(page).evaluate((el) => {
       el.scrollTop = 0;
     });
     await expect
-      .poll(() => textMessages(handle).filter((m) => m.includes('"hold":true')).length, { timeout: 3_000 })
+      .poll(() => textMessages(handle).filter((m) => m.includes('"type":"window"')).length, { timeout: 3_000 })
       .toBeGreaterThan(0);
-
-    // Returning to live releases the hold so a fresh frame repaints.
-    await page.getByRole("button", { name: "Back to live" }).tap();
     await expect
       .poll(() => {
-        const msgs = textMessages(handle).filter((m) => m.includes('"type":"hold"'));
+        const msgs = textMessages(handle).filter((m) => m.includes('"type":"cadence"'));
         return msgs[msgs.length - 1] ?? "";
       })
-      .toContain('"hold":false');
+      .toContain('"fast":false');
+
+    const all = textMessages(handle).join("");
+    expect(all, "the hold control message is retired").not.toContain('"type":"hold"');
+
+    // A streamed frame still renders while reading (pane is not frozen).
+    handle.pushLiveFrame({
+      content: Array.from({ length: 24 }, (_, n) => `still streaming ${n}`).join("\n") + "\n",
+      rows: 24,
+      history: 200,
+    });
+    await expect.poll(() => page.locator("[data-live-content]").innerText()).toContain("still streaming");
   });
 });


### PR DESCRIPTION
## Description

Two device-reported problems in the mobile live terminal view:

1. **Opening the soft keyboard hid the agent's input box.** The viewport bottom-pinned onto the tmux screen's blank tail, so on a fresh session (where Claude draws its prompt near the top) the input box scrolled off the top and stayed there.
2. **Scrolling up froze the pane.** The hold protocol stopped all frames behind the Back-to-live button until you returned to the live edge, so you could not watch the agent while reading scrollback.

What changed:

- **Cursor-anchored pinning under the keyboard.** The live-edge scroll target is the literal bottom at full height (identical to the shipped behavior), but while the keyboard has the container shrunk below the latched no-keyboard height, it anchors the cursor near the viewport bottom (`liveScrollTarget` in `MobileLiveTerminal.tsx`). The cursor is the stable anchor: two alternatives were tried on device and reverted, resizing tmux per keyboard cycle (blank-then-redraw flash over the capture+network gap, clipped scrollback) and pinning to the last non-blank row (capture-pane catches mid-repaint states, so the viewport jittered). The soft keyboard still never resizes tmux.
- **The hold/freeze reading model is deleted on both sides** (`live_ws.rs` + `useLiveTerminal.ts`). Frames keep streaming while reading at idle cadence, mirroring the TUI's live mode; the spacer model keeps the reading position stable without a freeze. While reading, the client re-widens the capture window as history grows so the oldest lines do not decay into blank spacer, and the server caps fast cadence to screen-sized windows so a stale PWA bundle speaking the retired hold protocol cannot keep it pushing full-history frames at 20/s.
- **Hardened from adversarial review:** keyboard height changes observed while a touch gesture suppresses pinning are latched until a pin can run, and the pixel-scale cursor anchor invalidates on font-scale changes.

Known limitation, matching the TUI's reading semantics: when tmux history is at its limit, the reading position drifts while the agent streams (`history_size` plateaus, so the spacer cannot absorb appends).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No recording attached: the behaviors (soft-keyboard viewport shrink, capture flutter, touch momentum) do not reproduce in emulation; @njbrake verified all three flows on a real device (fresh session + keyboard, busy session at rest, scroll-up reading while streaming).

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

New/updated mocked specs: `keyboard-auto-resize.spec.ts` gains "the prompt cursor stays visible in the keyboard-shrunk viewport" (the regression test for bug 1) and keeps the never-resizes-tmux assertions; `scrollback-exit.spec.ts` replaces the hold round-trip test with "reading keeps the stream flowing (no hold/freeze)" plus an assertion that the hold control message is retired. Matrix: both keyboard specs added to the `terminal.mobile-live-view` surface.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Test runs: `cargo fmt`, `cargo clippy --features serve`, `cargo test --features serve` (3883 passed; 1 pre-existing failure, `test_update_write_failure_emits_no_notify`, the chmod-based root-environment artifact also noted in #2085, unrelated to this diff), vitest 1827 passed, coverage-matrix validation passed. Mocked Playwright could not run in the dev sandbox (unsupported arch for Playwright browsers); CI is its first run.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Fable 5; one earlier iteration round by Opus 4.8)

**Any Additional AI Details you'd like to share:**
Implemented via iterative on-device testing with @njbrake: two candidate fixes were built, device-tested, and reverted before this design. An adversarial review subagent surfaced the reading-window decay, the touch-suppressed height-pin race, and the stale-client cadence hole, all fixed here; it also identified the history-saturation drift documented above as a known limitation.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783698638&installation_id=139138837&pr_number=2087&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2087&signature=5b8f92ab0f96e891b8496b4b50a2c8d0c12aa3271e5bc81829e800634cbad8f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR fixes two critical mobile terminal issues by removing the "hold/freeze" streaming mechanism and adding keyboard-aware positioning for the input cursor.

### Removed
- **Hold/Freeze Protocol**: The server (live_ws.rs) and client (useLiveTerminal.ts) no longer stop streaming frames when users read scrollback history. Instead, frames continue to stream at an idle cadence while users browse previous output.

### Added
- **Cursor Anchor Positioning**: When the soft keyboard shrinks the viewport, the live-edge scroll target now anchors near the cursor position rather than staying at the absolute bottom, keeping the input/cursor visible on screen.
- **Window-Widening Approach**: When reading scrollback, the client gradually expands the capture window to cover both the live pane and growing history, with the server capping fast cadence for backward compatibility.
- **Test Coverage**: New Playwright specs verify keyboard behavior (`keyboard-auto-resize.spec.ts`) and confirm streaming continues while reading (`scrollback-exit.spec.ts`).

### Updated
- **CI Documentation**: `AGENTS.md` now explicitly requires running `npm run format:check` and `npm run lint` for web changes as part of the definition-of-done.

## Benefits

- **Uninterrupted Streaming**: Users can read historical output without freezing the agent's live stream.
- **Keyboard-Friendly Input**: The input prompt stays visible even when the soft keyboard opens, improving usability on mobile.
- **Better Readback Experience**: Streaming continues at a controlled cadence during history reads, eliminating the "frozen during scrollback" experience.

## Technical Details

The streaming model shifted from an explicit hold/freeze mechanism to a continuous frame pipeline with intelligent cadence management. Fast capture is now gated by window size (preventing high-rate multi-thousand-line frames) and client state (active, visible, not reading). On the UI side, the scroll positioning uses a computed `liveScrollTarget` that can anchor to the cursor when the keyboard reduces the viewport, with cursor geometry memoized to improve performance. The window-widening logic incrementally expands the capture request (capped at 4000 lines) to prevent reader spacer drift as the agent appends output. All hardening includes latching keyboard-height changes during touch suppression and invalidating pixel-scale cursor anchors on font changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->