### PR TITLE
feat(structured-view): recall and edit queued prompts with ArrowUp/ArrowDown

### DIFF
--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -50,6 +50,7 @@ banner at the bottom shows the current focus.
 | Composer    | `@`             | Open the file-mention picker; keep typing to filter   |
 | Composer    | `Enter` (empty) | Retry draining the queue when idle (e.g. after a failed send) |
 | Composer    | `/`             | Type a slash at the start of an empty line to open the command picker |
+| Composer    | `↑` / `↓`       | Recall queued prompts to edit (caret at start); `↓` past the newest restores your draft |
 | Composer    | `↑` / `↓`       | Move the picker highlight (picker open)               |
 | Composer    | `Ctrl+n` / `Ctrl+p` | Move the picker highlight down / up (picker open) |
 | Composer    | `Enter` / `Tab` | Insert the highlighted command or file (picker open)  |
@@ -204,6 +205,14 @@ the whole row is dropped on reload rather than draining a text-only
 prompt with the image missing. There is no server-side durability;
 clearing site data wipes the queue.
 
+**Editing a queued prompt.** Click any queued row to edit it inline, or,
+with the composer empty (caret at the start), press `↑` to pull the most
+recent queued prompt back into the composer; `↑` again walks toward older
+entries and `↓` walks back toward newer ones, restoring your in-progress
+draft once you step past the newest. Editing a recalled prompt and
+pressing `Enter` updates that entry in place rather than queueing a
+duplicate.
+
 **TUI structured view.** The TUI has the same client-side queue.
 Pressing `Enter` while a turn is active (or while the WebSocket is down)
 parks the prompt in a **Queued (N)** strip instead of sending; the queue
@@ -211,9 +220,12 @@ drains on the next `Stopped` per the daemon's `acp.queue_drain_mode`
 (read from `/api/about`, so a remote attach honors the remote daemon's
 setting). `Ctrl+X` clears the queue, and pressing `Enter` on an empty
 composer when idle retries the drain (useful if a send failed and left
-prompts parked). Two differences from the web composer: queued rows
-can't be edited in place (clear and retype), and the TUI queue is
-in-memory only, so it does not survive leaving the structured view.
+prompts parked). Queued prompts can be recalled for editing the same way
+as the web: with the composer empty (caret at the top-left), `↑` pulls
+the newest queued prompt back into the composer, `↑` / `↓` walk the queue,
+and editing then `Enter` updates that entry in place. One difference from
+the web composer remains: the TUI queue is in-memory only, so it does not
+survive leaving the structured view.
 
 ## Stopping a turn
 

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -209,9 +209,11 @@ clearing site data wipes the queue.
 with the composer empty (caret at the start), press `↑` to pull the most
 recent queued prompt back into the composer; `↑` again walks toward older
 entries and `↓` walks back toward newer ones, restoring your in-progress
-draft once you step past the newest. Editing a recalled prompt and
-pressing `Enter` updates that entry in place rather than queueing a
-duplicate.
+draft once you step past the newest. While recalling, a banner above the
+composer reads **Editing queued message N of M** so the mode is
+unmistakable; `Esc` abandons the edit and restores your draft. Editing a
+recalled prompt and pressing `Enter` updates that entry in place rather
+than queueing a duplicate.
 
 **TUI structured view.** The TUI has the same client-side queue.
 Pressing `Enter` while a turn is active (or while the WebSocket is down)
@@ -223,9 +225,11 @@ composer when idle retries the drain (useful if a send failed and left
 prompts parked). Queued prompts can be recalled for editing the same way
 as the web: with the composer empty (caret at the top-left), `↑` pulls
 the newest queued prompt back into the composer, `↑` / `↓` walk the queue,
-and editing then `Enter` updates that entry in place. One difference from
-the web composer remains: the TUI queue is in-memory only, so it does not
-survive leaving the structured view.
+and editing then `Enter` updates that entry in place. While recalling, the
+composer border title reads **Editing queued message N of M**, and `Esc`
+restores your draft. One difference from the web composer remains: the TUI
+queue is in-memory only, so it does not survive leaving the structured
+view.
 
 ## Stopping a turn
 

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -223,7 +223,7 @@ drains on the next `Stopped` per the daemon's `acp.queue_drain_mode`
 setting). `Ctrl+X` clears the queue, and pressing `Enter` on an empty
 composer when idle retries the drain (useful if a send failed and left
 prompts parked). Queued prompts can be recalled for editing the same way
-as the web: with the composer empty (caret at the top-left), `↑` pulls
+as the web: with the composer empty (caret at the start), `↑` pulls
 the newest queued prompt back into the composer, `↑` / `↓` walk the queue,
 and editing then `Enter` updates that entry in place. While recalling, the
 composer border title reads **Editing queued message N of M**, and `Esc`

--- a/src/tui/structured_view/input.rs
+++ b/src/tui/structured_view/input.rs
@@ -41,6 +41,11 @@ pub enum Intent {
     CancelInFlight,
     /// Drop every queued (not-yet-sent) prompt.
     ClearQueue,
+    /// Browse the prompt queue from the composer (shell-history style):
+    /// negative steps toward older entries (ArrowUp), positive toward
+    /// newer (ArrowDown). The view layer loads the entry into the composer
+    /// for editing.
+    RecallQueued(i32),
     /// Open the daemon URL for this session in the user's browser.
     OpenInBrowser,
     /// Move focus to the named region.
@@ -68,7 +73,7 @@ pub enum Intent {
 /// `@`-mention picker is currently open (each claims navigation keys in
 /// the composer). Passed as a struct instead of positional bools so call
 /// sites stay readable.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct InputContext {
     pub has_pending_approval: bool,
     /// A pending `AskUserQuestion` elicitation exists. Gates the
@@ -77,6 +82,16 @@ pub struct InputContext {
     pub has_pending_elicitation: bool,
     pub slash_picker_open: bool,
     pub mention_picker_open: bool,
+    /// Composer caret is at row 0, col 0. Gates ArrowUp entry into
+    /// queue-recall so multi-line caret movement keeps working until the
+    /// user reaches the top-left.
+    pub caret_at_origin: bool,
+    /// A queue-recall browse is already active; while browsing, ArrowUp /
+    /// ArrowDown navigate the queue regardless of caret position.
+    pub browsing_queue: bool,
+    /// Number of queued prompts; ArrowUp only enters recall when there is
+    /// something to recall.
+    pub queue_len: usize,
 }
 
 /// Translate a key event into an [`Intent`] based on the current
@@ -105,7 +120,7 @@ pub fn dispatch(focus: Focus, key: &KeyEvent, ctx: InputContext) -> Intent {
     }
 
     match focus {
-        Focus::Composer => composer_keys(key, ctx.slash_picker_open, ctx.mention_picker_open),
+        Focus::Composer => composer_keys(key, ctx),
         Focus::Transcript => {
             transcript_keys(key, ctx.has_pending_approval, ctx.has_pending_elicitation)
         }
@@ -113,7 +128,9 @@ pub fn dispatch(focus: Focus, key: &KeyEvent, ctx: InputContext) -> Intent {
     }
 }
 
-fn composer_keys(key: &KeyEvent, slash_picker_open: bool, mention_picker_open: bool) -> Intent {
+fn composer_keys(key: &KeyEvent, ctx: InputContext) -> Intent {
+    let slash_picker_open = ctx.slash_picker_open;
+    let mention_picker_open = ctx.mention_picker_open;
     // When a picker is open it claims navigation + accept/dismiss keys
     // so the user can drive it without the textarea swallowing them.
     // Everything else (typing, cursor motion the picker doesn't use)
@@ -149,6 +166,19 @@ fn composer_keys(key: &KeyEvent, slash_picker_open: bool, mention_picker_open: b
         }
     }
     match (key.modifiers, key.code) {
+        // Queue recall: ArrowUp browses toward older queued prompts when
+        // already browsing, or when the caret is at the top-left and the
+        // queue is non-empty; ArrowDown walks back toward newer entries
+        // (and the stashed draft) only while browsing. Outside those
+        // conditions Up / Down fall through to normal textarea caret
+        // movement so multi-line editing is unaffected.
+        (m, KeyCode::Up)
+            if m.is_empty()
+                && (ctx.browsing_queue || (ctx.caret_at_origin && ctx.queue_len > 0)) =>
+        {
+            Intent::RecallQueued(-1)
+        }
+        (m, KeyCode::Down) if m.is_empty() && ctx.browsing_queue => Intent::RecallQueued(1),
         // Plain Enter submits.
         (m, KeyCode::Enter) if m.is_empty() => Intent::SubmitPrompt,
         // Shift+Enter inserts a newline (passed through to textarea).
@@ -238,38 +268,27 @@ mod tests {
     /// No pending approval, pickers closed: the common case for the
     /// pre-existing focus tests.
     fn ctx() -> InputContext {
-        InputContext {
-            has_pending_approval: false,
-            has_pending_elicitation: false,
-            slash_picker_open: false,
-            mention_picker_open: false,
-        }
+        InputContext::default()
     }
 
     fn ctx_pending() -> InputContext {
         InputContext {
             has_pending_approval: true,
-            has_pending_elicitation: false,
-            slash_picker_open: false,
-            mention_picker_open: false,
+            ..InputContext::default()
         }
     }
 
     fn ctx_picker() -> InputContext {
         InputContext {
-            has_pending_approval: false,
-            has_pending_elicitation: false,
             slash_picker_open: true,
-            mention_picker_open: false,
+            ..InputContext::default()
         }
     }
 
     fn ctx_mention() -> InputContext {
         InputContext {
-            has_pending_approval: false,
-            has_pending_elicitation: false,
-            slash_picker_open: false,
             mention_picker_open: true,
+            ..InputContext::default()
         }
     }
 
@@ -329,10 +348,17 @@ mod tests {
 
     fn ctx_pending_elicitation() -> InputContext {
         InputContext {
-            has_pending_approval: false,
             has_pending_elicitation: true,
-            slash_picker_open: false,
-            mention_picker_open: false,
+            ..InputContext::default()
+        }
+    }
+
+    fn ctx_recall(caret_at_origin: bool, browsing_queue: bool, queue_len: usize) -> InputContext {
+        InputContext {
+            caret_at_origin,
+            browsing_queue,
+            queue_len,
+            ..InputContext::default()
         }
     }
 
@@ -572,6 +598,78 @@ mod tests {
             dispatch(Focus::Composer, &key(KeyCode::Esc), ctx()),
             Intent::SetFocus(Focus::Transcript)
         );
+    }
+
+    #[test]
+    fn arrow_up_recalls_when_caret_at_origin_with_a_queue() {
+        assert_eq!(
+            dispatch(
+                Focus::Composer,
+                &key(KeyCode::Up),
+                ctx_recall(true, false, 2)
+            ),
+            Intent::RecallQueued(-1)
+        );
+    }
+
+    #[test]
+    fn arrow_up_moves_caret_when_not_at_origin() {
+        // Multi-line draft, caret mid-text: Up is normal caret movement,
+        // never a recall, even with a non-empty queue.
+        assert!(matches!(
+            dispatch(
+                Focus::Composer,
+                &key(KeyCode::Up),
+                ctx_recall(false, false, 2)
+            ),
+            Intent::Compose(_)
+        ));
+    }
+
+    #[test]
+    fn arrow_up_does_not_recall_with_empty_queue() {
+        assert!(matches!(
+            dispatch(
+                Focus::Composer,
+                &key(KeyCode::Up),
+                ctx_recall(true, false, 0)
+            ),
+            Intent::Compose(_)
+        ));
+    }
+
+    #[test]
+    fn arrows_navigate_queue_while_browsing_regardless_of_caret() {
+        // Once browsing, both arrows own navigation even though the caret
+        // is not at the origin (it sits at the end of the loaded prompt).
+        assert_eq!(
+            dispatch(
+                Focus::Composer,
+                &key(KeyCode::Up),
+                ctx_recall(false, true, 2)
+            ),
+            Intent::RecallQueued(-1)
+        );
+        assert_eq!(
+            dispatch(
+                Focus::Composer,
+                &key(KeyCode::Down),
+                ctx_recall(false, true, 2)
+            ),
+            Intent::RecallQueued(1)
+        );
+    }
+
+    #[test]
+    fn arrow_down_does_not_recall_when_not_browsing() {
+        assert!(matches!(
+            dispatch(
+                Focus::Composer,
+                &key(KeyCode::Down),
+                ctx_recall(true, false, 2)
+            ),
+            Intent::Compose(_)
+        ));
     }
 
     #[test]

--- a/src/tui/structured_view/input.rs
+++ b/src/tui/structured_view/input.rs
@@ -134,6 +134,20 @@ pub fn dispatch(focus: Focus, key: &KeyEvent, ctx: InputContext) -> Intent {
 fn composer_keys(key: &KeyEvent, ctx: InputContext) -> Intent {
     let slash_picker_open = ctx.slash_picker_open;
     let mention_picker_open = ctx.mention_picker_open;
+    // While browsing the queue, recall navigation owns its core keys even
+    // when the recalled text would otherwise open the slash / `@` picker
+    // (e.g. a queued "/clear"). Without this the picker would steal
+    // Up/Down/Esc/Enter and break recall navigation, restore, and save.
+    // Typed characters still fall through below to narrow the picker.
+    if ctx.browsing_queue {
+        match (key.modifiers, key.code) {
+            (m, KeyCode::Up) if m.is_empty() => return Intent::RecallQueued(-1),
+            (m, KeyCode::Down) if m.is_empty() => return Intent::RecallQueued(1),
+            (m, KeyCode::Esc) if m.is_empty() => return Intent::RecallCancel,
+            (m, KeyCode::Enter) if m.is_empty() => return Intent::SubmitPrompt,
+            _ => {}
+        }
+    }
     // When a picker is open it claims navigation + accept/dismiss keys
     // so the user can drive it without the textarea swallowing them.
     // Everything else (typing, cursor motion the picker doesn't use)
@@ -664,6 +678,39 @@ mod tests {
             ),
             Intent::RecallQueued(1)
         );
+    }
+
+    #[test]
+    fn recall_keys_win_over_open_picker_while_browsing() {
+        // A recalled prompt that looks like a slash query opens the picker;
+        // recall navigation must still own Up/Down/Esc/Enter.
+        let ctx = InputContext {
+            slash_picker_open: true,
+            browsing_queue: true,
+            queue_len: 2,
+            ..InputContext::default()
+        };
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Up), ctx),
+            Intent::RecallQueued(-1)
+        );
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Down), ctx),
+            Intent::RecallQueued(1)
+        );
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Esc), ctx),
+            Intent::RecallCancel
+        );
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Enter), ctx),
+            Intent::SubmitPrompt
+        );
+        // Typed characters still fall through to narrow the picker.
+        assert!(matches!(
+            dispatch(Focus::Composer, &key(KeyCode::Char('a')), ctx),
+            Intent::Compose(_)
+        ));
     }
 
     #[test]

