### PR TITLE
fix(tui): forward the wheel to full-screen live-send agents instead of dead scrollback

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -516,6 +516,7 @@ mod tests {
             pane_width: 74,
             alternate_on: false,
             mouse_tracking: false,
+            mouse_sgr: false,
         };
         let json = frame_json("hello\nworld", Some(&cursor));
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -538,6 +539,7 @@ mod tests {
             pane_width: 74,
             alternate_on: false,
             mouse_tracking: false,
+            mouse_sgr: false,
         };
         let v: serde_json::Value = serde_json::from_str(&frame_json("x", Some(&cursor))).unwrap();
         assert!(v["cursor"].is_null());

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -514,6 +514,8 @@ mod tests {
             pane_height: 46,
             history_size: 1200,
             pane_width: 74,
+            alternate_on: false,
+            mouse_tracking: false,
         };
         let json = frame_json("hello\nworld", Some(&cursor));
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -534,6 +536,8 @@ mod tests {
             pane_height: 46,
             history_size: 0,
             pane_width: 74,
+            alternate_on: false,
+            mouse_tracking: false,
         };
         let v: serde_json::Value = serde_json::from_str(&frame_json("x", Some(&cursor))).unwrap();
         assert!(v["cursor"].is_null());

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -11,11 +11,16 @@
 //! Protocol (one WS per viewer, route `/sessions/{id}/live-ws`):
 //!
 //! Server -> client, JSON text frames:
-//!   `{"type":"frame","content":"<ANSI text>","cursor":{"x":..,"y":..,
-//!     "visible":..,"screen_rows":..}|null}`
+//!   `{"type":"frame","content":"<ANSI text>","rows":..,"history":..,
+//!     "cursor":{"x":..,"y":..}|null,
+//!     "altScreen":bool,"mouse":bool,"mouseSgr":bool}`
 //!   `content` is verbatim `capture-pane -e` output for the requested
-//!   window: history lines first, the live screen as the last
-//!   `screen_rows` lines (trailing blank screen rows preserved).
+//!   window: history lines first, the live screen as the last `rows`
+//!   lines (trailing blank screen rows preserved). `altScreen` /`mouse` /
+//!   `mouseSgr` mirror tmux's `#{alternate_on}` / `#{mouse_any_flag}` /
+//!   `#{mouse_sgr_flag}`: when the pane is a full-screen mouse app the
+//!   client forwards the wheel to it (as input bytes) instead of widening
+//!   the capture window, since the alternate screen has no scrollback.
 //!
 //! Client -> server:
 //!   Binary frames: raw bytes for the pane (keystrokes, escape
@@ -497,6 +502,12 @@ fn frame_json(content: &str, cursor: Option<&crate::tmux::PaneCursor>) -> String
         "rows": cursor.map(|c| c.pane_height).unwrap_or(0),
         "history": cursor.map(|c| c.history_size).unwrap_or(0),
         "cursor": cursor_value,
+        // Full-screen (alternate-screen) mouse apps have no capturable
+        // scrollback; the client forwards the wheel to the app instead of
+        // widening the capture window. `mouseSgr` picks the wire encoding.
+        "altScreen": cursor.map(|c| c.alternate_on).unwrap_or(false),
+        "mouse": cursor.map(|c| c.mouse_tracking).unwrap_or(false),
+        "mouseSgr": cursor.map(|c| c.mouse_sgr).unwrap_or(false),
     })
     .to_string()
 }
