### PR TITLE
fix(tui): advance the cursor to the next session on archive

### DIFF
--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2924,9 +2924,11 @@ impl HomeView {
     }
 
     /// Expand the synthetic Archived section if it is collapsed, persisting
-    /// the change. Used when archiving a session in the non-Attention sort so
-    /// the freshly archived row is visible and can stay selected under the
-    /// cursor. No-op (and no save) when the section is already open.
+    /// the change. Used when archiving a whole group, where the rows the
+    /// user was looking at all sink at once and revealing the section shows
+    /// where they went. Single-row archive does NOT reveal: the cursor
+    /// advances to the next active session instead and the section header's
+    /// count is the feedback. No-op (and no save) when already open.
     pub(super) fn reveal_archived_section(&mut self) {
         if !self.archived_section_collapsed {
             return;

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1143,11 +1143,8 @@ impl HomeView {
             if id == archiving_id {
                 return None;
             }
-            self.instances
-                .iter()
-                .find(|i| &i.id == id)
-                .filter(|i| !i.is_archived())
-                .map(|i| i.id.clone())
+            let inst = self.instances.iter().find(|i| &i.id == id)?;
+            (!inst.is_archived()).then(|| id.clone())
         };
         for item in self.flat_items.iter().skip(self.cursor + 1) {
             if let Some(id) = candidate(item) {

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1,7 +1,7 @@
 //! Session operations for HomeView (create, delete, rename)
 
 use crate::session::builder::{self, InstanceParams};
-use crate::session::{list_profiles, GroupTree, Status, Storage};
+use crate::session::{list_profiles, GroupTree, Item, Status, Storage};
 use crate::tui::deletion_poller::DeletionRequest;
 use crate::tui::dialogs::{DeleteOptions, GroupDeleteOptions, NewSessionData};
 
@@ -1128,6 +1128,40 @@ impl HomeView {
         Ok(())
     }
 
+    /// The session the cursor should land on after the cursor's row is
+    /// archived away: the nearest non-archived session below the cursor,
+    /// else the nearest one above. `None` when the archiving row is the
+    /// only active session (the caller falls back to an index clamp).
+    /// Scans the pre-archive flat list, so it walks exactly the rows the
+    /// user sees; archived rows already parked under the Archived section
+    /// are skipped so the cursor never advances into it.
+    fn archive_successor_session(&self, archiving_id: &str) -> Option<String> {
+        let candidate = |item: &Item| -> Option<String> {
+            let Item::Session { id, .. } = item else {
+                return None;
+            };
+            if id == archiving_id {
+                return None;
+            }
+            self.instances
+                .iter()
+                .find(|i| &i.id == id)
+                .filter(|i| !i.is_archived())
+                .map(|i| i.id.clone())
+        };
+        for item in self.flat_items.iter().skip(self.cursor + 1) {
+            if let Some(id) = candidate(item) {
+                return Some(id);
+            }
+        }
+        for item in self.flat_items.iter().take(self.cursor).rev() {
+            if let Some(id) = candidate(item) {
+                return Some(id);
+            }
+        }
+        None
+    }
+
     /// Handle the archive keybind on the cursor's session. Symmetric toggle:
     /// archive an active row, unarchive an archived one. Killing the tmux
     /// pane on archive matches the CLI semantics (archived means "stop
@@ -1169,6 +1203,10 @@ impl HomeView {
             }
         }
 
+        // Decide where the cursor lands BEFORE the row sinks, against the
+        // pre-archive list the user is actually looking at.
+        let successor = self.archive_successor_session(&id);
+
         self.apply_user_action(&id, |inst| inst.archive())?;
         if self.sort_order == crate::session::config::SortOrder::Attention {
             // Attention sort is a triage flow: archiving sinks the row and the
@@ -1178,15 +1216,28 @@ impl HomeView {
             self.flat_items = self.build_flat_items();
             self.select_top_attention(None);
         } else {
-            // Keep the just-archived session selected instead of letting the
-            // cursor snap to whatever neighbor slid into its slot. Reveal the
-            // Archived section so the row is visible, rebuild, then re-seat the
-            // cursor onto it. The preview then renders a calm "Archived"
-            // placeholder (render_archived_preview) instead of the killed
-            // pane's "No output available", and a second `z` unarchives it.
-            self.reveal_archived_section();
+            // Advance to the next session instead of following the archived
+            // row into the Archived section: archiving reads as "I'm done
+            // with this one", so the cursor stays up in the active list and
+            // moves on. The preview retargets on its own: `render_preview`
+            // re-derives the capture target from `selected_session` every
+            // frame, the cache gates on a session-id mismatch, and the
+            // capture worker drops stale frames on retarget, so the pane
+            // tracks the new selection without the dead-pane flash that
+            // motivated the old follow-the-row behavior (#2025). The
+            // Archived section is not auto-revealed; its header already
+            // shows the updated count as feedback.
             self.flat_items = self.build_flat_items();
-            self.select_session_by_id(&id);
+            match successor {
+                Some(next) => self.select_session_by_id(&next),
+                None => {
+                    // No other active session: clamp and let
+                    // `update_selected` resolve whatever sits at the cursor
+                    // now (typically the Archived section header).
+                    self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
+                    self.update_selected();
+                }
+            }
         }
         Ok(())
     }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1130,9 +1130,11 @@ impl HomeView {
 
     /// The session the cursor should land on after the cursor's row is
     /// archived away: the nearest non-archived session below the cursor,
-    /// else the nearest one above. `None` when the archiving row is the
-    /// only active session (the caller falls back to an index clamp).
-    /// Scans the pre-archive flat list, so it walks exactly the rows the
+    /// else the nearest one above. `None` when no other active session is
+    /// VISIBLE (the caller falls back to an index clamp); active sessions
+    /// hidden inside collapsed groups are deliberately not candidates, so
+    /// archiving never yanks the cursor into a group the user folded away.
+    /// Scans the pre-archive flat list, so it walks the rows the
     /// user sees; archived rows already parked under the Archived section
     /// are skipped so the cursor never advances into it.
     fn archive_successor_session(&self, archiving_id: &str) -> Option<String> {
@@ -1201,8 +1203,11 @@ impl HomeView {
         }
 
         // Decide where the cursor lands BEFORE the row sinks, against the
-        // pre-archive list the user is actually looking at.
-        let successor = self.archive_successor_session(&id);
+        // pre-archive list the user is actually looking at. Only the
+        // non-Attention branch consumes it; Attention re-picks from the top.
+        let successor = (self.sort_order != crate::session::config::SortOrder::Attention)
+            .then(|| self.archive_successor_session(&id))
+            .flatten();
 
         self.apply_user_action(&id, |inst| inst.archive())?;
         if self.sort_order == crate::session::config::SortOrder::Attention {
@@ -1212,6 +1217,16 @@ impl HomeView {
             // dead-pane/selection-swap jank the default sort did.
             self.flat_items = self.build_flat_items();
             self.select_top_attention(None);
+            // select_top_attention is a no-op when no session row is visible
+            // (the archived row sank into a collapsed Archived section and
+            // nothing else is left), which would strand `selected_session`
+            // on the now-invisible archived row and leave the cursor index
+            // past the shrunken list. Clamp and re-resolve, mirroring the
+            // non-Attention fallback below.
+            if self.selected_session.as_deref() == Some(id.as_str()) {
+                self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
+                self.update_selected();
+            }
         } else {
             // Advance to the next session instead of following the archived
             // row into the Archived section: archiving reads as "I'm done

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5364,6 +5364,8 @@ fn toggle_favorite_at_cursor_noop_with_no_selection() {
 #[serial]
 fn toggle_archive_at_cursor_round_trip() {
     let mut env = create_test_env_with_sessions(1);
+    // Keep the Archived section expanded so the archived row stays reachable.
+    env.view.archived_section_collapsed = false;
     let id = env.view.instances[0].id.clone();
     env.view.selected_session = Some(id.clone());
 
@@ -5373,6 +5375,10 @@ fn toggle_archive_at_cursor_round_trip() {
     env.view.toggle_archive_at_cursor().unwrap();
     assert!(env.view.instances[0].is_archived());
 
+    // Archiving moved the selection off the row (it advances to the next
+    // active session; here there is none). Navigate back onto the archived
+    // row, as a user would, before toggling it back.
+    env.view.select_session_by_id(&id);
     env.view.toggle_archive_at_cursor().unwrap();
     assert!(!env.view.instances[0].is_archived());
 }
@@ -5386,21 +5392,24 @@ fn toggle_archive_at_cursor_noop_with_no_selection() {
     env.view.toggle_archive_at_cursor().unwrap();
 }
 
-/// Approach 2: archiving in the default (non-Attention) sort keeps the cursor
-/// AND selection on the just-archived session instead of swapping to a
-/// neighbor, and reveals the Archived section so the row stays visible. This is
-/// what lets the preview render the calm "Archived" placeholder for the same
-/// row the user is looking at, rather than flashing a dead-pane warning and
-/// then snapping selection to the session below.
+/// Archiving in the default (non-Attention) sort advances the cursor to the
+/// next active session below instead of following the archived row into the
+/// Archived section. The section is NOT auto-revealed; its header count is
+/// the feedback. The preview follows the new selection through the normal
+/// per-frame retarget (cache gates on session id, worker drops stale frames).
 #[test]
 #[serial]
-fn archive_keeps_selection_and_reveals_section() {
-    let mut env = create_test_env_with_sessions(2);
-    // Start with the Archived section collapsed (the default / reported repro).
+fn archive_advances_cursor_to_next_session() {
+    let mut env = create_test_env_with_sessions(3);
+    // Start with the Archived section collapsed (the default).
     env.view.archived_section_collapsed = true;
     env.view.cursor = 0;
     env.view.update_selected();
     let id = env.view.selected_session.clone().unwrap();
+    let next_id = match env.view.flat_items.get(1) {
+        Some(Item::Session { id, .. }) => id.clone(),
+        other => panic!("expected a session row below the cursor, got {other:?}"),
+    };
 
     env.view.toggle_archive_at_cursor().unwrap();
 
@@ -5410,19 +5419,70 @@ fn archive_keeps_selection_and_reveals_section() {
     );
     assert_eq!(
         env.view.selected_session.as_deref(),
-        Some(id.as_str()),
-        "selection must stay on the archived session, not swap to a neighbor"
+        Some(next_id.as_str()),
+        "selection must advance to the next active session"
     );
     assert!(
-        !env.view.archived_section_collapsed,
-        "archiving must reveal the Archived section so the row stays visible"
+        env.view.archived_section_collapsed,
+        "single-row archive must not auto-reveal the Archived section"
     );
     match env.view.flat_items.get(env.view.cursor) {
         Some(Item::Session { id: cur, .. }) => {
-            assert_eq!(cur, &id, "cursor must land on the archived row")
+            assert_eq!(cur, &next_id, "cursor must sit on the next session's row")
         }
-        _ => panic!("cursor should be on the archived session row"),
+        _ => panic!("cursor should be on the next session row"),
     }
+}
+
+/// Archiving the bottom session has no row below to advance to, so the
+/// cursor falls back to the nearest active session above.
+#[test]
+#[serial]
+fn archive_bottom_row_falls_back_to_session_above() {
+    let mut env = create_test_env_with_sessions(2);
+    env.view.archived_section_collapsed = true;
+    let last = env.view.flat_items.len() - 1;
+    env.view.cursor = last;
+    env.view.update_selected();
+    let id = env.view.selected_session.clone().unwrap();
+    let above_id = match env.view.flat_items.get(last - 1) {
+        Some(Item::Session { id, .. }) => id.clone(),
+        other => panic!("expected a session row above the cursor, got {other:?}"),
+    };
+
+    env.view.toggle_archive_at_cursor().unwrap();
+
+    assert!(env.view.get_instance(&id).unwrap().is_archived());
+    assert_eq!(
+        env.view.selected_session.as_deref(),
+        Some(above_id.as_str()),
+        "with nothing below, selection must land on the session above"
+    );
+}
+
+/// Archiving the only active session leaves nothing to advance to: the
+/// cursor clamps into the remaining list (the Archived section header) and
+/// the selection clears instead of pointing at a vanished row.
+#[test]
+#[serial]
+fn archive_last_active_session_clears_selection() {
+    let mut env = create_test_env_with_sessions(1);
+    env.view.archived_section_collapsed = true;
+    env.view.cursor = 0;
+    env.view.update_selected();
+    let id = env.view.selected_session.clone().unwrap();
+
+    env.view.toggle_archive_at_cursor().unwrap();
+
+    assert!(env.view.get_instance(&id).unwrap().is_archived());
+    assert_eq!(
+        env.view.selected_session, None,
+        "no active session remains, so nothing should be selected"
+    );
+    assert!(
+        env.view.cursor < env.view.flat_items.len(),
+        "cursor must stay clamped inside the rebuilt list"
+    );
 }
 
 /// Restoring with `z` unarchives the row and keeps it selected, following it
@@ -5440,6 +5500,9 @@ fn unarchive_keeps_selection() {
     env.view.toggle_archive_at_cursor().unwrap();
     assert!(env.view.get_instance(&id).unwrap().is_archived());
 
+    // The archive advanced the cursor to the neighbor; navigate back onto
+    // the archived row (visible because the section is expanded) to restore.
+    env.view.select_session_by_id(&id);
     env.view.toggle_archive_at_cursor().unwrap();
     assert!(
         !env.view.get_instance(&id).unwrap().is_archived(),

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5485,6 +5485,68 @@ fn archive_last_active_session_clears_selection() {
     );
 }
 
+/// The successor scan must skip rows already parked under an EXPANDED
+/// Archived section: archiving the last active row with an archived row
+/// visible below clears the selection instead of advancing into the section.
+#[test]
+#[serial]
+fn archive_successor_skips_archived_rows() {
+    let mut env = create_test_env_with_sessions(2);
+    env.view.archived_section_collapsed = false;
+
+    // Park the second session first, so an archived row sits below.
+    let parked_id = match env.view.flat_items.get(1) {
+        Some(Item::Session { id, .. }) => id.clone(),
+        other => panic!("expected a second session row, got {other:?}"),
+    };
+    env.view.select_session_by_id(&parked_id);
+    env.view.toggle_archive_at_cursor().unwrap();
+    assert!(env.view.get_instance(&parked_id).unwrap().is_archived());
+
+    // Archive the remaining active session. The only session row left below
+    // the cursor is the parked one, which must NOT become the selection.
+    let id = env.view.selected_session.clone().unwrap();
+    assert_ne!(
+        id, parked_id,
+        "selection must have fallen back to the active row"
+    );
+    env.view.toggle_archive_at_cursor().unwrap();
+
+    assert!(env.view.get_instance(&id).unwrap().is_archived());
+    assert_eq!(
+        env.view.selected_session, None,
+        "the cursor must not advance onto a row inside the Archived section"
+    );
+}
+
+/// Attention sort: archiving the only active session with the Archived
+/// section collapsed leaves no session row for `select_top_attention` to
+/// land on. Selection must clear (not stay pinned to the invisible archived
+/// row) and the cursor must clamp into the shrunken list.
+#[test]
+#[serial]
+fn archive_last_active_session_attention_sort_clears_selection() {
+    let mut env = create_test_env_with_sessions(1);
+    env.view.sort_order = crate::session::config::SortOrder::Attention;
+    env.view.flat_items = env.view.build_flat_items();
+    env.view.archived_section_collapsed = true;
+    env.view.cursor = 0;
+    env.view.update_selected();
+    let id = env.view.selected_session.clone().unwrap();
+
+    env.view.toggle_archive_at_cursor().unwrap();
+
+    assert!(env.view.get_instance(&id).unwrap().is_archived());
+    assert_eq!(
+        env.view.selected_session, None,
+        "selection must not point at the archived row hidden in the collapsed section"
+    );
+    assert!(
+        env.view.cursor < env.view.flat_items.len(),
+        "cursor must stay clamped inside the rebuilt list"
+    );
+}
+
 /// Restoring with `z` unarchives the row and keeps it selected, following it
 /// back to its real tier. Unarchive does not restart the agent: the row stays
 /// Stopped (archive killed its pane) and the user restarts with `e`.

--- a/tests/e2e/archive_restore.rs
+++ b/tests/e2e/archive_restore.rs
@@ -40,10 +40,12 @@ fn install_persistent_claude(h: &mut TuiTestHarness) {
 
 /// Drive a full archive -> unarchive cycle through the real TUI.
 ///
-/// Verifies the user-visible contract end to end: archiving keeps the row
-/// selected (its calm "Archived" placeholder is what the preview shows, even
-/// with another session present to swap to) and reveals the Archived section;
-/// unarchiving brings the row back to the active list and keeps it selected.
+/// Verifies the user-visible contract end to end: archiving advances the
+/// cursor to the next active session (the preview follows it; no "parked"
+/// placeholder for a row the user just dismissed) while the collapsed
+/// Archived section header appears with the count as feedback; navigating
+/// into the section and unarchiving brings the row back to the active list
+/// and keeps it selected.
 #[test]
 #[serial]
 fn test_archive_then_unarchive_cycle() {
@@ -53,8 +55,7 @@ fn test_archive_then_unarchive_cycle() {
     install_persistent_claude(&mut h);
 
     let project = h.project_path();
-    // Two sessions so "selection stays on the archived row" is meaningful: the
-    // pre-fix bug swapped the selection to the neighbour below.
+    // Two sessions so "cursor advances to the neighbour" is meaningful.
     seed_sessions(
         &h,
         project.to_str().unwrap(),
@@ -70,23 +71,31 @@ fn test_archive_then_unarchive_cycle() {
 
     // Archive the selected session.
     h.send_keys("z");
-    h.wait_for("Archived");
+    h.wait_for("Archived (");
     let after_archive = h.capture_screen();
 
-    // The calm placeholder proves the archived session is still the selected
-    // preview target (it did not swap to Neighbor) and the Archived section
-    // was revealed.
+    // The selection advanced to Neighbor, so the preview must NOT render the
+    // archived "parked" placeholder; the collapsed Archived section header
+    // (with its count) is the only trace of the dismissed row.
     assert!(
-        after_archive.contains("is parked"),
-        "archived preview should explain the parked state for the still-selected row\n{after_archive}"
-    );
-    assert!(
-        after_archive.contains("to unarchive"),
-        "archived preview should point at z to unarchive\n{after_archive}"
+        !after_archive.contains("is parked"),
+        "preview must follow the cursor to the next session, not the archived row\n{after_archive}"
     );
     assert!(
         after_archive.contains("Archived ("),
-        "the Archived section should be revealed\n{after_archive}"
+        "the Archived section header should appear with the count\n{after_archive}"
+    );
+
+    // Navigate into the Archived section: down to the header, expand it,
+    // down onto the parked row. Its preview shows the calm placeholder.
+    h.send_keys("j");
+    h.send_keys("l");
+    h.send_keys("j");
+    h.wait_for("is parked");
+    let parked = h.capture_screen();
+    assert!(
+        parked.contains("to unarchive"),
+        "archived preview should point at z to unarchive\n{parked}"
     );
 
     // Unarchive it; the row returns to the active list, still selected.


### PR DESCRIPTION
## Description

Archiving a session with `z` in the TUI (default, non-Attention sort) used to keep the cursor and selection on the just-archived row and reveal the Archived section, so the cursor followed the row down into the Archived section. The ask: keep the cursor up in the active list and advance to the next session instead.

That follow-the-row behavior came from #2025, where it masked preview jank that no longer exists. The preview pipeline now retargets every frame off `selected_session` (`refresh_preview_cache_core` gates on a session-id mismatch and `LiveCaptureWorker::set_target` drops stale captures on retarget), so there is no dead-pane "No output available" flash to hide. That stale-preview problem is what an earlier attempt at this fix ran into.

### What changed

- `toggle_archive_at_cursor` (non-Attention sort) now advances to the nearest non-archived session below the cursor, falling back to the nearest one above, via the new `archive_successor_session`. The successor is resolved against the pre-archive flat list so it walks exactly the rows the user sees and never lands in the Archived section.
- It no longer auto-reveals the Archived section on single-row archive; the `Archived (N)` header count is the feedback. Group archive (`archive_selected_group`) still reveals the section, since whole-group dismissals would otherwise look like the rows vanished.
- When the archived row was the only active session, the cursor clamps into the rebuilt list and `update_selected` resolves whatever remains (typically the section header), clearing the selection rather than pointing at a vanished row.
- The unarchive path is unchanged. The Attention-sort branch picks up one fix from the adversarial review pass: archiving the only active session with the Archived section collapsed used to leave the selection pinned to the now-invisible row (and the cursor could point past the shrunken list, since `select_top_attention` no-ops when no session row is visible). It now clamps and re-resolves, mirroring the non-Attention fallback.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (doc comment on `reveal_archived_section` updated to reflect it is now group-archive only)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Unit tests (`src/tui/home/tests.rs`):
- `archive_advances_cursor_to_next_session` (new) - cursor advances to the next active session, section stays collapsed
- `archive_bottom_row_falls_back_to_session_above` (new) - fallback to the row above when nothing is below
- `archive_last_active_session_clears_selection` (new) - the only-active-session edge case
- `archive_successor_skips_archived_rows` (new) - the successor scan must skip rows parked in an EXPANDED Archived section
- `archive_last_active_session_attention_sort_clears_selection` (new) - the attention-sort collapsed-section clamp
- `toggle_archive_at_cursor_round_trip`, `unarchive_keeps_selection` (updated) - navigate back onto the row before restoring

E2E (`tests/e2e/archive_restore.rs`): rewritten to assert the preview does NOT show the parked placeholder after archive (it followed the cursor to the neighbor), then navigates into the Archived section and restores.

### How I tested

- `cargo fmt --check`, `cargo clippy --all-targets` clean
- `cargo test --lib tui::home::tests`: 408 passed
- `cargo test --test e2e archive`: passed (full flow through the real `aoe` binary via tmux)
- Full `cargo test`: 3021 passed. One unrelated pre-existing failure (`session::storage::tests::test_update_write_failure_emits_no_notify`) also fails on a clean tree in this sandbox: it simulates a write failure via permission bits, which root bypasses.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8 and Fable 5), including an adversarial review subagent whose findings were fixed in the follow-up commit.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783773766&installation_id=139138837&pr_number=2107&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2107&signature=69ddc249319dc4071637ce2415f2108a865a7cde7fd30d9855300e96f42771ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR changes TUI archive behavior so single-row archives no longer move the user into the Archived section. Instead the cursor advances to the nearest active session (below first, then above) using the pre-archive list; if none exist selection is cleared and the cursor clamps into the rebuilt list. Group archives still reveal Archived. Tests and an e2e expectation were updated to reflect the new navigation contract.

## What changed (user-facing)

- Single-row archive advances selection to the nearest visible active session below the archived row, falling back to the nearest above.
- Single-row archive no longer auto-reveals the Archived section; the Archived (N) header provides feedback.
- Group archive behavior unchanged: it still opens/reveals the Archived section.
- If the archived row was the only active session, selection is cleared and the cursor is clamped (often landing on the header).
- Attention-sort and unarchive main flows are preserved.
- E2E test updated: preview must follow the new cursor (no “parked” archived placeholder shown after single-row archive) and unarchive is still exercized.

## What changed (code & tests)

- src/tui/home/operations.rs
  - Compute a pre-archive successor via a new archive_successor_session helper that scans the pre-archive flat_items (below→above), skipping the archived row and already-archived sessions.
  - Use the successor after archiving: rebuild flat_items and select the successor if present; otherwise clamp/clear selection. Adjusted attention-sort clamping for edge cases.
  - Minor import/comment adjustments and a small refactor to avoid an unnecessary clone.
- src/tui/home/tests.rs
  - Added tests: successor selection, bottom-row fallback to above, last-active-session clearing, and an attention-sort edge-case.
  - Updated tests to re-select by id where necessary so assertions target the intended rows after archive.
- src/tui/home/mod.rs
  - Doc comment revised to clarify when the Archived section is revealed and that single-row archive uses the header count instead of auto-revealing.
- tests/e2e/archive_restore.rs
  - Reworked to assert the preview follows the cursor (no parked placeholder) after single-row archive, then navigates into Archived to verify unarchive behavior.
- CI/dev
  - Local formatting/lint/tests run: 3019 tests passed; one unrelated pre-existing failure noted.

## Benefits

- Better UX: users remain focused on active items after archiving instead of being moved into Archived.
- Predictable navigation: successor selection mirrors what users see (pre-archive ordering) and avoids selecting already-archived rows.
- Clearer feedback: header count signals archive action without force-opening Archived for single-row operations.
- Improved test coverage for archive navigation edge cases.

## Technical summary (concise)

- archive_successor_session scans the pre-archive flat_items in visible order (rows below then above the cursor), selects the nearest session id that is not the archived row and not already archived, and returns None when no visible successor exists.
- toggle_archive_at_cursor computes that successor before applying the archive. After archiving it rebuilds flat_items and selects the precomputed successor or clamps/clears selection when none exist. Attention-sort path receives clamping/resolution fixes for single-active-session edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
