### PR TITLE
feat: add "New Session" to the session right-click menu (TUI and web)

### DIFF
--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -21,10 +21,11 @@ pub enum ContextMenuAction {
     ToggleSnooze,
     /// Open the new-session dialog (mirrors the `'n'` hotkey).
     NewSession,
-    /// Open the new-session dialog prefilled from the right-clicked
-    /// project/group (mirrors `'N'` "new from selection" on a group),
+    /// Open the new-session dialog prefilled from the right-clicked row
+    /// (mirrors `'N'` "new from selection"): a session row inherits its
+    /// repo path and group, a project/group row borrows a member's path,
     /// so the mouse path matches the web sidebar's per-project "+".
-    NewFromGroup,
+    NewFromSelection,
     /// Open the sort-order picker (mirrors `'o'`).
     OpenSortPicker,
     /// Open the group-by mode picker (mirrors `'g'`).
@@ -80,6 +81,7 @@ impl ContextMenuDialog {
     pub fn for_session(anchor: (u16, u16), is_archived: bool, snooze: Option<bool>) -> Self {
         let archive_label = if is_archived { "Unarchive" } else { "Archive" };
         let mut items = vec![
+            (ContextMenuAction::NewFromSelection, "New Session"),
             (ContextMenuAction::Rename, "Rename"),
             (ContextMenuAction::ToggleArchive, archive_label),
         ];
@@ -95,7 +97,7 @@ impl ContextMenuDialog {
         Self::new(
             anchor,
             vec![
-                (ContextMenuAction::NewFromGroup, "New Session"),
+                (ContextMenuAction::NewFromSelection, "New Session"),
                 (ContextMenuAction::Rename, "Rename Group"),
                 (ContextMenuAction::Delete, "Delete Group"),
             ],
@@ -117,7 +119,7 @@ impl ContextMenuDialog {
         Self::new(
             anchor,
             vec![
-                (ContextMenuAction::NewFromGroup, "New Session"),
+                (ContextMenuAction::NewFromSelection, "New Session"),
                 (ContextMenuAction::TogglePin, pin_label),
             ],
         )
@@ -158,6 +160,14 @@ impl ContextMenuDialog {
     #[cfg(test)]
     pub fn items_for_test(&self) -> &[(ContextMenuAction, &'static str)] {
         &self.items
+    }
+
+    /// Test-only accessor: returns the area the menu rendered into
+    /// last frame. Lets a cross-module test compute the row of a given
+    /// item without re-deriving the layout math.
+    #[cfg(test)]
+    pub fn last_area_for_test(&self) -> Rect {
+        self.last_area
     }
 
     /// Returns true when `(col, row)` falls outside the last rendered area.
@@ -239,16 +249,16 @@ impl ContextMenuDialog {
                     'z' | 'Z' => Some(ContextMenuAction::ToggleArchive),
                     'h' | 'H' => Some(ContextMenuAction::ToggleSnooze),
                     // `n` opens a new session from whichever new-session entry
-                    // the current menu carries: the group/project menu prefills
-                    // from the row (NewFromGroup), the empty-sidebar menu opens
-                    // a blank one (NewSession).
+                    // the current menu carries: the session/group/project menu
+                    // prefills from the row (NewFromSelection), the empty-sidebar
+                    // menu opens a blank one (NewSession).
                     'n' | 'N' => {
                         if self
                             .items
                             .iter()
-                            .any(|(item, _)| *item == ContextMenuAction::NewFromGroup)
+                            .any(|(item, _)| *item == ContextMenuAction::NewFromSelection)
                         {
-                            Some(ContextMenuAction::NewFromGroup)
+                            Some(ContextMenuAction::NewFromSelection)
                         } else {
                             Some(ContextMenuAction::NewSession)
                         }
@@ -341,14 +351,14 @@ mod tests {
     }
 
     #[test]
-    fn session_menu_starts_on_rename() {
+    fn session_menu_starts_on_new_session() {
         let menu = ContextMenuDialog::for_session((0, 0), false, Some(false));
-        assert_eq!(menu.selected_action(), ContextMenuAction::Rename);
+        assert_eq!(menu.selected_action(), ContextMenuAction::NewFromSelection);
     }
 
     #[test]
-    fn down_then_enter_selects_toggle_archive() {
-        // Rename -> ToggleArchive is one Down in the 3-item session menu.
+    fn down_then_enter_selects_rename() {
+        // NewFromSelection -> Rename is one Down in the session menu.
         let mut menu = ContextMenuDialog::for_session((0, 0), false, Some(false));
         assert!(matches!(
             menu.handle_key(key(KeyCode::Down)),
@@ -357,14 +367,16 @@ mod tests {
         let result = menu.handle_key(key(KeyCode::Enter));
         assert!(matches!(
             result,
-            DialogResult::Submit(ContextMenuAction::ToggleArchive)
+            DialogResult::Submit(ContextMenuAction::Rename)
         ));
     }
 
     #[test]
-    fn down_twice_then_enter_selects_snooze() {
-        // Rename -> Archive -> Snooze is two Downs in the 4-item session menu.
+    fn down_thrice_then_enter_selects_snooze() {
+        // NewSession -> Rename -> Archive -> Snooze is three Downs in the
+        // 5-item session menu.
         let mut menu = ContextMenuDialog::for_session((0, 0), false, Some(false));
+        menu.handle_key(key(KeyCode::Down));
         menu.handle_key(key(KeyCode::Down));
         menu.handle_key(key(KeyCode::Down));
         let result = menu.handle_key(key(KeyCode::Enter));
@@ -375,8 +387,9 @@ mod tests {
     }
 
     #[test]
-    fn down_thrice_then_enter_selects_delete() {
+    fn down_four_times_then_enter_selects_delete() {
         let mut menu = ContextMenuDialog::for_session((0, 0), false, Some(false));
+        menu.handle_key(key(KeyCode::Down));
         menu.handle_key(key(KeyCode::Down));
         menu.handle_key(key(KeyCode::Down));
         menu.handle_key(key(KeyCode::Down));
@@ -398,7 +411,7 @@ mod tests {
         assert_eq!(
             items,
             vec![
-                (ContextMenuAction::NewFromGroup, "New Session"),
+                (ContextMenuAction::NewFromSelection, "New Session"),
                 (ContextMenuAction::Rename, "Rename Group"),
                 (ContextMenuAction::Delete, "Delete Group"),
             ]
@@ -406,21 +419,21 @@ mod tests {
     }
 
     #[test]
-    fn n_hotkey_in_group_menu_submits_new_from_group() {
+    fn n_hotkey_in_group_menu_submits_new_from_selection() {
         let mut menu = ContextMenuDialog::for_group((0, 0));
         // Pre-select Delete to prove the hotkey wins over the cursor.
         menu.handle_key(key(KeyCode::Up));
         let result = menu.handle_key(key(KeyCode::Char('n')));
         assert!(matches!(
             result,
-            DialogResult::Submit(ContextMenuAction::NewFromGroup)
+            DialogResult::Submit(ContextMenuAction::NewFromSelection)
         ));
     }
 
     #[test]
     fn n_hotkey_in_empty_sidebar_menu_submits_new_session() {
         // The empty-sidebar menu carries the blank NewSession entry, so `n`
-        // must resolve there and never to the group-scoped NewFromGroup.
+        // must resolve there and never to the row-scoped NewFromSelection.
         let mut menu = ContextMenuDialog::for_empty_sidebar((0, 0));
         let result = menu.handle_key(key(KeyCode::Char('n')));
         assert!(matches!(
@@ -433,29 +446,51 @@ mod tests {
     fn archived_session_menu_labels_unarchive() {
         let menu = ContextMenuDialog::for_session((0, 0), true, Some(false));
         let labels: Vec<&str> = menu.items_for_test().iter().map(|(_, l)| *l).collect();
-        assert_eq!(labels, vec!["Rename", "Unarchive", "Snooze", "Delete"]);
+        assert_eq!(
+            labels,
+            vec!["New Session", "Rename", "Unarchive", "Snooze", "Delete"]
+        );
     }
 
     #[test]
     fn snoozed_session_menu_labels_unsnooze() {
         let menu = ContextMenuDialog::for_session((0, 0), false, Some(true));
         let labels: Vec<&str> = menu.items_for_test().iter().map(|(_, l)| *l).collect();
-        assert_eq!(labels, vec!["Rename", "Archive", "Unsnooze", "Delete"]);
+        assert_eq!(
+            labels,
+            vec!["New Session", "Rename", "Archive", "Unsnooze", "Delete"]
+        );
     }
 
     #[test]
-    fn active_session_menu_lists_all_four_actions() {
+    fn active_session_menu_lists_all_five_actions() {
         let menu = ContextMenuDialog::for_session((0, 0), false, Some(false));
         let items: Vec<ContextMenuAction> = menu.items_for_test().iter().map(|(a, _)| *a).collect();
         assert_eq!(
             items,
             vec![
+                ContextMenuAction::NewFromSelection,
                 ContextMenuAction::Rename,
                 ContextMenuAction::ToggleArchive,
                 ContextMenuAction::ToggleSnooze,
                 ContextMenuAction::Delete,
             ]
         );
+    }
+
+    #[test]
+    fn n_hotkey_in_session_menu_submits_new_from_selection() {
+        // The session menu carries the prefill-from-row entry, so `n`/`N` must
+        // resolve to NewFromSelection, matching the `'N'` keybinding's
+        // new-from-selection behavior on a session.
+        let mut menu = ContextMenuDialog::for_session((0, 0), false, Some(false));
+        // Pre-select Delete to prove the hotkey wins over the cursor.
+        menu.handle_key(key(KeyCode::Up));
+        let result = menu.handle_key(key(KeyCode::Char('n')));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::NewFromSelection)
+        ));
     }
 
     #[test]
@@ -475,7 +510,7 @@ mod tests {
         // Snooze item to resolve to), matching the Attention-gated keybinding.
         let mut menu = ContextMenuDialog::for_session((0, 0), false, None);
         let labels: Vec<&str> = menu.items_for_test().iter().map(|(_, l)| *l).collect();
-        assert_eq!(labels, vec!["Rename", "Archive", "Delete"]);
+        assert_eq!(labels, vec!["New Session", "Rename", "Archive", "Delete"]);
         assert!(matches!(
             menu.handle_key(key(KeyCode::Char('h'))),
             DialogResult::Continue
@@ -493,12 +528,12 @@ mod tests {
     }
 
     #[test]
-    fn enter_on_default_submits_rename() {
+    fn enter_on_default_submits_new_session() {
         let mut menu = ContextMenuDialog::for_session((0, 0), false, Some(false));
         let result = menu.handle_key(key(KeyCode::Enter));
         assert!(matches!(
             result,
-            DialogResult::Submit(ContextMenuAction::Rename)
+            DialogResult::Submit(ContextMenuAction::NewFromSelection)
         ));
     }
 
@@ -523,8 +558,9 @@ mod tests {
     #[test]
     fn down_wraps_from_last_to_first() {
         let mut menu = ContextMenuDialog::for_session((0, 0), false, Some(false));
-        // 4 items: Down x4 walks Rename -> Archive -> Snooze -> Delete -> back
-        // to Rename.
+        // 5 items: Down x5 walks NewSession -> Rename -> Archive -> Snooze ->
+        // Delete -> back to NewSession.
+        menu.handle_key(key(KeyCode::Down));
         menu.handle_key(key(KeyCode::Down));
         menu.handle_key(key(KeyCode::Down));
         menu.handle_key(key(KeyCode::Down));
@@ -532,15 +568,16 @@ mod tests {
         let result = menu.handle_key(key(KeyCode::Enter));
         assert!(matches!(
             result,
-            DialogResult::Submit(ContextMenuAction::Rename)
+            DialogResult::Submit(ContextMenuAction::NewFromSelection)
         ));
     }
 
     #[test]
     fn r_hotkey_submits_rename() {
         let mut menu = ContextMenuDialog::for_session((0, 0), false, Some(false));
-        // Pre-select Delete to prove the hotkey wins over the cursor.
-        menu.handle_key(key(KeyCode::Down));
+        // Pre-select Delete (Up wraps to the last item) to prove the hotkey
+        // wins over the cursor.
+        menu.handle_key(key(KeyCode::Up));
         let result = menu.handle_key(key(KeyCode::Char('r')));
         assert!(matches!(
             result,
@@ -610,12 +647,23 @@ mod tests {
     }
 
     #[test]
-    fn click_on_first_row_submits_rename() {
+    fn click_on_first_row_submits_new_session() {
         let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
-        stub_render(&mut menu, 10, 10, 14, 4);
+        stub_render(&mut menu, 10, 10, 14, 7);
         // Item rows live inside the bordered block, so row y+1 is the
         // first item and y+2 is the second.
         let result = menu.handle_click(12, 11);
+        assert!(matches!(
+            result,
+            Some(DialogResult::Submit(ContextMenuAction::NewFromSelection))
+        ));
+    }
+
+    #[test]
+    fn click_on_second_row_submits_rename() {
+        let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
+        stub_render(&mut menu, 10, 10, 14, 7);
+        let result = menu.handle_click(12, 12);
         assert!(matches!(
             result,
             Some(DialogResult::Submit(ContextMenuAction::Rename))
@@ -623,10 +671,10 @@ mod tests {
     }
 
     #[test]
-    fn click_on_second_row_submits_toggle_archive() {
+    fn click_on_third_row_submits_toggle_archive() {
         let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
-        stub_render(&mut menu, 10, 10, 14, 5);
-        let result = menu.handle_click(12, 12);
+        stub_render(&mut menu, 10, 10, 14, 7);
+        let result = menu.handle_click(12, 13);
         assert!(matches!(
             result,
             Some(DialogResult::Submit(ContextMenuAction::ToggleArchive))
@@ -634,24 +682,13 @@ mod tests {
     }
 
     #[test]
-    fn click_on_third_row_submits_toggle_snooze() {
+    fn click_on_fourth_row_submits_toggle_snooze() {
         let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
-        stub_render(&mut menu, 10, 10, 14, 6);
-        let result = menu.handle_click(12, 13);
-        assert!(matches!(
-            result,
-            Some(DialogResult::Submit(ContextMenuAction::ToggleSnooze))
-        ));
-    }
-
-    #[test]
-    fn click_on_fourth_row_submits_delete() {
-        let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
-        stub_render(&mut menu, 10, 10, 14, 6);
+        stub_render(&mut menu, 10, 10, 14, 7);
         let result = menu.handle_click(12, 14);
         assert!(matches!(
             result,
-            Some(DialogResult::Submit(ContextMenuAction::Delete))
+            Some(DialogResult::Submit(ContextMenuAction::ToggleSnooze))
         ));
     }
 
@@ -698,11 +735,11 @@ mod tests {
     #[test]
     fn hover_moves_highlight() {
         let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
-        stub_render(&mut menu, 10, 10, 14, 5);
-        assert_eq!(menu.selected_action(), ContextMenuAction::Rename);
+        stub_render(&mut menu, 10, 10, 14, 7);
+        assert_eq!(menu.selected_action(), ContextMenuAction::NewFromSelection);
         let changed = menu.handle_hover(12, 12);
         assert!(changed, "hover onto second row should change highlight");
-        assert_eq!(menu.selected_action(), ContextMenuAction::ToggleArchive);
+        assert_eq!(menu.selected_action(), ContextMenuAction::Rename);
     }
 
     #[test]
@@ -718,8 +755,8 @@ mod tests {
     #[test]
     fn hover_off_menu_leaves_selection_alone() {
         let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
-        stub_render(&mut menu, 10, 10, 14, 6);
-        menu.handle_hover(12, 14); // Delete (fourth/last row)
+        stub_render(&mut menu, 10, 10, 14, 7);
+        menu.handle_hover(12, 15); // Delete (fifth/last row)
         assert_eq!(menu.selected_action(), ContextMenuAction::Delete);
         assert!(!menu.handle_hover(40, 40));
         assert_eq!(

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3423,11 +3423,11 @@ impl HomeView {
                 }
             }
             ContextMenuAction::NewSession => self.open_new_session_dialog(),
-            // The right-click already moved the cursor onto the group row, so
-            // reuse the "new from selection" path: with a group selected it
-            // prefills the project's repo path (and group) the same way `'N'`
-            // does on a session.
-            ContextMenuAction::NewFromGroup => self.open_new_from_selection(),
+            // The right-click already moved the cursor onto the row, so reuse
+            // the "new from selection" path: a session row prefills its own repo
+            // path and group, a group/project row borrows a member's path, the
+            // same way `'N'` does.
+            ContextMenuAction::NewFromSelection => self.open_new_from_selection(),
             ContextMenuAction::OpenSortPicker => self.show_sort_picker(),
             ContextMenuAction::OpenGroupPicker => self.show_group_picker(),
             ContextMenuAction::TogglePin => {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4018,12 +4018,12 @@ fn test_group_context_menu_new_session_prefills_path() {
 
     // The group right-click menu's "New Session" routes here.
     env.view
-        .dispatch_context_menu_action(ContextMenuAction::NewFromGroup);
+        .dispatch_context_menu_action(ContextMenuAction::NewFromSelection);
     let dialog = env
         .view
         .new_dialog
         .as_ref()
-        .expect("NewFromGroup should open the new-session dialog");
+        .expect("NewFromSelection should open the new-session dialog");
     assert_eq!(dialog.path_value(), "/tmp/work");
     assert_eq!(dialog.group_value(), "work");
 }
@@ -4046,7 +4046,7 @@ fn test_group_context_menu_new_session_shows_no_agents_without_tools() {
     env.view.update_selected();
 
     env.view
-        .dispatch_context_menu_action(ContextMenuAction::NewFromGroup);
+        .dispatch_context_menu_action(ContextMenuAction::NewFromSelection);
     assert!(
         env.view.new_dialog.is_none(),
         "no agents means the new-session form must not open"
@@ -4079,17 +4079,54 @@ fn test_group_context_menu_new_session_prefills_path_in_project_mode() {
     env.view.update_selected();
 
     env.view
-        .dispatch_context_menu_action(ContextMenuAction::NewFromGroup);
+        .dispatch_context_menu_action(ContextMenuAction::NewFromSelection);
     let dialog = env
         .view
         .new_dialog
         .as_ref()
-        .expect("NewFromGroup should open the new-session dialog");
+        .expect("NewFromSelection should open the new-session dialog");
     assert_eq!(
         dialog.path_value(),
         "/tmp/work",
         "project-mode prefill should borrow the member repo path"
     );
+}
+
+#[test]
+#[serial]
+fn test_session_context_menu_new_session_prefills_from_session() {
+    use crate::tui::dialogs::ContextMenuAction;
+
+    let mut env = create_test_env_with_groups();
+
+    // Move cursor onto the "work-project" session row, as a right-click would.
+    let target_id = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.repo_path() == "/tmp/work")
+        .map(|i| i.id.clone())
+        .expect("work-project instance should exist");
+    let session_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Session { id, .. } if *id == target_id))
+        .expect("work-project session row should exist in flat_items");
+    env.view.cursor = session_idx;
+    env.view.update_selected();
+
+    // The session right-click menu's "New Session" routes here, prefilling the
+    // dialog from the right-clicked session's repo path and group (issue #2023).
+    env.view
+        .dispatch_context_menu_action(ContextMenuAction::NewFromSelection);
+    let dialog = env
+        .view
+        .new_dialog
+        .as_ref()
+        .expect("NewFromSelection should open the new-session dialog");
+    assert_eq!(dialog.path_value(), "/tmp/work");
+    assert_eq!(dialog.group_value(), "work");
 }
 
 #[test]
@@ -11421,7 +11458,7 @@ mod right_click_context_menu {
             .context_menu
             .as_ref()
             .expect("context_menu should be open");
-        assert_eq!(menu.selected_action(), ContextMenuAction::Rename);
+        assert_eq!(menu.selected_action(), ContextMenuAction::NewFromSelection);
         // The selected item is a session, not a group.
         assert!(matches!(
             env.view.flat_items[env.view.cursor],
@@ -11469,7 +11506,8 @@ mod right_click_context_menu {
         setup_inner(&mut env);
         env.view.handle_right_click(5, 1);
         assert!(env.view.context_menu.is_some());
-        // First item is Rename; Enter submits it.
+        // First item is New Session; Rename is one Down away. Enter submits it.
+        env.view.handle_key(key(KeyCode::Down), None);
         env.view.handle_key(key(KeyCode::Enter), None);
         assert!(
             env.view.context_menu.is_none(),
@@ -11486,11 +11524,12 @@ mod right_click_context_menu {
     fn down_then_enter_in_menu_opens_delete_dialog() {
         let mut env = create_test_env_with_sessions(2);
         setup_inner(&mut env);
-        // Attention sort surfaces the full session menu (Rename / Archive /
-        // Snooze / Delete), so Delete is three Downs away.
+        // Attention sort surfaces the full session menu (New Session / Rename /
+        // Archive / Snooze / Delete), so Delete is four Downs away.
         env.view.sort_order = SortOrder::Attention;
         env.view.flat_items = env.view.build_flat_items();
         env.view.handle_right_click(5, 1);
+        env.view.handle_key(key(KeyCode::Down), None);
         env.view.handle_key(key(KeyCode::Down), None);
         env.view.handle_key(key(KeyCode::Down), None);
         env.view.handle_key(key(KeyCode::Down), None);
@@ -11514,9 +11553,9 @@ mod right_click_context_menu {
         assert!(env.view.unified_delete_dialog.is_none());
     }
 
-    /// Right-click a session, pick the Archive item (Rename -> Archive is one
-    /// Down), and the row gets archived through the same `z` codepath. No
-    /// follow-up dialog: archiving is immediate.
+    /// Right-click a session, pick the Archive item (New Session -> Rename ->
+    /// Archive is two Downs), and the row gets archived through the same `z`
+    /// codepath. No follow-up dialog: archiving is immediate.
     #[test]
     #[serial]
     fn right_click_archive_action_archives_session() {
@@ -11529,6 +11568,7 @@ mod right_click_context_menu {
             "precondition: session starts unarchived"
         );
 
+        env.view.handle_key(key(KeyCode::Down), None); // New Session -> Rename
         env.view.handle_key(key(KeyCode::Down), None); // Rename -> Archive
         env.view.handle_key(key(KeyCode::Enter), None);
 
@@ -11573,9 +11613,10 @@ mod right_click_context_menu {
             .map(|(_, l)| *l)
             .collect();
         // Default sort here is Newest, where Snooze is gated out, so the
-        // archived-row menu is just Rename / Unarchive / Delete.
-        assert_eq!(labels, vec!["Rename", "Unarchive", "Delete"]);
+        // archived-row menu is just New Session / Rename / Unarchive / Delete.
+        assert_eq!(labels, vec!["New Session", "Rename", "Unarchive", "Delete"]);
 
+        env.view.handle_key(key(KeyCode::Down), None); // New Session -> Rename
         env.view.handle_key(key(KeyCode::Down), None); // Rename -> Unarchive
         env.view.handle_key(key(KeyCode::Enter), None);
         assert!(
@@ -11848,18 +11889,22 @@ mod right_click_context_menu {
 
     #[test]
     #[serial]
-    fn session_menu_n_hotkey_is_inert() {
-        // Sanity: the session-row menu only has Rename/Delete actions,
-        // so 'n' must NOT submit NewSession when the wrong menu is open.
-        // This proves the hotkey gate (action must be in items) holds.
+    fn session_menu_n_hotkey_opens_new_session() {
+        // The session-row menu now carries a New Session entry (issue #2023),
+        // so 'n' submits NewFromSelection just like the group/project menus,
+        // closing the menu and opening the new-session dialog prefilled from
+        // the right-clicked session.
         let mut env = create_test_env_with_sessions(2);
         setup_inner(&mut env);
         env.view.handle_right_click(5, 1); // row 1 = first session
         send_key(&mut env, crossterm::event::KeyCode::Char('n'));
-        assert!(env.view.context_menu.is_some(), "menu should stay open");
         assert!(
-            env.view.new_dialog.is_none(),
-            "n on session menu must not open new-session"
+            env.view.context_menu.is_none(),
+            "menu should close on submit"
+        );
+        assert!(
+            env.view.new_dialog.is_some(),
+            "n on session menu must open the new-session dialog"
         );
     }
 }

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -23,6 +23,7 @@ import {
   Pencil,
   Pin,
   Play,
+  Plus,
 } from "lucide-react";
 import {
   DndContext,
@@ -396,6 +397,7 @@ function SortableSessionRow({
   onDelete?: (workspaceId: string) => void;
   onStop?: (workspaceId: string) => void;
   onStart?: (workspaceId: string) => void;
+  onCreateSession?: (repoPath: string) => void;
   readOnly?: boolean;
   dragDisabled?: boolean;
   optimistic: OptimisticTriage;
@@ -515,6 +517,7 @@ export const SessionRow = memo(function SessionRow({
   onDelete,
   onStop,
   onStart,
+  onCreateSession,
   readOnly,
   indented,
   optimistic,
@@ -533,6 +536,9 @@ export const SessionRow = memo(function SessionRow({
   onDelete?: (workspaceId: string) => void;
   onStop?: (workspaceId: string) => void;
   onStart?: (workspaceId: string) => void;
+  // Open the session wizard prefilled from this row's project (path, agent,
+  // and the latest session's options), mirroring the per-project "+" button.
+  onCreateSession?: (repoPath: string) => void;
   readOnly?: boolean;
   indented?: boolean;
   // Optimistic triage overlay for this row plus the parent-owned mutation
@@ -554,6 +560,9 @@ export const SessionRow = memo(function SessionRow({
     idleDecayWindowMs,
   );
   const firstSession = workspace.sessions[0];
+  // Repo path used to prefill a "New Session" launched from this row, matching
+  // the per-project "+" button (handleCreateSession keys off this same path).
+  const newSessionRepoPath = firstSession?.main_repo_path || firstSession?.project_path || null;
   // The structured view session backing this row, if any. Drives the "Switch
   // agent" context-menu item, which only makes sense for an ACP structured view
   // session (tmux rows have no agent to hand off). Multi-session rows are
@@ -1024,6 +1033,19 @@ export const SessionRow = memo(function SessionRow({
               maxHeight: "calc(100vh - 16px)",
             }}
           >
+            {!readOnly && onCreateSession && newSessionRepoPath && (
+              <button
+                onClick={() => {
+                  setContextMenu(null);
+                  onCreateSession(newSessionRepoPath);
+                }}
+                data-testid="sidebar-context-menu-new-session"
+                className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+              >
+                <Plus className="h-3.5 w-3.5 shrink-0" />
+                New Session
+              </button>
+            )}
             <button
               onClick={startRename}
               data-testid="sidebar-context-menu-rename"
@@ -2498,6 +2520,7 @@ export function WorkspaceSidebar({
                                     onDelete={onDeleteSession}
                                     onStop={onStopSession}
                                     onStart={onStartSession}
+                                    onCreateSession={onCreateSession}
                                     readOnly={readOnly}
                                     optimistic={triage.optimisticFor(v.workspace.id)}
                                     onPinToggle={triage.pinToggle}

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -76,7 +76,15 @@ function Wrap({ children }: { children: ReactNode }) {
 // so bulk actions can share them, see #1724), so the row + hook are
 // exercised together here rather than the row owning the mutation. Returns
 // `null` while the workspace has no row to render.
-function Row({ ws, readOnly }: { ws: Workspace; readOnly?: boolean }) {
+function Row({
+  ws,
+  readOnly,
+  onCreateSession,
+}: {
+  ws: Workspace;
+  readOnly?: boolean;
+  onCreateSession?: (repoPath: string) => void;
+}) {
   const workspaces = useMemo(() => [ws], [ws]);
   const triage = useSidebarTriage(workspaces);
   return (
@@ -85,6 +93,7 @@ function Row({ ws, readOnly }: { ws: Workspace; readOnly?: boolean }) {
       isActive={false}
       isSelected={false}
       onActivate={() => {}}
+      onCreateSession={onCreateSession}
       readOnly={readOnly}
       optimistic={triage.optimisticFor(ws.id)}
       onPinToggle={triage.pinToggle}
@@ -451,5 +460,34 @@ describe("SessionRow triage actions", () => {
       window.removeEventListener(OPEN_SESSION_EVENT, onOpen);
       window.removeEventListener(OPEN_SWITCH_AGENT_EVENT, onSwitch);
     }
+  });
+
+  it("New Session click calls onCreateSession with the row's repo path", () => {
+    // main_repo_path wins over project_path, matching handleCreateSession's
+    // own project key (`main_repo_path || project_path`), so the wizard
+    // prefills from the right-clicked session's project (issue #2023).
+    const ws = workspace("w-new", [session({ id: "sess-new", project_path: "/p", main_repo_path: "/repos/work" })]);
+    const onCreateSession = vi.fn();
+    render(
+      <Wrap>
+        <Row ws={ws} onCreateSession={onCreateSession} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-new-session"));
+    expect(onCreateSession).toHaveBeenCalledWith("/repos/work");
+    // It's a client-side wizard open, not a server mutation.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("hides New Session in read-only mode", () => {
+    const ws = workspace("w-ro", [session({ id: "sess-ro", project_path: "/p" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} readOnly onCreateSession={vi.fn()} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    expect(screen.queryByTestId("sidebar-context-menu-new-session")).toBeNull();
   });
 });

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2202,6 +2202,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.session-new-session",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/__tests__/SessionRowTriage.test.tsx"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.multi-select-logic",
       "kind": "vitest",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The session right-click menu offered Rename / Archive / Snooze / Delete (TUI) and Rename / Edit group / Switch agent / Stop / Notifications / Pin / Archive / Snooze / Delete (web), but no way to launch a new session from a session row. The only new-session entry points were the `'N'` keybinding (TUI) and the per-project `+` button (web). PR #2051 added "New Session" to the project/group right-click menus only, leaving the session menus out of sync.

This adds a "New Session" entry to the session right-click menu on both surfaces, prefilled from the right-clicked session's project so it matches the existing "new from selection" behavior:

- **TUI** (`src/tui/`): prepends "New Session" to the session menu, wired to the existing `open_new_from_selection` path so it prefills the new-session dialog with the right-clicked session's repo path and group and lands focus on the title field. `n`/`N` inside the menu submit it too. The menu action `NewFromGroup` is renamed to `NewFromSelection` since it now serves session, group, and project rows (no behavior change for the group/project menus).
- **Web** (`web/src/components/WorkspaceSidebar.tsx`): prepends a "New Session" item to the session-row context menu, wired to the existing `onCreateSession` handler with the row's repo path (`main_repo_path || project_path`). That reuses `handleCreateSession`, so the wizard prefills from the project's latest session (agent, yolo, sandbox, profile, group) exactly like the `+` button. Gated to writable mode and to rows that have a repo path.

Closes #2023

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] TUI: right-click a session row, confirm "New Session" is the first menu entry.
- [ ] TUI: pick it (or press `n`/`N` in the menu); confirm the new-session dialog opens prefilled with that session's working directory and group, focused on the title field.
- [ ] Web: right-click a session in the sidebar, confirm "New Session" is the top item.
- [ ] Web: pick it; confirm the session wizard opens prefilled from that project's latest session (path, agent, profile, group) at the review step.
- [ ] Both: right-click a project/group header and an empty sidebar area; confirm those menus are unchanged. Confirm the session menu has no "New Session" in read-only/viewer mode (web).

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A
- [x] Added or updated a test and updated `web/tests/coverage-matrix.json`: extended `src/components/__tests__/SessionRowTriage.test.tsx` (Vitest + RTL) to cover the new session-menu item (calls `onCreateSession` with the row's repo path; hidden in read-only), with a matching `sidebar.session-new-session` matrix entry.

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a full e2e, because: the menu construction, ordering, hotkeys, and the new-from-selection dispatch are covered by unit tests in `src/tui/dialogs/context_menu.rs` and `src/tui/home/tests.rs` (including a new test that the session menu's "New Session" prefills from the right-clicked session).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. I made the design calls (e.g. "New Session" as the first session-menu item, extending the change to the web sidebar, the action rename) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784189300&installation_id=139138837&pr_number=2195&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2195&signature=f6b91ad7f150a8289cbdbd5b8de1c9492f1656acb5e17478d6975b6bc150b487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds a "New Session" entry to session right-click context menus in both the TUI (terminal user interface) and web interfaces. Previously, users could create new sessions from existing sessions only via keyboard shortcuts (`'N'` in TUI) or per-project buttons in the web interface, but context menus lacked this option even though project and group menus already had it.

## What Changed

**TUI Changes** (`src/tui/`):
- Added "New Session" as the first item in session row context menus
- Renamed the `NewFromGroup` menu action to `NewFromSelection` to reflect that it now serves sessions, groups, and projects (not just groups)
- When selected, the new-session dialog opens prefilled with the right-clicked session's repository path and group
- The `n`/`N` hotkey within the menu now submits the "New Session" entry when available
- Updated all related test expectations to account for the new menu structure

**Web Changes** (`web/src/components/WorkspaceSidebar.tsx`):
- Added "New Session" button to session row context menus (first item)
- The button appears only when the sidebar is in writable mode and the session has a repo path
- Clicking it triggers the same new-session flow as the per-project `+` button, prefilling the wizard with the session's project details
- Extended `SessionRow` component to accept an optional `onCreateSession` callback prop
- Added comprehensive test coverage for the new context menu action

## Benefits

- **Improved Discoverability**: Users can now discover the "create new session from existing session" workflow through visible UI menus rather than relying on keyboard shortcuts
- **Consistency**: Session context menus are now on parity with project and group menus, providing a unified experience across the application
- **Reduced Friction**: The feature eliminates the need to remember keyboard shortcuts or navigate to per-project buttons
- **Seamless Integration**: Both implementations reuse existing code paths (`open_new_from_selection` in TUI, `handleCreateSession` in web), minimizing complexity and maintaining consistency with existing behavior

## Technical Details

The implementation follows existing patterns:
- **TUI**: Leverages the `open_new_from_selection()` path with the renamed `ContextMenuAction::NewFromSelection` variant
- **Web**: Derives the repo path from the session's `main_repo_path` (fallback to `project_path`) and calls the same handler used by the `+` button
- **Tests**: Updated and added comprehensive test coverage including menu ordering, hotkey behavior (TUI), read-only mode gating (web), and prefill verification

Closes issue `#2023`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->