### PR TITLE
feat(serve): web UI to install or update a missing or out-of-date ACP agent

### DIFF
--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -65,6 +65,37 @@ Then run `claude login` if you haven't already. If an older version is pinned by
 an internal mirror, ship the required floor from the mirror or run the `@latest`
 install above before starting `aoe serve`.
 
+### Recovering a missing or out-of-date agent from the web dashboard
+
+When the structured view refuses a session because the agent is missing or too
+old, the web dashboard surfaces the reason inline instead of leaving you to read
+the logs:
+
+- The compatibility screen shows the installed vs required version and the exact
+  install command to copy.
+- A missing-binary error message includes the install command for the agent it
+  could not find.
+
+Two recovery controls sit on the compatibility screen:
+
+- **Restart agent** respawns the worker and re-runs the version check at the next
+  handshake. Use it after you have installed or updated the adapter in a shell;
+  no full restart of `aoe serve` is needed.
+- **Update & restart** runs the agent's `npm install -g` on the host (as the
+  user running the daemon) and then respawns. It appears only for
+  npm-installable agents (`claude-agent-acp`, `codex-acp`, `gemini`) and only
+  when `acp.allow_agent_install` is enabled.
+
+`acp.allow_agent_install` is **off by default**: running a global package install
+from the daemon is a host-level capability that executes the package's npm
+lifecycle scripts as the daemon user. It is always blocked in `--read-only` mode,
+and the setting is `local_only` (you can only turn it on from a dashboard
+connection to localhost, not a remote one). For agents that install some other
+way (`opencode`, `vibe-acp`, `pi-acp`), the screen shows the manual command
+instead of an Update button. Inside a sandbox session, a host install would not
+reach the containerized agent, so the action is refused; install the agent in the
+container image instead.
+
 ### "Failed to start structured view agent" while the adapter is installed
 
 `aoe serve` captures the launching shell's PATH at startup. If the adapter lives

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -144,6 +144,22 @@ impl AcpError {
         }
         AcpError::Spawn(format!("{err} (command `{spawn_command}`)"))
     }
+
+    /// Build the enriched "binary not found" spawn error for a bare-command
+    /// ENOENT (no PATH resolution, cwd present). Appends the exact install
+    /// command when the binary is a known ACP adapter so the web banner can
+    /// show a copyable line instead of making the user guess. See #2109.
+    fn missing_binary_spawn_error(err: &std::io::Error, command: &str) -> Self {
+        let hint = crate::acp::install_hints::install_hint_for(command)
+            .map(|cmd| format!(". Install with: {cmd}"))
+            .unwrap_or_default();
+        AcpError::Spawn(format!(
+            "{err} (binary `{command}` not found on the daemon's PATH or in \
+             any known node-manager bin dir; install it where the daemon can \
+             see it, or restart `aoe serve` from a shell where `which \
+             {command}` resolves){hint}"
+        ))
+    }
 }
 
 /// Inspect an ACP-level error response from a `session/prompt` request
@@ -2570,13 +2586,7 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
         //      Spawn message hinting at the frozen-PATH cause. See #1048.
         //   3. fallback → generic Spawn classification.
         if e.kind() == std::io::ErrorKind::NotFound && config.cwd.exists() && resolved.is_none() {
-            AcpError::Spawn(format!(
-                "{} (binary `{}` not found on the daemon's PATH or in any \
-                 known node-manager bin dir; install it where the daemon \
-                 can see it, or restart `aoe serve` from a shell where \
-                 `which {}` resolves)",
-                e, config.spec.command, config.spec.command
-            ))
+            AcpError::missing_binary_spawn_error(&e, &config.spec.command)
         } else {
             AcpError::classify_spawn_error(e, &config.cwd, &spawn_command)
         }
@@ -6840,6 +6850,36 @@ mod tests {
                     msg.contains("/nonexistent/bin/foo"),
                     "spawn message should echo command: {msg}"
                 );
+            }
+            other => panic!("expected Spawn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_binary_spawn_error_appends_install_hint_for_known_agent() {
+        let io_err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        match AcpError::missing_binary_spawn_error(&io_err, "codex-acp") {
+            AcpError::Spawn(msg) => {
+                assert!(msg.contains("codex-acp"), "should echo the binary: {msg}");
+                assert!(
+                    msg.contains("Install with: npm install -g @zed-industries/codex-acp"),
+                    "should append the exact install command: {msg}"
+                );
+            }
+            other => panic!("expected Spawn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_binary_spawn_error_omits_hint_for_unknown_binary() {
+        let io_err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        match AcpError::missing_binary_spawn_error(&io_err, "totally-unknown-bin") {
+            AcpError::Spawn(msg) => {
+                assert!(
+                    msg.contains("totally-unknown-bin"),
+                    "should echo binary: {msg}"
+                );
+                assert!(!msg.contains("Install with:"), "no hint for unknown: {msg}");
             }
             other => panic!("expected Spawn, got {other:?}"),
         }

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -151,6 +151,7 @@ pub enum StartupError {
         installed: String,
         required: String,
         install_command: String,
+        auto_install: bool,
     },
     /// Adapter passed name/version checks but reported a protocol version
     /// aoe does not speak.
@@ -160,6 +161,7 @@ pub enum StartupError {
     MissingAgentInfo {
         expected_package: String,
         install_command: String,
+        auto_install: bool,
     },
     /// Adapter advertised a different package name than aoe expected for
     /// this `ExpectedAgent`. Probably a wrapper or stale install.
@@ -167,6 +169,7 @@ pub enum StartupError {
         expected: String,
         received: String,
         install_command: String,
+        auto_install: bool,
     },
     /// `agent_info.version` was present but did not parse as semver.
     UnparseableAgentVersion {
@@ -174,6 +177,7 @@ pub enum StartupError {
         raw_version: String,
         required: String,
         install_command: String,
+        auto_install: bool,
     },
 }
 
@@ -201,12 +205,14 @@ impl StartupError {
                 installed,
                 required,
                 install_command,
+                ..
             } => format!(
                 "{package_name} {installed} installed; aoe requires >={required}. Run: {install_command}",
             ),
             Self::MissingAgentInfo {
                 expected_package,
                 install_command,
+                ..
             } => format!(
                 "Adapter did not report its package version. aoe requires {expected_package} >={CLAUDE_AGENT_ACP_MIN_VERSION}. Run: {install_command}",
             ),
@@ -214,6 +220,7 @@ impl StartupError {
                 expected,
                 received,
                 install_command,
+                ..
             } => format!(
                 "Adapter reported package name `{received}` but aoe expected `{expected}`. Run: {install_command}",
             ),
@@ -222,6 +229,7 @@ impl StartupError {
                 raw_version,
                 required,
                 install_command,
+                ..
             } => format!(
                 "{package_name} reported version `{raw_version}` which is not valid semver. aoe requires >={required}. Run: {install_command}",
             ),
@@ -240,38 +248,46 @@ impl From<&StartupError> for StartupErrorDetail {
                 installed,
                 required,
                 install_command,
+                auto_install,
             } => StartupErrorDetail::IncompatibleAgentVersion {
                 package_name: package_name.clone(),
                 installed: installed.clone(),
                 required: required.clone(),
                 install_command: install_command.clone(),
+                auto_install: *auto_install,
             },
             StartupError::MissingAgentInfo {
                 expected_package,
                 install_command,
+                auto_install,
             } => StartupErrorDetail::MissingAgentInfo {
                 expected_package: expected_package.clone(),
                 install_command: install_command.clone(),
+                auto_install: *auto_install,
             },
             StartupError::MismatchedAgentName {
                 expected,
                 received,
                 install_command,
+                auto_install,
             } => StartupErrorDetail::MismatchedAgentName {
                 expected: expected.clone(),
                 received: received.clone(),
                 install_command: install_command.clone(),
+                auto_install: *auto_install,
             },
             StartupError::UnparseableAgentVersion {
                 package_name,
                 raw_version,
                 required,
                 install_command,
+                auto_install,
             } => StartupErrorDetail::UnparseableAgentVersion {
                 package_name: package_name.clone(),
                 raw_version: raw_version.clone(),
                 required: required.clone(),
                 install_command: install_command.clone(),
+                auto_install: *auto_install,
             },
             StartupError::UnsupportedProtocolVersion { expected, received } => {
                 StartupErrorDetail::UnsupportedProtocolVersion {
@@ -304,12 +320,14 @@ pub fn validate(expected: ExpectedAgent, init: &InitializeResponse) -> Result<()
 
     let install_command =
         install_command_for(expected).unwrap_or_else(|| "(see project docs)".to_string());
+    let auto_install = auto_install_for(expected);
 
     let Some(info) = init.agent_info.as_ref() else {
         if policy.fail_on_missing_agent_info {
             return Err(StartupError::MissingAgentInfo {
                 expected_package: policy.expected_name.unwrap_or("(unspecified)").to_string(),
                 install_command,
+                auto_install,
             });
         }
         return Ok(());
@@ -321,6 +339,7 @@ pub fn validate(expected: ExpectedAgent, init: &InitializeResponse) -> Result<()
                 expected: expected_name.to_string(),
                 received: info.name.clone(),
                 install_command,
+                auto_install,
             });
         }
     }
@@ -335,6 +354,7 @@ pub fn validate(expected: ExpectedAgent, init: &InitializeResponse) -> Result<()
                         .unwrap_or(info.name.as_str())
                         .to_string(),
                     install_command,
+                    auto_install,
                 });
             }
             return Ok(());
