### PR TITLE
feat(file-watch): apply theme on watcher-driven config refresh

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1252,6 +1252,9 @@ impl App {
             if config_kick {
                 let result = self.home.try_refresh_from_config_watcher();
                 handle_tick_reload_config(result, &mut self.home.reload_failure_state);
+                if let Some(theme_name) = self.home.take_pending_watcher_theme() {
+                    self.set_theme(&theme_name);
+                }
                 refresh_needed = true;
                 needs_full_refresh = true;
             }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -892,6 +892,14 @@ pub struct HomeView {
     /// single aggregated `info_dialog` (multi-source body) and avoid
     /// spamming on every tick while a file remains broken.
     pub(super) reload_failure_state: ReloadFailureState,
+    /// Theme name queued by `apply_config_to_state` on the Watcher path.
+    /// Drained by the tick loop in `App::run` via `take_pending_watcher_theme`
+    /// so `App::set_theme` can be called (theme state lives on `App`, not
+    /// `HomeView`). The Interactive path dispatches `Action::SetTheme`
+    /// directly and never sets this field. On a settings save the watcher
+    /// echo also fires this path (idempotent: the Interactive dispatch
+    /// already applied the same theme).
+    pub(super) pending_watcher_theme: Option<String>,
 }
 
 /// Identifies config-watch entries without letting a profile literally named
@@ -1405,6 +1413,8 @@ impl HomeView {
             config_watch_handles: HashMap::new(),
             watcher_config_refresh_count: std::sync::atomic::AtomicU64::new(0),
             reload_failure_state: ReloadFailureState::default(),
+            // App::new loads the boot theme; no startup stash from HomeView.
+            pending_watcher_theme: None,
         };
 
         view.tool_hotkey_cache = input::build_tool_hotkey_cache(&view.tool_configs);
@@ -5375,6 +5385,31 @@ impl HomeView {
                 &hotkey_warnings.join("\n"),
             ));
         }
+        // Watcher path: stash for tick-loop dispatch (App owns theme state).
+        // Reads via `resolve_theme_name` (global-only by contract), not
+        // `config.theme.name` which would carry a stale per-profile override.
+        // Guard is load-bearing: Interactive already returns
+        // `Action::SetTheme` directly from input handlers, so stashing
+        // unconditionally would double-dispatch on every settings save.
+        // Note: `resolve_theme_name` swallows read errors via `load_or_warn`
+        // and falls back to "zinc"; a peer write landing between the
+        // `resolve_config` above and this call momentarily flips the theme
+        // and the next watcher event recovers. Diverges from the
+        // "preserve prior state on Err" contract honored by other fields
+        // here; acceptable since `set_theme` is idempotent and the race
+        // window is microseconds wide.
+        if matches!(origin, ConfigRefreshOrigin::Watcher) {
+            self.pending_watcher_theme = Some(crate::session::config::resolve_theme_name());
+        }
+    }
+
+    /// Drain the theme name stashed by `apply_config_to_state` on the
+    /// Watcher path. The tick loop in `App::run` calls this after
+    /// `try_refresh_from_config_watcher` and dispatches the result to
+    /// `App::set_theme`. Returns `None` outside the watcher path or
+    /// after a previous take in the same tick.
+    pub(super) fn take_pending_watcher_theme(&mut self) -> Option<String> {
+        self.pending_watcher_theme.take()
     }
 
     /// Export the watcher-config-refresh counter to a hidden file in

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -160,6 +160,148 @@ fn interactive_refresh_reopens_hotkey_warning_dialog() {
     );
 }
 
