### PR TITLE
fix: block tied-worktree rename while a sandbox container holds the mount

### DIFF
--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1042,7 +1042,15 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         let mut live = inst.clone();
         crate::tmux::refresh_session_cache();
         live.update_status();
-        if live.status.blocks_worktree_edit() {
+        // A sandbox session's container keeps the worktree dir mounted even
+        // while the agent is Idle, so `git worktree move` would fail with
+        // EBUSY; stopping the session tears the container down and releases it.
+        if live.status.blocks_worktree_edit()
+            || crate::session::worktree_edit::sandbox_container_holds_worktree(
+                &id,
+                live.is_sandboxed(),
+            )
+        {
             bail!("Stop the session before renaming it: its worktree directory moves to match the new name. Disable session.tie_workdir_to_name to relabel a running session.");
         }
         let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
@@ -1180,7 +1188,12 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
     let mut live = inst.clone();
     crate::tmux::refresh_session_cache();
     live.update_status();
-    if live.status.blocks_worktree_edit() {
+    // A sandbox container keeps the worktree dir mounted even while the agent
+    // is Idle, so the move would fail with EBUSY; stopping the session releases
+    // the mount, same as the active-status case.
+    if live.status.blocks_worktree_edit()
+        || crate::session::worktree_edit::sandbox_container_holds_worktree(&id, live.is_sandboxed())
+    {
         bail!("Cannot edit the workdir name while the session is active; stop it first");
     }
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1063,6 +1063,16 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
             },
         ) {
             Ok(outcome) => {
+                // The dir moved (path changed): a sandbox container created
+                // against the old path is now stale, so drop it to force a
+                // fresh create on next start. A branch-only edit leaves the
+                // path (and the mount) unchanged.
+                if outcome.new_path != std::path::Path::new(&current_path) {
+                    crate::session::worktree_edit::discard_sandbox_container_after_move(
+                        &id,
+                        live.is_sandboxed(),
+                    );
+                }
                 new_path = Some(outcome.new_path.to_string_lossy().to_string());
                 new_branch = outcome.new_branch;
             }
@@ -1205,6 +1215,15 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
             rename_branch: args.rename_branch,
         },
     )?;
