### PR TITLE
feat(web): restore last session on PWA relaunch

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -176,6 +176,8 @@ The dashboard installs as a Progressive Web App for an app-like, standalone wind
 
 The PWA needs the server running; use `--daemon` to keep it up (`aoe serve --stop` to stop). For a stable URL that survives restarts, install from a Tailscale Funnel or named-Cloudflare URL, not a quick tunnel.
 
+When you leave the PWA and come back, it reopens to the session you last had open rather than the dashboard. The last session is remembered per device (not synced across devices); if you were on the dashboard when you left, or that session no longer exists, you land on the dashboard.
+
 `Ctrl-C` on a foreground server, or `aoe serve --stop` against a daemon, both exit within ~5 seconds even with open tabs. Live clients receive a `1001` ("going away") close frame and reconnect once a fresh server is running.
 
 For build, architecture, and frontend-development details, see [Web Dashboard Development](../development/web-dashboard.md).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useMatch, useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import { IDLE_DECAY_WINDOW_MS, isSessionActive } from "./lib/session";
 import { useSessions } from "./hooks/useSessions";
 import { clearAcpCache } from "./hooks/useAcpSession";
@@ -94,6 +94,11 @@ import { UpdateBanner } from "./components/UpdateBanner";
 import { DashboardUpdateBanner } from "./components/DashboardUpdateBanner";
 
 const RIGHT_PANEL_COLLAPSED_KEY = "aoe-right-collapsed";
+// Device-local id of the last session the user had open, so an installed PWA
+// reopens to it instead of the dashboard (#2103). Not registered in webUiSync:
+// sessions/worktrees are host-specific, so syncing this across devices would
+// redirect to ids that don't exist locally.
+const LAST_SESSION_KEY = "aoe-last-session-id";
 // Pre-#1832 per-browser tour-seen flag. Read once on load to migrate users who
 // already dismissed the tour to the backend; no longer written.
 const LEGACY_TOUR_SEEN_KEY = "aoe-tour-seen";
@@ -215,6 +220,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   }, []);
 
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const idleDecayWindowMs = useIdleDecayWindowMs();
   const { settings: webSettings } = useWebSettings();
@@ -240,6 +246,36 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     setSessionStatus,
   } = useSessions();
   const workspaces = useWorkspaces(sessions);
+
+  // Remember the active session so a relaunched PWA can restore it (#2103).
+  // Clearing only fires on an in-app return to the dashboard (`key !== "default"`),
+  // never on the initial entry, so the restore effect below still sees the
+  // stored id on a cold launch that lands on "/".
+  useEffect(() => {
+    if (activeSessionId) {
+      safeSetItem(LAST_SESSION_KEY, activeSessionId);
+    } else if (location.pathname === "/" && location.key !== "default") {
+      safeRemoveItem(LAST_SESSION_KEY);
+    }
+  }, [activeSessionId, location.pathname, location.key]);
+
+  // Restore the last session on a cold launch that lands on the dashboard root
+  // (#2103): an installed PWA reopens at its install URL "/", losing the session
+  // the user was in. Scoped to the initial history entry (`key === "default"`)
+  // so an in-app navigation to "/" never bounces the user back. A stored id that
+  // no longer matches a loaded session is dropped instead of redirected to.
+  useEffect(() => {
+    if (location.key !== "default" || activeSessionId || location.pathname !== "/" || !sessionsLoaded) {
+      return;
+    }
+    const saved = safeGetItem(LAST_SESSION_KEY);
+    if (!saved) return;
+    if (sessions.some((s) => s.id === saved)) {
+      navigate(`/session/${encodeURIComponent(saved)}`, { replace: true });
+    } else {
+      safeRemoveItem(LAST_SESSION_KEY);
+    }
+  }, [location.key, location.pathname, activeSessionId, sessionsLoaded, sessions, navigate]);
 
   // One-shot orphan-draft sweep once useSessions has settled its first
   // fetch (success or null). Catches acp:draft:<id> keys left behind

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useLocation, useMatch, useNavigate, useSearchParams } from "react-router-dom";
+import { useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import { IDLE_DECAY_WINDOW_MS, isSessionActive } from "./lib/session";
 import { useSessions } from "./hooks/useSessions";
 import { clearAcpCache } from "./hooks/useAcpSession";
@@ -7,6 +7,7 @@ import { clearDraft, sweepOrphanDrafts } from "./lib/acpDrafts";
 import { AcpPrefsProvider } from "./lib/acpPrefs";
 import { safeGetItem, safeRemoveItem, safeSetItem } from "./lib/safeStorage";
 import { useWorkspaces } from "./hooks/useWorkspaces";
+import { useLastSessionRestore } from "./hooks/useLastSessionRestore";
 import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useSessionGroups } from "./hooks/useSessionGroups";
 import { useNestedSidebarGroups } from "./hooks/useNestedSidebarGroups";
