### PR TITLE
feat(web): dedicated tool cards for ToolSearch, Monitor, TaskStop

### DIFF
--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -114,7 +114,7 @@ content preview; a delete shows the target path. The diff is capped at
 20 changed lines and previews at 12 lines, with a "+N more" footer when
 there is more; press `o` to open the web dashboard for the full diff and
 output. A single patch touching several files shows each file's path and
-diff in one card. Claude's harness tools render as dedicated cards too:
+diff in one card. In the web dashboard, Claude's harness tools render as dedicated cards too:
 a tool search shows its query, a background monitor shows its description
 and command, and a task stop shows the stopped task id. Other tool kinds
 fall back to a generic one-liner (name, arguments, output).

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -114,8 +114,10 @@ content preview; a delete shows the target path. The diff is capped at
 20 changed lines and previews at 12 lines, with a "+N more" footer when
 there is more; press `o` to open the web dashboard for the full diff and
 output. A single patch touching several files shows each file's path and
-diff in one card. Other tool kinds fall back to a generic one-liner
-(name, arguments, output).
+diff in one card. Claude's harness tools render as dedicated cards too:
+a tool search shows its query, a background monitor shows its description
+and command, and a task stop shows the stopped task id. Other tool kinds
+fall back to a generic one-liner (name, arguments, output).
 
 **Structured completion payloads.** When a tool returns images, audio,
 or resources, they render inline on the card (a textual placeholder in

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -232,6 +232,52 @@ describe("ToolCards profile-gated dispatch (claude)", () => {
     );
     expect(container.textContent).toContain("checking deploy");
   });
+
+  it("routes ToolSearch to the harness card under the claude profile", () => {
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={fixtures.toolSearch} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("tool search");
+    expect(container.textContent).toContain("select:Read,Edit");
+  });
+
+  it("routes Monitor to the harness card under the claude profile", () => {
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={fixtures.monitor} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("monitor");
+    expect(container.textContent).toContain("errors in deploy.log");
+    expect(container.textContent).toContain("persistent");
+  });
+
+  it("routes TaskStop to the harness card under the claude profile", () => {
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={fixtures.taskStop} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("task stop");
+    expect(container.textContent).toContain("task-abc123");
+  });
+});
+
+describe("ToolCards harness-tool gating (non-claude)", () => {
+  it("does not fire the harness card for a coincidental Monitor name under codex", () => {
+    const { container } = render(
+      <Wrap toolKey="codex">
+        <ToolCard tool={fixtures.monitor} result={undefined} />
+      </Wrap>,
+    );
+    // Generic fallback: header shows the raw name + "other" kind, and the
+    // collapsed body keeps the description (`errors in deploy.log`) out of
+    // the DOM. The harness card would have surfaced it in the header.
+    expect(container.textContent).toContain("Monitor");
+    expect(container.textContent).not.toContain("errors in deploy.log");
+  });
 });
 
 describe("ToolCards profile-gated dispatch (opencode)", () => {

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -280,6 +280,53 @@ describe("ToolCards harness-tool gating (non-claude)", () => {
   });
 });
 
