### PR TITLE
feat(tui): optional branch rename in the tied worktree rename dialog

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -84,7 +84,7 @@ tie_workdir_to_name = true
 When tied:
 
 - Renaming a session (TUI rename, web inline rename, `aoe session rename`, or `PATCH /api/sessions/{id}`) moves the worktree directory to the title's path-safe slug first, then sets the title only if the move succeeds, so the two cannot drift on a partial failure.
-- The git branch is never swept in by a title rename. Pass `--rename-branch` to `aoe session rename` (or `rename_branch: true` to the PATCH) to rename it too; it stays opt-in because a branch may carry an upstream or an open PR.
+- The git branch is never swept in by a title rename by default. To rename it too, check "Also rename git branch" in the TUI rename dialog, pass `--rename-branch` to `aoe session rename`, or send `rename_branch: true` to the PATCH. It stays opt-in because a branch may carry an upstream or an open PR; the TUI toggle warns when the branch tracks a remote, since the remote branch (and any open PR) won't follow the local rename.
 - The session must be stopped first. Moving the directory of a running worktree is unsafe, so a tied rename of a running session is refused with a clear message. Stop the session, or disable the setting, to relabel it freely.
 - Naming collapses into the single rename action: the standalone "edit workdir name" affordance is hidden (TUI and web) and the standalone CLI / REST workdir-name edit is rejected, since the directory now follows the title.
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -1000,6 +1000,28 @@ impl GitWorktree {
         }
     }
 
+    /// The short upstream tracking ref for a local branch (e.g. `origin/hi`),
+    /// or `None` when the branch has no upstream configured.
+    ///
+    /// Used to warn before a branch rename: `git branch -m` only touches the
+    /// local ref, so a branch that tracks a remote leaves that remote branch
+    /// behind (and any open PR pinned to it) until the new name is pushed and
+    /// the old one deleted. `for-each-ref` is quiet, it prints an empty line
+    /// rather than erroring when there is no upstream.
+    pub fn branch_upstream(&self, branch: &str) -> Option<String> {
+        let refname = format!("refs/heads/{branch}");
+        let output = super::command::run_git(
+            &self.repo_path,
+            ["for-each-ref", "--format=%(upstream:short)", &refname],
+        )
+        .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let upstream = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!upstream.is_empty()).then_some(upstream)
+    }
+
     /// Move a managed worktree directory via `git worktree move`, which
     /// relocates the checkout and updates the linked-worktree gitdir
     /// metadata. A plain filesystem rename would leave git's bookkeeping