@@ -526,6 +537,28 @@ mod tests {
         assert_eq!(v["history"], 1200);
         assert_eq!(v["cursor"]["x"], 3);
         assert_eq!(v["cursor"]["y"], 7);
+        assert_eq!(v["altScreen"], false);
+        assert_eq!(v["mouse"], false);
+        assert_eq!(v["mouseSgr"], false);
+    }
+
+    #[test]
+    fn frame_json_reports_alt_screen_mouse_flags() {
+        let cursor = crate::tmux::PaneCursor {
+            x: 0,
+            y: 0,
+            visible: true,
+            pane_height: 40,
+            history_size: 0,
+            pane_width: 80,
+            alternate_on: true,
+            mouse_tracking: true,
+            mouse_sgr: false,
+        };
+        let v: serde_json::Value = serde_json::from_str(&frame_json("x", Some(&cursor))).unwrap();
+        assert_eq!(v["altScreen"], true);
+        assert_eq!(v["mouse"], true);
+        assert_eq!(v["mouseSgr"], false);
     }
 
     #[test]

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -50,19 +50,26 @@ pub struct PaneCursor {
     /// history; the TUI forwards the wheel to the app instead. Optional in
     /// the format line; parses as `false` when absent.
     pub alternate_on: bool,
-    /// `#{mouse_any_flag}`: the foreground app currently has some mouse
-    /// tracking mode enabled, so it will consume forwarded SGR wheel
-    /// events rather than treat them as garbage keystrokes. The wheel is
-    /// only forwarded when this is set. Optional; parses as `false`.
+    /// `#{mouse_any_flag}`: the foreground app has requested some mouse
+    /// tracking mode (it wants mouse events at all). Optional; parses as
+    /// `false`.
     pub mouse_tracking: bool,
+    /// `#{mouse_sgr_flag}`: the app is in SGR (1006) mouse encoding, so it
+    /// will parse the `\e[<..M` wheel bytes the TUI forwards as a mouse
+    /// event rather than garbage keystrokes. The wheel is only forwarded
+    /// when BOTH this and `mouse_tracking` are set: `mouse_tracking` alone
+    /// can mean the legacy X10 encoding, which our SGR bytes would corrupt.
+    /// Optional; parses as `false`.
+    pub mouse_sgr: bool,
 }
 
 impl PaneCursor {
     /// Parse the single space-separated line emitted by the
     /// `#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height}
-    /// #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag}`
-    /// format. The trailing fields are optional so an older four-field
-    /// line still parses (numeric fields as 0, flag fields as `false`).
+    /// #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag}
+    /// #{mouse_sgr_flag}` format. The trailing fields are optional so an
+    /// older four-field line still parses (numeric fields as 0, flag
+    /// fields as `false`).
     fn parse(line: &str) -> Option<Self> {
         let mut fields = line.split_whitespace();
         let x = fields.next()?.parse().ok()?;
@@ -73,6 +80,7 @@ impl PaneCursor {
         let pane_width = fields.next().and_then(|f| f.parse().ok()).unwrap_or(0);
         let alternate_on = fields.next().map(|f| f != "0").unwrap_or(false);
         let mouse_tracking = fields.next().map(|f| f != "0").unwrap_or(false);
+        let mouse_sgr = fields.next().map(|f| f != "0").unwrap_or(false);
         Some(Self {
             x,
             y,
@@ -82,6 +90,7 @@ impl PaneCursor {
             pane_width,
             alternate_on,
             mouse_tracking,
+            mouse_sgr,
         })
     }
 }
@@ -387,7 +396,7 @@ impl Session {
                 "-t",
                 &target,
                 "-F",
-                "#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height} #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag}",
+                "#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height} #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag}",
                 ";",
                 "capture-pane",
                 "-t",
@@ -772,7 +781,7 @@ mod tests {
 
     #[test]
     fn pane_cursor_parses_format_line() {
-        let c = PaneCursor::parse("3 2 1 24 120 74 1 1").expect("parses");
+        let c = PaneCursor::parse("3 2 1 24 120 74 1 1 1").expect("parses");
         assert_eq!(
             c,
             PaneCursor {
@@ -784,13 +793,19 @@ mod tests {
                 pane_width: 74,
                 alternate_on: true,
                 mouse_tracking: true,
+                mouse_sgr: true,
             }
         );
-        // The six-field (pre-alternate/mouse) line still parses, the two
-        // new flags defaulting to false.
+        // Legacy mouse (tracking on, SGR off) parses with mouse_sgr false.
+        let c = PaneCursor::parse("3 2 1 24 120 74 1 1 0").expect("parses");
+        assert!(c.mouse_tracking);
+        assert!(!c.mouse_sgr);
+        // The six-field (pre-alternate/mouse) line still parses, the new
+        // flags defaulting to false.
         let c = PaneCursor::parse("3 2 1 24 120 74").expect("parses");
         assert!(!c.alternate_on);
         assert!(!c.mouse_tracking);
+        assert!(!c.mouse_sgr);
         // Four-field (pre-history) lines still parse, trailing fields 0.
         let c = PaneCursor::parse("3 2 0 24").expect("parses");
         assert!(!c.visible);
@@ -798,6 +813,7 @@ mod tests {
         assert_eq!(c.pane_width, 0);
         assert!(!c.alternate_on);
         assert!(!c.mouse_tracking);
+        assert!(!c.mouse_sgr);
         // cursor_flag 0 => hidden.
         assert!(!PaneCursor::parse("0 0 0 10").unwrap().visible);
         // Garbage / short input yields None rather than a bogus cursor.

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -44,13 +44,25 @@ pub struct PaneCursor {
     /// preview sync) resizing the window out from under it. Optional in
     /// the format line; parses as 0 when absent.
     pub pane_width: u16,
+    /// `#{alternate_on}`: the pane is on the alternate screen (a
+    /// full-screen / TUI app). The alternate screen has no scrollback, so
+    /// the live preview's capture-window scroll can't reach the app's own
+    /// history; the TUI forwards the wheel to the app instead. Optional in
+    /// the format line; parses as `false` when absent.
+    pub alternate_on: bool,
+    /// `#{mouse_any_flag}`: the foreground app currently has some mouse
+    /// tracking mode enabled, so it will consume forwarded SGR wheel
+    /// events rather than treat them as garbage keystrokes. The wheel is
+    /// only forwarded when this is set. Optional; parses as `false`.
+    pub mouse_tracking: bool,
 }
 
 impl PaneCursor {
     /// Parse the single space-separated line emitted by the
     /// `#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height}
-    /// #{history_size} #{pane_width}` format. The trailing fields are
-    /// optional so an older four-field line still parses (as 0).
+    /// #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag}`
+    /// format. The trailing fields are optional so an older four-field
+    /// line still parses (numeric fields as 0, flag fields as `false`).
     fn parse(line: &str) -> Option<Self> {
         let mut fields = line.split_whitespace();
         let x = fields.next()?.parse().ok()?;
@@ -59,6 +71,8 @@ impl PaneCursor {
         let pane_height = fields.next()?.parse().ok()?;
         let history_size = fields.next().and_then(|f| f.parse().ok()).unwrap_or(0);
         let pane_width = fields.next().and_then(|f| f.parse().ok()).unwrap_or(0);
+        let alternate_on = fields.next().map(|f| f != "0").unwrap_or(false);
+        let mouse_tracking = fields.next().map(|f| f != "0").unwrap_or(false);
         Some(Self {
             x,
             y,
@@ -66,6 +80,8 @@ impl PaneCursor {
             pane_height,
             history_size,
             pane_width,
+            alternate_on,
+            mouse_tracking,
         })
     }
 }
@@ -371,7 +387,7 @@ impl Session {
                 "-t",
                 &target,
                 "-F",
-                "#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height} #{history_size} #{pane_width}",
+                "#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height} #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag}",
                 ";",
                 "capture-pane",
                 "-t",
@@ -756,7 +772,7 @@ mod tests {
 
     #[test]
     fn pane_cursor_parses_format_line() {
-        let c = PaneCursor::parse("3 2 1 24 120 74").expect("parses");
+        let c = PaneCursor::parse("3 2 1 24 120 74 1 1").expect("parses");
         assert_eq!(
             c,
             PaneCursor {
@@ -766,13 +782,22 @@ mod tests {
                 pane_height: 24,
                 history_size: 120,
                 pane_width: 74,
+                alternate_on: true,
+                mouse_tracking: true,
             }
         );
+        // The six-field (pre-alternate/mouse) line still parses, the two
+        // new flags defaulting to false.
+        let c = PaneCursor::parse("3 2 1 24 120 74").expect("parses");
+        assert!(!c.alternate_on);
+        assert!(!c.mouse_tracking);
         // Four-field (pre-history) lines still parse, trailing fields 0.
         let c = PaneCursor::parse("3 2 0 24").expect("parses");
         assert!(!c.visible);
         assert_eq!(c.history_size, 0);
         assert_eq!(c.pane_width, 0);
+        assert!(!c.alternate_on);
+        assert!(!c.mouse_tracking);
         // cursor_flag 0 => hidden.
         assert!(!PaneCursor::parse("0 0 0 10").unwrap().visible);
         // Garbage / short input yields None rather than a bogus cursor.

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3112,10 +3112,12 @@ impl HomeView {
     /// does when you wheel over a mouse-tracking pane on attach, so the
     /// app scrolls its OWN content.
     ///
-    /// Gated on `mouse_tracking` so we never send `\e[<..M` bytes to an
-    /// app that hasn't asked for mouse input (it would read them as
-    /// garbage keystrokes); in that case the caller keeps the existing
-    /// capture-window scroll. Returns true when the event was forwarded.
+    /// Gated on mouse tracking AND SGR encoding (`mouse_sgr`) so we never
+    /// send `\e[<..M` bytes to an app that wouldn't parse them as a mouse
+    /// event: an app in the legacy X10 encoding, or no mouse mode at all,
+    /// would read them as garbage keystrokes. In those cases the caller
+    /// keeps the existing capture-window scroll. Returns true when the
+    /// event was forwarded.
     fn forward_wheel_to_live_pane(&self, up: bool, col: u16, row: u16) -> bool {
         if self.live_send.is_none() {
             return false;
@@ -3128,7 +3130,7 @@ impl HomeView {
             .as_ref()
             .and_then(|w| w.current_cursor());
         let Some(cursor) = cursor else { return false };
-        if !(cursor.alternate_on && cursor.mouse_tracking) {
+        if !(cursor.alternate_on && cursor.mouse_tracking && cursor.mouse_sgr) {
             return false;
         }
         let bytes = wheel_sgr_bytes(up, self.preview_text_view.pane, col, row);

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -187,6 +187,25 @@ fn split_bracketed_paste(text: &str) -> Vec<live_send::TmuxKey> {
     vec![live_send::TmuxKey::HexBytes(bytes)]
 }
 
+/// Build the SGR mouse-wheel byte sequence to forward to a full-screen
+/// app under the live preview. `up` selects wheel-up (button 64) vs
+/// wheel-down (65). The hovered screen cell `(col, row)` is mapped into
+/// the app's 1-based coordinate space relative to its pane `pane` (the
+/// live-send target is sized to the preview output rect, so this maps
+/// directly), clamped inside the pane; an unpopulated rect falls back to
+/// the top-left cell.
+fn wheel_sgr_bytes(up: bool, pane: ratatui::layout::Rect, col: u16, row: u16) -> Vec<u8> {
+    let (cx, cy) = if pane.width == 0 || pane.height == 0 {
+        (1u16, 1u16)
+    } else {
+        let cx = col.saturating_sub(pane.x).min(pane.width - 1) + 1;
+        let cy = row.saturating_sub(pane.y).min(pane.height - 1) + 1;
+        (cx, cy)
+    };
+    let button = if up { 64 } else { 65 };
+    format!("\x1b[<{button};{cx};{cy}M").into_bytes()
+}
+
 fn resolve_hook_install_agent(
     tool_name: &str,
     session_config: &crate::session::config::SessionConfig,
@@ -3084,6 +3103,39 @@ impl HomeView {
     /// redraw. Scrolls do not cross pane boundaries: a wheel over the
     /// preview never moves the list cursor, even when the preview is at
     /// its scroll boundary or has no session selected.
+    /// When a live-send target is a full-screen (alternate-screen) app
+    /// that has mouse tracking on, the preview's capture-window scroll is
+    /// useless: the alternate screen has no scrollback, so growing the
+    /// window only exposes the unrelated normal-buffer history underneath
+    /// and the view bottoms out at the session's start. Instead, forward
+    /// the wheel to the app as an SGR mouse event, exactly as a terminal
+    /// does when you wheel over a mouse-tracking pane on attach, so the
+    /// app scrolls its OWN content.
+    ///
+    /// Gated on `mouse_tracking` so we never send `\e[<..M` bytes to an
+    /// app that hasn't asked for mouse input (it would read them as
+    /// garbage keystrokes); in that case the caller keeps the existing
+    /// capture-window scroll. Returns true when the event was forwarded.
+    fn forward_wheel_to_live_pane(&self, up: bool, col: u16, row: u16) -> bool {
+        if self.live_send.is_none() {
+            return false;
+        }
+        let Some(worker) = &self.live_send_worker else {
+            return false;
+        };
+        let cursor = self
+            .preview_capture_worker
+            .as_ref()
+            .and_then(|w| w.current_cursor());
+        let Some(cursor) = cursor else { return false };
+        if !(cursor.alternate_on && cursor.mouse_tracking) {
+            return false;
+        }
+        let bytes = wheel_sgr_bytes(up, self.preview_text_view.pane, col, row);
+        worker.send(crate::tui::home::live_send::TmuxKey::HexBytes(bytes));
+        true
+    }
+
     pub fn handle_scroll_up(&mut self, col: u16, row: u16) -> bool {
         const STEP: u16 = 3;
         // A preview selection is anchored to absolute scrollback lines,
@@ -3118,6 +3170,12 @@ impl HomeView {
         }
         if self.selected_session.is_none() {
             return false;
+        }
+        // Full-screen mouse app under live-send: send the wheel to the app
+        // instead of scrolling the (irrelevant) normal-buffer capture.
+        if self.forward_wheel_to_live_pane(true, col, row) {
+            self.preview_scroll_offset = 0;
+            return true;
         }
 
         let active_cache = match self.view_mode {
@@ -3908,6 +3966,12 @@ impl HomeView {
         if self.selected_session.is_none() {
             return false;
         }
+        // Mirror handle_scroll_up: a full-screen mouse app gets the wheel
+        // forwarded rather than moving the preview's capture window.
+        if self.forward_wheel_to_live_pane(false, col, row) {
+            self.preview_scroll_offset = 0;
+            return true;
+        }
         if self.preview_scroll_offset == 0 {
             return false;
         }
@@ -4687,6 +4751,33 @@ impl HomeView {
 mod tests {
     use super::*;
     use crate::session::config::{SessionConfig, ToolSessionConfig};
+
+    #[test]
+    fn wheel_sgr_bytes_maps_cell_and_button() {
+        use ratatui::layout::Rect;
+        // Pane at (10,5), 80x24. Wheel up over screen cell (12,7) maps to
+        // 1-based pane cell (3,3): cx = 12-10+1, cy = 7-5+1.
+        let pane = Rect::new(10, 5, 80, 24);
+        assert_eq!(
+            wheel_sgr_bytes(true, pane, 12, 7),
+            b"\x1b[<64;3;3M".to_vec()
+        );
+        // Wheel down flips the button to 65.
+        assert_eq!(
+            wheel_sgr_bytes(false, pane, 12, 7),
+            b"\x1b[<65;3;3M".to_vec()
+        );
+        // A cell past the pane edge clamps to the last column/row.
+        assert_eq!(
+            wheel_sgr_bytes(true, pane, 999, 999),
+            b"\x1b[<64;80;24M".to_vec()
+        );
+        // An unpopulated rect falls back to the top-left cell.
+        assert_eq!(
+            wheel_sgr_bytes(true, Rect::new(0, 0, 0, 0), 40, 40),
+            b"\x1b[<64;1;1M".to_vec()
+        );
+    }
 
     #[test]
     fn format_target_label_distinguishes_terminal_panes() {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -187,14 +187,21 @@ fn split_bracketed_paste(text: &str) -> Vec<live_send::TmuxKey> {
     vec![live_send::TmuxKey::HexBytes(bytes)]
 }
 
-/// Build the SGR mouse-wheel byte sequence to forward to a full-screen
-/// app under the live preview. `up` selects wheel-up (button 64) vs
-/// wheel-down (65). The hovered screen cell `(col, row)` is mapped into
-/// the app's 1-based coordinate space relative to its pane `pane` (the
-/// live-send target is sized to the preview output rect, so this maps
-/// directly), clamped inside the pane; an unpopulated rect falls back to
-/// the top-left cell.
-fn wheel_sgr_bytes(up: bool, pane: ratatui::layout::Rect, col: u16, row: u16) -> Vec<u8> {
+/// Build the mouse-wheel byte sequence to forward to a full-screen app
+/// under the live preview. `up` selects wheel-up (button 64) vs wheel-down
+/// (65); `sgr` selects the SGR (1006) encoding vs the legacy X10 encoding,
+/// matching whatever the app has enabled. The hovered screen cell
+/// `(col, row)` is mapped into the app's 1-based coordinate space relative
+/// to its pane `pane` (the live-send target is sized to the preview output
+/// rect, so this maps directly), clamped inside the pane; an unpopulated
+/// rect falls back to the top-left cell.
+fn wheel_mouse_bytes(
+    up: bool,
+    sgr: bool,
+    pane: ratatui::layout::Rect,
+    col: u16,
+    row: u16,
+) -> Vec<u8> {
     let (cx, cy) = if pane.width == 0 || pane.height == 0 {
         (1u16, 1u16)
     } else {
@@ -202,8 +209,17 @@ fn wheel_sgr_bytes(up: bool, pane: ratatui::layout::Rect, col: u16, row: u16) ->
         let cy = row.saturating_sub(pane.y).min(pane.height - 1) + 1;
         (cx, cy)
     };
-    let button = if up { 64 } else { 65 };
-    format!("\x1b[<{button};{cx};{cy}M").into_bytes()
+    let button: u16 = if up { 64 } else { 65 };
+    if sgr {
+        // SGR (1006): textual, press marker `M`. No coordinate limit.
+        format!("\x1b[<{button};{cx};{cy}M").into_bytes()
+    } else {
+        // Legacy X10: `ESC [ M` then three bytes, each the value + 32.
+        // Bytes top out at 255, so coordinates above 223 can't be
+        // encoded; clamp there (preview cells are far below that anyway).
+        let enc = |v: u16| (v.min(223) + 32) as u8;
+        vec![0x1b, b'[', b'M', enc(button), enc(cx), enc(cy)]
+    }
 }
 
 fn resolve_hook_install_agent(
@@ -3108,16 +3124,15 @@ impl HomeView {
     /// useless: the alternate screen has no scrollback, so growing the
     /// window only exposes the unrelated normal-buffer history underneath
     /// and the view bottoms out at the session's start. Instead, forward
-    /// the wheel to the app as an SGR mouse event, exactly as a terminal
-    /// does when you wheel over a mouse-tracking pane on attach, so the
-    /// app scrolls its OWN content.
+    /// the wheel to the app as a mouse event, exactly as a terminal does
+    /// when you wheel over a mouse-tracking pane on attach, so the app
+    /// scrolls its OWN content.
     ///
-    /// Gated on mouse tracking AND SGR encoding (`mouse_sgr`) so we never
-    /// send `\e[<..M` bytes to an app that wouldn't parse them as a mouse
-    /// event: an app in the legacy X10 encoding, or no mouse mode at all,
-    /// would read them as garbage keystrokes. In those cases the caller
-    /// keeps the existing capture-window scroll. Returns true when the
-    /// event was forwarded.
+    /// Gated on mouse tracking (`mouse_tracking`): with no mouse mode the
+    /// app would read the bytes as garbage keystrokes, so the caller keeps
+    /// the capture-window scroll. The encoding follows the app: SGR (1006)
+    /// when `mouse_sgr` is set, otherwise the legacy X10 encoding. Returns
+    /// true when the event was forwarded.
     fn forward_wheel_to_live_pane(&self, up: bool, col: u16, row: u16) -> bool {
         if self.live_send.is_none() {
             return false;
@@ -3130,10 +3145,10 @@ impl HomeView {
             .as_ref()
             .and_then(|w| w.current_cursor());
         let Some(cursor) = cursor else { return false };
-        if !(cursor.alternate_on && cursor.mouse_tracking && cursor.mouse_sgr) {
+        if !(cursor.alternate_on && cursor.mouse_tracking) {
             return false;
         }
-        let bytes = wheel_sgr_bytes(up, self.preview_text_view.pane, col, row);
+        let bytes = wheel_mouse_bytes(up, cursor.mouse_sgr, self.preview_text_view.pane, col, row);
         worker.send(crate::tui::home::live_send::TmuxKey::HexBytes(bytes));
         true
     }
@@ -4755,29 +4770,52 @@ mod tests {
     use crate::session::config::{SessionConfig, ToolSessionConfig};
 
     #[test]
-    fn wheel_sgr_bytes_maps_cell_and_button() {
+    fn wheel_mouse_bytes_sgr_maps_cell_and_button() {
         use ratatui::layout::Rect;
         // Pane at (10,5), 80x24. Wheel up over screen cell (12,7) maps to
         // 1-based pane cell (3,3): cx = 12-10+1, cy = 7-5+1.
         let pane = Rect::new(10, 5, 80, 24);
         assert_eq!(
-            wheel_sgr_bytes(true, pane, 12, 7),
+            wheel_mouse_bytes(true, true, pane, 12, 7),
             b"\x1b[<64;3;3M".to_vec()
         );
         // Wheel down flips the button to 65.
         assert_eq!(
-            wheel_sgr_bytes(false, pane, 12, 7),
+            wheel_mouse_bytes(false, true, pane, 12, 7),
             b"\x1b[<65;3;3M".to_vec()
         );
         // A cell past the pane edge clamps to the last column/row.
         assert_eq!(
-            wheel_sgr_bytes(true, pane, 999, 999),
+            wheel_mouse_bytes(true, true, pane, 999, 999),
             b"\x1b[<64;80;24M".to_vec()
         );
         // An unpopulated rect falls back to the top-left cell.
         assert_eq!(
-            wheel_sgr_bytes(true, Rect::new(0, 0, 0, 0), 40, 40),
+            wheel_mouse_bytes(true, true, Rect::new(0, 0, 0, 0), 40, 40),
             b"\x1b[<64;1;1M".to_vec()
+        );
+    }
+
+    #[test]
+    fn wheel_mouse_bytes_legacy_encodes_x10() {
+        use ratatui::layout::Rect;
+        let pane = Rect::new(10, 5, 80, 24);
+        // Legacy X10: ESC [ M then (button+32, col+32, row+32). Cell (3,3),
+        // wheel up (button 64) => 0x60, 0x23, 0x23.
+        assert_eq!(
+            wheel_mouse_bytes(true, false, pane, 12, 7),
+            vec![0x1b, b'[', b'M', 64 + 32, 3 + 32, 3 + 32]
+        );
+        // Wheel down => button 65 => 0x61.
+        assert_eq!(
+            wheel_mouse_bytes(false, false, pane, 12, 7),
+            vec![0x1b, b'[', b'M', 65 + 32, 3 + 32, 3 + 32]
+        );
+        // Coordinates above 223 can't be encoded in one byte; clamp there.
+        let wide = Rect::new(0, 0, 400, 400);
+        assert_eq!(
+            wheel_mouse_bytes(true, false, wide, 300, 300),
+            vec![0x1b, b'[', b'M', 64 + 32, 223 + 32, 223 + 32]
         );
     }
 

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -795,6 +795,16 @@ impl LiveCaptureWorker {
     pub(in crate::tui) fn current_cursor(&self) -> Option<crate::tmux::PaneCursor> {
         self.cursor.lock().ok().and_then(|guard| *guard)
     }
+
+    /// Inject a cursor without running a capture cycle, so scroll-routing
+    /// tests can exercise the alternate-screen / mouse-tracking branch
+    /// deterministically instead of standing up a real full-screen pane.
+    #[cfg(test)]
+    pub(in crate::tui) fn set_cursor_for_test(&self, cursor: Option<crate::tmux::PaneCursor>) {
+        if let Ok(mut guard) = self.cursor.lock() {
+            *guard = cursor;
+        }
+    }
 }
 
 /// Walk one drained batch and execute it as one-shot `tmux` subprocesses.

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2883,6 +2883,7 @@ mod tests {
             pane_width: 0,
             alternate_on: false,
             mouse_tracking: false,
+            mouse_sgr: false,
         }
     }
 

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2881,6 +2881,8 @@ mod tests {
             pane_height,
             history_size: 0,
             pane_width: 0,
+            alternate_on: false,
+            mouse_tracking: false,
         }
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7651,7 +7651,11 @@ mod scroll_pane_isolation {
         env
     }
 
-    fn alt_screen_cursor(alternate_on: bool, mouse_tracking: bool) -> crate::tmux::PaneCursor {
+    fn alt_screen_cursor(
+        alternate_on: bool,
+        mouse_tracking: bool,
+        mouse_sgr: bool,
+    ) -> crate::tmux::PaneCursor {
         crate::tmux::PaneCursor {
             x: 0,
             y: 0,
@@ -7661,21 +7665,22 @@ mod scroll_pane_isolation {
             pane_width: 80,
             alternate_on,
             mouse_tracking,
+            mouse_sgr,
         }
     }
 
-    /// Live-send target is a full-screen app with mouse tracking on: the
-    /// wheel is forwarded to the app (returns to the live edge) instead of
-    /// growing the useless normal-buffer capture window. This is the fix
+    /// Live-send target is a full-screen app with SGR mouse tracking on:
+    /// the wheel is forwarded to the app (returns to the live edge) instead
+    /// of growing the useless normal-buffer capture window. This is the fix
     /// for the "scroll up a little then snap to the very first part of the
     /// session" report on alternate-screen agents.
     #[test]
     #[serial]
-    fn wheel_over_alt_screen_mouse_pane_forwards_instead_of_scrollback() {
-        let mut env = live_env_with_cursor(alt_screen_cursor(true, true));
+    fn wheel_over_alt_screen_sgr_mouse_pane_forwards_instead_of_scrollback() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, true, true));
 
         let up = env.view.handle_scroll_up(50, 10);
-        assert!(up, "wheel over a full-screen mouse pane is handled");
+        assert!(up, "wheel over a full-screen SGR-mouse pane is handled");
         assert_eq!(
             env.view.preview_scroll_offset, 0,
             "forwarding pins the preview to the live edge, never the normal-buffer history"
@@ -7687,13 +7692,13 @@ mod scroll_pane_isolation {
         assert_eq!(env.view.preview_scroll_offset, 0);
     }
 
-    /// Guard the gate: a full-screen app WITHOUT mouse tracking must not
-    /// get raw SGR bytes (it would read them as garbage keystrokes). The
-    /// wheel falls back to the existing capture-window scroll.
+    /// Guard the gate: a full-screen app WITHOUT any mouse tracking must
+    /// not get raw SGR bytes (it would read them as garbage keystrokes).
+    /// The wheel falls back to the existing capture-window scroll.
     #[test]
     #[serial]
     fn wheel_over_alt_screen_without_mouse_uses_capture_scroll() {
-        let mut env = live_env_with_cursor(alt_screen_cursor(true, false));
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, false, false));
 
         let up = env.view.handle_scroll_up(50, 10);
         assert!(up);
@@ -7703,13 +7708,30 @@ mod scroll_pane_isolation {
         );
     }
 
+    /// Guard the encoding: a full-screen app with mouse tracking but in the
+    /// LEGACY (non-SGR) encoding must not get SGR bytes either; they would
+    /// be misparsed. Falls back to capture-window scroll. (Regression for
+    /// the CodeRabbit finding on #2123: mouse_any_flag is not SGR support.)
+    #[test]
+    #[serial]
+    fn wheel_over_alt_screen_legacy_mouse_uses_capture_scroll() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, true, false));
+
+        let up = env.view.handle_scroll_up(50, 10);
+        assert!(up);
+        assert!(
+            env.view.preview_scroll_offset > 10,
+            "legacy (non-SGR) mouse: keep the capture-window scroll"
+        );
+    }
+
     /// And a normal-screen agent (no alternate screen) keeps the capture
-    /// scroll even if it happens to have mouse tracking on: the preview's
+    /// scroll even if it happens to have SGR mouse on: the preview's
     /// scrollback is genuinely useful there.
     #[test]
     #[serial]
     fn wheel_over_normal_screen_pane_uses_capture_scroll() {
-        let mut env = live_env_with_cursor(alt_screen_cursor(false, true));
+        let mut env = live_env_with_cursor(alt_screen_cursor(false, true, true));
 
         let up = env.view.handle_scroll_up(50, 10);
         assert!(up);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7616,6 +7616,109 @@ mod scroll_pane_isolation {
         env.view.preview_area = Rect::new(30, 0, 100, 40);
     }
 
+    /// Build a live-send env whose preview-capture worker reports the
+    /// given cursor, so the alternate-screen wheel-forwarding branch can
+    /// be exercised without a real full-screen pane.
+    fn live_env_with_cursor(cursor: crate::tmux::PaneCursor) -> TestEnv {
+        use crate::tui::home::live_send::{LiveSendState, LiveSendTarget, LiveSendWorker};
+        let mut env = create_test_env_with_sessions(3);
+        setup_panes(&mut env);
+        env.view.cursor = 1;
+        env.view.update_selected();
+        env.view.preview_cache.dimensions = (80, 24);
+        env.view.preview_cache.captured_lines = 200;
+        env.view.preview_scroll_offset = 10;
+        env.view.live_send = Some(LiveSendState {
+            session_id: "fake".to_string(),
+            title: "fake".to_string(),
+            tmux_name: "fake".to_string(),
+            target: LiveSendTarget::Agent,
+            exit_chords: crate::tui::home::live_send::parse_chord_list(
+                crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
+            ),
+            leader: None,
+        });
+        env.view.live_send_worker = Some(LiveSendWorker::spawn("fake".to_string(), None));
+        // Spawn the capture worker, then inject the cursor (set_target
+        // clears it, so the injection must come after).
+        env.view
+            .sync_preview_capture_worker(Some("fake".to_string()));
+        env.view
+            .preview_capture_worker
+            .as_ref()
+            .expect("capture worker spawned")
+            .set_cursor_for_test(Some(cursor));
+        env
+    }
+
+    fn alt_screen_cursor(alternate_on: bool, mouse_tracking: bool) -> crate::tmux::PaneCursor {
+        crate::tmux::PaneCursor {
+            x: 0,
+            y: 0,
+            visible: true,
+            pane_height: 24,
+            history_size: 1800,
+            pane_width: 80,
+            alternate_on,
+            mouse_tracking,
+        }
+    }
+
+    /// Live-send target is a full-screen app with mouse tracking on: the
+    /// wheel is forwarded to the app (returns to the live edge) instead of
+    /// growing the useless normal-buffer capture window. This is the fix
+    /// for the "scroll up a little then snap to the very first part of the
+    /// session" report on alternate-screen agents.
+    #[test]
+    #[serial]
+    fn wheel_over_alt_screen_mouse_pane_forwards_instead_of_scrollback() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, true));
+
+        let up = env.view.handle_scroll_up(50, 10);
+        assert!(up, "wheel over a full-screen mouse pane is handled");
+        assert_eq!(
+            env.view.preview_scroll_offset, 0,
+            "forwarding pins the preview to the live edge, never the normal-buffer history"
+        );
+
+        env.view.preview_scroll_offset = 10;
+        let down = env.view.handle_scroll_down(50, 10);
+        assert!(down);
+        assert_eq!(env.view.preview_scroll_offset, 0);
+    }
+
+    /// Guard the gate: a full-screen app WITHOUT mouse tracking must not
+    /// get raw SGR bytes (it would read them as garbage keystrokes). The
+    /// wheel falls back to the existing capture-window scroll.
+    #[test]
+    #[serial]
+    fn wheel_over_alt_screen_without_mouse_uses_capture_scroll() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, false));
+
+        let up = env.view.handle_scroll_up(50, 10);
+        assert!(up);
+        assert!(
+            env.view.preview_scroll_offset > 10,
+            "no mouse tracking: keep the capture-window scroll (offset advances)"
+        );
+    }
+
+    /// And a normal-screen agent (no alternate screen) keeps the capture
+    /// scroll even if it happens to have mouse tracking on: the preview's
+    /// scrollback is genuinely useful there.
+    #[test]
+    #[serial]
+    fn wheel_over_normal_screen_pane_uses_capture_scroll() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(false, true));
+
+        let up = env.view.handle_scroll_up(50, 10);
+        assert!(up);
+        assert!(
+            env.view.preview_scroll_offset > 10,
+            "normal screen: capture-window scroll still drives the preview"
+        );
+    }
+
     /// Wheel-down over preview when offset is already at the bottom (0)
     /// must NOT advance the list cursor.
     #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7708,20 +7708,20 @@ mod scroll_pane_isolation {
         );
     }
 
-    /// Guard the encoding: a full-screen app with mouse tracking but in the
-    /// LEGACY (non-SGR) encoding must not get SGR bytes either; they would
-    /// be misparsed. Falls back to capture-window scroll. (Regression for
-    /// the CodeRabbit finding on #2123: mouse_any_flag is not SGR support.)
+    /// A full-screen app with mouse tracking but in the LEGACY (non-SGR)
+    /// encoding is still forwarded; the byte builder emits X10-encoded
+    /// bytes for it instead of SGR (see `wheel_mouse_bytes_legacy_encodes_x10`).
+    /// Forwarding pins the preview to the live edge like the SGR case.
     #[test]
     #[serial]
-    fn wheel_over_alt_screen_legacy_mouse_uses_capture_scroll() {
+    fn wheel_over_alt_screen_legacy_mouse_forwards() {
         let mut env = live_env_with_cursor(alt_screen_cursor(true, true, false));
 
         let up = env.view.handle_scroll_up(50, 10);
-        assert!(up);
-        assert!(
-            env.view.preview_scroll_offset > 10,
-            "legacy (non-SGR) mouse: keep the capture-window scroll"
+        assert!(up, "wheel over a full-screen legacy-mouse pane is handled");
+        assert_eq!(
+            env.view.preview_scroll_offset, 0,
+            "legacy mouse is forwarded too (X10 encoding), not dead-scrolled"
         );
     }
 

--- a/web/src/components/LiveTerminalView.tsx
+++ b/web/src/components/LiveTerminalView.tsx
@@ -208,6 +208,7 @@ export function LiveTerminalView({ session, active = true, surface = "agent" }: 
           enterReading={live.enterReading}
           returnToLive={live.returnToLive}
           sendData={live.sendData}
+          forwardWheel={live.forwardWheel}
           ctrlActiveRef={ctrlActiveRef}
           clearCtrl={() => setCtrlActive(false)}
           inputRef={inputRef}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import type { CSSProperties, RefObject } from "react";
 import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
 import { ansiToLines, wrapLine } from "../lib/liveTermLines";
+import { wheelNotches } from "../lib/liveMouse";
 import type { LiveFrame } from "../hooks/useLiveTerminal";
 import { useWebSettings } from "../hooks/useWebSettings";
 
@@ -61,6 +62,10 @@ export interface MobileLiveTerminalProps {
   enterReading: (rows: number) => void;
   returnToLive: (rows: number) => void;
   sendData: (data: string) => void;
+  /** Forward a wheel notch to a full-screen mouse app (alternate screen).
+   *  Used instead of capture-window scrolling when the frame reports the
+   *  pane is such an app. */
+  forwardWheel: (up: boolean, sgr: boolean, col: number, row: number) => void;
   /** Virtual Ctrl modifier from the mobile toolbar. */
   ctrlActiveRef: RefObject<boolean>;
   clearCtrl: () => void;
@@ -116,6 +121,7 @@ export function MobileLiveTerminal({
   enterReading,
   returnToLive,
   sendData,
+  forwardWheel,
   ctrlActiveRef,
   clearCtrl,
   inputRef,
@@ -269,6 +275,24 @@ export function MobileLiveTerminal({
   const history = frame?.history ?? 0;
   const fetchedHistory = Math.max(0, lines.length - screenRows);
   const spacerLines = Math.max(0, history - fetchedHistory);
+  // Full-screen mouse app (alternate screen): its scrollback is not
+  // capturable, so the spacer of unrelated normal-buffer history is
+  // useless. Pin to the live edge (no spacer, no native scroll) and
+  // forward the wheel to the app instead; the next frame reflects its
+  // scroll. Mirrors the TUI's forward_wheel_to_live_pane.
+  const forwardMode = (frame?.altScreen ?? false) && (frame?.mouse ?? false);
+  const mouseSgr = frame?.mouseSgr ?? false;
+  const effectiveSpacerLines = forwardMode ? 0 : spacerLines;
+  const forwardModeRef = useRef(forwardMode);
+  const mouseSgrRef = useRef(mouseSgr);
+  useEffect(() => {
+    forwardModeRef.current = forwardMode;
+    mouseSgrRef.current = mouseSgr;
+  }, [forwardMode, mouseSgr]);
+  // Sub-notch scroll remainder (px) carried across events, and the last
+  // touch Y while forwarding a single-finger drag.
+  const wheelAccumRef = useRef(0);
+  const touchForwardYRef = useRef<number | null>(null);
   useEffect(() => {
     rowsRef.current = screenRows || rowsRef.current;
   }, [screenRows]);
@@ -285,11 +309,11 @@ export function MobileLiveTerminal({
       const baseRow = visual.lineStartRow[lineIdx] ?? visual.rows.length;
       const cols = renderCols > 0 ? renderCols : Number.POSITIVE_INFINITY;
       const wrapOffset = Number.isFinite(cols) ? Math.floor(cursor.x / cols) : 0;
-      cursorTop = (spacerLines + baseRow + wrapOffset) * lineH;
+      cursorTop = (effectiveSpacerLines + baseRow + wrapOffset) * lineH;
       cursorLeft = (Number.isFinite(cols) ? cursor.x % cols : cursor.x) * charW;
     }
     return { cursor, cursorTop, cursorLeft };
-  }, [reading, frame, lines.length, screenRows, visual, renderCols, charW, spacerLines, lineH]);
+  }, [reading, frame, lines.length, screenRows, visual, renderCols, charW, effectiveSpacerLines, lineH]);
 
   const atBottom = useCallback(() => {
     const el = scrollerRef.current;
@@ -301,6 +325,9 @@ export function MobileLiveTerminal({
   }, [lineH, liveScrollTarget]);
 
   const onScroll = useCallback(() => {
+    // Forward mode pins the live edge (overflow hidden); the wheel goes to
+    // the app, so there is no scrollback reading state to enter.
+    if (forwardModeRef.current) return;
     if (!atBottom()) {
       enterReading(rowsRef.current);
     } else if (!touchActiveRef.current) {
@@ -317,6 +344,47 @@ export function MobileLiveTerminal({
     returnToLive(rowsRef.current);
   }, [returnToLive, liveScrollTarget]);
 
+  // Map a viewport point to the app's 1-based pane cell for the forwarded
+  // wheel event (apps mostly ignore the exact cell, but send a sane one).
+  const pointerCell = useCallback(
+    (clientX: number, clientY: number) => {
+      const el = scrollerRef.current;
+      if (!el || charW <= 0 || lineH <= 0) return { col: 1, row: 1 };
+      const r = el.getBoundingClientRect();
+      const cols = renderCols > 0 ? renderCols : 1;
+      const rows = Math.max(1, screenRows || rowsRef.current);
+      const col = Math.min(cols, Math.max(1, Math.floor((clientX - r.left) / charW) + 1));
+      const row = Math.min(rows, Math.max(1, Math.floor((clientY - r.top) / lineH) + 1));
+      return { col, row };
+    },
+    [charW, lineH, renderCols, screenRows],
+  );
+
+  // Translate an accumulated pixel delta (positive = toward newer/down)
+  // into forwarded wheel notches, one per text row, carrying the leftover.
+  const forwardWheelDelta = useCallback(
+    (deltaPx: number, clientX: number, clientY: number) => {
+      wheelAccumRef.current += deltaPx;
+      const { notches, remainder } = wheelNotches(wheelAccumRef.current, lineH || 16, 8);
+      wheelAccumRef.current = remainder;
+      if (notches === 0) return;
+      const { col, row } = pointerCell(clientX, clientY);
+      const up = notches < 0;
+      for (let i = 0; i < Math.abs(notches); i++) forwardWheel(up, mouseSgrRef.current, col, row);
+    },
+    [lineH, pointerCell, forwardWheel],
+  );
+
+  const onWheel = useCallback(
+    (e: React.WheelEvent) => {
+      if (!forwardModeRef.current) return;
+      // Normalize line/page deltas to pixels so a notch is ~one row.
+      const factor = e.deltaMode === 1 ? lineH || 16 : e.deltaMode === 2 ? (lineH || 16) * (rowsRef.current || 1) : 1;
+      forwardWheelDelta(e.deltaY * factor, e.clientX, e.clientY);
+    },
+    [lineH, forwardWheelDelta],
+  );
+
   // --- pinch zoom (two-finger) ---------------------------------------------
   const pinchRef = useRef<{ startDist: number; startSize: number; changed: boolean } | null>(null);
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -324,33 +392,55 @@ export function MobileLiveTerminal({
     (e: React.TouchEvent) => {
       touchActiveRef.current = true;
       if (e.touches.length === 2) {
-        const [a, b] = [e.touches[0]!, e.touches[1]!];
         pinchRef.current = {
-          startDist: Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY),
+          startDist: Math.hypot(
+            e.touches[0]!.clientX - e.touches[1]!.clientX,
+            e.touches[0]!.clientY - e.touches[1]!.clientY,
+          ),
           startSize: fontSize,
           changed: false,
         };
+        touchForwardYRef.current = null;
+      } else if (e.touches.length === 1 && forwardModeRef.current) {
+        // Single-finger drag drives the app's wheel in forward mode.
+        touchForwardYRef.current = e.touches[0]!.clientY;
+        wheelAccumRef.current = 0;
       }
     },
     [fontSize],
   );
-  const onTouchMove = useCallback((e: React.TouchEvent) => {
-    if (e.touches.length === 2 && pinchRef.current) {
-      e.preventDefault();
-      const [a, b] = [e.touches[0]!, e.touches[1]!];
-      const dist = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
-      const { startDist, startSize } = pinchRef.current;
-      if (startDist > 0) {
-        const next = Math.round(Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, startSize * (dist / startDist))));
-        if (next !== startSize) pinchRef.current.changed = true;
-        setFontSize(next);
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (e.touches.length === 2 && pinchRef.current) {
+        e.preventDefault();
+        const [a, b] = [e.touches[0]!, e.touches[1]!];
+        const dist = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+        const { startDist, startSize } = pinchRef.current;
+        if (startDist > 0) {
+          const next = Math.round(Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, startSize * (dist / startDist))));
+          if (next !== startSize) pinchRef.current.changed = true;
+          setFontSize(next);
+        }
+        return;
       }
-    }
-  }, []);
+      if (e.touches.length === 1 && forwardModeRef.current && touchForwardYRef.current != null) {
+        // Stop the (overflow-hidden) container / page from scrolling and
+        // translate the drag into wheel notches. Finger moving DOWN reveals
+        // older content = wheel up, so the delta is negated.
+        e.preventDefault();
+        const y = e.touches[0]!.clientY;
+        const dy = y - touchForwardYRef.current;
+        touchForwardYRef.current = y;
+        forwardWheelDelta(-dy, e.touches[0]!.clientX, y);
+      }
+    },
+    [forwardWheelDelta],
+  );
   const onTouchEnd = useCallback(
     (e: React.TouchEvent) => {
       if (e.touches.length === 0) {
         touchActiveRef.current = false;
+        touchForwardYRef.current = null;
         // Settle the live-edge decision deferred by onScroll; momentum
         // scroll events after this keep re-evaluating via onScroll.
         if (atBottom()) {
@@ -579,11 +669,14 @@ export function MobileLiveTerminal({
       <div
         ref={scrollerRef}
         onScroll={onScroll}
+        onWheel={onWheel}
         onTouchStart={onTouchStart}
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
         onTouchCancel={onTouchEnd}
-        className="absolute inset-0 overflow-y-auto overflow-x-hidden font-mono"
+        className={`absolute inset-0 font-mono ${
+          forwardMode ? "overflow-hidden" : "overflow-y-auto overflow-x-hidden"
+        }`}
         style={{
           fontSize: `${fontSize}px`,
           lineHeight: `${lineH}px`,
@@ -608,7 +701,9 @@ export function MobileLiveTerminal({
           MMMMMMMMMMMMMMMMMMMM
         </span>
         <div className="relative whitespace-pre" data-live-content>
-          {spacerLines > 0 && <div style={{ height: `${spacerLines * lineH}px` }} aria-hidden="true" />}
+          {effectiveSpacerLines > 0 && (
+            <div style={{ height: `${effectiveSpacerLines * lineH}px` }} aria-hidden="true" />
+          )}
           {visual.rows.map((segs, i) => (
             <Row key={i} segs={segs} />
           ))}

--- a/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
@@ -76,6 +76,13 @@ describe("MobileLiveTerminal wheel forwarding", () => {
     expect(lastUp).toBe(true);
   });
 
+  it("normalizes line-mode wheel deltas (deltaMode 1)", () => {
+    const { scroller, forwardWheel } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
+    // deltaMode 1 = lines; a few lines should still forward at least one notch.
+    fireEvent.wheel(scroller, { deltaY: 3, deltaMode: 1 });
+    expect(forwardWheel).toHaveBeenCalled();
+  });
+
   it("does NOT forward when the app has no mouse mode (keeps capture scroll)", () => {
     const { scroller, forwardWheel } = renderTerm(frame({ altScreen: true, mouse: false }));
     expect(scroller.className).toContain("overflow-y-auto");
@@ -87,5 +94,42 @@ describe("MobileLiveTerminal wheel forwarding", () => {
     const { scroller, forwardWheel } = renderTerm(frame({ altScreen: false, mouse: true, mouseSgr: true }));
     fireEvent.wheel(scroller, { deltaY: 120 });
     expect(forwardWheel).not.toHaveBeenCalled();
+  });
+
+  it("forwards a single-finger drag as wheel notches", () => {
+    const { scroller, forwardWheel } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
+    const touch = (y: number) => ({ clientX: 100, clientY: y }) as Touch;
+    // Finger moves UP (y decreases) => content scrolls down => wheel down.
+    fireEvent.touchStart(scroller, { touches: [touch(300)] });
+    fireEvent.touchMove(scroller, { touches: [touch(220)] });
+    fireEvent.touchEnd(scroller, { touches: [] });
+    expect(forwardWheel).toHaveBeenCalled();
+    expect(forwardWheel.mock.calls[0][0]).toBe(false); // up === false (wheel down)
+  });
+
+  it("does not enter reading mode on scroll while forwarding", () => {
+    const enterReading = vi.fn();
+    const utils = render(
+      <MobileLiveTerminal
+        frame={frame({ altScreen: true, mouse: true, mouseSgr: true })}
+        connected
+        active
+        reading={false}
+        sendResize={vi.fn()}
+        setWindow={vi.fn()}
+        setCadence={vi.fn()}
+        enterReading={enterReading}
+        returnToLive={vi.fn()}
+        sendData={vi.fn()}
+        forwardWheel={vi.fn()}
+        ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
+        clearCtrl={vi.fn()}
+        inputRef={createRef<HTMLTextAreaElement>()}
+        onInputFocusChange={vi.fn()}
+      />,
+    );
+    const scroller = utils.container.querySelector("[data-live-terminal] > div") as HTMLElement;
+    fireEvent.scroll(scroller);
+    expect(enterReading).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// The mobile live view forwards the wheel to a full-screen mouse app
+// (alternate screen) instead of scrolling the useless normal-buffer
+// capture. This guards that routing: forward only when the frame reports
+// altScreen && mouse, and not otherwise. Byte encodings are covered by
+// ../../lib/__tests__/liveMouse.test.ts.
+
+import { createRef } from "react";
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { MobileLiveTerminal } from "../MobileLiveTerminal";
+import type { LiveFrame } from "../../hooks/useLiveTerminal";
+
+vi.mock("../../hooks/useWebSettings", () => ({
+  useWebSettings: () => ({ settings: { mobileFontSize: 14 }, update: vi.fn() }),
+}));
+
+beforeAll(() => {
+  // The component observes its container; jsdom has no ResizeObserver.
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+function frame(over: Partial<LiveFrame>): LiveFrame {
+  return {
+    content: "a\nb\nc\n",
+    rows: 3,
+    history: 1000,
+    cursor: null,
+    altScreen: false,
+    mouse: false,
+    mouseSgr: false,
+    ...over,
+  };
+}
+
+function renderTerm(f: LiveFrame, forwardWheel = vi.fn()) {
+  const utils = render(
+    <MobileLiveTerminal
+      frame={f}
+      connected
+      active
+      reading={false}
+      sendResize={vi.fn()}
+      setWindow={vi.fn()}
+      setCadence={vi.fn()}
+      enterReading={vi.fn()}
+      returnToLive={vi.fn()}
+      sendData={vi.fn()}
+      forwardWheel={forwardWheel}
+      ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
+      clearCtrl={vi.fn()}
+      inputRef={createRef<HTMLTextAreaElement>()}
+      onInputFocusChange={vi.fn()}
+    />,
+  );
+  const scroller = utils.container.querySelector("[data-live-terminal] > div") as HTMLElement;
+  return { ...utils, scroller, forwardWheel };
+}
+
+describe("MobileLiveTerminal wheel forwarding", () => {
+  it("forwards the wheel to a full-screen mouse app and pins the live edge", () => {
+    const { scroller, forwardWheel } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
+    expect(scroller.className).toContain("overflow-hidden");
+    fireEvent.wheel(scroller, { deltaY: 120 });
+    expect(forwardWheel).toHaveBeenCalled();
+    // deltaY > 0 = scroll down = wheel down (up === false), SGR encoding.
+    expect(forwardWheel.mock.calls[0][0]).toBe(false);
+    expect(forwardWheel.mock.calls[0][1]).toBe(true);
+    fireEvent.wheel(scroller, { deltaY: -120 });
+    const lastUp = forwardWheel.mock.calls[forwardWheel.mock.calls.length - 1][0];
+    expect(lastUp).toBe(true);
+  });
+
+  it("does NOT forward when the app has no mouse mode (keeps capture scroll)", () => {
+    const { scroller, forwardWheel } = renderTerm(frame({ altScreen: true, mouse: false }));
+    expect(scroller.className).toContain("overflow-y-auto");
+    fireEvent.wheel(scroller, { deltaY: 120 });
+    expect(forwardWheel).not.toHaveBeenCalled();
+  });
+
+  it("does NOT forward for a normal-screen agent", () => {
+    const { scroller, forwardWheel } = renderTerm(frame({ altScreen: false, mouse: true, mouseSgr: true }));
+    fireEvent.wheel(scroller, { deltaY: 120 });
+    expect(forwardWheel).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useLiveTerminal.forward.test.ts
+++ b/web/src/hooks/useLiveTerminal.forward.test.ts
@@ -59,6 +59,15 @@ describe("useLiveTerminal forwardWheel", () => {
     expect(hit).toBe(true);
   });
 
+  it("does not send when the socket is not open", () => {
+    const { result } = renderHook(() => useLiveTerminal("s", "live-ws"));
+    const ws = FakeWS.last!;
+    ws.readyState = FakeWS.CLOSED;
+    ws.sent.length = 0;
+    act(() => result.current.forwardWheel(true, true, 3, 3));
+    expect(sentBytes(ws).length).toBe(0);
+  });
+
   it("surfaces altScreen / mouse / mouseSgr from incoming frames", () => {
     const { result } = renderHook(() => useLiveTerminal("s", "live-ws"));
     const ws = FakeWS.last!;

--- a/web/src/hooks/useLiveTerminal.forward.test.ts
+++ b/web/src/hooks/useLiveTerminal.forward.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+//
+// Covers the live-view wheel forwarding the mobile component relies on:
+// `forwardWheel` emits the right bytes over the socket (SGR vs legacy),
+// and incoming frames surface the altScreen / mouse / mouseSgr flags.
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useLiveTerminal } from "./useLiveTerminal";
+
+vi.mock("../lib/token", () => ({ getToken: () => null }));
+vi.mock("../lib/deviceBinding", () => ({ getOrCreateDeviceBindingSecret: () => null }));
+
+class FakeWS {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static last: FakeWS | null = null;
+  readyState = FakeWS.OPEN;
+  onopen: ((e: unknown) => void) | null = null;
+  onmessage: ((e: { data: unknown }) => void) | null = null;
+  onclose: ((e: unknown) => void) | null = null;
+  sent: unknown[] = [];
+  constructor(_url: string, _protocols?: string | string[]) {
+    FakeWS.last = this;
+  }
+  send(d: unknown) {
+    this.sent.push(d);
+  }
+  close() {
+    this.readyState = FakeWS.CLOSED;
+  }
+}
+
+beforeEach(() => {
+  FakeWS.last = null;
+  vi.stubGlobal("WebSocket", FakeWS as unknown as typeof WebSocket);
+});
+
+const sentBytes = (ws: FakeWS) => ws.sent.filter((d): d is Uint8Array => d instanceof Uint8Array);
+
+describe("useLiveTerminal forwardWheel", () => {
+  it("sends SGR wheel bytes when the app is in SGR encoding", () => {
+    const { result } = renderHook(() => useLiveTerminal("s", "live-ws"));
+    act(() => result.current.forwardWheel(true, true, 3, 3));
+    const ws = FakeWS.last!;
+    const hit = sentBytes(ws).some((b) => new TextDecoder().decode(b) === "\x1b[<64;3;3M");
+    expect(hit).toBe(true);
+  });
+
+  it("sends legacy X10 wheel bytes when SGR is off", () => {
+    const { result } = renderHook(() => useLiveTerminal("s", "live-ws"));
+    act(() => result.current.forwardWheel(false, false, 3, 3));
+    const ws = FakeWS.last!;
+    const hit = sentBytes(ws).some(
+      (b) => b.length === 6 && b[0] === 0x1b && b[1] === 0x5b && b[2] === 0x4d && b[3] === 0x61,
+    );
+    expect(hit).toBe(true);
+  });
+
+  it("surfaces altScreen / mouse / mouseSgr from incoming frames", () => {
+    const { result } = renderHook(() => useLiveTerminal("s", "live-ws"));
+    const ws = FakeWS.last!;
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "frame",
+          content: "x\n",
+          rows: 1,
+          history: 0,
+          cursor: null,
+          altScreen: true,
+          mouse: true,
+          mouseSgr: false,
+        }),
+      });
+    });
+    expect(result.current.state.frame?.altScreen).toBe(true);
+    expect(result.current.state.frame?.mouse).toBe(true);
+    expect(result.current.state.frame?.mouseSgr).toBe(false);
+  });
+});

--- a/web/src/hooks/useLiveTerminal.ts
+++ b/web/src/hooks/useLiveTerminal.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import { getOrCreateDeviceBindingSecret } from "../lib/deviceBinding";
 import { getToken } from "../lib/token";
+import { wheelMouseBytes } from "../lib/liveMouse";
 import { retryDelayMs } from "./useTerminal";
 
 // Capture-snapshot live view transport (mobile). Mirrors the TUI's
@@ -29,6 +30,16 @@ export interface LiveFrame {
   history: number;
   /** Cursor cell, or null when hidden (DECTCEM off) or unavailable. */
   cursor: LiveCursor | null;
+  /** Pane is on the alternate screen (a full-screen / TUI app). Its
+   *  scrollback is not capturable, so scroll gestures forward the wheel
+   *  to the app instead of widening the capture window. */
+  altScreen: boolean;
+  /** App has some mouse tracking mode on (it will consume forwarded wheel
+   *  events). Forwarding only happens when this AND altScreen are set. */
+  mouse: boolean;
+  /** App is in SGR (1006) mouse encoding; picks the forwarded wire format
+   *  (SGR vs legacy X10). */
+  mouseSgr: boolean;
 }
 
 export interface LiveTerminalState {
@@ -160,6 +171,9 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
           rows?: number;
           history?: number;
           cursor?: LiveCursor | null;
+          altScreen?: boolean;
+          mouse?: boolean;
+          mouseSgr?: boolean;
         };
         try {
           msg = JSON.parse(event.data) as typeof msg;
@@ -178,6 +192,9 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
           rows: msg.rows ?? 0,
           history: msg.history ?? 0,
           cursor: msg.cursor ?? null,
+          altScreen: msg.altScreen ?? false,
+          mouse: msg.mouse ?? false,
+          mouseSgr: msg.mouseSgr ?? false,
         };
         // While reading, keep the capture window covering the FULL
         // history as the agent appends: the window was sized at entry,
@@ -284,6 +301,17 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
     }
   }, []);
 
+  /** Forward a wheel notch to a full-screen mouse app (alternate screen),
+   *  encoded as the app expects. Sent as raw input bytes, NOT as a window
+   *  request: the alternate screen has no capturable scrollback, so the
+   *  app scrolls its own content and the next frame reflects it. */
+  const forwardWheel = useCallback((up: boolean, sgr: boolean, col: number, row: number) => {
+    const ws = wsRef.current;
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(wheelMouseBytes(up, sgr, col, row));
+    }
+  }, []);
+
   const sendResize = useCallback((cols: number, rows: number) => {
     // Dedup: the sizing observer recomputes on every container change,
     // but rows are latched to the no-keyboard height, so keyboard cycles
@@ -360,6 +388,7 @@ export function useLiveTerminal(sessionId: string | null, wsPath: string = "live
   return {
     state,
     sendData,
+    forwardWheel,
     sendResize,
     setWindow,
     setCadence,

--- a/web/src/lib/__tests__/liveMouse.test.ts
+++ b/web/src/lib/__tests__/liveMouse.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { wheelMouseBytes, wheelNotches } from "../liveMouse";
+
+const bytes = (...n: number[]) => new Uint8Array(n);
+const ascii = (s: string) => new Uint8Array([...s].map((c) => c.charCodeAt(0)));
+
+describe("wheelMouseBytes", () => {
+  it("encodes SGR wheel up/down at a 1-based cell", () => {
+    expect(wheelMouseBytes(true, true, 3, 3)).toEqual(ascii("\x1b[<64;3;3M"));
+    expect(wheelMouseBytes(false, true, 3, 3)).toEqual(ascii("\x1b[<65;3;3M"));
+  });
+
+  it("encodes legacy X10 wheel up/down (value + 32, ESC [ M prefix)", () => {
+    // wheel up = button 64 -> 0x60; col/row 3 -> 0x23.
+    expect(wheelMouseBytes(true, false, 3, 3)).toEqual(bytes(0x1b, 0x5b, 0x4d, 64 + 32, 3 + 32, 3 + 32));
+    expect(wheelMouseBytes(false, false, 3, 3)).toEqual(bytes(0x1b, 0x5b, 0x4d, 65 + 32, 3 + 32, 3 + 32));
+  });
+
+  it("clamps legacy coordinates at 223 (single-byte limit)", () => {
+    expect(wheelMouseBytes(true, false, 300, 300)).toEqual(bytes(0x1b, 0x5b, 0x4d, 64 + 32, 223 + 32, 223 + 32));
+  });
+
+  it("floors coordinates to at least 1", () => {
+    expect(wheelMouseBytes(true, true, 0, -5)).toEqual(ascii("\x1b[<64;1;1M"));
+  });
+});
+
+describe("wheelNotches", () => {
+  it("converts accumulated pixels into whole notches and keeps the remainder", () => {
+    expect(wheelNotches(50, 16, 8)).toEqual({ notches: 3, remainder: 2 });
+    expect(wheelNotches(-50, 16, 8)).toEqual({ notches: -3, remainder: -2 });
+  });
+
+  it("caps notches per event so a flick can't flood", () => {
+    expect(wheelNotches(1000, 16, 8)).toEqual({ notches: 8, remainder: 1000 - 8 * 16 });
+  });
+
+  it("emits nothing below one notch, carrying the sub-notch remainder", () => {
+    expect(wheelNotches(10, 16, 8)).toEqual({ notches: 0, remainder: 10 });
+  });
+
+  it("is a no-op for a zero threshold", () => {
+    expect(wheelNotches(99, 0, 8)).toEqual({ notches: 0, remainder: 99 });
+  });
+});

--- a/web/src/lib/liveMouse.ts
+++ b/web/src/lib/liveMouse.ts
@@ -1,0 +1,53 @@
+// Mouse-wheel forwarding for the mobile live view. When the live-send
+// target is a full-screen (alternate-screen) app with mouse tracking on,
+// its scrollback is not capturable, so scroll gestures forward the wheel
+// to the app as input bytes instead of widening the capture window. This
+// mirrors the TUI's `wheel_mouse_bytes` (src/tui/home/input.rs) so both
+// surfaces speak the same encodings. See src/server/live_ws.rs for the
+// frame flags (altScreen / mouse / mouseSgr) that drive this.
+
+/**
+ * Build the wheel byte sequence for a full-screen mouse app. `up` selects
+ * wheel-up (button 64) vs wheel-down (65); `sgr` picks SGR (1006) vs the
+ * legacy X10 encoding, matching what the app enabled. `col`/`row` are
+ * 1-based pane cells.
+ */
+export function wheelMouseBytes(up: boolean, sgr: boolean, col: number, row: number): Uint8Array<ArrayBuffer> {
+  const button = up ? 64 : 65;
+  const cx = Math.max(1, Math.floor(col));
+  const cy = Math.max(1, Math.floor(row));
+  // Both branches build via `new Uint8Array(len)` (a fresh, non-shared
+  // ArrayBuffer) so the result is exactly what WebSocket.send accepts.
+  if (sgr) {
+    // SGR (1006): textual, press marker `M`. Pure ASCII, no coord limit.
+    const s = `\x1b[<${button};${cx};${cy}M`;
+    const out = new Uint8Array(s.length);
+    for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+    return out;
+  }
+  // Legacy X10: `ESC [ M` then three bytes, each value + 32. Bytes top out
+  // at 255, so coordinates above 223 can't be encoded; clamp there.
+  const enc = (v: number) => Math.min(223, v) + 32;
+  const out = new Uint8Array(6);
+  out.set([0x1b, 0x5b, 0x4d, enc(button), enc(cx), enc(cy)]);
+  return out;
+}
+
+/**
+ * Convert an accumulated scroll delta (in pixels, positive = scroll toward
+ * newer/down) into a whole number of wheel notches plus the leftover that
+ * didn't reach a full notch. `thresholdPx` is the pixels per notch (one
+ * text row). The leftover is fed back in on the next event so a slow drag
+ * still scrolls smoothly without losing motion. `maxNotches` caps a single
+ * event so a fast flick can't flood the agent.
+ */
+export function wheelNotches(
+  accumPx: number,
+  thresholdPx: number,
+  maxNotches: number,
+): { notches: number; remainder: number } {
+  if (thresholdPx <= 0) return { notches: 0, remainder: accumPx };
+  const raw = Math.trunc(accumPx / thresholdPx);
+  const notches = Math.max(-maxNotches, Math.min(maxNotches, raw));
+  return { notches, remainder: accumPx - notches * thresholdPx };
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -104,7 +104,11 @@
       "id": "terminal.mobile-live-wheel-forward",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/lib/__tests__/liveMouse.test.ts", "src/components/__tests__/MobileLiveTerminal.forward.test.tsx"],
+      "specs": [
+        "src/lib/__tests__/liveMouse.test.ts",
+        "src/hooks/useLiveTerminal.forward.test.ts",
+        "src/components/__tests__/MobileLiveTerminal.forward.test.tsx"
+      ],
       "components": [
         "web/src/lib/liveMouse.ts",
         "web/src/components/MobileLiveTerminal.tsx",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -101,6 +101,17 @@
       "components": ["web/src/hooks/useLiveTerminal.ts", "web/src/components/MobileLiveTerminal.tsx"]
     },
     {
+      "id": "terminal.mobile-live-wheel-forward",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/lib/__tests__/liveMouse.test.ts", "src/components/__tests__/MobileLiveTerminal.forward.test.tsx"],
+      "components": [
+        "web/src/lib/liveMouse.ts",
+        "web/src/components/MobileLiveTerminal.tsx",
+        "web/src/hooks/useLiveTerminal.ts"
+      ]
+    },
+    {
       "id": "auth.no-auth",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -116,6 +116,17 @@
       ]
     },
     {
+      "id": "terminal.mobile-live-wheel-forward-e2e",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": ["tests/live-wheel-forward.spec.ts"],
+      "components": [
+        "web/src/lib/liveMouse.ts",
+        "web/src/components/MobileLiveTerminal.tsx",
+        "web/src/hooks/useLiveTerminal.ts"
+      ]
+    },
+    {
       "id": "auth.no-auth",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live-wheel-forward.spec.ts
+++ b/web/tests/live-wheel-forward.spec.ts
@@ -59,6 +59,22 @@ test("swipe over a full-screen SGR-mouse app forwards SGR wheel bytes", async ({
   await expect.poll(() => scroller(page).getAttribute("class")).toContain("overflow-hidden");
   await swipeUp(page);
   await expect.poll(() => texts(handle).some((s) => s.includes("\x1b[<65;"))).toBe(true);
+
+  // Downward swipe forwards wheel UP (button 64).
+  await fireTouches(page, "touchstart", [{ x: 100, y: 120 }]);
+  await fireTouches(page, "touchmove", [{ x: 100, y: 300 }]);
+  await fireTouches(page, "touchend", [{ x: 100, y: 300 }]);
+  await expect.poll(() => texts(handle).some((s) => s.includes("\x1b[<64;"))).toBe(true);
+
+  // Wheel events in all three deltaModes (px / line / page) + a sub-notch
+  // delta (no-op) + a scroll (which must NOT enter reading in forward mode).
+  await scroller(page).dispatchEvent("wheel", { deltaY: 120, deltaMode: 0 });
+  await scroller(page).dispatchEvent("wheel", { deltaY: 3, deltaMode: 1 });
+  await scroller(page).dispatchEvent("wheel", { deltaY: 1, deltaMode: 2 });
+  await scroller(page).dispatchEvent("wheel", { deltaY: 1, deltaMode: 0 });
+  await scroller(page).dispatchEvent("scroll", {});
+  // Still forwarding, still pinned, still no "Back to live" affordance.
+  await expect(page.getByRole("button", { name: "Back to live" })).toHaveCount(0);
 });
 
 test("swipe over a full-screen LEGACY-mouse app forwards X10 wheel bytes", async ({ page }) => {

--- a/web/tests/live-wheel-forward.spec.ts
+++ b/web/tests/live-wheel-forward.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+import {
+  mockTerminalApis,
+  installTerminalSpies,
+  seedSettings,
+  makeLiveFrame,
+  fireTouches,
+  type MockHandle,
+} from "./helpers/terminal-mocks";
+
+// A full-screen (alternate-screen) mouse agent has no capturable
+// scrollback, so the mobile live view forwards the wheel to the app as
+// input bytes instead of widening the capture window. This drives the
+// real bundle (useLiveTerminal -> wheelMouseBytes -> WebSocket) so the
+// forwarded bytes are asserted on the wire, per encoding.
+test.use({ ...devices["iPhone 13"] });
+
+async function openSession(page: Page, handle: MockHandle) {
+  await openMobileSidebar(page);
+  await clickSidebarSession(page, "pinch-test");
+  await page.locator("[data-live-terminal]").waitFor({ state: "visible", timeout: 10_000 });
+  await expect.poll(() => handle.liveMessages.length, { timeout: 5_000 }).toBeGreaterThan(0);
+  await page.waitForTimeout(400);
+}
+
+function pushFrame(handle: MockHandle, flags: { altScreen: boolean; mouse: boolean; mouseSgr: boolean }) {
+  handle.pushLiveFrame({
+    ...makeLiveFrame({ rows: 24, history: 120, window: 24 }),
+    ...flags,
+  } as Parameters<MockHandle["pushLiveFrame"]>[0]);
+}
+
+const scroller = (page: Page) => page.locator("[data-live-terminal] > div").first();
+const texts = (h: MockHandle) => h.liveMessages.map((b) => b.toString("latin1"));
+const hasLegacyDown = (h: MockHandle) =>
+  h.liveMessages.some((b) => b.length >= 4 && b[0] === 0x1b && b[1] === 0x5b && b[2] === 0x4d && b[3] === 0x61);
+
+async function setup(page: Page) {
+  await installTerminalSpies(page);
+  const handle = await mockTerminalApis(page);
+  await page.goto("/");
+  await seedSettings(page, { mobileFontSize: 14 });
+  await page.reload();
+  await openSession(page, handle);
+  return handle;
+}
+
+async function swipeUp(page: Page) {
+  await fireTouches(page, "touchstart", [{ x: 100, y: 300 }]);
+  await fireTouches(page, "touchmove", [{ x: 100, y: 220 }]);
+  await fireTouches(page, "touchend", [{ x: 100, y: 220 }]);
+}
+
+test("swipe over a full-screen SGR-mouse app forwards SGR wheel bytes", async ({ page }) => {
+  const handle = await setup(page);
+  pushFrame(handle, { altScreen: true, mouse: true, mouseSgr: true });
+  await expect.poll(() => scroller(page).getAttribute("class")).toContain("overflow-hidden");
+  await swipeUp(page);
+  await expect.poll(() => texts(handle).some((s) => s.includes("\x1b[<65;"))).toBe(true);
+});
+
+test("swipe over a full-screen LEGACY-mouse app forwards X10 wheel bytes", async ({ page }) => {
+  const handle = await setup(page);
+  pushFrame(handle, { altScreen: true, mouse: true, mouseSgr: false });
+  await expect.poll(() => scroller(page).getAttribute("class")).toContain("overflow-hidden");
+  await swipeUp(page);
+  await expect.poll(() => hasLegacyDown(handle)).toBe(true);
+  expect(texts(handle).some((s) => s.includes("\x1b[<"))).toBe(false);
+});
+
+test("normal-screen agent does NOT forward mouse bytes", async ({ page }) => {
+  const handle = await setup(page);
+  pushFrame(handle, { altScreen: false, mouse: true, mouseSgr: true });
+  await expect.poll(() => scroller(page).getAttribute("class")).toContain("overflow-y-auto");
+  await swipeUp(page);
+  await page.waitForTimeout(300);
+  expect(texts(handle).some((s) => s.includes("\x1b[<") || s.includes("\x1b[M"))).toBe(false);
+  expect(hasLegacyDown(handle)).toBe(false);
+});


### PR DESCRIPTION
## Description

In live-send mode, wheeling over the preview of an agent running on the **alternate screen** (a full-screen / TUI agent) scrolls up a little, then snaps to the very first part of the session.

Root cause: the alternate screen has no scrollback. The preview scrolls by growing a `tmux capture-pane` window, but for an alt-screen pane that window is the unrelated **normal-buffer** history underneath the app, so a few wheel ticks leave the live UI and bottom out at the session start. Attaching to tmux "works" because the wheel reaches the live app, which scrolls its own content; `capture-pane` never can.

Fix: when the live-send target is on the alternate screen **and** has mouse tracking on, forward the wheel as an SGR mouse event (the same thing a terminal does on attach) so the app scrolls itself. Gated on `#{mouse_any_flag}` so we never send `ESC[<..M` bytes to an app that would read them as garbage keystrokes; every other case keeps the existing capture-window scroll.

`PaneCursor` gains `alternate_on` and `mouse_tracking`, folded into the existing cursor query (`#{alternate_on} #{mouse_any_flag}`), so this costs no extra `tmux` fork.

### How it was diagnosed
Reproduced against real tmux: confirmed a capture of an alt-screen pane returns `[normal-buffer history] + [alt screen]`, and that `#{mouse_any_flag}` cleanly distinguishes mouse-enabled apps (`alternate_on=1 mouse_any_flag=1`) from non-mouse ones. The reporter's session confirmed `alternate_on=1`.

### Known limitation (not addressed here)
A full-screen app **without** mouse tracking (`alternate_on=1, mouse_any_flag=0`, e.g. a plain pager) keeps today's capture-scroll, since forwarding SGR there would garble it and there is no universal "scroll" key. The web live view (`src/server/live_ws.rs`) shares the same capture model and has the same limitation for full-screen agents; left as a follow-up. The `PaneCursor` fields added here are already plumbed through the shared capture, so the web side has what it needs.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (n/a: no user-facing docs change)
- [ ] For UI changes: included screenshot or recording (n/a: interaction-timing behavior, not a visual change; repro steps above)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a `tests/e2e/` test, because: the scroll-routing is covered by deterministic unit/integration tests instead (`wheel_over_alt_screen_mouse_pane_forwards_instead_of_scrollback` plus `_without_mouse` and `_normal_screen` controls in `src/tui/home/tests.rs`, `wheel_sgr_bytes_maps_cell_and_button` in `src/tui/home/input.rs`, and the extended `pane_cursor_parses_format_line`). A full e2e would need a real alternate-screen mouse app under tmux, which is flaky and adds little over the injected-cursor tests.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:** Root-cause investigation and implementation were done with Claude Code through back-and-forth with @njbrake; the diagnosis (alternate-screen + mouse-tracking gating) and the decision to forward the wheel were his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784039362&installation_id=139138837&pr_number=2123&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2123&signature=7fe4bb73918826430ea5bf40b5a1d3a3ac43bf021f0046c2b0c70efbe66d347d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a live-send scrolling glitch in the TUI when a full-screen (alternate-screen) agent is running: using the mouse wheel over the preview could briefly scroll up and then snap back to the beginning. It also extends the fix to the mobile web live view.

## What Changed

- **The “capabilities” sent to the front-end are richer and more accurate:**
  - The TUI now detects whether the target is on the **alternate screen**, whether **mouse tracking** is enabled, and whether **SGR mouse** is supported.
  - Those flags are added to the live WebSocket frame so the UI can choose the correct scrolling behavior.

- **Wheel scrolling is now routed to the live app when safe (alternate-screen mouse apps):**
  - In **TUI live-send**, when the target is on the **alternate screen** *and* has **mouse tracking**, wheel input is forwarded directly to the running full-screen app as proper mouse escape sequences.
  - Otherwise, the existing preview/capture-window scrolling behavior remains unchanged.
  - Forwarded wheel events are encoded as **SGR** or **legacy X10** depending on what the target supports.

- **Mobile web live view now supports the same “forward wheel” behavior:**
  - Mobile now enters a “forward mode” for **alternate-screen mouse** frames, forwarding wheel/touch scroll gestures to the app instead of using the normal spacer/history scroll model.
  - It supports both **SGR** and **legacy X10** wheel encodings.

## Testing Strengthened

- **TUI tests** were updated to include the new cursor flags (alternate screen + mouse tracking + encoding support) via deterministic helpers.
- Added regression tests to verify wheel behavior across:
  - alternate-screen + SGR mouse tracking (forwarding)
  - alternate-screen without mouse tracking (fallback)
  - alternate-screen + legacy encoding (forwarding)
  - normal-screen (fallback)
- **Mobile web tests** added/expanded with Vitest to validate:
  - the correct byte encoding (SGR vs legacy),
  - wheel forwarding conditions (requires `altScreen && mouse && mouseSgr`),
  - and gesture-to-wheel notch routing logic.
- Added/updated unit tests for the underlying mouse-wheel helpers used by the mobile forwarding path.

## Benefits

- **Direct user-facing fix:** Full-screen agents in live-send no longer “snap back” when scrolling over the preview.
- **Better compatibility:** Wheel forwarding adapts to terminals/apps that require **SGR** vs **legacy X10** encodings.
- **Consistent experience:** Mobile web now follows the intended alternate-screen mouse app behavior.

## Known Limitation

- Full-screen applications **without mouse tracking** still use the older preview/capture scrolling behavior. The web path shares the same capture/scroll limitation outside the forwarding-enabled condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->