--- a/src/tui/structured_view/input.rs
+++ b/src/tui/structured_view/input.rs
@@ -46,6 +46,9 @@ pub enum Intent {
     /// newer (ArrowDown). The view layer loads the entry into the composer
     /// for editing.
     RecallQueued(i32),
+    /// Abandon an in-progress queue browse, restoring the stashed draft to
+    /// the composer (the `Esc` while browsing).
+    RecallCancel,
     /// Open the daemon URL for this session in the user's browser.
     OpenInBrowser,
     /// Move focus to the named region.
@@ -179,6 +182,9 @@ fn composer_keys(key: &KeyEvent, ctx: InputContext) -> Intent {
             Intent::RecallQueued(-1)
         }
         (m, KeyCode::Down) if m.is_empty() && ctx.browsing_queue => Intent::RecallQueued(1),
+        // Esc while browsing the queue restores the stashed draft instead
+        // of leaving the composer.
+        (m, KeyCode::Esc) if m.is_empty() && ctx.browsing_queue => Intent::RecallCancel,
         // Plain Enter submits.
         (m, KeyCode::Enter) if m.is_empty() => Intent::SubmitPrompt,
         // Shift+Enter inserts a newline (passed through to textarea).
@@ -657,6 +663,23 @@ mod tests {
                 ctx_recall(false, true, 2)
             ),
             Intent::RecallQueued(1)
+        );
+    }
+
+    #[test]
+    fn esc_while_browsing_cancels_recall() {
+        assert_eq!(
+            dispatch(
+                Focus::Composer,
+                &key(KeyCode::Esc),
+                ctx_recall(false, true, 2)
+            ),
+            Intent::RecallCancel
+        );
+        // Not browsing: Esc still returns focus to the transcript.
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Esc), ctx()),
+            Intent::SetFocus(Focus::Transcript)
         );
     }
 

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -524,6 +524,10 @@ async fn handle_terminal_event(
             state.recall_step(delta);
             Ok(false)
         }
