### PR TITLE
feat(web): pin a project so it persists in the sidebar without sessions

### DIFF
--- a/docs/guides/multi-repo-workspaces.md
+++ b/docs/guides/multi-repo-workspaces.md
@@ -80,6 +80,10 @@ aoe -p other project add /repo/foo --allow-override    # profile shadows global
 
 In the TUI's project view (press `g` and pick Project grouping), a project header normally disappears once its last session is gone. Press `p` on a project header, or pick "Pin project" from its right-click menu, to register that repo in the global registry. A pinned project keeps its header (marked with a `◆`) even with zero sessions, so you can launch new work under it later, mirroring the web dashboard, where a project is a registry entry independent of any session. Press `p` again to unpin; an unpinned project drops from the view once it has no sessions.
 
+### Pinning a project from the web dashboard
+
+The web sidebar's project (repository) grouping mirrors the TUI. A pinned project shows a `◆` next to its name and keeps its header even with zero sessions; its `+` New session button launches work under that repo. Open a project header's actions menu (right-click, or the menu on the header) and choose "Pin project" to register the repo (global scope) or "Unpin project" to remove every registry entry for it. Pinned-but-empty projects sort below your active repositories. A pin made in the TUI shows up here when the dashboard regains focus, and vice versa.
+
 ## CLI Reference
 
 ```bash

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -692,7 +692,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     async (repoPath: string) => {
       const res = await createProject({ path: repoPath, scope: "global" });
       if (!res.ok) {
-        toastBus.push(res.error ?? "Failed to pin project", "error");
+        toastBus.handler?.error(res.error ?? "Failed to pin project");
         return;
       }
       await refreshProjects();
@@ -707,7 +707,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       const results = await Promise.all(group.registeredProjects.map((p) => deleteProject(p.name, p.scope)));
       const failed = results.find((r) => !r.ok);
       if (failed) {
-        toastBus.push(failed.error ?? "Failed to unpin project", "error");
+        toastBus.handler?.error(failed.error ?? "Failed to unpin project");
       }
       await refreshProjects();
     },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,8 @@ import { useSessionGroups } from "./hooks/useSessionGroups";
 import { useNestedSidebarGroups } from "./hooks/useNestedSidebarGroups";
 import { useSidebarSortMode } from "./hooks/useSidebarSortMode";
 import { useSidebarAxis } from "./hooks/useSidebarAxis";
-import { repoGroupToSidebarGroup } from "./lib/sidebarGroups";
+import { repoGroupToSidebarGroup, type SidebarGroup } from "./lib/sidebarGroups";
+import { useProjects } from "./hooks/useProjects";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useResolvedTheme } from "./hooks/useResolvedTheme";
 import { useWebSettings } from "./hooks/useWebSettings";
@@ -39,6 +40,8 @@ import {
   isDebugBuild,
   markWebTourSeen,
   updateWorkspaceOrdering,
+  createProject,
+  deleteProject,
 } from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { IdleDecayWindowContext, parseIdleDecayWindowMs, useIdleDecayWindowMs } from "./lib/idleDecay";
@@ -269,12 +272,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [sidebarSortMode, setSidebarSortMode] = useSidebarSortMode();
   const [sidebarAxis, setSidebarAxis] = useSidebarAxis();
 
+  const { projects, refresh: refreshProjects } = useProjects();
   const {
     groups: repoGroups,
     toggleRepoCollapsed,
     updateRepoAppearance,
     reorderRepoGroups,
-  } = useRepoGroups(workspaces, workspaceOrdering, sidebarSortMode);
+  } = useRepoGroups(workspaces, workspaceOrdering, sidebarSortMode, projects);
   const { groups: sessionGroups, toggleGroupCollapsed } = useSessionGroups(workspaces, sidebarSortMode);
   // The nested `repo+group` axis reuses the already-built repo groups for
   // its top level (so repo collapse, appearance, and ordering are shared
@@ -679,6 +683,35 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       setShowSessionWizard(true);
     },
     [sessions],
+  );
+
+  // Pin a repo: register it (scope global, matching the TUI's global
+  // registry) so its header persists with zero sessions, then refresh so the
+  // diamond / empty header reflects it. See #2047.
+  const handlePinProject = useCallback(
+    async (repoPath: string) => {
+      const res = await createProject({ path: repoPath, scope: "global" });
+      if (!res.ok) {
+        toastBus.push(res.error ?? "Failed to pin project", "error");
+        return;
+      }
+      await refreshProjects();
+    },
+    [refreshProjects],
+  );
+
+  // Unpin a repo: remove every registry entry for its path (a path can be
+  // registered under both global and profile scope), then refresh. See #2047.
+  const handleUnpinProject = useCallback(
+    async (group: SidebarGroup) => {
+      const results = await Promise.all(group.registeredProjects.map((p) => deleteProject(p.name, p.scope)));
+      const failed = results.find((r) => !r.ok);
+      if (failed) {
+        toastBus.push(failed.error ?? "Failed to unpin project", "error");
+      }
+      await refreshProjects();
+    },
+    [refreshProjects],
   );
 
   // The right-panel control toggles the desktop split, but on mobile there
@@ -1290,6 +1323,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                 setShowSessionWizard(true);
               }}
               onCreateSession={handleCreateSession}
+              onPinProject={handlePinProject}
+              onUnpinProject={handleUnpinProject}
               onSettings={handleOpenSettings}
               onProjects={handleOpenProjects}
               onProfiles={handleOpenProfiles}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -40,8 +40,9 @@ import type { SessionResponse, SessionStatus, Workspace } from "../lib/types";
 import type { SidebarAxis } from "../lib/sidebarAxis";
 import {
   archivableWorkspaces,
-  nestedSidebarGroupHasLiveWorkspace,
+  nestedSidebarGroupShouldRender,
   sidebarGroupHasLiveWorkspace,
+  sidebarGroupShouldRender,
   type NestedSidebarGroup,
   type SidebarGroup,
 } from "../lib/sidebarGroups";
@@ -150,6 +151,10 @@ interface Props {
   onUpdateRepoAppearance: (repoId: string, update: RepoAppearanceUpdate) => void;
   onNew: () => void;
   onCreateSession: (repoPath: string) => void;
+  /** Pin a repo (register it) so it persists with zero sessions. See #2047. */
+  onPinProject?: (repoPath: string) => void;
+  /** Unpin a repo: remove every registry entry for its path. See #2047. */
+  onUnpinProject?: (group: SidebarGroup) => void;
   onSettings: () => void;
   onProjects: () => void;
   onProfiles: () => void;
@@ -1585,6 +1590,8 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
   onNewSession,
   onUpdateAppearance,
   onArchiveAll,
+  onPin,
+  onUnpin,
   offline,
   dragHandle,
 }: {
@@ -1596,6 +1603,12 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
   /** Archive every active session under this group. Omitted (read-only /
    *  offline) hides the action; the parent owns the confirmation. */
   onArchiveAll?: () => void;
+  /** Register this repo in the pin registry so it persists with zero
+   *  sessions. Repo axis only; omitted (read-only / offline) hides it. */
+  onPin?: (repoPath: string) => void;
+  /** Remove every registry entry for this repo path (unpin). Omitted
+   *  (read-only / offline) hides it. */
+  onUnpin?: (group: SidebarGroup) => void;
   offline: boolean;
   dragHandle?: DragHandleProps;
 }) {
@@ -1609,7 +1622,11 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
   // action hides once everything is already archived.
   const archivableCount = onArchiveAll ? archivableWorkspaces(group).length : 0;
   const canArchiveAll = archivableCount > 0;
-  const hasMenu = canAppearance || canArchiveAll;
+  // Pin/unpin is repo-axis only and needs a concrete repo path. Pin shows
+  // when the repo is not yet registered; unpin when it is. See #2047.
+  const canPin = !!onPin && group.capabilities.create === "repo" && !!group.repoPath && !group.pinned;
+  const canUnpin = !!onUnpin && group.kind === "repo" && group.pinned;
+  const hasMenu = canAppearance || canArchiveAll || canPin || canUnpin;
   const headerTitle = group.groupPath ?? group.repoPath;
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -1760,6 +1777,16 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
             />
           </svg>
           <OwnerAvatar owner={group.remoteOwner} size={16} />
+          {group.pinned && (
+            <span
+              className="shrink-0 text-[10px] leading-none text-text-dim"
+              data-testid="sidebar-group-pinned-marker"
+              title="Pinned project (persists without sessions)"
+              aria-label="Pinned project"
+            >
+              ◆
+            </span>
+          )}
           <span className="text-[13px] md:text-[14px] font-medium truncate flex-1" title={headerTitle}>
             {group.displayName}
           </span>
@@ -1799,6 +1826,33 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
               maxHeight: "calc(100vh - 16px)",
             }}
           >
+            {canPin && (
+              <button
+                onClick={() => {
+                  setContextMenu(null);
+                  if (group.repoPath) onPin?.(group.repoPath);
+                }}
+                data-testid="sidebar-group-context-menu-pin"
+                className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+              >
+                Pin project
+              </button>
+            )}
+            {canUnpin && (
+              <button
+                onClick={() => {
+                  setContextMenu(null);
+                  onUnpin?.(group);
+                }}
+                data-testid="sidebar-group-context-menu-unpin"
+                className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+              >
+                Unpin project
+              </button>
+            )}
+            {(canPin || canUnpin) && (canArchiveAll || canAppearance) && (
+              <div className="border-t border-surface-700/20 my-1" />
+            )}
             {canArchiveAll && (
               <button
                 onClick={() => {
@@ -1931,6 +1985,8 @@ export function WorkspaceSidebar({
   onUpdateRepoAppearance,
   onNew,
   onCreateSession,
+  onPinProject,
+  onUnpinProject,
   onSettings,
   onProjects,
   onProfiles,
@@ -2439,7 +2495,7 @@ export function WorkspaceSidebar({
                 onDragEnd={reorderDisabled ? undefined : handleDragEnd}
               >
                 {(() => {
-                  const liveGroups = filteredGroups.filter(sidebarGroupHasLiveWorkspace);
+                  const liveGroups = filteredGroups.filter(sidebarGroupShouldRender);
                   // Every visible group is sortable, synthetic Multi-repo /
                   // Scratch included: they default to the bottom but can be
                   // dragged to any position. Group drag is off while a filter
@@ -2465,6 +2521,8 @@ export function WorkspaceSidebar({
                           onClick={() => !q && onToggleGroup(group.id)}
                           onUpdateAppearance={onUpdateRepoAppearance}
                           onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(fullGroup)}
+                          onPin={readOnly || offline ? undefined : onPinProject}
+                          onUnpin={readOnly || offline ? undefined : onUnpinProject}
                           onNewSession={() =>
                             group.capabilities.create === "repo" && group.repoPath
                               ? onCreateSession(group.repoPath)
@@ -2540,7 +2598,7 @@ export function WorkspaceSidebar({
             </DragSuppressContext.Provider>
           )}
           {isNested &&
-            filteredNested.filter(nestedSidebarGroupHasLiveWorkspace).map((ng) => {
+            filteredNested.filter(nestedSidebarGroupShouldRender).map((ng) => {
               const repo = ng.repo;
               const repoExpanded = q ? true : !repo.collapsed;
               const repoHasActiveChild = ng.subgroups.some((sg) =>
@@ -2554,6 +2612,8 @@ export function WorkspaceSidebar({
                     onClick={() => !q && onToggleGroup(repo.id)}
                     onUpdateAppearance={onUpdateRepoAppearance}
                     onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(repo)}
+                    onPin={readOnly || offline ? undefined : onPinProject}
+                    onUnpin={readOnly || offline ? undefined : onUnpinProject}
                     onNewSession={() =>
                       repo.capabilities.create === "repo" && repo.repoPath ? onCreateSession(repo.repoPath) : onNew()
                     }

--- a/web/src/hooks/__tests__/useNestedSidebarGroups.test.tsx
+++ b/web/src/hooks/__tests__/useNestedSidebarGroups.test.tsx
@@ -70,6 +70,7 @@ function repoGroup(): RepoGroup {
     workspaces: [workspace("team-a")],
     status: "idle",
     collapsed: false,
+    registeredProjects: [],
   };
 }
 

--- a/web/src/hooks/useProjects.ts
+++ b/web/src/hooks/useProjects.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from "react";
+import { fetchProjects } from "../lib/api";
+import type { ProjectInfo } from "../lib/types";
+
+// Registered projects (the pin registry) drive the sidebar's empty-project
+// headers and the pin/unpin controls. Unlike sessions (polled every 3s),
+// the registry only changes on an explicit pin/unpin, so this fetches once
+// on mount, exposes a `refresh()` the mutation handlers call after a
+// pin/unpin, and re-fetches on window focus / tab visibility so a pin made
+// in the TUI (or another tab) shows up when the user returns here, without
+// a constant poll. See #2047.
+export function useProjects(): {
+  projects: ProjectInfo[];
+  refresh: () => Promise<void>;
+} {
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
+
+  const refresh = useCallback(async () => {
+    setProjects(await fetchProjects());
+  }, []);
+
+  useEffect(() => {
+    void fetchProjects().then(setProjects);
+    const onFocus = () => {
+      if (document.visibilityState === "visible") void fetchProjects().then(setProjects);
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    };
+  }, [refresh]);
+
+  return { projects, refresh };
+}

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
-import type { Workspace, RepoGroup } from "../lib/types";
+import type { ProjectInfo, Workspace, RepoGroup } from "../lib/types";
+import { mergeRegisteredProjects } from "../lib/registeredProjects";
 import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
 import {
   applyRepoAppearanceUpdate,
@@ -59,6 +60,7 @@ export function useRepoGroups(
   workspaces: Workspace[],
   workspaceOrdering: readonly string[] = [],
   sortMode: SidebarSortMode = "manual",
+  projects: readonly ProjectInfo[] = [],
 ): {
   groups: RepoGroup[];
   toggleRepoCollapsed: (repoId: string) => void;
@@ -154,6 +156,9 @@ export function useRepoGroups(
         workspaces: sorted,
         status: hasActive ? "active" : "idle",
         collapsed,
+        // Filled by mergeRegisteredProjects below; populated groups get
+        // their registry entries (if any) keyed by path there.
+        registeredProjects: [],
       });
     }
 
@@ -174,6 +179,9 @@ export function useRepoGroups(
         workspaces: sorted,
         status: hasActive ? "active" : "idle",
         collapsed,
+        // Filled by mergeRegisteredProjects below; populated groups get
+        // their registry entries (if any) keyed by path there.
+        registeredProjects: [],
       });
     }
 
@@ -194,12 +202,35 @@ export function useRepoGroups(
         workspaces: sorted,
         status: hasActive ? "active" : "idle",
         collapsed,
+        // Filled by mergeRegisteredProjects below; populated groups get
+        // their registry entries (if any) keyed by path there.
+        registeredProjects: [],
       });
     }
 
-    const isSyntheticGroup = (id: string) => id === MULTI_REPO_GROUP_ID || id === SCRATCH_GROUP_ID;
+    // Fold the registry in: populated groups gain their entries, and every
+    // registered repo with no live group is appended as a zero-workspace
+    // header. Appended groups inherit the per-browser alias/color/collapse
+    // for their path, so a repo that empties out but stays pinned keeps its
+    // look. See #2047.
+    const merged = mergeRegisteredProjects(repoGroups, [...projects], {
+      alias: (repoPath) => appearanceMap[repoPath]?.alias ?? null,
+      color: (repoPath) => appearanceMap[repoPath]?.color ?? null,
+      collapsed: (repoPath) => collapsedMap[repoPath] ?? loadCollapsed(repoPath),
+    });
 
-    repoGroups.sort((a, b) => {
+    const isSyntheticGroup = (id: string) => id === MULTI_REPO_GROUP_ID || id === SCRATCH_GROUP_ID;
+    // Sort category: populated real repos first, then pinned-but-empty
+    // projects, then the synthetic Multi-repo / Scratch buckets. Keeps an
+    // empty pinned project from leapfrogging active work in every mode while
+    // still sitting above the synthetic buckets. See #2047.
+    const isRegisteredEmpty = (g: RepoGroup) => g.workspaces.length === 0 && g.registeredProjects.length > 0;
+    const groupCategory = (g: RepoGroup) => (isSyntheticGroup(g.id) ? 2 : isRegisteredEmpty(g) ? 1 : 0);
+
+    merged.sort((a, b) => {
+      const ca = groupCategory(a);
+      const cb = groupCategory(b);
+      if (ca !== cb) return ca - cb;
       if (sortMode === "attention") {
         // Computed order, like lastActivity: manual group drag does not
         // apply and synthetic groups stay pinned to the bottom in a stable
@@ -268,8 +299,8 @@ export function useRepoGroups(
       return a.repoPath.localeCompare(b.repoPath);
     });
 
-    return repoGroups;
-  }, [workspaces, workspaceOrdering, sortMode, collapsedMap, appearanceMap, groupOrder]);
+    return merged;
+  }, [workspaces, workspaceOrdering, sortMode, projects, collapsedMap, appearanceMap, groupOrder]);
 
   const toggleRepoCollapsed = useCallback((repoId: string) => {
     setCollapsedMap((prev) => {

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -220,17 +220,14 @@ export function useRepoGroups(
     });
 
     const isSyntheticGroup = (id: string) => id === MULTI_REPO_GROUP_ID || id === SCRATCH_GROUP_ID;
-    // Sort category: populated real repos first, then pinned-but-empty
-    // projects, then the synthetic Multi-repo / Scratch buckets. Keeps an
-    // empty pinned project from leapfrogging active work in every mode while
-    // still sitting above the synthetic buckets. See #2047.
+    // A pinned-but-empty project: registered, with no live workspace. It
+    // sorts below populated real repos but above the synthetic Multi-repo /
+    // Scratch buckets, so a stale pin never leapfrogs active work. This only
+    // governs the unranked fallback: an explicit drag rank still wins for any
+    // group (preserving the dragged-synthetic-above-real behavior). See #2047.
     const isRegisteredEmpty = (g: RepoGroup) => g.workspaces.length === 0 && g.registeredProjects.length > 0;
-    const groupCategory = (g: RepoGroup) => (isSyntheticGroup(g.id) ? 2 : isRegisteredEmpty(g) ? 1 : 0);
 
     merged.sort((a, b) => {
-      const ca = groupCategory(a);
-      const cb = groupCategory(b);
-      if (ca !== cb) return ca - cb;
       if (sortMode === "attention") {
         // Computed order, like lastActivity: manual group drag does not
         // apply and synthetic groups stay pinned to the bottom in a stable
@@ -244,6 +241,9 @@ export function useRepoGroups(
         if (b.id === SCRATCH_GROUP_ID) return -1;
         if (a.id === MULTI_REPO_GROUP_ID) return 1;
         if (b.id === MULTI_REPO_GROUP_ID) return -1;
+        const ae = isRegisteredEmpty(a);
+        const be = isRegisteredEmpty(b);
+        if (ae !== be) return ae ? 1 : -1;
         const au = repoGroupIsUrgent(a.workspaces);
         const bu = repoGroupIsUrgent(b.workspaces);
         if (au !== bu) return au ? -1 : 1;
@@ -266,6 +266,9 @@ export function useRepoGroups(
         if (b.id === SCRATCH_GROUP_ID) return -1;
         if (a.id === MULTI_REPO_GROUP_ID) return 1;
         if (b.id === MULTI_REPO_GROUP_ID) return -1;
+        const ae = isRegisteredEmpty(a);
+        const be = isRegisteredEmpty(b);
+        if (ae !== be) return ae ? 1 : -1;
         const ak = repoGroupLastActivityMs(a.workspaces);
         const bk = repoGroupLastActivityMs(b.workspaces);
         if (ak !== bk) return bk - ak;
@@ -280,10 +283,16 @@ export function useRepoGroups(
       const ag = groupRank.get(a.id);
       const bg = groupRank.get(b.id);
       const SYNTHETIC_BOTTOM = Number.MAX_SAFE_INTEGER;
-      const keyOf = (id: string, rank: number | undefined) =>
-        rank != null ? rank : isSyntheticGroup(id) ? SYNTHETIC_BOTTOM : -1;
-      const ka = keyOf(a.id, ag);
-      const kb = keyOf(b.id, bg);
+      // Unranked fallback by type: a brand-new real project floats to the top
+      // (-1, matching new-workspace behavior), a pinned-but-empty project
+      // sinks below real repos but above synthetic, and an untouched
+      // synthetic group sits at the bottom. A stored rank overrides all of
+      // this. See #1644, #2047.
+      const fallbackRank = (g: RepoGroup) =>
+        isSyntheticGroup(g.id) ? SYNTHETIC_BOTTOM : isRegisteredEmpty(g) ? SYNTHETIC_BOTTOM - 1 : -1;
+      const keyOf = (g: RepoGroup, rank: number | undefined) => (rank != null ? rank : fallbackRank(g));
+      const ka = keyOf(a, ag);
+      const kb = keyOf(b, bg);
       if (ka !== kb) return ka - kb;
       if (ka === SYNTHETIC_BOTTOM) {
         // Two untouched synthetic groups: multi-repo above scratch.

--- a/web/src/lib/__tests__/registeredProjects.test.ts
+++ b/web/src/lib/__tests__/registeredProjects.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+//
+// Unit tests for the registry merge that brings the TUI's project-pin
+// feature to the web sidebar (#2047): populated repo groups gain their
+// registry entries, and registered repos with no live group are appended as
+// pinned-but-empty headers, deduped by normalized path.
+
+import { describe, expect, it } from "vitest";
+
+import { mergeRegisteredProjects, normalizeProjectPathKey } from "../registeredProjects";
+import { repoGroupToSidebarGroup, sidebarGroupShouldRender } from "../sidebarGroups";
+import { MULTI_REPO_GROUP_ID } from "../../hooks/useRepoGroups";
+import type { ProjectInfo, RepoGroup, Workspace } from "../types";
+
+function workspace(repoPath: string): Workspace {
+  return {
+    id: `${repoPath}::w`,
+    branch: null,
+    projectPath: repoPath,
+    displayName: "w",
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    sessions: [],
+  };
+}
+
+function repoGroup(repoPath: string, over: Partial<RepoGroup> = {}): RepoGroup {
+  return {
+    id: repoPath,
+    repoPath,
+    displayName: repoPath.split("/").pop() ?? repoPath,
+    defaultDisplayName: repoPath.split("/").pop() ?? repoPath,
+    alias: null,
+    color: null,
+    remoteOwner: null,
+    workspaces: [workspace(repoPath)],
+    status: "idle",
+    collapsed: false,
+    registeredProjects: [],
+    ...over,
+  };
+}
+
+function project(path: string, over: Partial<ProjectInfo> = {}): ProjectInfo {
+  return { name: path.split("/").pop() ?? path, path, scope: "global", ...over };
+}
+
+describe("normalizeProjectPathKey", () => {
+  it("trims and strips trailing slashes without lowercasing", () => {
+    expect(normalizeProjectPathKey("/work/Foo/ ".trim())).toBe("/work/Foo");
+    expect(normalizeProjectPathKey("/work/foo/")).toBe("/work/foo");
+    expect(normalizeProjectPathKey("/work/foo")).toBe("/work/foo");
+    // Case is preserved: distinct repos on a case-sensitive filesystem.
+    expect(normalizeProjectPathKey("/work/Foo")).not.toBe(normalizeProjectPathKey("/work/foo"));
+  });
+});
+
+describe("mergeRegisteredProjects", () => {
+  it("attaches the registry entry to a matching populated group (no duplicate header)", () => {
+    const groups = [repoGroup("/work/alpha")];
+    const merged = mergeRegisteredProjects(groups, [project("/work/alpha")]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.registeredProjects).toHaveLength(1);
+    expect(merged[0]!.workspaces).toHaveLength(1);
+  });
+
+  it("matches across a trailing-slash difference", () => {
+    const groups = [repoGroup("/work/alpha")];
+    const merged = mergeRegisteredProjects(groups, [project("/work/alpha/")]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.registeredProjects).toHaveLength(1);
+  });
+
+  it("appends a zero-workspace group for a registered repo with no live group", () => {
+    const merged = mergeRegisteredProjects([], [project("/work/beta")]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.repoPath).toBe("/work/beta");
+    expect(merged[0]!.displayName).toBe("beta");
+    expect(merged[0]!.workspaces).toHaveLength(0);
+    expect(merged[0]!.registeredProjects).toHaveLength(1);
+  });
+
+  it("collapses a path registered under both global and profile into one group", () => {
+    const merged = mergeRegisteredProjects(
+      [],
+      [project("/work/beta", { scope: "global" }), project("/work/beta", { scope: "profile" })],
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.registeredProjects.map((p) => p.scope)).toEqual(["global", "profile"]);
+  });
+
+  it("leaves an unregistered populated repo untouched", () => {
+    const merged = mergeRegisteredProjects([repoGroup("/work/gamma")], [project("/work/beta")]);
+    const gamma = merged.find((g) => g.repoPath === "/work/gamma")!;
+    expect(gamma.registeredProjects).toHaveLength(0);
+  });
+
+  it("never pins synthetic Multi-repo / Scratch buckets", () => {
+    const synthetic = repoGroup(MULTI_REPO_GROUP_ID, { id: MULTI_REPO_GROUP_ID });
+    const merged = mergeRegisteredProjects([synthetic], [project(MULTI_REPO_GROUP_ID)]);
+    const found = merged.find((g) => g.id === MULTI_REPO_GROUP_ID)!;
+    expect(found.registeredProjects).toHaveLength(0);
+  });
+
+  it("applies resolved alias/color/collapse to appended empty groups", () => {
+    const merged = mergeRegisteredProjects([], [project("/work/beta")], {
+      alias: () => "Beta",
+      color: () => "teal",
+      collapsed: () => true,
+    });
+    expect(merged[0]!.displayName).toBe("Beta");
+    expect(merged[0]!.alias).toBe("Beta");
+    expect(merged[0]!.color).toBe("teal");
+    expect(merged[0]!.collapsed).toBe(true);
+  });
+});
+
+describe("SidebarGroup pin derivation + render gating", () => {
+  it("marks a populated registered repo pinned but not pinnedEmpty, and renders it", () => {
+    const [g] = mergeRegisteredProjects([repoGroup("/work/alpha")], [project("/work/alpha")]);
+    const sg = repoGroupToSidebarGroup(g!);
+    expect(sg.pinned).toBe(true);
+    expect(sg.pinnedEmpty).toBe(false);
+    expect(sidebarGroupShouldRender(sg)).toBe(true);
+  });
+
+  it("marks an empty registered repo pinnedEmpty and renders it despite no live rows", () => {
+    const [g] = mergeRegisteredProjects([], [project("/work/beta")]);
+    const sg = repoGroupToSidebarGroup(g!);
+    expect(sg.pinned).toBe(true);
+    expect(sg.pinnedEmpty).toBe(true);
+    expect(sidebarGroupShouldRender(sg)).toBe(true);
+  });
+
+  it("leaves an unregistered repo unpinned", () => {
+    const sg = repoGroupToSidebarGroup(repoGroup("/work/gamma"));
+    expect(sg.pinned).toBe(false);
+    expect(sg.pinnedEmpty).toBe(false);
+  });
+});

--- a/web/src/lib/__tests__/sidebarGroups.test.ts
+++ b/web/src/lib/__tests__/sidebarGroups.test.ts
@@ -191,6 +191,7 @@ describe("repoGroupToSidebarGroup", () => {
       workspaces: [workspace("w1", [session({ id: "s1" })])],
       status: "idle",
       collapsed: false,
+      registeredProjects: [],
       ...over,
     };
   }
@@ -228,6 +229,7 @@ describe("buildNestedSidebarGroups", () => {
       workspaces: [],
       status: "idle",
       collapsed: false,
+      registeredProjects: [],
       ...over,
     };
   }

--- a/web/src/lib/registeredProjects.ts
+++ b/web/src/lib/registeredProjects.ts
@@ -1,0 +1,87 @@
+import type { ProjectInfo, RepoGroup } from "./types";
+import type { RepoColor } from "./repoAppearance";
+import { MULTI_REPO_GROUP_ID, SCRATCH_GROUP_ID } from "../hooks/useRepoGroups";
+
+// Best-effort path key for matching a session-derived repo group against a
+// registered project. The backend canonicalizes paths when a project is
+// added, but the web only has the raw `Workspace.projectPath` and
+// `ProjectInfo.path` strings, so this just trims and strips trailing
+// slashes (NO lowercasing: that would wrongly fold distinct repos on a
+// case-sensitive filesystem). A symlink / case mismatch the backend would
+// resolve can still slip a duplicate header through; the real fix is a
+// server endpoint returning the canonical key (tracked as follow-up), but
+// session and registry paths share the same backend derivation so an exact
+// match is the common case. See #2047.
+export function normalizeProjectPathKey(path: string): string {
+  return path.trim().replace(/[\\/]+$/g, "");
+}
+
+function isSyntheticRepoGroup(id: string): boolean {
+  return id === MULTI_REPO_GROUP_ID || id === SCRATCH_GROUP_ID;
+}
+
+// Attach registry metadata to the session-derived repo groups and append a
+// zero-workspace group for every registered project that has no live group
+// (a pinned-but-empty project). Pure so it can be unit-tested directly and
+// memoized in `useRepoGroups`.
+//
+// A registered path that matches a populated group attaches to it (so the
+// group renders a pin marker) instead of producing a second empty header.
+// Registrations are grouped by normalized path, so the same repo registered
+// under both global and profile scope collapses into one group carrying both
+// (unpin removes every registration for the path). Synthetic Multi-repo /
+// Scratch buckets never pin: their `repoPath` is a sentinel, not a repo.
+export function mergeRegisteredProjects(
+  repoGroups: RepoGroup[],
+  projects: ProjectInfo[],
+  // Per-browser appearance/collapse for the appended empty groups, so a
+  // repo that was aliased / colored / collapsed while it had sessions keeps
+  // that look once it empties out and only the pin keeps it visible. Omitted
+  // in unit tests, where the structural shape is what matters.
+  resolve?: {
+    alias: (repoPath: string) => string | null;
+    color: (repoPath: string) => RepoColor | null;
+    collapsed: (repoPath: string) => boolean;
+  },
+): RepoGroup[] {
+  const byKey = new Map<string, ProjectInfo[]>();
+  for (const project of projects) {
+    const key = normalizeProjectPathKey(project.path);
+    if (!key) continue;
+    const list = byKey.get(key);
+    if (list) list.push(project);
+    else byKey.set(key, [project]);
+  }
+
+  const seen = new Set<string>();
+  const merged = repoGroups.map((group) => {
+    if (isSyntheticRepoGroup(group.id)) {
+      return { ...group, registeredProjects: [] };
+    }
+    const key = normalizeProjectPathKey(group.repoPath);
+    seen.add(key);
+    return { ...group, registeredProjects: byKey.get(key) ?? [] };
+  });
+
+  for (const [key, registrations] of byKey) {
+    if (seen.has(key)) continue;
+    const primary = registrations[0];
+    const defaultDisplayName = primary.path.split("/").pop() || primary.path;
+    const alias = resolve?.alias(primary.path) ?? null;
+    merged.push({
+      id: primary.path,
+      repoPath: primary.path,
+      displayName: alias ?? defaultDisplayName,
+      defaultDisplayName,
+      alias,
+      color: resolve?.color(primary.path) ?? null,
+      remoteOwner: null,
+      workspaces: [],
+      status: "idle",
+      collapsed: resolve?.collapsed(primary.path) ?? false,
+      registeredProjects: registrations,
+    });
+  }
+
+  return merged;
+}

--- a/web/src/lib/registeredProjects.ts
+++ b/web/src/lib/registeredProjects.ts
@@ -66,6 +66,7 @@ export function mergeRegisteredProjects(
   for (const [key, registrations] of byKey) {
     if (seen.has(key)) continue;
     const primary = registrations[0];
+    if (!primary) continue;
     const defaultDisplayName = primary.path.split("/").pop() || primary.path;
     const alias = resolve?.alias(primary.path) ?? null;
     merged.push({

--- a/web/src/lib/sidebarGroups.ts
+++ b/web/src/lib/sidebarGroups.ts
@@ -1,5 +1,5 @@
 import type { RepoColor } from "./repoAppearance";
-import type { RepoGroup, SessionResponse, Workspace, WorkspaceStatus } from "./types";
+import type { ProjectInfo, RepoGroup, SessionResponse, Workspace, WorkspaceStatus } from "./types";
 import { isSessionActive } from "./session";
 import { compareWorkspacesForComputedSortMode, type SidebarSortMode, workspaceIsSunk } from "./sidebarSort";
 import { MULTI_REPO_GROUP_ID, SCRATCH_GROUP_ID } from "../hooks/useRepoGroups";
@@ -50,6 +50,14 @@ export interface SidebarGroup {
   repoPath?: string;
   /** Set when `kind === "sessionGroup"`. Empty string for Ungrouped. */
   groupPath?: string;
+  /** Registry entries for this repo path (the "pin"); empty when unpinned.
+   *  Repo axis only. See #2047. */
+  registeredProjects: ProjectInfo[];
+  /** Derived: the repo is registered (pinned). */
+  pinned: boolean;
+  /** Derived: registered with no live workspace, so it shows as an empty
+   *  header that only the pin keeps visible. */
+  pinnedEmpty: boolean;
 }
 
 function isSyntheticRepoGroup(id: string): boolean {
@@ -62,6 +70,7 @@ function isSyntheticRepoGroup(id: string): boolean {
 // repo path); real repos create directly in their repo.
 export function repoGroupToSidebarGroup(group: RepoGroup): SidebarGroup {
   const synthetic = isSyntheticRepoGroup(group.id);
+  const pinned = !synthetic && group.registeredProjects.length > 0;
   return {
     id: group.id,
     kind: "repo",
@@ -82,6 +91,9 @@ export function repoGroupToSidebarGroup(group: RepoGroup): SidebarGroup {
       create: synthetic ? "generic" : "repo",
     },
     repoPath: group.repoPath,
+    registeredProjects: synthetic ? [] : group.registeredProjects,
+    pinned,
+    pinnedEmpty: pinned && group.workspaces.length === 0,
   };
 }
 
@@ -174,6 +186,9 @@ export function buildSessionGroups(
       collapsed: opts.isCollapsed(id, gp),
       capabilities: { appearance: false, reorder: false, create: "generic" },
       groupPath: gp,
+      registeredProjects: [],
+      pinned: false,
+      pinnedEmpty: false,
     });
   }
 
@@ -191,6 +206,14 @@ export function buildSessionGroups(
 // footer, so an all-sunk group's header is not rendered empty.
 export function sidebarGroupHasLiveWorkspace(group: SidebarGroup): boolean {
   return group.workspaces.some((v) => !workspaceIsSunk(v.workspace));
+}
+
+// Whether a group's header should render at all. A pinned-but-empty project
+// has no live rows but must still show its header (that is the whole point
+// of pinning), so it renders even though `sidebarGroupHasLiveWorkspace` is
+// false. See #2047.
+export function sidebarGroupShouldRender(group: SidebarGroup): boolean {
+  return group.pinnedEmpty || sidebarGroupHasLiveWorkspace(group);
 }
 
 // The workspaces an "archive all in group" action would act on: every member
@@ -259,4 +282,11 @@ export function buildNestedSidebarGroups(
 // rendered as an empty header.
 export function nestedSidebarGroupHasLiveWorkspace(group: NestedSidebarGroup): boolean {
   return group.subgroups.some(sidebarGroupHasLiveWorkspace);
+}
+
+// Nested-axis equivalent of `sidebarGroupShouldRender`: a pinned-but-empty
+// repo has no subgroups (no sessions), so it would fail the live check, but
+// its header must still render. See #2047.
+export function nestedSidebarGroupShouldRender(group: NestedSidebarGroup): boolean {
+  return group.repo.pinnedEmpty || group.subgroups.some(sidebarGroupShouldRender);
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -281,6 +281,12 @@ export interface RepoGroup {
   workspaces: Workspace[];
   status: WorkspaceStatus;
   collapsed: boolean;
+  /** Registry entries (the "pin") for this repo path, keyed by normalized
+   *  path. Empty when the repo is not pinned. More than one entry means the
+   *  same path is registered under multiple scopes (global + profile); the
+   *  group is rendered pinned and unpin removes every entry. A group with
+   *  entries but no workspaces is a pinned-but-empty project. See #2047. */
+  registeredProjects: ProjectInfo[];
 }
 
 /** Workspace: a group of sessions sharing the same project + branch */

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2146,6 +2146,18 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx", "web/src/lib/sidebarSort.ts"]
     },
     {
+      "id": "sidebar.project-pin",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/project-pin.spec.ts"],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/lib/registeredProjects.ts",
+        "web/src/hooks/useRepoGroups.ts",
+        "web/src/hooks/useProjects.ts"
+      ]
+    },
+    {
       "id": "triage.archive-toggle",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/project-pin.spec.ts
+++ b/web/tests/live/project-pin.spec.ts
@@ -31,10 +31,18 @@ function seedSessionAndEmptyProject(opts: {
       GIT_COMMITTER_NAME: "t",
       GIT_COMMITTER_EMAIL: "t@t",
     };
+    const runGit = (args: string[], dir: string) => {
+      const res = spawnSync("git", args, { cwd: dir, env: gitEnv });
+      if (res.error || res.status !== 0) {
+        throw new Error(
+          `git ${args.join(" ")} failed in ${dir}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"} error=${res.error?.message ?? "<none>"}`,
+        );
+      }
+    };
     const initRepo = (dir: string) => {
       mkdirSync(dir, { recursive: true });
-      spawnSync("git", ["init", "-q"], { cwd: dir });
-      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], { cwd: dir, env: gitEnv });
+      runGit(["init", "-q"], dir);
+      runGit(["commit", "--allow-empty", "-q", "-m", "init"], dir);
     };
 
     const projectA = join(home, "projectA");

