### PR TITLE
refactor(web): early-return form for clientFormFactor (codecov pipeline probe)

### DIFF
--- a/web/src/lib/formFactor.ts
+++ b/web/src/lib/formFactor.ts
@@ -31,8 +31,9 @@ const isStandalone = (): boolean => {
  *    narrow fine-pointer client (small desktop window) both stay `desktop`;
  *  - `desktop` otherwise. */
 export function clientFormFactor(): ClientFormFactor {
-  const pwa = isStandalone();
   const mobile = matchesMedia("(pointer: coarse)") && !matchesMedia("(min-width: 768px)");
-  const base = mobile ? "mobile" : "desktop";
-  return pwa ? `${base}_pwa` : base;
+  if (isStandalone()) {
+    return mobile ? "mobile_pwa" : "desktop_pwa";
+  }
+  return mobile ? "mobile" : "desktop";
 }


### PR DESCRIPTION
## Description

Equivalent rewrite of the `clientFormFactor` branch structure (early return for the PWA suffix). No behavior change; all four classification combos remain covered by the existing vitest suite.

This PR is a deliberate coverage-pipeline probe. It is the first `web/src` change after Codecov support moved the `agent-of-empires` org off the team tier onto `users-basic` (support ticket #115844). With the team tier active, the worker hard-disabled every status notifier except patch and forced the condensed `TeamPlanWriter` comment, regardless of `codecov.yml`. This PR verifies the fix end to end. Expected on this PR:

- both `codecov/patch` AND `codecov/project` status checks
- the full PR comment layout: project coverage delta, components table, sunburst, uncovered, footer

## PR Type

- [x] Refactor

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Fable 5)

**Any Additional AI Details you'd like to share:**
Claude investigated the Codecov tier regression, drafted the support correspondence, and authored this probe PR. Decisions are @Seluj78's.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783788355&installation_id=139138837&pr_number=2111&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2111&signature=efdc61490a1db120f021aa3dc45e86b8494ba093628df9a0d388d1843024abbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The `clientFormFactor()` function in `web/src/lib/formFactor.ts` was refactored to use an early-return pattern instead of building and conditionally suffixing a string. The function now:
1. Computes the `mobile` classification once upfront
2. Returns the PWA variant (`mobile_pwa` or `desktop_pwa`) immediately if the app is running standalone
3. Returns the base variant (`mobile` or `desktop`) otherwise

## Impact

- **No behavior changes**: All four form-factor classifications (mobile, mobile_pwa, desktop, desktop_pwa) remain functionally identical and are fully covered by existing tests
- **Code clarity**: Early-return pattern makes the branching logic more explicit and easier to follow
- **Performance**: Eliminates string concatenation in favor of direct returns
- **Maintainability**: Clearer control flow reduces cognitive load

## Context

This PR serves as a test probe for Codecov functionality following the organization's tier plan change. The minimal scope of changes allows verification that Codecov's status checks and detailed PR comment reporting are working as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->