### PR TITLE
fix(git): diff against origin tip when local base is stale

### DIFF
--- a/docs/guides/diff-view.md
+++ b/docs/guides/diff-view.md
@@ -8,7 +8,7 @@ From the main screen, press `D` to open the diff view. It shows:
 - **Left panel**: List of changed files with status indicators (M=modified, A=added, D=deleted)
 - **Right panel**: Diff content for the selected file
 
-The diff is computed against the base branch (defaults to `main` or your repo's default branch). Auto-detection considers every configured remote, not just `origin`, so a fork plus `upstream` layout compares against the branch point rather than a stale fork-main.
+The diff is computed against the base branch (defaults to `main` or your repo's default branch). Auto-detection considers every configured remote, not just `origin`, so a fork plus `upstream` layout compares against the branch point rather than a stale fork-main. When the base resolves to a local branch that is strictly behind its `origin/` tracking counterpart (your local `main` drifted behind `origin/main`), the diff compares against the remote tip, so upstream commits you haven't pulled don't show up as session changes.
 
 ## Navigation
 

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -217,13 +217,31 @@ fn get_commit_from_ref<'a>(
     repo: &'a git2::Repository,
     reference: &str,
 ) -> Result<git2::Commit<'a>> {
+    let remote_ref = format!("origin/{}", reference);
+
     // Try as a local branch
     if let Ok(branch) = repo.find_branch(reference, git2::BranchType::Local) {
-        return Ok(branch.get().peel_to_commit()?);
+        let local_commit = branch.get().peel_to_commit()?;
+        // When the local branch is strictly behind its `origin/<ref>`
+        // tracking counterpart (local is a strict ancestor, no
+        // divergence), diff against the remote tip instead. This matches
+        // GitHub PR semantics and stops a stale local base from rendering
+        // upstream churn as session changes. See #1029, #1951, #2164.
+        if let Ok(remote) = repo.find_branch(&remote_ref, git2::BranchType::Remote) {
+            if let Ok(remote_commit) = remote.get().peel_to_commit() {
+                if local_commit.id() != remote_commit.id()
+                    && repo
+                        .graph_descendant_of(remote_commit.id(), local_commit.id())
+                        .unwrap_or(false)
+                {
+                    return Ok(remote_commit);
+                }
+            }
+        }
+        return Ok(local_commit);
     }
 
     // Try as a remote branch
-    let remote_ref = format!("origin/{}", reference);
     if let Ok(branch) = repo.find_branch(&remote_ref, git2::BranchType::Remote) {
         return Ok(branch.get().peel_to_commit()?);
     }
@@ -1341,5 +1359,153 @@ mod tests {
 
         let loaded = get_working_file_content(dir.path(), Path::new("test.txt")).unwrap();
         assert_eq!(loaded, content);
+    }
+
+    /// Build a repo where `origin/main` is ahead of a stale local `main`,
+    /// with HEAD detached at the `origin/main` tip and a clean working tree.
+    /// Mirrors the #2164 scenario: a worktree cut from `origin/main` whose
+    /// local `main` ref drifted behind. Returns (dir, repo, origin_tip).
+    fn setup_stale_local_main() -> (TempDir, git2::Repository, git2::Oid) {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        // Base commit, then a local `main` pinned to it.
+        commit_file(&repo, "shared.txt", "base\n", "Initial commit");
+        let base = repo.head().unwrap().peel_to_commit().unwrap().id();
+        ensure_local_branch(&repo, "main", &repo.find_commit(base).unwrap());
+
+        // Advance `main` with two upstream commits (the dependabot-style churn).
+        repo.set_head("refs/heads/main").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+        commit_file(&repo, "upstream_a.txt", "a\n", "Upstream commit A");
+        commit_file(&repo, "upstream_b.txt", "b\n", "Upstream commit B");
+        let origin_tip = repo.head().unwrap().peel_to_commit().unwrap().id();
+
+        // Record that tip as origin/main, then rewind local `main` to base so
+        // it is strictly behind origin/main.
+        repo.reference(
+            "refs/remotes/origin/main",
+            origin_tip,
+            true,
+            "set origin/main",
+        )
+        .unwrap();
+        repo.reference("refs/heads/main", base, true, "rewind local main")
+            .unwrap();
+
+        // Detach HEAD at the origin tip with a matching (clean) working tree.
+        repo.set_head_detached(origin_tip).unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+
+        (dir, repo, origin_tip)
+    }
+
+    #[test]
+    fn test_stale_local_main_resolves_to_remote() {
+        // Story: worktree HEAD == origin/main, local `main` strictly behind.
+        // The diff must show zero changed files, not the upstream commits.
+        let (dir, _repo, _tip) = setup_stale_local_main();
+        let files = compute_changed_files(dir.path(), "main").unwrap();
+        assert!(
+            files.is_empty(),
+            "stale local main behind origin/main should yield no phantom changes, got: {:?}",
+            files.iter().map(|f| &f.path).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_local_main_equals_origin_diff_unchanged() {
+        // Story: local `main` == origin/main, so resolution and the computed
+        // diff are identical to the no-remote case (regression guard).
+        let (dir, repo) = setup_branching_repo();
+        let main_tip = repo
+            .find_branch("main", git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+        repo.reference(
+            "refs/remotes/origin/main",
+            main_tip,
+            true,
+            "origin/main == main",
+        )
+        .unwrap();
+
+        let files = compute_changed_files(dir.path(), "main").unwrap();
+        let paths: Vec<&Path> = files.iter().map(|f| f.path.as_path()).collect();
+        assert!(
+            paths.contains(&Path::new("feature_only.txt")),
+            "feature_only.txt should appear, got: {:?}",
+            paths
+        );
+        assert!(
+            !paths.contains(&Path::new("main_only.txt")),
+            "main_only.txt should NOT appear, got: {:?}",
+            paths
+        );
+    }
+
+    #[test]
+    fn test_diverged_local_main_stays_local() {
+        // Story: local base branch genuinely diverged from its remote (not a
+        // strict ancestor), so the diff still resolves against the local branch.
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        commit_file(&repo, "shared.txt", "base\n", "Initial commit");
+        let base = repo.head().unwrap().peel_to_commit().unwrap().id();
+        ensure_local_branch(&repo, "main", &repo.find_commit(base).unwrap());
+
+        // Local `main`: base -> local_main.txt.
+        repo.set_head("refs/heads/main").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+        commit_file(&repo, "local_main.txt", "local\n", "Local main commit");
+
+        // origin/main diverges off the same base via a throwaway branch.
+        ensure_local_branch(&repo, "origintmp", &repo.find_commit(base).unwrap());
+        repo.set_head("refs/heads/origintmp").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+        commit_file(&repo, "origin_main.txt", "origin\n", "Origin main commit");
+        let origin_tip = repo.head().unwrap().peel_to_commit().unwrap().id();
+        repo.reference(
+            "refs/remotes/origin/main",
+            origin_tip,
+            true,
+            "diverged origin/main",
+        )
+        .unwrap();
+
+        // Feature branch off local `main`, then a feature change.
+        repo.set_head("refs/heads/main").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+        let local_main_tip = repo.head().unwrap().peel_to_commit().unwrap();
+        ensure_local_branch(&repo, "feature", &local_main_tip);
+        repo.set_head("refs/heads/feature").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+        commit_file(&repo, "feature.txt", "feature\n", "Feature commit");
+
+        let files = compute_changed_files(dir.path(), "main").unwrap();
+        let paths: Vec<&Path> = files.iter().map(|f| f.path.as_path()).collect();
+        assert!(
+            paths.contains(&Path::new("feature.txt")),
+            "feature.txt should appear, got: {:?}",
+            paths
+        );
+        // Resolving against the diverged origin tip would drop the merge-base
+        // back to the common ancestor and surface local_main.txt. Its absence
+        // proves the local branch was used.
+        assert!(
+            !paths.contains(&Path::new("local_main.txt")),
+            "local_main.txt should NOT appear (diverged local must not switch to origin), got: {:?}",
+            paths
+        );
     }
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A freshly created session whose worktree `HEAD` equals `origin/main`, with a clean working tree and no changes of its own, showed a large phantom diff in the web "Changes" panel: `.github/workflows/*.yml`, `package-lock.json`, `Cargo.*`, and similar files appeared as session changes. Those files were exactly the commits that had landed on `origin/main` after the contributor's local `main` ref was last updated. Anyone who creates worktrees off `origin/main` without first fast-forwarding their local `main` hits this, which is the common case, and it buries real session changes under unrelated upstream churn.

Root cause: the diff base resolves to the bare name `"main"`, and `get_commit_from_ref` (`src/git/diff.rs`) looked up a local branch first, binding `"main"` to the stale local `main`. The merge-base of `HEAD` and a stale local `main` is the stale-main tip itself (an ancestor of `HEAD`), so every upstream commit between local `main` and `origin/main` rendered as a session change. This is the same class of bug that #1029 fixed for the auto-detect path, resurfacing through the worktree-recorded base (#1951) and the profile default, which both store the bare short name and bypass that helper.

Fix (Option A from the issue): when a bare ref resolves to a local branch that is a strict ancestor of its `origin/<ref>` tracking counterpart (the local branch is purely behind, no divergence), diff against the remote tip instead. This matches GitHub PR semantics, where a PR diffs against the remote base, not your local copy. The strict-ancestor guard is conservative: it only switches when the local branch is purely behind, so a genuinely diverged local branch is left alone. Because the fix sits in `get_commit_from_ref`, it corrects every surface that funnels through it consistently: the file-list endpoint, the per-file endpoint, `check_merge_base_status`, and `validate_ref`.

`origin` stays hard-coded, matching the sibling remote-branch lookup already in the function; broader non-`origin` remote detection is out of scope here and tracked conceptually in #1029 / #1511.

Closes #2164

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a worktree off `origin/main` while your local `main` ref is behind `origin/main` (e.g. don't fast-forward local `main` after fetching), with the worktree `HEAD` at `origin/main` and a clean working tree.
- [ ] Open the session's "Changes" panel in the web dashboard and confirm it reports zero changed files (not the upstream commits between local `main` and `origin/main`).
- [ ] Fast-forward your local `main` to `origin/main`, reopen the panel, and confirm the diff is still empty (no regression when local and remote match).
- [ ] On a base branch that has genuinely diverged from its remote (local commits the remote doesn't have), confirm the diff still resolves against your local branch.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the bug and its fix live entirely in the shared Rust git layer (`src/git/diff.rs`); no `web/` file changed. The three regression stories from the issue are covered by new Rust unit tests in `src/git/diff.rs` (stale-local-main resolves to remote, local==origin unchanged, diverged-local stays local), with the red direction proven against the pre-fix tree.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle (the change is in the shared git diff layer, covered by unit tests)
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (Option A, strict-ancestor guard, hard-coded `origin`), reviewed each commit, and confirmed the reproduce-then-fix test goes red on the pre-fix tree.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784189158&installation_id=139138837&pr_number=2194&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2194&signature=a9114759837162aa7dd11cae8e8c6dd8018647f079da970cf71d131f2e5ac77c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

- Fixed a “phantom diff” issue in the web dashboard where worktrees created from `origin/main` could appear to have unrelated upstream changes when the local `main` branch was stale.
- Updated the branch/base detection logic so comparisons use the remote branch tip when the local branch is simply behind (not diverged), preventing commits that are already on the remote from showing up as session changes.
- Centralized this correction in the shared diff base resolution code path, so it consistently affects multiple UI/API views (not just one screen).
- Added unit tests for three key scenarios: stale local `main` vs `origin/main`, local and remote matching, and genuinely diverged local branches.
- Updated the “Diff View” documentation to clarify how base-branch auto-detection works across remotes and when the remote tip is used.

## Benefits

- Eliminates misleading “phantom” changes in the dashboard when local branch state is behind its remote counterpart.
- Aligns diff behavior with expected GitHub-like semantics for upstream/base comparisons.
- Keeps behavior safe: if the local branch has diverged, it continues to compare against the local version.

## Technical Notes (for reviewers)

- Implemented the fix in `src/git/diff.rs` within `get_commit_from_ref`: when a bare ref (e.g., `main`) resolves to a local branch that is a strict ancestor of its `origin/<ref>` tracking counterpart (local strictly behind, no divergence), the code returns the `origin/<ref>` commit/OID for diff base calculation.
- Added/updated tests to cover stale-behind, equal, and diverged cases, ensuring the strict-ancestor guard prevents unintended switching for diverged branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->