### PR TITLE
feat(web): render structured-view history recent-first with Load earlier

### DIFF
--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -67,6 +67,10 @@ aoe add . --agent aoe-agent --model gpt-5   # pick an ACP agent + model (implies
 
 `--agent` for an uninstalled adapter errors with an install hint; `--structured-view` (no `--agent`) falls back to the terminal view with a warning so the command still succeeds.
 
+## Transcript history
+
+Opening a session renders the most recent slice of the transcript first, so a long conversation lands you at the latest message instead of painting the whole backlog (noticeable on mobile). Earlier turns stay loaded; a "Load earlier messages" button at the top of the transcript reveals more, a chunk at a time. The window resets to recent when you switch sessions. The full transcript is still fetched in the background, so search, scrollback, and `aoe acp history <id>` see everything.
+
 ## Requirements
 
 - aoe built with `--features serve`.

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -66,11 +66,6 @@ aoe add . --agent aoe-agent --model gpt-5   # pick an ACP agent + model (implies
 ```
 
 `--agent` for an uninstalled adapter errors with an install hint; `--structured-view` (no `--agent`) falls back to the terminal view with a warning so the command still succeeds.
-
-## Transcript history
-
-Opening a session renders the most recent slice of the transcript first, so a long conversation lands you at the latest message instead of painting the whole backlog (noticeable on mobile). Earlier turns stay loaded; a "Load earlier messages" button at the top of the transcript reveals more, a chunk at a time. The window resets to recent when you switch sessions. The full transcript is still fetched in the background, so search, scrollback, and `aoe acp history <id>` see everything.
-
 ## Requirements
 
 - aoe built with `--features serve`.

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -40,7 +40,7 @@ import type {
   ToolCall,
 } from "../../lib/acpTypes";
 import { hasTodoItemsArgsText, parseJsonObject } from "../../lib/acpArgs";
-import { DEFAULT_HISTORY_WINDOW, HISTORY_WINDOW_STEP, historyWindow } from "../../lib/acpHistoryWindow";
+import { useHistoryWindow } from "../../hooks/useHistoryWindow";
 import { useAgentProfile } from "../../lib/agentProfileContext";
 
 interface Props {
@@ -132,22 +132,11 @@ export function AcpRuntime({
   }, [pendingAttachments]);
   // Render only the most recent slice of the transcript so a long
   // session does not block first paint on mobile; older rows stay in
-  // reducer state and are revealed via "Load earlier". Reset the window
-  // on session switch (adjust-state-on-prop-change, no effect, per the
-  // react-you-might-not-need-an-effect lint). See #2144.
-  const [visibleRows, setVisibleRows] = useState(DEFAULT_HISTORY_WINDOW);
-  const [windowSessionId, setWindowSessionId] = useState(sessionId);
-  if (windowSessionId !== sessionId) {
-    setWindowSessionId(sessionId);
-    setVisibleRows(DEFAULT_HISTORY_WINDOW);
-  }
-  const { start: historyStart, canLoadEarlier } = useMemo(
-    () => historyWindow(acp.state.activity, visibleRows, showClearedTurns),
-    [acp.state.activity, visibleRows, showClearedTurns],
-  );
-  const windowedActivity = useMemo(
-    () => (historyStart === 0 ? acp.state.activity : acp.state.activity.slice(historyStart)),
-    [acp.state.activity, historyStart],
+  // reducer state and are revealed via "Load earlier". See #2144.
+  const { windowedActivity, canLoadEarlier, loadEarlier } = useHistoryWindow(
+    sessionId,
+    acp.state.activity,
+    showClearedTurns,
   );
 
   // Memoise the activity → ThreadMessageLike conversion. The function
@@ -229,7 +218,7 @@ export function AcpRuntime({
         setConfigOption: acp.setConfigOption,
         dismissConfigOptionSwitchFailed: acp.dismissConfigOptionSwitchFailed,
         canLoadEarlierHistory: canLoadEarlier,
-        loadEarlierHistory: () => setVisibleRows((v) => v + HISTORY_WINDOW_STEP),
+        loadEarlierHistory: loadEarlier,
       })}
     </AssistantRuntimeProvider>
   );

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -40,6 +40,7 @@ import type {
   ToolCall,
 } from "../../lib/acpTypes";
 import { hasTodoItemsArgsText, parseJsonObject } from "../../lib/acpArgs";
+import { DEFAULT_HISTORY_WINDOW, HISTORY_WINDOW_STEP, historyWindowStart } from "../../lib/acpHistoryWindow";
 import { useAgentProfile } from "../../lib/agentProfileContext";
 
 interface Props {
@@ -98,6 +99,11 @@ export interface AcpContext {
   dismissModeSwitchFailed: () => void;
   setConfigOption: (configId: string, value: string) => Promise<void>;
   dismissConfigOptionSwitchFailed: () => void;
+  /** True when older activity rows exist above the rendered window, so
+   *  the view can offer a "Load earlier" control. See #2144. */
+  canLoadEarlierHistory: boolean;
+  /** Reveal an additional chunk of older history. */
+  loadEarlierHistory: () => void;
 }
 
 /**
@@ -124,21 +130,41 @@ export function AcpRuntime({
   useEffect(() => {
     pendingAttachmentsRef.current = pendingAttachments;
   }, [pendingAttachments]);
+  // Render only the most recent slice of the transcript so a long
+  // session does not block first paint on mobile; older rows stay in
+  // reducer state and are revealed via "Load earlier". Reset the window
+  // on session switch (adjust-state-on-prop-change, no effect, per the
+  // react-you-might-not-need-an-effect lint). See #2144.
+  const [visibleRows, setVisibleRows] = useState(DEFAULT_HISTORY_WINDOW);
+  const [windowSessionId, setWindowSessionId] = useState(sessionId);
+  if (windowSessionId !== sessionId) {
+    setWindowSessionId(sessionId);
+    setVisibleRows(DEFAULT_HISTORY_WINDOW);
+  }
+  const historyStart = useMemo(
+    () => historyWindowStart(acp.state.activity, visibleRows),
+    [acp.state.activity, visibleRows],
+  );
+  const windowedActivity = useMemo(
+    () => (historyStart === 0 ? acp.state.activity : acp.state.activity.slice(historyStart)),
+    [acp.state.activity, historyStart],
+  );
+
   // Memoise the activity → ThreadMessageLike conversion. The function
-  // walks the entire activity array, allocates a new AssistantBuilder
+  // walks the activity array, allocates a new AssistantBuilder
   // per turn, and produces brand-new message objects. Without
   // useMemo, every parent re-render (e.g. WS heartbeat, hover state)
-  // re-builds the entire transcript and assistant-ui treats every
+  // re-builds the transcript and assistant-ui treats every
   // message as changed. Memo on the inputs the function reads.
   const messages = useMemo(
     () =>
       activityToThreadMessages(
-        acp.state.activity,
+        windowedActivity,
         acp.state.turnActive,
         showClearedTurns,
         agentProfile.capabilities.todos,
       ),
-    [acp.state.activity, acp.state.turnActive, showClearedTurns, agentProfile.capabilities.todos],
+    [windowedActivity, acp.state.turnActive, showClearedTurns, agentProfile.capabilities.todos],
   );
 
   const runtime = useExternalStoreRuntime<ThreadMessageLike>({
@@ -202,6 +228,8 @@ export function AcpRuntime({
         dismissModeSwitchFailed: acp.dismissModeSwitchFailed,
         setConfigOption: acp.setConfigOption,
         dismissConfigOptionSwitchFailed: acp.dismissConfigOptionSwitchFailed,
+        canLoadEarlierHistory: historyStart > 0,
+        loadEarlierHistory: () => setVisibleRows((v) => v + HISTORY_WINDOW_STEP),
       })}
     </AssistantRuntimeProvider>
   );

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -40,7 +40,7 @@ import type {
   ToolCall,
 } from "../../lib/acpTypes";
 import { hasTodoItemsArgsText, parseJsonObject } from "../../lib/acpArgs";
-import { DEFAULT_HISTORY_WINDOW, HISTORY_WINDOW_STEP, historyWindowStart } from "../../lib/acpHistoryWindow";
+import { DEFAULT_HISTORY_WINDOW, HISTORY_WINDOW_STEP, historyWindow } from "../../lib/acpHistoryWindow";
 import { useAgentProfile } from "../../lib/agentProfileContext";
 
 interface Props {
@@ -141,25 +141,14 @@ export function AcpRuntime({
     setWindowSessionId(sessionId);
     setVisibleRows(DEFAULT_HISTORY_WINDOW);
   }
-  const historyStart = useMemo(
-    () => historyWindowStart(acp.state.activity, visibleRows),
-    [acp.state.activity, visibleRows],
+  const { start: historyStart, canLoadEarlier } = useMemo(
+    () => historyWindow(acp.state.activity, visibleRows, showClearedTurns),
+    [acp.state.activity, visibleRows, showClearedTurns],
   );
   const windowedActivity = useMemo(
     () => (historyStart === 0 ? acp.state.activity : acp.state.activity.slice(historyStart)),
     [acp.state.activity, historyStart],
   );
-  // Index of the latest `/clear` divider when cleared turns are folded.
-  // Rows before it are already hidden behind the ClearedTurnsBanner, so
-  // "Load earlier" must not offer to reveal them, that click would be a
-  // no-op. See #2144.
-  const lastClearIndex = useMemo(() => {
-    if (showClearedTurns) return -1;
-    for (let i = acp.state.activity.length - 1; i >= 0; i -= 1) {
-      if (acp.state.activity[i]!.kind === "session_cleared") return i;
-    }
-    return -1;
-  }, [acp.state.activity, showClearedTurns]);
 
   // Memoise the activity → ThreadMessageLike conversion. The function
   // walks the activity array, allocates a new AssistantBuilder
@@ -239,7 +228,7 @@ export function AcpRuntime({
         dismissModeSwitchFailed: acp.dismissModeSwitchFailed,
         setConfigOption: acp.setConfigOption,
         dismissConfigOptionSwitchFailed: acp.dismissConfigOptionSwitchFailed,
-        canLoadEarlierHistory: lastClearIndex < 0 ? historyStart > 0 : historyStart > lastClearIndex,
+        canLoadEarlierHistory: canLoadEarlier,
         loadEarlierHistory: () => setVisibleRows((v) => v + HISTORY_WINDOW_STEP),
       })}
     </AssistantRuntimeProvider>

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -149,6 +149,17 @@ export function AcpRuntime({
     () => (historyStart === 0 ? acp.state.activity : acp.state.activity.slice(historyStart)),
     [acp.state.activity, historyStart],
   );
+  // Index of the latest `/clear` divider when cleared turns are folded.
+  // Rows before it are already hidden behind the ClearedTurnsBanner, so
+  // "Load earlier" must not offer to reveal them, that click would be a
+  // no-op. See #2144.
+  const lastClearIndex = useMemo(() => {
+    if (showClearedTurns) return -1;
+    for (let i = acp.state.activity.length - 1; i >= 0; i -= 1) {
+      if (acp.state.activity[i]!.kind === "session_cleared") return i;
+    }
+    return -1;
+  }, [acp.state.activity, showClearedTurns]);
 
   // Memoise the activity → ThreadMessageLike conversion. The function
   // walks the activity array, allocates a new AssistantBuilder
@@ -228,7 +239,7 @@ export function AcpRuntime({
         dismissModeSwitchFailed: acp.dismissModeSwitchFailed,
         setConfigOption: acp.setConfigOption,
         dismissConfigOptionSwitchFailed: acp.dismissConfigOptionSwitchFailed,
-        canLoadEarlierHistory: historyStart > 0,
+        canLoadEarlierHistory: lastClearIndex < 0 ? historyStart > 0 : historyStart > lastClearIndex,
         loadEarlierHistory: () => setVisibleRows((v) => v + HISTORY_WINDOW_STEP),
       })}
     </AssistantRuntimeProvider>

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -407,7 +407,7 @@ function AcpChrome({
                   type="button"
                   onClick={loadEarlierHistory}
                   data-testid="acp-load-earlier"
-                  className="rounded-full border border-surface-700 bg-surface-800 px-3 py-1 text-xs text-text-secondary hover:bg-surface-700 hover:text-text-primary cursor-pointer"
+                  className="h-8 rounded-md border border-surface-700 bg-surface-800 px-3 text-xs text-text-secondary hover:bg-surface-700 hover:text-text-primary transition-colors cursor-pointer"
                 >
                   Load earlier messages
                 </button>

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -204,6 +204,8 @@ function AcpChrome({
   dismissModeSwitchFailed,
   setConfigOption,
   dismissConfigOptionSwitchFailed,
+  canLoadEarlierHistory,
+  loadEarlierHistory,
 }: AcpContext & {
   sessionId: string;
   acpWorkerState: "absent" | "resuming" | "running";
@@ -397,6 +399,19 @@ function AcpChrome({
                 expanded={showClearedTurns}
                 onToggle={onToggleClearedTurns}
               />
+            )}
+
+            {canLoadEarlierHistory && (
+              <div className="mb-3 flex justify-center">
+                <button
+                  type="button"
+                  onClick={loadEarlierHistory}
+                  data-testid="acp-load-earlier"
+                  className="rounded-full border border-surface-700 bg-surface-800 px-3 py-1 text-xs text-text-secondary hover:bg-surface-700 hover:text-text-primary cursor-pointer"
+                >
+                  Load earlier messages
+                </button>
+              </div>
             )}
 
             <ThreadPrimitive.Messages

--- a/web/src/hooks/__tests__/useHistoryWindow.test.tsx
+++ b/web/src/hooks/__tests__/useHistoryWindow.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import type { ActivityRow } from "../../lib/acpTypes";
+import { DEFAULT_HISTORY_WINDOW } from "../../lib/acpHistoryWindow";
+import { useHistoryWindow } from "../useHistoryWindow";
+
+function transcript(turns: number, perTurn: number): ActivityRow[] {
+  const rows: ActivityRow[] = [];
+  for (let t = 0; t < turns; t += 1) {
+    rows.push({ id: `u-${t}`, kind: "user_prompt", text: `prompt ${t}` });
+    for (let r = 0; r < perTurn; r += 1) rows.push({ id: `m-${t}-${r}`, kind: "message", text: `msg ${t}.${r}` });
+  }
+  return rows;
+}
+
+describe("useHistoryWindow", () => {
+  it("windows a long transcript and offers Load earlier", () => {
+    const activity = transcript(100, 1); // 200 rows
+    const { result } = renderHook(() => useHistoryWindow("s1", activity, false));
+    expect(result.current.windowedActivity.length).toBeLessThanOrEqual(DEFAULT_HISTORY_WINDOW);
+    expect(result.current.windowedActivity.length).toBeLessThan(activity.length);
+    expect(result.current.canLoadEarlier).toBe(true);
+  });
+
+  it("renders everything and hides the control for a short transcript", () => {
+    const activity = transcript(3, 1); // 6 rows
+    const { result } = renderHook(() => useHistoryWindow("s1", activity, false));
+    expect(result.current.windowedActivity).toHaveLength(activity.length);
+    expect(result.current.canLoadEarlier).toBe(false);
+  });
+
+  it("loadEarlier grows the window until the whole transcript shows", () => {
+    const activity = transcript(100, 1); // 200 rows
+    const { result } = renderHook(() => useHistoryWindow("s1", activity, false));
+    for (let i = 0; i < 5 && result.current.canLoadEarlier; i += 1) {
+      act(() => result.current.loadEarlier());
+    }
+    expect(result.current.windowedActivity).toHaveLength(activity.length);
+    expect(result.current.canLoadEarlier).toBe(false);
+  });
+
+  it("resets the window to recent when the session changes", () => {
+    const activity = transcript(100, 1);
+    const { result, rerender } = renderHook(({ id }) => useHistoryWindow(id, activity, false), {
+      initialProps: { id: "s1" },
+    });
+    act(() => result.current.loadEarlier());
+    act(() => result.current.loadEarlier());
+    const grown = result.current.windowedActivity.length;
+    rerender({ id: "s2" });
+    expect(result.current.windowedActivity.length).toBeLessThan(grown);
+    expect(result.current.canLoadEarlier).toBe(true);
+  });
+});

--- a/web/src/hooks/useHistoryWindow.ts
+++ b/web/src/hooks/useHistoryWindow.ts
@@ -1,0 +1,40 @@
+import { useCallback, useMemo, useState } from "react";
+
+import type { ActivityRow } from "../lib/acpTypes";
+import { DEFAULT_HISTORY_WINDOW, HISTORY_WINDOW_STEP, historyWindow } from "../lib/acpHistoryWindow";
+
+export interface HistoryWindowState {
+  /** The recent slice of `activity` to render. */
+  windowedActivity: ActivityRow[];
+  /** True when older rows remain that "Load earlier" would reveal. */
+  canLoadEarlier: boolean;
+  /** Reveal an additional chunk of older history. */
+  loadEarlier: () => void;
+}
+
+/**
+ * Window the structured-view transcript to its most recent rows so a
+ * long session does not block first paint, growing on demand via
+ * `loadEarlier`. The visible window resets to recent whenever
+ * `sessionId` changes (adjust-state-on-prop-change, no effect, per the
+ * react-you-might-not-need-an-effect lint). See #2144.
+ */
+export function useHistoryWindow(
+  sessionId: string,
+  activity: ActivityRow[],
+  showClearedTurns: boolean,
+): HistoryWindowState {
+  const [visibleRows, setVisibleRows] = useState(DEFAULT_HISTORY_WINDOW);
+  const [windowSessionId, setWindowSessionId] = useState(sessionId);
+  if (windowSessionId !== sessionId) {
+    setWindowSessionId(sessionId);
+    setVisibleRows(DEFAULT_HISTORY_WINDOW);
+  }
+  const { start, canLoadEarlier } = useMemo(
+    () => historyWindow(activity, visibleRows, showClearedTurns),
+    [activity, visibleRows, showClearedTurns],
+  );
+  const windowedActivity = useMemo(() => (start === 0 ? activity : activity.slice(start)), [activity, start]);
+  const loadEarlier = useCallback(() => setVisibleRows((v) => v + HISTORY_WINDOW_STEP), []);
+  return { windowedActivity, canLoadEarlier, loadEarlier };
+}

--- a/web/src/lib/acpHistoryWindow.test.ts
+++ b/web/src/lib/acpHistoryWindow.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import type { ActivityRow } from "./acpTypes";
+import { DEFAULT_HISTORY_WINDOW, historyWindowStart } from "./acpHistoryWindow";
+
+function row(kind: ActivityRow["kind"], i: number): ActivityRow {
+  return { id: `${kind}-${i}`, kind, text: `${kind} ${i}` };
+}
+
+/** A transcript of `turns` turns, each a user_prompt followed by
+ *  `perTurn` assistant/tool rows. */
+function transcript(turns: number, perTurn: number): ActivityRow[] {
+  const rows: ActivityRow[] = [];
+  for (let t = 0; t < turns; t += 1) {
+    rows.push(row("user_prompt", t));
+    for (let r = 0; r < perTurn; r += 1) rows.push(row("message", t * 100 + r));
+  }
+  return rows;
+}
+
+describe("historyWindowStart", () => {
+  it("returns 0 when everything fits", () => {
+    const rows = transcript(2, 3); // 8 rows
+    expect(historyWindowStart(rows, DEFAULT_HISTORY_WINDOW)).toBe(0);
+    expect(historyWindowStart(rows, 8)).toBe(0);
+  });
+
+  it("snaps the cap cut forward to the nearest user turn boundary", () => {
+    // 10 turns x 10 rows = 110 rows, prompts at 0,11,22,...,99.
+    const rows = transcript(10, 10);
+    // visibleRows 30 -> cap = 80. Next boundary at index 88 (turn 8).
+    const start = historyWindowStart(rows, 30);
+    expect(rows[start]!.kind).toBe("user_prompt");
+    expect(start).toBe(88);
+    // Never renders MORE than the cap allows.
+    expect(rows.length - start).toBeLessThanOrEqual(30);
+  });
+
+  it("hard-cuts at the cap when one huge turn has no boundary after it", () => {
+    // One prompt then 500 tool rows: no boundary at or after the cap.
+    const rows: ActivityRow[] = [row("user_prompt", 0)];
+    for (let i = 0; i < 500; i += 1) rows.push(row("tool_complete", i));
+    const start = historyWindowStart(rows, 150);
+    expect(start).toBe(rows.length - 150); // 351
+    expect(rows.length - start).toBe(150);
+  });
+
+  it("counts user_diff_comments as a turn boundary", () => {
+    const rows: ActivityRow[] = [];
+    for (let i = 0; i < 40; i += 1) rows.push(row("message", i));
+    rows[35] = row("user_diff_comments", 35);
+    // cap = 40 - 10 = 30; first boundary at or after 30 is index 35.
+    expect(historyWindowStart(rows, 10)).toBe(35);
+  });
+
+  it("walks down to 0 as the window grows past the transcript", () => {
+    const rows = transcript(5, 5); // 30 rows
+    expect(historyWindowStart(rows, 30)).toBe(0);
+    expect(historyWindowStart(rows, 1000)).toBe(0);
+  });
+});

--- a/web/src/lib/acpHistoryWindow.test.ts
+++ b/web/src/lib/acpHistoryWindow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { ActivityRow } from "./acpTypes";
-import { DEFAULT_HISTORY_WINDOW, historyWindowStart } from "./acpHistoryWindow";
+import { DEFAULT_HISTORY_WINDOW, historyWindow, historyWindowStart } from "./acpHistoryWindow";
 
 function row(kind: ActivityRow["kind"], i: number): ActivityRow {
   return { id: `${kind}-${i}`, kind, text: `${kind} ${i}` };
@@ -57,5 +57,53 @@ describe("historyWindowStart", () => {
     const rows = transcript(5, 5); // 30 rows
     expect(historyWindowStart(rows, 30)).toBe(0);
     expect(historyWindowStart(rows, 1000)).toBe(0);
+  });
+
+  it("treats a non-positive window as show-all", () => {
+    const rows = transcript(10, 10);
+    expect(historyWindowStart(rows, 0)).toBe(0);
+    expect(historyWindowStart(rows, -5)).toBe(0);
+  });
+});
+
+describe("historyWindow", () => {
+  it("can load earlier when rows are windowed out and there is no clear", () => {
+    const rows = transcript(10, 10); // 110 rows
+    const w = historyWindow(rows, 30, false);
+    expect(w.start).toBeGreaterThan(0);
+    expect(w.canLoadEarlier).toBe(true);
+  });
+
+  it("cannot load earlier when everything fits", () => {
+    const rows = transcript(2, 3); // 8 rows
+    expect(historyWindow(rows, DEFAULT_HISTORY_WINDOW, false)).toEqual({ start: 0, canLoadEarlier: false });
+  });
+
+  it("suppresses load-earlier when the only hidden rows are pre-clear", () => {
+    // 100 pre-clear turns, a clear, then 2 short post-clear turns.
+    const rows: ActivityRow[] = [];
+    for (let t = 0; t < 100; t += 1) {
+      rows.push(row("user_prompt", t));
+      rows.push(row("message", t));
+    }
+    rows.push(row("session_cleared", 999));
+    for (let t = 0; t < 2; t += 1) {
+      rows.push(row("user_prompt", 1000 + t));
+      rows.push(row("message", 1000 + t));
+    }
+    const w = historyWindow(rows, DEFAULT_HISTORY_WINDOW, false);
+    // The window starts well before the clear, but those rows are folded
+    // behind the banner, so the control must stay hidden.
+    expect(w.start).toBeLessThan(rows.length - 5);
+    expect(w.canLoadEarlier).toBe(false);
+  });
+
+  it("can load earlier post-clear rows, and ignores the clear when cleared turns are shown", () => {
+    const rows: ActivityRow[] = [row("session_cleared", 0)];
+    for (let i = 0; i < 200; i += 1) rows.push(row("message", i));
+    // Folding on: hidden rows are post-clear, so load-earlier is offered.
+    expect(historyWindow(rows, 30, false).canLoadEarlier).toBe(true);
+    // Folding off (showClearedTurns): clear is ignored, gate is start > 0.
+    expect(historyWindow(rows, 30, true).canLoadEarlier).toBe(true);
   });
 });

--- a/web/src/lib/acpHistoryWindow.ts
+++ b/web/src/lib/acpHistoryWindow.ts
@@ -1,0 +1,41 @@
+import type { ActivityRow } from "./acpTypes";
+
+/** Recent activity rows the structured view paints on open. Older rows
+ *  stay in reducer state but are not rendered until the user loads them,
+ *  so a long transcript no longer blocks first paint on mobile. The
+ *  whole-history fetch + reduce still happens (proposal A in #2144); the
+ *  multi-page network cost on very large sessions is a separate
+ *  follow-up. See #2144. */
+export const DEFAULT_HISTORY_WINDOW = 150;
+
+/** Extra rows revealed per "Load earlier" activation. */
+export const HISTORY_WINDOW_STEP = 150;
+
+/** User turns anchor the window's top so it never opens on a dangling
+ *  mid-turn assistant fragment. Typed diff-comment turns count too. */
+function isUserTurnBoundary(row: ActivityRow): boolean {
+  return row.kind === "user_prompt" || row.kind === "user_diff_comments";
+}
+
+/**
+ * Index into `rows` from which the transcript should render, given how
+ * many recent rows the caller wants visible (`visibleRows`).
+ *
+ * The hard cap is primary: the result is never below
+ * `rows.length - visibleRows`, so a single huge agent turn (hundreds of
+ * tool rows under one prompt) can never blow the window past the cap.
+ * Within that cap the start snaps FORWARD to the nearest user turn
+ * boundary so the top is a clean user message rather than a half turn.
+ * When no boundary sits at or after the cap cut, the cut is used as-is.
+ *
+ * Returns 0 when every row fits (nothing earlier to load).
+ */
+export function historyWindowStart(rows: readonly ActivityRow[], visibleRows: number): number {
+  if (visibleRows <= 0) return 0;
+  const cap = Math.max(0, rows.length - visibleRows);
+  if (cap === 0) return 0;
+  for (let i = cap; i < rows.length; i += 1) {
+    if (isUserTurnBoundary(rows[i]!)) return i;
+  }
+  return cap;
+}

--- a/web/src/lib/acpHistoryWindow.ts
+++ b/web/src/lib/acpHistoryWindow.ts
@@ -39,3 +39,35 @@ export function historyWindowStart(rows: readonly ActivityRow[], visibleRows: nu
   }
   return cap;
 }
+
+/** Index of the latest `/clear` divider, or -1 when cleared turns are
+ *  shown (folding off) or there is no clear. Rows before it are hidden
+ *  behind the ClearedTurnsBanner, not by the history window. */
+function lastClearedIndex(rows: readonly ActivityRow[], showClearedTurns: boolean): number {
+  if (showClearedTurns) return -1;
+  for (let i = rows.length - 1; i >= 0; i -= 1) {
+    if (rows[i]!.kind === "session_cleared") return i;
+  }
+  return -1;
+}
+
+export interface HistoryWindow {
+  /** Index to start rendering from; 0 renders the whole transcript. */
+  start: number;
+  /** Whether older rows remain that "Load earlier" would actually
+   *  reveal. False when the only hidden rows are pre-`/clear` (those are
+   *  reached via the ClearedTurnsBanner), so the control is not a no-op. */
+  canLoadEarlier: boolean;
+}
+
+/** Resolve the render window for the structured-view transcript. */
+export function historyWindow(
+  rows: readonly ActivityRow[],
+  visibleRows: number,
+  showClearedTurns: boolean,
+): HistoryWindow {
+  const start = historyWindowStart(rows, visibleRows);
+  const clearIndex = lastClearedIndex(rows, showClearedTurns);
+  const canLoadEarlier = clearIndex < 0 ? start > 0 : start > clearIndex;
+  return { start, canLoadEarlier };
+}

--- a/web/tests/acp-history-window.spec.ts
+++ b/web/tests/acp-history-window.spec.ts
@@ -1,0 +1,52 @@
+// User story (#2144): opening a long structured-view transcript renders
+// the most recent slice first, so the user lands at the latest message
+// instead of waiting for the whole backlog to paint. Older turns are
+// revealed by the "Load earlier messages" button, a chunk at a time.
+//
+// Seeds 100 turns (a UserPromptSent + an agent reply each = 200 activity
+// rows, past the 150-row default window) and asserts the oldest turn is
+// not painted until the user loads earlier history.
+
+import { test, expect } from "./helpers/mockedTest";
+import { mockAcpSession, openStructuredSession, agentMessageChunk, stopped } from "./helpers/acpMock";
+
+function userPrompt(text: string) {
+  return { UserPromptSent: { text } };
+}
+
+const TURNS = 100;
+
+function longTranscript(): unknown[] {
+  const events: unknown[] = [];
+  for (let i = 0; i < TURNS; i += 1) {
+    events.push(userPrompt(`prompt number ${i}`));
+    events.push(agentMessageChunk(`reply number ${i}`));
+    events.push(stopped());
+  }
+  return events;
+}
+
+test("long transcript renders recent first and reveals older on Load earlier", async ({ page }) => {
+  const mock = await mockAcpSession(page, {
+    title: "story-history-window",
+    initialEvents: longTranscript(),
+  });
+  await openStructuredSession(page, mock);
+
+  // Recent turn is painted on open.
+  await expect(page.getByText(`reply number ${TURNS - 1}`)).toBeVisible({ timeout: 10_000 });
+
+  // The oldest turn is windowed out (200 rows, 150-row default window).
+  await expect(page.getByText("prompt number 0")).toHaveCount(0);
+
+  // The control to widen the window is offered.
+  const loadEarlier = page.getByTestId("acp-load-earlier");
+  await expect(loadEarlier).toBeVisible();
+
+  // Growing the window enough times reveals the oldest turn.
+  for (let i = 0; i < 3; i += 1) {
+    if ((await page.getByText("prompt number 0").count()) > 0) break;
+    await loadEarlier.click();
+  }
+  await expect(page.getByText("prompt number 0")).toBeVisible({ timeout: 10_000 });
+});

--- a/web/tests/acp-history-window.spec.ts
+++ b/web/tests/acp-history-window.spec.ts
@@ -50,3 +50,34 @@ test("long transcript renders recent first and reveals older on Load earlier", a
   }
   await expect(page.getByText("prompt number 0")).toBeVisible({ timeout: 10_000 });
 });
+
+// User story (#2144): when /clear is active and the windowed-out rows are
+// all before the clear divider, "Load earlier" would be a no-op (those
+// turns are reached via the cleared-turns banner, not this control), so
+// the button must not appear.
+test("Load earlier stays hidden when only pre-clear rows are windowed out", async ({ page }) => {
+  const events: unknown[] = [];
+  // 100 pre-clear turns (200 rows) so the window cut lands well before
+  // the clear divider, then a /clear and a couple of short post-clear turns.
+  for (let i = 0; i < 100; i += 1) {
+    events.push(userPrompt(`old prompt ${i}`));
+    events.push(agentMessageChunk(`old reply ${i}`));
+    events.push(stopped());
+  }
+  events.push("SessionCleared");
+  for (let i = 0; i < 2; i += 1) {
+    events.push(userPrompt(`new prompt ${i}`));
+    events.push(agentMessageChunk(`new reply ${i}`));
+    events.push(stopped());
+  }
+
+  const mock = await mockAcpSession(page, { title: "story-history-window-clear", initialEvents: events });
+  await openStructuredSession(page, mock);
+
+  // Post-clear content renders; pre-clear turns are folded behind the banner.
+  await expect(page.getByText("new reply 1")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("old prompt 0")).toHaveCount(0);
+
+  // The windowed-out rows are all pre-clear, so the control is suppressed.
+  await expect(page.getByTestId("acp-load-earlier")).toHaveCount(0);
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -945,9 +945,14 @@
       "id": "acp.history-window",
       "kind": "mocked-playwright",
       "risk": "medium",
-      "specs": ["tests/acp-history-window.spec.ts", "src/lib/acpHistoryWindow.test.ts"],
+      "specs": [
+        "tests/acp-history-window.spec.ts",
+        "src/lib/acpHistoryWindow.test.ts",
+        "src/hooks/__tests__/useHistoryWindow.test.tsx"
+      ],
       "components": [
         "web/src/lib/acpHistoryWindow.ts",
+        "web/src/hooks/useHistoryWindow.ts",
         "web/src/components/acp/AcpRuntime.tsx",
         "web/src/components/acp/StructuredView.tsx"
       ]

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -943,9 +943,9 @@
     },
     {
       "id": "acp.history-window",
-      "kind": "vitest",
+      "kind": "mocked-playwright",
       "risk": "medium",
-      "specs": ["src/lib/acpHistoryWindow.test.ts"],
+      "specs": ["tests/acp-history-window.spec.ts", "src/lib/acpHistoryWindow.test.ts"],
       "components": [
         "web/src/lib/acpHistoryWindow.ts",
         "web/src/components/acp/AcpRuntime.tsx",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -942,6 +942,17 @@
       ]
     },
     {
+      "id": "acp.history-window",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/acpHistoryWindow.test.ts"],
+      "components": [
+        "web/src/lib/acpHistoryWindow.ts",
+        "web/src/components/acp/AcpRuntime.tsx",
+        "web/src/components/acp/StructuredView.tsx"
+      ]
+    },
+    {
       "id": "diff-comments.storage-cleanup",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Opening a structured-view session with a long transcript made the user wait while the entire history painted before the latest message appeared, worst on mobile. This renders only the most recent slice first and reveals older turns on demand.

`activityToThreadMessages(acp.state.activity, ...)` walks the whole activity array and `ThreadPrimitive.Messages` renders every row with no virtualization, so the paint of hundreds of bubbles is the dominant cost on a cold open. The reducer (`applyEvent`) is an order-dependent forward folder that derives `usageBaseline`, `plan`, `inFlightTool`, `thinking`, and `pendingApprovals` from prior state, so prepending an older fetch window after newer state is built would corrupt those fields. The fix therefore keeps the full state building exactly as today and windows only what is rendered.

A new pure helper, `historyWindowStart`, returns the index to render from: it keeps the most recent N rows under a hard cap (so one huge agent turn cannot blow the window) and snaps the top up to the nearest user turn boundary (`user_prompt` or `user_diff_comments`) so the transcript never opens on a dangling mid-turn fragment. `AcpRuntime` slices the activity array before the message conversion and exposes a "Load earlier messages" control that grows the window a chunk at a time; the window resets to recent on session switch. Older rows stay in reducer state, so search and `aoe acp history` still see the full transcript.

Scope note: this is proposal A from the issue. It removes the dominant paint cost for the common single-page case. Very large multi-thousand-event sessions still fetch every replay page (oldest-first) before first paint; deferring that network cost (a backend tail/reverse endpoint plus decoupling derived state from history) stays the documented follow-up.

Closes #2144

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session with a long transcript (150+ activity rows) on a fresh device or after clearing site data, and confirm it lands at the latest message without first painting the whole backlog.
- [ ] Confirm a "Load earlier messages" button appears at the top of the transcript; click it and confirm older turns appear above without the view jumping.
- [ ] Keep clicking "Load earlier" until it disappears; confirm the full transcript is then shown.
- [ ] Send a new prompt and confirm the new turn renders normally and the transcript stays anchored to recent content.
- [ ] Switch to another session and back; confirm the window reset to recent (button reappears on the long session).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a Playwright spec, because: the windowing decision (which rows render, turn-boundary snap, hard cap, grow-to-all) is pure logic and is covered by a Vitest unit test (`web/src/lib/acpHistoryWindow.test.ts`); the "Load earlier" button is a thin wrapper that calls the tested helper. `web/tests/coverage-matrix.json` was updated with an `acp.history-window` entry. A live Playwright pass over a seeded long transcript can follow if reviewers want the end-to-end scroll behavior locked down.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, the approach debate (render-side vs fetch-side windowing), implementation, and prose were drafted by Claude under my direction. I made the design calls, reviewed each commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784120306&installation_id=139138837&pr_number=2161&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2161&signature=b0b65b6ac0e6016ecafaa7f3f59fe6983335824301bd590afb8a88a69d34533b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR improves ACP structured-view “cold open” performance for long sessions by rendering only the most recent part of the transcript first, instead of waiting for the entire backlog to be processed and painted. It also adds an “Load earlier messages” control to reveal older content gradually, starting cleanly at message/turn boundaries (and respecting cleared-session behavior).

## What Changed
- **Added transcript windowing logic** in `web/src/lib/acpHistoryWindow.ts`:
  - `historyWindowStart` (plus `historyWindow`) decides where the initial render window should begin.
  - Uses a fixed-size recent window (`DEFAULT_HISTORY_WINDOW`) and step growth (`HISTORY_WINDOW_STEP`).
  - Snaps the start to safe “user turn” boundaries and accounts for `/clear` divider behavior.
- **Updated `AcpRuntime` to render only a slice** of the activity array:
  - Keeps the full transcript-derived state available, but converts/renders only the “visible” portion.
  - Resets the visible window when switching sessions.
  - Extends `AcpContext` with `canLoadEarlierHistory` and `loadEarlierHistory` to drive incremental expansion.
- **Updated UI in `StructuredView`**:
  - Shows a centered **“Load earlier messages”** button when more history can be revealed.
- **Documentation update** (`docs/structured-view.md`):
  - Documents recent-first rendering, incremental reveal, session switching reset behavior, and that the full transcript is still available for search/scrollback and `aoe acp history <id>`.
- **Testing & coverage**:
  - Vitest unit tests for the windowing decision logic (`acpHistoryWindowStart` / `historyWindow`).
  - Playwright tests validating the user experience (initial window, incremental loading, and cleared-session cases).
  - Added `acp.history-window` entry to the web coverage matrix.

## Benefits
- **Much faster first paint / reduced cold-open latency**, especially for mobile users with long transcripts.
- **Cleaner UX**: users immediately see the latest messages, and older content can be revealed without landing mid-turn.
- **No functional regression**: the application still retains the complete transcript state for search/history commands.

## Potential Further Enhancement
For extremely large sessions, the PR notes that the app may still need time to fetch/process the entire replay backlog before everything is fully ready—backend support for tail/backward paging and/or deeper virtualization is left as a follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->