### PR TITLE
refactor(acp): single-source the claude-agent-acp floor so a bump touches fewer files

### DIFF
--- a/docs/development/internals/sandbox.md
+++ b/docs/development/internals/sandbox.md
@@ -56,7 +56,7 @@ docker volume rm aoe-claude-auth aoe-opencode-auth aoe-codex-auth aoe-gemini-aut
 
 Agent-view sessions can run inside the container. When both are enabled, the structured view runner wraps the ACP agent in `docker exec`, so the adapter binary must exist inside the container. The published `aoe-sandbox` image bundles the npm-distributed ACP adapters:
 
-- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@^0.44.0`, floor pin)
+- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp`, pinned to the host floor; see `docker/Dockerfile`)
 - `codex-acp` (`@zed-industries/codex-acp`)
 - `pi-acp`
 

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -20,7 +20,7 @@ aoe ships an ACP registry entry for each tool whose ACP server we've verified. F
 
 | Agent | ACP adapter | Install | Auth |
 |-------|-------------|---------|------|
-| `claude` | `claude-agent-acp` (Zed, requires ≥0.44.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` | `claude login`, or `ANTHROPIC_API_KEY` |
+| `claude` | `claude-agent-acp` (Zed, recent version required) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` | `claude login`, or `ANTHROPIC_API_KEY` |
 | `codex` | `codex-acp` (Zed) | `npm install -g @zed-industries/codex-acp` | `OPENAI_API_KEY`, or ChatGPT login (local-only) |
 | `opencode` | `opencode acp` (native, ≥1.16.0 recommended) | `curl -fsSL https://opencode.ai/install \| bash` | `opencode auth` / provider env |
 | `gemini` | `gemini --acp` (native) | `npm install -g @google/gemini-cli` | `GEMINI_API_KEY`, OAuth, or Vertex |

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -53,15 +53,17 @@ install is incomplete. Reinstall aoe via your package manager (e.g.,
 
 ### `aoe acp doctor` says claude-code adapter is missing
 
-aoe requires `claude-agent-acp` v0.44.0 or newer. Install the official adapter:
+aoe requires a recent `claude-agent-acp`. If your installed adapter is too old,
+aoe refuses to start the session and reports the exact required version. Install
+the official adapter:
 
 ```bash
 npm install -g @agentclientprotocol/claude-agent-acp@latest
 ```
 
 Then run `claude login` if you haven't already. If an older version is pinned by
-an internal mirror, ship 0.44.0 from the mirror or run the `@latest` install
-above before starting `aoe serve`.
+an internal mirror, ship the required floor from the mirror or run the `@latest`
+install above before starting `aoe serve`.
 
 ### "Failed to start structured view agent" while the adapter is installed
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -402,7 +402,7 @@ const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from
 /// claude-agent-acp >=0.41.0 (upstream #680) also force-resolves a
 /// prompt loop wedged in a `TaskOutput { block: true }` poll against a
 /// hung background task: ~30s after the first cancel it returns
-/// `cancelled` instead of hanging forever. The 0.44.0 floor (see
+/// `cancelled` instead of hanging forever. The floor (see
 /// `agent_compat`) guarantees that path, so a cancel during off-protocol
 /// background work no longer rides the 30-minute
 /// `OFF_PROTOCOL_WORK_GRACE_FLOOR` below before recovering.

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -7,7 +7,8 @@
 //! single hook to call after `initialize` succeeds, instead of scattering
 //! ad-hoc semver checks at every spawn site.
 //!
-//! Today only `ClaudeAgentAcp` carries a minimum version (>=0.44.0,
+//! Today only `ClaudeAgentAcp` carries a minimum version (see
+//! `CLAUDE_AGENT_ACP_MIN_VERSION`,
 //! required for `memory_recall` tool-call emission, native `cancelled`
 //! stop reason, force-cancel of a wedged `TaskOutput` block (upstream
 //! #680), the upstream #641 fix, the `fable` model, and several other
@@ -24,6 +25,25 @@
 use agent_client_protocol::schema::{InitializeResponse, ProtocolVersion};
 
 use super::state::StartupErrorDetail;
+
+/// Single source of truth for the `claude-agent-acp` minimum-version floor.
+///
+/// Bumping the floor is a one-line edit here: the gate, the startup-error
+/// strings, and the boundary tests all derive from this value. The one
+/// peer that cannot read a Rust const, the npm pin in `docker/Dockerfile`,
+/// is held in sync by the `dockerfile_pin_matches_floor` test below, so a
+/// bump that forgets the Dockerfile fails CI rather than shipping a
+/// sandbox image stuck below the host floor. User docs deliberately do not
+/// restate the number; the startup-error path reports the exact floor
+/// dynamically at rejection time.
+pub const CLAUDE_AGENT_ACP_MIN_VERSION: &str = "0.44.0";
+
+/// Parsed form of [`CLAUDE_AGENT_ACP_MIN_VERSION`]. Runs once per adapter
+/// initialize, not in a hot path, so parsing on demand is fine.
+fn claude_agent_acp_min_version() -> semver::Version {
+    semver::Version::parse(CLAUDE_AGENT_ACP_MIN_VERSION)
+        .expect("CLAUDE_AGENT_ACP_MIN_VERSION must be valid semver")
+}
 
 /// The adapter aoe is trying to launch. Drives which `CompatibilityPolicy`
 /// is applied at initialize-time.
@@ -49,7 +69,7 @@ impl ExpectedAgent {
     /// separators, and the `.exe` / `.cmd` suffixes Windows shims add.
     /// Without this normalization a wrapped or Windows-installed
     /// `claude-agent-acp` would land in `Other` and silently bypass the
-    /// >=0.44.0 gate.
+    /// minimum-version gate.
     pub fn from_command(command: &str) -> Self {
         // Scan every whitespace-separated token. The actual binary can
         // be the first token (`/usr/local/bin/claude-agent-acp`) but
@@ -57,7 +77,7 @@ impl ExpectedAgent {
         // (`bash claude-agent-acp`, `env -u FOO claude-agent-acp`,
         // `npx claude-agent-acp`, etc.). Match against the first token
         // that classifies as a known adapter so wrappers don't bypass
-        // the >=0.44.0 gate.
+        // the minimum-version gate.
         command
             .split_whitespace()
             .find_map(|token| {
@@ -100,7 +120,7 @@ impl ExpectedAgent {
         match self {
             Self::ClaudeAgentAcp => CompatibilityPolicy {
                 expected_name: Some("@agentclientprotocol/claude-agent-acp"),
-                min_version: Some(semver::Version::new(0, 44, 0)),
+                min_version: Some(claude_agent_acp_min_version()),
                 required_protocol: ProtocolVersion::V1,
                 fail_on_missing_agent_info: true,
             },
@@ -188,7 +208,7 @@ impl StartupError {
                 expected_package,
                 install_command,
             } => format!(
-                "Adapter did not report its package version. aoe requires {expected_package} >=0.44.0. Run: {install_command}",
+                "Adapter did not report its package version. aoe requires {expected_package} >={CLAUDE_AGENT_ACP_MIN_VERSION}. Run: {install_command}",
             ),
             Self::MismatchedAgentName {
                 expected,
@@ -374,7 +394,7 @@ mod tests {
 
     #[test]
     fn claude_below_minimum_rejected() {
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.32.0");
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.0.0");
         let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
         assert_eq!(err.kind(), "incompatible_agent_version");
         let StartupError::IncompatibleAgentVersion {
@@ -385,31 +405,59 @@ mod tests {
         else {
             panic!()
         };
-        assert_eq!(installed, "0.32.0");
-        assert_eq!(required, "0.44.0");
+        assert_eq!(installed, "0.0.0");
+        assert_eq!(required, CLAUDE_AGENT_ACP_MIN_VERSION);
     }
 
     #[test]
-    fn claude_below_new_floor_rejected() {
-        // 0.43.x carries the model selector, native cancel, and the
-        // wedged-TaskOutput force-cancel, but lacks the upstream #641 fix
-        // and the `fable` model, which the 0.44.0 floor requires. Pin the
-        // boundary so a future accidental floor downgrade is caught.
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.43.9");
+    fn claude_just_below_floor_rejected() {
+        // The strict lower boundary, derived from the floor so a bump
+        // never needs to touch this fixture: a prerelease of the floor
+        // sorts strictly below the release under semver, so it must be
+        // rejected. Guards an accidental `<=` slip in the gate.
+        let version = format!("{CLAUDE_AGENT_ACP_MIN_VERSION}-alpha.1");
+        let init = make_init("@agentclientprotocol/claude-agent-acp", &version);
         let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
         assert_eq!(err.kind(), "incompatible_agent_version");
     }
 
     #[test]
     fn claude_at_minimum_accepted() {
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.44.0");
+        let init = make_init(
+            "@agentclientprotocol/claude-agent-acp",
+            CLAUDE_AGENT_ACP_MIN_VERSION,
+        );
         validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap();
     }
 
     #[test]
     fn claude_above_minimum_accepted() {
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.44.1");
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "999.0.0");
         validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap();
+    }
+
+    #[test]
+    fn dockerfile_pin_matches_floor() {
+        // docker/Dockerfile cannot read a Rust const, so the sandbox npm
+        // pin is the one floor restatement outside this module. Assert it
+        // tracks the gate so a bump that forgets the Dockerfile fails CI
+        // instead of shipping an image stuck below the host floor.
+        let dockerfile = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docker/Dockerfile"));
+        let needle = "@agentclientprotocol/claude-agent-acp@^";
+        let pins: Vec<String> = dockerfile
+            .match_indices(needle)
+            .map(|(idx, _)| {
+                dockerfile[idx + needle.len()..]
+                    .chars()
+                    .take_while(|c| c.is_ascii_digit() || *c == '.')
+                    .collect()
+            })
+            .collect();
+        assert_eq!(
+            pins,
+            vec![CLAUDE_AGENT_ACP_MIN_VERSION.to_string()],
+            "docker/Dockerfile claude-agent-acp pin must match CLAUDE_AGENT_ACP_MIN_VERSION",
+        );
     }
 
     #[test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Bumping the `claude-agent-acp` minimum-version floor used to mean editing roughly ten spots across six files: the comma-form `Version::new(0, 44, 0)` gate, a hardcoded `>=0.44.0` string in the `MissingAgentInfo` error, four boundary test fixtures and assertions, three doc-comments, an `acp_client.rs` comment, the `docker/Dockerfile` npm pin, and three `docs/*.md` files. Two of those (the gate const form and the test fixtures) are exactly the spots a dotted-version find-and-replace silently skips, so CI and CodeRabbit kept catching misses on every upstream bump.

This collapses the floor to a single source of truth, `CLAUDE_AGENT_ACP_MIN_VERSION`, in `src/acp/agent_compat.rs`. The gate, the `MissingAgentInfo` error string, and every boundary test now derive from it. The bump-specific `0.43.9` fixture (which had to move on every floor raise) is replaced by a prerelease strict-lower-boundary test that tracks the const automatically, and a new `dockerfile_pin_matches_floor` test reads `docker/Dockerfile` and asserts its npm pin equals the const, so a future bump that forgets the Dockerfile fails CI instead of shipping a sandbox image stuck below the host floor (the drift PR #2077 had to fix by hand).

The user-facing docs no longer restate the floor number at all. The startup-error path already reports the exact required version to the user at rejection time, so the three docs defer to it (and the sandbox internals doc points its pin at `docker/Dockerfile`) rather than being manual bump locations that drift.

After this, a floor bump edits one const plus the Dockerfile pin (CI-enforced to match); docs need zero edits. Historical behavior-arrival references (`v0.37.0`, the `>=0.41.0` upstream #680 force-cancel, the `>=0.44` AskUserQuestion re-enable notes) are intentionally left intact since they record when a behavior landed, not the floor.

Closes #2078

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Change only the `CLAUDE_AGENT_ACP_MIN_VERSION` const in `src/acp/agent_compat.rs` (e.g. to `0.45.0`) and run `cargo test --lib --features serve agent_compat`; confirm `dockerfile_pin_matches_floor` fails until `docker/Dockerfile` is updated to match, and that the boundary tests still bracket the new floor without edits.
- [ ] With a `claude-agent-acp` below the floor installed, start a structured-view `claude` session and confirm aoe rejects it with a message naming the exact required version.
- [ ] Grep the docs (`docs/structured-view.md`, `docs/development/internals/sandbox.md`, `docs/structured-view/troubleshooting.md`) and confirm none hardcode the floor version anymore.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The change is covered by the `agent_compat` unit tests, which now derive their fixtures from the const, plus the new `dockerfile_pin_matches_floor` guard.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (synthesized from a gemini + gpt-5.5 design debate), and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784189334&installation_id=139138837&pr_number=2196&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2196&signature=2451322d83060ccb3c51cdc3ba2a03bc437025522a31b5bee7bb58db8cfba28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Overview

This PR consolidates the `claude-agent-acp` minimum version requirement into a single source of truth, eliminating scattered version strings across the codebase and documentation.

### What Changed

**Version Management Consolidation:**
- Introduced a new `CLAUDE_AGENT_ACP_MIN_VERSION` constant in `src/acp/agent_compat.rs` as the single authoritative source for the minimum version requirement
- All version validation logic (version gates, error messages, and tests) now derive from this constant instead of being hardcoded in multiple places
- Previously, bumping the minimum version required edits in approximately 10 locations across 6 different files; now it only requires updating the constant and the Dockerfile

**Documentation Updates:**
- Removed hardcoded version numbers (e.g., "≥0.44.0") from user-facing documentation
- Updated documentation to defer version requirements to the startup error message, which reports the exact required version to users at runtime
- Clarified troubleshooting guide to state that AoE reports the actual floor version when startup fails

**Testing Improvements:**
- Replaced hardcoded boundary test fixtures with automatic tests derived from the constant
- Added a new integration test that validates the Dockerfile npm pin matches the constant, catching missed updates at CI time
- Strengthened coverage with prerelease-below-floor rejection testing

**Code Cleanup:**
- Simplified documentation comments that previously referenced the specific version number
- Removed redundant version hardcoding from error messages

### Benefits

1. **Single Source of Truth:** Version bumps now require editing only one constant plus the Dockerfile pin
2. **Reduced Error Risk:** Eliminates the previous pattern of missed updates being caught by CI or CodeRabbit on every upstream bump
3. **Automated Consistency:** New CI test ensures Dockerfile pin stays in sync, preventing version mismatches between docs and runtime
4. **Better User Experience:** Users see the actual required version in error messages rather than relying on potentially outdated documentation
5. **Lower Maintenance Burden:** No need to update documentation for each version bump, reducing manual effort and potential documentation drift

### Technical Details

- New public constant: `CLAUDE_AGENT_ACP_MIN_VERSION: &str` exported from `src/acp/agent_compat.rs`
- Version parsing helper function added to convert the constant into `semver::Version` for validation
- The `ExpectedAgent::ClaudeAgentAcp` compatibility gate now parses this constant instead of using hardcoded `semver::Version::new(0, 44, 0)`
- Error message formatting dynamically includes the constant value, ensuring it always matches the actual requirement
- Added `dockerfile_pin_matches_floor` test that reads and validates `docker/Dockerfile` against the constant

<!-- end of auto-generated comment: release notes by coderabbit.ai -->