@@ -94,11 +95,6 @@ import { UpdateBanner } from "./components/UpdateBanner";
 import { DashboardUpdateBanner } from "./components/DashboardUpdateBanner";
 
 const RIGHT_PANEL_COLLAPSED_KEY = "aoe-right-collapsed";
-// Device-local id of the last session the user had open, so an installed PWA
-// reopens to it instead of the dashboard (#2103). Not registered in webUiSync:
-// sessions/worktrees are host-specific, so syncing this across devices would
-// redirect to ids that don't exist locally.
-const LAST_SESSION_KEY = "aoe-last-session-id";
 // Pre-#1832 per-browser tour-seen flag. Read once on load to migrate users who
 // already dismissed the tour to the backend; no longer written.
 const LEGACY_TOUR_SEEN_KEY = "aoe-tour-seen";
@@ -220,7 +216,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   }, []);
 
   const navigate = useNavigate();
-  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const idleDecayWindowMs = useIdleDecayWindowMs();
   const { settings: webSettings } = useWebSettings();
@@ -247,35 +242,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   } = useSessions();
   const workspaces = useWorkspaces(sessions);
 
-  // Remember the active session so a relaunched PWA can restore it (#2103).
-  // Clearing only fires on an in-app return to the dashboard (`key !== "default"`),
-  // never on the initial entry, so the restore effect below still sees the
-  // stored id on a cold launch that lands on "/".
-  useEffect(() => {
-    if (activeSessionId) {
-      safeSetItem(LAST_SESSION_KEY, activeSessionId);
-    } else if (location.pathname === "/" && location.key !== "default") {
-      safeRemoveItem(LAST_SESSION_KEY);
-    }
-  }, [activeSessionId, location.pathname, location.key]);
-
-  // Restore the last session on a cold launch that lands on the dashboard root
-  // (#2103): an installed PWA reopens at its install URL "/", losing the session
-  // the user was in. Scoped to the initial history entry (`key === "default"`)
-  // so an in-app navigation to "/" never bounces the user back. A stored id that
-  // no longer matches a loaded session is dropped instead of redirected to.
-  useEffect(() => {
-    if (location.key !== "default" || activeSessionId || location.pathname !== "/" || !sessionsLoaded) {
-      return;
-    }
-    const saved = safeGetItem(LAST_SESSION_KEY);
-    if (!saved) return;
-    if (sessions.some((s) => s.id === saved)) {
-      navigate(`/session/${encodeURIComponent(saved)}`, { replace: true });
-    } else {
-      safeRemoveItem(LAST_SESSION_KEY);
-    }
-  }, [location.key, location.pathname, activeSessionId, sessionsLoaded, sessions, navigate]);
+  // Remember the active session and restore it on a PWA relaunch (#2103).
+  useLastSessionRestore({ activeSessionId, sessions, sessionsLoaded });
 
   // One-shot orphan-draft sweep once useSessions has settled its first
   // fetch (success or null). Catches acp:draft:<id> keys left behind

