### PR TITLE
revert(nix): drop rust-overlay pin, fix cfg_select via nixpkgs lock bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -68,28 +68,7 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781493707,
-        "narHash": "sha256-lzf7qdQWuiY0T9VEbfH2CmP1LZQAYooU/sZuSgEJEBk=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "06f25b8e40805beb2121a4dae4cc37d6f981800f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,31 +5,15 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     crane.url = "github:ipetkov/crane";
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs = inputs @ { flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
 
-      perSystem = { config, self', inputs', system, ... }:
+      perSystem = { config, self', inputs', pkgs, system, ... }:
         let
-          pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [ (import inputs.rust-overlay) ];
-          };
-
-          # Pin an explicit stable rustc instead of inheriting whatever rustc
-          # the pinned nixpkgs happens to ship. nixpkgs lags stable, which
-          # broke the nix build when libsqlite3-sys 0.38.1 started using the
-          # cfg_select! macro (stable in rustc >= 1.93) while nixpkgs still
-          # shipped 1.92.0. Tracking latest stable here keeps the nix
-          # toolchain in step with the rustup-stable used by the regular CI.
-          rustToolchain = pkgs.rust-bin.stable.latest.default;
-          craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+          craneLib = inputs.crane.mkLib pkgs;
 
           # git2 uses vendored-openssl (needs perl to build OpenSSL)
           # and libgit2-sys vendors libgit2 (needs cmake to build it)


### PR DESCRIPTION
## Description

Reverts #2181. The rust-overlay approach was the wrong fix: it adds a whole toolchain input when all the Cachix build actually needed was a newer rustc from nixpkgs.

This PR:
1. **Reverts** the rust-overlay change from #2181 (flake.nix back to plain `crane.mkLib pkgs`, drops the `rust-overlay` input/lock node).
2. **Bumps the `nixpkgs` lock** from 2026-02-17 to 2026-06-10, which moves the default rustc 1.92.0 -> **1.95.0** , enough for `libsqlite3-sys 0.38.1`'s `cfg_select!` macro (stable in rustc >= 1.93), the thing that broke the Cachix build after the #2129 rusqlite bump.

Net effect: the original cfg_select failure stays fixed, but via a one-line lock bump instead of a new flake input.

### Verification

Evaluated locally with the bumped lock: the flake evaluates, `aoe-with-web` resolves, and `pkgs.rustc.version` is `1.95.0` (no overlay). The full `nix build .#aoe-with-web` compile is gated by the Push to Cachix workflow (paths filter includes `flake.nix` + `flake.lock`); happy to trigger a branch run before merge if you want.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: nix toolchain/lock change only; the regression gate is the Push to Cachix workflow re-running on the flake change.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude reverted #2181 and applied the simpler lock-bump fix per @njbrake's direction, and verified the resulting rustc version (1.95.0) locally.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784164991&installation_id=139138837&pr_number=2192&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2192&signature=86b167b6604d0b1aca355859487747d2e51571252d53671dc23f29bba40d1686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR simplifies the Rust build configuration by reverting the previous rust-overlay approach and instead bumping the nixpkgs lock file. The nixpkgs date was moved from 2026-02-17 to 2026-06-10, which automatically upgrades the default Rust compiler (rustc) from version 1.92.0 to 1.95.0.

## What Changed
**Removed:** The explicit Rust toolchain pinning logic and manual override of the `craneLib` build utility that was added in the previous attempt to fix the Cachix build.

**Added:** Direct definition of `craneLib` as `inputs.crane.mkLib pkgs` without manual toolchain overrides.

**Lines changed:** +2/-18 (net reduction of 16 lines)

## Technical Details
The underlying issue was that the rusqlite dependency (version 0.38.1) uses the `cfg_select!` macro, which requires Rust 1.93 or later. Rather than introducing a separate rust-overlay input to pin the toolchain, this PR achieves the same result through a simpler approach: bumping the nixpkgs lock file to a version that includes rustc 1.95.0 by default.

## Benefits
- **Simplified configuration:** Eliminates unnecessary complexity from the build setup
- **Cleaner dependency graph:** Removes the need for an additional toolchain input
- **Still resolves the underlying issue:** The nixpkgs bump provides the required Rust version (1.95.0) to support the `cfg_select!` macro
- **Verified locally:** The flake evaluates correctly, and the rustc version requirement is satisfied

## Impact
Infrastructure/CI improvement with no impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->