--- a/web/tests/live/project-pin.spec.ts
+++ b/web/tests/live/project-pin.spec.ts
@@ -1,0 +1,121 @@
+// Live coverage for pinning a project from the web sidebar (#2047):
+//   - A registered project with no sessions shows as an empty header in the
+//     sidebar (the ◆ marker + a New session button), parity with the TUI.
+//   - "Pin project" on a populated repo header POSTs /api/projects and the
+//     ◆ marker appears and survives a reload (registry persistence).
+//   - "Unpin project" on the empty project DELETEs /api/projects and its
+//     header drops from the sidebar (it had no sessions keeping it alive).
+//
+// The render path is in web/src/components/WorkspaceSidebar.tsx + the merge
+// in web/src/lib/registeredProjects.ts; the registry CRUD is
+// src/server/api/projects.rs. Live coverage catches wire-format drift the
+// mocked specs miss.
+
+import { test as base, expect } from "@playwright/test";
+import { join } from "node:path";
+import { mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { spawnAoeServe, listSessions, resolveAoeBinary } from "../helpers/aoeServe";
+
+// Seed a session in `projectA` and register `projectB` (a git repo with no
+// session) so the sidebar shows one populated header and one pinned-but-empty
+// header. Runs before serve spawns so the in-memory caches pick both up.
+function seedSessionAndEmptyProject(opts: {
+  title: string;
+}): (seedEnv: { home: string; shimBin: string; env: NodeJS.ProcessEnv }) => void {
+  return ({ home, env }) => {
+    const gitEnv = {
+      ...env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@t",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@t",
+    };
+    const initRepo = (dir: string) => {
+      mkdirSync(dir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: dir });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], { cwd: dir, env: gitEnv });
+    };
+
+    const projectA = join(home, "projectA");
+    const projectB = join(home, "projectB");
+    initRepo(projectA);
+    initRepo(projectB);
+
+    const add = spawnSync(resolveAoeBinary(), ["add", projectA, "-t", opts.title, "-c", "claude"], { env });
+    if (add.status !== 0) {
+      throw new Error(`aoe add failed: status=${add.status} stderr=${add.stderr?.toString() ?? "<none>"}`);
+    }
+    // Register projectB with no session: the pinned-but-empty case.
+    const reg = spawnSync(resolveAoeBinary(), ["project", "add", projectB, "--scope", "global"], { env });
+    if (reg.status !== 0) {
+      throw new Error(`aoe project add failed: status=${reg.status} stderr=${reg.stderr?.toString() ?? "<none>"}`);
+    }
+  };
+}
+
+base.describe("pin a project from the web sidebar (#2047)", () => {
+  base("empty project shows, pin persists, unpin removes", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionAndEmptyProject({ title: "pin-session" }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      expect(sessions).toHaveLength(1);
+      const repoA = sessions[0]!.project_path as string;
+
+      await page.goto(`${serve.baseUrl}/`);
+
+      // The populated repo header (projectA) renders from its session.
+      const headerA = page.locator(`[data-testid='sidebar-group-header'][data-group-id='${repoA}']`);
+      await expect(headerA).toBeVisible({ timeout: 10_000 });
+
+      // The pinned-but-empty project (projectB) renders despite no sessions,
+      // with the ◆ marker and a New session button.
+      const headerB = page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "projectB" });
+      await expect(headerB).toBeVisible({ timeout: 10_000 });
+      await expect(headerB.locator("[data-testid='sidebar-group-pinned-marker']")).toBeVisible();
+      await expect(headerB.locator("[aria-label='New session in projectB']")).toBeVisible();
+
+      // ---- Pin projectA from its header menu ----
+      await headerA.click({ button: "right" });
+      const pinPost = page.waitForResponse(
+        (res) => res.url().endsWith("/api/projects") && res.request().method() === "POST",
+      );
+      await page.locator("[data-testid='sidebar-group-context-menu-pin']").click();
+      const pinRes = await pinPost;
+      expect(pinRes.ok()).toBe(true);
+      expect(pinRes.request().postDataJSON()).toMatchObject({ path: repoA, scope: "global" });
+
+      await expect(headerA.locator("[data-testid='sidebar-group-pinned-marker']")).toBeVisible({ timeout: 5_000 });
+
+      // Registry persisted: reload and the marker is still there.
+      await page.reload();
+      const headerAReloaded = page.locator(`[data-testid='sidebar-group-header'][data-group-id='${repoA}']`);
+      await expect(headerAReloaded.locator("[data-testid='sidebar-group-pinned-marker']")).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // ---- Unpin the empty projectB: its header drops (no sessions) ----
+      const headerBReloaded = page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "projectB" });
+      await headerBReloaded.click({ button: "right" });
+      const unpinDelete = page.waitForResponse(
+        (res) => res.url().includes("/api/projects/") && res.request().method() === "DELETE",
+      );
+      await page.locator("[data-testid='sidebar-group-context-menu-unpin']").click();
+      const unpinRes = await unpinDelete;
+      expect(unpinRes.ok()).toBe(true);
+
+      await expect(page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "projectB" })).toHaveCount(
+        0,
+        { timeout: 10_000 },
+      );
+    } finally {
+      await serve.stop();
+    }
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