--- a/web/src/hooks/useLastSessionRestore.test.tsx
+++ b/web/src/hooks/useLastSessionRestore.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
+import type { ReactNode } from "react";
+
+import { LAST_SESSION_KEY, useLastSessionRestore } from "./useLastSessionRestore";
+
+type Params = {
+  activeSessionId: string | null;
+  sessions: readonly { id: string }[];
+  sessionsLoaded: boolean;
+};
+
+function setup(initialEntry: string, initialProps: Params) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[initialEntry]}>{children}</MemoryRouter>
+  );
+  return renderHook(
+    (props: Params) => {
+      const location = useLocation();
+      const navigate = useNavigate();
+      useLastSessionRestore(props);
+      return { location, navigate };
+    },
+    { wrapper, initialProps },
+  );
+}
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("useLastSessionRestore", () => {
+  it("persists the active session id", async () => {
+    setup("/session/s1", { activeSessionId: "s1", sessions: [{ id: "s1" }], sessionsLoaded: true });
+    await waitFor(() => expect(localStorage.getItem(LAST_SESSION_KEY)).toBe("s1"));
+  });
+
+  it("restores the stored session on a cold launch to the dashboard root", async () => {
+    localStorage.setItem(LAST_SESSION_KEY, "s1");
+    const { result } = setup("/", {
+      activeSessionId: null,
+      sessions: [{ id: "s1" }],
+      sessionsLoaded: true,
+    });
+    await waitFor(() => expect(result.current.location.pathname).toBe("/session/s1"));
+  });
+
+  it("drops a stored id that no longer matches a loaded session", async () => {
+    localStorage.setItem(LAST_SESSION_KEY, "gone");
+    const { result } = setup("/", {
+      activeSessionId: null,
+      sessions: [{ id: "s1" }],
+      sessionsLoaded: true,
+    });
+    await waitFor(() => expect(localStorage.getItem(LAST_SESSION_KEY)).toBeNull());
+    expect(result.current.location.pathname).toBe("/");
+  });
+
+  it("does nothing on a cold launch with no stored session", async () => {
+    const { result } = setup("/", {
+      activeSessionId: null,
+      sessions: [{ id: "s1" }],
+      sessionsLoaded: true,
+    });
+    // Give effects a tick; the dashboard stays put and no key is written.
+    await waitFor(() => expect(result.current.location.pathname).toBe("/"));
+    expect(localStorage.getItem(LAST_SESSION_KEY)).toBeNull();
+  });
+
+  it("waits for the sessions list before restoring", async () => {
+    localStorage.setItem(LAST_SESSION_KEY, "s1");
+    const { result, rerender } = setup("/", {
+      activeSessionId: null,
+      sessions: [],
+      sessionsLoaded: false,
+    });
+    // Not loaded yet: no redirect.
+    expect(result.current.location.pathname).toBe("/");
+    rerender({ activeSessionId: null, sessions: [{ id: "s1" }], sessionsLoaded: true });
+    await waitFor(() => expect(result.current.location.pathname).toBe("/session/s1"));
+  });
+
+  it("does not override a deep link to a session", async () => {
+    localStorage.setItem(LAST_SESSION_KEY, "s1");
+    const { result } = setup("/session/other", {
+      activeSessionId: "other",
+      sessions: [{ id: "s1" }, { id: "other" }],
+      sessionsLoaded: true,
+    });
+    await waitFor(() => expect(localStorage.getItem(LAST_SESSION_KEY)).toBe("other"));
+    expect(result.current.location.pathname).toBe("/session/other");
+  });
+
+  it("clears the stored session on an in-app return to the dashboard", async () => {
+    const { result, rerender } = setup("/session/s1", {
+      activeSessionId: "s1",
+      sessions: [{ id: "s1" }],
+      sessionsLoaded: true,
+    });
+    await waitFor(() => expect(localStorage.getItem(LAST_SESSION_KEY)).toBe("s1"));
+
+    act(() => result.current.navigate("/"));
+    rerender({ activeSessionId: null, sessions: [{ id: "s1" }], sessionsLoaded: true });
+
+    await waitFor(() => expect(localStorage.getItem(LAST_SESSION_KEY)).toBeNull());
+    expect(result.current.location.pathname).toBe("/");
+  });
+});

