### PR TITLE
feat(web): show saved projects in new-session wizard Recent tab

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -19,7 +19,7 @@ Each sidebar row carries an animated braille glyph encoding the session's state:
 
 The **New session** wizard walks four steps:
 
-- **Project**: pick the working directory from recent and registered projects, or start a scratch session with no path. The Recent list keeps a project around after its last session is deleted, so you can quickly start there again; entries whose directory no longer exists are dropped.
+- **Project**: pick the working directory from the Recent tab, browse for one, clone a URL, or start a scratch session with no path. The Recent tab lists your saved projects under a "Saved projects" section above the directories of your recent sessions. The recent list keeps a project around after its last session is deleted, so you can quickly start there again; entries whose directory no longer exists are dropped.
 - **Session**: set the title (auto-slugifies into a worktree branch name unless you edit the branch), or attach an existing branch instead.
 - **Agent**: select the tool and profile, plus per-session knobs (auto-approve / YOLO mode, "Run in a safe container" sandbox, command override, extra args / env).
 - **Review**: confirm before the session spawns.

--- a/web/src/components/session-wizard/__tests__/ProjectStep.persisted-recents.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.persisted-recents.test.tsx
@@ -18,6 +18,7 @@ import type { RecentProjectEntry } from "../../../lib/api";
 vi.mock("../../../lib/api", () => ({
   fetchSessions: vi.fn(),
   fetchRecentProjects: vi.fn(),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   cloneRepo: vi.fn(),
 }));
 

--- a/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
@@ -1,0 +1,60 @@
+// Vitest coverage for `splitSavedAndRecent` (#2140). Saved projects are a
+// curated registry surfaced in the wizard's Recent tab alongside the
+// session-derived recents. A path present in both sources must render
+// once, in the Saved section, so the recent entry is dropped. Path
+// matching uses the same trailing-slash normalization as
+// `collectRecentProjects` (see ProjectStep.recents-normalize.test.tsx).
+
+import { describe, expect, it } from "vitest";
+
+import { splitSavedAndRecent } from "../steps/ProjectStep";
+import type { ProjectInfo } from "../../../lib/types";
+
+function savedProject(overrides: Partial<ProjectInfo> = {}): ProjectInfo {
+  return {
+    name: overrides.name ?? "alpha",
+    path: overrides.path ?? "/repo/alpha",
+    scope: overrides.scope ?? "global",
+    default_base_branch: overrides.default_base_branch,
+  };
+}
+
+function recentRow(path: string) {
+  return {
+    path,
+    displayName: path.split("/").filter(Boolean).pop() || path,
+    lastAccessedAt: null,
+    tool: "claude",
+    sessionCount: 1,
+  };
+}
+
+describe("splitSavedAndRecent (#2140)", () => {
+  it("drops a recent whose path is also a saved project, keeping it in Saved only", () => {
+    const out = splitSavedAndRecent([savedProject({ path: "/repo/alpha" })], [recentRow("/repo/alpha")]);
+
+    expect(out.saved).toHaveLength(1);
+    expect(out.recent).toHaveLength(0);
+  });
+
+  it("matches across a trailing-slash difference between the two sources", () => {
+    const out = splitSavedAndRecent([savedProject({ path: "/repo/alpha/" })], [recentRow("/repo/alpha")]);
+
+    expect(out.recent).toHaveLength(0);
+  });
+
+  it("keeps recents that are not saved projects", () => {
+    const out = splitSavedAndRecent([savedProject({ path: "/repo/alpha" })], [recentRow("/repo/beta")]);
+
+    expect(out.saved).toHaveLength(1);
+    expect(out.recent.map((r) => r.path)).toEqual(["/repo/beta"]);
+  });
+
+  it("returns saved projects untouched", () => {
+    const saved = [savedProject({ name: "a", path: "/a" }), savedProject({ name: "b", path: "/b", scope: "profile" })];
+    const out = splitSavedAndRecent(saved, []);
+
+    expect(out.saved).toEqual(saved);
+    expect(out.recent).toHaveLength(0);
+  });
+});