+        Intent::RecallCancel => {
+            state.recall_cancel_restore();
+            Ok(false)
+        }
         Intent::Scroll(delta) => {
             apply_scroll(state, delta);
             Ok(false)

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -373,6 +373,9 @@ async fn handle_terminal_event(
         has_pending_elicitation: !state.transcript.pending_elicitations.is_empty(),
         slash_picker_open: state.slash_picker_open(),
         mention_picker_open: state.mention.is_some(),
+        caret_at_origin: state.caret_at_origin(),
+        browsing_queue: state.browsing_queue(),
+        queue_len: state.queue.len(),
     };
     let intent = input::dispatch(state.focus, &key, ctx);
     match intent {
@@ -386,6 +389,11 @@ async fn handle_terminal_event(
             } else {
                 focus
             };
+            // Leaving the composer ends any queue-recall browse; the
+            // in-progress text stays put as a draft.
+            if state.focus != Focus::Composer {
+                state.cancel_recall();
+            }
             state.reconcile_selection();
             Ok(false)
         }
@@ -436,7 +444,28 @@ async fn handle_terminal_event(
             Ok(false)
         }
         Intent::SubmitPrompt => {
+            // Capture the browse target before take_composer_text resets
+            // the recall state.
+            let recall = state.recall.take();
             let text = state.take_composer_text();
+            // Submitting while browsing edits that queued entry in place,
+            // preserving its position rather than enqueuing a duplicate.
+            // If the entry drained between recall and now, the index is
+            // stale; fall through to the normal send / queue path so the
+            // edited text is never lost.
+            if !text.is_empty() {
+                if let Some(r) = recall {
+                    if state.queue.replace(r.index, text.clone()) {
+                        set_toast(
+                            state,
+                            toast_deadline,
+                            format!("edited queued prompt ({} waiting)", state.queue.len()),
+                            ToastKind::Info,
+                        );
+                        return Ok(false);
+                    }
+                }
+            }
             if text.is_empty() {
                 // Empty Enter is a manual flush: if the agent is idle and
                 // prompts are stuck in the queue (e.g. a drain POST failed
@@ -480,12 +509,19 @@ async fn handle_terminal_event(
                 return Ok(false);
             }
             state.queue.clear();
+            // The browsed entry no longer exists; end the browse but keep
+            // whatever text is in the composer as a draft.
+            state.cancel_recall();
             set_toast(
                 state,
                 toast_deadline,
                 "queue cleared".into(),
                 ToastKind::Info,
             );
+            Ok(false)
+        }
+        Intent::RecallQueued(delta) => {
+            state.recall_step(delta);
             Ok(false)
         }
         Intent::Scroll(delta) => {
@@ -838,6 +874,9 @@ async fn maybe_drain(state: &mut StructuredViewState, toast_deadline: &mut Optio
     };
     if send_prompt_now(state, toast_deadline, &text).await {
         state.queue.drop_front(count);
+        // Keep an in-progress ArrowUp/ArrowDown browse pointing at the
+        // right entry now that the front of the queue shifted.
+        state.reconcile_recall_after_drain(count);
         let remaining = state.queue.len();
         let msg = if remaining == 0 {
             "queue drained".to_string()

--- a/src/tui/structured_view/queue.rs
+++ b/src/tui/structured_view/queue.rs
@@ -34,6 +34,27 @@ impl PromptQueue {
         self.items.push(text);
     }
 
+    /// Borrow the queued entry at `index` (0 = oldest / front), or `None`
+    /// when out of range. Used by the composer's ArrowUp/ArrowDown recall
+    /// to load a queued prompt back for editing.
+    pub fn get(&self, index: usize) -> Option<&String> {
+        self.items.get(index)
+    }
+
+    /// Replace the entry at `index` in place, preserving its queue
+    /// position. Returns `false` when the index is out of range, e.g. the
+    /// browsed entry drained between recall and submit; the caller then
+    /// treats the edited text as a fresh prompt.
+    pub fn replace(&mut self, index: usize, text: String) -> bool {
+        match self.items.get_mut(index) {
+            Some(slot) => {
+                *slot = text;
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Drop the whole queue (the user hit the clear-queue hotkey).
     pub fn clear(&mut self) {
         self.items.clear();
@@ -189,5 +210,29 @@ mod tests {
         let mut q = queue(&["x", "y"]);
         q.clear();
         assert!(q.is_empty());
+    }
+
+    #[test]
+    fn get_borrows_by_index_or_none() {
+        let q = queue(&["a", "b"]);
+        assert_eq!(q.get(0).map(String::as_str), Some("a"));
+        assert_eq!(q.get(1).map(String::as_str), Some("b"));
+        assert_eq!(q.get(2), None);
+    }
+
+    #[test]
+    fn replace_edits_in_place_and_reports_hit() {
+        let mut q = queue(&["a", "b", "c"]);
+        assert!(q.replace(1, "B".to_string()));
+        let items: Vec<&String> = q.iter().collect();
+        assert_eq!(items, vec!["a", "B", "c"]);
+    }
+
+    #[test]
+    fn replace_out_of_range_is_a_miss() {
+        let mut q = queue(&["only"]);
+        assert!(!q.replace(3, "x".to_string()));
+        let items: Vec<&String> = q.iter().collect();
+        assert_eq!(items, vec!["only"]);
     }
 }

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -445,6 +445,7 @@ fn render_composer(frame: &mut Frame, area: Rect, theme: &Theme, state: &Structu
     };
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .title(title)
         .border_style(composer_border);
     // ratatui-textarea borrows the Frame's buffer indirectly via

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -420,14 +420,33 @@ fn render_status(frame: &mut Frame, area: Rect, theme: &Theme, state: &Structure
 }
 
 fn render_composer(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredViewState) {
-    let title = match state.focus {
-        Focus::Composer => " Composer (Enter=send, Shift+Enter=newline, Esc=back) ",
-        _ => " Composer (Tab/i to focus) ",
+    // While browsing the queue, the title signals that an existing queued
+    // prompt is being edited (and where it sits), so the composer does not
+    // look like it merely copied text in. Position counts from the newest
+    // entry (1 = newest), matching the ArrowUp-from-newest browse order.
+    let title: String = if let Some(recall) = &state.recall {
+        let total = state.queue.len();
+        let pos = total.saturating_sub(recall.index);
+        format!(
+            " Editing queued message {pos} of {total} (Enter=save, Esc=restore draft, ↑/↓=browse) "
+        )
+    } else {
+        match state.focus {
+            Focus::Composer => " Composer (Enter=send, Shift+Enter=newline, Esc=back) ".to_string(),
+            _ => " Composer (Tab/i to focus) ".to_string(),
+        }
+    };
+    // Highlight the border while editing a queued prompt so the mode is
+    // obvious at a glance.
+    let composer_border = if state.recall.is_some() {
+        Style::default().fg(theme.title)
+    } else {
+        border_style(theme, state, Focus::Composer)
     };
     let block = Block::default()
         .borders(Borders::ALL)
         .title(title)
-        .border_style(border_style(theme, state, Focus::Composer));
+        .border_style(composer_border);
     // ratatui-textarea borrows the Frame's buffer indirectly via
     // widget impl; render the block first, then the textarea inside.
     let inner = block.inner(area);

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -277,6 +277,15 @@ impl StructuredViewState {
         self.recall = None;
     }
 
+    /// Abandon a queue-recall browse and restore the draft that was in the
+    /// composer before browsing began (the `Esc` while browsing).
+    pub fn recall_cancel_restore(&mut self) {
+        if let Some(r) = self.recall.take() {
+            let draft = r.stashed_draft;
+            self.set_composer_text(&draft);
+        }
+    }
+
     /// The current single-line slash query (without the leading slash),
     /// or `None` when the composer doesn't hold one.
     pub fn slash_query(&self) -> Option<String> {
@@ -495,6 +504,18 @@ mod tests {
         // The browsed entry is gone: browse cancelled, edited text retained.
         assert!(state.recall.is_none());
         assert_eq!(composer_text(&state), browsed);
+    }
+
+    #[test]
+    fn recall_cancel_restore_brings_back_the_draft() {
+        let mut state = test_state(None);
+        state.queue.push("queued".into());
+        state.composer.insert_str("draft");
+        state.recall_step(-1);
+        assert_eq!(composer_text(&state), "queued");
+        state.recall_cancel_restore();
+        assert!(state.recall.is_none());
+        assert_eq!(composer_text(&state), "draft");
     }
 
     #[test]

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -65,6 +65,20 @@ pub struct StructuredViewState {
     /// Keeps the picker closed while they keep typing in that same
     /// token; cleared once the token goes away or a fresh `@` is typed.
     pub dismissed_mention: Option<(usize, usize)>,
+    /// Active ArrowUp/ArrowDown queue-recall browse, or `None` when the
+    /// composer is in its normal typing mode. See [`RecallState`].
+    pub recall: Option<RecallState>,
+}
+
+/// In-progress shell-history-style browse of the prompt queue. The user
+/// pressed ArrowUp on an empty-origin composer; `index` points at the
+/// queued entry currently loaded into the composer and `stashed_draft`
+/// holds the text that was there before browsing started, restored when
+/// ArrowDown walks back past the newest entry.
+#[derive(Debug, Clone)]
+pub struct RecallState {
+    pub index: usize,
+    pub stashed_draft: String,
 }
 
 /// Build a composer textarea with the shared placeholder + cursor
@@ -132,6 +146,7 @@ impl StructuredViewState {
             file_index: FileIndex::Unloaded,
             mention: None,
             dismissed_mention: None,
+            recall: None,
         }
     }
 
@@ -157,7 +172,109 @@ impl StructuredViewState {
         // too. The fetched file_index cache survives for the session.
         self.mention = None;
         self.dismissed_mention = None;
+        // A submit / reset ends any queue-recall browse.
+        self.recall = None;
         text
+    }
+
+    /// True when the composer caret sits at the very start (row 0, col 0).
+    /// An empty composer trivially satisfies this. Gates entry into
+    /// queue-recall so ArrowUp keeps moving the caret inside a multi-line
+    /// draft until the user is at the top-left, then falls through to the
+    /// queue like a shell history.
+    pub fn caret_at_origin(&self) -> bool {
+        self.composer.cursor() == (0, 0)
+    }
+
+    /// Whether an ArrowUp/ArrowDown queue browse is active.
+    pub fn browsing_queue(&self) -> bool {
+        self.recall.is_some()
+    }
+
+    /// Replace the composer contents with `text`, caret at the end.
+    /// Mirrors [`take_composer_text`]'s fresh-textarea swap since
+    /// ratatui-textarea has no public clear.
+    fn set_composer_text(&mut self, text: &str) {
+        self.composer = new_composer_textarea();
+        self.composer.insert_str(text);
+        self.slash_selected = 0;
+        self.dismissed_slash_query = None;
+        self.mention = None;
+        self.dismissed_mention = None;
+    }
+
+    /// Step the queue-recall browse by `delta` (-1 = older via ArrowUp,
+    /// +1 = newer via ArrowDown). Entering from the normal composer
+    /// stashes the current draft; walking past the newest entry restores
+    /// it and exits browse. A no-op on an empty queue.
+    pub fn recall_step(&mut self, delta: i32) {
+        let len = self.queue.len();
+        if len == 0 {
+            self.recall = None;
+            return;
+        }
+        match self.recall.take() {
+            None => {
+                // Only ArrowUp enters browse; ArrowDown with no browse is a
+                // no-op (the dispatcher already gates this, but stay safe).
+                if delta >= 0 {
+                    return;
+                }
+                let stashed_draft = self.composer.lines().join("\n");
+                let index = len - 1;
+                self.set_composer_text(&self.queue.get(index).cloned().unwrap_or_default());
+                self.recall = Some(RecallState {
+                    index,
+                    stashed_draft,
+                });
+            }
+            Some(mut r) => {
+                if delta < 0 {
+                    // Older: stop at the oldest entry, no wrap.
+                    if r.index > 0 {
+                        r.index -= 1;
+                        self.set_composer_text(
+                            &self.queue.get(r.index).cloned().unwrap_or_default(),
+                        );
+                    }
+                    self.recall = Some(r);
+                } else {
+                    // Newer: past the newest entry, restore the stashed draft.
+                    if r.index + 1 < len {
+                        r.index += 1;
+                        self.set_composer_text(
+                            &self.queue.get(r.index).cloned().unwrap_or_default(),
+                        );
+                        self.recall = Some(r);
+                    } else {
+                        let draft = r.stashed_draft.clone();
+                        self.set_composer_text(&draft);
+                        self.recall = None;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Reconcile an active browse after `dropped` entries drain off the
+    /// front of the queue. The browsed entry shifts down by `dropped`; if
+    /// it was among the drained ones (or the queue emptied) the browse is
+    /// cancelled, leaving the in-progress composer text as a normal draft.
+    pub fn reconcile_recall_after_drain(&mut self, dropped: usize) {
+        if let Some(r) = self.recall.as_mut() {
+            if r.index < dropped || self.queue.is_empty() {
+                self.recall = None;
+            } else {
+                r.index -= dropped;
+            }
+        }
+    }
+
+    /// End a queue-recall browse without touching the composer text, so
+    /// any edited prompt is retained as a draft. Called when the queue is
+    /// cleared or focus leaves the composer mid-browse.
+    pub fn cancel_recall(&mut self) {
+        self.recall = None;
     }
 
     /// The current single-line slash query (without the leading slash),
@@ -304,6 +421,99 @@ mod tests {
         // boundaries can't be observed to drive an immediate send.
         let state = test_state(None);
         assert!(state.is_busy());
+    }
+
+    fn composer_text(state: &StructuredViewState) -> String {
+        state.composer.lines().join("\n")
+    }
+
+    #[test]
+    fn recall_browses_from_newest_and_stashes_the_draft() {
+        let mut state = test_state(None);
+        state.queue.push("first".into());
+        state.queue.push("second".into());
+        state.composer.insert_str("my draft");
+
+        // ArrowUp loads the newest queued prompt and stashes the draft.
+        state.recall_step(-1);
+        assert_eq!(composer_text(&state), "second");
+        assert_eq!(state.recall.as_ref().unwrap().index, 1);
+
+        // ArrowUp again walks to the older entry.
+        state.recall_step(-1);
+        assert_eq!(composer_text(&state), "first");
+        assert_eq!(state.recall.as_ref().unwrap().index, 0);
+
+        // Past the oldest: no wrap, stays put.
+        state.recall_step(-1);
+        assert_eq!(composer_text(&state), "first");
+        assert_eq!(state.recall.as_ref().unwrap().index, 0);
+    }
+
+    #[test]
+    fn recall_down_past_newest_restores_the_stashed_draft() {
+        let mut state = test_state(None);
+        state.queue.push("only".into());
+        state.composer.insert_str("draft text");
+
+        state.recall_step(-1);
+        assert_eq!(composer_text(&state), "only");
+        // ArrowDown past the newest restores the draft and ends browse.
+        state.recall_step(1);
+        assert_eq!(composer_text(&state), "draft text");
+        assert!(state.recall.is_none());
+    }
+
+    #[test]
+    fn reconcile_shifts_browse_index_when_front_drains() {
+        let mut state = test_state(None);
+        state.queue.push("a".into());
+        state.queue.push("b".into());
+        state.queue.push("c".into());
+        state.recall_step(-1); // browsing "c" at index 2
+        assert_eq!(state.recall.as_ref().unwrap().index, 2);
+
+        // Two entries drain off the front; the browsed entry shifts to 0.
+        state.queue.drop_front(2);
+        state.reconcile_recall_after_drain(2);
+        assert_eq!(state.recall.as_ref().unwrap().index, 0);
+    }
+
+    #[test]
+    fn reconcile_cancels_browse_when_browsed_entry_drains() {
+        let mut state = test_state(None);
+        state.queue.push("a".into());
+        state.queue.push("b".into());
+        // Browse the oldest ("a", index 0) by walking up twice.
+        state.recall_step(-1);
+        state.recall_step(-1);
+        assert_eq!(state.recall.as_ref().unwrap().index, 0);
+        let browsed = composer_text(&state);
+
+        state.queue.drop_front(1);
+        state.reconcile_recall_after_drain(1);
+        // The browsed entry is gone: browse cancelled, edited text retained.
+        assert!(state.recall.is_none());
+        assert_eq!(composer_text(&state), browsed);
+    }
+
+    #[test]
+    fn cancel_recall_keeps_composer_text() {
+        let mut state = test_state(None);
+        state.queue.push("queued".into());
+        state.recall_step(-1);
+        assert_eq!(composer_text(&state), "queued");
+        state.cancel_recall();
+        assert!(state.recall.is_none());
+        assert_eq!(composer_text(&state), "queued");
+    }
+
+    #[test]
+    fn caret_at_origin_tracks_cursor() {
+        let mut state = test_state(None);
+        assert!(state.caret_at_origin());
+        state.composer.insert_str("text");
+        assert!(!state.caret_at_origin());
     }
 
     #[test]

--- a/web/src/components/acp/Composer.recall.dom.test.tsx
+++ b/web/src/components/acp/Composer.recall.dom.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+//
+// RTL mount of the real <Composer> exercising the ArrowUp/ArrowDown queue
+// recall handlers, the "Editing queued message" banner, Esc-restore, and
+// the edit-in-place submit path. The mocked + live Playwright specs drive
+// the same flow, but the v8(vitest)+istanbul merge keeps v8 line hits more
+// reliably, so this jsdom mount is what lifts the component handlers in the
+// merged coverage report. Heavy/IO hooks are stubbed; the assistant-ui
+// runtime is provided via useExternalStoreRuntime like Composer.escape.test.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AssistantRuntimeProvider, useExternalStoreRuntime, type ThreadMessageLike } from "@assistant-ui/react";
+
+import { Composer } from "./Composer";
+import type { QueuedPrompt } from "../../lib/acpTypes";
+
+vi.mock("./useFilesIndex", () => ({
+  useFilesIndex: () => ({ files: [] }),
+  fuzzyFilter: <T,>(items: T[]) => items,
+}));
+vi.mock("./SessionConfigControls", () => ({ SessionConfigControls: () => null }));
+vi.mock("./SwitchAgentModal", () => ({ SwitchAgentModal: () => null }));
+vi.mock("../../hooks/useMobileKeyboard", () => ({ useMobileKeyboard: () => ({ keyboardOpen: false }) }));
+vi.mock("../../hooks/useFocusTerminalTarget", () => ({ useFocusTerminalTarget: () => {} }));
+vi.mock("../../lib/agentProfileContext", () => ({
+  useAgentProfile: () => ({ clearAliases: [], capabilities: { legacyModeFallback: false } }),
+}));
+vi.mock("../../lib/acpDrafts", () => ({ getDraft: () => "", setDraft: () => {} }));
+vi.mock("./useDictationBurstGuard", () => ({
+  useDictationBurstGuard: () => ({
+    observeInputType: () => {},
+    shouldSuppressUpstream: () => false,
+    flushOnBlur: () => {},
+  }),
+}));
+
+const QUEUE: QueuedPrompt[] = [
+  { id: "q-a", text: "first queued", queuedAt: "2026-01-01T00:00:00Z" },
+  { id: "q-b", text: "second queued", queuedAt: "2026-01-01T00:00:01Z" },
+];
+
+function Harness({ editQueuedPrompt }: { editQueuedPrompt: (id: string, text: string) => void }) {
+  const runtime = useExternalStoreRuntime<ThreadMessageLike>({
+    messages: [],
+    isRunning: true,
+    convertMessage: (m) => m,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Composer
+        sessionId="s-recall"
+        currentAgent={"claude" as never}
+        availableModes={[] as never}
+        currentModeId={null as never}
+        legacyMode={null as never}
+        configOptions={[] as never}
+        pendingConfigOption={null as never}
+        setConfigOption={() => {}}
+        sessionUsage={null as never}
+        availableCommands={[] as never}
+        connected={true}
+        turnActive={true}
+        queuedCount={QUEUE.length}
+        enqueuePrompt={() => {}}
+        promptCapabilities={null}
+        pendingAttachments={[]}
+        setPendingAttachments={() => {}}
+        primerPrefill={null}
+        queuedPrompts={QUEUE}
+        editQueuedPrompt={editQueuedPrompt}
+      />
+    </AssistantRuntimeProvider>
+  );
+}
+
+function getComposer(): HTMLTextAreaElement {
+  return screen.getByRole("textbox") as HTMLTextAreaElement;
+}
+
+let rafSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+beforeEach(() => {
+  // assistant-ui's ComposerPrimitive.Input calls useMediaQuery, which jsdom
+  // does not implement; stub a non-matching media query.
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+  }
+  // Run requestAnimationFrame callbacks synchronously so loadRecallText's
+  // focus/caret/resize body executes within the test.
+  rafSpy = vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+});
+
+afterEach(() => {
+  rafSpy?.mockRestore();
+  cleanup();
+});
+
+describe("<Composer> queue recall (#2147)", () => {
+  it("ArrowUp recalls, banner shows, ArrowDown cycles, Esc restores", async () => {
+    render(<Harness editQueuedPrompt={() => {}} />);
+    const ta = getComposer();
+    expect(ta.value).toBe("");
+
+    // ArrowUp at the empty/origin composer enters recall on the newest.
+    ta.focus();
+    ta.setSelectionRange(0, 0);
+    fireEvent.keyDown(ta, { key: "ArrowUp" });
+    await waitFor(() => expect(getComposer().value).toBe("second queued"));
+    expect(screen.queryByText(/Editing queued message 1 of 2/)).not.toBeNull();
+
+    // ArrowUp again walks to the older entry.
+    fireEvent.keyDown(getComposer(), { key: "ArrowUp" });
+    await waitFor(() => expect(getComposer().value).toBe("first queued"));
+    expect(screen.queryByText(/Editing queued message 2 of 2/)).not.toBeNull();
+
+    // ArrowUp at the oldest is a no-op (no wrap).
+    fireEvent.keyDown(getComposer(), { key: "ArrowUp" });
+    await waitFor(() => expect(getComposer().value).toBe("first queued"));
+
+    // ArrowDown walks back toward newer.
+    fireEvent.keyDown(getComposer(), { key: "ArrowDown" });
+    await waitFor(() => expect(getComposer().value).toBe("second queued"));
+
+    // Esc restores the stashed (empty) draft and clears the banner.
+    fireEvent.keyDown(getComposer(), { key: "Escape" });
+    await waitFor(() => expect(getComposer().value).toBe(""));
+    expect(screen.queryByText(/Editing queued message/)).toBeNull();
+  });
+
+  it("ArrowDown past the newest restores the stashed draft", async () => {
+    render(<Harness editQueuedPrompt={() => {}} />);
+    const ta = getComposer();
+    ta.focus();
+    ta.setSelectionRange(0, 0);
+    fireEvent.keyDown(ta, { key: "ArrowUp" });
+    await waitFor(() => expect(getComposer().value).toBe("second queued"));
+    // Already at the newest: ArrowDown restores the draft and exits.
+    fireEvent.keyDown(getComposer(), { key: "ArrowDown" });
+    await waitFor(() => expect(getComposer().value).toBe(""));
+    expect(screen.queryByText(/Editing queued message/)).toBeNull();
+  });
+
+  it("editing a recalled prompt and pressing Enter edits it in place", async () => {
+    const editQueuedPrompt = vi.fn();
+    render(<Harness editQueuedPrompt={editQueuedPrompt} />);
+    const ta = getComposer();
+    ta.focus();
+    ta.setSelectionRange(0, 0);
+    fireEvent.keyDown(ta, { key: "ArrowUp" });
+    await waitFor(() => expect(getComposer().value).toBe("second queued"));
+
+    fireEvent.change(getComposer(), { target: { value: "second queued edited" } });
+    fireEvent.keyDown(getComposer(), { key: "Enter" });
+
+    await waitFor(() => expect(editQueuedPrompt).toHaveBeenCalledWith("q-b", "second queued edited"));
+  });
+});

--- a/web/src/components/acp/Composer.recall.dom.test.tsx
+++ b/web/src/components/acp/Composer.recall.dom.test.tsx
@@ -40,7 +40,15 @@ const QUEUE: QueuedPrompt[] = [
   { id: "q-b", text: "second queued", queuedAt: "2026-01-01T00:00:01Z" },
 ];
 
-function Harness({ editQueuedPrompt }: { editQueuedPrompt: (id: string, text: string) => void }) {
+function Harness({
+  editQueuedPrompt = () => {},
+  enqueuePrompt = () => {},
+  queue = QUEUE,
+}: {
+  editQueuedPrompt?: (id: string, text: string) => void;
+  enqueuePrompt?: (text: string) => void;
+  queue?: QueuedPrompt[];
+}) {
   const runtime = useExternalStoreRuntime<ThreadMessageLike>({
     messages: [],
     isRunning: true,
@@ -62,13 +70,13 @@ function Harness({ editQueuedPrompt }: { editQueuedPrompt: (id: string, text: st
         availableCommands={[] as never}
         connected={true}
         turnActive={true}
-        queuedCount={QUEUE.length}
-        enqueuePrompt={() => {}}
+        queuedCount={queue.length}
+        enqueuePrompt={enqueuePrompt}
         promptCapabilities={null}
         pendingAttachments={[]}
         setPendingAttachments={() => {}}
         primerPrefill={null}
-        queuedPrompts={QUEUE}
+        queuedPrompts={queue}
         editQueuedPrompt={editQueuedPrompt}
       />
     </AssistantRuntimeProvider>
@@ -167,5 +175,30 @@ describe("<Composer> queue recall (#2147)", () => {
     fireEvent.keyDown(getComposer(), { key: "Enter" });
 
     await waitFor(() => expect(editQueuedPrompt).toHaveBeenCalledWith("q-b", "second queued edited"));
+  });
+
+  it("plain Enter when not browsing sends through enqueue", async () => {
+    const enqueuePrompt = vi.fn();
+    render(<Harness enqueuePrompt={enqueuePrompt} />);
+    const ta = getComposer();
+    fireEvent.change(ta, { target: { value: "brand new" } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+    await waitFor(() => expect(enqueuePrompt).toHaveBeenCalledWith("brand new", undefined));
+  });
+
+  it("draining the browsed entry mid-browse exits recall, keeping the text", async () => {
+    const { rerender } = render(<Harness />);
+    const ta = getComposer();
+    ta.focus();
+    ta.setSelectionRange(0, 0);
+    fireEvent.keyDown(ta, { key: "ArrowUp" });
+    await waitFor(() => expect(getComposer().value).toBe("second queued"));
+
+    // The browsed entry (q-b) drains away; only q-a remains. The next
+    // ArrowUp finds the cursor id gone and exits, leaving the text put.
+    rerender(<Harness queue={[QUEUE[0]!]} />);
+    fireEvent.keyDown(getComposer(), { key: "ArrowUp" });
+    await waitFor(() => expect(screen.queryByText(/Editing queued message/)).toBeNull());
+    expect(getComposer().value).toBe("second queued");
   });
 });

--- a/web/src/components/acp/Composer.recall.test.ts
+++ b/web/src/components/acp/Composer.recall.test.ts
@@ -1,0 +1,56 @@
+// Decision-matrix tests for the composer's ArrowUp/ArrowDown queue
+// recall (#2147). The pure helper lets us exercise the hijack guard and
+// browse routing without mounting the composer + assistant-ui runtime.
+
+import { describe, expect, it } from "vitest";
+
+import { decideArrowRecall } from "./Composer";
+
+const up = {
+  key: "ArrowUp",
+  shiftKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  isComposing: false,
+};
+const down = { ...up, key: "ArrowDown" };
+
+describe("decideArrowRecall (#2147)", () => {
+  it("ArrowUp at the caret origin with a queue enters recall", () => {
+    expect(decideArrowRecall(up, { caretAtStart: true, browsing: false, queueLen: 2 })).toBe("older");
+  });
+
+  it("ArrowUp not at the origin moves the caret, never recalls", () => {
+    expect(decideArrowRecall(up, { caretAtStart: false, browsing: false, queueLen: 2 })).toBe("default");
+  });
+
+  it("ArrowUp with an empty queue does not recall", () => {
+    expect(decideArrowRecall(up, { caretAtStart: true, browsing: false, queueLen: 0 })).toBe("default");
+  });
+
+  it("while browsing, both arrows own navigation regardless of caret", () => {
+    expect(decideArrowRecall(up, { caretAtStart: false, browsing: true, queueLen: 2 })).toBe("older");
+    expect(decideArrowRecall(down, { caretAtStart: false, browsing: true, queueLen: 2 })).toBe("newer");
+  });
+
+  it("ArrowDown does not recall when not browsing", () => {
+    expect(decideArrowRecall(down, { caretAtStart: true, browsing: false, queueLen: 2 })).toBe("default");
+  });
+
+  it("modifiers and IME composition pass through to the caret", () => {
+    for (const mod of [
+      { shiftKey: true },
+      { ctrlKey: true },
+      { metaKey: true },
+      { altKey: true },
+      { isComposing: true },
+    ]) {
+      expect(decideArrowRecall({ ...up, ...mod }, { caretAtStart: true, browsing: true, queueLen: 2 })).toBe("default");
+    }
+  });
+
+  it("non-arrow keys pass through", () => {
+    expect(decideArrowRecall({ ...up, key: "a" }, { caretAtStart: true, browsing: true, queueLen: 2 })).toBe("default");
+  });
+});

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -16,7 +16,7 @@ import {
   type Unstable_TriggerItem,
 } from "@assistant-ui/core";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import { AtSign, ChevronUp, Paperclip, Slash, Square, X } from "lucide-react";
+import { AtSign, ChevronUp, Paperclip, Pencil, Slash, Square, X } from "lucide-react";
 
 import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import { SessionConfigControls } from "./SessionConfigControls";
@@ -472,6 +472,25 @@ export function Composer({
   // reads the live value with no stale closure. Anchored on the stable
   // queued-prompt id so a background drain never targets the wrong row.
   const recallRef = useRef<{ id: string; stashedDraft: string } | null>(null);
+  // Render-visible mirror of the browse: drives the "Editing queued
+  // message N of M" banner. recallRef stays the synchronous source of
+  // truth for the keydown handler; applyRecall keeps the two in step.
+  const [recallInfo, setRecallInfo] = useState<{ pos: number; total: number } | null>(null);
+
+  const applyRecall = useCallback(
+    (next: { id: string; stashedDraft: string } | null) => {
+      recallRef.current = next;
+      if (!next) {
+        setRecallInfo(null);
+        return;
+      }
+      const idx = queuedPrompts.findIndex((p) => p.id === next.id);
+      // Position counts from the newest entry (1 = newest), matching the
+      // ArrowUp-from-newest browse order.
+      setRecallInfo(idx === -1 ? null : { pos: queuedPrompts.length - idx, total: queuedPrompts.length });
+    },
+    [queuedPrompts],
+  );
 
   // Load `text` into the composer with the caret at the end, mirroring
   // the primer-prefill effect's focus + resize dance (setText alone does
@@ -504,31 +523,31 @@ export function Composer({
     if (q.length === 0) {
       // Queue drained out from under the browse; end it so the next
       // ArrowUp moves the caret instead of being swallowed.
-      recallRef.current = null;
+      applyRecall(null);
       return;
     }
     const cur = recallRef.current;
     if (!cur) {
       const target = q[q.length - 1];
       if (!target) return;
-      recallRef.current = { id: target.id, stashedDraft: composerRuntime.getState().text };
+      applyRecall({ id: target.id, stashedDraft: composerRuntime.getState().text });
       loadRecallText(target.text);
       return;
     }
     const idx = q.findIndex((p) => p.id === cur.id);
     if (idx === -1) {
       // The browsed entry drained mid-browse; end browse, keep the text.
-      recallRef.current = null;
+      applyRecall(null);
       return;
     }
     if (idx > 0) {
       const target = q[idx - 1];
       if (!target) return;
-      recallRef.current = { ...cur, id: target.id };
+      applyRecall({ ...cur, id: target.id });
       loadRecallText(target.text);
     }
     // idx === 0 is the oldest entry: stay put.
-  }, [queuedPrompts, composerRuntime, loadRecallText]);
+  }, [queuedPrompts, composerRuntime, loadRecallText, applyRecall]);
 
   // Browse toward newer queued prompts; past the newest, restore the
   // stashed draft and exit browse.
@@ -538,19 +557,28 @@ export function Composer({
     const q = queuedPrompts;
     const idx = q.findIndex((p) => p.id === cur.id);
     if (idx === -1) {
-      recallRef.current = null;
+      applyRecall(null);
       return;
     }
     if (idx + 1 < q.length) {
       const target = q[idx + 1];
       if (!target) return;
-      recallRef.current = { ...cur, id: target.id };
+      applyRecall({ ...cur, id: target.id });
       loadRecallText(target.text);
     } else {
       loadRecallText(cur.stashedDraft);
-      recallRef.current = null;
+      applyRecall(null);
     }
-  }, [queuedPrompts, loadRecallText]);
+  }, [queuedPrompts, loadRecallText, applyRecall]);
+
+  // Esc while browsing restores the stashed draft and exits, matching the
+  // banner's hint.
+  const cancelRecallToDraft = useCallback(() => {
+    const cur = recallRef.current;
+    if (!cur) return;
+    loadRecallText(cur.stashedDraft);
+    applyRecall(null);
+  }, [loadRecallText, applyRecall]);
 
   // Unified submit for the custom Send / QueueSend buttons and the
   // mid-turn Enter path: drains the textarea text + staged attachments
@@ -561,7 +589,7 @@ export function Composer({
   const submitComposer = useCallback(() => {
     const cur = recallRef.current;
     if (cur) {
-      recallRef.current = null;
+      applyRecall(null);
       const text = composerRuntime.getState().text.trim();
       // Submitting while browsing edits that queued entry in place rather
       // than enqueuing a duplicate. If it drained since recall (id gone),
@@ -584,6 +612,7 @@ export function Composer({
     supportedPendingAttachments,
     queuedPrompts,
     editQueuedPrompt,
+    applyRecall,
   ]);
 
   // Manual agent switch dialog. Opened from the sidebar row context menu
@@ -778,6 +807,19 @@ export function Composer({
               "transition-colors duration-150",
             ].join(" ")}
           >
+            {/* Queue-recall banner (#2147): signals that the composer is
+                editing an existing queued prompt rather than composing a
+                new one. */}
+            {recallInfo && (
+              <div className="flex items-center justify-between gap-2 rounded-t-xl border-b border-brand-600/40 bg-brand-600/10 px-3 py-1.5 text-xs text-brand-200">
+                <span className="flex items-center gap-1.5 font-medium">
+                  <Pencil className="h-3.5 w-3.5" />
+                  Editing queued message {recallInfo.pos} of {recallInfo.total}
+                </span>
+                <span className="text-brand-300/70">Enter saves · Esc restores draft · ↑ ↓ to browse</span>
+              </div>
+            )}
+
             {/* @ file picker — Directive behavior chips the path into
                 the prompt text using the default formatter. */}
             <ComposerPrimitive.Unstable_TriggerPopover
@@ -893,6 +935,15 @@ export function Composer({
                 // toward newer entries and the stashed draft. Decided by
                 // decideArrowRecall so multi-line caret movement is never
                 // hijacked. Runs before the Enter matrix below.
+                //
+                // Esc while browsing restores the stashed draft and exits,
+                // intercepted before ComposerPrimitive.Input's cancelOnEscape.
+                if (e.key === "Escape" && recallRef.current != null) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  cancelRecallToDraft();
+                  return;
+                }
                 const el = taRef.current;
                 const caretAtStart = !!el && el.selectionStart === 0 && el.selectionEnd === 0;
                 const recallAction = decideArrowRecall(

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -40,6 +40,7 @@ import { useAgentProfile } from "../../lib/agentProfileContext";
 import { resolveModeChannel } from "../../lib/modeChannel";
 import { useFocusTerminalTarget } from "../../hooks/useFocusTerminalTarget";
 import { useDictationBurstGuard } from "./useDictationBurstGuard";
+import { nextRecallTarget, recallBannerInfo, type RecallCursor, type RecallNav } from "./recallNav";
 
 export {
   DICTATION_BURST_TIMEOUT_MS,
@@ -471,23 +472,16 @@ export function Composer({
   // browsing. A ref (not state) so the synchronous keydown handler always
   // reads the live value with no stale closure. Anchored on the stable
   // queued-prompt id so a background drain never targets the wrong row.
-  const recallRef = useRef<{ id: string; stashedDraft: string } | null>(null);
+  const recallRef = useRef<RecallCursor | null>(null);
   // Render-visible mirror of the browse: drives the "Editing queued
   // message N of M" banner. recallRef stays the synchronous source of
   // truth for the keydown handler; applyRecall keeps the two in step.
   const [recallInfo, setRecallInfo] = useState<{ pos: number; total: number } | null>(null);
 
   const applyRecall = useCallback(
-    (next: { id: string; stashedDraft: string } | null) => {
+    (next: RecallCursor | null) => {
       recallRef.current = next;
-      if (!next) {
-        setRecallInfo(null);
-        return;
-      }
-      const idx = queuedPrompts.findIndex((p) => p.id === next.id);
-      // Position counts from the newest entry (1 = newest), matching the
-      // ArrowUp-from-newest browse order.
-      setRecallInfo(idx === -1 ? null : { pos: queuedPrompts.length - idx, total: queuedPrompts.length });
+      setRecallInfo(recallBannerInfo(queuedPrompts, next));
     },
     [queuedPrompts],
   );
@@ -515,61 +509,39 @@ export function Composer({
     [composerRuntime],
   );
 
-  // Browse toward older queued prompts. Entering from normal typing
-  // stashes the current draft and loads the newest entry; subsequent
-  // calls walk down the list and stop at the oldest (no wrap).
-  const recallOlder = useCallback(() => {
-    const q = queuedPrompts;
-    if (q.length === 0) {
-      // Queue drained out from under the browse; end it so the next
-      // ArrowUp moves the caret instead of being swallowed.
-      applyRecall(null);
-      return;
-    }
-    const cur = recallRef.current;
-    if (!cur) {
-      const target = q[q.length - 1];
-      if (!target) return;
-      applyRecall({ id: target.id, stashedDraft: composerRuntime.getState().text });
-      loadRecallText(target.text);
-      return;
-    }
-    const idx = q.findIndex((p) => p.id === cur.id);
-    if (idx === -1) {
-      // The browsed entry drained mid-browse; end browse, keep the text.
-      applyRecall(null);
-      return;
-    }
-    if (idx > 0) {
-      const target = q[idx - 1];
-      if (!target) return;
-      applyRecall({ ...cur, id: target.id });
-      loadRecallText(target.text);
-    }
-    // idx === 0 is the oldest entry: stay put.
-  }, [queuedPrompts, composerRuntime, loadRecallText, applyRecall]);
+  // Apply a pure recall navigation decision to the composer.
+  const applyNav = useCallback(
+    (nav: RecallNav) => {
+      switch (nav.kind) {
+        case "load":
+          applyRecall(nav.cursor);
+          loadRecallText(nav.text);
+          break;
+        case "restore":
+          loadRecallText(nav.text);
+          applyRecall(null);
+          break;
+        case "exit":
+          applyRecall(null);
+          break;
+        case "none":
+          break;
+      }
+    },
+    [applyRecall, loadRecallText],
+  );
 
-  // Browse toward newer queued prompts; past the newest, restore the
-  // stashed draft and exit browse.
+  // Browse toward older queued prompts (ArrowUp): enters recall stashing
+  // the current draft, then walks down and stops at the oldest.
+  const recallOlder = useCallback(() => {
+    applyNav(nextRecallTarget(queuedPrompts, recallRef.current, "older", composerRuntime.getState().text));
+  }, [queuedPrompts, composerRuntime, applyNav]);
+
+  // Browse toward newer queued prompts (ArrowDown); past the newest,
+  // restore the stashed draft and exit.
   const recallNewer = useCallback(() => {
-    const cur = recallRef.current;
-    if (!cur) return;
-    const q = queuedPrompts;
-    const idx = q.findIndex((p) => p.id === cur.id);
-    if (idx === -1) {
-      applyRecall(null);
-      return;
-    }
-    if (idx + 1 < q.length) {
-      const target = q[idx + 1];
-      if (!target) return;
-      applyRecall({ ...cur, id: target.id });
-      loadRecallText(target.text);
-    } else {
-      loadRecallText(cur.stashedDraft);
-      applyRecall(null);
-    }
-  }, [queuedPrompts, loadRecallText, applyRecall]);
+    applyNav(nextRecallTarget(queuedPrompts, recallRef.current, "newer", ""));
+  }, [queuedPrompts, applyNav]);
 
   // Esc while browsing restores the stashed draft and exits, matching the
   // banner's hint.

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -26,7 +26,13 @@ import {
   getPendingSwitchAgent,
   subscribePendingSwitchAgent,
 } from "../../lib/switchAgentTrigger";
-import type { AcpState, PromptAttachmentInput, PromptAttachmentKind, PromptCapabilities } from "../../lib/acpTypes";
+import type {
+  AcpState,
+  PromptAttachmentInput,
+  PromptAttachmentKind,
+  PromptCapabilities,
+  QueuedPrompt,
+} from "../../lib/acpTypes";
 import { getDraft, setDraft } from "../../lib/acpDrafts";
 import { TOUR_ANCHORS, tourAnchor } from "../../lib/tourSteps";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
@@ -81,6 +87,43 @@ export function decideEnterAction(
   // "send" queue path below.
   if (ctx.isMobile) return "default";
   if (ctx.turnActive) return "send";
+  return "default";
+}
+
+/** Decision returned by {@link decideArrowRecall} for an ArrowUp /
+ *  ArrowDown keystroke on the composer textarea.
+ *  - `older`: browse toward older queued prompts (ArrowUp).
+ *  - `newer`: browse toward newer queued prompts, or the stashed draft
+ *    past the newest (ArrowDown).
+ *  - `default`: let the textarea move the caret as usual. */
+export type ArrowRecallAction = "older" | "newer" | "default";
+
+/** Pure decision helper for shell-history-style queue recall. ArrowUp
+ *  enters recall only when the caret is at the very start and the queue
+ *  is non-empty, so multi-line caret movement is never hijacked; once
+ *  browsing, both arrows own navigation regardless of caret. Extracted
+ *  so the matrix is unit-testable without mounting the composer. */
+export function decideArrowRecall(
+  event: {
+    key: string;
+    shiftKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    altKey: boolean;
+    isComposing: boolean;
+  },
+  ctx: { caretAtStart: boolean; browsing: boolean; queueLen: number },
+): ArrowRecallAction {
+  if (event.isComposing) return "default";
+  if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return "default";
+  if (event.key === "ArrowUp") {
+    if (ctx.browsing || (ctx.caretAtStart && ctx.queueLen > 0)) return "older";
+    return "default";
+  }
+  if (event.key === "ArrowDown") {
+    if (ctx.browsing) return "newer";
+    return "default";
+  }
   return "default";
 }
 
@@ -246,6 +289,14 @@ interface Props {
    *  a fresh nonce per insertion so the effect re-fires even when
    *  the same text is inserted twice. See #1004. */
   primerPrefill?: { id: string; text: string } | null;
+  /** The prompt queue, oldest first. Drives ArrowUp/ArrowDown recall:
+   *  ArrowUp on an origin caret loads the newest entry for editing,
+   *  further arrows walk the queue shell-history style. */
+  queuedPrompts: QueuedPrompt[];
+  /** Edit a queued prompt in place by id, preserving its position. Used
+   *  when the user submits while browsing the queue, so an edit does not
+   *  enqueue a duplicate. */
+  editQueuedPrompt: (id: string, text: string) => void;
 }
 
 export function Composer({
@@ -267,6 +318,8 @@ export function Composer({
   pendingAttachments,
   setPendingAttachments,
   primerPrefill,
+  queuedPrompts,
+  editQueuedPrompt,
 }: Props) {
   const taRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -412,6 +465,93 @@ export function Composer({
 
   const composerRuntime = useComposerRuntime();
 
+  // ArrowUp/ArrowDown queue recall (shell-history style). recallRef holds
+  // the id of the queued prompt currently loaded into the composer plus
+  // the draft that was there before browsing began; null when not
+  // browsing. A ref (not state) so the synchronous keydown handler always
+  // reads the live value with no stale closure. Anchored on the stable
+  // queued-prompt id so a background drain never targets the wrong row.
+  const recallRef = useRef<{ id: string; stashedDraft: string } | null>(null);
+
+  // Load `text` into the composer with the caret at the end, mirroring
+  // the primer-prefill effect's focus + resize dance (setText alone does
+  // not fire onInput, so auto-grow has to be nudged manually).
+  const loadRecallText = useCallback(
+    (text: string) => {
+      composerRuntime.setText(text);
+      requestAnimationFrame(() => {
+        const el = taRef.current;
+        if (!el) return;
+        el.focus();
+        const len = el.value.length;
+        try {
+          el.setSelectionRange(len, len);
+        } catch {
+          // ignore: setSelectionRange can throw on detached nodes
+        }
+        el.style.height = "auto";
+        el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+      });
+    },
+    [composerRuntime],
+  );
+
+  // Browse toward older queued prompts. Entering from normal typing
+  // stashes the current draft and loads the newest entry; subsequent
+  // calls walk down the list and stop at the oldest (no wrap).
+  const recallOlder = useCallback(() => {
+    const q = queuedPrompts;
+    if (q.length === 0) {
+      // Queue drained out from under the browse; end it so the next
+      // ArrowUp moves the caret instead of being swallowed.
+      recallRef.current = null;
+      return;
+    }
+    const cur = recallRef.current;
+    if (!cur) {
+      const target = q[q.length - 1];
+      if (!target) return;
+      recallRef.current = { id: target.id, stashedDraft: composerRuntime.getState().text };
+      loadRecallText(target.text);
+      return;
+    }
+    const idx = q.findIndex((p) => p.id === cur.id);
+    if (idx === -1) {
+      // The browsed entry drained mid-browse; end browse, keep the text.
+      recallRef.current = null;
+      return;
+    }
+    if (idx > 0) {
+      const target = q[idx - 1];
+      if (!target) return;
+      recallRef.current = { ...cur, id: target.id };
+      loadRecallText(target.text);
+    }
+    // idx === 0 is the oldest entry: stay put.
+  }, [queuedPrompts, composerRuntime, loadRecallText]);
+
+  // Browse toward newer queued prompts; past the newest, restore the
+  // stashed draft and exit browse.
+  const recallNewer = useCallback(() => {
+    const cur = recallRef.current;
+    if (!cur) return;
+    const q = queuedPrompts;
+    const idx = q.findIndex((p) => p.id === cur.id);
+    if (idx === -1) {
+      recallRef.current = null;
+      return;
+    }
+    if (idx + 1 < q.length) {
+      const target = q[idx + 1];
+      if (!target) return;
+      recallRef.current = { ...cur, id: target.id };
+      loadRecallText(target.text);
+    } else {
+      loadRecallText(cur.stashedDraft);
+      recallRef.current = null;
+    }
+  }, [queuedPrompts, loadRecallText]);
+
   // Unified submit for the custom Send / QueueSend buttons and the
   // mid-turn Enter path: drains the textarea text + staged attachments
   // through `enqueuePrompt` (which is the structured view `sendPrompt`), then
@@ -419,10 +559,32 @@ export function Composer({
   // runtime's `onNew`, which reads the same staged attachments from
   // AcpRuntime. See #1000 / #965.
   const submitComposer = useCallback(() => {
+    const cur = recallRef.current;
+    if (cur) {
+      recallRef.current = null;
+      const text = composerRuntime.getState().text.trim();
+      // Submitting while browsing edits that queued entry in place rather
+      // than enqueuing a duplicate. If it drained since recall (id gone),
+      // fall through to a normal send so the edited text is never lost.
+      if (text && queuedPrompts.some((p) => p.id === cur.id)) {
+        editQueuedPrompt(cur.id, text);
+        composerRuntime.setText("");
+        const el = taRef.current;
+        if (el) el.style.height = "auto";
+        return;
+      }
+    }
     void sendFromTextarea(taRef, composerRuntime, enqueuePrompt, supportedPendingAttachments, () =>
       setPendingAttachments([]),
     );
-  }, [composerRuntime, enqueuePrompt, setPendingAttachments, supportedPendingAttachments]);
+  }, [
+    composerRuntime,
+    enqueuePrompt,
+    setPendingAttachments,
+    supportedPendingAttachments,
+    queuedPrompts,
+    editQueuedPrompt,
+  ]);
 
   // Manual agent switch dialog. Opened from the sidebar row context menu
   // (see WorkspaceSidebar's "Switch agent" item) via the cross-component
@@ -725,6 +887,36 @@ export function Composer({
                 dictationGuard.flushOnBlur();
               }}
               onKeyDown={(e) => {
+                // Queue recall (#2147). ArrowUp at the caret origin (or
+                // while already browsing) walks toward older queued
+                // prompts and loads them for editing; ArrowDown walks back
+                // toward newer entries and the stashed draft. Decided by
+                // decideArrowRecall so multi-line caret movement is never
+                // hijacked. Runs before the Enter matrix below.
+                const el = taRef.current;
+                const caretAtStart = !!el && el.selectionStart === 0 && el.selectionEnd === 0;
+                const recallAction = decideArrowRecall(
+                  {
+                    key: e.key,
+                    shiftKey: e.shiftKey,
+                    ctrlKey: e.ctrlKey,
+                    metaKey: e.metaKey,
+                    altKey: e.altKey,
+                    isComposing: e.nativeEvent.isComposing,
+                  },
+                  {
+                    caretAtStart,
+                    browsing: recallRef.current != null,
+                    queueLen: queuedPrompts.length,
+                  },
+                );
+                if (recallAction !== "default") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (recallAction === "older") recallOlder();
+                  else recallNewer();
+                  return;
+                }
                 // Two-way Enter dispatch. See decideEnterAction for
                 // the full matrix; the inline branches below handle
                 // each outcome:

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -811,12 +811,12 @@ export function Composer({
                 editing an existing queued prompt rather than composing a
                 new one. */}
             {recallInfo && (
-              <div className="flex items-center justify-between gap-2 rounded-t-xl border-b border-brand-600/40 bg-brand-600/10 px-3 py-1.5 text-xs text-brand-200">
-                <span className="flex items-center gap-1.5 font-medium">
-                  <Pencil className="h-3.5 w-3.5" />
+              <div className="flex items-center justify-between gap-2 rounded-t-lg border-b border-surface-700 bg-surface-800 px-3 py-1.5 text-xs text-text-secondary">
+                <span className="flex items-center gap-1.5 font-medium text-text-primary">
+                  <Pencil className="h-3.5 w-3.5 text-brand-400" />
                   Editing queued message {recallInfo.pos} of {recallInfo.total}
                 </span>
-                <span className="text-brand-300/70">Enter saves · Esc restores draft · ↑ ↓ to browse</span>
+                <span className="text-text-dim">Enter saves · Esc restores draft · ↑ ↓ to browse</span>
               </div>
             )}
 

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -498,6 +498,8 @@ function AcpChrome({
             pendingAttachments={pendingAttachments}
             setPendingAttachments={setPendingAttachments}
             primerPrefill={primerPrefill}
+            queuedPrompts={state.queuedPrompts}
+            editQueuedPrompt={editQueuedPrompt}
           />
         </div>
       </ThreadPrimitive.Root>

--- a/web/src/components/acp/recallNav.test.ts
+++ b/web/src/components/acp/recallNav.test.ts
@@ -1,0 +1,81 @@
+// Branch coverage for the pure queue-recall navigation (#2147).
+
+import { describe, expect, it } from "vitest";
+
+import { nextRecallTarget, recallBannerInfo, type RecallCursor } from "./recallNav";
+import type { QueuedPrompt } from "../../lib/acpTypes";
+
+const q = (...ids: string[]): QueuedPrompt[] =>
+  ids.map((id) => ({ id, text: `text-${id}`, queuedAt: "2026-01-01T00:00:00Z" }));
+
+const cursor = (id: string, stashedDraft = "draft"): RecallCursor => ({ id, stashedDraft });
+
+describe("nextRecallTarget — older (ArrowUp)", () => {
+  it("exits when the queue is empty", () => {
+    expect(nextRecallTarget([], null, "older", "draft")).toEqual({ kind: "exit" });
+  });
+
+  it("enters at the newest entry, stashing the current draft", () => {
+    expect(nextRecallTarget(q("a", "b"), null, "older", "my draft")).toEqual({
+      kind: "load",
+      cursor: { id: "b", stashedDraft: "my draft" },
+      text: "text-b",
+    });
+  });
+
+  it("walks to the older entry, preserving the stashed draft", () => {
+    expect(nextRecallTarget(q("a", "b"), cursor("b", "kept"), "older", "ignored")).toEqual({
+      kind: "load",
+      cursor: { id: "a", stashedDraft: "kept" },
+      text: "text-a",
+    });
+  });
+
+  it("stays put at the oldest entry (no wrap)", () => {
+    expect(nextRecallTarget(q("a", "b"), cursor("a"), "older", "draft")).toEqual({ kind: "none" });
+  });
+
+  it("exits when the browsed entry has drained", () => {
+    expect(nextRecallTarget(q("a", "b"), cursor("gone"), "older", "draft")).toEqual({ kind: "exit" });
+  });
+});
+
+describe("nextRecallTarget — newer (ArrowDown)", () => {
+  it("no-ops when not browsing", () => {
+    expect(nextRecallTarget(q("a", "b"), null, "newer", "draft")).toEqual({ kind: "none" });
+  });
+
+  it("exits when the browsed entry has drained", () => {
+    expect(nextRecallTarget(q("a", "b"), cursor("gone"), "newer", "draft")).toEqual({ kind: "exit" });
+  });
+
+  it("walks to the newer entry", () => {
+    expect(nextRecallTarget(q("a", "b"), cursor("a", "kept"), "newer", "draft")).toEqual({
+      kind: "load",
+      cursor: { id: "b", stashedDraft: "kept" },
+      text: "text-b",
+    });
+  });
+
+  it("restores the stashed draft past the newest entry", () => {
+    expect(nextRecallTarget(q("a", "b"), cursor("b", "my draft"), "newer", "draft")).toEqual({
+      kind: "restore",
+      text: "my draft",
+    });
+  });
+});
+
+describe("recallBannerInfo", () => {
+  it("is null without a cursor", () => {
+    expect(recallBannerInfo(q("a", "b"), null)).toBeNull();
+  });
+
+  it("counts position from the newest entry", () => {
+    expect(recallBannerInfo(q("a", "b", "c"), cursor("c"))).toEqual({ pos: 1, total: 3 });
+    expect(recallBannerInfo(q("a", "b", "c"), cursor("a"))).toEqual({ pos: 3, total: 3 });
+  });
+
+  it("is null when the cursor entry has drained", () => {
+    expect(recallBannerInfo(q("a", "b"), cursor("gone"))).toBeNull();
+  });
+});

--- a/web/src/components/acp/recallNav.ts
+++ b/web/src/components/acp/recallNav.ts
@@ -1,0 +1,76 @@
+// Pure navigation logic for the composer's ArrowUp/ArrowDown queue recall
+// (#2147). Kept out of the component so the branching (entry, step, stop
+// at oldest, restore-draft past newest, drained-entry exit) is unit
+// testable without mounting the assistant-ui composer. The component owns
+// only the side effects (setText, focus, banner state).
+
+import type { QueuedPrompt } from "../../lib/acpTypes";
+
+/** Active browse cursor: the queued-prompt id currently loaded into the
+ *  composer plus the draft that was there before browsing began. */
+export interface RecallCursor {
+  id: string;
+  stashedDraft: string;
+}
+
+/** What the composer should do in response to a recall step.
+ *  - `load`: set the cursor and load `text` for editing.
+ *  - `restore`: load `text` (the stashed draft) and exit browse.
+ *  - `exit`: end browse, leave the composer text as-is.
+ *  - `none`: no-op (empty queue entry attempt, or already at the oldest). */
+export type RecallNav =
+  | { kind: "load"; cursor: RecallCursor; text: string }
+  | { kind: "restore"; text: string }
+  | { kind: "exit" }
+  | { kind: "none" };
+
+/** Resolve the next recall step. Anchored on the stable queued-prompt id
+ *  so a background drain never targets the wrong row. `direction` is
+ *  "older" (ArrowUp) or "newer" (ArrowDown); `currentDraft` is the
+ *  composer text to stash when first entering recall. */
+export function nextRecallTarget(
+  queue: QueuedPrompt[],
+  cursor: RecallCursor | null,
+  direction: "older" | "newer",
+  currentDraft: string,
+): RecallNav {
+  if (direction === "older") {
+    if (queue.length === 0) return { kind: "exit" };
+    if (!cursor) {
+      const target = queue[queue.length - 1];
+      if (!target) return { kind: "none" };
+      return { kind: "load", cursor: { id: target.id, stashedDraft: currentDraft }, text: target.text };
+    }
+    const idx = queue.findIndex((p) => p.id === cursor.id);
+    if (idx === -1) return { kind: "exit" };
+    if (idx > 0) {
+      const target = queue[idx - 1];
+      if (!target) return { kind: "none" };
+      return { kind: "load", cursor: { ...cursor, id: target.id }, text: target.text };
+    }
+    return { kind: "none" }; // oldest entry: no wrap
+  }
+  // "newer"
+  if (!cursor) return { kind: "none" };
+  const idx = queue.findIndex((p) => p.id === cursor.id);
+  if (idx === -1) return { kind: "exit" };
+  if (idx + 1 < queue.length) {
+    const target = queue[idx + 1];
+    if (!target) return { kind: "none" };
+    return { kind: "load", cursor: { ...cursor, id: target.id }, text: target.text };
+  }
+  return { kind: "restore", text: cursor.stashedDraft };
+}
+
+/** Banner position for the active cursor, or null when the cursor is
+ *  absent or its entry has drained. Position counts from the newest entry
+ *  (1 = newest), matching the ArrowUp-from-newest browse order. */
+export function recallBannerInfo(
+  queue: QueuedPrompt[],
+  cursor: RecallCursor | null,
+): { pos: number; total: number } | null {
+  if (!cursor) return null;
+  const idx = queue.findIndex((p) => p.id === cursor.id);
+  if (idx === -1) return null;
+  return { pos: queue.length - idx, total: queue.length };
+}

--- a/web/tests/acp-composer-recall.spec.ts
+++ b/web/tests/acp-composer-recall.spec.ts
@@ -110,6 +110,19 @@ test.describe("Structured-view composer queue recall (#2147)", () => {
     await expect(composer).toHaveValue("second queued");
     await expect(page.getByText(/Editing queued message 1 of 2/)).toBeVisible();
 
+    // ArrowDown past the newest restores the stashed (empty) draft and exits.
+    await composer.press("ArrowDown");
+    await expect(composer).toHaveValue("");
+    await expect(page.getByText(/Editing queued message/)).toHaveCount(0);
+
+    // Re-enter and walk to the oldest.
+    await composer.press("ArrowUp");
+    await expect(composer).toHaveValue("second queued");
+    await composer.press("ArrowUp");
+    await expect(composer).toHaveValue("first queued");
+    await expect(page.getByText(/Editing queued message 2 of 2/)).toBeVisible();
+
+    // ArrowUp at the oldest is a no-op (no wrap): stays on the oldest.
     await composer.press("ArrowUp");
     await expect(composer).toHaveValue("first queued");
     await expect(page.getByText(/Editing queued message 2 of 2/)).toBeVisible();

--- a/web/tests/acp-composer-recall.spec.ts
+++ b/web/tests/acp-composer-recall.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, type Page } from "./helpers/mockedTest";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+
+// Queue-recall behavior for the structured-view composer (#2147), driven
+// through the real component in mocked mode so the ArrowUp/ArrowDown
+// handlers, the "Editing queued message" banner, Esc-restore, and the
+// edit-in-place submit path all execute in the browser.
+//
+// Sending the first prompt flips the session turn-active (optimistic
+// user_prompt dispatch), so subsequent submissions park in the queue
+// rather than sending. From there the arrows browse the queue.
+
+const SESSION_ID = "sess-acp-recall";
+const TITLE = "acp-recall";
+
+async function setup(page: Page) {
+  await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+    "system/update-status",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({
+        json:
+          path === "docker/status" || path === "about" || path === "settings" || path === "system/update-status"
+            ? {}
+            : [],
+      }),
+    );
+  }
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: [
+          {
+            id: SESSION_ID,
+            title: TITLE,
+            project_path: "/tmp/acp-recall",
+            group_path: "/tmp",
+            tool: "claude",
+            status: "Running",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+            workspace_repos: [],
+            view: "structured",
+            acp_worker_state: "running",
+            claude_fullscreen: false,
+          },
+        ],
+        workspace_ordering: [],
+      },
+    });
+  });
+  await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
+  // Prompt POSTs + replay succeed (empty), so the optimistic send sticks.
+  await page.route("**/api/sessions/*/acp/**", (r) => r.fulfill({ json: {} }));
+  // Accept both sockets as open-but-silent: the session reads as connected
+  // so the first Enter sends (turn active) and the rest queue.
+  await page.routeWebSocket(/\/sessions\/[^/]+\/ws(\?|$)/, () => {});
+  await page.routeWebSocket(/\/sessions\/[^/]+\/acp\/ws/, () => {});
+}
+
+async function openStructuredSession(page: Page) {
+  await page.goto("/");
+  await expect(page.locator("header")).toBeVisible();
+  await openMobileSidebar(page);
+  await clickSidebarSession(page, TITLE);
+  await expect(page.getByTestId("structured-view-root")).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("Structured-view composer queue recall (#2147)", () => {
+  test("ArrowUp recalls queued prompts, banner + Esc + edit-in-place", async ({ page }) => {
+    await setup(page);
+    await openStructuredSession(page);
+
+    const composer = page.getByRole("textbox", {
+      name: /Send a message|Queue a follow-up/i,
+    });
+
+    // Send the first prompt to put the turn active, then queue two follow-ups.
+    await composer.fill("kick off");
+    await composer.press("Enter");
+    const queueButton = page.getByRole("button", { name: /Queue follow-up message/i });
+    await expect(queueButton).toBeVisible({ timeout: 10000 });
+
+    await composer.fill("first queued");
+    await queueButton.click();
+    await composer.fill("second queued");
+    await queueButton.click();
+    await expect(page.getByRole("button", { name: /^second queued$/ })).toBeVisible({ timeout: 5000 });
+
+    // Empty composer: ArrowUp enters recall on the newest, banner shows.
+    await expect(composer).toHaveValue("");
+    await composer.press("ArrowUp");
+    await expect(composer).toHaveValue("second queued");
+    await expect(page.getByText(/Editing queued message 1 of 2/)).toBeVisible();
+
+    await composer.press("ArrowUp");
+    await expect(composer).toHaveValue("first queued");
+    await expect(page.getByText(/Editing queued message 2 of 2/)).toBeVisible();
+
+    await composer.press("ArrowDown");
+    await expect(composer).toHaveValue("second queued");
+
+    // Esc restores the stashed (empty) draft and clears the banner.
+    await composer.press("Escape");
+    await expect(composer).toHaveValue("");
+    await expect(page.getByText(/Editing queued message/)).toHaveCount(0);
+
+    // Re-enter, edit, submit: the queued entry updates in place, no dup.
+    await composer.press("ArrowUp");
+    await expect(composer).toHaveValue("second queued");
+    await composer.fill("second queued edited");
+    await composer.press("Enter");
+    await expect(page.getByRole("button", { name: /^second queued edited$/ })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("button", { name: /^second queued$/ })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^first queued$/ })).toBeVisible();
+    await expect(page.getByText(/Editing queued message/)).toHaveCount(0);
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1958,6 +1958,13 @@
       "components": ["web/src/components/acp/StructuredView.tsx"]
     },
     {
+      "id": "acp.story.queue-recall-arrow",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/acp-stories/queue-recall-arrow.spec.ts"],
+      "components": ["web/src/components/acp/Composer.tsx", "web/src/components/acp/StructuredView.tsx"]
+    },
+    {
       "id": "acp.story.composer-toolbar-insert",
       "kind": "vitest",
       "risk": "low",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1152,6 +1152,17 @@
       "components": ["web/src/components/acp/StructuredView.tsx"]
     },
     {
+      "id": "acp.composer-queue-recall",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/acp-composer-recall.spec.ts",
+        "src/components/acp/recallNav.test.ts",
+        "src/components/acp/Composer.recall.test.ts"
+      ],
+      "components": ["web/src/components/acp/Composer.tsx", "web/src/components/acp/recallNav.ts"]
+    },
+    {
       "id": "acp.config-pickers",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1158,7 +1158,8 @@
       "specs": [
         "tests/acp-composer-recall.spec.ts",
         "src/components/acp/recallNav.test.ts",
-        "src/components/acp/Composer.recall.test.ts"
+        "src/components/acp/Composer.recall.test.ts",
+        "src/components/acp/Composer.recall.dom.test.tsx"
       ],
       "components": ["web/src/components/acp/Composer.tsx", "web/src/components/acp/recallNav.ts"]
     },

--- a/web/tests/live/acp-stories/queue-recall-arrow.spec.ts
+++ b/web/tests/live/acp-stories/queue-recall-arrow.spec.ts
@@ -1,0 +1,109 @@
+// User story: recall and edit queued follow-ups with ArrowUp/ArrowDown.
+//
+// While a turn is active, follow-ups stash onto the QueuedPromptsStrip.
+// With the composer empty, ArrowUp walks backward through the queue
+// (newest first), loading each prompt into the composer for editing;
+// ArrowDown walks forward and past the newest restores the draft.
+// Submitting while browsing edits that queued entry in place rather than
+// enqueuing a duplicate. See #2147.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../../helpers/aoeServe";
+import { waitForStructuredView, enableStructuredViewAndWait, attachServeDiagnostics } from "../../helpers/acp";
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Working on turn 1..." },
+        },
+        { sessionUpdate: "wait_ms", ms: 10_000 },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("recall queued prompts with ArrowUp and edit in place", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-story-queue-recall-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      acp: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-queue-recall" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-queue-recall");
+    if (!seeded) throw new Error("seeded session 'story-queue-recall' missing");
+    const sessionId = seeded.id;
+    await enableStructuredViewAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForStructuredView(page);
+
+    const composer = page.getByRole("textbox", {
+      name: /Send a message|Queue a follow-up/i,
+    });
+
+    // Kick off the long-running turn so follow-ups queue.
+    await composer.fill("kick off");
+    await composer.press("Enter");
+    await expect(page.getByText("Working on turn 1...")).toBeVisible({ timeout: 10_000 });
+
+    // Queue two follow-ups.
+    const queueButton = page.getByRole("button", { name: /Queue follow-up message/i });
+    await composer.fill("first queued");
+    await queueButton.click();
+    await composer.fill("second queued");
+    await queueButton.click();
+    await expect(page.getByRole("button", { name: /^second queued$/ })).toBeVisible({ timeout: 5_000 });
+
+    // Composer is empty; ArrowUp loads the newest queued prompt.
+    await expect(composer).toHaveValue("");
+    await composer.press("ArrowUp");
+    await expect(composer).toHaveValue("second queued");
+
+    // ArrowUp again walks to the older entry.
+    await composer.press("ArrowUp");
+    await expect(composer).toHaveValue("first queued");
+
+    // ArrowDown walks back toward newer.
+    await composer.press("ArrowDown");
+    await expect(composer).toHaveValue("second queued");
+
+    // Edit it and submit: the queued row updates in place, no duplicate.
+    await composer.fill("second queued edited");
+    await composer.press("Enter");
+    await expect(page.getByRole("button", { name: /^second queued edited$/ })).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole("button", { name: /^second queued$/ })).toHaveCount(0);
+    // The other entry is untouched and the queue still holds exactly two.
+    await expect(page.getByRole("button", { name: /^first queued$/ })).toBeVisible();
+    await expect(composer).toHaveValue("");
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/web/tests/live/acp-stories/queue-recall-arrow.spec.ts
+++ b/web/tests/live/acp-stories/queue-recall-arrow.spec.ts
@@ -22,7 +22,7 @@ const SCRIPT = {
           sessionUpdate: "agent_message_chunk",
           content: { type: "text", text: "Working on turn 1..." },
         },
-        { sessionUpdate: "wait_ms", ms: 10_000 },
+        { sessionUpdate: "wait_ms", ms: 30_000 },
       ],
       stopReason: "end_turn",
     },
@@ -73,22 +73,36 @@ base("recall queued prompts with ArrowUp and edit in place", async ({ page }, te
     await queueButton.click();
     await expect(page.getByRole("button", { name: /^second queued$/ })).toBeVisible({ timeout: 5_000 });
 
-    // Composer is empty; ArrowUp loads the newest queued prompt.
+    // Composer empty: ArrowUp enters recall, loading the newest prompt and
+    // surfacing the editing banner.
     await expect(composer).toHaveValue("");
     await composer.press("ArrowUp");
     await expect(composer).toHaveValue("second queued");
+    await expect(page.getByText(/Editing queued message 1 of 2/)).toBeVisible();
 
     // ArrowUp again walks to the older entry.
     await composer.press("ArrowUp");
     await expect(composer).toHaveValue("first queued");
+    await expect(page.getByText(/Editing queued message 2 of 2/)).toBeVisible();
 
     // ArrowDown walks back toward newer.
     await composer.press("ArrowDown");
     await expect(composer).toHaveValue("second queued");
 
-    // Edit it and submit: the queued row updates in place, no duplicate.
+    // Esc abandons the browse and restores the stashed draft (empty here),
+    // clearing the banner.
+    await composer.press("Escape");
+    await expect(composer).toHaveValue("");
+    await expect(page.getByText(/Editing queued message/)).toHaveCount(0);
+
+    // Re-enter and edit: submitting while browsing updates the queued entry
+    // in place, no duplicate, and the editing banner clears.
+    await composer.press("ArrowUp");
+    await expect(composer).toHaveValue("second queued");
+    await expect(page.getByText(/Editing queued message 1 of 2/)).toBeVisible();
     await composer.fill("second queued edited");
     await composer.press("Enter");
+    await expect(page.getByText(/Editing queued message/)).toHaveCount(0);
     await expect(page.getByRole("button", { name: /^second queued edited$/ })).toBeVisible({ timeout: 5_000 });
     await expect(page.getByRole("button", { name: /^second queued$/ })).toHaveCount(0);
     // The other entry is untouched and the queue still holds exactly two.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds shell-history-style recall of queued prompts to both the web cockpit composer and the TUI structured-view composer. While an agent is mid-turn, follow-up prompts park in the queue; until now the only way to fix one was clicking its row (web) or clear-and-retype (TUI had no edit at all).

With the composer empty (caret at the very start), `↑` pulls the most recent queued prompt back into the composer for editing; `↑` again walks toward older entries and `↓` walks back toward newer ones, restoring your in-progress draft once you step past the newest. Submitting while browsing edits that queued entry in place rather than enqueuing a duplicate. If the entry drained between recall and submit, the edited text falls through to a normal send so nothing is lost.

The browse is non-destructive and never mutates the queue during navigation. On the web it anchors on the stable queued-prompt id, so a background drain cannot target the wrong row. On the TUI the recall index lives in view state and is reconciled when the queue drains off the front. Clearing the queue or leaving the composer ends the browse but keeps the in-progress text as a draft. The routing decision is a pure helper on each side (`decideArrowRecall` in the web composer, an extended `InputContext` plus a new `Intent::RecallQueued` in the TUI dispatch), so the hijack guard stays unit-testable and multi-line caret movement is never stolen.

While recalling, the composer makes the mode unmistakable: the web shows an "Editing queued message N of M" banner above the input, the TUI puts the same text in the composer border title and highlights it. `Esc` while browsing abandons the edit and restores the stashed draft on both surfaces.

Closes #2147

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Web: open the cockpit structured view, send a prompt to start a turn, then queue two follow-ups while it runs. With the composer empty, press `↑`: the newest queued prompt loads into the composer. Press `↑` again to reach the older one, `↓` to walk back.
- [ ] Web: while browsing a recalled prompt, edit the text and press `Enter`. The queued row updates in place; no duplicate row appears and the count stays the same.
- [ ] Web: type a multi-line draft, move the caret into the middle, press `↑`. The caret moves between lines as normal and does NOT hijack into recall.
- [ ] Web: press `↓` past the newest queued prompt while browsing; your original draft is restored.
- [ ] Web: while browsing, confirm the "Editing queued message N of M" banner shows above the composer, and `Esc` clears it and restores your draft.
- [ ] TUI: `aoe` structured view, queue follow-ups mid-turn, then from the empty composer press Up to cycle the queue, edit one, and press Enter to update it in place. While browsing, the composer title reads "Editing queued message N of M"; `Esc` restores the draft.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added `web/tests/live/acp-stories/queue-recall-arrow.spec.ts` (ArrowUp recall, cycle, edit-in-place, no duplicate) plus a Vitest matrix for the pure `decideArrowRecall` helper (`web/src/components/acp/Composer.recall.test.ts`).

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Covered by unit tests in `src/tui/structured_view/input.rs` (key routing) and `src/tui/structured_view/state.rs` (recall browse, drain reconciliation, cancel), plus `queue.rs` get/replace. The recall logic is pure state on the existing dispatch seam, so unit coverage exercises it directly without a new full-binary e2e.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the cross-surface design (debated via multiple models for the queue-drain race and the hijack guard), and implementation were drafted by Claude under my direction. I made the design calls, reviewed each commit, and ran the validation.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784119573&installation_id=139138837&pr_number=2155&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2155&signature=93b06989266f20222b91742ef56675e806deefe26edac72612bf916a6f0d4562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Shell-History-Style Recall for Queued Composer Prompts

## Overview
This PR adds keyboard-based “recall/edit” for queued follow-up prompts (shown while an agent is mid-turn) in both the web composer and the TUI structured-view composer. Instead of being forced to click/edit the row (web) or manually clear and retype (TUI), users can now use ArrowUp/ArrowDown like shell history to bring queued prompts back for editing.

## What Changed

### Added
- **ArrowUp / ArrowDown queue recall (when the composer is empty):**
  - **ArrowUp** loads the **newest queued** prompt for editing, then steps older entries on repeated presses
  - **ArrowDown** steps back toward newer entries, and moves past the newest to restore the original draft
- **Clear “editing queued message N of M” mode indicator:**
  - **Web:** banner above the input
  - **TUI:** bordered composer title changes to show the same “N of M” context with highlighted styling
- **Esc to cancel recall**: abandons browsing and restores the stashed draft on both surfaces
- **Submit while browsing edits in place**: updating a recalled queued prompt replaces the existing queue entry rather than creating a duplicate

### Updated
- **Queue-safe behavior while the queue drains:**
  - **Web:** recall is anchored to a stable queued-prompt identifier so background draining won’t target the wrong row
  - **TUI:** recall state is kept in view state and reconciled as the front of the queue advances
- **Cleaner, testable routing logic:**
  - **Web:** Arrow recall decision is factored into a pure helper so caret navigation (including multi-line editing) isn’t hijacked
  - **TUI:** input handling gains explicit “recall queued” and “cancel recall” intents, with recall state driving render/edit behavior

### Removed
- The previous **TUI limitation** that prevented editing queued prompts in place is removed (now supported with the same recall flow).

## Benefits
- **Faster follow-up fixes** using the keyboard instead of mouse-clicking rows or retyping
- **Consistent workflow across web and TUI**: Arrow recall, visible edit mode, Esc cancel/restore, and submit-in-place behavior
- **More reliable behavior under live updates** while queued prompts drain in the background

## Notes / Remaining Difference
- **TUI recall is session/view scoped in-memory** and may not persist the same way as the web when leaving the structured view.

## Tests & Docs
- Updated structured-view interface docs for the new ArrowUp/ArrowDown recall behavior
- Added/extended:
  - **Web:** unit tests for the pure Arrow recall helper + Playwright user-story coverage for recall/cycling/banner/Esc/submit-in-place
  - **TUI:** Rust unit tests for queue get/replace, recall step/cancel, input routing, and drain reconciliation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->