--- a/web/src/hooks/useLastSessionRestore.ts
+++ b/web/src/hooks/useLastSessionRestore.ts
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
+
+// Device-local id of the last session the user had open, so an installed PWA
+// reopens to it instead of the dashboard (#2103). Not registered in webUiSync:
+// sessions/worktrees are host-specific, so syncing this across devices would
+// redirect to ids that don't exist locally.
+export const LAST_SESSION_KEY = "aoe-last-session-id";
+
+/**
+ * Remember the active session and restore it on a PWA relaunch (#2103).
+ *
+ * An installed PWA reopens at its install URL "/", so it always landed on the
+ * dashboard instead of the session the user last had open. This persists the
+ * active session id whenever it changes and, on a cold launch that lands on the
+ * dashboard root, redirects to it once sessions have loaded.
+ *
+ * Restore is scoped to the initial history entry (`location.key === "default"`)
+ * so an in-app navigation to the dashboard never bounces the user back into a
+ * session, and the persist effect only clears the key on such an in-app return,
+ * never on the initial entry, so the restore below still sees it on a cold
+ * launch. A stored id that no longer matches a loaded session is dropped.
+ */
+export function useLastSessionRestore(params: {
+  activeSessionId: string | null;
+  sessions: readonly { id: string }[];
+  sessionsLoaded: boolean;
+}): void {
+  const { activeSessionId, sessions, sessionsLoaded } = params;
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (activeSessionId) {
+      safeSetItem(LAST_SESSION_KEY, activeSessionId);
+    } else if (location.pathname === "/" && location.key !== "default") {
+      safeRemoveItem(LAST_SESSION_KEY);
+    }
+  }, [activeSessionId, location.pathname, location.key]);
+
+  useEffect(() => {
+    // Restore reacts to router state (cold-launch URL, back/forward, deep links,
+    // push-driven navigation), not a single DOM event, so it must be an effect.
+    // The rule misreads the hook's params as component props and the navigate as
+    // passing data to a parent; neither applies to a router-state reactor.
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
+    if (location.key !== "default" || activeSessionId || location.pathname !== "/" || !sessionsLoaded) {
+      return;
+    }
+    const saved = safeGetItem(LAST_SESSION_KEY);
+    if (!saved) return;
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent
+    if (sessions.some((s) => s.id === saved)) {
+      navigate(`/session/${encodeURIComponent(saved)}`, { replace: true });
+    } else {
+      safeRemoveItem(LAST_SESSION_KEY);
+    }
+  }, [location.key, location.pathname, activeSessionId, sessionsLoaded, sessions, navigate]);
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -357,6 +357,13 @@
       "components": []
     },
     {
+      "id": "app-shell.last-session-restore",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/hooks/useLastSessionRestore.test.tsx"],
+      "components": []
+    },
+    {
       "id": "profiles.lifecycle",
       "kind": "mocked-playwright",
       "risk": "high",

--- a/web/tests/routing.spec.ts
+++ b/web/tests/routing.spec.ts
@@ -137,3 +137,110 @@ test.describe("URL routing", () => {
     await expect(page).toHaveURL("/settings");
   });
 });