--- a/src/tui/dialogs/rename.rs
+++ b/src/tui/dialogs/rename.rs
@@ -22,6 +22,10 @@ pub struct RenameData {
     pub group: Option<String>,
     /// New profile (None means keep current, Some(name) means move to that profile)
     pub profile: Option<String>,
+    /// Whether to also rename the git branch to match the title. Only ever
+    /// true for a tied aoe-managed worktree session that opted into the
+    /// branch toggle; always false otherwise.
+    pub rename_branch: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +52,23 @@ pub struct RenameDialog {
     /// Hit rect per focusable field (title / group / profile), set by
     /// `render`. Drives click + hover routing.
     focusable_rects: Vec<(usize, Rect)>,
+    /// Set for a tied aoe-managed worktree session via
+    /// [`Self::with_worktree_branch`]. When present, the dialog grows a
+    /// fourth focusable field: an "Also rename git branch" toggle. The
+    /// payload is `(current_branch, upstream)`; `upstream` drives the
+    /// remote-orphan warning when the toggle is on.
+    worktree_branch: Option<WorktreeBranch>,
+    /// State of the branch toggle. Meaningless unless `worktree_branch` is set.
+    rename_branch: bool,
+}
+
+/// Branch context for a tied worktree session's rename toggle.
+struct WorktreeBranch {
+    /// The session's current git branch (shown in the toggle row).
+    current: String,
+    /// Short upstream ref (e.g. `origin/hi`) when the branch tracks a remote,
+    /// else `None`. Drives the "remote branch won't follow" warning.
+    upstream: Option<String>,
 }
 
 impl RenameDialog {
@@ -82,7 +103,22 @@ impl RenameDialog {
             group_ghost: None,
             validation_error: None,
             focusable_rects: Vec::new(),
+            worktree_branch: None,
+            rename_branch: false,
         }
+    }
+
+    /// Attach tied-worktree branch context, enabling the "Also rename git
+    /// branch" toggle. Call only for a Session-mode dialog whose session is a
+    /// tied aoe-managed worktree. `upstream` is the short tracking ref
+    /// (`origin/hi`) when the branch tracks a remote, used to warn that a
+    /// rename leaves that remote branch behind.
+    pub fn with_worktree_branch(mut self, current_branch: &str, upstream: Option<String>) -> Self {
+        self.worktree_branch = Some(WorktreeBranch {
+            current: current_branch.to_string(),
+            upstream,
+        });
+        self
     }
 
     pub fn new_for_group(
@@ -111,13 +147,32 @@ impl RenameDialog {
             group_ghost: None,
             validation_error: None,
             focusable_rects: Vec::new(),
+            worktree_branch: None,
+            rename_branch: false,
         }
+    }
+
+    /// Whether the "Also rename git branch" toggle is present (tied worktree
+    /// session only). When true it occupies focusable field index 3.
+    fn shows_branch_toggle(&self) -> bool {
+        self.mode == RenameMode::Session && self.worktree_branch.is_some()
+    }
+
+    fn is_branch_toggle_field(&self) -> bool {
+        self.shows_branch_toggle() && self.focused_field == 3
     }
 
     fn field_count(&self) -> usize {
         match self.mode {
-            RenameMode::Session => 3, // title, group, profile
-            RenameMode::Group => 2,   // group, profile
+            // title, group, profile, and the branch toggle when present.
+            RenameMode::Session => {
+                if self.shows_branch_toggle() {
+                    4
+                } else {
+                    3
+                }
+            }
+            RenameMode::Group => 2, // group, profile
         }
     }
 
@@ -145,9 +200,12 @@ impl RenameDialog {
             .find(|(_, rect)| rect.contains(pos))
             .map(|(f, _)| *f)?;
         self.focused_field = hit;
-        // Cycle the profile chip on click; text fields just take focus.
+        // Cycle the profile chip on click; flip the branch toggle on click;
+        // text fields just take focus.
         if self.is_profile_field() && !self.available_profiles.is_empty() {
             self.profile_index = (self.profile_index + 1) % self.available_profiles.len();
+        } else if self.is_branch_toggle_field() {
+            self.rename_branch = !self.rename_branch;
         }
         Some(DialogResult::Continue)
     }
@@ -268,8 +326,15 @@ impl RenameDialog {
                 let selected_profile = self.selected_profile();
                 let profile_changed = selected_profile != self.current_profile;
 
-                // If nothing has changed, cancel
-                if title_value.is_empty() && group_value == self.current_group && !profile_changed {
+                // If nothing has changed, cancel. Arming the branch toggle
+                // counts as a change even when title/group/profile are
+                // untouched (rename a drifted branch in place).
+                let branch_rename = self.shows_branch_toggle() && self.rename_branch;
+                if title_value.is_empty()
+                    && group_value == self.current_group
+                    && !profile_changed
+                    && !branch_rename
+                {
                     return DialogResult::Cancel;
                 }
 
@@ -309,6 +374,7 @@ impl RenameDialog {
                     title: title_value,
                     group,
                     profile,
+                    rename_branch: self.shows_branch_toggle() && self.rename_branch,
                 })
             }
             KeyCode::Tab => {
@@ -340,6 +406,10 @@ impl RenameDialog {
                 } else {
                     self.group_ghost = None;
                 }
+                DialogResult::Continue
+            }
+            KeyCode::Char(' ') if self.is_branch_toggle_field() => {
+                self.rename_branch = !self.rename_branch;
                 DialogResult::Continue
             }
             KeyCode::Left if self.is_profile_field() => {
@@ -387,8 +457,19 @@ impl RenameDialog {
 
     fn render_session(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         self.focusable_rects.clear();
+        let show_toggle = self.shows_branch_toggle();
+        // The remote-orphan warning only matters once the toggle is armed and
+        // the branch actually tracks a remote.
+        let show_warning = show_toggle
+            && self.rename_branch
+            && self
+                .worktree_branch
+                .as_ref()
+                .is_some_and(|w| w.upstream.is_some());
+
         let dialog_width = 50;
-        let dialog_area = super::centered_rect(area, dialog_width, 15);
+        let height = 15 + if show_toggle { 1 } else { 0 } + if show_warning { 2 } else { 0 };
+        let dialog_area = super::centered_rect(area, dialog_width, height);
 
         frame.render_widget(Clear, dialog_area);
 
@@ -402,20 +483,34 @@ impl RenameDialog {
         let inner = block.inner(dialog_area);
         frame.render_widget(block, dialog_area);
 
+        // Fixed rows first (current values, spacer, the three input fields),
+        // then the optional branch toggle / warning, then spacer + hint. The
+        // dynamic indices are tracked so the wiring below stays in sync.
+        let mut constraints = vec![
+            Constraint::Length(1), // 0 Current title
+            Constraint::Length(1), // 1 Current group
+            Constraint::Length(1), // 2 Current profile
+            Constraint::Length(1), // 3 Spacer
+            Constraint::Length(1), // 4 New title field
+            Constraint::Length(1), // 5 New group field
+            Constraint::Length(1), // 6 Profile selector
+        ];
+        let toggle_idx = show_toggle.then(|| {
+            constraints.push(Constraint::Length(1));
+            constraints.len() - 1
+        });
+        let warning_idx = show_warning.then(|| {
+            constraints.push(Constraint::Length(2));
+            constraints.len() - 1
+        });
+        constraints.push(Constraint::Length(1)); // Spacer
+        constraints.push(Constraint::Min(1)); // Hint
+        let hint_idx = constraints.len() - 1;
+
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .margin(1)
-            .constraints([
-                Constraint::Length(1), // Current title
-                Constraint::Length(1), // Current group
-                Constraint::Length(1), // Current profile
-                Constraint::Length(1), // Spacer
-                Constraint::Length(1), // New title field
-                Constraint::Length(1), // New group field
-                Constraint::Length(1), // Profile selector
-                Constraint::Length(1), // Spacer
-                Constraint::Min(1),    // Hint
-            ])
+            .constraints(constraints)
             .split(inner);
 
         // Current title
@@ -451,13 +546,65 @@ impl RenameDialog {
         self.render_profile_selector(frame, chunks[6], theme);
         self.focusable_rects.push((2, chunks[6]));
 
+        // Branch toggle + remote-orphan warning (tied worktree only)
+        if let Some(idx) = toggle_idx {
+            self.render_branch_toggle(frame, chunks[idx], theme);
+            self.focusable_rects.push((3, chunks[idx]));
+        }
+        if let Some(idx) = warning_idx {
+            self.render_branch_warning(frame, chunks[idx], theme);
+        }
+
         // Hint
-        self.render_hints(frame, chunks[8], theme);
+        self.render_hints(frame, chunks[hint_idx], theme);
 
         // Render group picker overlay
         if self.group_picker.is_active() {
             self.group_picker.render(frame, area, theme);
         }
+    }
+
+    fn render_branch_toggle(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let focused = self.is_branch_toggle_field();
+        let checkbox = if self.rename_branch { "[x]" } else { "[ ]" };
+        let style = if focused {
+            Style::default().fg(theme.accent)
+        } else {
+            Style::default().fg(theme.text)
+        };
+        let mut spans = vec![
+            Span::styled(format!("{checkbox} "), style),
+            Span::styled("Also rename git branch", style),
+        ];
+        // Show the current branch dimmed so the user knows what is being
+        // renamed (and from what), since the title may already match the dir.
+        if let Some(wt) = &self.worktree_branch {
+            spans.push(Span::styled(
+                format!("  ({})", wt.current),
+                Style::default().fg(theme.dimmed),
+            ));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    fn render_branch_warning(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let Some(wt) = &self.worktree_branch else {
+            return;
+        };
+        let Some(upstream) = &wt.upstream else {
+            return;
+        };
+        let lines = vec![
+            Line::from(Span::styled(
+                format!("! branch '{}' tracks {};", wt.current, upstream),
+                Style::default().fg(theme.error),
+            )),
+            Line::from(Span::styled(
+                "  the remote branch won't follow",
+                Style::default().fg(theme.error),
+            )),
+        ];
+        frame.render_widget(Paragraph::new(lines), area);
     }
 
     fn render_group(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -608,6 +755,10 @@ impl RenameDialog {
             Span::styled("Tab", Style::default().fg(theme.hint)),
             Span::raw(" switch  "),
         ];
+        if self.is_branch_toggle_field() {
+            hint_spans.push(Span::styled("Space", Style::default().fg(theme.hint)));
+            hint_spans.push(Span::raw(" toggle  "));
+        }
         if self.is_group_field() && !self.existing_groups.is_empty() {
             if self.group_ghost_text().is_some() {
                 hint_spans.push(Span::styled("→", Style::default().fg(theme.hint)));
@@ -1492,6 +1643,101 @@ mod tests {
             dialog.validation_error.is_none(),
             "no validation error for own name"
         );
+    }
+
+    // --- Branch-rename toggle (tied worktree) tests ---
+
+    fn tied_dialog(upstream: Option<&str>) -> RenameDialog {
+        RenameDialog::new("hi", "", "default", default_profiles(), Vec::new())
+            .with_worktree_branch("thing", upstream.map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn test_branch_toggle_absent_without_worktree_context() {
+        // A plain session (no with_worktree_branch) has no 4th field and
+        // never emits rename_branch=true.
+        let mut dialog = RenameDialog::new("hi", "", "default", default_profiles(), Vec::new());
+        assert_eq!(dialog.field_count(), 3);
+        assert!(!dialog.shows_branch_toggle());
+        dialog.handle_key(key(KeyCode::Char('x')));
+        match dialog.handle_key(key(KeyCode::Enter)) {
+            DialogResult::Submit(data) => assert!(!data.rename_branch),
+            _ => panic!("expected submit"),
+        }
+    }
+
+    #[test]
+    fn test_branch_toggle_present_for_tied_worktree() {
+        let dialog = tied_dialog(Some("origin/thing"));
+        assert!(dialog.shows_branch_toggle());
+        assert_eq!(dialog.field_count(), 4);
+    }
+
+    #[test]
+    fn test_branch_toggle_defaults_off_and_flips_with_space() {
+        let mut dialog = tied_dialog(None);
+        // Tab title -> group -> profile -> toggle (index 3).
+        dialog.handle_key(key(KeyCode::Tab));
+        dialog.handle_key(key(KeyCode::Tab));
+        dialog.handle_key(key(KeyCode::Tab));
+        assert!(dialog.is_branch_toggle_field());
+        assert!(!dialog.rename_branch);
+        dialog.handle_key(key(KeyCode::Char(' ')));
+        assert!(dialog.rename_branch);
+        // Space again toggles back off.
+        dialog.handle_key(key(KeyCode::Char(' ')));
+        assert!(!dialog.rename_branch);
+    }
+
+    #[test]
+    fn test_branch_toggle_emitted_in_submit() {
+        let mut dialog = tied_dialog(Some("origin/thing"));
+        // Change the title so submit is not a no-op, then arm the toggle.
+        dialog.handle_key(key(KeyCode::Char('x')));
+        dialog.handle_key(key(KeyCode::Tab)); // group
+        dialog.handle_key(key(KeyCode::Tab)); // profile
+        dialog.handle_key(key(KeyCode::Tab)); // toggle
+        dialog.handle_key(key(KeyCode::Char(' ')));
+        match dialog.handle_key(key(KeyCode::Enter)) {
+            DialogResult::Submit(data) => {
+                assert_eq!(data.title, "x");
+                assert!(data.rename_branch);
+            }
+            _ => panic!("expected submit"),
+        }
+    }
+
+    #[test]
+    fn test_branch_toggle_can_rename_branch_without_title_change() {
+        // The toggle must be usable to bring a drifted branch in line with
+        // the title even when the title itself is unchanged: arming it makes
+        // the dialog submit (not cancel) so the rename flow runs.
+        let mut dialog = tied_dialog(None);
+        dialog.handle_key(key(KeyCode::Tab)); // group
+        dialog.handle_key(key(KeyCode::Tab)); // profile
+        dialog.handle_key(key(KeyCode::Tab)); // toggle
+        dialog.handle_key(key(KeyCode::Char(' ')));
+        match dialog.handle_key(key(KeyCode::Enter)) {
+            DialogResult::Submit(data) => {
+                assert_eq!(data.title, ""); // title unchanged
+                assert!(data.rename_branch);
+            }
+            _ => panic!("expected submit even with no title change"),
+        }
+    }
+
+    #[test]
+    fn test_space_still_cycles_profile_not_branch_toggle() {
+        // The branch-toggle space handler must not steal space from the
+        // profile chip.
+        let mut dialog = RenameDialog::new("hi", "", "default", multi_profiles(), Vec::new())
+            .with_worktree_branch("thing", None);
+        dialog.handle_key(key(KeyCode::Tab)); // group
+        dialog.handle_key(key(KeyCode::Tab)); // profile
+        assert!(dialog.is_profile_field());
+        dialog.handle_key(key(KeyCode::Char(' '))); // cycle profile
+        assert_eq!(dialog.profile_index, 1);
+        assert!(!dialog.rename_branch);
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1785,6 +1785,7 @@ impl HomeView {
                                 &data.title,
                                 data.group.as_deref(),
                                 data.profile.as_deref(),
+                                data.rename_branch,
                             ) {
                                 tracing::error!(target: "tui.input", "Failed to rename session: {}", e);
                             }
@@ -3432,27 +3433,49 @@ impl HomeView {
     /// Shared by the `'r'` / `'R'` key handlers and the right-click
     /// context menu so all three entry points stay byte-identical.
     pub(super) fn open_rename_for_selected(&mut self) {
-        if let Some(id) = &self.selected_session {
-            if let Some(inst) = self.get_instance(id) {
-                if matches!(inst.status, Status::Deleting | Status::Creating) {
-                    return;
-                }
-                // Rename is anchored to the selected session, so the dialog
-                // must open against that session's profile, not the
-                // view-level active/config profile (which can differ in
-                // all-profiles mode).
-                let current_profile = inst.source_profile.clone();
-                let profiles = list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-                let existing_groups: Vec<String> =
-                    self.all_groups().iter().map(|g| g.path.clone()).collect();
-                self.rename_dialog = Some(RenameDialog::new(
-                    &inst.title,
-                    &inst.group_path,
-                    &current_profile,
-                    profiles,
-                    existing_groups,
-                ));
+        if let Some(id) = self.selected_session.clone() {
+            let Some(inst) = self.get_instance(&id) else {
+                return;
+            };
+            if matches!(inst.status, Status::Deleting | Status::Creating) {
+                return;
             }
+            // Rename is anchored to the selected session, so the dialog
+            // must open against that session's profile, not the
+            // view-level active/config profile (which can differ in
+            // all-profiles mode).
+            let current_profile = inst.source_profile.clone();
+            let title = inst.title.clone();
+            let group_path = inst.group_path.clone();
+            // Capture branch context up front; a tied aoe-managed worktree
+            // can opt to rename the branch alongside the directory.
+            let branch_ctx = inst
+                .worktree_info
+                .as_ref()
+                .map(|w| (w.branch.clone(), w.main_repo_path.clone()));
+
+            let profiles = list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
+            let existing_groups: Vec<String> =
+                self.all_groups().iter().map(|g| g.path.clone()).collect();
+            let mut dialog = RenameDialog::new(
+                &title,
+                &group_path,
+                &current_profile,
+                profiles,
+                existing_groups,
+            );
+            if self.tie_workdir_applies_for(&id) {
+                if let Some((branch, main_repo)) = branch_ctx {
+                    // The upstream probe is a quick `git for-each-ref`; this
+                    // is a one-shot on dialog open, not a hot path.
+                    let upstream =
+                        crate::git::GitWorktree::new(std::path::PathBuf::from(&main_repo))
+                            .ok()
+                            .and_then(|g| g.branch_upstream(&branch));
+                    dialog = dialog.with_worktree_branch(&branch, upstream);
+                }
+            }
+            self.rename_dialog = Some(dialog);
         } else if let Some(group_path) = &self.selected_group {
             if self.group_by == GroupByMode::Project {
                 let hint = if self.strict_hotkeys {

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -882,6 +882,7 @@ impl HomeView {
         new_title: &str,
         new_group: Option<&str>,
         new_profile: Option<&str>,
+        rename_branch: bool,
     ) -> anyhow::Result<()> {
         if let Some(id) = &self.selected_session {
             let id = id.clone();
@@ -911,7 +912,13 @@ impl HomeView {
             // session surfaces a warning and nothing is renamed. Applied below
             // in both the profile-move and the standard persist paths.
             let mut new_path: Option<String> = None;
-            if current_title != effective_title && self.tie_workdir_applies_for(&id) {
+            let mut new_branch: Option<String> = None;
+            // Fire when the title changed (dir follows it) OR the user opted to
+            // rename the branch (which may be requested even with the title
+            // unchanged, to bring a drifted branch back in line with the dir).
+            if (current_title != effective_title || rename_branch)
+                && self.tie_workdir_applies_for(&id)
+            {
                 let snapshot = self.get_instance(&id).map(|i| {
                     (
                         i.worktree_info.clone(),
@@ -956,21 +963,27 @@ impl HomeView {
                             worktree_info: &worktree_info,
                             current_path: std::path::Path::new(&project_path),
                             new_name: &leaf,
-                            rename_branch: false,
+                            rename_branch,
                         },
                     ) {
                         Ok(outcome) => {
+                            // Discard the stale container only when the dir
+                            // actually moved. A branch-only rename (title
+                            // unchanged, toggle armed) leaves the path, and thus
+                            // the mount and working dir, valid, so there is
+                            // nothing stale to recreate.
+                            let dir_moved = outcome.new_path != std::path::Path::new(&project_path);
                             new_path = Some(outcome.new_path.to_string_lossy().to_string());
-                            // The dir moved; a sandbox container created against
-                            // the old path is now stale, so drop it to force a
-                            // fresh create on next start.
-                            crate::session::worktree_edit::discard_sandbox_container_after_move(
-                                &id,
-                                is_sandboxed,
-                            );
+                            new_branch = outcome.new_branch;
+                            if dir_moved {
+                                crate::session::worktree_edit::discard_sandbox_container_after_move(
+                                    &id,
+                                    is_sandboxed,
+                                );
+                            }
                         }
-                        // Leaf maps to the current dir: nothing to move, just
-                        // rename the title.
+                        // Leaf maps to the current dir and no branch rename was
+                        // requested: nothing to move, just rename the title.
                         Err(crate::session::worktree_edit::WorktreeEditError::Unchanged) => {}
                         Err(e) => {
                             self.info_dialog = Some(crate::tui::dialogs::InfoDialog::new(
@@ -1036,6 +1049,7 @@ impl HomeView {
                     instance.source_profile = target_profile.to_string();
                     let new_title = instance.title.clone();
                     let moved_path = new_path.clone();
+                    let moved_branch = new_branch.clone();
                     self.move_to_profile(&id, target_profile, instance.group_path.clone())?;
                     // apply_user_action (not mutate_instance + save) so a tied
                     // worktree's moved project_path actually persists; save()
@@ -1044,6 +1058,11 @@ impl HomeView {
                         inst.title = new_title.clone();
                         if let Some(path) = &moved_path {
                             inst.project_path = path.clone();
+                        }
+                        if let Some(branch) = &moved_branch {
+                            if let Some(wt) = inst.worktree_info.as_mut() {
+                                wt.branch = branch.clone();
+                            }
                         }
                     })?;
 
@@ -1085,6 +1104,11 @@ impl HomeView {
                 inst.group_path = effective_group.clone();
                 if let Some(path) = &new_path {
                     inst.project_path = path.clone();
+                }
+                if let Some(branch) = &new_branch {
+                    if let Some(wt) = inst.worktree_info.as_mut() {
+                        wt.branch = branch.clone();
+                    }
                 }
             })?;
 

--- a/tests/e2e/archive_restore.rs
+++ b/tests/e2e/archive_restore.rs
@@ -101,6 +101,12 @@ fn test_archive_then_unarchive_cycle() {
     // Unarchive it; the row returns to the active list, still selected.
     h.send_keys("z");
     h.wait_for_absent("is parked", Duration::from_secs(5));
+    // The unarchive triggers a full clear+redraw. `wait_for_absent` above can
+    // satisfy on the transient blank frame mid-redraw, so a bare capture here
+    // races the repaint and sometimes catches an empty screen (the same blank
+    // capture `assert_screen_contains` retries around). Poll for the row to
+    // actually repaint into the active list before asserting on a single frame.
+    h.wait_for("Archivo");
     let after_unarchive = h.capture_screen();
     assert!(
         after_unarchive.contains("Archivo"),


### PR DESCRIPTION
## Description

Closes a parity gap: the TUI's tied title-rename moved the worktree directory but hardcoded `rename_branch=false`, so a session's git branch could only be renamed via the CLI (`--rename-branch`) or the web PATCH (`rename_branch: true`). The standalone TUI worktree-name dialog already had an "Also rename git branch" toggle; the tied rename did not.

This adds that toggle to the tied rename dialog (default off) for tied aoe-managed worktree sessions.

Behavior:
- Default stays dir-only; the branch is only renamed when the user opts in.
- When the branch tracks a remote, the dialog shows a warning that the remote branch (and any open PR) won't follow the local `git branch -m`, since that only touches the local ref.
- The toggle also works with an unchanged title, so you can bring a drifted branch back in line with the directory (the `hi` / `thing` divergence case).

Implementation:
- New `GitWorktree::branch_upstream()` (a quiet `git for-each-ref`) drives the warning; probed once on dialog open, not on a hot path.
- `RenameDialog` grows an optional 4th focusable field (index 3) only when `with_worktree_branch()` is called, so non-tied sessions are unchanged.
- `rename_selected` now fires the worktree edit when the title changed OR the branch toggle is armed, and persists the renamed branch in both the standard and profile-move persist paths.

This is split out from the sandbox-container rename fix (#2117); it is an independent feature off `main`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (docs/guides/worktrees.md)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (TUI only; the web rename already supports `rename_branch`)

**TUI / CLI (e2e test)**
- [x] Added or updated unit tests: 6 new tests in `src/tui/dialogs/rename.rs` covering toggle presence (tied vs not), default-off, space/click flip, emission in the submit payload, rename-branch-without-title-change, and that the toggle's space handler does not steal space from the profile chip. The pre-existing 47 dialog tests still pass.
- [x] Skipped a full tests/e2e run, because: the end-to-end branch rename (git side effect + persistence) needs a real worktree + tmux session; the decision/wiring logic is unit-covered and the git side effect path (`edit_worktree_workdir`) was already exercised by the existing CLI/web rename-branch support.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Built via Claude Code, reviewed and directed by me.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783863453&installation_id=139138837&pr_number=2118&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2118&signature=df50f191b65fca8b2a24b5dffe2de4e645edf5b806fabcad5609fd990772e078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds an optional "Also rename git branch" toggle to the TUI tied-worktree rename dialog so users can opt to rename the underlying git branch when renaming a session directory. The toggle defaults to off, preserving directory-only behavior unless explicitly enabled.

## What changed (high-level)

- UI: The Rename dialog can show a fourth focusable field — an "Also rename git branch" toggle — and displays a warning if the branch tracks a remote.
- Git probing: Adds a quiet upstream probe so the dialog can detect remote tracking and show the appropriate warning.
- Rename flow: The rename operation will perform a branch rename if the toggle is armed; this can occur even when the session title is unchanged (to realign branch ↔ directory).
- Persistence: When a branch rename occurs, the new branch name is persisted in both the normal and profile-move persist paths.
- Docs & tests: Updated docs (worktrees guide) and added six unit tests covering toggle presence, default-off, toggle interaction, submit payload, rename-without-title-change, and input handling.

## Technical details (concise)

- New method: GitWorktree::branch_upstream(&self, branch: &str) -> Option<String> — runs git for-each-ref to detect upstream tracking.
- UI API: RenameDialog::with_worktree_branch(current_branch: &str, upstream: Option<String>) -> Self — enables the branch-toggle UI.
- Data/flow changes:
  - RenameData now includes pub rename_branch: bool.
  - rename_selected(...) signature extended to accept rename_branch: bool; worktree edit is triggered when title changes OR rename_branch is true.
  - Sandbox/container discard after worktree edits occurs only when the worktree directory actually moved (avoids cleanup for branch-only renames).
- Rendering/input: Dialog layout, focus routing, and hints updated to include the toggle and its Space-toggle interaction; remote-upstream warning shown when appropriate.
- Tests: Six unit tests added in src/tui/dialogs/rename.rs.

## Benefits

- Restores parity with CLI/REST by making branch renames possible from the TUI while keeping a safe opt-in default.
- Lets users realign branches and directories without forcing a title change.
- Warns about remote-tracking limitations (local git branch rename does not move remote branches or open PRs).
- Avoids unnecessary sandbox cleanup for branch-only renames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->