### PR TITLE
fix(web): render structured-view tool-card file paths repo-relative

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1060,6 +1060,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                       archivedAt={activeSession.archived_at ?? null}
                       snoozedUntil={activeSession.snoozed_until ?? null}
                       onOpenFileRef={handleOpenFileRef}
+                      fileRefSession={activeSession}
                     />
                   </Suspense>
                 ) : (

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -110,6 +110,7 @@ export function MobileMainPane({
                 archivedAt={activeSession.archived_at ?? null}
                 snoozedUntil={activeSession.snoozed_until ?? null}
                 onOpenFileRef={onOpenFileRef}
+                fileRefSession={activeSession}
               />
             </Suspense>
           ) : (

--- a/web/src/components/acp/AcpFileRefContext.tsx
+++ b/web/src/components/acp/AcpFileRefContext.tsx
@@ -6,13 +6,17 @@
 // Markdown.tsx consumes it. See #1718.
 
 import { createContext, useContext } from "react";
-import type { FileRef } from "../../lib/fileRef";
+import type { FileRef, FileRefSession } from "../../lib/fileRef";
 
 export interface AcpFileRefContextValue {
   /** Open a local file reference cited in the transcript. Absent when
    *  the structured view is rendered without a file-open target, in which case
    *  the anchor override leaves links as normal (new-tab) anchors. */
   onOpenFileRef?: (ref: FileRef) => void;
+  /** Repo roots for the active session, used to render tool-card file
+   *  paths repo-relative (strip the worktree prefix). Absent when no
+   *  session is mounted, in which case cards show the raw path. See #2143. */
+  fileRefSession?: FileRefSession | null;
 }
 
 export const AcpFileRefContext = createContext<AcpFileRefContextValue>({});

--- a/web/src/components/acp/StructuredView.fileRef.test.tsx
+++ b/web/src/components/acp/StructuredView.fileRef.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+//
+// StructuredView forwards the active session's repo roots into
+// AcpFileRefContext so the tool cards can render file paths
+// repo-relative (#2143). The full component mounts the live ACP runtime
+// (WebSocket worker), so we mock AcpRuntime down to a probe that reads
+// the context and renders what it received. This pins the one-line
+// provider plumbing that no other unit test exercises.
+
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+import { useAcpFileRef } from "./AcpFileRefContext";
+import type { FileRefSession } from "../../lib/fileRef";
+
+vi.mock("./AcpRuntime", () => ({
+  SUBAGENT_TASK_NAME: "Task",
+  TODO_GROUP_NAME: "Todos",
+  TOOL_GROUP_NAME: "Tools",
+  AcpRuntime: () => {
+    const { fileRefSession } = useAcpFileRef();
+    return <div data-testid="probe">{fileRefSession?.project_path ?? "none"}</div>;
+  },
+}));
+
+import { StructuredView } from "./StructuredView";
+
+describe("StructuredView fileRef plumbing (#2143)", () => {
+  it("provides the session repo roots through AcpFileRefContext", () => {
+    const fileRefSession: FileRefSession = {
+      project_path: "/Users/me/wt",
+      main_repo_path: null,
+      workspace_repos: [],
+    };
+    const { getByTestId } = render(
+      <StructuredView
+        sessionId="s1"
+        acpWorkerState="running"
+        tool="claude"
+        archivedAt={null}
+        snoozedUntil={null}
+        fileRefSession={fileRefSession}
+      />,
+    );
+    expect(getByTestId("probe").textContent).toBe("/Users/me/wt");
+  });
+
+  it("provides no session when none is passed", () => {
+    const { getByTestId } = render(
+      <StructuredView sessionId="s1" acpWorkerState="absent" tool="claude" archivedAt={null} snoozedUntil={null} />,
+    );
+    expect(getByTestId("probe").textContent).toBe("none");
+  });
+});

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -98,15 +98,8 @@ const STARTER_PROMPTS = [
   "What does the build pipeline do?",
 ];
 
-export function StructuredView({
-  sessionId,
-  acpWorkerState,
-  tool,
-  archivedAt,
-  snoozedUntil,
-  onOpenFileRef,
-  fileRefSession,
-}: Props) {
+export function StructuredView(props: Props) {
+  const { sessionId, acpWorkerState, tool, archivedAt, snoozedUntil, onOpenFileRef, fileRefSession } = props;
   // Folds rows above the most recent `/clear` divider out of the
   // thread by default; the disclosure banner toggles this. Lives on
   // the view (not the reducer) because it's a UI preference, not

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -21,7 +21,7 @@ import { AlertTriangle, Check, ChevronDown, Clock, Info, ListChecks, Paperclip, 
 import { ApprovalCard } from "./ApprovalCard";
 import { AskUserQuestionCard } from "./AskUserQuestionCard";
 import { AcpFileRefContext } from "./AcpFileRefContext";
-import type { FileRef } from "../../lib/fileRef";
+import type { FileRef, FileRefSession } from "../../lib/fileRef";
 import { ToolDensityToggle, ToolDisplayModeProvider, useToolDensityPref } from "./ToolDisplayMode";
 import { AcpRuntime, SUBAGENT_TASK_NAME, TODO_GROUP_NAME, TOOL_GROUP_NAME, type AcpContext } from "./AcpRuntime";
 import { Composer } from "./Composer";
@@ -87,6 +87,9 @@ interface Props {
    *  instead of navigating away. Omit to leave such links as normal
    *  anchors. See #1718. */
   onOpenFileRef?: (ref: FileRef) => void;
+  /** Repo roots for this session, forwarded to the tool cards so file
+   *  paths render repo-relative instead of absolute. See #2143. */
+  fileRefSession?: FileRefSession | null;
 }
 
 const STARTER_PROMPTS = [
@@ -95,7 +98,15 @@ const STARTER_PROMPTS = [
   "What does the build pipeline do?",
 ];
 
-export function StructuredView({ sessionId, acpWorkerState, tool, archivedAt, snoozedUntil, onOpenFileRef }: Props) {
+export function StructuredView({
+  sessionId,
+  acpWorkerState,
+  tool,
+  archivedAt,
+  snoozedUntil,
+  onOpenFileRef,
+  fileRefSession,
+}: Props) {
   // Folds rows above the most recent `/clear` divider out of the
   // thread by default; the disclosure banner toggles this. Lives on
   // the view (not the reducer) because it's a UI preference, not
@@ -105,7 +116,7 @@ export function StructuredView({ sessionId, acpWorkerState, tool, archivedAt, sn
   // not reducer state and not a daemon config field. See #1767.
   const [toolDensity, toggleToolDensity] = useToolDensityPref();
   return (
-    <AcpFileRefContext.Provider value={{ onOpenFileRef }}>
+    <AcpFileRefContext.Provider value={{ onOpenFileRef, fileRefSession }}>
       <AgentProfileProvider toolKey={tool}>
         <ToolDisplayModeProvider density={toolDensity}>
           <AcpRuntime

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -753,6 +753,9 @@ describe("ToolCards repo-relative paths (#2143)", () => {
       </WrapWithSession>,
     );
     expect(container.textContent).toContain("api/src/h.ts");
+    // The visible label must not be the absolute path; the absolute form
+    // only survives in the title tooltip (an attribute, not textContent).
+    expect(container.textContent).not.toContain("/tmp/api/src/h.ts");
   });
 
   it("falls back to the absolute path when outside every known root", () => {
@@ -767,5 +770,37 @@ describe("ToolCards repo-relative paths (#2143)", () => {
       </WrapWithSession>,
     );
     expect(container.textContent).toContain("/etc/hosts");
+  });
+
+  it("renders a delete path repo-relative under the session root", () => {
+    const { container } = render(
+      <WrapWithSession session={session}>
+        <ToolCard tool={fixtures.del} result={undefined} />
+      </WrapWithSession>,
+    );
+    expect(container.textContent).toContain("delete");
+    expect(container.textContent).toContain("gone.rs");
+    expect(container.textContent).not.toContain("/tmp/gone.rs");
+  });
+
+  it("renders a write path repo-relative under the session root", () => {
+    const { container } = render(
+      <WrapWithSession session={session}>
+        <ToolCard tool={fixtures.write} result={undefined} />
+      </WrapWithSession>,
+    );
+    expect(container.textContent).toContain("new.rs");
+    expect(container.textContent).not.toContain("/tmp/new.rs");
+  });
+
+  it("keeps the absolute path in the title tooltip while showing the relative label", () => {
+    const { container } = render(
+      <WrapWithSession session={session}>
+        <ToolCard tool={fixtures.edit} result={undefined} />
+      </WrapWithSession>,
+    );
+    const titled = container.querySelector('[title="/tmp/main.rs"]');
+    expect(titled).not.toBeNull();
+    expect(titled!.textContent).toContain("main.rs");
   });
 });

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -793,6 +793,32 @@ describe("ToolCards repo-relative paths (#2143)", () => {
     expect(container.textContent).not.toContain("/tmp/new.rs");
   });
 
+  it("renders a multi-file edit with each diff header repo-relative", () => {
+    const tool = makeToolCall({
+      id: "edit-multi-file",
+      name: "apply_patch",
+      kind: "edit",
+      args_preview: "{}",
+      diffs: [
+        { path: "/tmp/src/alpha.rs", old_text: "a", new_text: "b", created_at: "2026-05-21T00:00:00Z" },
+        { path: "/tmp/src/beta.rs", old_text: null, new_text: "c", created_at: "2026-05-21T00:00:00Z" },
+      ],
+    });
+    const { container, getByRole } = render(
+      <WrapWithSession session={session}>
+        <ToolCard tool={tool} result={undefined} />
+      </WrapWithSession>,
+    );
+    // Collapsed: primary shows the first path relative + "+N more".
+    expect(container.textContent).toContain("src/alpha.rs");
+    expect(container.textContent).toContain("+1 more");
+    expect(container.textContent).not.toContain("/tmp/src/alpha.rs");
+    // Expanded: each per-file diff header renders its path relative too.
+    fireEvent.click(getByRole("button"));
+    expect(container.textContent).toContain("src/beta.rs");
+    expect(container.textContent).not.toContain("/tmp/src/beta.rs");
+  });
+
   it("keeps the absolute path in the title tooltip while showing the relative label", () => {
     const { container } = render(
       <WrapWithSession session={session}>

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -819,6 +819,21 @@ describe("ToolCards repo-relative paths (#2143)", () => {
     expect(container.textContent).not.toContain("/tmp/src/beta.rs");
   });
 
+  it.each([
+    ["read", "read"],
+    ["edit", "write"],
+    ["delete", "delete"],
+  ])("falls back to (unknown file) for a path-less %s tool", (kind, label) => {
+    const tool = makeToolCall({ id: `${kind}-no-path`, name: "", kind, args_preview: "{}" });
+    const { container } = render(
+      <WrapWithSession session={session}>
+        <ToolCard tool={tool} result={undefined} />
+      </WrapWithSession>,
+    );
+    expect(container.textContent).toContain(label);
+    expect(container.textContent).toContain("(unknown file)");
+  });
+
   it("keeps the absolute path in the title tooltip while showing the relative label", () => {
     const { container } = render(
       <WrapWithSession session={session}>

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -32,10 +32,20 @@ vi.mock("../../hooks/useShikiTheme", () => ({
 
 import { ToolCard, TodoGroupCard } from "./ToolCards";
 import { AgentProfileProvider } from "../../lib/agentProfileContext";
+import { AcpFileRefContext } from "./AcpFileRefContext";
+import type { FileRefSession } from "../../lib/fileRef";
 import { fixtures, makeCompletion, makeError, makeStopped, makeToolCall } from "./__fixtures__/toolCalls";
 
 function Wrap({ toolKey, children }: { toolKey?: string; children: ReactNode }) {
   return <AgentProfileProvider toolKey={toolKey ?? null}>{children}</AgentProfileProvider>;
+}
+
+function WrapWithSession({ session, children }: { session: FileRefSession | null; children: ReactNode }) {
+  return (
+    <AcpFileRefContext.Provider value={{ fileRefSession: session }}>
+      <AgentProfileProvider toolKey={null}>{children}</AgentProfileProvider>
+    </AcpFileRefContext.Provider>
+  );
 }
 
 afterEach(() => {
@@ -696,5 +706,66 @@ describe("ToolCards failed-card folding (#1467)", () => {
     expect(container.textContent).not.toContain("hello world");
     fireEvent.click(getByRole("button"));
     expect(container.textContent).toContain("hello world");
+  });
+});
+
+describe("ToolCards repo-relative paths (#2143)", () => {
+  const session: FileRefSession = {
+    project_path: "/tmp",
+    main_repo_path: null,
+    workspace_repos: [],
+  };
+
+  it("renders an edit path repo-relative when it sits under the session root", () => {
+    const { container } = render(
+      <WrapWithSession session={session}>
+        <ToolCard tool={fixtures.edit} result={undefined} />
+      </WrapWithSession>,
+    );
+    expect(container.textContent).toContain("main.rs");
+    expect(container.textContent).not.toContain("/tmp/main.rs");
+  });
+
+  it("renders a read path repo-relative under the session root", () => {
+    const { container } = render(
+      <WrapWithSession session={session}>
+        <ToolCard tool={fixtures.read} result={undefined} />
+      </WrapWithSession>,
+    );
+    expect(container.textContent).toContain("main.rs");
+    expect(container.textContent).not.toContain("/tmp/main.rs");
+  });
+
+  it("prefixes the repo name in a multi-repo workspace", () => {
+    const multi: FileRefSession = {
+      project_path: "/tmp/ws",
+      main_repo_path: null,
+      workspace_repos: [{ name: "api", source_path: "/tmp/api" }],
+    };
+    const tool = makeToolCall({
+      id: "edit-multi-repo",
+      kind: "edit",
+      args_preview: JSON.stringify({ file_path: "/tmp/api/src/h.ts", old_string: "a", new_string: "b" }),
+    });
+    const { container } = render(
+      <WrapWithSession session={multi}>
+        <ToolCard tool={tool} result={undefined} />
+      </WrapWithSession>,
+    );
+    expect(container.textContent).toContain("api/src/h.ts");
+  });
+
+  it("falls back to the absolute path when outside every known root", () => {
+    const tool = makeToolCall({
+      id: "edit-outside",
+      kind: "edit",
+      args_preview: JSON.stringify({ file_path: "/etc/hosts", old_string: "a", new_string: "b" }),
+    });
+    const { container } = render(
+      <WrapWithSession session={session}>
+        <ToolCard tool={tool} result={undefined} />
+      </WrapWithSession>,
+    );
+    expect(container.textContent).toContain("/etc/hosts");
   });
 });

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -54,6 +54,8 @@ import { classifyMcp, humanizeServer, humanizeVerb } from "../../lib/mcpClassify
 import { classifyMemory, parseMemoryFrontmatter, type MemoryHit } from "../../lib/memoryClassify";
 import { reclassifyBash } from "../../lib/toolReclassify";
 import { useAgentProfile } from "../../lib/agentProfileContext";
+import { useAcpFileRef } from "./AcpFileRefContext";
+import { relativeDisplayPath } from "../../lib/fileRef";
 import { useToolDisplayMode, type ToolDensity } from "./ToolDisplayMode";
 import type { AgentProfile, CardKind } from "../../lib/agentProfiles";
 
@@ -778,10 +780,11 @@ function ExecuteToolCard({ tool, result }: Props) {
 
 function ReadToolCard({ tool, result }: Props) {
   const status = statusFor(result);
+  const { fileRefSession } = useAcpFileRef();
   const args = parseJsonObject(tool.args_preview);
   const argPath = pickStr(args, "path", "file_path", "filePath", "filename");
   const title = pickStr(args, "_aoe_title");
-  const path = pickFirst(argPath, title, tool.name) ?? "(unknown file)";
+  const path = relativeDisplayPath(pickFirst(argPath, title, tool.name) ?? "(unknown file)", fileRefSession);
   const range = formatRange(args);
   const ext = argPath?.match(/\.([a-z0-9]+)$/i)?.[1]?.toLowerCase();
   const content = result?.text ?? "";
@@ -830,6 +833,7 @@ function formatRange(args: Record<string, unknown> | null): string | null {
 
 function EditToolCard({ tool, result }: Props) {
   const status = statusFor(result);
+  const { fileRefSession } = useAcpFileRef();
   const args = parseJsonObject(tool.args_preview);
   const argPath = pickStr(args, "path", "file_path", "filePath", "filename");
   const title = pickStr(args, "_aoe_title");
@@ -841,7 +845,10 @@ function EditToolCard({ tool, result }: Props) {
   const legacyOld = pickStr(args, "old_string", "oldString", "old_str") ?? "";
   const legacyNew = pickStr(args, "new_string", "newString", "new_str", "content") ?? "";
   const hasLegacyDiff = legacyOld !== "" || legacyNew !== "";
-  const path = pickFirst(structuredDiffs[0]?.path, argPath, title, tool.name) ?? "(unknown file)";
+  const path = relativeDisplayPath(
+    pickFirst(structuredDiffs[0]?.path, argPath, title, tool.name) ?? "(unknown file)",
+    fileRefSession,
+  );
   const [open, setOpen] = useToolCardExpansion(status);
   const hasDiff = hasStructuredDiffs || hasLegacyDiff;
   // "edit" when a prior version existed, "write" for a fresh file.
@@ -889,7 +896,11 @@ function EditToolCard({ tool, result }: Props) {
             <div className="border-t border-surface-800 bg-surface-950">
               {structuredDiffs.map((d, i) => (
                 <div key={`${d.path}-${i}`}>
-                  {multiFile && <div className="px-2 py-1 text-[11px] text-text-dim">{d.path}</div>}
+                  {multiFile && (
+                    <div className="px-2 py-1 text-[11px] text-text-dim">
+                      {relativeDisplayPath(d.path, fileRefSession)}
+                    </div>
+                  )}
                   <StringDiff oldText={d.old_text ?? ""} newText={d.new_text ?? ""} filePath={d.path} />
                 </div>
               ))}
@@ -911,10 +922,11 @@ function EditToolCard({ tool, result }: Props) {
 
 function DeleteToolCard({ tool, result }: Props) {
   const status = statusFor(result);
+  const { fileRefSession } = useAcpFileRef();
   const args = parseJsonObject(tool.args_preview);
   const argPath = pickStr(args, "path", "file_path", "filePath", "filename");
   const title = pickStr(args, "_aoe_title");
-  const path = pickFirst(argPath, title, tool.name) ?? "(unknown file)";
+  const path = relativeDisplayPath(pickFirst(argPath, title, tool.name) ?? "(unknown file)", fileRefSession);
   const [open, setOpen] = useToolCardExpansion(status);
   return (
     <CardChrome

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -784,7 +784,8 @@ function ReadToolCard({ tool, result }: Props) {
   const args = parseJsonObject(tool.args_preview);
   const argPath = pickStr(args, "path", "file_path", "filePath", "filename");
   const title = pickStr(args, "_aoe_title");
-  const path = relativeDisplayPath(pickFirst(argPath, title, tool.name) ?? "(unknown file)", fileRefSession);
+  const rawPath = pickFirst(argPath, title, tool.name) ?? "(unknown file)";
+  const path = relativeDisplayPath(rawPath, fileRefSession);
   const range = formatRange(args);
   const ext = argPath?.match(/\.([a-z0-9]+)$/i)?.[1]?.toLowerCase();
   const content = result?.text ?? "";
@@ -801,7 +802,7 @@ function ReadToolCard({ tool, result }: Props) {
       endedAt={result?.at}
       icon={<FileText className="h-3.5 w-3.5" />}
       label="read"
-      primary={path}
+      primary={<span title={rawPath}>{path}</span>}
       meta={
         <>
           {range && <span className="text-[11px] text-text-dim">{range}</span>}
@@ -845,10 +846,8 @@ function EditToolCard({ tool, result }: Props) {
   const legacyOld = pickStr(args, "old_string", "oldString", "old_str") ?? "";
   const legacyNew = pickStr(args, "new_string", "newString", "new_str", "content") ?? "";
   const hasLegacyDiff = legacyOld !== "" || legacyNew !== "";
-  const path = relativeDisplayPath(
-    pickFirst(structuredDiffs[0]?.path, argPath, title, tool.name) ?? "(unknown file)",
-    fileRefSession,
-  );
+  const rawPath = pickFirst(structuredDiffs[0]?.path, argPath, title, tool.name) ?? "(unknown file)";
+  const path = relativeDisplayPath(rawPath, fileRefSession);
   const [open, setOpen] = useToolCardExpansion(status);
   const hasDiff = hasStructuredDiffs || hasLegacyDiff;
   // "edit" when a prior version existed, "write" for a fresh file.
@@ -886,7 +885,7 @@ function EditToolCard({ tool, result }: Props) {
       endedAt={result?.at}
       icon={<Pencil className="h-3.5 w-3.5" />}
       label={verb}
-      primary={multiFile ? `${path} +${structuredDiffs.length - 1} more` : path}
+      primary={<span title={rawPath}>{multiFile ? `${path} +${structuredDiffs.length - 1} more` : path}</span>}
       meta={errorChip ? undefined : meta}
       expanded={open}
       onToggle={status === "err" || hasDiff ? () => setOpen((v) => !v) : undefined}
@@ -897,7 +896,7 @@ function EditToolCard({ tool, result }: Props) {
               {structuredDiffs.map((d, i) => (
                 <div key={`${d.path}-${i}`}>
                   {multiFile && (
-                    <div className="px-2 py-1 text-[11px] text-text-dim">
+                    <div className="px-2 py-1 text-[11px] text-text-dim" title={d.path}>
                       {relativeDisplayPath(d.path, fileRefSession)}
                     </div>
                   )}
@@ -926,7 +925,8 @@ function DeleteToolCard({ tool, result }: Props) {
   const args = parseJsonObject(tool.args_preview);
   const argPath = pickStr(args, "path", "file_path", "filePath", "filename");
   const title = pickStr(args, "_aoe_title");
-  const path = relativeDisplayPath(pickFirst(argPath, title, tool.name) ?? "(unknown file)", fileRefSession);
+  const rawPath = pickFirst(argPath, title, tool.name) ?? "(unknown file)";
+  const path = relativeDisplayPath(rawPath, fileRefSession);
   const [open, setOpen] = useToolCardExpansion(status);
   return (
     <CardChrome
@@ -935,7 +935,7 @@ function DeleteToolCard({ tool, result }: Props) {
       endedAt={result?.at}
       icon={<Trash2 className="h-3.5 w-3.5 text-rose-400" />}
       label="delete"
-      primary={path}
+      primary={<span title={rawPath}>{path}</span>}
       expanded={open}
       onToggle={status === "err" ? () => setOpen((v) => !v) : undefined}
       body={

--- a/web/src/lib/__tests__/fileRef.test.ts
+++ b/web/src/lib/__tests__/fileRef.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseFileRef, resolveToRepoRelative, type FileRefSession } from "../fileRef";
+import { parseFileRef, relativeDisplayPath, resolveToRepoRelative, type FileRefSession } from "../fileRef";
 
 describe("parseFileRef", () => {
   it("parses an absolute path with a line suffix", () => {
@@ -157,5 +157,36 @@ describe("resolveToRepoRelative", () => {
       relativePath: "src/app.ts",
       repoName: "web",
     });
+  });
+});
+
+describe("relativeDisplayPath", () => {
+  const single: FileRefSession = {
+    project_path: "/Users/me/.aoe/worktrees/feat",
+    main_repo_path: "/Users/me/repo",
+    workspace_repos: [],
+  };
+
+  it("strips the worktree root to a bare relative path", () => {
+    expect(relativeDisplayPath("/Users/me/.aoe/worktrees/feat/src/hooks/mod.rs", single)).toBe("src/hooks/mod.rs");
+  });
+
+  it("prefixes the repo name in a multi-repo workspace", () => {
+    const workspace: FileRefSession = {
+      project_path: "/Users/me/.aoe/worktrees/ws",
+      main_repo_path: null,
+      workspace_repos: [{ name: "api", source_path: "/Users/me/api" }],
+    };
+    expect(relativeDisplayPath("/Users/me/api/src/h.ts", workspace)).toBe("api/src/h.ts");
+  });
+
+  it("returns the raw absolute path when outside every known root", () => {
+    expect(relativeDisplayPath("/etc/hosts", single)).toBe("/etc/hosts");
+  });
+
+  it("returns the raw path when there is no session", () => {
+    expect(relativeDisplayPath("/Users/me/.aoe/worktrees/feat/src/app.ts", null)).toBe(
+      "/Users/me/.aoe/worktrees/feat/src/app.ts",
+    );
   });
 });

--- a/web/src/lib/fileRef.ts
+++ b/web/src/lib/fileRef.ts
@@ -160,3 +160,18 @@ export function resolveToRepoRelative(
 
   return null;
 }
+
+/**
+ * Display form of a tool-card file path: strip the session's repo root so
+ * an edit of `/Users/me/wt/src/hooks/mod.rs` shows `src/hooks/mod.rs`. In a
+ * multi-repo workspace the repo name is prefixed (`api/src/h.ts`) so paths
+ * from different repos stay unambiguous. Falls back to the raw path when
+ * there is no session or the path is outside every known root (e.g.
+ * `/etc/hosts`), so a path is never silently mangled. See #2143.
+ */
+export function relativeDisplayPath(raw: string, session: FileRefSession | null | undefined): string {
+  if (!session || !raw) return raw;
+  const resolved = resolveToRepoRelative(raw, session);
+  if (!resolved) return raw;
+  return resolved.repoName ? `${resolved.repoName}/${resolved.relativePath}` : resolved.relativePath;
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Structured-view tool cards showed the full absolute path for every file an agent touched, e.g. `/Users/Seluj78/aoe/.../src/hooks/mod.rs`. The worktree prefix is noise: it repeats on every card, leaks the local username and machine layout, and pushes the part that matters off the right edge on narrow panels.

The cards now render the path repo-relative. An edit of `/Users/me/wt/src/hooks/mod.rs` in a session whose worktree is `/Users/me/wt` shows `src/hooks/mod.rs`. In a multi-repo workspace the repo name is prefixed (`api/src/h.ts`) so paths from different repos stay unambiguous. A path outside every known repo root (for example `/etc/hosts`) falls back to the full absolute path, so nothing is ever silently mangled.

This reuses the existing `resolveToRepoRelative` resolver (added in #1718 for transcript markdown links) via a small `relativeDisplayPath` helper. The active session's repo roots reach the tool cards through `AcpFileRefContext`, the same injection vehicle already used for the file-open handler, because the cards mount under assistant-ui parts and cannot be prop-drilled.

Scope is the web dashboard. The native TUI structured view still renders absolute paths: its render path has no access to the session worktree root (it would need a new daemon fetch plus a `StructuredViewState` field), so that parity work is split into a follow-up issue rather than bundled here.

Closes #2143

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard and a structured-view session whose worktree is an absolute path (e.g. `/Users/you/wt`).
- [ ] Have the agent edit a file in the repo; confirm the edit card shows `src/...` (relative), not `/Users/you/wt/src/...`.
- [ ] Have the agent read and delete a file in the repo; confirm both cards show the relative path.
- [ ] In a multi-repo workspace, edit a file in a secondary repo; confirm the card shows `reponame/rest/of/path`.
- [ ] Have the agent touch a file outside the repo root (e.g. `/etc/hosts`); confirm the card still shows the full absolute path.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Note: path display is render-only logic, so per `AGENTS.md` (render permutations belong in Vitest + RTL, not Playwright) the regression tests are Vitest + RTL render tests in `web/src/components/acp/ToolCards.render.test.tsx` plus unit tests for the helper in `web/src/lib/__tests__/fileRef.test.ts`. The coverage matrix already maps `web/src/components/acp/ToolCards.tsx`, so no matrix entry was added.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (relative display, repo-name prefix in multi-repo, absolute fallback, web-only scope with a TUI follow-up), reviewed each commit, and verified the regression test goes red on the pre-fix tree.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784120558&installation_id=139138837&pr_number=2162&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2162&signature=bb3dbbf8b5e3af846d2917c282acf0d69df86b572596bd36b7d89f0eca8d58a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed
- Web structured-view “tool cards” now display file paths in a repo-relative form (e.g., `src/hooks/mod.rs`) instead of full absolute paths.
- In multi-repo workspaces, paths are prefixed with the relevant repo name (e.g., `api/src/h.ts`) to keep them clear and unambiguous.
- When a path can’t be mapped to a known session repo root, the UI safely falls back to the original absolute path (so it won’t “mangle” the display).
- The same relative-path display is applied consistently across card headers and multi-file diff per-file headers.
- Absolute paths are still available via tooltips (so you don’t lose the full information—just stop showing it by default).

## What Was Added / Moved
- Session repo-root info is now passed into structured-view rendering via `AcpFileRefContext` (through a new `fileRefSession` prop), enabling cards to format paths correctly.
- A new `relativeDisplayPath` helper converts raw paths into the correct UI-friendly display form (relative, repo-prefixed, or absolute fallback).
- Additional unit/render tests verify:
  - relative display for files inside the worktree,
  - repo-scoped prefixes for multi-repo scenarios,
  - absolute fallback for unknown-root files,
  - tooltip behavior for the raw absolute path.

## Benefits
- Better usability: shorter paths fit better in narrow layouts and reduce horizontal scrolling.
- Privacy: avoids leaking local machine/user directory details in visible card text.
- Clearer multi-repo workflows: repo-prefixed paths prevent confusion.
- Safer behavior: absolute fallback prevents incorrect path transformations.

## Further Enhancement
- Native TUI structured view still shows absolute paths; parity is intentionally deferred to a follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->