+
+const LAST_SESSION_KEY = "aoe-last-session-id";
+
+function makeSession(id: string) {
+  return {
+    id,
+    title: id,
+    project_path: `/tmp/${id}`,
+    group_path: "/tmp",
+    tool: "claude",
+    status: "Running",
+    yolo_mode: false,
+    created_at: new Date().toISOString(),
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {},
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+  };
+}
+
+async function stubSessions(page: import("@playwright/test").Page, ids: string[]) {
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+    return r.fulfill({ json: { sessions: ids.map(makeSession), workspace_ordering: [] } });
+  });
+  await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
+  await page.route("**/api/sessions/*/terminal", (r) => r.fulfill({ status: 200, body: "" }));
+  await page.routeWebSocket(/\/sessions\/.*\/(ws|acp-ws)$/, () => {});
+}
+
+// Verifies the PWA reopens to the session the user last had open (#2103).
+test.describe("PWA last-session restore", () => {
+  test("cold launch to '/' restores the stored last session", async ({ page }) => {
+    await stubSessions(page, ["known-session"]);
+    await page.addInitScript(
+      ([key, id]) => {
+        try {
+          localStorage.setItem(key, id);
+        } catch {
+          // storage disabled; the app degrades to no-restore
+        }
+      },
+      [LAST_SESSION_KEY, "known-session"],
+    );
+
+    await page.goto("/");
+    await expect(page).toHaveURL("/session/known-session");
+    await expect(page.getByRole("button", { name: NEW_SESSION_PANE_NAME })).not.toBeVisible();
+  });
+
+  test("cold launch stays on the dashboard when the stored session no longer exists", async ({ page }) => {
+    await stubSessions(page, ["other-session"]);
+    await page.addInitScript(
+      ([key, id]) => {
+        try {
+          localStorage.setItem(key, id);
+        } catch {
+          // storage disabled; the app degrades to no-restore
+        }
+      },
+      [LAST_SESSION_KEY, "deleted-session"],
+    );
+
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: NEW_SESSION_PANE_NAME })).toBeVisible();
+    await expect(page).toHaveURL("/");
+    // The stale id is dropped so it is not re-evaluated on the next launch.
+    await expect.poll(() => page.evaluate((k) => localStorage.getItem(k), LAST_SESSION_KEY)).toBe(null);
+  });
+
+  test("a deep link to a session is not overridden by the stored last session", async ({ page }) => {
+    await stubSessions(page, ["known-session", "deep-link-session"]);
+    await page.addInitScript(
+      ([key, id]) => {
+        try {
+          localStorage.setItem(key, id);
+        } catch {
+          // storage disabled; the app degrades to no-restore
+        }
+      },
+      [LAST_SESSION_KEY, "known-session"],
+    );
+
+    await page.goto("/session/deep-link-session");
+    await expect(page).toHaveURL("/session/deep-link-session");
+  });
+
+  test("visiting a session records it as the last session", async ({ page }) => {
+    await stubSessions(page, ["known-session"]);
+
+    await page.goto("/session/known-session");
+    await expect(page).toHaveURL("/session/known-session");
+    await expect.poll(() => page.evaluate((k) => localStorage.getItem(k), LAST_SESSION_KEY)).toBe("known-session");
+  });
+});

--- a/web/tests/routing.spec.ts
+++ b/web/tests/routing.spec.ts
@@ -243,4 +243,17 @@ test.describe("PWA last-session restore", () => {
     await expect(page).toHaveURL("/session/known-session");
     await expect.poll(() => page.evaluate((k) => localStorage.getItem(k), LAST_SESSION_KEY)).toBe("known-session");
   });
+
+  test("returning to the dashboard in-app clears the stored last session", async ({ page }) => {
+    await stubSessions(page, ["known-session"]);
+
+    await page.goto("/session/known-session");
+    await expect.poll(() => page.evaluate((k) => localStorage.getItem(k), LAST_SESSION_KEY)).toBe("known-session");
+
+    await page.getByRole("button", { name: "Go to dashboard" }).click();
+    await expect(page).toHaveURL("/");
+    // Leaving for the dashboard makes the dashboard the remembered view, so a
+    // later cold launch should not bounce the user back into the session.
+    await expect.poll(() => page.evaluate((k) => localStorage.getItem(k), LAST_SESSION_KEY)).toBe(null);
+  });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