#2055 brought the project pin to the TUI: pinning registers a repo in the shared project registry so its header stays visible with zero sessions. This brings parity to the web dashboard, which previously surfaced empty registered projects only on the separate Projects page.

The web sidebar's project (repository) grouping now mirrors the TUI:

- A pinned project shows a `◆` marker next to its name and renders as an inline header even with zero sessions; its `+` New session button launches work under that repo.
- A repo header's actions menu gains "Pin project" (registers the repo, global scope, matching the TUI's global registry) and "Unpin project" (removes every registry entry for the path, so a path registered under both global and profile is fully unpinned).
- Pinned-but-empty projects sort below your active repositories and above the synthetic Multi-repo / Scratch buckets, so a stale pin never leapfrogs active work.

The merge is computed client-side from the existing `/api/projects` registry and the session-derived repo groups, deduped by normalized path; no backend or API change. The registry is fetched on mount and refreshed on window focus, so a pin made in the TUI shows up when the dashboard regains focus.

Closes #2047

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the TUI, pin a project (`p` on a project header). Open the web dashboard sidebar in repo grouping: the project shows as an inline header with a `◆` marker even with zero sessions.
- [ ] On a repo header with sessions, open its actions menu and choose "Pin project". A `◆` appears; reload the page and it persists.
- [ ] Delete that repo's last session: the header stays (pinned), with a working New session button.
- [ ] Open a pinned project's menu and choose "Unpin project": the `◆` clears, and an empty project's header disappears from the sidebar.
- [ ] Confirm pinned-but-empty projects sort below repos that have active sessions.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (cross-checked with a multi-model design debate), and implementation drafted by Claude under my direction. I made the design calls (scope, marker, pin/unpin UX) and reviewed each commit. Verified with a new live Playwright spec plus the unit tests for the registry merge.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784188910&installation_id=139138837&pr_number=2193&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2193&signature=611d83803209ebdec3c2a696847b53ac5046484f7c99a3b68e1cf0271aafd372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Project Pinning for Web Dashboard Sidebar

