### PR TITLE
fix(web): suppress working spinner while a question or approval card is pending

### DIFF
--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -205,8 +205,10 @@ container (rather than bind-mounting from the host).
 If the agent finished a turn but the working spinner is still rattling, a small
 **Force end turn** button appears beneath it. Click it to clear the spinner and
 cancel the agent. It only appears for a silent model with no tool running, and
-the view auto-recovers on its own if you do nothing. During a healthy turn, or
-while a tool is in flight, the button stays hidden.
+the view auto-recovers on its own if you do nothing. During a healthy turn,
+while a tool is in flight, or while a question or approval card is awaiting your
+input, the spinner and the button stay hidden; the turn is parked on you, not
+stalled.
 
 ### Editing settings asks for the passphrase again
 

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -205,10 +205,10 @@ container (rather than bind-mounting from the host).
 If the agent finished a turn but the working spinner is still rattling, a small
 **Force end turn** button appears beneath it. Click it to clear the spinner and
 cancel the agent. It only appears for a silent model with no tool running, and
-the view auto-recovers on its own if you do nothing. During a healthy turn,
-while a tool is in flight, or while a question or approval card is awaiting your
-input, the spinner and the button stay hidden; the turn is parked on you, not
-stalled.
+the view auto-recovers on its own if you do nothing. During healthy streaming, or
+while a tool is in flight, the spinner keeps running but the button stays hidden.
+While a question or approval card is awaiting your input, both the spinner and the
+button are hidden, so the actionable card stands alone.
 
 ### Editing settings asks for the passphrase again
 

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -407,16 +407,24 @@ function AcpChrome({
             />
 
             <ThreadPrimitive.If running>
-              <div className="mt-3 ml-1">
-                <WorkingSpinner
-                  thinking={state.thinking}
-                  tool={state.inFlightTool?.name ?? null}
-                  cancelling={state.cancelling}
-                  cancelEscalatesAt={state.cancelEscalatesAt}
-                  lastActivityRef={lastActivityRef}
-                  onForceEndTurn={forceEndTurn}
-                />
-              </div>
+              {/* The turn is "running" while an elicitation or approval card is
+                  on screen, but the agent is parked on the user's answer, not
+                  stalled. Suppress the spinner (rattle verbs, "Waiting on
+                  model…", and the Force end turn watchdog) so the actionable
+                  card stands alone; it returns once the turn resumes. See
+                  #2145. */}
+              {state.pendingElicitations.length === 0 && state.pendingApprovals.length === 0 ? (
+                <div className="mt-3 ml-1">
+                  <WorkingSpinner
+                    thinking={state.thinking}
+                    tool={state.inFlightTool?.name ?? null}
+                    cancelling={state.cancelling}
+                    cancelEscalatesAt={state.cancelEscalatesAt}
+                    lastActivityRef={lastActivityRef}
+                    onForceEndTurn={forceEndTurn}
+                  />
+                </div>
+              ) : null}
             </ThreadPrimitive.If>
 
             {state.pendingApprovals.map((approval) => (
@@ -1041,7 +1049,7 @@ export function WorkingSpinner({
   const showForceEnd = !cancelling && showStalled && !toolInFlight;
 
   return (
-    <div className="flex flex-col gap-2 text-sm italic text-text-muted">
+    <div data-testid="acp-working-spinner" className="flex flex-col gap-2 text-sm italic text-text-muted">
       <div className="flex items-center gap-2">
         <span className="inline-block w-3 text-center font-mono text-brand-500" aria-hidden="true">
           {SPINNER_FRAMES[frame]}

--- a/web/tests/live/acp-stories/approval-allow.spec.ts
+++ b/web/tests/live/acp-stories/approval-allow.spec.ts
@@ -74,6 +74,11 @@ base("ApprovalCard Allow resolves and the turn continues", async ({ page }, test
     });
     await expect(approvalDialog).toBeVisible({ timeout: 10_000 });
 
+    // #2145: the approval branch of the spinner gate. The turn is still
+    // "running" while the card is pending, but the agent is parked on the
+    // decision, so the working spinner must not render beneath it.
+    await expect(page.getByTestId("acp-working-spinner")).toHaveCount(0);
+
     // The fake script gates the post-approval chunk on the user's
     // Allow click. Prove the gate works by asserting the
     // post-approval text is absent BEFORE clicking; otherwise this

--- a/web/tests/live/acp-stories/ask-user-question.spec.ts
+++ b/web/tests/live/acp-stories/ask-user-question.spec.ts
@@ -114,6 +114,13 @@ base("AskUserQuestion card submit resolves and the turn continues", async ({ pag
     });
     await expect(questionDialog).toBeVisible({ timeout: 10_000 });
 
+    // #2145: the turn is still "running" while the question is pending, but
+    // the agent is parked on the answer, not stalled. The working spinner
+    // (rattle verbs, "Waiting on model…", the Force end turn watchdog) must
+    // not render beneath the card. The spinner mounts immediately when shown,
+    // so a count of 0 is decisive without waiting for the stall threshold.
+    await expect(page.getByTestId("acp-working-spinner")).toHaveCount(0);
+
     // The fake gates the post-answer chunk on the user's submit. Assert it
     // is absent first so a no-op card couldn't pass this spec.
     const postAnswerChunk = page.getByText("Got your answer.");


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the structured view, the turn stays "running" while an `AskUserQuestion` elicitation or an approval card is on screen, because no `Stopped` frame arrives until the user answers. The `WorkingSpinner` was rendered on that running flag alone, so it sat beneath the card cycling rattle verbs ("Smelting iron…") and, once the stall threshold passed, flipped to "Waiting on model…" plus a **Force end turn** button. The agent was parked on the user, not stalled, so the spinner and the escape hatch were both misleading; tapping Force end turn cancels the very turn the user is about to answer.

The fix gates the spinner render on `state.pendingElicitations.length === 0 && state.pendingApprovals.length === 0`, so an actionable card stands alone and the spinner returns as soon as the turn resumes streaming. Approvals are gated too (the issue's open question, confirmed): an approval card is equally "waiting on you", and no existing test asserted a spinner during one.

A `data-testid="acp-working-spinner"` is added to the spinner root so the existing `ask-user-question` live story can assert its absence while the question card is up. The troubleshooting doc now notes the spinner stays hidden while a card awaits input.

Closes #2145

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, attach the structured view to a session running an agent that calls `AskUserQuestion` (or use the fake-ACP `elicitation_request` script).
- [ ] When the question card appears, confirm no spinner, no rattle verb, and no "Force end turn" button render beneath it, even after waiting past the stall threshold (default 30s).
- [ ] Answer the question; confirm the turn resumes and the normal working spinner reappears while the agent streams.
- [ ] Trigger a tool that needs approval; confirm the approval card shows with no spinner beneath it, and the spinner returns after you allow.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

(The `acp.elicitation` matrix entry already maps `tests/live/acp-stories/ask-user-question.spec.ts` to `StructuredView.tsx`; the spec was extended with the spinner-absence assertion, so no new matrix entry was needed. Verified red on the pre-fix tree, green after.)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (gate on both elicitations and approvals), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784114829&installation_id=139138837&pr_number=2151&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2151&signature=73437f74c0a41f8a80be012426c795506fbebc7bc1f3ff7f0f364ed8f60dcb5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a misleading UI bug in the web dashboard’s structured view where a “working” spinner and a “Force end turn” escape hatch could appear beneath user-actionable cards (question prompts and approval requests). The UI incorrectly suggested the turn was stalled, even though the system was simply waiting for the user to respond—and the button could cancel the turn the user was about to answer.

## Changes Made

**Documentation Update**
- Updated the structured-view troubleshooting guidance to clarify that the spinner and “Force end turn” button stay hidden while the user must act on a **question** or **approval** card, and that the view auto-recovers during normal flow.

**Spinner Visibility Logic**
- Updated `StructuredView` so the `WorkingSpinner` only renders when there are **no pending question elicitations and no pending approvals**.
- Added `data-testid="acp-working-spinner"` to the spinner root to make its presence/absence testable.

**Test Coverage**
- Enhanced the live “AskUserQuestion card submit resolves and the turn continues” story to assert the spinner is **not** shown while the question card is pending.
- Added a regression assertion in `approval-allow.spec.ts` to verify the spinner is also **not** shown while an approval card is pending.

## Benefits

- **Clearer User Experience:** Prevents users from confusing “waiting for your input” with “the turn is stalled.”
- **Safer Interaction:** Reduces the risk of users clicking “Force end turn” while they’re supposed to answer a card.
- **More Reliable UI Consistency:** Ensures the same behavior for both question and approval card flows, not just one branch.

## Technical notes (for context)

- The spinner render is gated on `state.pendingElicitations.length === 0` **and** `state.pendingApprovals.length === 0`, so actionable card chrome appears without spinner/escape-hatch noise while the app is waiting on user input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->