### PR TITLE
feat(web): surface individual settings in the command palette

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -30,6 +30,8 @@ Choosing a profile seeds the agent-step defaults. If you have already edited a f
 
 The command palette (top-bar button or keyboard shortcut) is a fuzzy launcher for global actions: jump to a session, open settings, start a new session, toggle the right panel.
 
+Individual settings also appear in the palette under `Settings`. A writable toggle flips inline from the palette (a toast confirms, and the subtitle shows its current state and scope); every other setting opens the settings view on its tab. Read-only servers and settings that need elevation jump to the settings view instead of writing.
+
 ## First-run onboarding
 
 The first time you open the dashboard in a browser, a **Choose your theme** card appears before anything else. Picking a theme applies it live and saves it to your default profile; you can switch freely, then click **Continue**. Change it later in Settings > Appearance. The card is skipped in read-only mode and for anyone who already finished the tutorial.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { useDiffComments } from "./hooks/useDiffComments";
 import { clearStoredComments, sweepOrphanComments } from "./components/diff/comments/storage";
 import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialog";
 import { useCommandActions } from "./hooks/useCommandActions";
+import { useSettingsCommands } from "./hooks/useSettingsCommands";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useIsCoarsePointer } from "./hooks/useIsCoarsePointer";
 import { useIsWideViewport } from "./hooks/useIsWideViewport";
@@ -981,6 +982,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     onLogout,
   });
 