@@ -347,6 +367,7 @@ pub fn validate(expected: ExpectedAgent, init: &InitializeResponse) -> Result<()
                     raw_version: raw.to_string(),
                     required: min.to_string(),
                     install_command,
+                    auto_install,
                 });
             }
         };
@@ -356,6 +377,7 @@ pub fn validate(expected: ExpectedAgent, init: &InitializeResponse) -> Result<()
                 installed: parsed.to_string(),
                 required: min.to_string(),
                 install_command,
+                auto_install,
             });
         }
     }
@@ -363,20 +385,34 @@ pub fn validate(expected: ExpectedAgent, init: &InitializeResponse) -> Result<()
     Ok(())
 }
 
+/// The ACP binary name aoe expects for this agent, or `None` for agents
+/// with no fixed binary (`AoeAgent`, `Other`).
+fn binary_for(expected: ExpectedAgent) -> Option<&'static str> {
+    Some(match expected {
+        ExpectedAgent::ClaudeAgentAcp => "claude-agent-acp",
+        ExpectedAgent::CodexAcp => "codex-acp",
+        ExpectedAgent::OpenCode => "opencode",
+        ExpectedAgent::Gemini => "gemini",
+        ExpectedAgent::PiAcp => "pi-acp",
+        ExpectedAgent::AoeAgent | ExpectedAgent::Other => return None,
+    })
+}
+
 /// Lookup table for the install commands surfaced in startup errors.
 /// Kept in sync with `install_hints::install_hint_for` so the error UI
 /// shows the exact command the doctor would run.
 fn install_command_for(expected: ExpectedAgent) -> Option<String> {
-    let bin = match expected {
-        ExpectedAgent::ClaudeAgentAcp => "claude-agent-acp",
-        ExpectedAgent::CodexAcp => "codex-acp",
-        ExpectedAgent::OpenCode => "opencode",
-        ExpectedAgent::AoeAgent => return None,
-        ExpectedAgent::Gemini => "gemini",
-        ExpectedAgent::PiAcp => "pi-acp",
-        ExpectedAgent::Other => return None,
-    };
+    let bin = binary_for(expected)?;
     crate::acp::install_hints::install_hint_for(bin).map(|s| s.to_string())
+}
+
+/// Whether the web "Update & restart" action can install this agent itself
+/// via a plain `npm install -g`. Server-authoritative pre-gate for the
+/// button; non-npm agents fall back to the displayed manual hint. See #2109.
+fn auto_install_for(expected: ExpectedAgent) -> bool {
+    binary_for(expected)
+        .and_then(crate::acp::install_hints::npm_package_for)
+        .is_some()
 }
 
 #[cfg(test)]
@@ -400,6 +436,7 @@ mod tests {
         let StartupError::IncompatibleAgentVersion {
             installed,
             required,
+            auto_install,
             ..
         } = err
         else {
@@ -407,6 +444,21 @@ mod tests {
         };
         assert_eq!(installed, "0.0.0");
         assert_eq!(required, CLAUDE_AGENT_ACP_MIN_VERSION);
+        // claude-agent-acp is npm-installable, so the web can offer
+        // "Update & restart". See #2109.
+        assert!(auto_install);
+    }
+
+    #[test]
+    fn auto_install_only_for_npm_agents() {
+        assert!(auto_install_for(ExpectedAgent::ClaudeAgentAcp));
+        assert!(auto_install_for(ExpectedAgent::CodexAcp));
+        assert!(auto_install_for(ExpectedAgent::Gemini));
+        // Manual-install agents fall back to the displayed hint.
+        assert!(!auto_install_for(ExpectedAgent::OpenCode));
+        assert!(!auto_install_for(ExpectedAgent::PiAcp));
+        assert!(!auto_install_for(ExpectedAgent::AoeAgent));
+        assert!(!auto_install_for(ExpectedAgent::Other));
     }
 
     #[test]

--- a/src/acp/install_hints.rs
+++ b/src/acp/install_hints.rs
@@ -22,9 +22,42 @@ pub fn install_hint_for(binary: &str) -> Option<&'static str> {
     })
 }
 