--- a/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
@@ -20,6 +20,9 @@ import type { ProjectInfo, SessionResponse } from "../../../lib/types";
 vi.mock("../../../lib/api", () => ({
   fetchSessions: vi.fn(),
   fetchProjects: vi.fn(),
+  // Persisted recent-projects store (#2141); these tests drive recents
+  // through fetchSessions, so default it to an empty store.
+  fetchRecentProjects: vi.fn().mockResolvedValue({ projects: [] }),
   cloneRepo: vi.fn(),
   // The Browse-fallback test mounts DirectoryBrowser, which probes the
   // filesystem on mount. Stub both so it renders without a network hit.

--- a/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
@@ -11,7 +11,7 @@
 // ProjectStep.recents-normalize.test.tsx (#1843).
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { ProjectStep, splitSavedAndRecent } from "../steps/ProjectStep";
 import { initialData } from "../wizardReducer";
@@ -21,6 +21,10 @@ vi.mock("../../../lib/api", () => ({
   fetchSessions: vi.fn(),
   fetchProjects: vi.fn(),
   cloneRepo: vi.fn(),
+  // The Browse-fallback test mounts DirectoryBrowser, which probes the
+  // filesystem on mount. Stub both so it renders without a network hit.
+  getHomePath: vi.fn().mockResolvedValue(null),
+  browseFilesystem: vi.fn().mockResolvedValue({ ok: false, entries: [] }),
 }));
 
 import { fetchSessions, fetchProjects } from "../../../lib/api";
@@ -178,5 +182,68 @@ describe("ProjectStep saved-projects render (#2140)", () => {
     const { findByText, queryByText } = renderStep("zeta");
     expect(await findByText("/repo/zeta")).toBeTruthy();
     expect(queryByText("/repo/alpha")).toBeNull();
+  });
+
+  it("selects a saved project's path when its row is clicked", async () => {
+    vi.mocked(fetchProjects).mockResolvedValue([savedProject({ name: "alpha", path: "/repo/alpha" })]);
+    vi.mocked(fetchSessions).mockResolvedValue({ sessions: [], workspace_ordering: [] });
+
+    const { onChange, findByText } = renderStep();
+    const row = (await findByText("/repo/alpha")).closest("button");
+    fireEvent.click(row!);
+    expect(onChange).toHaveBeenCalledWith("path", "/repo/alpha");
+  });
+
+  it("marks a saved row as selected when its path is already chosen", async () => {
+    vi.mocked(fetchProjects).mockResolvedValue([savedProject({ name: "alpha", path: "/repo/alpha" })]);
+    vi.mocked(fetchSessions).mockResolvedValue({ sessions: [], workspace_ordering: [] });
+
+    // data.path equal to the saved path exercises the selected-row styling.
+    // Scope to the row's <span> (the Selected-project panel also shows the
+    // path, but in a <p> outside any button).
+    const { findByText } = renderStep("/repo/alpha");
+    const row = (await findByText("/repo/alpha", { selector: "span" })).closest("button");
+    expect(row?.className).toContain("border-brand-600");
+  });
+
+  it("selects a recent project's path when its row is clicked", async () => {
+    vi.mocked(fetchProjects).mockResolvedValue([]);
+    vi.mocked(fetchSessions).mockResolvedValue({
+      sessions: [mockSession({ id: "s-beta", project_path: "/repo/beta" })],
+      workspace_ordering: [],
+    });
+
+    const { onChange, findByText } = renderStep();
+    const row = (await findByText("/repo/beta")).closest("button");
+    fireEvent.click(row!);
+    expect(onChange).toHaveBeenCalledWith("path", "/repo/beta");
+  });
+
+  it("highlights the already-selected row and pluralizes the session count", async () => {
+    vi.mocked(fetchProjects).mockResolvedValue([]);
+    // Two sessions at the same path collapse to one recent with count 2,
+    // exercising the plural-label branch and the selected-row styling.
+    vi.mocked(fetchSessions).mockResolvedValue({
+      sessions: [
+        mockSession({ id: "s1", project_path: "/repo/multi", last_accessed_at: "2025-09-01T00:00:00Z" }),
+        mockSession({ id: "s2", project_path: "/repo/multi", last_accessed_at: "2025-09-02T00:00:00Z" }),
+      ],
+      workspace_ordering: [],
+    });
+
+    const { findByText } = renderStep("/repo/multi");
+    expect(await findByText("/repo/multi")).toBeTruthy();
+    expect(await findByText(/2 sessions/)).toBeTruthy();
+  });
+
+  it("falls back to the Browse tab when there are neither saved projects nor recents", async () => {
+    vi.mocked(fetchProjects).mockResolvedValue([]);
+    // Null envelope (request failed) exercises the empty-recents fallback.
+    vi.mocked(fetchSessions).mockResolvedValue(null);
+
+    const { findByRole, queryByText } = renderStep();
+    // Browse tab is active; no Recent tab button exists with nothing to pick.
+    expect(await findByRole("button", { name: "Browse" })).toBeTruthy();
+    expect(queryByText("Recent", asHeader)).toBeNull();
   });
 });

--- a/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
@@ -1,14 +1,34 @@
-// Vitest coverage for `splitSavedAndRecent` (#2140). Saved projects are a
-// curated registry surfaced in the wizard's Recent tab alongside the
-// session-derived recents. A path present in both sources must render
-// once, in the Saved section, so the recent entry is dropped. Path
-// matching uses the same trailing-slash normalization as
-// `collectRecentProjects` (see ProjectStep.recents-normalize.test.tsx).
+// @vitest-environment jsdom
+//
+// Vitest coverage for saved projects in the wizard Recent tab (#2140).
+// Saved projects are a curated registry surfaced alongside the
+// session-derived recents. A path present in both sources renders once,
+// in the Saved section. The pure-function tests pin the dedup
+// (`splitSavedAndRecent`); the render tests pin the two-section layout,
+// the section headers, and the path-filter narrowing.
+//
+// Sits next to ProjectStep.workspace.test.tsx (#1645) and
+// ProjectStep.recents-normalize.test.tsx (#1843).
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
 
-import { splitSavedAndRecent } from "../steps/ProjectStep";
-import type { ProjectInfo } from "../../../lib/types";
+import { ProjectStep, splitSavedAndRecent } from "../steps/ProjectStep";
+import { initialData } from "../wizardReducer";
+import type { ProjectInfo, SessionResponse } from "../../../lib/types";
+
+vi.mock("../../../lib/api", () => ({
+  fetchSessions: vi.fn(),
+  fetchProjects: vi.fn(),
+  cloneRepo: vi.fn(),
+}));
+
+import { fetchSessions, fetchProjects } from "../../../lib/api";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 function savedProject(overrides: Partial<ProjectInfo> = {}): ProjectInfo {
   return {
@@ -27,6 +47,46 @@ function recentRow(path: string) {
     tool: "claude",
     sessionCount: 1,
   };
+}
+
+function mockSession(overrides: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: overrides.id ?? "s1",
+    title: "session",
+    project_path: overrides.project_path ?? "/repo/beta",
+    group_path: "/repo/beta",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: overrides.last_accessed_at ?? "2025-09-01T00:00:00Z",
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: overrides.main_repo_path ?? null,
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: { delete_worktree: false, delete_branch: false, delete_sandbox: false },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+    scratch: false,
+    ...overrides,
+  } as SessionResponse;
+}
+
+function renderStep(path = "") {
+  const onChange = vi.fn();
+  const utils = render(
+    <ProjectStep data={{ ...initialData, path, extraRepoPaths: [], scratch: false }} onChange={onChange} />,
+  );
+  return { onChange, ...utils };
 }
 
 describe("splitSavedAndRecent (#2140)", () => {
@@ -56,5 +116,67 @@ describe("splitSavedAndRecent (#2140)", () => {
 
     expect(out.saved).toEqual(saved);
     expect(out.recent).toHaveLength(0);
+  });
+});
+
+describe("ProjectStep saved-projects render (#2140)", () => {
+  // The Recent *tab* button always carries the text "Recent"; the Recent
+  // *section* header is a styled <p>. Scope header assertions to <p> so
+  // they don't collide with the tab button.
+  const asHeader = { selector: "p" } as const;
+
+  it("renders both a Saved projects section and a Recent section header", async () => {
+    vi.mocked(fetchProjects).mockResolvedValue([savedProject({ name: "alpha", path: "/repo/alpha" })]);
+    vi.mocked(fetchSessions).mockResolvedValue({
+      sessions: [mockSession({ id: "s-beta", project_path: "/repo/beta" })],
+      workspace_ordering: [],
+    });
+
+    const { findByText } = renderStep();
+    expect(await findByText("Saved projects", asHeader)).toBeTruthy();
+    expect(await findByText("Recent", asHeader)).toBeTruthy();
+    // Saved project path and the recent session path both render.
+    expect(await findByText("/repo/alpha")).toBeTruthy();
+    expect(await findByText("/repo/beta")).toBeTruthy();
+  });
+
+  it("renders the Saved projects section but no Recent section header when there are no recents", async () => {
+    vi.mocked(fetchProjects).mockResolvedValue([savedProject({ name: "solo", path: "/repo/solo" })]);
+    vi.mocked(fetchSessions).mockResolvedValue({ sessions: [], workspace_ordering: [] });
+
+    const { findByText, queryByText } = renderStep();
+    expect(await findByText("Saved projects", asHeader)).toBeTruthy();
+    expect(await findByText("/repo/solo")).toBeTruthy();
+    // No recents, so the Recent section header is suppressed (the tab
+    // button labeled "Recent" is a <button>, not the <p> header).
+    expect(queryByText("Recent", asHeader)).toBeNull();
+  });
+
+  it("renders a path shared by saved and recent only once (in the Saved section)", async () => {
+    vi.mocked(fetchProjects).mockResolvedValue([savedProject({ name: "dup", path: "/repo/dup" })]);
+    vi.mocked(fetchSessions).mockResolvedValue({
+      sessions: [mockSession({ id: "s-dup", project_path: "/repo/dup" })],
+      workspace_ordering: [],
+    });
+
+    const { findByText, findAllByText, queryByText } = renderStep();
+    await findByText("Saved projects", asHeader);
+    // The shared path appears once (the saved row); the recent section,
+    // now empty after dedup, renders no header and no duplicate row.
+    expect((await findAllByText("/repo/dup")).length).toBe(1);
+    expect(queryByText("Recent", asHeader)).toBeNull();
+  });
+
+  it("narrows the Saved projects section to entries matching the path filter", async () => {
+    vi.mocked(fetchProjects).mockResolvedValue([
+      savedProject({ name: "alpha", path: "/repo/alpha" }),
+      savedProject({ name: "zeta", path: "/repo/zeta" }),
+    ]);
+    vi.mocked(fetchSessions).mockResolvedValue({ sessions: [], workspace_ordering: [] });
+
+    // data.path acts as the filter query against both sections.
+    const { findByText, queryByText } = renderStep("zeta");
+    expect(await findByText("/repo/zeta")).toBeTruthy();
+    expect(queryByText("/repo/alpha")).toBeNull();
   });
 });

--- a/web/src/components/session-wizard/__tests__/ProjectStep.scratch.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.scratch.test.tsx
@@ -22,6 +22,7 @@ import type { SessionResponse } from "../../../lib/types";
 vi.mock("../../../lib/api", () => ({
   fetchSessions: vi.fn(),
   fetchRecentProjects: vi.fn(),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   cloneRepo: vi.fn(),
   // The Browse tab mounts DirectoryBrowser, which probes the filesystem on
   // mount (getHomePath -> browseFilesystem). Stub both so the tab renders

--- a/web/src/components/session-wizard/__tests__/ProjectStep.workspace.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.workspace.test.tsx
@@ -20,6 +20,7 @@ import type { SessionResponse, WorkspaceRepoSummary } from "../../../lib/types";
 vi.mock("../../../lib/api", () => ({
   fetchSessions: vi.fn(),
   fetchRecentProjects: vi.fn(),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   cloneRepo: vi.fn(),
 }));
 

--- a/web/src/components/session-wizard/steps/ProjectStep.tsx
+++ b/web/src/components/session-wizard/steps/ProjectStep.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useEffect, useMemo, useState } from "react";
-import { fetchSessions, fetchRecentProjects, cloneRepo } from "../../../lib/api";
+import { fetchSessions, fetchRecentProjects, fetchProjects, cloneRepo } from "../../../lib/api";
 import type { RecentProjectEntry } from "../../../lib/api";
-import type { SessionResponse } from "../../../lib/types";
+import type { ProjectInfo, SessionResponse } from "../../../lib/types";
 import { DirectoryBrowser } from "../../DirectoryBrowser";
 import { ExtraReposPicker } from "./ExtraReposPicker";
 
@@ -128,6 +128,21 @@ export function mergeRecentProjects(sessionDerived: RecentProject[], persisted: 
   return Array.from(byPath.values()).sort((a, b) => (b.lastAccessedAt ?? "").localeCompare(a.lastAccessedAt ?? ""));
 }
 
+/** Saved projects are a curated registry (#2140); recents are derived from
+ *  live sessions and the persisted recent-projects store. A path can be in
+ *  both. Drop it from recents so it renders once, in the Saved section.
+ *  Path keys are normalized the same way the recents are (trailing slashes
+ *  trimmed, root kept as "/") so `/foo/bar` and `/foo/bar/` match across the
+ *  two sources. */
+export function splitSavedAndRecent(
+  saved: ProjectInfo[],
+  recent: RecentProject[],
+): { saved: ProjectInfo[]; recent: RecentProject[] } {
+  const norm = (p: string) => p.replace(/\/+$/, "") || "/";
+  const savedPaths = new Set(saved.map((s) => norm(s.path)));
+  return { saved, recent: recent.filter((r) => !savedPaths.has(norm(r.path))) };
+}
+
 function timeAgo(ts: string | null): string {
   if (!ts) return "";
   const diff = Date.now() - new Date(ts).getTime();
@@ -142,6 +157,7 @@ function timeAgo(ts: string | null): string {
 
 export function ProjectStep({ data, onChange, initialTab }: Props) {
   const [recent, setRecent] = useState<RecentProject[]>([]);
+  const [saved, setSaved] = useState<ProjectInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<Tab>(initialTab ?? "recent");
 
@@ -155,17 +171,22 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   useEffect(() => {
-    Promise.all([fetchSessions(), fetchRecentProjects()]).then(([envelope, recentEnvelope]) => {
-      if (envelope) {
-        const sessionDerived = collectRecentProjects(envelope.sessions);
-        const projects = mergeRecentProjects(sessionDerived, recentEnvelope?.projects ?? []).slice(0, 6);
-        setRecent(projects);
-        if (projects.length === 0 && !initialTab) {
+    Promise.all([fetchSessions(), fetchRecentProjects(), fetchProjects()]).then(
+      ([envelope, recentEnvelope, savedProjects]) => {
+        const sessionDerived = envelope ? collectRecentProjects(envelope.sessions) : [];
+        const merged = mergeRecentProjects(sessionDerived, recentEnvelope?.projects ?? []).slice(0, 6);
+        const split = splitSavedAndRecent(savedProjects, merged);
+        setSaved(split.saved);
+        setRecent(split.recent);
+        // Default to Browse only when there is nothing to pick from either
+        // source; a user with saved projects but no recents should still
+        // land on the Recent tab.
+        if (split.saved.length === 0 && split.recent.length === 0 && !initialTab) {
           setActiveTab("browse");
         }
-      }
-      setLoading(false);
-    });
+        setLoading(false);
+      },
+    );
   }, [initialTab]);
 
   const filteredRecent = useMemo(() => {
@@ -174,7 +195,13 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
     return recent.filter((r) => r.path.toLowerCase().includes(q) || r.displayName.toLowerCase().includes(q));
   }, [recent, data.path]);
 
-  const hasRecents = recent.length > 0;
+  const filteredSaved = useMemo(() => {
+    if (!data.path) return saved;
+    const q = data.path.toLowerCase();
+    return saved.filter((s) => s.path.toLowerCase().includes(q) || s.name.toLowerCase().includes(q));
+  }, [saved, data.path]);
+
+  const hasPicks = recent.length > 0 || saved.length > 0;
 
   const handleBrowseSelect = (path: string) => {
     onChange("path", path);
@@ -204,7 +231,7 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
   };
 
   const tabs: { id: Tab; label: string }[] = [
-    ...(hasRecents ? [{ id: "recent" as Tab, label: "Recent" }] : []),
+    ...(hasPicks ? [{ id: "recent" as Tab, label: "Recent" }] : []),
     { id: "browse", label: "Browse" },
     { id: "clone", label: "Clone URL" },
   ];
@@ -278,37 +305,73 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
             </div>
           )}
 
-          {/* Recent projects tab */}
-          {!loading && activeTab === "recent" && hasRecents && (
-            <div className="flex flex-col gap-1.5">
-              {filteredRecent.map((r) => (
-                <button
-                  key={r.path}
-                  type="button"
-                  onClick={() => onChange("path", r.path)}
-                  className={`flex items-center gap-3 px-3 py-2.5 rounded-md border transition-colors text-left cursor-pointer ${
-                    data.path === r.path
-                      ? "border-brand-600 bg-surface-900"
-                      : "border-surface-700/40 bg-surface-900 hover:border-surface-700 hover:bg-surface-850"
-                  }`}
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-text-primary truncate">{r.displayName}</span>
-                      <span className="text-[10px] font-mono text-text-dim shrink-0">{r.tool}</span>
-                    </div>
-                    <div className="flex items-center gap-2 mt-0.5">
-                      <span className="font-mono text-[11px] text-text-dim truncate">{r.path}</span>
-                    </div>
-                  </div>
-                  <div className="flex flex-col items-end shrink-0 gap-0.5">
-                    <span className="text-[10px] text-text-dim">{timeAgo(r.lastAccessedAt)}</span>
-                    <span className="text-[10px] text-text-dim">
-                      {r.sessionCount} session{r.sessionCount !== 1 ? "s" : ""}
-                    </span>
-                  </div>
-                </button>
-              ))}
+          {/* Recent projects tab: saved (curated registry) on top, then
+              session-derived and persisted recents below. */}
+          {!loading && activeTab === "recent" && hasPicks && (
+            <div className="flex flex-col gap-4">
+              {filteredSaved.length > 0 && (
+                <div className="flex flex-col gap-1.5">
+                  <p className="text-[10px] font-mono uppercase tracking-wider text-text-dim">Saved projects</p>
+                  {filteredSaved.map((s) => (
+                    <button
+                      key={`saved:${s.scope}:${s.path}`}
+                      type="button"
+                      onClick={() => onChange("path", s.path)}
+                      className={`flex items-center gap-3 px-3 py-2.5 rounded-md border transition-colors text-left cursor-pointer ${
+                        data.path === s.path
+                          ? "border-brand-600 bg-surface-900"
+                          : "border-surface-700/40 bg-surface-900 hover:border-surface-700 hover:bg-surface-850"
+                      }`}
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-text-primary truncate">{s.name}</span>
+                          <span className="text-[10px] font-mono text-text-dim shrink-0">{s.scope}</span>
+                        </div>
+                        <div className="flex items-center gap-2 mt-0.5">
+                          <span className="font-mono text-[11px] text-text-dim truncate">{s.path}</span>
+                        </div>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {filteredRecent.length > 0 && (
+                <div className="flex flex-col gap-1.5">
+                  {filteredSaved.length > 0 && (
+                    <p className="text-[10px] font-mono uppercase tracking-wider text-text-dim">Recent</p>
+                  )}
+                  {filteredRecent.map((r) => (
+                    <button
+                      key={r.path}
+                      type="button"
+                      onClick={() => onChange("path", r.path)}
+                      className={`flex items-center gap-3 px-3 py-2.5 rounded-md border transition-colors text-left cursor-pointer ${
+                        data.path === r.path
+                          ? "border-brand-600 bg-surface-900"
+                          : "border-surface-700/40 bg-surface-900 hover:border-surface-700 hover:bg-surface-850"
+                      }`}
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-text-primary truncate">{r.displayName}</span>
+                          <span className="text-[10px] font-mono text-text-dim shrink-0">{r.tool}</span>
+                        </div>
+                        <div className="flex items-center gap-2 mt-0.5">
+                          <span className="font-mono text-[11px] text-text-dim truncate">{r.path}</span>
+                        </div>
+                      </div>
+                      <div className="flex flex-col items-end shrink-0 gap-0.5">
+                        <span className="text-[10px] text-text-dim">{timeAgo(r.lastAccessedAt)}</span>
+                        <span className="text-[10px] text-text-dim">
+                          {r.sessionCount} session{r.sessionCount !== 1 ? "s" : ""}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
           )}
 

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2121,6 +2121,13 @@
       "components": ["web/src/components/session-wizard/steps/ProjectStep.tsx"]
     },
     {
+      "id": "story.wizard-saved-projects",
+      "kind": "mocked-playwright",
+      "risk": "low",
+      "specs": ["tests/wizard-project-step.spec.ts"],
+      "components": ["web/src/components/session-wizard/steps/ProjectStep.tsx"]
+    },
+    {
       "id": "story.wizard-browse-disk",
       "kind": "mocked-playwright",
       "risk": "low",

--- a/web/tests/wizard-project-step.spec.ts
+++ b/web/tests/wizard-project-step.spec.ts
@@ -9,6 +9,7 @@ import { Page } from "@playwright/test";
 
 async function mockBaseApis(page: Page) {
   await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  await page.route("**/api/projects", (r) => r.fulfill({ json: [] }));
   for (const path of ["settings", "themes", "profiles", "groups", "devices", "about", "system/update-status"]) {
     await page.route(`**/api/${path}`, (r) =>
       r.fulfill({
@@ -91,6 +92,30 @@ test.describe("Wizard project step (#1219)", () => {
     await expect(page.getByRole("button", { name: "Recent" })).toHaveCount(0);
     // Browse tab is active: directory-browser breadcrumb root (`~`) renders.
     await expect(page.getByTitle("Go to home")).toBeVisible();
+  });
+
+  test("saved projects show under the Recent tab even with no sessions (#2140)", async ({ page }) => {
+    await mockBaseApis(page);
+    await page.route("**/api/sessions", (r) => r.fulfill({ json: { sessions: [], workspace_ordering: [] } }));
+    // Saved registry has one project; no live sessions exist.
+    await page.route("**/api/projects", (r) =>
+      r.fulfill({ json: [{ name: "my-saved-repo", path: "/srv/my-saved-repo", scope: "global" }] }),
+    );
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openWizard(page);
+    // Recent tab is present and active despite zero sessions, because a
+    // saved project exists.
+    await expect(page.getByRole("button", { name: "Recent", exact: true })).toBeVisible();
+    await expect(page.getByText("Saved projects")).toBeVisible();
+    const savedRow = page.getByRole("button").filter({ hasText: "/srv/my-saved-repo" }).first();
+    await expect(savedRow).toBeVisible();
+    // Selecting the saved project populates the wizard path.
+    await savedRow.click();
+    await expect(page.getByText("Selected project")).toBeVisible();
+    // Scope to the selected-project panel's paragraph; the saved row also
+    // renders the same path (in a span), so an unscoped match is ambiguous.
+    await expect(page.getByRole("paragraph").filter({ hasText: "/srv/my-saved-repo" })).toBeVisible();
   });
 
   test("switching to Browse tab renders DirectoryBrowser and selecting a repo populates path", async ({ page }) => {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The new-session wizard's Recent tab only listed project folders derived from live sessions. The saved-project registry (the named repos curated via `aoe project add` or the web Projects page) never appeared there, so a saved project with no active session was unreachable from the wizard's default tab; the user had to fall back to Browse and re-navigate to a path they had already bookmarked.

`ProjectStep` now fetches the project registry (`fetchProjects()`) alongside the session list and renders it in a "Saved projects" section above the session-derived recents, inside the same Recent tab. A path present in both sources is deduped so it shows once (in the Saved section), reusing the same trailing-slash normalization the recents already apply. The tab-visibility and default-tab logic widen so a user with saved projects but no sessions still lands on the Recent tab instead of being bounced to Browse.

Closes #2140

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard with at least one saved project (add one via the Projects page or `aoe project add`) and no recent sessions; open New session and confirm the Recent tab is shown by default with the saved project under a "Saved projects" section.
- [ ] With both a saved project and a recent session at the same path, open the wizard and confirm the path appears once, under Saved projects, not duplicated in Recent.
- [ ] Click a saved project row and confirm it populates the Selected project path and proceeds through the wizard.
- [ ] With saved projects plus distinct recent sessions, confirm both the Saved projects and Recent sections render with their own headers.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. I made the design calls (two-section layout, dedup behavior), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784121610&installation_id=139138837&pr_number=2166&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2166&signature=91c108b92fd05e129c751d548c5d2e46065b5c01dbdaa0fd68881935a76c3420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

The new-session wizard’s **Project** step “**Recent**” tab now includes **saved projects** in addition to entries derived from **active sessions**. Previously, only live-session folders appeared there, so saved projects could be unreachable from the wizard unless a session existed.

## What Was Added / Updated

- **`ProjectStep.tsx`**
  - Fetches the saved **project registry** (`fetchProjects`) alongside session/recent data.
  - Splits results into two labeled areas within the same tab:
    - **Saved projects** (top)
    - Existing **Recent** entries (below)
  - **Deduplicates** overlapping paths across saved vs recent using the existing trailing-slash normalization.
  - Applies the **path search filter** to **both** sections.
  - Updates **Recent tab visibility/default tab logic** so users with saved projects but **no active sessions** still land on **Recent** (not Browse).
- **Tests**
  - Added comprehensive unit/render tests for saved-vs-recent splitting, deduplication, section rendering, and filtering.
  - Added coverage for selection behavior from either section.
  - Added Playwright coverage for the “**no live sessions, but saved projects exist**” flow.
  - Extended test mocks to include `fetchProjects`.
  - Updated coverage configuration to include the new story.
- **Docs**
  - Updated the dashboard guide to explain the new **Recent tab structure** (saved projects presented above session-derived recents).

## Benefits

- **Saved projects are discoverable by default** in the wizard, even when no sessions are running.
- **Cleaner UX** by avoiding duplicate path entries across saved and recent sources.
- **Consistent search/filtering** across both saved projects and session-derived recents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->