+    // The dir moved (path changed): a sandbox container created against the old
+    // path is now stale, so drop it to force a fresh create on next start. A
+    // branch-only edit leaves the path (and the mount) unchanged.
+    if outcome.new_path != std::path::Path::new(&current_path) {
+        crate::session::worktree_edit::discard_sandbox_container_after_move(
+            &id,
+            live.is_sandboxed(),
+        );
+    }
     let new_path = outcome.new_path.to_string_lossy().to_string();
     let new_branch = outcome.new_branch.clone();
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -764,7 +764,7 @@ pub async fn rename_session(
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
-    let (worktree_info, current_path, status, profile) = {
+    let (worktree_info, current_path, status, profile, is_sandboxed) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return (
@@ -778,6 +778,7 @@ pub async fn rename_session(
             inst.project_path.clone(),
             inst.status,
             inst.source_profile.clone(),
+            inst.is_sandboxed(),
         )
     };
 
@@ -796,7 +797,12 @@ pub async fn rename_session(
         // The dir move is gated on a quiescent worktree, exactly like the
         // standalone worktree-name edit. A running session must be stopped
         // first; the setting is the escape hatch for free-form relabeling.
-        if status.blocks_worktree_edit() {
+        // A sandbox session's container keeps the worktree dir mounted even
+        // while the agent is Idle, so the move would fail with EBUSY; stopping
+        // the session tears the container down and releases the mount.
+        if status.blocks_worktree_edit()
+            || crate::session::worktree_edit::sandbox_container_holds_worktree(&id, is_sandboxed)
+        {
             return (
                 StatusCode::CONFLICT,
                 Json(serde_json::json!({
@@ -1014,7 +1020,7 @@ pub async fn set_worktree_name(
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
-    let (worktree_info, current_path, status, profile) = {
+    let (worktree_info, current_path, status, profile, is_sandboxed) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return (
@@ -1028,6 +1034,7 @@ pub async fn set_worktree_name(
             inst.project_path.clone(),
             inst.status,
             inst.source_profile.clone(),
+            inst.is_sandboxed(),
         )
     };
 
@@ -1055,7 +1062,12 @@ pub async fn set_worktree_name(
         )
             .into_response();
     }
-    if status.blocks_worktree_edit() {
+    // A sandbox container keeps the worktree dir mounted even while the agent
+    // is Idle, so the move would fail with EBUSY; stopping the session releases
+    // the mount, same as the active-status case.
+    if status.blocks_worktree_edit()
+        || crate::session::worktree_edit::sandbox_container_holds_worktree(&id, is_sandboxed)
+    {
         return (
             StatusCode::CONFLICT,
             Json(serde_json::json!({

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -799,10 +799,18 @@ pub async fn rename_session(
         // first; the setting is the escape hatch for free-form relabeling.
         // A sandbox session's container keeps the worktree dir mounted even
         // while the agent is Idle, so the move would fail with EBUSY; stopping
-        // the session tears the container down and releases the mount.
-        if status.blocks_worktree_edit()
-            || crate::session::worktree_edit::sandbox_container_holds_worktree(&id, is_sandboxed)
-        {
+        // the session tears the container down and releases the mount. The
+        // container probe is a subprocess, so it runs on the blocking pool
+        // like the other process-spawning work in this file.
+        let container_holds = {
+            let id = id.clone();
+            tokio::task::spawn_blocking(move || {
+                crate::session::worktree_edit::sandbox_container_holds_worktree(&id, is_sandboxed)
+            })
+            .await
+            .unwrap_or(false)
+        };
+        if status.blocks_worktree_edit() || container_holds {
             return (
                 StatusCode::CONFLICT,
                 Json(serde_json::json!({
@@ -835,12 +843,18 @@ pub async fn rename_session(
                 // The dir moved (path changed): a sandbox container created
                 // against the old path is now stale, so drop it to force a
                 // fresh create on next start. A branch-only edit leaves the
-                // path (and the mount) unchanged, so skip it then.
+                // path (and the mount) unchanged, so skip it then. Awaited so
+                // the response only lands once the stale container is gone; an
+                // immediate restart must not race the removal and revive it.
                 if path != current_path {
-                    crate::session::worktree_edit::discard_sandbox_container_after_move(
-                        &id,
-                        is_sandboxed,
-                    );
+                    let id = id.clone();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        crate::session::worktree_edit::discard_sandbox_container_after_move(
+                            &id,
+                            is_sandboxed,
+                        )
+                    })
+                    .await;
                 }
                 new_path = Some(path);
                 new_branch = branch;
@@ -1074,10 +1088,18 @@ pub async fn set_worktree_name(
     }
     // A sandbox container keeps the worktree dir mounted even while the agent
     // is Idle, so the move would fail with EBUSY; stopping the session releases
-    // the mount, same as the active-status case.
-    if status.blocks_worktree_edit()
-        || crate::session::worktree_edit::sandbox_container_holds_worktree(&id, is_sandboxed)
-    {
+    // the mount, same as the active-status case. The container probe is a
+    // subprocess, so it runs on the blocking pool like the other
+    // process-spawning work in this file.
+    let container_holds = {
+        let id = id.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::session::worktree_edit::sandbox_container_holds_worktree(&id, is_sandboxed)
+        })
+        .await
+        .unwrap_or(false)
+    };
+    if status.blocks_worktree_edit() || container_holds {
         return (
             StatusCode::CONFLICT,
             Json(serde_json::json!({
@@ -1123,9 +1145,18 @@ pub async fn set_worktree_name(
 
     // The dir moved (path changed): a sandbox container created against the old
     // path is now stale, so drop it to force a fresh create on next start. A
-    // branch-only edit leaves the path (and the mount) unchanged.
+    // branch-only edit leaves the path (and the mount) unchanged. Awaited so
+    // the response only lands once the stale container is gone; an immediate
+    // restart must not race the removal and revive it.
     if new_path != current_path {
-        crate::session::worktree_edit::discard_sandbox_container_after_move(&id, is_sandboxed);
+        let id_for_discard = id.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            crate::session::worktree_edit::discard_sandbox_container_after_move(
+                &id_for_discard,
+                is_sandboxed,
+            )
+        })
+        .await;
     }
 
     // The git move has already landed, so persist to disk BEFORE mutating

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -832,6 +832,16 @@ pub async fn rename_session(
 
         match edit {
             Ok(Ok((path, branch))) => {
+                // The dir moved (path changed): a sandbox container created
+                // against the old path is now stale, so drop it to force a
+                // fresh create on next start. A branch-only edit leaves the
+                // path (and the mount) unchanged, so skip it then.
+                if path != current_path {
+                    crate::session::worktree_edit::discard_sandbox_container_after_move(
+                        &id,
+                        is_sandboxed,
+                    );
+                }
                 new_path = Some(path);
                 new_branch = branch;
             }
@@ -1110,6 +1120,13 @@ pub async fn set_worktree_name(
                 .into_response();
         }
     };
+
+    // The dir moved (path changed): a sandbox container created against the old
+    // path is now stale, so drop it to force a fresh create on next start. A
+    // branch-only edit leaves the path (and the mount) unchanged.
+    if new_path != current_path {
+        crate::session::worktree_edit::discard_sandbox_container_after_move(&id, is_sandboxed);
+    }
 
     // The git move has already landed, so persist to disk BEFORE mutating
     // in-memory state. A silent persist failure here would leave stale

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -58,6 +58,49 @@ pub fn sandbox_container_holds_worktree(session_id: &str, is_sandboxed: bool) ->
             .unwrap_or(false)
 }
 
+/// Drop a sandbox session's container after its worktree directory has been
+/// moved by a rename.
+///
+/// A container's bind mounts and working dir are baked in at creation time
+/// (`src/containers/runtime_base.rs`); they do NOT follow a host-side
+/// `git worktree move`. `get_container_for_instance` reuses an existing
+/// stopped container as-is, so without this the restarted container would
+/// still mount (and `cd` into) the old path. Removing it here forces a fresh
+/// `create` with the new path on next start. `remove(force)` drops only the
+/// container and its anonymous volumes; named ignore volumes (node_modules,
+/// target) are keyed by session id and survive for the recreated container.
+///
+/// No-op for non-sandbox sessions. The rename gate requires a stopped session
+/// (see [`sandbox_container_holds_worktree`]), so the container is not running
+/// here. Best-effort: a failure is logged, not surfaced, since the rename
+/// itself has already succeeded. See #1927 follow-up.
+pub fn discard_sandbox_container_after_move(session_id: &str, is_sandboxed: bool) {
+    if !is_sandboxed {
+        return;
+    }
+    let container = crate::containers::DockerContainer::from_session_id(session_id);
+    match container.exists() {
+        Ok(true) => match container.remove(true) {
+            Ok(()) => tracing::info!(
+                target: "containers.runtime",
+                session = %session_id,
+                "removed stale sandbox container after worktree move; it will be recreated with the new path on next start"
+            ),
+            Err(e) => tracing::warn!(
+                target: "containers.runtime",
+                session = %session_id,
+                "failed to remove stale sandbox container after worktree move: {e}"
+            ),
+        },
+        Ok(false) => {}
+        Err(e) => tracing::warn!(
+            target: "containers.runtime",
+            session = %session_id,
+            "could not check sandbox container existence after worktree move: {e}"
+        ),
+    }
+}
+
 /// Inputs for an in-place worktree workdir edit.
 pub struct WorktreeEditRequest<'a> {
     /// The session's current worktree metadata.

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -40,6 +40,24 @@ pub fn worktree_leaf_from_title(title: &str) -> String {
     crate::session::builder::branch_name_from_title(title)
 }
 
+/// Whether a sandbox session's container is still running and therefore
+/// bind-mounting its worktree directory.
+///
+/// A sandbox container runs `sleep infinity` for the life of the session
+/// (`src/containers/runtime_base.rs`), so it holds the worktree dir as an
+/// active mount source even while the agent is Idle. A `git worktree move`
+/// then `rename(2)`s that dir and the kernel refuses with `EBUSY`, surfaced
+/// as `fatal: failed to move`. Callers about to move the worktree must refuse
+/// and have the user stop the session first, which tears the container down
+/// and releases the mount. `is_sandboxed` is taken so non-sandbox sessions
+/// skip the `docker inspect` subprocess entirely. See #1927 follow-up.
+pub fn sandbox_container_holds_worktree(session_id: &str, is_sandboxed: bool) -> bool {
+    is_sandboxed
+        && crate::containers::DockerContainer::from_session_id(session_id)
+            .is_running()
+            .unwrap_or(false)
+}
+
 /// Inputs for an in-place worktree workdir edit.
 pub struct WorktreeEditRequest<'a> {
     /// The session's current worktree metadata.

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -21,6 +21,39 @@ fn humanize_minutes(m: u32) -> String {
     }
 }
 
+/// Why a tied-worktree rename must refuse to move the worktree directory.
+///
+/// `git worktree move` does a `rename(2)` on the worktree dir, which the
+/// kernel refuses while anything holds it. Two distinct holders matter and
+/// they need different wording: an active agent (the session's `status`),
+/// and a sandbox session's container, which bind-mounts the worktree dir and
+/// stays alive on `sleep infinity` even while the agent is Idle. Both are
+/// cleared by stopping the session.
+#[derive(Debug, PartialEq, Eq)]
+enum WorktreeRenameBlock {
+    /// The session's agent is busy (running, starting, etc.).
+    ActiveAgent,
+    /// A sandbox container is running and mounting the worktree dir.
+    SandboxContainer,
+}
+
+/// Decide whether a tied-worktree rename must be blocked, and why. Status
+/// takes precedence so a busy agent reports as `ActiveAgent` rather than
+/// reaching for the container reason. Returns `None` when the move is safe.
+fn worktree_rename_block(
+    status: Status,
+    is_sandboxed: bool,
+    container_running: bool,
+) -> Option<WorktreeRenameBlock> {
+    if status.blocks_worktree_edit() {
+        Some(WorktreeRenameBlock::ActiveAgent)
+    } else if is_sandboxed && container_running {
+        Some(WorktreeRenameBlock::SandboxContainer)
+    } else {
+        None
+    }
+}
+
 impl HomeView {
     /// Pin or unpin the project header under the cursor (project view only).
     ///
@@ -879,14 +912,40 @@ impl HomeView {
             // in both the profile-move and the standard persist paths.
             let mut new_path: Option<String> = None;
             if current_title != effective_title && self.tie_workdir_applies_for(&id) {
-                let snapshot = self
-                    .get_instance(&id)
-                    .map(|i| (i.worktree_info.clone(), i.status, i.project_path.clone()));
-                if let Some((Some(worktree_info), status, project_path)) = snapshot {
-                    if status.blocks_worktree_edit() {
+                let snapshot = self.get_instance(&id).map(|i| {
+                    (
+                        i.worktree_info.clone(),
+                        i.status,
+                        i.project_path.clone(),
+                        i.is_sandboxed(),
+                    )
+                });
+                if let Some((Some(worktree_info), status, project_path, is_sandboxed)) = snapshot {
+                    // A sandbox session keeps its container alive (running
+                    // `sleep infinity`) even while the agent is Idle, and that
+                    // container bind-mounts the worktree directory. The move
+                    // below `git worktree move`s that dir, which the kernel
+                    // refuses while it is an active mount source (EBUSY ->
+                    // "fatal: failed to move"). Stopping the session tears the
+                    // container down and releases the mount. We only inspect
+                    // the container when the status check hasn't already
+                    // blocked, so the common non-sandbox path spawns no
+                    // `docker inspect`. See #1927 follow-up.
+                    let container_running = !status.blocks_worktree_edit()
+                        && crate::session::worktree_edit::sandbox_container_holds_worktree(
+                            &id,
+                            is_sandboxed,
+                        );
+                    if let Some(reason) =
+                        worktree_rename_block(status, is_sandboxed, container_running)
+                    {
+                        let body = match reason {
+                            WorktreeRenameBlock::ActiveAgent => "This worktree session's directory moves to match the new name, which can't happen while it's running. Stop the session first, or disable \"Tie Worktree Directory to Session Name\" to relabel it freely.",
+                            WorktreeRenameBlock::SandboxContainer => "This sandbox session's container is mounting the worktree directory, so it can't be moved to match the new name. Stop the session first, or disable \"Tie Worktree Directory to Session Name\" to relabel it freely.",
+                        };
                         self.info_dialog = Some(crate::tui::dialogs::InfoDialog::new(
                             "Stop the Session to Rename",
-                            "This worktree session's directory moves to match the new name, which can't happen while it's running. Stop the session first, or disable \"Tie Worktree Directory to Session Name\" to relabel it freely.",
+                            body,
                         ));
                         return Ok(());
                     }
@@ -1325,5 +1384,62 @@ impl HomeView {
         }
         self.update_selected();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // An Idle sandbox session whose container is still running is the #1927
+    // follow-up bug: the worktree dir is an active bind-mount source, so
+    // `git worktree move` fails with EBUSY. Before the fix this returned
+    // `None` (the rename proceeded and the move blew up with "fatal: failed
+    // to move"); it must now block with the sandbox-specific reason.
+    #[test]
+    fn idle_sandbox_with_running_container_blocks() {
+        assert_eq!(
+            worktree_rename_block(Status::Idle, true, true),
+            Some(WorktreeRenameBlock::SandboxContainer)
+        );
+    }
+
+    #[test]
+    fn idle_sandbox_with_stopped_container_is_safe() {
+        // Stopping the session tears the container down, releasing the mount.
+        assert_eq!(worktree_rename_block(Status::Idle, true, false), None);
+    }
+
+    #[test]
+    fn idle_non_sandbox_is_safe() {
+        // No container, nothing holds the dir; the move proceeds.
+        assert_eq!(worktree_rename_block(Status::Idle, false, false), None);
+    }
+
+    #[test]
+    fn active_status_blocks_as_active_agent() {
+        for status in [
+            Status::Running,
+            Status::Waiting,
+            Status::Starting,
+            Status::Creating,
+            Status::Deleting,
+        ] {
+            assert_eq!(
+                worktree_rename_block(status, false, false),
+                Some(WorktreeRenameBlock::ActiveAgent),
+                "{status:?} should block as ActiveAgent"
+            );
+        }
+    }
+
+    #[test]
+    fn active_status_takes_precedence_over_container() {
+        // A busy agent reports as ActiveAgent even on a sandbox session with a
+        // live container; status is checked first.
+        assert_eq!(
+            worktree_rename_block(Status::Running, true, true),
+            Some(WorktreeRenameBlock::ActiveAgent)
+        );
     }
 }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -960,7 +960,14 @@ impl HomeView {
                         },
                     ) {
                         Ok(outcome) => {
-                            new_path = Some(outcome.new_path.to_string_lossy().to_string())
+                            new_path = Some(outcome.new_path.to_string_lossy().to_string());
+                            // The dir moved; a sandbox container created against
+                            // the old path is now stale, so drop it to force a
+                            // fresh create on next start.
+                            crate::session::worktree_edit::discard_sandbox_container_after_move(
+                                &id,
+                                is_sandboxed,
+                            );
                         }
                         // Leaf maps to the current dir: nothing to move, just
                         // rename the title.


### PR DESCRIPTION
## Description

Renaming a worktree session that is sandboxed fails with a cryptic dialog:

> Could not move the worktree directory: Git worktree command failed: fatal: failed to move

**Root cause.** A sandbox session keeps its container alive (`run -d ... sleep infinity`) for the whole session, and that container bind-mounts the worktree directory itself (`src/session/container_config.rs`, sibling/non-bare layout). A tied rename runs `git worktree move`, which `rename(2)`s that directory; the kernel refuses to rename an active mount source and returns `EBUSY`, surfaced by git as "fatal: failed to move".

The rename gates only checked `Status::blocks_worktree_edit()` (agent activity), so an **Idle** sandbox session passed the gate even though its container still held the mount, and the move blew up.

**Fix.** New shared helper `sandbox_container_holds_worktree()` (`src/session/worktree_edit.rs`), true when the session is sandboxed and its container is running. Wired into all three rename surfaces so each refuses the move with a clear "stop the session first" message (stopping the session stops the container, releasing the mount):

- TUI: `src/tui/home/operations.rs` (sandbox-specific dialog)
- Web API: `src/server/api/sessions.rs` (both the rename and the standalone workdir-edit handlers, 409 CONFLICT)
- CLI: `src/cli/session.rs` (both the unified rename and the standalone workdir edit)

The container is only inspected when the status check hasn't already blocked, so the common non-sandbox path spawns no `docker inspect`.

### Follow-up: recreate the container after the dir moves

Blocking the move while the container runs is only half the story. After the user stops the session, renames, and restarts, the restart reused the stopped container as-is. A container's bind mounts and working dir are baked in at creation time and do not follow a host-side `git worktree move`; `get_container_for_instance` only builds fresh config in its `create` branch, which an existing (stopped) container never reaches. So the restarted container kept mounting and `cd`-ing into the old leaf (observed: `pwd` still showed the pre-rename path).

Added `discard_sandbox_container_after_move()`, called from every rename surface whenever the dir actually moves. Removing the stale container forces a fresh create against the new path on next start. `remove(force)` drops only the container and its anonymous volumes; named ignore volumes (node_modules, target) are keyed by session id and survive.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Skipped a test, because: the web change is a backend gate addition mirroring the existing active-status gate (returns 409 for a sandboxed session whose container is live). The decision logic is unit-tested via the shared helper and the `worktree_rename_block` matrix; a live Playwright test would require a running Docker sandbox, which the web suite does not provision.

**TUI / CLI (e2e test)**
- [x] Skipped a tests/e2e test, because: exercising the real failure needs a running Docker sandbox (the worktree dir must be a live bind-mount source for `git worktree move` to hit EBUSY), which the e2e harness does not provision outside the `#[ignore]`d Docker tests. Instead the decision logic is covered by 5 unit tests over `worktree_rename_block()` in `src/tui/home/operations.rs`; the key case (an Idle sandbox session with a running container) fails against the pre-fix logic and passes with the fix.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause investigation and the fix were done via Claude Code, reviewed and directed by me.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR prevents tied-worktree renames from failing with a cryptic git error when a sandboxed session's container still holds a bind-mounted worktree directory by detecting and blocking such renames and cleaning up stale containers after a successful move.

### What changed (high-level)
- Added sandbox detection and cleanup:
  - sandbox_container_holds_worktree(session_id, is_sandboxed) — detects when a running sandbox container holds the worktree mount.
  - discard_sandbox_container_after_move(session_id, is_sandboxed) — best-effort removal of a stale container after a directory move.
- Applied the check and cleanup across all rename surfaces so operations are refused with a clear "stop the session first" message instead of producing EBUSY/git errors:
  - CLI: src/cli/session.rs (rename_session, set_worktree_name)
  - Web API: src/server/api/sessions.rs (rename and workdir-edit handlers; return 409 CONFLICT when blocked)
  - TUI: src/tui/home/operations.rs (sandbox-aware dialog and blocking logic)
- Performance-conscious behavior: only inspect container state when existing status checks don’t already block the operation.
- Tests: unit tests added/updated to cover decision logic; E2E/Playwright tests requiring Docker sandboxes were skipped/marked accordingly.

### Key benefits
- Prevents rename failures caused by kernel EBUSY when a sandbox container bind-mounts the worktree.
- Provides clear, actionable feedback to users (stop the session/container) instead of cryptic git errors.
- Ensures restarted sessions recreate containers with correct bind mounts by discarding stale containers after a move.
- Consistent behavior across CLI, API, and TUI while minimizing unnecessary container inspections.

### Technical details (concise)
- New public helpers in src/session/worktree_edit.rs:
  - pub fn sandbox_container_holds_worktree(session_id: &str, is_sandboxed: bool) -> bool
  - pub fn discard_sandbox_container_after_move(session_id: &str, is_sandboxed: bool)
- Rename gates now check both Status::blocks_worktree_edit() and sandbox_container_holds_worktree(...) to decide whether to refuse the operation.
- After a successful move that changes the filesystem path, code awaits discard_sandbox_container_after_move(...) so the HTTP/TUI/CLI surface only returns once the stale container is removed, avoiding races.
- Docker inspect/remove calls are executed on a blocking pool (spawn_blocking) instead of inline on the async runtime.
- Error handling: container-inspect failures are treated conservatively (not blocking renames); container removal is best-effort and does not surface errors to callers.

### Potential areas for further improvement
- Re-enable or add integration tests that run against real Docker sandboxes to exercise the full EBUSY path.
- Add targeted telemetry/logging for container-inspect/remove failures to aid debugging in CI or user environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->