+/// The npm package spec for an agent the daemon can install itself via a
+/// plain `npm install -g <pkg>`, or `None` for agents that need a different
+/// installer (curl|bash, brew, manual). Distinct from `install_hint_for`,
+/// whose strings are human-facing and not shell-safe to execute. Only the
+/// npm subset is eligible for the web "Update & restart" action; everything
+/// else falls back to the displayed manual hint. See #2109.
+pub fn npm_package_for(binary: &str) -> Option<&'static str> {
+    Some(match binary {
+        "claude-agent-acp" => "@agentclientprotocol/claude-agent-acp@latest",
+        "codex-acp" => "@zed-industries/codex-acp",
+        "gemini" => "@google/gemini-cli",
+        _ => return None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn npm_package_only_for_clean_npm_agents() {
+        assert_eq!(
+            npm_package_for("codex-acp"),
+            Some("@zed-industries/codex-acp")
+        );
+        assert_eq!(
+            npm_package_for("claude-agent-acp"),
+            Some("@agentclientprotocol/claude-agent-acp@latest")
+        );
+        assert_eq!(npm_package_for("gemini"), Some("@google/gemini-cli"));
+        // curl|bash and manual-install agents are intentionally excluded.
+        assert_eq!(npm_package_for("opencode"), None);
+        assert_eq!(npm_package_for("vibe-acp"), None);
+        assert_eq!(npm_package_for("pi-acp"), None);
+        assert_eq!(npm_package_for("nonexistent"), None);
+    }
 
     #[test]
     fn covers_every_default_registry_binary() {

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -319,21 +319,31 @@ pub enum StartupErrorDetail {
         installed: String,
         required: String,
         install_command: String,
+        /// True when the web "Update & restart" action can install this
+        /// agent via `npm install -g`; false means the manual hint only.
+        #[serde(default)]
+        auto_install: bool,
     },
     MissingAgentInfo {
         expected_package: String,
         install_command: String,
+        #[serde(default)]
+        auto_install: bool,
     },
     MismatchedAgentName {
         expected: String,
         received: String,
         install_command: String,
+        #[serde(default)]
+        auto_install: bool,
     },
     UnparseableAgentVersion {
         package_name: String,
         raw_version: String,
         required: String,
         install_command: String,
+        #[serde(default)]
+        auto_install: bool,
     },
     UnsupportedProtocolVersion {
         expected: String,

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -460,8 +460,12 @@ pub async fn install_agent(
             .into_response();
     };
 
-    // Serialize against concurrent installs / spawns for this session.
-    let _inst_lock = state.instance_lock(&id).await;
+    // Serialize against concurrent installs / spawns for this session: a
+    // double-click must not run two installs against the global npm prefix.
+    // `instance_lock` returns the lock handle; hold the guard across the
+    // install.
+    let inst_lock = state.instance_lock(&id).await;
+    let _guard = inst_lock.lock().await;
 
     let Ok(npm) = which::which("npm") else {
         return (
@@ -474,18 +478,35 @@ pub async fn install_agent(
             .into_response();
     };
 
-    let output = match tokio::process::Command::new(&npm)
-        .arg("install")
-        .arg("-g")
-        .arg(package)
-        .output()
-        .await
+    // Bound the install so a network stall or a wedged lifecycle script
+    // cannot hang the request (and the held lock) forever. kill_on_drop
+    // reaps the child if the timeout fires.
+    let output = match tokio::time::timeout(
+        std::time::Duration::from_secs(180),
+        tokio::process::Command::new(&npm)
+            .arg("install")
+            .arg("-g")
+            .arg(package)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
     {
-        Ok(o) => o,
-        Err(e) => {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("npm install failed to start: {e}"),
+            )
+                .into_response();
+        }
+        Err(_) => {
+            return (
+                StatusCode::GATEWAY_TIMEOUT,
+                Json(serde_json::json!({
+                    "error": "install_timeout",
+                    "message": "`npm install -g` did not finish within 180s.",
+                })),
             )
                 .into_response();
         }

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -364,6 +364,31 @@ pub async fn spawn_acp(
     }
 }
 
+/// Process-wide guard so concurrent `npm install -g` runs (across any
+/// sessions) never race the daemon user's shared global npm prefix. See #2109.
+static INSTALL_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+/// Cap per stream on the npm output echoed back to the web. `npm install -g`
+/// runs arbitrary lifecycle scripts; a verbose or hostile package could emit
+/// huge output, so truncate what we serialize and mark it. See #2109.
+const MAX_INSTALL_LOG_BYTES: usize = 64 * 1024;
+
+fn truncate_install_log(raw: &[u8]) -> String {
+    let text = String::from_utf8_lossy(raw);
+    if text.len() <= MAX_INSTALL_LOG_BYTES {
+        return text.into_owned();
+    }
+    let mut cut = MAX_INSTALL_LOG_BYTES;
+    while cut > 0 && !text.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!(
+        "{}\n... [truncated, output exceeded {MAX_INSTALL_LOG_BYTES} bytes]",
+        &text[..cut]
+    )
+}
+
 /// Result of a server-run agent install. The "& restart" half is the
 /// client's job: on `success` the web re-POSTs `/acp/spawn` (the same
 /// respawn path the Restart button uses), so this endpoint stays a pure
@@ -441,7 +466,10 @@ pub async fn install_agent(
         Err(e) => {
             return (
                 StatusCode::BAD_REQUEST,
-                format!("could not resolve agent `{agent}`: {e}"),
+                Json(serde_json::json!({
+                    "error": "agent_resolve_failed",
+                    "message": format!("could not resolve agent `{agent}`: {e}"),
+                })),
             )
                 .into_response();
         }
@@ -460,10 +488,12 @@ pub async fn install_agent(
             .into_response();
     };
 
-    // Serialize against concurrent installs / spawns for this session: a
-    // double-click must not run two installs against the global npm prefix.
-    // `instance_lock` returns the lock handle; hold the guard across the
-    // install.
+    // `npm install -g` mutates the daemon user's shared global prefix, so two
+    // *different* sessions installing at once would race. Serialize all
+    // installs process-wide, and also hold the per-session lock so a same-
+    // session spawn cannot run mid-install. `instance_lock` returns the lock
+    // handle; hold the guard across the install.
+    let _install_guard = INSTALL_LOCK.lock().await;
     let inst_lock = state.instance_lock(&id).await;
     let _guard = inst_lock.lock().await;
 
@@ -496,7 +526,10 @@ pub async fn install_agent(
         Ok(Err(e)) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("npm install failed to start: {e}"),
+                Json(serde_json::json!({
+                    "error": "npm_start_failed",
+                    "message": format!("npm install failed to start: {e}"),
+                })),
             )
                 .into_response();
         }
@@ -517,8 +550,8 @@ pub async fn install_agent(
         package: package.to_string(),
         success: output.status.success(),
         exit_code: output.status.code(),
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        stdout: truncate_install_log(&output.stdout),
+        stderr: truncate_install_log(&output.stderr),
     })
     .into_response()
 }

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -364,6 +364,144 @@ pub async fn spawn_acp(
     }
 }
 
+/// Result of a server-run agent install. The "& restart" half is the
+/// client's job: on `success` the web re-POSTs `/acp/spawn` (the same
+/// respawn path the Restart button uses), so this endpoint stays a pure
+/// install with no server-side respawn duplication. See #2109.
+#[derive(Serialize)]
+pub struct InstallAgentResponse {
+    pub session_id: String,
+    pub package: String,
+    pub success: bool,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// `POST /api/sessions/{id}/acp/install-agent`: run `npm install -g <pkg>`
+/// for the session's agent on the host, then let the client respawn.
+///
+/// Hardened, opt-in (Tier 2 of #2109): blocked in read-only mode; gated on
+/// the `acp.allow_agent_install` setting (default off, `local_only`); the
+/// package is resolved server-side from the session's agent via a static
+/// npm-only table, never from client input; npm runs with fixed argv and no
+/// shell; the per-session instance lock serializes installs so a
+/// double-click cannot race the global npm prefix. Sandbox sessions are
+/// refused because a host install never reaches the containerized agent.
+pub async fn install_agent(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if let Some(resp) = read_only_block(&state) {
+        return resp;
+    }
+    if !crate::session::Config::load_or_warn()
+        .acp
+        .allow_agent_install
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "install_disabled",
+                "message": "Installing agents from the web is off. Enable acp.allow_agent_install (Settings, local only).",
+            })),
+        )
+            .into_response();
+    }
+
+    let instances = state.instances.read().await;
+    let Some(instance) = instances.iter().find(|i| i.id == id).cloned() else {
+        return (StatusCode::NOT_FOUND, "session not found").into_response();
+    };
+    drop(instances);
+
+    if instance.is_sandboxed() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "sandboxed",
+                "message": "This session runs in a sandbox container; a host install would not reach the agent. Install it inside the container or rebuild its image.",
+            })),
+        )
+            .into_response();
+    }
+
+    // Resolve the binary the session would spawn, then its npm package.
+    let agent = state
+        .acp_supervisor
+        .pick_agent_for_tool(
+            &instance.tool,
+            instance.agent_name.as_deref(),
+            &instance.source_profile,
+            std::path::Path::new(&instance.project_path),
+        )
+        .await;
+    let binary = match state.acp_supervisor.resolve_agent(&agent).await {
+        Ok(spec) => spec.command,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("could not resolve agent `{agent}`: {e}"),
+            )
+                .into_response();
+        }
+    };
+    let Some(package) = crate::acp::install_hints::npm_package_for(&binary) else {
+        let hint =
+            crate::acp::install_hints::install_hint_for(&binary).unwrap_or("(see project docs)");
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "not_npm_installable",
+                "message": format!("`{binary}` cannot be installed via npm from the daemon. Install it manually: {hint}"),
+                "install_command": hint,
+            })),
+        )
+            .into_response();
+    };
+
+    // Serialize against concurrent installs / spawns for this session.
+    let _inst_lock = state.instance_lock(&id).await;
+
+    let Ok(npm) = which::which("npm") else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "npm_missing",
+                "message": "`npm` is not on the daemon's PATH. Start `aoe serve` from a shell where `which npm` resolves.",
+            })),
+        )
+            .into_response();
+    };
+
+    let output = match tokio::process::Command::new(&npm)
+        .arg("install")
+        .arg("-g")
+        .arg(package)
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("npm install failed to start: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    Json(InstallAgentResponse {
+        session_id: id,
+        package: package.to_string(),
+        success: output.status.success(),
+        exit_code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+    .into_response()
+}
+
 pub async fn shutdown_acp(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -26,8 +26,8 @@ mod telemetry;
 pub use acp::{
     acp_attachment, acp_cancel, acp_context_primer, acp_disable, acp_enable, acp_files,
     acp_force_end_turn, acp_prompt, acp_prompt_diff_comments, acp_replay, acp_set_config_option,
-    acp_set_mode, acp_worker_log, list_acp_agents, resolve_approval, resolve_elicitation,
-    shutdown_acp, spawn_acp, switch_acp_agent,
+    acp_set_mode, acp_worker_log, install_agent, list_acp_agents, resolve_approval,
+    resolve_elicitation, shutdown_acp, spawn_acp, switch_acp_agent,
 };
 
 #[cfg(feature = "serve")]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1523,6 +1523,10 @@ fn build_router(state: Arc<AppState>) -> Router {
     let app = app
         .route("/sessions/{id}/acp/ws", get(acp_ws::acp_ws))
         .route("/api/sessions/{id}/acp/spawn", post(api::spawn_acp))
+        .route(
+            "/api/sessions/{id}/acp/install-agent",
+            post(api::install_agent),
+        )
         .route("/api/sessions/{id}/acp", delete(api::shutdown_acp))
         .route(
             "/api/sessions/{id}/acp/switch-agent",

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -444,6 +444,22 @@ pub struct AcpConfig {
     #[serde(default = "default_rate_limit_auto_resume_grace_secs")]
     #[setting(label = "Auto-resume grace (s)", widget = "number", min = 0, advanced)]
     pub rate_limit_auto_resume_grace_secs: u32,
+    /// Allow the web dashboard's "Update & restart" control to run the
+    /// agent's `npm install -g <pkg>` on the host and respawn the worker.
+    /// Off by default: the daemon executing a global package install is a
+    /// host-level capability (it runs arbitrary npm lifecycle scripts as the
+    /// daemon user), so it stays opt-in, is always blocked in read-only mode,
+    /// and is `local_only` so a remote dashboard client cannot flip it on.
+    /// Only npm-installable agents are eligible; others keep the manual
+    /// install hint. See #2109.
+    #[serde(default)]
+    #[setting(
+        label = "Allow agent install from web",
+        widget = "toggle",
+        web = "local_only:runs npm install on the host as the daemon user",
+        advanced
+    )]
+    pub allow_agent_install: bool,
 }
 
 fn default_rate_limit_auto_resume_grace_secs() -> u32 {
@@ -520,6 +536,7 @@ impl Default for AcpConfig {
             auto_stop_idle_secs: default_auto_stop_idle_secs(),
             rate_limit_auto_resume: false,
             rate_limit_auto_resume_grace_secs: default_rate_limit_auto_resume_grace_secs(),
+            allow_agent_install: false,
         }
     }
 }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -457,6 +457,7 @@ pub struct AcpConfig {
         label = "Allow agent install from web",
         widget = "toggle",
         web = "local_only:runs npm install on the host as the daemon user",
+        global_only,
         advanced
     )]
     pub allow_agent_install: bool,

