### PR TITLE
feat(sandbox): per-session input + repo slug for before_start hooks

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -221,10 +221,15 @@ The `[host_hooks]` block declares hooks that run on the **host** (not inside the
 
 ```toml
 [host_hooks]
-before_start = ['echo "GH_TOKEN=$(my-mint-tool $AOE_PROJECT_PATH)"']
+before_start = ['echo "GH_TOKEN=$(my-mint-tool "$AOE_REPO_SLUG")"']
 ```
 
-`before_start` runs each time a sandbox container comes up (on create and on restart, so short-lived values are refreshed before the agent launches). Each `KEY=VALUE` line the command prints to stdout is injected into the container environment as an **inherited** variable: the value is passed to the `docker` invocation through the process environment, never in argv, so it does not appear in `ps`. Lines that are not `KEY=VALUE` are ignored, and the hook's stdout is never logged, so it is safe to print a secret. A non-zero exit aborts bringing the container up. The lifecycle env vars (`AOE_PROJECT_PATH`, `AOE_SESSION_ID`, `AOE_PROFILE`, ...) are available to the command.
+`before_start` runs each time a sandbox container comes up (on create and on restart, so short-lived values are refreshed before the agent launches). Each `KEY=VALUE` line the command prints to stdout is injected into the container environment as an **inherited** variable: the value is passed to the `docker` invocation through the process environment, never in argv, so it does not appear in `ps`. Lines that are not `KEY=VALUE` are ignored, and the hook's stdout is never logged, so it is safe to print a secret. A non-zero exit aborts bringing the container up.
+
+The command's environment carries:
+
+- **Lifecycle vars:** `AOE_SESSION_ID`, `AOE_SESSION_TITLE`, `AOE_PROJECT_PATH`, `AOE_PROFILE`, `AOE_TOOL`, `AOE_GROUP_PATH`, `AOE_SESSION_BRANCH` (worktree sessions only), and `AOE_REPO_SLUG` (the `owner/repo` of the project's `origin` remote, when it parses; useful for minting a repo-scoped credential without parsing the path yourself).
+- **The session's resolved sandbox environment**, so a per-session value reaches the hook. Set `TEST_VAR=foo` in the session's sandbox env (the new-session dialog's env list accepts `KEY=VALUE`), and the hook reads `$TEST_VAR`; a different session can set a different value. This is the per-session input channel (the host process env, e.g. `TEST_VAR=foo aoe add ...`, only varies per CLI invocation, so in the long-running TUI it would otherwise be fixed for every session).
 
 The canonical use case is per-session, repo-scoped, short-lived credentials: mint a one-hour, single-repo token on the host (where the broad credential lives) and inject only the narrow token, so the minting tool and host credential never enter the container.
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -23,7 +23,7 @@ mod remote;
 pub mod template;
 mod worktree;
 
-pub use remote::{clone_bare_repo, clone_repo, get_remote_owner};
+pub use remote::{clone_bare_repo, clone_repo, get_remote_owner, get_remote_slug};
 pub use worktree::{GitWorktree, WorktreeEntry};
 
 /// Open a git repository at the given path without searching parent directories.

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -329,6 +329,40 @@ pub fn get_remote_owner(path: &Path) -> Option<String> {
     parse_owner_from_remote_url(url)
 }
 
+/// Extract the `owner/repo` slug from a git remote URL, stripping any `.git`
+/// suffix and trailing slash. Handles the same formats as
+/// [`parse_owner_from_remote_url`]. Returns `None` if either segment is missing.
+pub(crate) fn parse_slug_from_remote_url(url: &str) -> Option<String> {
+    // Reduce to the path after the host: `owner/repo(.git)`.
+    let path = if !url.contains("://") {
+        // SSH shorthand: git@host:owner/repo.git
+        let colon_pos = url.find(':')?;
+        if !url[..colon_pos].contains('@') {
+            return None;
+        }
+        &url[colon_pos + 1..]
+    } else {
+        let without_scheme = url.split("://").nth(1)?;
+        &without_scheme[without_scheme.find('/')? + 1..]
+    };
+    let path = path.trim_end_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let mut segments = path.split('/');
+    let owner = segments.next().filter(|s| !s.is_empty())?;
+    let repo = segments.next().filter(|s| !s.is_empty())?;
+    Some(format!("{}/{}", owner, repo))
+}
+
+/// Look up the `owner/repo` slug of a git repository by reading the `origin`
+/// remote URL. Returns `None` if the path is not a git repo, has no origin
+/// remote, or the URL cannot be parsed into an owner/repo pair.
+pub fn get_remote_slug(path: &Path) -> Option<String> {
+    let repo = open_repo_at(path).ok()?;
+    let remote = repo.find_remote("origin").ok()?;
+    let url = remote.url().ok()?;
+    parse_slug_from_remote_url(url)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,6 +373,31 @@ mod tests {
             parse_owner_from_remote_url("git@github.com:agent-of-empires/agent-of-empires.git"),
             Some("agent-of-empires".to_string()),
         );
+    }
+
+    #[test]
+    fn test_parse_slug_formats() {
+        for url in [
+            "git@github.com:mozilla-ai/any-llm.git",
+            "https://github.com/mozilla-ai/any-llm.git",
+            "ssh://git@github.com/mozilla-ai/any-llm.git",
+            "https://github.com/mozilla-ai/any-llm", // no .git suffix
+            "git@github.com:mozilla-ai/any-llm",
+        ] {
+            assert_eq!(
+                parse_slug_from_remote_url(url),
+                Some("mozilla-ai/any-llm".to_string()),
+                "failed for {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_slug_rejects_incomplete() {
+        assert_eq!(parse_slug_from_remote_url(""), None);
+        // Owner but no repo segment.
+        assert_eq!(parse_slug_from_remote_url("git@github.com:owner"), None);
+        assert_eq!(parse_slug_from_remote_url("https://github.com/owner"), None);
     }
 
     #[test]

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -229,6 +229,49 @@ pub(crate) fn host_environment_prefix(entries: &[String]) -> String {
     out
 }
 
+/// Resolve a session's sandbox environment entries to concrete `(KEY, VALUE)`
+/// pairs on the host, for feeding into a host-side hook's process environment
+/// (so a `before_start` hook can read a per-session `$TEST_VAR`).
+///
+/// Mirrors [`collect_environment`]'s precedence (per-session `extra_env`
+/// overrides `sandbox.environment`) and the shared entry grammar, but resolves
+/// every entry to a plain host value: `KEY=value` is literal, `KEY=$VAR` reads
+/// the host env, `KEY=$$literal` escapes a `$`, and a bare `KEY` passes through
+/// from the host env. Unset host references and bare keys are skipped.
+/// Deduplicates by key (first wins).
+pub(crate) fn session_host_env_pairs(
+    profile: &str,
+    project_path: &std::path::Path,
+    sandbox_info: &SandboxInfo,
+) -> Vec<(String, String)> {
+    let sandbox_config = resolved_sandbox_config(profile, project_path);
+    let entries: &[String] = sandbox_info
+        .extra_env
+        .as_deref()
+        .unwrap_or(&sandbox_config.environment);
+    resolve_host_env_pairs(entries)
+}
+
+/// Resolve env entries to concrete host `(KEY, VALUE)` pairs (the pure core of
+/// [`session_host_env_pairs`], split out so it can be tested without touching
+/// config on disk).
+fn resolve_host_env_pairs(entries: &[String]) -> Vec<(String, String)> {
+    let mut seen = std::collections::HashSet::new();
+    let mut pairs = Vec::new();
+    for entry in entries {
+        let (key, value) = match entry.split_once('=') {
+            Some((k, v)) => (k.to_string(), resolve_env_value(v)),
+            None => (entry.clone(), std::env::var(entry).ok()),
+        };
+        if let Some(v) = value {
+            if seen.insert(key.clone()) {
+                pairs.push((key, v));
+            }
+        }
+    }
+    pairs
+}
+
 pub(crate) fn resolve_host_environment_value(
     entries: &[String],
     target_key: &str,
@@ -903,6 +946,36 @@ environment = ["GH_TOKEN=write_token"]
         assert_eq!(entry.value(), "test_value");
         assert!(matches!(entry, EnvEntry::Inherit { .. }));
         std::env::remove_var("AOE_TEST_ENV_PT");
+    }
+
+    #[test]
+    fn test_resolve_host_env_pairs_grammar() {
+        std::env::set_var("AOE_TEST_HOST_PAIR_REF", "from_host");
+        std::env::set_var("AOE_TEST_HOST_PAIR_BARE", "bare_val");
+        std::env::remove_var("AOE_TEST_HOST_PAIR_MISSING");
+        let entries = vec![
+            "TEST_VAR=literal".to_string(),
+            "FROM_HOST=$AOE_TEST_HOST_PAIR_REF".to_string(),
+            "ESCAPED=$$LIT".to_string(),
+            "AOE_TEST_HOST_PAIR_BARE".to_string(),
+            "MISSING=$AOE_TEST_HOST_PAIR_MISSING".to_string(), // unset host ref: skipped
+            "TEST_VAR=second".to_string(),                     // dup key: first wins
+        ];
+        let pairs = resolve_host_env_pairs(&entries);
+        assert_eq!(
+            pairs,
+            vec![
+                ("TEST_VAR".to_string(), "literal".to_string()),
+                ("FROM_HOST".to_string(), "from_host".to_string()),
+                ("ESCAPED".to_string(), "$LIT".to_string()),
+                (
+                    "AOE_TEST_HOST_PAIR_BARE".to_string(),
+                    "bare_val".to_string()
+                ),
+            ]
+        );
+        std::env::remove_var("AOE_TEST_HOST_PAIR_REF");
+        std::env::remove_var("AOE_TEST_HOST_PAIR_BARE");
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2524,8 +2524,21 @@ impl Instance {
 
         let hook_env = super::repo_config::lifecycle_env_vars(self);
         let project_path = PathBuf::from(&self.project_path);
-        let minted =
-            super::repo_config::run_before_start_hooks(&commands, &project_path, &hook_env)?;
+        // Feed the session's resolved sandbox env into the hook so it can read a
+        // per-session value (e.g. `$TEST_VAR`) to scope what it mints.
+        let session_env = self
+            .sandbox_info
+            .as_ref()
+            .map(|sb| {
+                super::environment::session_host_env_pairs(&self.source_profile, &project_path, sb)
+            })
+            .unwrap_or_default();
+        let minted = super::repo_config::run_before_start_hooks(
+            &commands,
+            &project_path,
+            &hook_env,
+            &session_env,
+        )?;
         if let Some(sb) = self.sandbox_info.as_mut() {
             sb.before_start_env = minted;
         }

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -844,8 +844,9 @@ fn build_hook_command(
 ///
 /// Mirrors the naming in [`crate::status_hooks::StatusHookContext::env_vars`]
 /// so a single vocabulary covers both hook surfaces. `AOE_SESSION_BRANCH` is
-/// only present when the session has a worktree; other fields may be empty
-/// strings (e.g., `AOE_GROUP_PATH` for ungrouped sessions).
+/// only present when the session has a worktree; `AOE_REPO_SLUG` only when the
+/// project has an `origin` remote that parses to `owner/repo`; other fields may
+/// be empty strings (e.g., `AOE_GROUP_PATH` for ungrouped sessions).
 pub(crate) fn lifecycle_env_vars(instance: &super::Instance) -> Vec<(&'static str, String)> {
     let mut env = vec![
         ("AOE_SESSION_ID", instance.id.clone()),
@@ -857,6 +858,12 @@ pub(crate) fn lifecycle_env_vars(instance: &super::Instance) -> Vec<(&'static st
     ];
     if let Some(wt) = instance.worktree_info.as_ref() {
         env.push(("AOE_SESSION_BRANCH", wt.branch.clone()));
+    }
+    // The `owner/repo` slug from the origin remote, so a hook can mint a
+    // repo-scoped credential (e.g. `mint "$AOE_REPO_SLUG"`) without parsing the
+    // filesystem path itself. Omitted when there is no parseable origin remote.
+    if let Some(slug) = crate::git::get_remote_slug(std::path::Path::new(&instance.project_path)) {
+        env.push(("AOE_REPO_SLUG", slug));
     }
     env
 }
@@ -1147,10 +1154,16 @@ fn parse_env_kv_lines(stdout: &str) -> Vec<(String, String)> {
 /// without the values the agent depends on); the error message includes stderr
 /// but never stdout. Honors the shared hook timeout so a hanging mint command
 /// cannot wedge a session launch.
+///
+/// `extra_env` carries the session lifecycle vars (`AOE_*`); `session_env`
+/// carries the session's resolved sandbox environment so the hook can read a
+/// per-session value (e.g. `$TEST_VAR`) to scope what it mints. `session_env`
+/// is applied last, so it overrides the inherited process env for the same key.
 pub fn run_before_start_hooks(
     commands: &[String],
     project_path: &Path,
     extra_env: &[(&'static str, String)],
+    session_env: &[(String, String)],
 ) -> Result<Vec<(String, String)>> {
     let timeout = crate::session::recovery::current_hook_timeout();
     let mut collected: Vec<(String, String)> = Vec::new();
@@ -1170,6 +1183,7 @@ pub fn run_before_start_hooks(
             },
             extra_env,
         );
+        command.envs(session_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
         command
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
@@ -1440,7 +1454,8 @@ mod tests {
             "echo GH_TOKEN=ghs_abc".to_string(),
             "printf 'FOO=bar\\nnoise line\\n'".to_string(),
         ];
-        let minted = run_before_start_hooks(&cmds, tmp.path(), &[]).expect("hooks should succeed");
+        let minted =
+            run_before_start_hooks(&cmds, tmp.path(), &[], &[]).expect("hooks should succeed");
         assert_eq!(
             minted,
             vec![
@@ -1451,10 +1466,24 @@ mod tests {
     }
 
     #[test]
+    fn test_run_before_start_hooks_reads_session_env() {
+        // A per-session value reaches the hook and can scope what it mints.
+        let tmp = tempfile::tempdir().unwrap();
+        let cmds = vec!["echo \"GH_TOKEN=tok-$TEST_VAR\"".to_string()];
+        let session_env = [("TEST_VAR".to_string(), "alpha".to_string())];
+        let minted = run_before_start_hooks(&cmds, tmp.path(), &[], &session_env)
+            .expect("hooks should succeed");
+        assert_eq!(
+            minted,
+            vec![("GH_TOKEN".to_string(), "tok-alpha".to_string())]
+        );
+    }
+
+    #[test]
     fn test_run_before_start_hooks_hard_fail() {
         let tmp = tempfile::tempdir().unwrap();
         let cmds = vec!["exit 3".to_string()];
-        let err = run_before_start_hooks(&cmds, tmp.path(), &[])
+        let err = run_before_start_hooks(&cmds, tmp.path(), &[], &[])
             .expect_err("non-zero exit must be an error");
         assert!(err.to_string().contains("exit code 3"), "got: {err}");
     }
@@ -1468,7 +1497,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let cmds = vec!["echo \"GH_TOKEN=$SECRET_SRC\"; echo boom 1>&2; exit 1".to_string()];
         let extra_env = [("SECRET_SRC", "topsecret".to_string())];
-        let err = run_before_start_hooks(&cmds, tmp.path(), &extra_env)
+        let err = run_before_start_hooks(&cmds, tmp.path(), &extra_env, &[])
             .expect_err("non-zero exit must be an error");
         let msg = err.to_string();
         assert!(!msg.contains("topsecret"), "stdout secret leaked: {msg}");

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3225,6 +3225,23 @@ impl HomeView {
                 if let Err(e) = self.reload() {
                     tracing::warn!(target: "tui.home", "Failed to reload session state: {e}");
                 }
+                // The creation poller may have minted `before_start_env` while
+                // bringing the container up. It is `#[serde(skip)]`, so the
+                // reload above dropped it; carry it back onto the live instance
+                // (mirroring the CLI's `merge_post_start` and the structured-view
+                // stamp-back) so the agent launch reuses it instead of re-minting.
+                let minted = instance
+                    .sandbox_info
+                    .as_mut()
+                    .map(|sb| std::mem::take(&mut sb.before_start_env))
+                    .unwrap_or_default();
+                if !minted.is_empty() {
+                    self.mutate_instance(&session_id, |inst| {
+                        if let Some(sb) = inst.sandbox_info.as_mut() {
+                            sb.before_start_env = minted.clone();
+                        }
+                    });
+                }
                 // reload()'s restore-previous-selection fallback lands
                 // the cursor on whichever flat_items index is closest
                 // to the now-removed stub, which in project-grouped


### PR DESCRIPTION
## Description

Follow-up to #2114 (host-side `before_start` hooks), closing #2120 and the gaps @peteski22 found while testing.

The core gap: the only per-session input channel for a `before_start` hook was the host process env. `TEST_VAR=foo aoe add ...` varies per CLI invocation, but the TUI is one long-running process, so the value was fixed for every session ("locked to that var for all sessions"). This PR adds a real per-session channel.

- **Per-session env into the hook.** The session's resolved sandbox environment is now fed into the `before_start` hook's process env, so a per-session value reaches the hook. Set `TEST_VAR=foo` in the session's sandbox env (the new-session dialog already accepts `KEY=VALUE`) and the hook reads `$TEST_VAR`; a different session can set a different value. Resolution reuses the existing host-env grammar (`KEY=value`, `KEY=$HOSTVAR`, `KEY=$$lit`, bare `KEY`), and `session_env` is applied last so it overrides the inherited process env.
- **`AOE_REPO_SLUG`.** Added the `owner/repo` of the project's `origin` remote to the lifecycle env vars, so a hook can mint a repo-scoped credential (`mint "$AOE_REPO_SLUG"`) without parsing the filesystem path. Omitted when there is no parseable origin remote.
- **TUI double-mint fix.** The creation poller mints `before_start_env` while bringing the container up, but `apply_creation_results` reloaded from disk afterward and dropped it (the field is `#[serde(skip)]`), so the first attach re-ran the host hook. Carry it back onto the live instance, mirroring the CLI's `merge_post_start` and the structured-view stamp-back. Matters for rate-limited or non-idempotent mint commands.

Investigation also confirmed that the issue's "editor only accepts a key" concern was a non-issue: both the TUI new-session dialog and the web wizard already accept full `KEY=VALUE` entries, so no UI changes were needed.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (`docs/guides/configuration.md` Host Hooks section)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

Added unit tests: the `owner/repo` slug parser (`src/git/remote.rs`: formats + rejects-incomplete), the host-env pair resolver (`src/session/environment.rs`: literal / `$VAR` / `$$` / bare-key / dup-key precedence), and `run_before_start_hooks` reading a per-session value (`src/session/repo_config.rs`). Verified with `cargo fmt`, `cargo clippy --features serve --tests`, and `cargo test --features serve`.

The TUI carry-back is not unit-tested because the full sandbox creation path requires Docker (the same reason the structured-view stamp-back it mirrors is not unit-tested); the logic mirrors the unit-tested `reconcile_from_disk` carry pattern.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (the web wizard already accepts `KEY=VALUE`; no web changes)

**TUI / CLI (e2e test)**
- [x] N/A: covered by unit tests; the session-lifecycle change is host-hook env plumbing, exercised by the unit tests above, and the TUI carry-back needs Docker

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implemented via Claude Code through back-and-forth with @njbrake and testing feedback from @peteski22; the design decisions are theirs.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783887907&installation_id=139138837&pr_number=2121&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2121&signature=08c40d8bc5663f5c3f5dbda0a75c3f0975860a21b261ebc8666cdc5fc1ce5562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR enhances the sandbox's before_start hooks system with three key improvements: enabling hooks to receive per-session configuration values, providing hooks with repository metadata, and fixing a TUI bug that caused duplicate hook executions.

## What Changed

**Documentation Updates**
- Updated the Host Hooks configuration guide to document the new environment variables and clarify how session-specific values are passed to hooks

**New Git Remote Slug Extraction**
- Added functions to parse and extract repository owner/repo "slug" from git remote URLs, supporting SSH shorthand, HTTPS, and `ssh://` URL formats

**Session-Specific Hook Environment**
- Hooks can now receive per-session environment variables from the session's resolved sandbox configuration
- Added helper functions to resolve host environment variables in multiple formats (bare keys, literal values, host variable references)

**Repository Metadata for Hooks**
- Added `AOE_REPO_SLUG` environment variable (formatted as `owner/repo`) to lifecycle environment variables passed to hooks, allowing hooks to reference repository information

**TUI Carry-Back Fix**
- Fixed an issue where minted before_start hook environment values were lost after reload in the TUI, preventing duplicate non-idempotent hook executions on subsequent agent attach operations

**Test Coverage**
- Added unit tests for slug parsing, host environment resolution, and per-session hook environment handling

## Benefits

- **Flexible Hook Configuration**: Hooks can now receive session-specific settings, enabling more dynamic and per-session hook behavior
- **Repository Awareness**: Hooks can access repository metadata (owner/repo slug) for operations like GitHub token minting or repository-specific actions
- **Reliability**: Fixes the double-execution bug in the TUI, preventing rate-limiting issues and duplicate side effects from non-idempotent hooks
- **Maintainability**: Clear documentation of available environment variables and proper test coverage for new functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->