### PR TITLE
feat(serve): smart-rename structured view sessions from the first message

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -73,6 +73,7 @@ The schema is flat and every field is optional. Missing color fields fall back t
 default_tool = "claude"   # any supported agent name
 yolo_mode_default = false
 agent_status_hooks = true
+smart_rename = true
 auto_stop_idle_secs = 0   # 0 disables; e.g. 7200 = stop after 2h idle
 
 [session.acp_defaults.opencode]
@@ -86,6 +87,7 @@ effort = "high"
 | `auto_stop_idle_secs` | `0` | Seconds a plain tmux session may sit `Idle` before it is auto-stopped: its tmux session and any sandbox container are killed, leaving a restartable `Stopped` row. `0` disables it; no session is ever auto-stopped for inactivity. Idle age is measured from the later of the last transition into `Idle` and the last user interaction, and a session with an attached tmux client is always spared, so a session you are reading is never reaped. Evaluated about once a minute (by the TUI and by `aoe serve`), so the stop can lag the threshold by up to a minute. Structured view workers use the separate `acp.auto_stop_idle_secs`. See #1689 and #1690. |
 | `yolo_mode_default` | `false` | Enable YOLO mode by default for new sessions (skip permission prompts). Works with or without sandbox. In tmux mode this passes `--dangerously-skip-permissions` to the agent CLI; in structured view it maps to ACP `bypassPermissions` (see [Structured view: Permission modes and YOLO](../structured-view/controls.md#permission-modes-and-yolo) for the adapter caveat). |
 | `agent_status_hooks` | `true` | Install status-detection hooks into the agent's config file. Codex uses the `[hooks]` table in its resolved `config.toml` (typically `~/.codex/config.toml`); other JSON-based agents use their settings JSON. Config-dir overrides are honored: `CODEX_HOME` (Codex), `CLAUDE_CONFIG_DIR` (Claude), or `CURSOR_CONFIG_DIR` (Cursor) set in the session's profile environment or in AoE's own environment redirects hooks to that directory instead of the `~/.codex` / `~/.claude` / `~/.cursor` default. When disabled, status detection falls back to tmux pane content parsing. Codex is hook-first, but known hook gaps are reconciled from pane content. |
+| `smart_rename` | `true` | Auto-rename a new structured view (ACP) session from its first message, using the session's own agent in one-shot mode (`claude -p`, `codex exec`, `opencode run`, `gemini -p`). Runs only while the session still carries its auto-generated civilization name; a manually named session is never touched. Title only: the worktree directory is not moved, since the running agent holds it. Skipped for sandboxed sessions (a host one-shot lacks the container's auth), agents with no one-shot mode, and command-overridden agents. Best-effort: a failed or timed-out call leaves the generated name and never affects the prompt. |
 | `agent_extra_args` | `{}` | Per-agent extra arguments appended after the binary (e.g., `{ opencode = "--port 8080" }`). |
 | `agent_command_override` | `{}` | Per-agent command override replacing the binary entirely (e.g., `{ claude = "my-claude-wrapper" }`). |
 | `custom_agents` | `{}` | User-defined agents: name to command mapping. Custom agent names appear in the TUI agent picker alongside built-in agents. |

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -95,6 +95,8 @@ Non-ACP tools always run in the terminal view, with no toggle.
 
 `aoe add` does not prompt for a name by default: it uses `--title`, else the worktree branch name, else a generated name. Pass `-i`/`--interactive` for the same name prompt the TUI and wizard show. Set per-agent defaults for web-created sessions under `[session.acp_defaults.<agent>]`:
 
+When a structured view session keeps its generated civilization name (no `--title`, no branch name), AoE auto-renames it from your first message using the session's own agent in one-shot mode (`claude -p`, `codex exec`, `opencode run`, `gemini -p`). This is on by default and controlled by `session.smart_rename`. It renames the title only, never the worktree directory (the running agent holds it), and never touches a session you named yourself. Sandboxed sessions, agents with no one-shot mode, and command-overridden agents keep the generated name. See [Configuration: Session](guides/configuration.md#session).
+
 ```toml
 [session.acp_defaults.opencode]
 model = "openai/gpt-5.5"

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -97,6 +97,8 @@ Non-ACP tools always run in the terminal view, with no toggle.
 
 When a structured view session keeps its generated civilization name (no `--title`, no branch name), AoE auto-renames it from your first message using the session's own agent in one-shot mode (`claude -p`, `codex exec`, `opencode run`, `gemini -p`). This is on by default and controlled by `session.smart_rename`. It renames the title only, never the worktree directory (the running agent holds it), and never touches a session you named yourself. Sandboxed sessions, agents with no one-shot mode, and command-overridden agents keep the generated name. See [Configuration: Session](guides/configuration.md#session).
 
+The sidebar shows where each session stands: an `Auto-name` chip (sparkle) marks a session that is still default-named and will be renamed on its first message, and a `Naming…` chip (pulsing dot) shows while the one-shot title call is in flight. The chips disappear once the session is renamed or if it is not eligible.
+
 ```toml
 [session.acp_defaults.opencode]
 model = "openai/gpt-5.5"

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -116,6 +116,14 @@ pub struct AgentDef {
     /// CLI flag template for custom instruction injection.
     /// `{}` is replaced with the shell-escaped instruction text.
     pub instruction_flag: Option<&'static str>,
+    /// Single argv token that runs this agent non-interactively (one-shot),
+    /// printing the model's response to stdout and exiting (e.g. claude `-p`,
+    /// codex `exec`, opencode `run`, gemini `-p`). It is exactly one token,
+    /// placed immediately before the prompt argument, and must NOT contain a
+    /// `{}` placeholder (the prompt is passed as its own argv element, never
+    /// interpolated). `None` means the agent has no known one-shot mode, so
+    /// smart session rename is skipped for it. See `session::smart_rename`.
+    pub oneshot_flag: Option<&'static str>,
     /// If true, `builder.rs` sets `instance.command = binary` for this agent.
     pub set_default_command: bool,
     /// Status detection function pointer. Takes raw (non-lowercased) pane content.
@@ -308,6 +316,7 @@ const CODEX_HOOK_EVENTS: &[HookEvent] = &[
 pub const AGENTS: &[AgentDef] = &[
     AgentDef {
         name: "claude",
+        oneshot_flag: Some("-p"),
         binary: "claude",
         aliases: &[],
         detection: DetectionMethod::Which("claude"),
@@ -332,6 +341,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "opencode",
+        oneshot_flag: Some("run"),
         binary: "opencode",
         aliases: &["open-code"],
         detection: DetectionMethod::Which("opencode"),
@@ -349,6 +359,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "vibe",
+        oneshot_flag: None,
         binary: "vibe",
         aliases: &["mistral-vibe"],
         detection: DetectionMethod::RunWithArg("vibe", "--version"),
@@ -366,6 +377,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "codex",
+        oneshot_flag: Some("exec"),
         binary: "codex",
         aliases: &[],
         detection: DetectionMethod::Which("codex"),
@@ -394,6 +406,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "gemini",
+        oneshot_flag: Some("-p"),
         binary: "gemini",
         aliases: &[],
         detection: DetectionMethod::Which("gemini"),
@@ -440,6 +453,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "cursor",
+        oneshot_flag: None,
         binary: "agent",
         aliases: &["agent"],
         detection: DetectionMethod::Which("agent"),
@@ -461,6 +475,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "copilot",
+        oneshot_flag: None,
         binary: "copilot",
         aliases: &["github-copilot"],
         detection: DetectionMethod::Which("copilot"),
@@ -478,6 +493,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "pi",
+        oneshot_flag: None,
         binary: "pi",
         aliases: &[],
         detection: DetectionMethod::Which("pi"),
@@ -496,6 +512,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "droid",
+        oneshot_flag: None,
         binary: "droid",
         aliases: &["factory-droid"],
         detection: DetectionMethod::Which("droid"),
@@ -513,6 +530,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "settl",
+        oneshot_flag: None,
         binary: "settl",
         aliases: &["settlers", "catan"],
         detection: DetectionMethod::Which("settl"),
@@ -539,6 +557,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "hermes",
+        oneshot_flag: None,
         binary: "hermes",
         aliases: &[],
         detection: DetectionMethod::Which("hermes"),
@@ -572,6 +591,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "kiro",
+        oneshot_flag: None,
         binary: "kiro-cli",
         aliases: &["kiro-cli"],
         detection: DetectionMethod::Which("kiro-cli"),
@@ -601,6 +621,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "qwen",
+        oneshot_flag: None,
         binary: "qwen",
         aliases: &[],
         detection: DetectionMethod::Which("qwen"),
@@ -625,6 +646,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "antigravity",
+        oneshot_flag: None,
         binary: "agy",
         aliases: &["agy"],
         detection: DetectionMethod::Which("agy"),

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -733,6 +733,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_oneshot_flags_are_single_tokens_without_placeholders() {
+        // The smart-rename safety contract: a non-None oneshot_flag is exactly
+        // one argv token placed before the prompt, and never interpolates the
+        // prompt. Keep future agent additions from weakening that.
+        for agent in AGENTS {
+            let Some(flag) = agent.oneshot_flag else {
+                continue;
+            };
+            assert_eq!(
+                flag,
+                flag.trim(),
+                "agent '{}' one-shot flag must not have surrounding whitespace",
+                agent.name
+            );
+            assert_eq!(
+                flag.split_whitespace().count(),
+                1,
+                "agent '{}' one-shot flag must be exactly one argv token",
+                agent.name
+            );
+            assert!(
+                !flag.contains("{}"),
+                "agent '{}' one-shot flag must not interpolate the prompt",
+                agent.name
+            );
+        }
+    }
+
+    #[test]
     fn test_get_agent_known() {
         assert_eq!(get_agent("claude").unwrap().binary, "claude");
         assert_eq!(get_agent("opencode").unwrap().binary, "opencode");

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -798,6 +798,14 @@ pub async fn acp_prompt(
         .acp_supervisor
         .publish_user_prompt_with_attachments(&id, req.text.clone(), &attachments)
         .await;
+    // Best-effort: auto-rename a still-default-named session from this first
+    // message via the agent's one-shot mode. Detached so it never blocks or
+    // fails the prompt; all gating lives inside. See session::smart_rename.
+    tokio::spawn(crate::session::smart_rename::try_smart_rename(
+        state.clone(),
+        id.clone(),
+        req.text.clone(),
+    ));
     match state
         .acp_supervisor
         .send_prompt(&id, &req.text, &attachments)

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -540,10 +540,20 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
             .lock()
             .map(|g| g.clone())
             .unwrap_or_default();
+        let attempted: HashSet<String> = state
+            .smart_rename_attempted
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default();
         let mut cfg_cache: HashMap<String, (bool, HashMap<String, String>)> = HashMap::new();
         for (resp, inst) in sessions.iter_mut().zip(instances.iter()) {
             if inflight.contains(&inst.id) {
                 resp.smart_rename = SmartRenameState::Running;
+                continue;
+            }
+            // A session whose one-shot already ran (and failed, since the name
+            // is still default) will not retry, so it is not pending either.
+            if attempted.contains(&inst.id) {
                 continue;
             }
             let (setting_on, overrides) = cfg_cache

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -95,6 +95,13 @@ pub struct SessionResponse {
     /// responses leave it `false` and the sidebar reads the list value. #1927.
     #[serde(default)]
     pub tie_workdir_to_name: bool,
+    /// Smart-rename indicator state for structured view sessions: `pending`
+    /// (still default-named and eligible, will auto-name on the next prompt),
+    /// `running` (a one-shot title call is in flight), or `inactive`. Populated
+    /// by `list_sessions`; single-session responses leave it `inactive`. See
+    /// `session::smart_rename`.
+    #[serde(default)]
+    pub smart_rename: crate::session::smart_rename::SmartRenameState,
     pub has_terminal: bool,
     pub profile: String,
     pub cleanup_defaults: CleanupDefaults,
@@ -264,6 +271,8 @@ impl SessionResponse {
                 .is_some_and(|w| w.managed_by_aoe),
             // Overlaid per-profile in list_sessions; see the field doc.
             tie_workdir_to_name: false,
+            // Overlaid in list_sessions; single-session responses stay inactive.
+            smart_rename: crate::session::smart_rename::SmartRenameState::Inactive,
             has_terminal: inst.terminal_info.is_some(),
             profile: inst.source_profile.clone(),
             cleanup_defaults: CleanupDefaults {
@@ -517,6 +526,48 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
                     .tie_workdir_to_name
             });
             session.tie_workdir_to_name = tied;
+        }
+    }
+
+    // Overlay the smart-rename indicator. `running` comes from the live
+    // in-flight set; `pending` from the shared eligibility predicate, so the
+    // chip cannot drift from the runtime gate. Config resolved once per profile.
+    {
+        use crate::session::smart_rename::{check_eligible, SmartRenameState};
+        use std::collections::{HashMap, HashSet};
+        let inflight: HashSet<String> = state
+            .smart_rename_inflight
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        let mut cfg_cache: HashMap<String, (bool, HashMap<String, String>)> = HashMap::new();
+        for (resp, inst) in sessions.iter_mut().zip(instances.iter()) {
+            if inflight.contains(&inst.id) {
+                resp.smart_rename = SmartRenameState::Running;
+                continue;
+            }
+            let (setting_on, overrides) = cfg_cache
+                .entry(inst.source_profile.clone())
+                .or_insert_with(|| {
+                    let cfg = crate::session::profile_config::resolve_config_or_warn(
+                        &inst.source_profile,
+                    )
+                    .session;
+                    (cfg.smart_rename, cfg.agent_command_override)
+                });
+            let eligible = check_eligible(
+                inst.is_structured(),
+                *setting_on,
+                &inst.title,
+                crate::agents::get_agent(&inst.tool),
+                inst.is_sandboxed(),
+                &inst.command,
+                overrides.contains_key(&inst.tool),
+            )
+            .is_ok();
+            if eligible {
+                resp.smart_rename = SmartRenameState::Pending;
+            }
         }
     }
 
@@ -6336,6 +6387,7 @@ mod workspace_ordering_tests {
             scratch: false,
             has_managed_worktree: false,
             tie_workdir_to_name: false,
+            smart_rename: crate::session::smart_rename::SmartRenameState::Inactive,
             has_terminal: false,
             profile: "default".to_string(),
             cleanup_defaults: CleanupDefaults {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -295,6 +295,11 @@ pub struct AppState {
     /// first use and live for the lifetime of the process — there are only
     /// as many as the user has sessions.
     pub instance_locks: RwLock<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Session ids with an in-flight smart-rename one-shot, so a burst of rapid
+    /// first prompts cannot spawn concurrent title generators for the same
+    /// session. Synchronous mutex: critical sections are tiny and never span an
+    /// `await`. See `session::smart_rename`.
+    pub smart_rename_inflight: std::sync::Mutex<std::collections::HashSet<String>>,
     /// Suppression set for the startup-recovery cascade. While an entry is
     /// present and younger than `recovery::RECENTLY_RESTARTED_TTL`, the
     /// `status_poll_loop` skips `update_status_with_metadata` for that
@@ -955,6 +960,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         auth_mode,
         serve_mode,
         instance_locks: RwLock::new(std::collections::HashMap::new()),
+        smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
         recently_restarted: crate::session::recovery::new_recently_restarted(),
         recovery_pending: crate::session::recovery::new_recovery_pending(),
         cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
@@ -3796,6 +3802,7 @@ pub mod test_support {
             auth_mode: "none",
             serve_mode: "local",
             instance_locks: RwLock::new(HashMap::new()),
+            smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
             recently_restarted: crate::session::recovery::new_recently_restarted(),
             recovery_pending: crate::session::recovery::new_recovery_pending(),
             cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -300,6 +300,12 @@ pub struct AppState {
     /// session. Synchronous mutex: critical sections are tiny and never span an
     /// `await`. See `session::smart_rename`.
     pub smart_rename_inflight: std::sync::Mutex<std::collections::HashSet<String>>,
+    /// Session ids that have already had a smart-rename one-shot attempt this
+    /// process lifetime (success or failure). A failed or unusable first try
+    /// leaves the name default, so without this every later prompt would
+    /// respawn a one-shot agent; one attempt per session bounds that cost and
+    /// clears the `pending` sidebar chip once an attempt has run.
+    pub smart_rename_attempted: std::sync::Mutex<std::collections::HashSet<String>>,
     /// Suppression set for the startup-recovery cascade. While an entry is
     /// present and younger than `recovery::RECENTLY_RESTARTED_TTL`, the
     /// `status_poll_loop` skips `update_status_with_metadata` for that
@@ -961,6 +967,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         serve_mode,
         instance_locks: RwLock::new(std::collections::HashMap::new()),
         smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
+        smart_rename_attempted: std::sync::Mutex::new(std::collections::HashSet::new()),
         recently_restarted: crate::session::recovery::new_recently_restarted(),
         recovery_pending: crate::session::recovery::new_recovery_pending(),
         cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
@@ -3803,6 +3810,7 @@ pub mod test_support {
             serve_mode: "local",
             instance_locks: RwLock::new(HashMap::new()),
             smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
+            smart_rename_attempted: std::sync::Mutex::new(std::collections::HashSet::new()),
             recently_restarted: crate::session::recovery::new_recently_restarted(),
             recovery_pending: crate::session::recovery::new_recovery_pending(),
             cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {

--- a/src/session/civilizations.rs
+++ b/src/session/civilizations.rs
@@ -109,6 +109,28 @@ pub fn generate_random_title(existing_titles: &[&str]) -> String {
     format!("{} {}", base, chrono::Utc::now().timestamp())
 }
 
+/// True when `title` is one this module could have produced via
+/// [`generate_random_title`]: a bare civilization name, or a civilization
+/// followed by a Roman-numeral suffix (`Britons II`) or a numeric timestamp
+/// suffix (`Britons 1700000000`). Civilization names are all single words, so
+/// the split on the last space is unambiguous. Used by `session::smart_rename`
+/// to decide whether a session still carries its auto-generated name and is
+/// therefore eligible for an automatic rename.
+pub fn is_default_civ_name(title: &str) -> bool {
+    let t = title.trim();
+    if CIVILIZATIONS.contains(&t) {
+        return true;
+    }
+    if let Some((base, suffix)) = t.rsplit_once(' ') {
+        if CIVILIZATIONS.contains(&base) && !suffix.is_empty() {
+            let is_roman = suffix.chars().all(|c| "IVXLCDM".contains(c));
+            let is_timestamp = suffix.chars().all(|c| c.is_ascii_digit());
+            return is_roman || is_timestamp;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,5 +169,22 @@ mod tests {
         let existing: Vec<&str> = CIVILIZATIONS.to_vec();
         let title = generate_random_title(&existing);
         assert!(title.contains(" II"));
+    }
+
+    #[test]
+    fn test_is_default_civ_name() {
+        // Bare civ names and every shape generate_random_title can emit.
+        assert!(is_default_civ_name("Vikings"));
+        assert!(is_default_civ_name("  Vikings  "));
+        assert!(is_default_civ_name("Britons II"));
+        assert!(is_default_civ_name("Franks XLIX"));
+        assert!(is_default_civ_name("Mongols 1700000000"));
+        // Not default: user-chosen titles, even ones embedding a civ word.
+        assert!(!is_default_civ_name("Fix login bug"));
+        assert!(!is_default_civ_name("My Vikings"));
+        assert!(!is_default_civ_name("Vikings raid plan"));
+        assert!(!is_default_civ_name("Vikings 2.0"));
+        assert!(!is_default_civ_name("Notaciv II"));
+        assert!(!is_default_civ_name(""));
     }
 }

--- a/src/session/civilizations.rs
+++ b/src/session/civilizations.rs
@@ -123,8 +123,12 @@ pub fn is_default_civ_name(title: &str) -> bool {
     }
     if let Some((base, suffix)) = t.rsplit_once(' ') {
         if CIVILIZATIONS.contains(&base) && !suffix.is_empty() {
-            let is_roman = suffix.chars().all(|c| "IVXLCDM".contains(c));
-            let is_timestamp = suffix.chars().all(|c| c.is_ascii_digit());
+            // Match only the exact suffixes generate_random_title emits: a Roman
+            // numeral in 2..=1000, or a timestamp (Unix seconds, >= 9 digits).
+            // A looser check (any IVXLCDM run, any digits) would treat
+            // user-chosen titles like "Vikings 2" or "Britons IM" as default.
+            let is_roman = (2..=1000).any(|n| to_roman(n) == suffix);
+            let is_timestamp = suffix.len() >= 9 && suffix.chars().all(|c| c.is_ascii_digit());
             return is_roman || is_timestamp;
         }
     }
@@ -185,6 +189,9 @@ mod tests {
         assert!(!is_default_civ_name("Vikings raid plan"));
         assert!(!is_default_civ_name("Vikings 2.0"));
         assert!(!is_default_civ_name("Notaciv II"));
+        // Suffixes generate_random_title can never emit: invalid roman, short numeric.
+        assert!(!is_default_civ_name("Britons IM"));
+        assert!(!is_default_civ_name("Vikings 2"));
         assert!(!is_default_civ_name(""));
     }
 }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -760,6 +760,17 @@ pub struct SessionConfig {
     #[setting(label = "Agent Status Hooks", widget = "toggle", category = "Agents")]
     pub agent_status_hooks: bool,
 
+    /// Auto-rename a new structured-view (ACP) session from its first message,
+    /// using the session's own agent in one-shot mode (e.g. `claude -p`). Only
+    /// applies while the session still carries its auto-generated name; a
+    /// manually named session is never touched. Title only: the worktree
+    /// directory is not moved (the running agent holds it). Agents without a
+    /// one-shot mode, sandboxed sessions, and command-overridden agents keep
+    /// the generated name.
+    #[serde(default = "default_true")]
+    #[setting(label = "Smart Session Rename", widget = "toggle", category = "Agents")]
+    pub smart_rename: bool,
+
     /// Request xterm mouse tracking so the TUI handles the scroll wheel
     /// (preview-pane scroll) and click-to-select rows. Disable to hand the
     /// wheel and text selection back to the terminal, e.g. iOS Mosh +
@@ -1088,6 +1099,7 @@ impl Default for SessionConfig {
             agent_extra_args: HashMap::new(),
             agent_command_override: HashMap::new(),
             agent_status_hooks: true,
+            smart_rename: true,
             mouse_capture: true,
             custom_agents: HashMap::new(),
             agent_detect_as: HashMap::new(),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -22,6 +22,7 @@ pub mod repo_config;
 pub mod scratch;
 pub(crate) mod serde_helpers;
 pub mod settings_schema;
+pub mod smart_rename;
 pub mod stop;
 mod storage;
 pub mod worktree_edit;

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -1,0 +1,475 @@
+//! Automatic "smart" rename of a structured-view (ACP) session from its first
+//! message.
+//!
+//! When a session still carries its auto-generated civilization name (see
+//! [`crate::session::civilizations`]) and the user sends a first prompt, the
+//! session's own agent is run once in non-interactive one-shot mode (e.g.
+//! `claude -p`) to produce a short title, and the session is renamed. This is
+//! best-effort and fire-and-forget: it never blocks or fails the user's prompt,
+//! and any failure leaves the generated name in place.
+//!
+//! Title only: the worktree directory is intentionally not moved. The live ACP
+//! worker holds the worktree as its working directory, so a directory move
+//! would fail exactly like a manual rename of a running tied session does. The
+//! visible session title is what gains meaning here.
+
+use crate::agents;
+
+/// Hard cap on how much of the user's first message is handed to the one-shot
+/// call. A title needs only the opening intent, and very large argv values can
+/// trip some shells/agents.
+const MAX_PROMPT_BYTES: usize = 4096;
+/// Reject a candidate title longer than this many characters.
+const MAX_TITLE_CHARS: usize = 60;
+/// Reject a candidate title with more than this many words.
+const MAX_TITLE_WORDS: usize = 8;
+
+/// Instruction prefix sent to the agent. Constrains the output so the sanitizer
+/// has the least possible work to do; anything off-format is rejected, never
+/// salvaged.
+const INSTRUCTION: &str = "Generate a concise 3 to 5 word title summarizing the following task. \
+Respond with ONLY the title: no quotes, no markdown, no surrounding punctuation, no explanation. \
+If you cannot, respond with exactly NONE.";
+
+/// Build the prompt string for the one-shot title call: the fixed instruction
+/// plus the (NUL-stripped, trimmed, byte-capped) first user message.
+pub fn build_prompt(user_message: &str) -> String {
+    let sanitized = user_message.replace('\0', " ");
+    let trimmed = sanitized.trim();
+    let capped = truncate_bytes(trimmed, MAX_PROMPT_BYTES);
+    format!("{INSTRUCTION}\n\nTask:\n{capped}")
+}
+
+/// Build the argv for a one-shot title call, or `None` when the agent has no
+/// known one-shot mode. Always `[binary, oneshot_token, prompt]`: the prompt is
+/// a single argv element passed straight to the process, never interpolated
+/// into a shell string, so untrusted user text cannot inject arguments.
+pub fn build_oneshot_argv(agent: &agents::AgentDef, prompt: &str) -> Option<Vec<String>> {
+    let token = agent.oneshot_flag?;
+    Some(vec![
+        agent.binary.to_string(),
+        token.to_string(),
+        prompt.to_string(),
+    ])
+}
+
+/// Turn raw agent stdout into a clean title, or `None` to keep the generated
+/// name. Strips ANSI escapes, scans every line, and returns the last line that
+/// looks like a plausible title (short, has letters, not a refusal, not an echo
+/// of the prompt). Verbose agents (`codex exec`, `opencode run`) print logs
+/// around the answer; the final qualifying line is the answer.
+pub fn sanitize_title(raw: &str, user_message: &str) -> Option<String> {
+    let cleaned = strip_ansi(raw);
+    let user_lc = user_message.trim().to_lowercase();
+    let mut best: Option<String> = None;
+    for line in cleaned.lines() {
+        let t = clean_line(line);
+        if t.is_empty() {
+            continue;
+        }
+        let lc = t.to_lowercase();
+        if lc == "none" || lc == user_lc || is_refusal(&lc) {
+            continue;
+        }
+        let words = t.split_whitespace().count();
+        if words == 0 || words > MAX_TITLE_WORDS {
+            continue;
+        }
+        if t.chars().count() > MAX_TITLE_CHARS {
+            continue;
+        }
+        if !t.chars().any(|c| c.is_alphabetic()) {
+            continue;
+        }
+        best = Some(t);
+    }
+    best
+}
+
+/// Strip leading markdown markers / list numbering, wrapping quotes and
+/// backticks, trailing sentence punctuation, and collapse inner whitespace.
+fn clean_line(line: &str) -> String {
+    let mut s = line.trim();
+    // Leading markdown markers: bullets, headings, blockquote.
+    s = s
+        .trim_start_matches(|c| matches!(c, '#' | '-' | '*' | '>' | '+'))
+        .trim_start();
+    // Leading list numbering like "1." or "2)".
+    let digits: String = s.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if !digits.is_empty() {
+        let rest = &s[digits.len()..];
+        if let Some(after) = rest.strip_prefix('.').or_else(|| rest.strip_prefix(')')) {
+            s = after.trim_start();
+        }
+    }
+    // Wrapping quotes / backticks / stray markdown emphasis.
+    let s = s.trim_matches(|c| matches!(c, '"' | '\'' | '`' | '*' | '_'));
+    // Trailing sentence punctuation.
+    let s = s.trim_end_matches(|c: char| matches!(c, '.' | ',' | ':' | ';' | '!'));
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn is_refusal(lc: &str) -> bool {
+    const PREFIXES: &[&str] = &[
+        "i cannot",
+        "i can't",
+        "i can not",
+        "i am unable",
+        "i'm unable",
+        "i won't",
+        "i will not",
+        "unable to",
+        "sorry",
+        "as an ai",
+    ];
+    PREFIXES.iter().any(|p| lc.starts_with(p)) || lc.contains("cannot determine")
+}
+
+/// Remove ANSI/CSI escape sequences (color codes etc.) that CLI agents emit.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            if chars.peek() == Some(&'[') {
+                chars.next();
+            }
+            // Consume until the final byte (a letter) of the escape sequence.
+            for n in chars.by_ref() {
+                if n.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn truncate_bytes(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(feature = "serve")]
+pub use serve::try_smart_rename;
+
+#[cfg(feature = "serve")]
+mod serve {
+    use super::*;
+    use crate::server::AppState;
+    use crate::session::civilizations::is_default_civ_name;
+    use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    const ONESHOT_TIMEOUT: Duration = Duration::from_secs(12);
+
+    /// Marks a session as having an in-flight one-shot rename so a burst of
+    /// rapid first prompts cannot spawn concurrent title generators. Removed on
+    /// drop, so every exit path (including early returns) releases it.
+    struct InflightGuard<'a> {
+        set: &'a Mutex<HashSet<String>>,
+        id: String,
+    }
+
+    impl<'a> InflightGuard<'a> {
+        fn acquire(set: &'a Mutex<HashSet<String>>, id: &str) -> Option<Self> {
+            let mut guard = set.lock().expect("smart_rename_inflight poisoned");
+            if !guard.insert(id.to_string()) {
+                return None;
+            }
+            Some(Self {
+                set,
+                id: id.to_string(),
+            })
+        }
+    }
+
+    impl Drop for InflightGuard<'_> {
+        fn drop(&mut self) {
+            if let Ok(mut guard) = self.set.lock() {
+                guard.remove(&self.id);
+            }
+        }
+    }
+
+    /// Best-effort auto-rename of a structured-view session from its first
+    /// message. Spawn this detached from the prompt handler; it never returns an
+    /// error and never touches the prompt flow. All gates are re-checked under
+    /// the per-session lock before the title is written, so a manual rename (or
+    /// a deletion) that lands during the one-shot call always wins.
+    pub async fn try_smart_rename(state: Arc<AppState>, session_id: String, first_message: String) {
+        if first_message.trim().is_empty() {
+            return;
+        }
+
+        let Some((profile, tool, command, project_path, sandboxed, title)) = ({
+            let instances = state.instances.read().await;
+            instances.iter().find(|i| i.id == session_id).map(|i| {
+                (
+                    i.source_profile.clone(),
+                    i.tool.clone(),
+                    i.command.clone(),
+                    i.project_path.clone(),
+                    i.is_sandboxed(),
+                    i.title.clone(),
+                )
+            })
+        }) else {
+            return;
+        };
+
+        if !is_default_civ_name(&title) {
+            return;
+        }
+        if sandboxed {
+            tracing::debug!(target: "smart_rename", session = %session_id, "skip: sandboxed session (host one-shot lacks container auth)");
+            return;
+        }
+
+        let config = crate::session::profile_config::resolve_config_or_warn(&profile);
+        if !config.session.smart_rename {
+            return;
+        }
+
+        let Some(agent) = agents::get_agent(&tool) else {
+            tracing::debug!(target: "smart_rename", session = %session_id, tool = %tool, "skip: no built-in agent");
+            return;
+        };
+        if agent.oneshot_flag.is_none() {
+            tracing::debug!(target: "smart_rename", session = %session_id, tool = %tool, "skip: agent has no one-shot mode");
+            return;
+        }
+
+        // A replaced binary (config override or a custom instance command) makes
+        // appending the one-shot token unsafe, so bail rather than guess.
+        let overridden = config.session.agent_command_override.contains_key(&tool)
+            || (!command.is_empty() && command != agent.binary);
+        if overridden {
+            tracing::debug!(target: "smart_rename", session = %session_id, tool = %tool, "skip: agent command overridden");
+            return;
+        }
+
+        let Some(_guard) = InflightGuard::acquire(&state.smart_rename_inflight, &session_id) else {
+            return;
+        };
+
+        let prompt = build_prompt(&first_message);
+        let Some(argv) = build_oneshot_argv(agent, &prompt) else {
+            return;
+        };
+
+        let Some(raw) = run_oneshot(&argv, &project_path).await else {
+            return;
+        };
+        let Some(new_title) = sanitize_title(&raw, &first_message) else {
+            tracing::debug!(target: "smart_rename", session = %session_id, "skip: agent output not a usable title");
+            return;
+        };
+
+        // Serialize against manual rename / worktree edits on this session.
+        let lock = state.instance_lock(&session_id).await;
+        let _serialized = lock.lock().await;
+        apply_title_only(&state, &session_id, &profile, &new_title).await;
+    }
+
+    /// Run the agent one-shot in the session's working directory, capturing
+    /// stdout. Returns `None` on spawn error, non-zero exit, or timeout. The
+    /// child is killed on drop, so a timed-out call leaves no orphan.
+    async fn run_oneshot(argv: &[String], cwd: &str) -> Option<String> {
+        use tokio::process::Command;
+        let mut cmd = Command::new(&argv[0]);
+        cmd.args(&argv[1..])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true);
+        if !cwd.is_empty() {
+            cmd.current_dir(cwd);
+        }
+        let child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(target: "smart_rename", "one-shot spawn failed: {e}");
+                return None;
+            }
+        };
+        match tokio::time::timeout(ONESHOT_TIMEOUT, child.wait_with_output()).await {
+            Ok(Ok(out)) if out.status.success() => {
+                Some(String::from_utf8_lossy(&out.stdout).into_owned())
+            }
+            Ok(Ok(out)) => {
+                tracing::debug!(target: "smart_rename", "one-shot exited {:?}", out.status.code());
+                None
+            }
+            Ok(Err(e)) => {
+                tracing::debug!(target: "smart_rename", "one-shot io error: {e}");
+                None
+            }
+            Err(_) => {
+                tracing::debug!(target: "smart_rename", "one-shot timed out");
+                None
+            }
+        }
+    }
+
+    /// Persist the new title (re-checking the still-default gate under the
+    /// storage lock) then mirror it into the in-memory instance list so
+    /// connected clients see it without waiting for a reload.
+    async fn apply_title_only(state: &Arc<AppState>, id: &str, profile: &str, new_title: &str) {
+        let storage = match crate::session::storage::Storage::new(profile, state.file_watch.clone())
+        {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(target: "smart_rename", session = %id, "storage open failed: {e}");
+                return;
+            }
+        };
+        let id_owned = id.to_string();
+        let title_owned = new_title.to_string();
+        let persisted = tokio::task::spawn_blocking(move || {
+            storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_owned) {
+                    if is_default_civ_name(&inst.title) {
+                        inst.title = title_owned.clone();
+                    }
+                }
+                Ok(())
+            })
+        })
+        .await;
+        match persisted {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::warn!(target: "smart_rename", session = %id, "persist failed: {e}");
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(target: "smart_rename", session = %id, "persist join failed: {e}");
+                return;
+            }
+        }
+
+        let mut instances = state.instances.write().await;
+        if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+            if is_default_civ_name(&inst.title) {
+                tracing::info!(target: "smart_rename", session = %id, old = %inst.title, new = %new_title, "renamed session from first message");
+                inst.title = new_title.to_string();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn claude() -> &'static agents::AgentDef {
+        agents::get_agent("claude").expect("claude agent exists")
+    }
+
+    #[test]
+    fn argv_is_binary_token_prompt() {
+        let argv = build_oneshot_argv(claude(), "hello").expect("claude has one-shot");
+        assert_eq!(argv, vec!["claude", "-p", "hello"]);
+    }
+
+    #[test]
+    fn argv_none_for_agent_without_oneshot() {
+        let cursor = agents::get_agent("cursor").expect("cursor agent exists");
+        assert!(build_oneshot_argv(cursor, "hello").is_none());
+    }
+
+    #[test]
+    fn argv_per_agent_tokens() {
+        assert_eq!(
+            build_oneshot_argv(agents::get_agent("codex").unwrap(), "x").unwrap()[1],
+            "exec"
+        );
+        assert_eq!(
+            build_oneshot_argv(agents::get_agent("opencode").unwrap(), "x").unwrap()[1],
+            "run"
+        );
+        assert_eq!(
+            build_oneshot_argv(agents::get_agent("gemini").unwrap(), "x").unwrap()[1],
+            "-p"
+        );
+    }
+
+    #[test]
+    fn build_prompt_truncates_and_strips_nul() {
+        let msg = format!("start{}\u{0}end", "x".repeat(5000));
+        let p = build_prompt(&msg);
+        assert!(p.contains("start"));
+        assert!(!p.contains('\u{0}'));
+        // Instruction + capped body, well under message length.
+        assert!(p.len() < 5000 + INSTRUCTION.len() + 64);
+    }
+
+    #[test]
+    fn sanitize_plain_title() {
+        assert_eq!(
+            sanitize_title("Fix login bug", "whatever").as_deref(),
+            Some("Fix login bug")
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_quotes_markdown_punctuation() {
+        assert_eq!(
+            sanitize_title("**\"Refactor auth module.\"**", "x").as_deref(),
+            Some("Refactor auth module")
+        );
+        assert_eq!(
+            sanitize_title("- Update README", "x").as_deref(),
+            Some("Update README")
+        );
+        assert_eq!(
+            sanitize_title("1. Add dark mode", "x").as_deref(),
+            Some("Add dark mode")
+        );
+    }
+
+    #[test]
+    fn sanitize_picks_last_qualifying_line_from_verbose_output() {
+        let raw = "[2024] booting agent\nthinking...\nWire up websockets\n";
+        assert_eq!(
+            sanitize_title(raw, "x").as_deref(),
+            Some("Wire up websockets")
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_ansi() {
+        let raw = "\u{1b}[32mGreen title here\u{1b}[0m";
+        assert_eq!(
+            sanitize_title(raw, "x").as_deref(),
+            Some("Green title here")
+        );
+    }
+
+    #[test]
+    fn sanitize_rejects_refusals_none_empty_and_echo() {
+        assert!(sanitize_title("I cannot help with that", "x").is_none());
+        assert!(sanitize_title("Sorry, no.", "x").is_none());
+        assert!(sanitize_title("NONE", "x").is_none());
+        assert!(sanitize_title("   \n  ", "x").is_none());
+        assert!(sanitize_title("fix the thing", "fix the thing").is_none());
+    }
+
+    #[test]
+    fn sanitize_rejects_too_long_or_wordy() {
+        assert!(sanitize_title("a ".repeat(20).trim(), "x").is_none());
+        assert!(sanitize_title(&"z".repeat(80), "x").is_none());
+        // Numeric-only is not a title.
+        assert!(sanitize_title("12345", "x").is_none());
+    }
+}

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -14,6 +14,86 @@
 //! visible session title is what gains meaning here.
 
 use crate::agents;
+use crate::session::civilizations::is_default_civ_name;
+use serde::Serialize;
+
+/// Per-session smart-rename state surfaced to the dashboard so the sidebar can
+/// show that a session will be (or is being) auto-named. `Inactive` for
+/// sessions that are not eligible or already renamed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SmartRenameState {
+    #[default]
+    Inactive,
+    /// Eligible and still default-named: will auto-name on the next prompt.
+    Pending,
+    /// A one-shot title call is in flight for this session right now.
+    Running,
+}
+
+/// Why a session is not eligible for smart rename, for logging and to gate the
+/// `Pending` indicator. The same predicate drives both the runtime gate and the
+/// sidebar state so they cannot drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    NotStructured,
+    Disabled,
+    NameNotDefault,
+    Sandboxed,
+    NoOneshot,
+    CommandOverridden,
+}
+
+impl SkipReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SkipReason::NotStructured => "not_structured",
+            SkipReason::Disabled => "disabled",
+            SkipReason::NameNotDefault => "name_not_default",
+            SkipReason::Sandboxed => "sandboxed",
+            SkipReason::NoOneshot => "no_oneshot",
+            SkipReason::CommandOverridden => "command_overridden",
+        }
+    }
+}
+
+/// Single source of truth for "is this session eligible to be auto-named right
+/// now". `Ok(())` means a first prompt would trigger a rename; `Err` carries the
+/// disqualifying reason. `command_override_in_cfg` is whether the profile config
+/// replaces this agent's binary; `command` is the instance's launch command (a
+/// non-empty value differing from the agent binary is also an override).
+pub fn check_eligible(
+    structured: bool,
+    setting_on: bool,
+    title: &str,
+    agent: Option<&agents::AgentDef>,
+    sandboxed: bool,
+    command: &str,
+    command_override_in_cfg: bool,
+) -> Result<(), SkipReason> {
+    if !structured {
+        return Err(SkipReason::NotStructured);
+    }
+    if !setting_on {
+        return Err(SkipReason::Disabled);
+    }
+    if !is_default_civ_name(title) {
+        return Err(SkipReason::NameNotDefault);
+    }
+    if sandboxed {
+        return Err(SkipReason::Sandboxed);
+    }
+    let Some(agent) = agent else {
+        return Err(SkipReason::NoOneshot);
+    };
+    if agent.oneshot_flag.is_none() {
+        return Err(SkipReason::NoOneshot);
+    }
+    if command_override_in_cfg || (!command.is_empty() && command != agent.binary) {
+        return Err(SkipReason::CommandOverridden);
+    }
+    Ok(())
+}
 
 /// Hard cap on how much of the user's first message is handed to the one-shot
 /// call. A title needs only the opening intent, and very large argv values can
@@ -91,9 +171,7 @@ pub fn sanitize_title(raw: &str, user_message: &str) -> Option<String> {
 fn clean_line(line: &str) -> String {
     let mut s = line.trim();
     // Leading markdown markers: bullets, headings, blockquote.
-    s = s
-        .trim_start_matches(|c| matches!(c, '#' | '-' | '*' | '>' | '+'))
-        .trim_start();
+    s = s.trim_start_matches(['#', '-', '*', '>', '+']).trim_start();
     // Leading list numbering like "1." or "2)".
     let digits: String = s.chars().take_while(|c| c.is_ascii_digit()).collect();
     if !digits.is_empty() {
@@ -103,9 +181,9 @@ fn clean_line(line: &str) -> String {
         }
     }
     // Wrapping quotes / backticks / stray markdown emphasis.
-    let s = s.trim_matches(|c| matches!(c, '"' | '\'' | '`' | '*' | '_'));
+    let s = s.trim_matches(['"', '\'', '`', '*', '_']);
     // Trailing sentence punctuation.
-    let s = s.trim_end_matches(|c: char| matches!(c, '.' | ',' | ':' | ';' | '!'));
+    let s = s.trim_end_matches(['.', ',', ':', ';', '!']);
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
@@ -165,7 +243,6 @@ pub use serve::try_smart_rename;
 mod serve {
     use super::*;
     use crate::server::AppState;
-    use crate::session::civilizations::is_default_civ_name;
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -211,7 +288,7 @@ mod serve {
             return;
         }
 
-        let Some((profile, tool, command, project_path, sandboxed, title)) = ({
+        let Some((profile, tool, command, project_path, sandboxed, title, structured)) = ({
             let instances = state.instances.read().await;
             instances.iter().find(|i| i.id == session_id).map(|i| {
                 (
@@ -221,42 +298,29 @@ mod serve {
                     i.project_path.clone(),
                     i.is_sandboxed(),
                     i.title.clone(),
+                    i.is_structured(),
                 )
             })
         }) else {
             return;
         };
 
-        if !is_default_civ_name(&title) {
-            return;
-        }
-        if sandboxed {
-            tracing::debug!(target: "smart_rename", session = %session_id, "skip: sandboxed session (host one-shot lacks container auth)");
-            return;
-        }
-
         let config = crate::session::profile_config::resolve_config_or_warn(&profile);
-        if !config.session.smart_rename {
+        let agent = agents::get_agent(&tool);
+        let command_override_in_cfg = config.session.agent_command_override.contains_key(&tool);
+        if let Err(reason) = check_eligible(
+            structured,
+            config.session.smart_rename,
+            &title,
+            agent,
+            sandboxed,
+            &command,
+            command_override_in_cfg,
+        ) {
+            tracing::debug!(target: "smart_rename", session = %session_id, tool = %tool, reason = reason.as_str(), "skip");
             return;
         }
-
-        let Some(agent) = agents::get_agent(&tool) else {
-            tracing::debug!(target: "smart_rename", session = %session_id, tool = %tool, "skip: no built-in agent");
-            return;
-        };
-        if agent.oneshot_flag.is_none() {
-            tracing::debug!(target: "smart_rename", session = %session_id, tool = %tool, "skip: agent has no one-shot mode");
-            return;
-        }
-
-        // A replaced binary (config override or a custom instance command) makes
-        // appending the one-shot token unsafe, so bail rather than guess.
-        let overridden = config.session.agent_command_override.contains_key(&tool)
-            || (!command.is_empty() && command != agent.binary);
-        if overridden {
-            tracing::debug!(target: "smart_rename", session = %session_id, tool = %tool, "skip: agent command overridden");
-            return;
-        }
+        let agent = agent.expect("check_eligible Ok implies a built-in agent");
 
         let Some(_guard) = InflightGuard::acquire(&state.smart_rename_inflight, &session_id) else {
             return;
@@ -386,6 +450,56 @@ mod tests {
     fn argv_none_for_agent_without_oneshot() {
         let cursor = agents::get_agent("cursor").expect("cursor agent exists");
         assert!(build_oneshot_argv(cursor, "hello").is_none());
+    }
+
+    #[test]
+    fn check_eligible_reasons() {
+        let c = Some(claude());
+        // Happy path.
+        assert!(check_eligible(true, true, "Vikings", c, false, "", false).is_ok());
+        // Each disqualifier maps to its reason.
+        assert_eq!(
+            check_eligible(false, true, "Vikings", c, false, "", false),
+            Err(SkipReason::NotStructured)
+        );
+        assert_eq!(
+            check_eligible(true, false, "Vikings", c, false, "", false),
+            Err(SkipReason::Disabled)
+        );
+        assert_eq!(
+            check_eligible(true, true, "Fix login bug", c, false, "", false),
+            Err(SkipReason::NameNotDefault)
+        );
+        assert_eq!(
+            check_eligible(true, true, "Vikings", c, true, "", false),
+            Err(SkipReason::Sandboxed)
+        );
+        assert_eq!(
+            check_eligible(true, true, "Vikings", None, false, "", false),
+            Err(SkipReason::NoOneshot)
+        );
+        assert_eq!(
+            check_eligible(
+                true,
+                true,
+                "Vikings",
+                Some(agents::get_agent("cursor").unwrap()),
+                false,
+                "",
+                false
+            ),
+            Err(SkipReason::NoOneshot)
+        );
+        assert_eq!(
+            check_eligible(true, true, "Vikings", c, false, "", true),
+            Err(SkipReason::CommandOverridden)
+        );
+        assert_eq!(
+            check_eligible(true, true, "Vikings", c, false, "my-wrapper", false),
+            Err(SkipReason::CommandOverridden)
+        );
+        // Command equal to the agent binary is not an override.
+        assert!(check_eligible(true, true, "Vikings", c, false, "claude", false).is_ok());
     }
 
     #[test]

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -326,6 +326,19 @@ mod serve {
             return;
         };
 
+        // One attempt per session lifetime. A failed or unusable first try
+        // leaves the name default; without this guard every later prompt would
+        // respawn a one-shot agent (12s + tokens) until one happened to succeed.
+        {
+            let mut attempted = state
+                .smart_rename_attempted
+                .lock()
+                .expect("smart_rename_attempted poisoned");
+            if !attempted.insert(session_id.clone()) {
+                return;
+            }
+        }
+
         let prompt = build_prompt(&first_message);
         let Some(argv) = build_oneshot_argv(agent, &prompt) else {
             return;

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -24,6 +24,7 @@ import {
   Pin,
   Play,
   Plus,
+  Sparkles,
 } from "lucide-react";
 import {
   DndContext,
@@ -984,6 +985,26 @@ export const SessionRow = memo(function SessionRow({
                 >
                   <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-amber-400/80" />
                   Resuming
+                </span>
+              )}
+              {firstSession?.smart_rename === "pending" && (
+                <span
+                  title="Will auto-name this session from your first message"
+                  aria-label="Will auto-name"
+                  className="inline-flex shrink-0 items-center gap-0.5 rounded border border-surface-700/40 bg-surface-800/40 px-1 py-0 text-[10px] font-mono font-medium text-text-dim"
+                >
+                  <Sparkles className="h-3 w-3" />
+                  <span className="hidden sm:inline">Auto-name</span>
+                </span>
+              )}
+              {firstSession?.smart_rename === "running" && (
+                <span
+                  title="Generating a name from your first message"
+                  aria-label="Naming"
+                  className="inline-flex shrink-0 items-center gap-0.5 rounded border border-amber-700/40 bg-amber-950/30 px-1 py-0 text-[10px] font-medium text-amber-300"
+                >
+                  <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-amber-400/80" />
+                  Naming…
                 </span>
               )}
               {firstSession?.next_wakeup_at && (

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -187,6 +187,41 @@ describe("SessionRow chips", () => {
   });
 });
 
+describe("SessionRow smart-rename chip", () => {
+  it("renders the Auto-name chip when smart_rename is pending", () => {
+    const ws = workspace("w-pending", [session({ view: "structured", smart_rename: "pending" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.queryByLabelText("Will auto-name")).not.toBeNull();
+    expect(screen.queryByLabelText("Naming")).toBeNull();
+  });
+
+  it("renders the Naming chip when smart_rename is running", () => {
+    const ws = workspace("w-running", [session({ view: "structured", smart_rename: "running" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.queryByLabelText("Naming")).not.toBeNull();
+    expect(screen.queryByLabelText("Will auto-name")).toBeNull();
+  });
+
+  it("renders no smart-rename chip when inactive", () => {
+    const ws = workspace("w-inactive", [session({ view: "structured", smart_rename: "inactive" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.queryByLabelText("Will auto-name")).toBeNull();
+    expect(screen.queryByLabelText("Naming")).toBeNull();
+  });
+});
+
 describe("SessionRow context menu", () => {
   it("shows only the Unpin toggle when pinned", () => {
     const ws = workspace("w-pinned", [session({ pinned_at: "2026-01-01T00:00:00Z" })]);

--- a/web/src/components/__tests__/SettingsView.session.test.tsx
+++ b/web/src/components/__tests__/SettingsView.session.test.tsx
@@ -40,6 +40,18 @@ const SESSION_SCHEMA = [
     validation: { rule: "none" },
     advanced: false,
   },
+  {
+    section: "session",
+    field: "smart_rename",
+    category: "Agents",
+    label: "Smart Session Rename",
+    description: "",
+    widget: { kind: "toggle" },
+    web_write: { policy: "allow" },
+    profile_overridable: true,
+    validation: { rule: "none" },
+    advanced: false,
+  },
 ];
 
 vi.mock("../../lib/api", () => ({
@@ -121,6 +133,31 @@ describe("Session tab auto-stop idle field", () => {
     await waitFor(() =>
       expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
         session: { auto_stop_idle_secs: 7200 },
+      }),
+    );
+  });
+
+  it("persists session.smart_rename through the profile path", async () => {
+    vi.mocked(api.fetchSettings).mockResolvedValue({
+      session: { smart_rename: true },
+      acp: {},
+      sandbox: {},
+      worktree: {},
+    } as never);
+
+    const { container } = render(
+      <SettingsView onClose={() => {}} tab="session" onSelectTab={() => {}} onServerAboutRefresh={() => {}} />,
+    );
+    await screen.findByText("Smart Session Rename");
+
+    // Only one toggle field is in SESSION_SCHEMA, so the lone switch is it.
+    const toggle = container.querySelector("button[role=switch]") as HTMLButtonElement;
+    expect(toggle).toBeTruthy();
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+        session: { smart_rename: false },
       }),
     );
   });

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -88,6 +88,11 @@ export interface SessionResponse {
    *  the supervisor holds a live worker. Drives the sidebar `Resuming…`
    *  chip and the per-session banner in the acp view. See #1088. */
   acp_worker_state?: AcpWorkerState;
+  /** Smart-rename indicator for structured view sessions. `pending`: still
+   *  default-named and eligible, will auto-name on the next prompt; `running`:
+   *  a one-shot title call is in flight; `inactive`/absent otherwise. Drives
+   *  the sidebar auto-name chip. See session::smart_rename. */
+  smart_rename?: "inactive" | "pending" | "running";
   /** True when this session's agent can run in acp: a built-in with
    *  an ACP adapter, or a custom agent whose profile config declares a
    *  valid `agent_acp_cmd`. The terminal view's "switch to acp"

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2304,6 +2304,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.smart-rename-chip-render",
+      "kind": "mocked-playwright",
+      "risk": "low",
+      "specs": ["tests/sidebar-smart-rename-chip.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.multi-select-logic",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2297,6 +2297,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.smart-rename-chip",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/__tests__/SessionRowTriage.test.tsx"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.multi-select-logic",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/sidebar-smart-rename-chip.spec.ts
+++ b/web/tests/sidebar-smart-rename-chip.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+
+// Renders the smart-rename sidebar chips through the real bundle so their JSX
+// lines get per-line istanbul coverage (vitest v8 attributes the whole
+// `{cond && <span/>}` to the outer expression, leaving the span body lines
+// uncounted). The chip only keys off `smart_rename`, so a plain session row is
+// enough to exercise both the `pending` and `running` branches.
+
+interface MockSession {
+  id: string;
+  title: string;
+  project_path: string;
+  smart_rename: "inactive" | "pending" | "running";
+}
+
+async function mockApis(page: Page, sessions: MockSession[]) {
+  await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: sessions.map((s) => ({
+          id: s.id,
+          title: s.title,
+          project_path: s.project_path,
+          group_path: s.project_path,
+          tool: "claude",
+          status: "Idle",
+          yolo_mode: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: null,
+          last_error: null,
+          branch: null,
+          main_repo_path: null,
+          is_sandboxed: false,
+          has_terminal: true,
+          profile: "default",
+          workspace_repos: [],
+          smart_rename: s.smart_rename,
+        })),
+        workspace_ordering: [],
+      },
+    });
+  });
+  for (const path of ["settings", "themes", "agents", "profiles", "groups", "devices", "docker/status", "about"]) {
+    await page.route(`**/api/${path}`, (r) => r.fulfill({ json: path === "docker/status" ? {} : [] }));
+  }
+}
+
+test.describe("Sidebar smart-rename chips", () => {
+  test("renders the Auto-name (pending) and Naming (running) chips", async ({ page }) => {
+    await mockApis(page, [
+      { id: "sess-pending", title: "Vikings", project_path: "/tmp/p-pending", smart_rename: "pending" },
+      { id: "sess-running", title: "Franks", project_path: "/tmp/p-running", smart_rename: "running" },
+      { id: "sess-inactive", title: "My session", project_path: "/tmp/p-inactive", smart_rename: "inactive" },
+    ]);
+    await page.goto("/");
+
+    await expect(page.getByLabel("Will auto-name")).toBeVisible();
+    await expect(page.getByLabel("Naming")).toBeVisible();
+    // The inactive session shows neither chip; exactly one of each is present.
+    await expect(page.getByLabel("Will auto-name")).toHaveCount(1);
+    await expect(page.getByLabel("Naming")).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Structured view (ACP) sessions start with a random civilization name (`Vikings`), which carries no context about what the session is for. This adds an opt-out "smart rename": on the first message in a structured view session, AoE runs the session's own agent once in non-interactive one-shot mode (`claude -p`, `codex exec`, `opencode run`, `gemini -p`) to produce a short title and renames the session, the way Conductor/cmux do.

It is title only. The live ACP worker holds the worktree as its working directory, so the directory cannot be moved while the session runs (the same constraint a manual rename of a running tied session hits); the visible session title is what gains meaning. It runs only while the session still carries its auto-generated name, so a session you named yourself is never touched, and it is fully best-effort: a failed, timed-out, or off-format one-shot leaves the generated name and never blocks or fails your prompt.

Design notes:
- Whether a name is "still default" is detected statelessly against the civilization list (plus the Roman-numeral / timestamp suffixes the generator can emit), so there is no new persisted field and no migration. The gate is re-checked under the per-session lock before the title is written, so a manual rename (or a deletion) landing during the one-shot call always wins.
- One-shot support is a per-agent `AgentDef.oneshot_flag`; the four agents above are wired and verified against their CLIs. Agents with no one-shot mode, sandboxed sessions (a host one-shot lacks the container's auth), and command-overridden agents keep the generated name.
- User text is passed as a lone argv element (never through a shell), truncated and NUL-stripped; agent output is strictly sanitized (ANSI stripped, refusals / over-long / echoed responses rejected). An in-flight guard prevents a burst of rapid first prompts from spawning concurrent renames.

The naming knob discussed in the issue (`session.smart_rename`, default on) is the single-source schema setting, so it appears in both the TUI and the web settings automatically.

The sidebar also shows where each session stands: a dim sparkle `Auto-name` chip marks a still-default-named eligible session (it will be named on its first message), and an amber pulsing `Naming…` chip shows while the one-shot title call is in flight. The chips clear once renamed or when the session is not eligible. The state is computed server-side in `list_sessions` from the same `check_eligible` predicate that gates the rename, so the indicator cannot drift from the behavior.

Closes #2026

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start the web dashboard, create a new structured view claude session with no title (it gets a civilization name like `Vikings`); the sidebar shows a sparkle `Auto-name` chip.
- [ ] Send a first message such as "help me add rate limiting to the login endpoint"; a `Naming…` chip appears briefly, then within ~12s the session title changes to a short summary and the chip clears. The worktree directory is unchanged.
- [ ] Rename the session manually first, then send a first message: the title is not auto-changed and no chip shows.
- [ ] Set `session.smart_rename = false` (or toggle "Smart Session Rename" off in Settings), create a session, send a message: the civilization name stays and no chip shows.
- [ ] Create a sandboxed structured view session and send a message: the civilization name stays (no error in the prompt flow).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

<!-- User-facing web changes: the schema-driven "Smart Session Rename" settings toggle (Vitest in SettingsView.session.test.tsx, mapped by settings.session-auto-stop-idle) and the sidebar Auto-name / Naming chips (Vitest in SessionRowTriage.test.tsx, mapped by the new sidebar.smart-rename-chip matrix entry). The rename behavior itself is server-side, covered by Rust unit tests on the eligibility predicate, one-shot argv build, and the output sanitizer. -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction, with a multi-model `/debate` shaping the design. I made the design calls (title-only, stateless default-name detection, per-agent one-shot, the sidebar indicator UX, edge-case handling), reviewed each commit, verified the one-shot tokens against the real CLIs, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784194819&installation_id=139138837&pr_number=2201&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2201&signature=4594f340eed2b132bcca0608bf03243dcb6c0e01813be6d2cf1f296762f6827d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Structured-view (ACP) sessions now automatically replace the initial random “civilization-style” name with a **meaningful short title** derived from what the user says in the **first message**. The auto-rename only triggers while the session is still using its **default generated name**, so **manual titles are never overwritten**.

## What Was Added / Updated

- **Smart rename engine (new `smart_rename` module)**
  - Detects whether the current session title is still the default civilization-based name (including common suffix patterns like Roman numerals / timestamps).
  - Generates a candidate title by running the **session’s own agent** in **one-shot** mode on the first message.
  - **Best-effort only**: failures, timeouts, or malformed output never block prompts; if it can’t produce a valid title, it’s simply left as-is.
  - **Runs once per session** (no repeated attempts on later prompts).
  - Avoids concurrent renames using an in-flight guard, and prevents duplicate work via “already attempted” tracking.
  - Updates only the **displayed title** (the worktree directory isn’t moved).

- **Agent one-shot support**
  - Introduces a `oneshot_flag` per agent definition so only agents capable of safe one-shot invocation are used for naming.
  - Non-supported / sandboxed / command-overridden cases are skipped.

- **Backend/API + session state**
  - Session list responses now include a structured smart-rename lifecycle state (`inactive`, `pending`, `running`) so the UI can show accurate progress.

- **Web UI indicators**
  - Workspace sidebar adds chips to reflect rename status:
    - **“Auto-name”** when eligible and waiting
    - **“Naming…”** while title generation is running
  - Adds/updates tests (unit + Playwright/Vitest) covering the chip behavior and the new settings toggle.

- **User configuration**
  - Adds a `session.smart_rename` setting (default **enabled**) exposed in the UI as **“Smart Session Rename”**.
  - Updated docs describe how and when smart renaming occurs and when it’s skipped.

## Benefits

- Sessions become **immediately understandable**, since titles reflect the actual work described in the first message.
- The behavior is **safe and non-disruptive**: it never blocks user prompts and never overwrites user-provided titles.
- Clear UI feedback makes it obvious when auto-naming is queued or actively generating.

## Potential Areas for Further Enhancement

- If future agent support becomes available, expand which agents can participate in one-shot naming.
- Consider adding an optional “preview before apply” workflow for users who want visibility into the generated title before it replaces the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->