An installed PWA always reopened to the dashboard instead of the session the user last had open. The active session is derived purely from the URL (`useMatch("/session/:sessionId")` in `web/src/App.tsx`), and on a cold launch the OS restores the install URL `/`, so nothing pointed the app back at the prior session.

This persists the active session id to a device-local `localStorage` key (`aoe-last-session-id`) whenever it changes, then, on a cold launch that lands on the root, redirects to it once the sessions list has loaded. The restore is scoped to the initial history entry (`location.key === "default"`) so an in-app navigation back to the dashboard never bounces the user into a session, and a stored id that no longer matches a loaded session is dropped rather than redirected to. The key is intentionally not synced across devices, since sessions and worktrees are host-specific.

User-observable impact: leave the PWA and come back, and you land back in the session you were using.

Closes #2103

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the dashboard, click into a session, then close the tab/app and reopen at `/` (or relaunch the installed PWA). You land back in that session.
- [ ] From a session, navigate back to the dashboard, then reopen at `/`. You stay on the dashboard (the last view was the dashboard).
- [ ] Be in a session, delete it (or have it deleted elsewhere), then reopen at `/`. You land on the dashboard, no broken `/session/<id>` route.
- [ ] Open a deep link `/session/<id>` directly. It loads that session and is not overridden by a previously stored session.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added four mocked-Playwright cases to `web/tests/routing.spec.ts` (cold-launch restore, stale-id falls back to dashboard, deep link is not overridden, visiting a session records it). These verify red on the pre-fix tree. The file is already mapped by the `app-shell.routing` entry in `web/tests/coverage-matrix.json`, so no matrix change was needed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (with a `/debate` design pass), and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784189743&installation_id=139138837&pr_number=2200&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2200&signature=78b438fb0d77ce42a74eb7d47d9a373d4a13d00ea663a776e9d765470b56fde1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR enhances the Web Dashboard PWA so that, when reopened, it restores the user’s last active session instead of always landing on the dashboard. The “last session” memory is stored on the device only.

## What Changed
- **Extracted session logic into a hook:** Moved the “persist/restore last session” behavior out of `App.tsx` into a dedicated `useLastSessionRestore` hook, keeping routing/session-state logic cleaner and easier to test.
- **Device-local persistence:** When the active session changes, the hook saves the session ID to a `localStorage` key (`aoe-last-session-id`).
- **Cold-launch restore from `/`:** On relaunches that start at the app root (`/`), the app waits for sessions to load and then redirects to `/session/<id>` if the stored session still exists.
- **Stale session safeguards:** If the stored session ID doesn’t match any loaded session, the PR drops the saved value and falls back to the dashboard.
- **Deep-link protection:** Opening a specific session URL directly (`/session/<id>`) is not overridden by the saved “last session.”
- **Navigation safeguard:** Restore/redirect is scoped to the initial landing state (using `location.key === "default"`) to avoid bouncing users back into sessions when they intentionally navigate to the dashboard.
- **Clears saved state when appropriate:** If the user navigates back to the dashboard, the stored session is cleared so future cold launches won’t redirect back to the previous session.
- **Testing improvements:**
  - Added **new Playwright E2E tests** covering cold-launch restoration, stale-session handling, deep-link behavior, and recording/clearing of the stored session.
  - Added **new Vitest hook unit tests** for `useLastSessionRestore`.
  - Updated the **coverage matrix** entry to reflect the new hook test surface.
- **Documentation update:** Updated the PWA install guide to clarify that session restore is **device-local** (not shared across devices).

## Benefits
- **Continuity of work:** Users resume where they left off with less navigation.
- **More predictable UX:** Prevents incorrect redirects for stale sessions and respects deliberate deep links to specific sessions.
- **Higher confidence:** Adds focused automated tests at both the unit (hook) and end-to-end (routing/session flow) levels.

## Potential Future Enhancements
- Consider an **opt-in cross-device** restore strategy if sessions/worktrees can be mapped consistently across devices (the current design is intentionally device-local).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->