+#[test]
+#[serial]
+fn watcher_refresh_stashes_pending_watcher_theme() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let _storage = Storage::new_unwatched("test").unwrap();
+    let global_config = crate::session::get_app_dir().unwrap().join("config.toml");
+    std::fs::write(&global_config, "[theme]\nname = \"dracula\"\n").unwrap();
+
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    assert!(
+        view.pending_watcher_theme.is_none(),
+        "precondition: HomeView::new must not stash a pending watcher theme"
+    );
+
+    view.refresh_from_config(super::ConfigRefreshOrigin::Watcher);
+    assert_eq!(
+        view.pending_watcher_theme.as_deref(),
+        Some("dracula"),
+        "watcher-driven refresh must stash the resolved theme name so the tick loop can dispatch App::set_theme"
+    );
+}
+
+#[test]
+#[serial]
+fn interactive_refresh_does_not_stash_pending_watcher_theme() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let _storage = Storage::new_unwatched("test").unwrap();
+    let global_config = crate::session::get_app_dir().unwrap().join("config.toml");
+    std::fs::write(&global_config, "[theme]\nname = \"dracula\"\n").unwrap();
+
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    assert!(
+        view.pending_watcher_theme.is_none(),
+        "precondition: HomeView::new must not stash a pending watcher theme"
+    );
+
+    view.refresh_from_config(super::ConfigRefreshOrigin::Interactive);
+    assert!(
+        view.pending_watcher_theme.is_none(),
+        "interactive refresh must not stash a pending theme; settings/intro input handlers dispatch Action::SetTheme directly"
+    );
+}
+
+#[test]
+#[serial]
+fn take_pending_watcher_theme_clears_the_field() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let _storage = Storage::new_unwatched("test").unwrap();
+
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    view.pending_watcher_theme = Some("zinc".to_string());
+
+    let first = view.take_pending_watcher_theme();
+    let second = view.take_pending_watcher_theme();
+    assert_eq!(first.as_deref(), Some("zinc"));
+    assert!(
+        second.is_none(),
+        "take must drain the pending field so a single watcher refresh dispatches at most one set_theme"
+    );
+}
+
+#[test]
+#[serial]
+fn watcher_refresh_stashes_global_theme_not_profile_override() {
+    use crate::session::profile_config::{save_profile_config, ProfileConfig};
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let _storage = Storage::new_unwatched("test").unwrap();
+
+    let global_config = crate::session::get_app_dir().unwrap().join("config.toml");
+    std::fs::write(&global_config, "[theme]\nname = \"dracula\"\n").unwrap();
+
+    let profile_overrides: ProfileConfig =
+        serde_json::from_value(serde_json::json!({"theme": {"name": "empire"}}))
+            .expect("legacy hand-edited overrides may carry a theme key even though theme is global by contract");
+    save_profile_config("test", &profile_overrides).unwrap();
+
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    assert!(
+        view.pending_watcher_theme.is_none(),
+        "precondition: HomeView::new must not stash a pending watcher theme"
+    );
+
+    view.refresh_from_config(super::ConfigRefreshOrigin::Watcher);
+    assert_eq!(
+        view.pending_watcher_theme.as_deref(),
+        Some("dracula"),
+        "watcher path must stash the global theme name via resolve_theme_name; a stale per-profile theme override (legacy or hand-edited) must not mask the global value"
+    );
+}
+
+#[test]
+#[serial]
+fn second_watcher_refresh_overwrites_stale_stash() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let _storage = Storage::new_unwatched("test").unwrap();
+
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+
+    let global_config = crate::session::get_app_dir().unwrap().join("config.toml");
+    std::fs::write(&global_config, "[theme]\nname = \"dracula\"\n").unwrap();
+    view.refresh_from_config(super::ConfigRefreshOrigin::Watcher);
+    assert_eq!(view.pending_watcher_theme.as_deref(), Some("dracula"));
+
+    std::fs::write(&global_config, "[theme]\nname = \"empire\"\n").unwrap();
+    view.refresh_from_config(super::ConfigRefreshOrigin::Watcher);
+    assert_eq!(
+        view.pending_watcher_theme.as_deref(),
+        Some("empire"),
+        "second watcher refresh must overwrite the stale stash; first-write-wins would silently drop the latest theme change"
+    );
+}
+
 fn create_test_env_with_sessions(count: usize) -> TestEnv {
     use crate::session::config::GroupByMode;
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
## Description

Watcher-driven `try_refresh_from_config_watcher` applies several HomeView fields through `apply_config_to_state` (terminal_mode, sound_config, status_hook_config, strict_hotkeys, idle_decay_window, tool_configs, etc.), but the UI theme is owned by `App` and applied via `Action::SetTheme` returned from interactive input handlers in `src/tui/home/input.rs` and `src/tui/dialogs/intro.rs`. A peer edit to `[theme] name = &#34;...&#34;` lands in memory through the watcher path but does not repaint until the user opens and closes settings or switches profile, leaving `config live-reload` incomplete for theme changes.

This closes the gap.

**Architecture**:

- New `HomeView::pending_watcher_theme: Option<String>` field. When `apply_config_to_state` runs on `ConfigRefreshOrigin::Watcher`, it stashes the global theme name via `crate::session::config::resolve_theme_name()` (global-only by contract; not the profile-merged `config.theme.name`).
- `HomeView::take_pending_watcher_theme(&mut self) -> Option<String>` drains the field via `Option::take`.
- The tick loop in `App::run` (after `try_refresh_from_config_watcher` and `handle_tick_reload_config`) consumes the pending name and dispatches `App::set_theme`, which loads the theme via `load_theme_with_mode(name, palette_mode)` and sets `needs_redraw`.
- Interactive path is unchanged: settings save and intro picker return `Action::SetTheme` directly from input handlers; the new field is bypassed. Gating the stash on Watcher origin prevents double-dispatch on settings save.
- Bridge pattern mirrors existing precedents in the same file: `pending_dialog_click_action` (set under `&mut self`, drained by App via `.take()` in the same event loop) and `pending_intro_theme` (same shape for a different dispatch path).

**Why `resolve_theme_name` and not `config.theme.name`**:

`try_refresh_from_config_watcher` calls `resolve_config(&profile)?` which returns a profile-merged `Config`. A stale per-profile `[theme] name = &#34;...&#34;` override (legacy from earlier releases or hand-edited config) would carry through to `config.theme.name`. The Interactive path reads the global config directly via `resolve_theme_name`, per the explicit doc on `src/session/config.rs::resolve_theme_name` (`Theme is a global preference: it is never profile-merged`). Stashing the global name keeps the watcher path consistent with that contract; a regression test (`watcher_refresh_stashes_global_theme_not_profile_override`) locks it.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**

- [x] N/A: this PR doesn&#39;t change a user-facing dashboard flow.

**TUI / CLI (e2e test)**

- [x] N/A: this PR is HomeView/App bridge logic; the unit tests lock the contract end-to-end at the dispatch boundary, and `App::set_theme` is the unchanged downstream sink already covered by existing tests.

Tests added in `src/tui/home/tests.rs`:

- `watcher_refresh_stashes_pending_watcher_theme`: locks the Watcher origin populating the field with the resolved theme name.
- `interactive_refresh_does_not_stash_pending_watcher_theme`: locks the Interactive origin leaving the field None, mirroring the existing `watcher_refresh_does_not_reopen_hotkey_warning_dialog` Interactive-only contract.
- `take_pending_watcher_theme_clears_the_field`: locks the take semantic so a single watcher refresh dispatches at most one `set_theme` call.
- `watcher_refresh_stashes_global_theme_not_profile_override`: locks the global-only resolution; a per-profile theme override (legacy or hand-edited) does not mask the global value.

Local CI gates verified clean on top of `main`:

- `cargo fmt --all -- --check`: clean
- `cargo clippy --features serve --tests --all-targets -- -D warnings`: clean
- `tui::home::tests`: 420 passed (incl. the 4 new tests above)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via OpenCode (Sisyphus orchestration: investigation, design, implementation, adversarial review).

**Any Additional AI Details you&#39;d like to share:**

Followed a structured methodology: parallel investigation (grep + read of dispatch sites, refresh paths, `Config` struct) → design artifact (invariants, type design, bridge pattern, test contracts) → implementation → 4-agent adversarial review of the dirty diff (concurrency/architecture, test contracts, pattern compliance, project quality scan).

The review surfaced one blocking finding: the initial implementation stashed `config.theme.name.clone()` from the profile-merged `Config`, contradicting the global-only contract documented at `src/session/config.rs::resolve_theme_name`. Fixed by reading via `resolve_theme_name()`. The 4th test (`watcher_refresh_stashes_global_theme_not_profile_override`) was added to lock the fix; without it, the existing T1 test would silently pass either implementation.

Three pattern-compliance fixes also applied: field renamed `pending_theme_apply` → `pending_watcher_theme` (matches the `pending_<noun>` shape used by every other `pending_*` field on `HomeView`, with the `_watcher` qualifier disambiguating from the existing `pending_intro_theme` for a different dispatch path); field docstring trimmed to match `pending_intro_theme` / `pending_dialog_click_action` density; inline comment trimmed while preserving the global-only-theme rationale.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783817187&installation_id=139138837&pr_number=2116&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2116&signature=0e9cec44f6e57ca5861ad1b681c3fccc699fb0d5050fc5155bb7b6d0fd28f9f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a gap where global theme changes detected by the config file watcher were not applied to the UI until the user reopened settings or switched profiles. It adds a lightweight "stash-and-drain" mechanism so watcher-driven theme updates are applied immediately on the next app tick while leaving interactive theme changes unchanged.

What changed (high level)
- HomeView gained a new field to hold a pending watcher theme: pending_watcher_theme (Option<String>).
- apply_config_to_state() stashes the resolved global theme name only when the config refresh origin is the watcher.
- A new method take_pending_watcher_theme() drains that field.
- The app tick loop (in src/tui/app.rs) now consumes the pending theme after watcher refresh handling and calls set_theme(...) to load and apply it, then requests a redraw.
- Tests added to verify watcher stashing, non-stashing for interactive changes, proper draining, and global-theme precedence over profile overrides.

Benefits
- Immediately applies global theme changes detected by file-watcher without requiring manual UI actions.
- Avoids duplicate theme application by restricting stashing to watcher-origin refreshes.
- Follows an established pattern (pending_* bridge fields) and keeps interactive flows unchanged.

Technical details (concise)
- Stash-and-drain pattern: apply_config_to_state checks ConfigRefreshOrigin::Watcher and stores a resolved theme name using crate::session::config::resolve_theme_name(). The tick loop calls HomeView::take_pending_watcher_theme(), then App::set_theme (which uses load_theme_with_mode(name, palette_mode)) and marks needs_redraw.
- Interactive path remains unchanged: input handlers still return Action::SetTheme directly.
- Tests (tui::home::tests) added to cover watcher vs interactive behavior, draining, overwrite semantics, and global-theme precedence. Cargo fmt/clippy pass and test suite including these new tests passed.

Files touched
- src/tui/home/mod.rs — added pending_watcher_theme field, initializer, and take_pending_watcher_theme().
- src/tui/app.rs — consume and apply pending watcher theme in the tick loop.
- src/tui/home/tests.rs — added unit tests for the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->