+  const openSettingsTab = useCallback((tab: string) => navigate(`/settings/${tab}`), [navigate]);
+  const settingsCommands = useSettingsCommands({
+    open: showPalette,
+    readOnly: !!serverAbout?.read_only,
+    onOpenSettingsTab: openSettingsTab,
+  });
+
   const renderContent = () => {
     if (showSettings) {
       return (
@@ -1392,7 +1400,11 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           />
         )}
 
-        <CommandPalette open={showPalette} onClose={() => setShowPalette(false)} actions={commandActions} />
+        <CommandPalette
+          open={showPalette}
+          onClose={() => setShowPalette(false)}
+          actions={[...commandActions, ...settingsCommands]}
+        />
 
         {activeWorkspace && activeSession && (
           <MobileRightPanelPicker

--- a/web/src/hooks/__tests__/useSettingsCommands.test.tsx
+++ b/web/src/hooks/__tests__/useSettingsCommands.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+//
+// Contract test for the per-setting command-palette entries (#2108). Asserts
+// schema -> entry generation (local_only omitted), that writable toggles flip
+// inline through the default profile, and that every other widget, elevation
+// toggles, and read-only mode produce a jump instead of a write.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useSettingsCommands } from "../useSettingsCommands";
+import type { SettingsFieldDescriptor, SettingsWidget, SettingsWebWritePolicy } from "../../lib/types";
+
+vi.mock("../../lib/api", () => ({
+  getSettingsSchema: vi.fn(),
+  fetchProfiles: vi.fn(),
+  fetchSettings: vi.fn(),
+  updateProfileSettings: vi.fn(),
+}));
+vi.mock("../../lib/toastBus", () => ({
+  reportInfo: vi.fn(),
+  reportError: vi.fn(),
+}));
+
+import { fetchProfiles, fetchSettings, getSettingsSchema, updateProfileSettings } from "../../lib/api";
+
+function field(
+  section: string,
+  name: string,
+  widget: SettingsWidget,
+  web_write: SettingsWebWritePolicy,
+  profile_overridable = true,
+): SettingsFieldDescriptor {
+  return {
+    section,
+    field: name,
+    category: section,
+    label: `${section}.${name}`,
+    description: "",
+    widget,
+    web_write,
+    profile_overridable,
+    validation: { rule: "none" },
+    advanced: false,
+  };
+}
+
+const SCHEMA: SettingsFieldDescriptor[] = [
+  field("session", "live_send", { kind: "toggle" }, { policy: "allow" }, true),
+  field("worktree", "auto_cleanup", { kind: "toggle" }, { policy: "allow" }, false),
+  field("security", "danger", { kind: "toggle" }, { policy: "requires_elevation", reason: "x" }),
+  field("acp", "replay", { kind: "select", options: [] }, { policy: "allow" }),
+  field("session", "secret", { kind: "toggle" }, { policy: "local_only", reason: "x" }),
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSettingsSchema).mockResolvedValue(SCHEMA);
+  vi.mocked(fetchProfiles).mockResolvedValue([{ name: "main", is_default: true }]);
+  vi.mocked(fetchSettings).mockResolvedValue({
+    session: { live_send: false },
+    worktree: { auto_cleanup: true },
+  } as never);
+  vi.mocked(updateProfileSettings).mockResolvedValue(true);
+});
+
+function render(overrides: Partial<Parameters<typeof useSettingsCommands>[0]> = {}) {
+  const onOpenSettingsTab = vi.fn();
+  const hook = renderHook((args: Parameters<typeof useSettingsCommands>[0]) => useSettingsCommands(args), {
+    initialProps: { open: true, readOnly: false, onOpenSettingsTab, ...overrides },
+  });
+  return { ...hook, onOpenSettingsTab };
+}
+
+describe("useSettingsCommands", () => {
+  it("generates one Settings entry per writable field, omitting local_only", async () => {
+    const { result } = render();
+    await waitFor(() => expect(result.current.length).toBe(4));
+    const ids = result.current.map((a) => a.id);
+    expect(ids).toContain("setting:session.live_send");
+    expect(ids).toContain("setting:worktree.auto_cleanup");
+    expect(ids).toContain("setting:security.danger");
+    expect(ids).toContain("setting:acp.replay");
+    expect(ids).not.toContain("setting:session.secret");
+    expect(result.current.every((a) => a.group === "Settings")).toBe(true);
+  });
+
+  it("flips a writable toggle inline through the default profile", async () => {
+    const { result } = render();
+    await waitFor(() => expect(result.current.length).toBe(4));
+    const toggle = result.current.find((a) => a.id === "setting:session.live_send");
+    expect(toggle?.subtitle).toBe("Off · main");
+    toggle?.perform();
+    await waitFor(() => expect(updateProfileSettings).toHaveBeenCalledWith("main", { session: { live_send: true } }));
+  });
+
+  it("labels a global-only toggle's scope as Global", async () => {
+    const { result } = render();
+    await waitFor(() => expect(result.current.length).toBe(4));
+    const toggle = result.current.find((a) => a.id === "setting:worktree.auto_cleanup");
+    expect(toggle?.subtitle).toBe("On · Global");
+  });
+
+  it("jumps for non-toggle widgets and elevation toggles, never writing", async () => {
+    const { result, onOpenSettingsTab } = render();
+    await waitFor(() => expect(result.current.length).toBe(4));
+    result.current.find((a) => a.id === "setting:acp.replay")?.perform();
+    expect(onOpenSettingsTab).toHaveBeenCalledWith("structured-view");
+    result.current.find((a) => a.id === "setting:security.danger")?.perform();
+    expect(onOpenSettingsTab).toHaveBeenCalledWith("security");
+    expect(updateProfileSettings).not.toHaveBeenCalled();
+  });
+
+  it("turns every toggle into a jump in read-only mode", async () => {
+    const { result, onOpenSettingsTab } = render({ readOnly: true });
+    await waitFor(() => expect(result.current.length).toBe(4));
+    result.current.find((a) => a.id === "setting:session.live_send")?.perform();
+    expect(onOpenSettingsTab).toHaveBeenCalledWith("session");
+    expect(updateProfileSettings).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useSettingsCommands.ts
+++ b/web/src/hooks/useSettingsCommands.ts
@@ -1,0 +1,118 @@
+import { useEffect, useMemo, useState } from "react";
+import { fetchProfiles, fetchSettings, getSettingsSchema, updateProfileSettings } from "../lib/api";
+import { reportError, reportInfo } from "../lib/toastBus";
+import type { CommandAction } from "../components/command-palette/types";
+import type { SettingsFieldDescriptor } from "../lib/types";
+
+interface Args {
+  /** Palette open state. Schema + values are (re)fetched on the rising edge so
+   *  toggle subtitles reflect the latest saved state without a global cache. */
+  open: boolean;
+  /** Read-only servers 403 every write, so every entry becomes a jump. */
+  readOnly: boolean;
+  /** Jump to a settings tab (e.g. `/settings/sandbox`). */
+  onOpenSettingsTab: (tab: string) => void;
+}
+
+/** Most schema sections render under a same-named settings tab; these two are
+ *  the only exceptions in SettingsView's tab layout. */
+function sectionToTab(section: string): string {
+  if (section === "web") return "notifications";
+  if (section === "acp") return "structured-view";
+  return section;
+}
+
+/**
+ * Per-setting command-palette entries (#2108) built from the settings schema
+ * (single source of truth, #1692).
+ *
+ * Writable `toggle` fields flip inline (pessimistic PATCH + toast); every other
+ * widget, plus elevation-gated toggles and everything in read-only mode, jumps
+ * to its settings tab. `local_only` fields are omitted because the server PATCH
+ * rejects them.
+ *
+ * Inline writes target the default profile, the same path SettingsView takes
+ * when its profile picker sits on the default, so there is no new write
+ * behavior. The write scope is named in the subtitle and toast rather than left
+ * implicit: a `profile_overridable` flip names the profile, a global-only flip
+ * reads "Global".
+ */
+export function useSettingsCommands({ open, readOnly, onOpenSettingsTab }: Args): CommandAction[] {
+  const [schema, setSchema] = useState<SettingsFieldDescriptor[]>([]);
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [defaultProfile, setDefaultProfile] = useState("default");
+  // Bumped after an inline flip to re-run the load effect, so a toggle's
+  // subtitle reflects the value it was just set to.
+  const [reloadNonce, setReloadNonce] = useState(0);
+
+  // The palette stays mounted, so it must (re)fetch each time it becomes
+  // visible: this keeps toggle subtitles fresh and, on a login-required
+  // server, picks up data that was 401-empty before sign-in.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void (async () => {
+      const [s, profiles] = await Promise.all([getSettingsSchema(), fetchProfiles()]);
+      if (cancelled) return;
+      if (s) setSchema(s);
+      const profile = profiles.find((p) => p.is_default)?.name ?? "default";
+      setDefaultProfile(profile);
+      const settings = await fetchSettings(profile);
+      if (cancelled) return;
+      if (settings) setValues(settings as Record<string, unknown>);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, reloadNonce]);
+
+  return useMemo(() => {
+    const actions: CommandAction[] = [];
+    for (const f of schema) {
+      if (f.web_write.policy === "local_only") continue;
+
+      const sectionValues = (values[f.section] ?? {}) as Record<string, unknown>;
+      const current = sectionValues[f.field];
+      const keywords = [f.section, f.field, f.category, f.label, f.widget.kind, "setting", "config"];
+      const id = `setting:${f.section}.${f.field}`;
+
+      const inlineToggle = f.widget.kind === "toggle" && f.web_write.policy === "allow" && !readOnly;
+
+      if (inlineToggle) {
+        const isOn = current === true;
+        const scope = f.profile_overridable ? defaultProfile : "Global";
+        actions.push({
+          id,
+          title: f.label,
+          subtitle: `${isOn ? "On" : "Off"} · ${scope}`,
+          group: "Settings",
+          keywords,
+          perform: () => {
+            const next = !isOn;
+            void (async () => {
+              const ok = await updateProfileSettings(defaultProfile, { [f.section]: { [f.field]: next } });
+              if (!ok) {
+                reportError(`Failed to update ${f.label}`);
+                return;
+              }
+              const where = f.profile_overridable ? ` (profile ${defaultProfile})` : "";
+              reportInfo(`${f.label} ${next ? "enabled" : "disabled"}${where}`);
+              setReloadNonce((n) => n + 1);
+            })();
+          },
+        });
+        continue;
+      }
+
+      actions.push({
+        id,
+        title: f.label,
+        subtitle: `Opens settings · ${f.category}`,
+        group: "Settings",
+        keywords,
+        perform: () => onOpenSettingsTab(sectionToTab(f.section)),
+      });
+    }
+    return actions;
+  }, [schema, values, defaultProfile, readOnly, onOpenSettingsTab]);
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1558,6 +1558,13 @@
       "components": ["web/src/components/command-palette/CommandPalette.tsx", "web/src/hooks/useKeyboardShortcuts.ts"]
     },
     {
+      "id": "settings.palette-entries",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/hooks/__tests__/useSettingsCommands.test.tsx"],
+      "components": ["web/src/hooks/useSettingsCommands.ts", "web/src/App.tsx"]
+    },
+    {
       "id": "story.shortcut-toggle-sidebar",
       "kind": "mocked-playwright",
       "risk": "medium",

--- a/web/tests/live/palette-scratch-launch.spec.ts
+++ b/web/tests/live/palette-scratch-launch.spec.ts
@@ -61,5 +61,11 @@ test("palette hides creation commands in read-only mode", async ({ serveReadOnly
   await expect(page.getByPlaceholder(PALETTE_PLACEHOLDER)).toBeVisible();
 
   await expect(page.getByRole("option", { name: /New scratch session/i })).toHaveCount(0);
-  await expect(page.getByRole("option", { name: /New session/i })).toHaveCount(0);
+  // Exclude per-setting palette entries (#2108): the "New Session Attach Mode"
+  // setting also matches /New session/i but is a settings jump, not a creation
+  // command. Its row carries the "Opens settings" subtitle; creation commands
+  // do not.
+  await expect(page.getByRole("option", { name: /New session/i }).filter({ hasNotText: "Opens settings" })).toHaveCount(
+    0,
+  );
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web command palette (Cmd/Ctrl+K) previously offered a single `Open settings` entry. This surfaces every writable setting as its own palette entry under the `Settings` group, generated from the settings schema (`GET /api/settings/schema`, single source of truth, #1692).

Behavior per widget:
- A `toggle` the dashboard may write flips inline from the palette: a pessimistic PATCH, a toast confirming the change, and a subtitle showing the current state and the write scope.
- Every other widget (select, number, text, slider, list, custom), plus elevation-gated toggles and everything on a read-only server, jumps to the matching settings tab instead of writing.
- `local_only` settings are omitted, since the server PATCH rejects them.

Inline writes target the default profile, which is the same path `SettingsView` takes when its profile picker sits on the default, so there is no new write behavior and no regression to settings-view saves. The write scope is named explicitly rather than left implicit: a profile-overridable flip names the profile in its subtitle and toast, a global-only flip reads `Global`.

The design went through a `/debate` pass (gemini-3.1-pro, gpt-5.5). The key resolution: do not silently mutate a profile the user cannot see. Inline flips are limited to settings the dashboard may write, the scope is always labeled, and writes are pessimistic rather than optimistic-with-rollback.

Closes #2108

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the dashboard, press Cmd/Ctrl+K, type a setting name; it appears under the `Settings` group.
- [ ] Select a writable toggle (e.g. a Session toggle): the palette closes, a toast confirms, and reopening the palette shows the subtitle flipped (On/Off).
- [ ] Select a non-toggle setting (e.g. a select or number field): the settings view opens on that setting's tab.
- [ ] Confirm a global-only toggle's subtitle reads `Global`, while a profile-overridable toggle's subtitle shows the default profile name.
- [ ] On a read-only server (`aoe serve` read-only), selecting a toggle opens the settings view instead of writing.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a test and updated `web/tests/coverage-matrix.json` (Vitest `useSettingsCommands.test.tsx`; per AGENTS.md, request-payload permutations belong in Vitest rather than Playwright; matrix entry `settings.palette-entries`).
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction, with a `/debate` design pass across gemini-3.1-pro and gpt-5.5. I made the design calls and reviewed each change.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784189499&installation_id=139138837&pr_number=2197&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2197&signature=1242c071dd036461d9f0d3b34becda1d882c2b9286e6391ca060eaf65f7e2c43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

- The web command palette (Cmd/Ctrl+K) now shows **individual settings** under a **“Settings”** group, generated dynamically from the server settings schema.
- Users can adjust **single settings** directly from the palette instead of opening the full settings UI and searching.
- **Inline toggle updates** are supported for eligible writable toggles; everything else takes the user to the appropriate settings screen.

## Key Behavior Changes

- **Writable toggles (non–local-only, non-read-only):**
  - Toggle changes **inline** via a **pessimistic PATCH**
  - Shows a **confirmation toast**
  - Subtitle clearly indicates **where the change applies**:
    - **Profile** (with profile labeling) for profile-overridable toggles
    - **Global** for global-only toggles
  - Reloads after success so the palette reflects the saved state
- **Other widget types** (select/number/text/slider/list/custom), **elevation-gated toggles**, and **read-only servers**:
  - Open the settings view focused on the relevant tab/section (no inline mutation)
- **Local-only settings**:
  - **Excluded** from the palette because the server PATCH endpoint rejects them

## Implementation Updates

- Added a new hook (**`useSettingsCommands`**) to:
  - Fetch the schema + profiles/current values
  - Generate per-setting palette actions under “Settings” (excluding `local_only`)
  - Reuse the same routing logic as the settings view for navigation-based actions

- Wired the generated settings actions into the existing `CommandPalette` in `web/src/App.tsx`.
- Updated the dashboard documentation to explain the new palette settings behavior.
- Expanded/updated test coverage and the Vitest coverage matrix, including:
  - Entry generation correctness
  - Inline toggle execution (including scope/subtitle and read-only behavior)
- Adjusted a live palette test to avoid false positives in read-only mode.

## Benefits

- **Lower friction**: change one setting immediately from the command palette.
- **Safer behavior**: prevents silent/unsupported writes by routing non-eligible settings to the settings UI.
- **Better clarity**: inline toggles communicate **exactly what scope** (profile vs Global) was updated.
- **Consistency**: inline writes follow the same save/routing semantics as the existing settings flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->