### PR TITLE
fix(session): skip a corrupt row in Storage::load

### DIFF
--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -316,7 +316,7 @@ impl Storage {
         let mut instances = Vec::with_capacity(rows.len());
         let mut corrupt: Vec<serde_json::Value> = Vec::new();
         for (idx, row) in rows.into_iter().enumerate() {
-            match serde_json::from_value::<Instance>(row.clone()) {
+            match <Instance as serde::Deserialize>::deserialize(&row) {
                 Ok(mut inst) => {
                     inst.set_file_watch(self.file_watch.clone());
                     instances.push(inst);
@@ -341,11 +341,18 @@ impl Storage {
         Ok(instances)
     }
 
-    /// Append corrupt session rows to a sibling `sessions.corrupt.jsonl`
+    /// Write corrupt session rows to a sibling `sessions.corrupt.jsonl`
     /// quarantine file (one JSON object per line) for later inspection and
     /// manual recovery. Best-effort: a failure to write the sidecar is
     /// logged but never fails the load, since the whole point is to keep the
     /// surviving sessions reachable.
+    ///
+    /// Truncates rather than appends: `load()` runs on read-only refresh
+    /// paths (TUI reconcile, web list, CLI) that never rewrite
+    /// `sessions.json`, so a persistently corrupt row would otherwise be
+    /// re-appended on every load and grow the sidecar without bound. Each
+    /// load sees the full current corrupt set, so an overwrite is a
+    /// complete, deduplicated snapshot.
     fn quarantine_corrupt_rows(&self, rows: &[serde_json::Value]) {
         let path = self.sessions_path.with_file_name("sessions.corrupt.jsonl");
 
@@ -366,12 +373,7 @@ impl Storage {
             return;
         }
 
-        if let Err(e) = fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .and_then(|mut f| f.write_all(buf.as_bytes()))
-        {
+        if let Err(e) = fs::write(&path, buf.as_bytes()) {
             tracing::warn!(
                 error = %e,
                 path = %path.display(),
@@ -591,6 +593,13 @@ mod tests {
         let q = fs::read_to_string(&quarantine)?;
         assert_eq!(q.lines().count(), 1, "exactly one row quarantined");
         assert!(q.contains("corrupt-no-id"), "malformed row is preserved");
+
+        // A second read-only load must not duplicate the row: load() runs on
+        // refresh paths that never rewrite sessions.json, so the sidecar is
+        // overwritten with the current corrupt set rather than appended to.
+        assert_eq!(storage.load()?.len(), 2);
+        let q = fs::read_to_string(&quarantine)?;
+        assert_eq!(q.lines().count(), 1, "repeated load must not duplicate");
 
         Ok(())
     }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -306,11 +306,78 @@ impl Storage {
             return Ok(Vec::new());
         }
 
-        let mut instances: Vec<Instance> = serde_json::from_str(&content)?;
-        for inst in &mut instances {
-            inst.set_file_watch(self.file_watch.clone());
+        // Two-phase parse: deserialise the outer array as opaque values
+        // first, then attempt `Instance` per row. A single unparseable row
+        // (forward-incompatible field, partial write, manual edit) degrades
+        // to "that one session is missing" instead of locking the user out
+        // of every session. Top-level corruption (not a valid JSON array)
+        // still propagates as `Err` so it is never silently masked.
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&content)?;
+        let mut instances = Vec::with_capacity(rows.len());
+        let mut corrupt: Vec<serde_json::Value> = Vec::new();
+        for (idx, row) in rows.into_iter().enumerate() {
+            match serde_json::from_value::<Instance>(row.clone()) {
+                Ok(mut inst) => {
+                    inst.set_file_watch(self.file_watch.clone());
+                    instances.push(inst);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        profile = %self.profile,
+                        row = idx,
+                        error = %e,
+                        path = %self.sessions_path.display(),
+                        "skipping corrupt session row"
+                    );
+                    corrupt.push(row);
+                }
+            }
         }
+
+        if !corrupt.is_empty() {
+            self.quarantine_corrupt_rows(&corrupt);
+        }
+
         Ok(instances)
+    }
+
+    /// Append corrupt session rows to a sibling `sessions.corrupt.jsonl`
+    /// quarantine file (one JSON object per line) for later inspection and
+    /// manual recovery. Best-effort: a failure to write the sidecar is
+    /// logged but never fails the load, since the whole point is to keep the
+    /// surviving sessions reachable.
+    fn quarantine_corrupt_rows(&self, rows: &[serde_json::Value]) {
+        let path = self.sessions_path.with_file_name("sessions.corrupt.jsonl");
+
+        let mut buf = String::new();
+        for row in rows {
+            match serde_json::to_string(row) {
+                Ok(line) => {
+                    buf.push_str(&line);
+                    buf.push('\n');
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    "failed to serialise corrupt session row for quarantine"
+                ),
+            }
+        }
+        if buf.is_empty() {
+            return;
+        }
+
+        if let Err(e) = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .and_then(|mut f| f.write_all(buf.as_bytes()))
+        {
+            tracing::warn!(
+                error = %e,
+                path = %path.display(),
+                "failed to write session quarantine file"
+            );
+        }
     }
 
     pub fn load_with_groups(&self) -> Result<(Vec<Instance>, Vec<Group>)> {
@@ -486,6 +553,72 @@ mod tests {
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded[0].title, "test1");
         assert_eq!(loaded[1].title, "test2");
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_skips_corrupt_row_and_quarantines() -> Result<()> {
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+        let storage = Storage::new_unwatched("test-profile")?;
+
+        // [ valid, malformed, valid ]: the malformed row is an object that
+        // is missing `Instance`'s required `id`/`project_path` fields.
+        let valid = [
+            Instance::new("alpha", "/tmp/alpha"),
+            Instance::new("beta", "/tmp/beta"),
+        ];
+        let mut rows: Vec<serde_json::Value> = valid
+            .iter()
+            .map(|i| serde_json::to_value(i).unwrap())
+            .collect();
+        rows.insert(1, serde_json::json!({ "title": "corrupt-no-id" }));
+
+        fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
+        fs::write(&storage.sessions_path, serde_json::to_vec_pretty(&rows)?)?;
+
+        let loaded = storage.load()?;
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].title, "alpha");
+        assert_eq!(loaded[1].title, "beta");
+
+        let quarantine = storage
+            .sessions_path
+            .with_file_name("sessions.corrupt.jsonl");
+        assert!(quarantine.exists(), "quarantine sidecar should be created");
+        let q = fs::read_to_string(&quarantine)?;
+        assert_eq!(q.lines().count(), 1, "exactly one row quarantined");
+        assert!(q.contains("corrupt-no-id"), "malformed row is preserved");
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_top_level_corruption_still_errors() -> Result<()> {
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+        let storage = Storage::new_unwatched("test-profile")?;
+
+        fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
+        // Not a valid JSON array: top-level corruption must not be silently
+        // masked by the per-row fallthrough.
+        fs::write(&storage.sessions_path, b"{ this is not valid json ]")?;
+
+        assert!(
+            storage.load().is_err(),
+            "top-level corruption should still surface as Err"
+        );
+
+        let quarantine = storage
+            .sessions_path
+            .with_file_name("sessions.corrupt.jsonl");
+        assert!(
+            !quarantine.exists(),
+            "no quarantine file for top-level corruption"
+        );
 
         Ok(())
     }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -373,7 +373,14 @@ impl Storage {
             return;
         }
 
-        if let Err(e) = fs::write(&path, buf.as_bytes()) {
+        // `atomic_write` (not `fs::write`) so the sidecar matches the
+        // durability and privacy guarantees of `sessions.json`: a crash
+        // mid-write cannot tear the only surviving copy of the lost row,
+        // the file lands at 0o600 (it can echo tokens from
+        // `Instance.command`) instead of umask-default 0o644, and the
+        // unlocked, concurrently-reachable `load()` callers collapse to a
+        // benign last-writer-wins instead of interleaving bytes.
+        if let Err(e) = atomic_write(&path, buf.as_bytes()) {
             tracing::warn!(
                 error = %e,
                 path = %path.display(),
@@ -593,6 +600,15 @@ mod tests {
         let q = fs::read_to_string(&quarantine)?;
         assert_eq!(q.lines().count(), 1, "exactly one row quarantined");
         assert!(q.contains("corrupt-no-id"), "malformed row is preserved");
+
+        // The sidecar can echo tokens carried in `Instance.command`, so it
+        // must be written 0o600 like `sessions.json`, not umask-default 0o644.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&quarantine)?.permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "quarantine sidecar must be owner-only");
+        }
 
         // A second read-only load must not duplicate the row: load() runs on
         // refresh paths that never rewrite sessions.json, so the sidecar is

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -612,22 +612,24 @@ mod tests {
         let storage = Storage::new_unwatched("test-profile")?;
 
         fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
-        // Not a valid JSON array: top-level corruption must not be silently
-        // masked by the per-row fallthrough.
-        fs::write(&storage.sessions_path, b"{ this is not valid json ]")?;
-
-        assert!(
-            storage.load().is_err(),
-            "top-level corruption should still surface as Err"
-        );
-
         let quarantine = storage
             .sessions_path
             .with_file_name("sessions.corrupt.jsonl");
-        assert!(
-            !quarantine.exists(),
-            "no quarantine file for top-level corruption"
-        );
+
+        // Both forms of top-level corruption must surface as Err and never be
+        // masked by the per-row fallthrough: valid JSON of the wrong shape (an
+        // object, not an array) and syntactically invalid JSON (a torn write).
+        for bad in [&b"{}"[..], &b"{ this is not valid json ]"[..]] {
+            fs::write(&storage.sessions_path, bad)?;
+            assert!(
+                storage.load().is_err(),
+                "top-level corruption should still surface as Err"
+            );
+            assert!(
+                !quarantine.exists(),
+                "no quarantine file for top-level corruption"
+            );
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Description

`Storage::load` deserialised `sessions.json` as a single `Vec<Instance>` (`src/session/storage.rs`), so one unparseable row (forward-incompatible field, partial write, manual edit, mid-flight migration) caused the entire load to fail. The user lost access to **every** session across TUI/CLI/web until they hand-edited the file.

This implements approach **A** from #1846 (two-phase parse):

1. Parse the file as `Vec<serde_json::Value>`.
2. Attempt `serde_json::from_value::<Instance>` per row. Successes load; each failure is `tracing::warn!`'d with the row index + serde error and appended to a sibling `sessions.corrupt.jsonl` quarantine file for recovery.
3. Return the surviving sessions.

Top-level corruption (the outer JSON is not a valid array) still returns `Err`, so it is never silently masked. No write-path or schema changes.

Closes #1846

### Before — one bad row, every session is gone

![before](https://raw.githubusercontent.com/markphilipp/agent-of-empires/assets/corrupt-row-handling/before.gif)

### After — the bad row is skipped + quarantined, the rest load

![after](https://raw.githubusercontent.com/markphilipp/agent-of-empires/assets/corrupt-row-handling/after.gif)

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none required)
- [x] For UI changes: included screenshot or recording (CLI/TUI behavior GIFs above)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the new behavior is pure load-path logic and is covered by two unit tests in `src/session/storage.rs` that directly exercise it, matching the acceptance criteria:
  - `test_load_skips_corrupt_row_and_quarantines`: a `[ valid, malformed, valid ]` file returns 2 sessions and writes the malformed entry to the quarantine sidecar.
  - `test_load_top_level_corruption_still_errors`: a non-array/invalid-JSON file still returns `Err` and writes no quarantine file.

  An e2e through tmux would add flake without exercising any path the unit tests miss.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implementation, unit tests, and before/after GIFs drafted with AI assistance; reviewed by the author.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783869641&installation_id=139138837&pr_number=2119&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2119&signature=cb19255f5d8aaa85f416372a3ece7d3d65070a0fd3165058498de0481add02c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR makes session loading more robust: if `sessions.json` contains a single corrupted row, the app will now load all valid sessions instead of failing entirely and locking users out.

## What Changed
- **`Storage::load`:** Switched to a two-step read process so it can validate the file structure first, then skip only the specific bad entries.
- **Quarantine sidecar:** Corrupt session rows are written to a sibling recovery file, `sessions.corrupt.jsonl` (JSONL), instead of being dropped silently.
- **Logging:** Each skipped row is logged with its array index and the serde error details for easier troubleshooting.
- **Helper added:** A new internal helper (`quarantine_corrupt_rows`) encapsulates writing quarantined rows to the sidecar safely (best-effort; failures don’t break loading).
- **Tests added:** 
  - Verifies `[valid, malformed, valid]` results in 2 loaded sessions and creates `sessions.corrupt.jsonl` with the malformed entry.
  - Verifies non-array top-level JSON (e.g. `{}`) still returns an error and does **not** create the quarantine file.

## What Stayed the Same
- The **write path** and **session schema** are unchanged.
- **Top-level JSON structure problems** still fail fast (they’re not masked).

## Benefits
- **Resilience:** One bad row no longer prevents all sessions from loading.
- **Recoverability:** Corrupt entries are isolated into a quarantine file for later investigation or repair.
- **Better visibility:** Clear warnings point to the exact row that failed deserialization.
- **Controlled sidecar behavior:** The quarantine file is overwritten with the current set of corrupt entries to avoid stale accumulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->