--- a/web/src/components/acp/StartupErrorScreen.tsx
+++ b/web/src/components/acp/StartupErrorScreen.tsx
@@ -1,7 +1,12 @@
+import { useEffect, useState } from "react";
+
 import type { IncompatibleAgentDetail } from "../../lib/acpTypes";
+import { fetchSettings, installAcpAgent } from "../../lib/api";
+import { useRespawnSession } from "../../hooks/useRespawnSession";
 
 interface Props {
   detail: IncompatibleAgentDetail;
+  sessionId: string;
 }
 
 /** Dedicated full-region replacement for the structured view chat layout when
@@ -10,11 +15,58 @@ interface Props {
  *  layered on top of the chat for free-form handshake failures. This
  *  screen surfaces the structured detail (installed vs required
  *  version, the exact remediation command) so the user can copy-paste
- *  it into a shell without parsing prose. */
-export function StartupErrorScreen({ detail }: Props) {
+ *  it into a shell without parsing prose, and offers in-UI recovery:
+ *  "Restart agent" respawns the worker (re-running the handshake after a
+ *  manual reinstall), and, when the agent is npm-installable and the
+ *  `acp.allow_agent_install` setting is on, "Update & restart" runs the
+ *  install on the host then respawns. See #2109. */
+export function StartupErrorScreen({ detail, sessionId }: Props) {
   const heading = headingFor(detail);
   const summary = summaryFor(detail);
   const installCommand = installCommandFor(detail);
+  const autoInstallable = "auto_install" in detail && detail.auto_install;
+
+  const { state: respawnState, error: respawnError, respawn } = useRespawnSession(sessionId);
+  const [allowInstall, setAllowInstall] = useState(false);
+  const [installState, setInstallState] = useState<"idle" | "installing" | "failed">("idle");
+  const [installError, setInstallError] = useState<string | null>(null);
+  const [installOutput, setInstallOutput] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetchSettings().then((s) => {
+      if (alive) {
+        setAllowInstall(Boolean((s as { acp?: { allow_agent_install?: boolean } } | null)?.acp?.allow_agent_install));
+      }
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const busy = respawnState === "retrying" || installState === "installing";
+
+  const handleUpdateAndRestart = async () => {
+    setInstallState("installing");
+    setInstallError(null);
+    setInstallOutput(null);
+    try {
+      const res = await installAcpAgent(sessionId);
+      const log = `${res.stdout}\n${res.stderr}`.trim();
+      setInstallOutput(log || null);
+      if (!res.success) {
+        setInstallState("failed");
+        setInstallError(`Install exited with code ${res.exit_code ?? "unknown"}.`);
+        return;
+      }
+      setInstallState("idle");
+      // Re-run the handshake against the freshly installed version.
+      await respawn();
+    } catch (e) {
+      setInstallState("failed");
+      setInstallError(e instanceof Error ? e.message : String(e));
+    }
+  };
 
   return (
     <div
@@ -33,7 +85,7 @@ export function StartupErrorScreen({ detail }: Props) {
         {installCommand && (
           <div className="mt-4">
             <div className="text-[11px] font-medium uppercase tracking-wide text-text-dim">
-              Run this, then restart the session
+              Run this, then restart the agent
             </div>
             <pre
               data-testid="startup-error-install-command"
@@ -46,11 +98,52 @@ export function StartupErrorScreen({ detail }: Props) {
 
         <DetailRows detail={detail} />
 
+        <div className="mt-5 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            data-testid="startup-error-restart"
+            onClick={respawn}
+            disabled={busy}
+            className="rounded-md border border-surface-700 bg-surface-800 px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-surface-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {respawnState === "retrying" ? "Restarting…" : "Restart agent"}
+          </button>
+          {autoInstallable && allowInstall && (
+            <button
+              type="button"
+              data-testid="startup-error-update-restart"
+              onClick={handleUpdateAndRestart}
+              disabled={busy}
+              className="rounded-md border border-status-error/60 bg-status-error/20 px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-status-error/30 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {installState === "installing" ? "Updating…" : "Update & restart"}
+            </button>
+          )}
+        </div>
+
+        {respawnState === "ok" && (
+          <div className="mt-2 text-xs text-emerald-200/90">
+            Restart requested. The agent re-runs the compatibility check on the next handshake.
+          </div>
+        )}
+        {respawnState === "failed" && respawnError && (
+          <div className="mt-2 text-xs text-status-error">Restart failed: {respawnError}</div>
+        )}
+        {installState === "failed" && installError && (
+          <div className="mt-2 text-xs text-status-error">{installError}</div>
+        )}
+        {installOutput && (
+          <pre className="mt-2 max-h-40 overflow-auto rounded-md border border-surface-700 bg-surface-950 p-2 font-mono text-[11px] text-text-secondary">
+            {installOutput}
+          </pre>
+        )}
+
         <div className="mt-4 text-xs text-text-dim">
-          The session is paused until the adapter satisfies the required version. Once you have run the command above,
-          restart <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">aoe serve</code> (or spawn a fresh
-          structured view session) and the check re-runs at the next ACP{" "}
-          <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">initialize</code> handshake.
+          The session is paused until the adapter satisfies the required version. After installing, use{" "}
+          <span className="font-medium text-text-secondary">Restart agent</span> above (no full restart of{" "}
+          <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">aoe serve</code> needed) and the check
+          re-runs at the next ACP <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">initialize</code>{" "}
+          handshake.
         </div>
       </div>
     </div>

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -46,6 +46,7 @@ import { useAcpPrefs } from "../../lib/acpPrefs";
 import { AgentProfileProvider, useAgentProfile } from "../../lib/agentProfileContext";
 import { isClearAlias } from "../../lib/agentProfiles";
 import { AttentionChime } from "./AttentionChime";
+import { useRespawnSession } from "../../hooks/useRespawnSession";
 import { useIsCoarsePointer } from "../../hooks/useIsCoarsePointer";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import type {
@@ -311,7 +312,7 @@ function AcpChrome({
   if (state.incompatibleAgent) {
     return (
       <div className="flex h-full flex-col bg-surface-900 text-text-primary">
-        <StartupErrorScreen detail={state.incompatibleAgent} />
+        <StartupErrorScreen detail={state.incompatibleAgent} sessionId={sessionId} />
       </div>
     );
   }
@@ -1473,32 +1474,9 @@ function ScheduledWakeupBanner({ wakeAt, reason }: { wakeAt: string; reason: str
 }
 
 function WorkerStoppedBanner({ sessionId }: { sessionId: string }) {
-  const [retryState, setRetryState] = useState<"idle" | "retrying" | "ok" | "failed">("idle");
-  const [retryError, setRetryError] = useState<string | null>(null);
-
-  const handleReconnect = async () => {
-    setRetryState("retrying");
-    setRetryError(null);
-    try {
-      const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/acp/spawn`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      if (res.ok) {
-        // The next AcpSessionAssigned (or UserPromptSent) clears
-        // workerStopped on the reducer side and this banner unmounts.
-        setRetryState("ok");
-      } else {
-        const detail = (await res.text().catch(() => "")).slice(0, 200);
-        setRetryState("failed");
-        setRetryError(`Server returned ${res.status}. ${detail}`.trim());
-      }
-    } catch (e) {
-      setRetryState("failed");
-      setRetryError(e instanceof Error ? e.message : String(e));
-    }
-  };
+  // The next AcpSessionAssigned (or UserPromptSent) clears workerStopped on
+  // the reducer side and this banner unmounts.
+  const { state: retryState, error: retryError, respawn: handleReconnect } = useRespawnSession(sessionId);
 
   return (
     <div className="border-b border-amber-900/60 bg-amber-950/40 px-4 py-3 text-amber-200">
@@ -1591,33 +1569,10 @@ export function StartupErrorBanner({ sessionId, message }: { sessionId: string; 
   // node_modules whose binary doesn't match the container arch. See
   // #1449.
   const isNativeBinaryLaunchFail = /native binary at .* exists but failed to launch/i.test(message);
-  const [retryState, setRetryState] = useState<"idle" | "retrying" | "ok" | "failed">("idle");
-  const [retryError, setRetryError] = useState<string | null>(null);
-
-  const handleRetry = async () => {
-    setRetryState("retrying");
-    setRetryError(null);
-    try {
-      const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/acp/spawn`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      if (res.ok) {
-        // The supervisor's drain task will start emitting events
-        // shortly; the banner will disappear when the next user
-        // prompt clears `startupError`.
-        setRetryState("ok");
-      } else {
-        const detail = (await res.text().catch(() => "")).slice(0, 200);
-        setRetryState("failed");
-        setRetryError(`Server returned ${res.status}. ${detail}`.trim());
-      }
-    } catch (e) {
-      setRetryState("failed");
-      setRetryError(e instanceof Error ? e.message : String(e));
-    }
-  };
+  // The supervisor's drain task starts emitting events shortly after a
+  // successful respawn; the banner disappears when the next user prompt
+  // clears `startupError`.
+  const { state: retryState, error: retryError, respawn: handleRetry } = useRespawnSession(sessionId);
 
   return (
     <div className="border-b border-rose-900/60 bg-rose-950/40 px-4 py-3 text-rose-200">

--- a/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
+++ b/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
@@ -28,6 +28,7 @@ const incompatible = (auto_install = true) => ({
 });
 
 beforeEach(() => {
+  fetchSettings.mockReset();
   fetchSettings.mockResolvedValue({});
   installAcpAgent.mockReset();
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") }));

--- a/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
+++ b/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
@@ -3,30 +3,44 @@
 // Smoke-coverage for the dedicated startup-error screen. The screen
 // only renders when the per-adapter compatibility check rejects the
 // adapter; we exercise each variant so a future schema change to
-// `IncompatibleAgentDetail` surfaces here loudly.
+// `IncompatibleAgentDetail` surfaces here loudly, plus the in-UI
+// recovery controls (Restart agent / Update & restart). See #2109.
 
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 import { StartupErrorScreen } from "../StartupErrorScreen";
 
+const fetchSettings = vi.fn();
+const installAcpAgent = vi.fn();
+vi.mock("../../../lib/api", () => ({
+  fetchSettings: (...args: unknown[]) => fetchSettings(...args),
+  installAcpAgent: (...args: unknown[]) => installAcpAgent(...args),
+}));
+
+const incompatible = (auto_install = true) => ({
+  kind: "incompatible_agent_version" as const,
+  package_name: "@agentclientprotocol/claude-agent-acp",
+  installed: "0.32.0",
+  required: "0.39.0",
+  install_command: "npm install -g @agentclientprotocol/claude-agent-acp@latest",
+  auto_install,
+});
+
+beforeEach(() => {
+  fetchSettings.mockResolvedValue({});
+  installAcpAgent.mockReset();
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") }));
+});
+
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 describe("StartupErrorScreen", () => {
   it("renders incompatible_agent_version with installed/required + install command", () => {
-    const { container, getByTestId } = render(
-      <StartupErrorScreen
-        detail={{
-          kind: "incompatible_agent_version",
-          package_name: "@agentclientprotocol/claude-agent-acp",
-          installed: "0.32.0",
-          required: "0.39.0",
-          install_command: "npm install -g @agentclientprotocol/claude-agent-acp@latest",
-        }}
-      />,
-    );
+    const { container, getByTestId } = render(<StartupErrorScreen detail={incompatible()} sessionId="s1" />);
     expect(container.textContent).toContain("0.32.0");
     expect(container.textContent).toContain("0.39.0");
     expect(container.textContent).toContain("@agentclientprotocol/claude-agent-acp");
@@ -41,7 +55,9 @@ describe("StartupErrorScreen", () => {
           kind: "missing_agent_info",
           expected_package: "@agentclientprotocol/claude-agent-acp",
           install_command: "npm install -g @agentclientprotocol/claude-agent-acp@latest",
+          auto_install: true,
         }}
+        sessionId="s1"
       />,
     );
     expect(container.textContent).toContain("did not report its package version");
@@ -56,7 +72,9 @@ describe("StartupErrorScreen", () => {
           expected: "@agentclientprotocol/claude-agent-acp",
           received: "some-wrapper-script",
           install_command: "npm install -g @agentclientprotocol/claude-agent-acp@latest",
+          auto_install: true,
         }}
+        sessionId="s1"
       />,
     );
     expect(container.textContent).toContain("@agentclientprotocol/claude-agent-acp");
@@ -72,7 +90,9 @@ describe("StartupErrorScreen", () => {
           raw_version: "not-semver",
           required: "0.39.0",
           install_command: "npm install -g @agentclientprotocol/claude-agent-acp@latest",
+          auto_install: true,
         }}
+        sessionId="s1"
       />,
     );
     expect(container.textContent).toContain("not-semver");
@@ -82,16 +102,66 @@ describe("StartupErrorScreen", () => {
   it("renders unsupported_protocol_version without an install command", () => {
     const { container, queryByTestId } = render(
       <StartupErrorScreen
-        detail={{
-          kind: "unsupported_protocol_version",
-          expected: "V1",
-          received: "V2",
-        }}
+        detail={{ kind: "unsupported_protocol_version", expected: "V1", received: "V2" }}
+        sessionId="s1"
       />,
     );
     expect(container.textContent).toContain("ACP protocol");
     expect(container.textContent).toContain("V1");
     expect(container.textContent).toContain("V2");
     expect(queryByTestId("startup-error-install-command")).toBeNull();
+  });
+
+  it("Restart agent POSTs to /acp/spawn", async () => {
+    const { getByTestId } = render(<StartupErrorScreen detail={incompatible()} sessionId="sess%2Fa" />);
+    fireEvent.click(getByTestId("startup-error-restart"));
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/sessions/sess%252Fa/acp/spawn",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("hides Update & restart when the install setting is off", async () => {
+    fetchSettings.mockResolvedValue({ acp: { allow_agent_install: false } });
+    const { queryByTestId } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" />);
+    // Give the settings effect a tick to resolve.
+    await waitFor(() => expect(fetchSettings).toHaveBeenCalled());
+    expect(queryByTestId("startup-error-update-restart")).toBeNull();
+  });
+
+  it("hides Update & restart for non-npm agents even when the setting is on", async () => {
+    fetchSettings.mockResolvedValue({ acp: { allow_agent_install: true } });
+    const { queryByTestId } = render(<StartupErrorScreen detail={incompatible(false)} sessionId="s1" />);
+    await waitFor(() => expect(fetchSettings).toHaveBeenCalled());
+    expect(queryByTestId("startup-error-update-restart")).toBeNull();
+  });
+
+  it("Update & restart installs then respawns on success", async () => {
+    fetchSettings.mockResolvedValue({ acp: { allow_agent_install: true } });
+    installAcpAgent.mockResolvedValue({
+      session_id: "s1",
+      package: "@agentclientprotocol/claude-agent-acp@latest",
+      success: true,
+      exit_code: 0,
+      stdout: "added 1 package",
+      stderr: "",
+    });
+    const { findByTestId } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" />);
+    const btn = await findByTestId("startup-error-update-restart");
+    fireEvent.click(btn);
+    expect(installAcpAgent).toHaveBeenCalledWith("s1");
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith("/api/sessions/s1/acp/spawn", expect.objectContaining({ method: "POST" })),
+    );
+  });
+
+  it("Update & restart surfaces the error and does not respawn on failure", async () => {
+    fetchSettings.mockResolvedValue({ acp: { allow_agent_install: true } });
+    installAcpAgent.mockRejectedValue(new Error("npm is not on the daemon's PATH"));
+    const { findByTestId, container } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" />);
+    const btn = await findByTestId("startup-error-update-restart");
+    fireEvent.click(btn);
+    await waitFor(() => expect(container.textContent).toContain("npm is not on the daemon's PATH"));
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
+++ b/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
@@ -164,4 +164,29 @@ describe("StartupErrorScreen", () => {
     await waitFor(() => expect(container.textContent).toContain("npm is not on the daemon's PATH"));
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it("Update & restart shows the exit code and skips respawn when the install fails", async () => {
+    fetchSettings.mockResolvedValue({ acp: { allow_agent_install: true } });
+    installAcpAgent.mockResolvedValue({
+      session_id: "s1",
+      package: "@agentclientprotocol/claude-agent-acp@latest",
+      success: false,
+      exit_code: 243,
+      stdout: "",
+      stderr: "npm ERR! EACCES",
+    });
+    const { findByTestId, container } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" />);
+    const btn = await findByTestId("startup-error-update-restart");
+    fireEvent.click(btn);
+    await waitFor(() => expect(container.textContent).toContain("Install exited with code 243"));
+    expect(container.textContent).toContain("npm ERR! EACCES");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("Restart agent surfaces a failed respawn", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve("boom") }));
+    const { getByTestId, container } = render(<StartupErrorScreen detail={incompatible()} sessionId="s1" />);
+    fireEvent.click(getByTestId("startup-error-restart"));
+    await waitFor(() => expect(container.textContent).toContain("Restart failed"));
+  });
 });

--- a/web/src/hooks/useRespawnSession.ts
+++ b/web/src/hooks/useRespawnSession.ts
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+export type RespawnState = "idle" | "retrying" | "ok" | "failed";
+
+/** Shared respawn machine for the structured-view recovery banners.
+ *  POSTs to `/acp/spawn` (which re-runs the ACP handshake) and tracks the
+ *  idle/retrying/ok/failed lifecycle. The next `AcpSessionAssigned` (or
+ *  user prompt) clears the banner on the reducer side, so callers only need
+ *  to fire `respawn` and reflect `state`/`error`. Extracted so the
+ *  WorkerStopped, StartupError, and compat-failure screens share one
+ *  implementation instead of three copies. See #2109. */
+export function useRespawnSession(sessionId: string) {
+  const [state, setState] = useState<RespawnState>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const respawn = async (): Promise<boolean> => {
+    setState("retrying");
+    setError(null);
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/acp/spawn`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (res.ok) {
+        setState("ok");
+        return true;
+      }
+      const detail = (await res.text().catch(() => "")).slice(0, 200);
+      setState("failed");
+      setError(`Server returned ${res.status}. ${detail}`.trim());
+      return false;
+    } catch (e) {
+      setState("failed");
+      setError(e instanceof Error ? e.message : String(e));
+      return false;
+    }
+  };
+
+  return { state, error, respawn };
+}

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -265,17 +265,23 @@ export type IncompatibleAgentDetail =
       installed: string;
       required: string;
       install_command: string;
+      /** True when the daemon can `npm install -g` this agent itself, so
+       *  the web can offer "Update & restart" (gated on the
+       *  `acp.allow_agent_install` setting). See #2109. */
+      auto_install: boolean;
     }
   | {
       kind: "missing_agent_info";
       expected_package: string;
       install_command: string;
+      auto_install: boolean;
     }
   | {
       kind: "mismatched_agent_name";
       expected: string;
       received: string;
       install_command: string;
+      auto_install: boolean;
     }
   | {
       kind: "unparseable_agent_version";
@@ -283,6 +289,7 @@ export type IncompatibleAgentDetail =
       raw_version: string;
       required: string;
       install_command: string;
+      auto_install: boolean;
     }
   | {
       kind: "unsupported_protocol_version";

--- a/web/src/lib/api.acp.test.ts
+++ b/web/src/lib/api.acp.test.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fetchAcpAgents, switchAcpAgent, type SwitchAgentResponse } from "./api";
+import { fetchAcpAgents, installAcpAgent, switchAcpAgent, type SwitchAgentResponse } from "./api";
 
 const originalFetch = globalThis.fetch;
 
@@ -122,5 +122,56 @@ describe("switchAcpAgent", () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(new Response("conflict", { status: 409 }));
     const result = await switchAcpAgent("s-1", "codex");
     expect(result).toBeNull();
+  });
+});
+
+describe("installAcpAgent", () => {
+  it("POSTs to /api/sessions/:id/acp/install-agent and returns the parsed body", async () => {
+    const body = {
+      session_id: "s-1",
+      package: "@zed-industries/codex-acp",
+      success: true,
+      exit_code: 0,
+      stdout: "added 1 package",
+      stderr: "",
+    };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(ok(body));
+    const result = await installAcpAgent("s-1");
+    expect(result).toEqual(body);
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/api/sessions/s-1/acp/install-agent");
+    expect((init as RequestInit).method).toBe("POST");
+  });
+
+  it("encodes the session id in the URL path", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      ok({ session_id: "weird/id", package: "p", success: true, exit_code: 0, stdout: "", stderr: "" }),
+    );
+    await installAcpAgent("weird/id");
+    const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(String(url)).toContain("weird%2Fid");
+  });
+
+  it("throws the server message on a non-2xx response", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "install_disabled", message: "Installing agents from the web is off." }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    await expect(installAcpAgent("s-1")).rejects.toThrow("Installing agents from the web is off.");
+  });
+
+  it("falls back to the status code when the error body has no message", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(new Response("boom", { status: 500 }));
+    await expect(installAcpAgent("s-1")).rejects.toThrow("Server returned 500");
+  });
+
+  it("throws on a 2xx response with an empty/invalid body", async () => {
+    // 200 but unparseable JSON -> body is null -> must throw, not return null.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response("not json", { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    await expect(installAcpAgent("s-1")).rejects.toThrow("invalid or empty response");
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -678,6 +678,37 @@ export async function switchAcpAgent(
   });
 }
 
+// --- Acp install agent (Tier 2 of #2109) ---
+
+export interface InstallAgentResponse {
+  session_id: string;
+  package: string;
+  success: boolean;
+  exit_code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run `npm install -g` for the session's agent on the host. Opt-in and
+ *  hardened server-side (see `install_agent` in src/server/api/acp.rs).
+ *  Resolves with the parsed body on 2xx; throws with the server's error
+ *  message on failure (disabled, sandboxed, not npm-installable, npm
+ *  missing) so the caller can surface why. The caller respawns the worker
+ *  separately via `useRespawnSession` on `success`. */
+export async function installAcpAgent(sessionId: string): Promise<InstallAgentResponse> {
+  const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/acp/install-agent`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+  const body = (await res.json().catch(() => null)) as
+    | (Partial<InstallAgentResponse> & { error?: string; message?: string })
+    | null;
+  if (!res.ok) {
+    throw new Error(body?.message || body?.error || `Server returned ${res.status}`);
+  }
+  return body as InstallAgentResponse;
+}
+
 /** Fetch a markdown primer built from events `seq < beforeSeq`. Used
  *  after a `session/load` failure: the agent's model context is empty
  *  but the transcript is intact in SQLite, so the user can opt in to

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -706,6 +706,9 @@ export async function installAcpAgent(sessionId: string): Promise<InstallAgentRe
   if (!res.ok) {
     throw new Error(body?.message || body?.error || `Server returned ${res.status}`);
   }
+  if (!body) {
+    throw new Error("Server returned an invalid or empty response");
+  }
   return body as InstallAgentResponse;
 }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Gives the web dashboard an in-UI path to recover from a missing or out-of-date ACP agent, instead of surfacing it only as a spawn error or empty state. Both tiers from the issue are implemented.

**Tier 1 (surface + restart):**
- The missing-binary spawn error now appends the exact install command (`install_hints::install_hint_for`), so the "binary not found" banner shows a copyable line instead of making the user guess the package.
- The compatibility screen (out-of-date / mismatched / unparseable adapter) gains a **Restart agent** control that respawns the worker and re-runs the handshake. No more "go restart `aoe serve` yourself".
- The duplicated inline `fetch(/acp/spawn)` + retry-state machine in the WorkerStopped and StartupError banners is extracted into a shared `useRespawnSession` hook (the new screen would have been a third copy).

**Tier 2 (opt-in, hardened server-run install):**
- New `POST /api/sessions/{id}/acp/install-agent` runs the agent's `npm install -g <pkg>` on the host, then the client respawns via the existing `/acp/spawn`. Surfaced as **Update & restart** on the compatibility screen.
- Hardening: blocked in `--read-only` mode; gated on a new opt-in setting `acp.allow_agent_install` (default off, `local_only` so only a localhost client can flip it); the package is resolved server-side from the session's agent via a static npm-only table (`npm_package_for`), never from client input; npm runs with fixed argv and no shell; the per-session instance lock serializes installs so a double-click cannot race the global prefix; a 180s timeout with `kill_on_drop` bounds a stalled install; sandbox sessions are refused (a host install would not reach the containerized agent); npm-not-on-PATH returns a clear error.

Design notes, after a debate with two external models:
- The **Update & restart** button is pre-gated by a server-authoritative `auto_install` flag on the structured startup error (true only for `claude-agent-acp`, `codex-acp`, `gemini`); non-npm agents (`opencode`, `vibe-acp`, `pi-acp`) keep the manual install hint.
- Tier 2 lives only on the structured compatibility screen, not the free-form error banner, because that banner cannot distinguish an install-fixable missing binary from an auth or project-path error.
- No output streaming in v1: the install runs synchronously with a spinner; the lock prevents concurrent runs. The residual risk (npm lifecycle scripts run as the daemon user) is why the capability is opt-in, local-only, and read-only-guarded.

Closes #2109

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] With an out-of-date `claude-agent-acp` (e.g. pin an older version), open a structured-view session; confirm the compatibility screen shows installed vs required version and the install command.
- [ ] Click **Restart agent**; confirm the worker respawns and the screen clears once a compatible version is installed (or reappears with the new version if still too old).
- [ ] Remove the agent binary from PATH; open the session; confirm the error message now includes the exact `Install with: ...` command.
- [ ] In Settings, enable **Allow agent install from web** (only flippable from a localhost connection); confirm an **Update & restart** button appears on the compatibility screen for an npm-installable agent.
- [ ] Click **Update & restart**; confirm `npm install -g` runs, output is shown, and the worker respawns.
- [ ] Confirm the button is hidden when the setting is off, for non-npm agents (`opencode`), and that the endpoint returns 403 under `aoe serve --read-only`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec (`StartupErrorScreen.test.tsx`) covering the Restart and Update & restart controls; `StartupErrorScreen.tsx` is already mapped in `web/tests/coverage-matrix.json` via `acp.startup-error-screen`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. New Rust unit tests cover the install-hint enrichment, the `npm_package_for` table, and the `auto_install` flag.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (with a two-model design debate), and implementation drafted by Claude under my direction. I made the scope and security calls, reviewed each commit, and run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784189564&installation_id=139138837&pr_number=2198&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2198&signature=7db25d73a5bd43b2ea00377bd5db16dcc48d7067852623d4cff46ae9dd02746a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a web-dashboard recovery flow for missing or out-of-date ACP agents (issue `#2109`). Instead of forcing users to manually restart the daemon and run install commands, the UI now offers guided “restart” and (optionally) “install + restart” actions, with stronger safeguards around anything that touches host-level installation.

## What changed

### User-facing improvements
- **Clearer compatibility messaging (Tier 1):**
  - The compatibility screen shows the installed vs. required adapter versions and a **copyable install command** for known npm-based agents.
  - A **Restart agent** button was added to automatically respawn the worker and retry the handshake.
- **Automated recovery (Tier 2, opt-in):**
  - A new **Update & restart** button appears only when:
    - `acp.allow_agent_install` is enabled (local-only advanced toggle), and
    - the agent is eligible for npm installation (server-controlled `auto_install`).
  - When enabled, the button installs the agent on the host and then restarts it; otherwise users are shown the manual install hint.
- **Documentation added:**
  - A new troubleshooting section explains both recovery actions, including behavior in `--read-only`, sandbox sessions, and eligibility rules.

### Backend changes
- **New endpoint:** `POST /api/sessions/{id}/acp/install-agent`
  - Installs only whitelisted npm agents via a server-resolved package mapping using `npm install -g <pkg>`.
  - Restarts via the existing respawn flow after install.
  - Hardened for safety:
    - blocked in **read-only** mode
    - rejected for **sandbox** sessions
    - gated by **`acp.allow_agent_install`**
    - no shell usage, fixed npm invocation, and both process-wide + per-session install locks to prevent concurrent global-prefix installs
    - **180s timeout** with kill-on-drop, plus bounded output size truncation
  - Returns structured JSON `{success, message/error details}` for consistent client handling.
- **More helpful error hints:**
  - Missing-binary spawn failures now include an “Install with:” hint when the adapter is recognized, making copy/paste recovery easier.
- **Server-to-UI eligibility plumbing:**
  - The structured startup error details now include an `auto_install` flag so the UI can decide whether “Update & restart” is safe/appropriate.

### Frontend changes
- **Unified respawn logic:**
  - Introduced `useRespawnSession(sessionId)` to standardize “respawn + retry” behavior across the structured view banners.
- **UI updates:**
  - `StartupErrorScreen` now uses the respawn hook for **Restart agent**.
  - Conditionally renders **Update & restart** based on settings + `auto_install`.
  - Added a client helper to call the new install endpoint.
- **Tests:**
  - Expanded Vitest coverage for both restart and update/install flows, including settings gating and failure-path messaging.
  - Updated/added Rust unit tests for npm package eligibility mapping and install-hint enrichment.

## Benefits
- **Self-healing dashboard:** users can recover from missing/out-of-date ACP agents without manual daemon restarts.
- **Lower friction + fewer terminal steps:** users get copyable install commands and one-click retry.
- **Security-first automation:** host installs are opt-in, tightly scoped to known npm agents, and blocked in unsafe modes (read-only + sandbox).
- **Cleaner frontend code:** respawn/retry handling is centralized in one hook and consistently tested.

## Potential areas for further enhancement
- Add/verify user-visible progress feedback for long installs (e.g., spinner/progress states) and ensure install attempts are observable via logs/metrics for debugging and audit trails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->