## Overview
This PR adds project pinning to the web dashboard sidebar so repos can stay visible and launchable even when they have zero active sessions. Pinned repos show a diamond marker (◆), appear as inline sidebar headers, and include a “+ New session” action for quick access—matching the existing TUI behavior.

## What Changed / Added
- **Pin/Unpin actions in the sidebar header menu**: Right-click repository headers to **Pin project** or **Unpin project**.
- **Pinned repos remain visible even when empty**: Empty pinned projects render as sidebar headers (with ◆ and “New session”).
- **Cross-UI persistence**: Pins created in the TUI show up in the web dashboard after the dashboard regains focus.
- **Correct placement in sidebar sorting**: Pinned empty projects are sorted below active repos but above the synthetic **Multi-repo** and **Scratch** buckets, preventing stale pins from displacing active work.

## How It Works (more technical, but still brief)
- Introduces a **`useProjects` hook** to fetch the project registry and refresh it on **mount**, **window focus**, and when the page becomes visible.
- Adds **client-side merging** of `/api/projects` (registry) with session-derived repo groups, using **normalized repo paths** to deduplicate entries and attach pinned metadata.
- Extends sidebar/group models with pin state (e.g., pinned vs pinned-empty) and adds render predicates so pinned-empty groups still render without live sessions.
- Updates unit tests and adds a live Playwright test covering pin persistence, unpin removal, and UI presence after reload.

## Modified Files (high level)
- `App.tsx`: Wires pin/unpin handlers and refresh behavior into the sidebar.
- `WorkspaceSidebar.tsx`: Adds the context menu actions and renders the pinned marker/state in headers.
- `useRepoGroups.ts` + `registeredProjects.ts`: Implements the registry/session merging and updated sorting/rendering logic.
- `sidebarGroups.ts` + `types.ts`: Extends data structures and visibility rules for pinned-empty projects.
- Tests + coverage + docs: Adds a live spec, normalization/merge/render unit tests, and a documentation guide section.

## Benefits
- **Feature parity** between the TUI and Web UI for keeping repos accessible without active sessions.
- **More reliable workflow**: users can keep important repos in a stable sidebar location and start new sessions immediately.
- **No backend/API changes required** beyond using existing create/delete project registry endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->