+describe("ToolCards harness-tool details", () => {
+  it("shows a timeout chip and the expanded body for a non-persistent Monitor", () => {
+    const tool = makeToolCall({
+      id: "monitor-timeout",
+      name: "Monitor",
+      kind: "other",
+      args_preview: JSON.stringify({
+        description: "watch the build",
+        command: "npm run build",
+        timeout_ms: 90000,
+      }),
+    });
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <ToolCard
+          tool={tool}
+          result={makeCompletion({ id: "m-done", toolCallId: "monitor-timeout", text: "build ok" })}
+        />
+      </Wrap>,
+    );
+    // timeout_ms 90000 -> formatted as "1m 30s" in the header chip.
+    expect(container.textContent).toContain("1m 30s");
+    fireEvent.click(container.querySelector("button")!);
+    expect(container.textContent).toContain("npm run build");
+    expect(container.textContent).toContain("build ok");
+  });
+
+  it("falls back to default primaries when harness args are empty", () => {
+    for (const [name, expected] of [
+      ["ToolSearch", "search tools"],
+      ["Monitor", "background watch"],
+      ["TaskStop", "stop task"],
+    ] as const) {
+      const { container } = render(
+        <Wrap toolKey="claude">
+          <ToolCard
+            tool={makeToolCall({ id: `empty-${name}`, name, kind: "other", args_preview: "{}" })}
+            result={undefined}
+          />
+        </Wrap>,
+      );
+      expect(container.textContent).toContain(expected);
+      cleanup();
+    }
+  });
+});
+
 describe("ToolCards profile-gated dispatch (opencode)", () => {
   it("routes OpenCode todowrite payloads to the todos card", () => {
     const { container } = render(

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -18,6 +18,7 @@ import {
   type SetStateAction,
 } from "react";
 import {
+  Activity,
   Brain,
   Calendar,
   CalendarPlus,
@@ -37,6 +38,7 @@ import {
   Plug,
   Search,
   Sparkles,
+  Square,
   Terminal,
   Trash2,
 } from "lucide-react";
@@ -274,6 +276,10 @@ function renderToolCard(tool: ToolCall, result: ActivityRow | undefined, profile
     if (schedule.kind) {
       return <ScheduleToolCard tool={tool} result={result} kind={schedule.kind} />;
     }
+  }
+  const harness = classifyHarnessTool(tool, profile);
+  if (harness.kind) {
+    return <HarnessToolCard tool={tool} result={result} kind={harness.kind} />;
   }
   const { kind, provenance } = reclassifyBash(tool);
   const effectiveKind = resolveEffectiveKind(tool, kind, profile);
@@ -1910,6 +1916,143 @@ function ScheduleToolCard({ tool, result, kind }: ScheduleProps) {
     icon = <CalendarX className="h-3.5 w-3.5" />;
     label = "cron schedule deleted";
     primary = id ? <span className="font-mono">{id}</span> : "deleted";
+  }
+
+  const hasBody = hasRawInput || Boolean(output) || status === "err";
+
+  return (
+    <CardChrome
+      status={status}
+      icon={icon}
+      label={label}
+      primary={primary}
+      meta={meta}
+      expanded={open}
+      onToggle={status === "err" || hasBody ? () => setOpen((v) => !v) : undefined}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
+      body={
+        <ToolErrorBody status={status} errorText={result?.text}>
+          {hasRawInput && (
+            <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
+              <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-wider text-text-dim">
+                <span>input</span>
+                <CopyButton text={inputJson} />
+              </div>
+              <pre className="overflow-x-auto font-mono text-[11px] text-text-muted whitespace-pre-wrap break-all">
+                {inputJson}
+              </pre>
+            </div>
+          )}
+          {output && status !== "err" && (
+            <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
+              <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-wider text-text-dim">
+                <span>output</span>
+                <CopyButton text={output} />
+              </div>
+              <pre className="overflow-x-auto font-mono text-[11px] text-text-secondary whitespace-pre-wrap break-all">
+                {output}
+              </pre>
+            </div>
+          )}
+        </ToolErrorBody>
+      }
+    />
+  );
+}
+
+/* ── harness tools (ToolSearch / Monitor / TaskStop) ─────────────── */
+
+/** Classify Claude's agent-runtime harness tools by their well-known
+ *  names. Like the schedule family, claude-agent-acp routes them through
+ *  the generic `Other` arm with no structured kind, so we name-match
+ *  against the profile's `harnessNames` allowlist (empty for non-Claude
+ *  agents, so a coincidental `Monitor` tool elsewhere stays generic).
+ *  See #2139.
+ *
+ *  - `"tool_search"`: ToolSearch ({ query, max_results })
+ *  - `"monitor"`: Monitor ({ description, command, timeout_ms, persistent })
+ *  - `"task_stop"`: TaskStop ({ task_id })
+ */
+function classifyHarnessTool(
+  tool: ToolCall,
+  profile: AgentProfile,
+): { kind: "tool_search" | "monitor" | "task_stop" | null } {
+  if (tool.kind !== "other") return { kind: null };
+  const args = parseJsonObject(tool.args_preview);
+  const title = (pickStr(args, "_aoe_title") ?? tool.name ?? "").trim();
+  if (!profile.specialTitles.harnessNames.includes(title)) return { kind: null };
+  switch (title) {
+    case "ToolSearch":
+      return { kind: "tool_search" };
+    case "Monitor":
+      return { kind: "monitor" };
+    case "TaskStop":
+      return { kind: "task_stop" };
+    default:
+      return { kind: null };
+  }
+}
+
+interface HarnessProps extends Props {
+  kind: "tool_search" | "monitor" | "task_stop";
+}
+
+function HarnessToolCard({ tool, result, kind }: HarnessProps) {
+  const status = statusFor(result);
+  const [open, setOpen] = useToolCardExpansion(status);
+  const args = useMemo(() => parseJsonObject(tool.args_preview), [tool.args_preview]);
+  const output = result?.text ?? "";
+
+  const inputJson = useMemo<string>(() => {
+    if (!args) return tool.args_preview;
+    const rest: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(args)) {
+      if (isAcpBookkeepingKey(k)) continue;
+      rest[k] = v;
+    }
+    return JSON.stringify(rest, null, 2);
+  }, [args, tool.args_preview]);
+
+  const hasRawInput = useMemo(() => {
+    if (!args) return Boolean(tool.args_preview);
+    return Object.keys(args).some((k) => !isAcpBookkeepingKey(k));
+  }, [args, tool.args_preview]);
+
+  let icon: React.ReactNode;
+  let label: string;
+  let primary: React.ReactNode;
+  let meta: React.ReactNode = undefined;
+
+  if (kind === "tool_search") {
+    const query = pickStr(args, "query");
+    icon = <Search className="h-3.5 w-3.5" />;
+    label = "tool search";
+    primary = query ? <span className="font-mono">{query}</span> : "search tools";
+  } else if (kind === "monitor") {
+    const description = pickStr(args, "description");
+    const persistentRaw = args ? args["persistent"] : undefined;
+    const timeoutRaw = args ? args["timeout_ms"] : undefined;
+    const timeoutMs =
+      typeof timeoutRaw === "number" ? timeoutRaw : typeof timeoutRaw === "string" ? Number(timeoutRaw) : NaN;
+    icon = <Activity className="h-3.5 w-3.5" />;
+    label = "monitor";
+    primary = description ? <span>{description}</span> : "background watch";
+    const chip =
+      persistentRaw === true
+        ? "persistent"
+        : Number.isFinite(timeoutMs)
+          ? formatDurationSeconds(timeoutMs / 1000)
+          : null;
+    if (chip) {
+      meta = <span className="hidden md:inline text-[11px] text-text-dim tabular-nums">{chip}</span>;
+    }
+  } else {
+    // task_stop
+    const taskId = pickStr(args, "task_id", "shell_id");
+    icon = <Square className="h-3.5 w-3.5" />;
+    label = "task stop";
+    primary = taskId ? <span className="font-mono">{taskId}</span> : "stop task";
   }
 
   const hasBody = hasRawInput || Boolean(output) || status === "err";

--- a/web/src/components/acp/__fixtures__/toolCalls.ts
+++ b/web/src/components/acp/__fixtures__/toolCalls.ts
@@ -155,6 +155,28 @@ export const fixtures = {
       reason: "checking deploy",
     }),
   }),
+  toolSearch: makeToolCall({
+    id: "toolsearch-1",
+    name: "ToolSearch",
+    kind: "other",
+    args_preview: JSON.stringify({ query: "select:Read,Edit", max_results: 5 }),
+  }),
+  monitor: makeToolCall({
+    id: "monitor-1",
+    name: "Monitor",
+    kind: "other",
+    args_preview: JSON.stringify({
+      description: "errors in deploy.log",
+      command: "tail -f deploy.log",
+      persistent: true,
+    }),
+  }),
+  taskStop: makeToolCall({
+    id: "taskstop-1",
+    name: "TaskStop",
+    kind: "other",
+    args_preview: JSON.stringify({ task_id: "task-abc123" }),
+  }),
   mcp: makeToolCall({
     id: "mcp-1",
     name: "mcp__slack__send_message",

--- a/web/src/lib/agentProfiles.ts
+++ b/web/src/lib/agentProfiles.ts
@@ -70,6 +70,9 @@ export interface AgentProfile {
     skillNames: string[];
     /** Exact title values matched for the Schedule cards. */
     scheduleNames: string[];
+    /** Exact title values matched for the harness-tool cards
+     *  (ToolSearch / Monitor / TaskStop). See #2139. */
+    harnessNames: string[];
   };
 }
 
@@ -89,6 +92,7 @@ const CLAUDE: AgentProfile = {
   specialTitles: {
     skillNames: ["skill", "claude-skill"],
     scheduleNames: ["ScheduleWakeup", "CronCreate", "CronList", "CronDelete"],
+    harnessNames: ["ToolSearch", "Monitor", "TaskStop"],
   },
 };
 
@@ -114,7 +118,7 @@ const CODEX: AgentProfile = {
     edit: ["apply_patch"],
     read: ["view_file", "read_file", "read"],
   },
-  specialTitles: { skillNames: [], scheduleNames: [] },
+  specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
 const OPENCODE: AgentProfile = {
@@ -137,7 +141,7 @@ const OPENCODE: AgentProfile = {
     fetch: ["webfetch"],
     think: ["task"],
   },
-  specialTitles: { skillNames: [], scheduleNames: [] },
+  specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
 const GEMINI: AgentProfile = {
@@ -159,7 +163,7 @@ const GEMINI: AgentProfile = {
     search: ["grep", "glob"],
     fetch: ["web_fetch"],
   },
-  specialTitles: { skillNames: [], scheduleNames: [] },
+  specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
 const VIBE: AgentProfile = {
@@ -175,7 +179,7 @@ const VIBE: AgentProfile = {
   mcpPrefixes: ["mcp__"],
   clearAliases: [],
   aliases: {},
-  specialTitles: { skillNames: [], scheduleNames: [] },
+  specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
 const PI: AgentProfile = {
@@ -191,7 +195,7 @@ const PI: AgentProfile = {
   mcpPrefixes: ["mcp__"],
   clearAliases: [],
   aliases: {},
-  specialTitles: { skillNames: [], scheduleNames: [] },
+  specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
 const AOE_AGENT: AgentProfile = {
@@ -215,7 +219,7 @@ export const DEFAULT_AGENT_PROFILE: AgentProfile = {
   mcpPrefixes: ["mcp__"],
   clearAliases: [],
   aliases: {},
-  specialTitles: { skillNames: [], scheduleNames: [] },
+  specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
 const PROFILES: Record<string, AgentProfile> = {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Claude's harness tools `ToolSearch`, `Monitor`, and `TaskStop` rendered as generic tool cards in the structured view: a `Sparkles` icon, the literal `other` kind label, the tool name, and a raw JSON dump. claude-agent-acp routes them through its generic `Other` arm with no structured `kind`, so they never matched a dedicated card.

This adds a `classifyHarnessTool` name-matcher and a `HarnessToolCard`, gated by a new `specialTitles.harnessNames` allowlist on the agent profile. The allowlist is populated only for the Claude family (`claude`, `claude-code`, `aoe-agent`) and empty everywhere else, so a non-Claude agent that happens to emit a tool named `Monitor` still falls through to the generic card. The shape mirrors the `ScheduleWakeup` / `Cron*` card family added in #1091; it is web-only (the Rust agent profile carries no tool-name lists).

Each card surfaces the useful bit: tool search shows its query, monitor shows its description plus a persistent/timeout chip and its command, task stop shows the stopped task id.

Closes #2139

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a Claude structured-view session and trigger a deferred-tool fetch; confirm the `ToolSearch` call shows a "tool search" card with the query, not a generic JSON card.
- [ ] Start a background `Monitor`; confirm a "monitor" card shows the description, a persistent or timeout chip, and the command on expand.
- [ ] Stop a background task; confirm the `TaskStop` call shows a "task stop" card with the task id.
- [ ] Confirm an unrelated generic tool still renders as the generic one-liner (no regression).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: card routing is pure dispatch logic, covered at the correct layer by Vitest render assertions in `ToolCards.render.test.tsx` (3 positive routes plus a negative gating case). `ToolCards.tsx` is already mapped in `coverage-matrix.json` via the existing `acp-tool-cards` entry, so no matrix change is needed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (dedicated cards over kind-aliasing, allowlist gating over a new capability flag) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784121763&installation_id=139138837&pr_number=2167&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2167&signature=e47d537a0d25e2a5b8bc7b62ece827a76416b067017e58c10b17b580660d9544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR significantly improves Structured View readability for three Claude “harness” tools by switching them from generic JSON-heavy cards to dedicated, purpose-built cards:

- **ToolSearch** now shows the **search query**.
- **Monitor** now shows a clear **description**, plus a **persistent/timeout indicator** and the **command**.
- **TaskStop** now shows the **stopped task ID**.

## Key additions/changes

- Added a **`HarnessToolCard`** that renders these three harness tools with tailored labels and content (instead of dumping raw JSON).
- Implemented **`classifyHarnessTool`** routing in the tool-card dispatcher so these tools use the new harness-specific UI.
- Added **profile-gating** via `specialTitles.harnessNames`:
  - Populated only for **Claude-family agents** (`claude`, `claude-code`, `aoe-agent`)
  - Left empty for other agents to avoid accidental “name match” misclassification.
- Extended **tool-call fixtures** and added **Vitest render assertions** to verify correct routing and the detailed card behavior (including expand/click behavior and timeout vs persistent chip handling).
- Updated the Structured View documentation to reflect the improved tool-card behavior (and clarified an unrelated multi-file patch rendering note).

## Benefits

- **Much clearer tool results**: users can understand what these harness tools did without reading raw JSON.
- **Less confusion / safer routing**: the allowlist prevents non-Claude agents from incorrectly receiving harness-specific rendering.
- **Consistency**: follows the same “dedicated card family” approach already used for the `ScheduleWakeup`/`Cron*` UI.
- **Regressions guarded**: tests cover both correct harness routing and non-routing under other profiles.

## Technical Details

- Harness-tool detection hinges on tools arriving through the “other” path and then matching the tool name against `agentProfile.specialTitles.harnessNames`.
- The `CLAUDE`/Claude-family agent profile is the only one that enables `["ToolSearch", "Monitor", "TaskStop"]`; all other profiles receive an empty allowlist.
- Web-only change: the Rust agent profile doesn’t participate in tool-name lists.
- Tests include both **Claude** (should render harness cards) and **non-Claude** (should fall back to the generic behavior) scenarios.

Closes issue `#2139`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->