### PR TITLE
fix(tui): run session restart off the event loop

### DIFF
--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -40,8 +40,14 @@ fn wait_with_timeout(mut child: Child, timeout: Duration) -> std::io::Result<Opt
     let deadline = Instant::now() + timeout;
     loop {
         if let Some(status) = child.try_wait()? {
-            let stdout = orx.recv().unwrap_or_default();
-            let stderr = erx.recv().unwrap_or_default();
+            // The child exited, but if it spawned a grandchild that inherited
+            // the pipe, `read_to_end` (and thus an unbounded `recv`) would block
+            // forever. Cap the drain at the remaining deadline so the timeout
+            // guarantee holds even then; the exit status is already in hand.
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let stdout = orx.recv_timeout(remaining).unwrap_or_default();
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let stderr = erx.recv_timeout(remaining).unwrap_or_default();
             return Ok(Some(Output {
                 status,
                 stdout,
@@ -852,6 +858,30 @@ mod tests {
             start.elapsed() < Duration::from_secs(5),
             "wait should return promptly after the deadline, not block on the child"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn wait_with_timeout_bounds_drain_when_grandchild_holds_pipe() {
+        // The immediate child (sh) exits fast but backgrounds a `sleep` that
+        // inherits stdout, so the pipe never closes. The drain must still
+        // return by the deadline rather than blocking on read_to_end. `sleep 30`
+        // (>> the 5s assertion) ensures an unbounded recv would visibly fail.
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("sleep 30 >&1 & printf done");
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        let child = cmd.spawn().unwrap();
+
+        let start = Instant::now();
+        let output = wait_with_timeout(child, Duration::from_millis(500))
+            .unwrap()
+            .expect("the sh child exits quickly, so an Output is produced");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "drain must be bounded by the deadline even while the pipe stays open"
+        );
+        assert!(output.status.success());
     }
 
     #[test]

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -1,6 +1,61 @@
 use super::container_interface::{docker_env_args, ContainerConfig};
 use super::error::{DockerError, Result};
-use std::process::Command;
+use std::io::Read;
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+/// Upper bound on a single `docker pull`. `docker pull` has no overall timeout
+/// of its own, so a stalled registry connection blocks the caller forever
+/// (observed as the TUI freezing mid-pull on a sandbox restart). Sized
+/// generously so a genuinely large
+/// image on a slow link still completes; it only fires on a wedged pull.
+const PULL_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Wait for `child` to exit, killing it if it outlives `timeout`.
+///
+/// stdout/stderr are drained on dedicated threads so a full pipe buffer cannot
+/// wedge the child (and thus this wait) before the deadline. Returns `Ok(None)`
+/// when the timeout fired and the child was killed.
+fn wait_with_timeout(mut child: Child, timeout: Duration) -> std::io::Result<Option<Output>> {
+    let mut stdout_pipe = child.stdout.take();
+    let mut stderr_pipe = child.stderr.take();
+    let (otx, orx) = mpsc::channel();
+    let (etx, erx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(ref mut p) = stdout_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        let _ = otx.send(buf);
+    });
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(ref mut p) = stderr_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        let _ = etx.send(buf);
+    });
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            let stdout = orx.recv().unwrap_or_default();
+            let stderr = erx.recv().unwrap_or_default();
+            return Ok(Some(Output {
+                status,
+                stdout,
+                stderr,
+            }));
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(None);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
 
 /// Shared implementation for container runtimes.
 ///
@@ -102,9 +157,31 @@ impl RuntimeBase {
         let mut cmd = self.command();
         cmd.args(self.pull_prefix);
         cmd.arg(image);
-        let start = std::time::Instant::now();
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        let start = Instant::now();
         tracing::info!(target: "containers.image", runtime = %self.name, %image, "pulling image");
-        let output = cmd.output()?;
+        let child = cmd.spawn()?;
+        let output = match wait_with_timeout(child, PULL_TIMEOUT)? {
+            Some(output) => output,
+            None => {
+                let dur_ms = start.elapsed().as_millis() as u64;
+                tracing::warn!(
+                    target: "containers.image",
+                    runtime = %self.name,
+                    %image,
+                    duration_ms = dur_ms,
+                    timeout_s = PULL_TIMEOUT.as_secs(),
+                    "image pull timed out; killed",
+                );
+                return Err(DockerError::ImageNotFound(format!(
+                    "{}: pull timed out after {}s",
+                    image,
+                    PULL_TIMEOUT.as_secs()
+                )));
+            }
+        };
         let dur_ms = start.elapsed().as_millis() as u64;
 
         if !output.status.success() {
@@ -751,5 +828,45 @@ mod tests {
         const { assert!(RuntimeBase::DOCKER.supports_named_volumes) };
         const { assert!(RuntimeBase::PODMAN.supports_named_volumes) };
         const { assert!(!RuntimeBase::APPLE_CONTAINER.supports_named_volumes) };
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn wait_with_timeout_kills_child_that_outlives_deadline() {
+        // A `docker pull` that wedges on the network has no timeout of its own
+        // and blocked the caller forever. `sleep 30` stands in for
+        // the wedged child; the timeout must fire and kill it.
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
+        cmd.stdout(Stdio::null());
+        cmd.stderr(Stdio::null());
+        let child = cmd.spawn().unwrap();
+
+        let start = Instant::now();
+        let result = wait_with_timeout(child, Duration::from_millis(300)).unwrap();
+        assert!(
+            result.is_none(),
+            "expected the timeout to fire and kill the child"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "wait should return promptly after the deadline, not block on the child"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn wait_with_timeout_returns_output_for_fast_child() {
+        let mut cmd = Command::new("printf");
+        cmd.arg("hello");
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        let child = cmd.spawn().unwrap();
+
+        let output = wait_with_timeout(child, Duration::from_secs(10))
+            .unwrap()
+            .expect("fast child should complete before the timeout");
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"hello");
     }
 }

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -500,7 +500,18 @@ fn copy_dir_recursive_inner(
             }
         };
         if metadata.is_dir() {
-            copy_dir_recursive_inner(&entry.path(), &target, visited)?;
+            // Catch-and-skip rather than `?`: an unreadable subdirectory (e.g.
+            // a Permission-denied dir under ~/.claude/plugins) must not abort
+            // the whole copy, matching how the metadata and file-copy errors
+            // above are handled.
+            if let Err(e) = copy_dir_recursive_inner(&entry.path(), &target, visited) {
+                tracing::warn!(
+                    target: "session.profile",
+                    "skipping dir {}: {}",
+                    entry.path().display(),
+                    e
+                );
+            }
         } else if let Err(e) = std::fs::copy(entry.path(), &target) {
             tracing::warn!(
                 target: "session.profile",

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -330,7 +330,13 @@ fn sync_agent_config(
         };
 
         if metadata.is_dir() {
-            if copy_dirs.iter().any(|&d| d == name_str.as_ref()) {
+            // copy_dirs (e.g. plugins, skills) are host -> sandbox pushes. Like
+            // the general file copy below, skip them once the sandbox has prior
+            // session data: re-copying a large tree (plugins can hold full git
+            // clones) on every restart stalled startup for tens of seconds and
+            // would clobber container-side changes. A fresh sandbox still gets
+            // them on its first launch.
+            if !has_prior_data && copy_dirs.iter().any(|&d| d == name_str.as_ref()) {
                 let dest = sandbox_dir.join(&name);
                 if let Err(e) = copy_dir_recursive(&entry.path(), &dest) {
                     tracing::warn!(target: "session.profile", "Failed to copy dir {}: {}", name_str, e);
@@ -448,16 +454,60 @@ fn rewrite_plugin_value_paths(
 
 /// Recursively copy a directory tree, following symlinks.
 fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
+    let mut visited = std::collections::HashSet::new();
+    copy_dir_recursive_inner(src, dest, &mut visited)
+}
+
+fn copy_dir_recursive_inner(
+    src: &Path,
+    dest: &Path,
+    visited: &mut std::collections::HashSet<PathBuf>,
+) -> Result<()> {
+    // Break symlink cycles. We follow symlinks (a legitimately symlinked config
+    // dir should be copied), but a link that points back up its own tree would
+    // otherwise recurse forever; a real cycle under ~/.claude/plugins churned
+    // for 30s before aborting. Keying on the canonical (symlink-
+    // resolved) source path stops the second visit.
+    if let Ok(real) = std::fs::canonicalize(src) {
+        if !visited.insert(real) {
+            tracing::warn!(
+                target: "session.profile",
+                "skipping already-visited dir (symlink cycle?): {}",
+                src.display()
+            );
+            return Ok(());
+        }
+    }
     std::fs::create_dir_all(dest)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
         let target = dest.join(entry.file_name());
-        // Follow symlinks so symlinked dirs/files are handled correctly.
-        let metadata = std::fs::metadata(entry.path())?;
+        // Follow symlinks so symlinked dirs/files are handled correctly; the
+        // visited-set guard above stops a cycle from looping forever. A single
+        // unreadable or dangling entry is skipped rather than aborting the whole
+        // copy: one Permission-denied file under ~/.claude/plugins used to fail
+        // the entire sync.
+        let metadata = match std::fs::metadata(entry.path()) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(
+                    target: "session.profile",
+                    "skipping {}: {}",
+                    entry.path().display(),
+                    e
+                );
+                continue;
+            }
+        };
         if metadata.is_dir() {
-            copy_dir_recursive(&entry.path(), &target)?;
-        } else {
-            std::fs::copy(entry.path(), &target)?;
+            copy_dir_recursive_inner(&entry.path(), &target, visited)?;
+        } else if let Err(e) = std::fs::copy(entry.path(), &target) {
+            tracing::warn!(
+                target: "session.profile",
+                "skipping file {}: {}",
+                entry.path().display(),
+                e
+            );
         }
     }
     Ok(())
@@ -2556,6 +2606,64 @@ mod tests {
             fs::read_to_string(sandbox.join("settings.json")).unwrap(),
             r#"{"theme":"dark"}"#,
             "container-side settings must not be overwritten when projects/ sentinel exists"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_copy_dir_recursive_terminates_on_symlink_cycle() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(src.join("sub")).unwrap();
+        fs::write(src.join("sub").join("file.txt"), "data").unwrap();
+        // Cycle: src/sub/loop -> src. The old code followed it and recursed
+        // forever; the visited-set guard must break it.
+        std::os::unix::fs::symlink(&src, src.join("sub").join("loop")).unwrap();
+
+        let dest = dir.path().join("dest");
+        // Must return rather than infinite-loop / stack-overflow.
+        copy_dir_recursive(&src, &dest).unwrap();
+        assert_eq!(
+            fs::read_to_string(dest.join("sub").join("file.txt")).unwrap(),
+            "data"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_copy_dir_recursive_skips_bad_entry_inside_subdir() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("good.txt"), "good").unwrap();
+        // Dangling symlink inside the copied tree. The old code propagated the
+        // stat error with `?` and aborted the whole copy (the log's "Failed to
+        // copy dir plugins: Permission denied"); now a single bad entry is
+        // skipped and the rest still copies.
+        std::os::unix::fs::symlink("/nonexistent/target", src.join("dangling")).unwrap();
+
+        let dest = dir.path().join("dest");
+        copy_dir_recursive(&src, &dest).unwrap();
+        assert_eq!(fs::read_to_string(dest.join("good.txt")).unwrap(), "good");
+        assert!(!dest.join("dangling").exists());
+    }
+
+    #[test]
+    fn test_copy_dirs_skipped_when_prior_data() {
+        let dir = TempDir::new().unwrap();
+        let host = dir.path().join("host");
+        fs::create_dir_all(host.join("plugins")).unwrap();
+        fs::write(host.join("plugins").join("p.txt"), "host-plugin").unwrap();
+        let sandbox = dir.path().join("sandbox");
+
+        // Prior container session sentinel.
+        fs::create_dir_all(sandbox.join("projects")).unwrap();
+
+        sync_agent_config(&host, &sandbox, &[], &[], &["plugins"], &[]).unwrap();
+        assert!(
+            !sandbox.join("plugins").exists(),
+            "copy_dirs must be skipped once the sandbox has prior session data, \
+             so a restart no longer re-copies the whole plugins tree"
         );
     }
 

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -458,6 +458,18 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
     copy_dir_recursive_inner(src, dest, &mut visited)
 }
 
+/// Whether an I/O error during the copy means the destination filesystem can no
+/// longer accept writes, in which case continuing would silently produce a
+/// partial copy (a sandbox missing arbitrary files, reported as success). Those
+/// must abort the whole copy. Everything else (a single unreadable or dangling
+/// source entry) is skipped best-effort.
+fn is_fatal_copy_error(e: &std::io::Error) -> bool {
+    // ENOSPC (no space), EROFS (read-only fs), EDQUOT (quota). EDQUOT differs by
+    // platform (122 on Linux, 69 on macOS). raw_os_error covers all three more
+    // portably than the (partly unstable) ErrorKind variants.
+    matches!(e.raw_os_error(), Some(28) | Some(30) | Some(69) | Some(122))
+}
+
 fn copy_dir_recursive_inner(
     src: &Path,
     dest: &Path,
@@ -466,21 +478,66 @@ fn copy_dir_recursive_inner(
     // Break symlink cycles. We follow symlinks (a legitimately symlinked config
     // dir should be copied), but a link that points back up its own tree would
     // otherwise recurse forever; a real cycle under ~/.claude/plugins churned
-    // for 30s before aborting. Keying on the canonical (symlink-
-    // resolved) source path stops the second visit.
-    if let Ok(real) = std::fs::canonicalize(src) {
-        if !visited.insert(real) {
+    // for 30s before aborting. Keying on the canonical (symlink-resolved) source
+    // path stops the second visit. A canonicalize failure (e.g. ELOOP) is
+    // exactly when we most need the guard, so skip the dir rather than descend
+    // blindly.
+    match std::fs::canonicalize(src) {
+        Ok(real) => {
+            if !visited.insert(real) {
+                tracing::warn!(
+                    target: "session.profile",
+                    "skipping already-visited dir (symlink cycle?): {}",
+                    src.display()
+                );
+                return Ok(());
+            }
+        }
+        Err(e) => {
             tracing::warn!(
                 target: "session.profile",
-                "skipping already-visited dir (symlink cycle?): {}",
-                src.display()
+                "skipping dir (cannot resolve, possible symlink loop): {}: {}",
+                src.display(),
+                e
             );
             return Ok(());
         }
     }
-    std::fs::create_dir_all(dest)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
+    // create_dir_all / read_dir failures: a filesystem that can't accept writes
+    // is fatal (silent partial copy); anything else means we just skip this
+    // subtree. This keeps the fail-soft behavior errno-aware and consistent.
+    if let Err(e) = std::fs::create_dir_all(dest) {
+        if is_fatal_copy_error(&e) {
+            return Err(e).with_context(|| format!("creating {}", dest.display()));
+        }
+        tracing::warn!(
+            target: "session.profile",
+            "skipping dir (cannot create destination): {}: {}",
+            dest.display(),
+            e
+        );
+        return Ok(());
+    }
+    let entries = match std::fs::read_dir(src) {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::warn!(
+                target: "session.profile",
+                "skipping dir (cannot read): {}: {}",
+                src.display(),
+                e
+            );
+            return Ok(());
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                tracing::warn!(target: "session.profile", "skipping entry in {}: {}", src.display(), e);
+                continue;
+            }
+        };
         let target = dest.join(entry.file_name());
         // Follow symlinks so symlinked dirs/files are handled correctly; the
         // visited-set guard above stops a cycle from looping forever. A single
@@ -500,19 +557,15 @@ fn copy_dir_recursive_inner(
             }
         };
         if metadata.is_dir() {
-            // Catch-and-skip rather than `?`: an unreadable subdirectory (e.g.
-            // a Permission-denied dir under ~/.claude/plugins) must not abort
-            // the whole copy, matching how the metadata and file-copy errors
-            // above are handled.
-            if let Err(e) = copy_dir_recursive_inner(&entry.path(), &target, visited) {
-                tracing::warn!(
-                    target: "session.profile",
-                    "skipping dir {}: {}",
-                    entry.path().display(),
-                    e
-                );
-            }
+            // Propagate with `?`: the child only returns Err for a fatal
+            // (filesystem-full) error, so a cycle / unreadable subdir resolves to
+            // Ok inside the child and is skipped there, while a real out-of-space
+            // condition aborts the whole copy.
+            copy_dir_recursive_inner(&entry.path(), &target, visited)?;
         } else if let Err(e) = std::fs::copy(entry.path(), &target) {
+            if is_fatal_copy_error(&e) {
+                return Err(e).with_context(|| format!("copying {}", entry.path().display()));
+            }
             tracing::warn!(
                 target: "session.profile",
                 "skipping file {}: {}",
@@ -2618,6 +2671,29 @@ mod tests {
             r#"{"theme":"dark"}"#,
             "container-side settings must not be overwritten when projects/ sentinel exists"
         );
+    }
+
+    #[test]
+    fn test_is_fatal_copy_error_discriminates_storage_exhaustion() {
+        use std::io::Error;
+        // ENOSPC / EROFS / EDQUOT mean the destination can't accept writes;
+        // continuing would silently produce a partial copy, so these abort.
+        assert!(is_fatal_copy_error(&Error::from_raw_os_error(28)), "ENOSPC");
+        assert!(is_fatal_copy_error(&Error::from_raw_os_error(30)), "EROFS");
+        assert!(
+            is_fatal_copy_error(&Error::from_raw_os_error(69)),
+            "EDQUOT (macOS)"
+        );
+        assert!(
+            is_fatal_copy_error(&Error::from_raw_os_error(122)),
+            "EDQUOT (Linux)"
+        );
+        // A single unreadable / missing source entry is best-effort skippable.
+        assert!(
+            !is_fatal_copy_error(&Error::from_raw_os_error(13)),
+            "EACCES"
+        );
+        assert!(!is_fatal_copy_error(&Error::from_raw_os_error(2)), "ENOENT");
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -19,6 +19,7 @@ pub mod project_mcp;
 pub mod projects;
 pub(crate) mod recovery;
 pub mod repo_config;
+pub mod restart;
 pub mod scratch;
 pub(crate) mod serde_helpers;
 pub mod settings_schema;

--- a/src/session/restart.rs
+++ b/src/session/restart.rs
@@ -1,0 +1,126 @@
+//! Shared session restart logic.
+//!
+//! Restarting a session re-runs the start cascade. For sandboxed sessions that
+//! shells out to Docker (image pull with no built-in timeout, container
+//! create/start) and runs the `before_start` host hook, any of which can block
+//! for seconds. Running it on the TUI event loop froze the whole UI, so the TUI
+//! drives this off the UI thread via `RestartPoller`, mirroring `StopPoller`.
+
+use crate::session::{Instance, StartOutcome};
+
+pub struct RestartRequest {
+    pub session_id: String,
+    /// The instance to restart. `perform_restart` mutates it through the start
+    /// cascade and hands the post-cascade snapshot back in `RestartResult`.
+    pub instance: Instance,
+    pub size: Option<(u16, u16)>,
+    /// Keys to send once the pane is live again. Empty disables the wake-up
+    /// (the documented opt-out via `session.restart_wake_message`).
+    pub wake_message: String,
+}
+
+pub struct RestartResult {
+    pub session_id: String,
+    /// Post-cascade instance snapshot. Written back into the TUI's in-memory
+    /// copy so `#[serde(skip)]` fields (e.g. `last_start_time`) and the
+    /// cascade's mutations (cleared stale `agent_session_id`, container id)
+    /// survive without a disk reload.
+    pub instance: Box<Instance>,
+    pub outcome: Result<StartOutcome, String>,
+}
+
+pub fn perform_restart(request: RestartRequest) -> RestartResult {
+    let RestartRequest {
+        session_id,
+        mut instance,
+        size,
+        wake_message,
+    } = request;
+
+    let title = instance.title.clone();
+    let tool = instance.tool.clone();
+    let outcome = instance.restart_with_size(size).map_err(|e| e.to_string());
+
+    // On a successful restart, send the wake-up keys on a detached thread so
+    // the result (and the row's status update) propagate back immediately
+    // rather than waiting out the up-to-3s pane-readiness probe.
+    if outcome.is_ok() && !wake_message.is_empty() {
+        spawn_wake_worker(session_id.clone(), title, tool, wake_message);
+    }
+
+    RestartResult {
+        session_id,
+        instance: Box::new(instance),
+        outcome,
+    }
+}
+
+/// Wait for the restarted pane to become live and past its boot shell, then
+/// send the wake-up message. Best-effort: a failure to spawn or send is logged,
+/// never fatal.
+fn spawn_wake_worker(session_id: String, title: String, tool: String, wake_message: String) {
+    let spawn_result = std::thread::Builder::new()
+        .name(format!("aoe-restart-wake/{}", session_id))
+        .stack_size(128 * 1024)
+        .spawn(move || {
+            let Ok(tmux_session) = crate::tmux::Session::new(&session_id, &title) else {
+                return;
+            };
+            let deadline = std::time::Instant::now() + std::time::Duration::from_millis(3000);
+            loop {
+                if !tmux_session.exists() {
+                    return;
+                }
+                let pane_alive = !tmux_session.is_pane_dead();
+                let hook_active = crate::hooks::read_hook_status(&session_id).is_some();
+                if pane_alive && (hook_active || !tmux_session.is_pane_running_shell()) {
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+
+            if !tmux_session.exists() {
+                return;
+            }
+            let delay = crate::agents::send_keys_enter_delay(&tool);
+            if let Err(e) = tmux_session.send_keys_with_delay(&wake_message, delay) {
+                tracing::warn!("failed to send wake-up message after restart: {}", e);
+            }
+        });
+    if let Err(err) = spawn_result {
+        tracing::warn!(?err, "failed to spawn restart wake-up worker");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_instance() -> Instance {
+        Instance::new("Test Session", "/tmp/test-project")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn perform_restart_preserves_session_id_and_returns_instance() {
+        let instance = test_instance();
+        let id = instance.id.clone();
+        let title = instance.title.clone();
+        let result = perform_restart(RestartRequest {
+            session_id: id.clone(),
+            instance,
+            size: None,
+            wake_message: String::new(),
+        });
+        // The cascade may create a real tmux session; tear it down so the test
+        // cleans up after itself.
+        if let Ok(session) = crate::tmux::Session::new(&id, &title) {
+            let _ = session.kill();
+        }
+        assert_eq!(result.session_id, id);
+        assert_eq!(result.instance.id, id);
+    }
+}

--- a/src/session/restart.rs
+++ b/src/session/restart.rs
@@ -39,7 +39,18 @@ pub fn perform_restart(request: RestartRequest) -> RestartResult {
 
     let title = instance.title.clone();
     let tool = instance.tool.clone();
-    let outcome = instance.restart_with_size(size).map_err(|e| e.to_string());
+
+    // Honor the same on_launch / before_start hook timeout the startup-recovery
+    // worker installs (`run_recovery_for_instance`). Without it, a hanging
+    // before_start hook (e.g. a `mint` script waiting on the network) runs with
+    // no kill timer and wedges this serial worker thread forever, taking every
+    // future restart down with it.
+    let outcome = {
+        let _scope = crate::session::recovery::HookTimeoutScope::new(
+            crate::session::recovery::recovery_hook_timeout(),
+        );
+        instance.restart_with_size(size).map_err(|e| e.to_string())
+    };
 
     // On a successful restart, send the wake-up keys on a detached thread so
     // the result (and the row's status update) propagate back immediately
@@ -87,11 +98,11 @@ fn spawn_wake_worker(session_id: String, title: String, tool: String, wake_messa
             }
             let delay = crate::agents::send_keys_enter_delay(&tool);
             if let Err(e) = tmux_session.send_keys_with_delay(&wake_message, delay) {
-                tracing::warn!("failed to send wake-up message after restart: {}", e);
+                tracing::warn!(target: "session.restart", "failed to send wake-up message after restart: {}", e);
             }
         });
     if let Err(err) = spawn_result {
-        tracing::warn!(?err, "failed to spawn restart wake-up worker");
+        tracing::warn!(target: "session.restart", ?err, "failed to spawn restart wake-up worker");
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1436,6 +1436,10 @@ impl App {
         }
 
         self.home.apply_session_id_updates();
+        // Drain any restart result that completed since the last tick so the
+        // post-cascade snapshot (cleared stale sid, container id, final status)
+        // is persisted instead of the stale `Starting` row.
+        self.home.apply_restart_results();
         self.home.cleanup_pending_creation();
 
         if let Err(e) = self.home.save() {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1214,6 +1214,11 @@ impl App {
                 needs_full_refresh = true;
             }
 
+            if self.home.apply_restart_results() {
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
+
             if let Some(session_id) = self.home.apply_creation_results() {
                 self.dispatch_new_session_attach(&session_id, terminal)?;
                 refresh_needed = true;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -43,6 +43,7 @@ use super::dialogs::{
     WorktreeNameDialog,
 };
 use super::diff::DiffView;
+use super::restart_poller::RestartPoller;
 use super::settings::SettingsView;
 use super::status_poller::{StatusPoller, StatusUpdate};
 use super::stop_poller::StopPoller;
@@ -609,6 +610,14 @@ pub struct HomeView {
 
     // Performance: background stop (docker stop can block up to ~10s)
     pub(super) stop_poller: StopPoller,
+
+    // Performance: background restart (the start cascade shells out to docker
+    // and runs the before_start host hook, which can block for seconds)
+    pub(super) restart_poller: RestartPoller,
+    /// Sessions whose restart cascade is in flight on the restart poller.
+    /// Suppresses the StatusPoller's missing-tmux Error transition until the
+    /// worker reports back via `apply_restart_results`.
+    pub(super) restart_in_flight: std::collections::HashSet<String>,
 
     // Performance: background session creation (for sandbox)
     pub(super) creation_poller: CreationPoller,
@@ -1343,6 +1352,8 @@ impl HomeView {
             pending_status_refresh: false,
             deletion_poller: DeletionPoller::new(),
             stop_poller: StopPoller::new(),
+            restart_poller: RestartPoller::new(),
+            restart_in_flight: std::collections::HashSet::new(),
             creation_poller: CreationPoller::new(),
             creation_cancelled: false,
             on_launch_hooks_ran: HashSet::new(),
@@ -2332,14 +2343,16 @@ impl HomeView {
     }
 
     /// Snapshot of `self.instances` eligible for status polling.
-    /// In-flight recovery candidates are excluded; their post-cascade
-    /// `Instance` arrives via `apply_recovery_updates` and skipping the
-    /// parallel poll prevents racing transitions during the suppression
-    /// window.
+    /// In-flight recovery and restart candidates are excluded; their
+    /// post-cascade `Instance` arrives via `apply_recovery_updates` /
+    /// `apply_restart_results` and skipping the parallel poll prevents racing
+    /// transitions during the suppression window.
     pub(super) fn pollable_instances(&self) -> Vec<Instance> {
         self.instances
             .iter()
-            .filter(|i| !self.recovery_in_flight.contains(&i.id))
+            .filter(|i| {
+                !self.recovery_in_flight.contains(&i.id) && !self.restart_in_flight.contains(&i.id)
+            })
             .cloned()
             .collect()
     }
@@ -2786,56 +2799,107 @@ impl HomeView {
             self.recovery_in_flight.clear();
         }
         if touched {
-            self.instance_map = self
-                .instances
-                .iter()
-                .map(|i| (i.id.clone(), i.clone()))
-                .collect();
-            // Preserve the selection across the rebuild. Without this, a
-            // recovery completion that reorders rows under
-            // `SortOrder::LastActivity` (the recovered session's
-            // `last_start_time` shifted) would silently latch the
-            // selection onto a neighbour because `update_selected()`
-            // resolves through `flat_items[cursor]`. Mirrors the
-            // canonical sequence in `reload()`.
-            let prev_selected_session = self.selected_session.clone();
-            let prev_selected_group = self.selected_group.clone();
+            self.refresh_rows_preserving_selection();
+        }
+        touched
+    }
 
-            self.flat_items = self.build_flat_items();
+    /// Rebuild `instance_map` + `flat_items` after a background worker replaced
+    /// an `Instance` snapshot, preserving the current selection. Without the
+    /// selection restore, a completion that reorders rows (e.g. a shifted
+    /// `last_start_time` under `SortOrder::LastActivity`) would silently latch
+    /// the cursor onto a neighbour, since `update_selected()` resolves through
+    /// `flat_items[cursor]`. Mirrors the canonical sequence in `reload()`.
+    /// Shared by `apply_recovery_updates` and `apply_restart_results`.
+    fn refresh_rows_preserving_selection(&mut self) {
+        self.instance_map = self
+            .instances
+            .iter()
+            .map(|i| (i.id.clone(), i.clone()))
+            .collect();
+        let prev_selected_session = self.selected_session.clone();
+        let prev_selected_group = self.selected_group.clone();
 
-            let mut restored = false;
-            if let Some(ref sid) = prev_selected_session {
-                for (idx, item) in self.flat_items.iter().enumerate() {
-                    if let Item::Session { id, .. } = item {
-                        if id == sid {
-                            self.cursor = idx;
-                            restored = true;
-                            break;
-                        }
-                    }
-                }
-            } else if let Some(ref gpath) = prev_selected_group {
-                for (idx, item) in self.flat_items.iter().enumerate() {
-                    if let Item::Group { path, .. } = item {
-                        if path == gpath {
-                            self.cursor = idx;
-                            restored = true;
-                            break;
-                        }
+        self.flat_items = self.build_flat_items();
+
+        let mut restored = false;
+        if let Some(ref sid) = prev_selected_session {
+            for (idx, item) in self.flat_items.iter().enumerate() {
+                if let Item::Session { id, .. } = item {
+                    if id == sid {
+                        self.cursor = idx;
+                        restored = true;
+                        break;
                     }
                 }
             }
-            if !restored && self.cursor >= self.flat_items.len() && !self.flat_items.is_empty() {
-                self.cursor = self.flat_items.len() - 1;
+        } else if let Some(ref gpath) = prev_selected_group {
+            for (idx, item) in self.flat_items.iter().enumerate() {
+                if let Item::Group { path, .. } = item {
+                    if path == gpath {
+                        self.cursor = idx;
+                        restored = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if !restored && self.cursor >= self.flat_items.len() && !self.flat_items.is_empty() {
+            self.cursor = self.flat_items.len() - 1;
+        }
+
+        if self.search_active && !self.search_query.value().is_empty() {
+            self.update_search();
+        } else if !self.search_matches.is_empty() {
+            self.refresh_search_matches();
+        }
+
+        self.update_selected();
+    }
+
+    /// Apply results from the restart poller. Writes the post-cascade `Instance`
+    /// snapshot back into memory (so `restart_with_size`'s mutations and the
+    /// `#[serde(skip)]` `last_start_time` survive), clears the in-flight marker,
+    /// and persists. A failed cascade surfaces as `Status::Error` with the
+    /// error text. Returns true if any instance changed.
+    pub fn apply_restart_results(&mut self) -> bool {
+        use crate::session::Status;
+
+        let mut touched = false;
+        while let Some(result) = self.restart_poller.try_recv_result() {
+            let crate::session::restart::RestartResult {
+                session_id,
+                mut instance,
+                outcome,
+            } = result;
+
+            self.restart_in_flight.remove(&session_id);
+
+            match outcome {
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        target: "tui.home",
+                        id = %session_id,
+                        error = %e,
+                        "restart cascade failed",
+                    );
+                    instance.status = Status::Error;
+                    instance.last_error = Some(e);
+                }
             }
 
-            if self.search_active && !self.search_query.value().is_empty() {
-                self.update_search();
-            } else if !self.search_matches.is_empty() {
-                self.refresh_search_matches();
+            if let Some(slot) = self.instances.iter_mut().find(|i| i.id == session_id) {
+                *slot = *instance;
+                touched = true;
             }
+        }
 
-            self.update_selected();
+        if touched {
+            self.refresh_rows_preserving_selection();
+            if let Err(e) = self.save() {
+                tracing::error!(target: "tui.home", "Failed to save after restart: {}", e);
+            }
         }
         touched
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2860,38 +2860,70 @@ impl HomeView {
     /// Apply results from the restart poller. Writes the post-cascade `Instance`
     /// snapshot back into memory (so `restart_with_size`'s mutations and the
     /// `#[serde(skip)]` `last_start_time` survive), clears the in-flight marker,
-    /// and persists. A failed cascade surfaces as `Status::Error` with the
-    /// error text. Returns true if any instance changed.
+    /// and persists. A failed cascade surfaces as `Status::Error` plus a
+    /// "Restart Failed" dialog (the user explicitly initiated the restart).
+    /// Returns true if any instance changed.
     pub fn apply_restart_results(&mut self) -> bool {
         use crate::session::Status;
+        use std::sync::mpsc::TryRecvError;
 
         let mut touched = false;
-        while let Some(result) = self.restart_poller.try_recv_result() {
-            let crate::session::restart::RestartResult {
-                session_id,
-                mut instance,
-                outcome,
-            } = result;
+        loop {
+            match self.restart_poller.try_recv_result() {
+                Ok(result) => {
+                    let crate::session::restart::RestartResult {
+                        session_id,
+                        mut instance,
+                        outcome,
+                    } = result;
 
-            self.restart_in_flight.remove(&session_id);
+                    self.restart_in_flight.remove(&session_id);
 
-            match outcome {
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        target: "tui.home",
-                        id = %session_id,
-                        error = %e,
-                        "restart cascade failed",
-                    );
-                    instance.status = Status::Error;
-                    instance.last_error = Some(e);
+                    match outcome {
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "session.restart",
+                                id = %session_id,
+                                error = %e,
+                                "restart cascade failed",
+                            );
+                            instance.status = Status::Error;
+                            instance.last_error = Some(e.clone());
+                            // Surface it: a cascade failure now arrives async, so
+                            // the input handler's "Restart Failed" dialog can no
+                            // longer catch it (restart_selected_session returned
+                            // Ok once the work was enqueued).
+                            self.info_dialog = Some(InfoDialog::new(
+                                "Restart Failed",
+                                &format!("Could not restart session: {e}"),
+                            ));
+                        }
+                    }
+
+                    if let Some(slot) = self.instances.iter_mut().find(|i| i.id == session_id) {
+                        *slot = *instance;
+                        touched = true;
+                    }
                 }
-            }
-
-            if let Some(slot) = self.instances.iter_mut().find(|i| i.id == session_id) {
-                *slot = *instance;
-                touched = true;
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    // The single worker thread is gone (a panic in
+                    // perform_restart dropped result_tx). Clear the in-flight set
+                    // defensively so the stuck rows fall back to the StatusPoller
+                    // (which marks them Error) instead of being filtered out of
+                    // polling forever by `pollable_instances`. Mirrors the
+                    // Disconnected handling in `apply_recovery_updates`.
+                    if !self.restart_in_flight.is_empty() {
+                        tracing::error!(
+                            target: "session.restart",
+                            "restart poller worker gone; clearing in-flight set",
+                        );
+                        self.restart_in_flight.clear();
+                        touched = true;
+                    }
+                    break;
+                }
             }
         }
 

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -4,6 +4,7 @@ use crate::session::builder::{self, InstanceParams};
 use crate::session::{list_profiles, GroupTree, Item, Status, Storage};
 use crate::tui::deletion_poller::DeletionRequest;
 use crate::tui::dialogs::{DeleteOptions, GroupDeleteOptions, NewSessionData};
+use crate::tui::restart_poller::RestartRequest;
 
 use super::HomeView;
 
@@ -289,17 +290,16 @@ impl HomeView {
     /// the field is updated before respawn so the new agent binary starts
     /// on the next launch.
     ///
-    /// Restart goes through `try_mutate_instance_writeback_on_err` so all
-    /// of `restart_with_size`'s mutations (cleared stale `agent_session_id`
-    /// on Tier-2 resume fallback, `last_accessed_at` bumps, etc.) are
-    /// preserved on the live instance.
+    /// The start cascade itself runs on the `RestartPoller` worker thread (it
+    /// shells out to docker and runs the before_start host hook, which can
+    /// block for seconds), so the TUI event loop never blocks. The post-cascade
+    /// `Instance` (with `restart_with_size`'s mutations: cleared stale
+    /// `agent_session_id` on Tier-2 resume fallback, container id, etc.) is
+    /// written back via `apply_restart_results`.
     ///
     /// The wake-up message is read from the resolved config
     /// (`session.restart_wake_message`); an empty value disables the
     /// wake-up entirely while still running the restart.
-    ///
-    /// The readiness probe + send-keys runs on a background OS thread so
-    /// the TUI event loop never blocks.
     pub(super) fn restart_selected_session(
         &mut self,
         new_profile: Option<&str>,
@@ -312,12 +312,10 @@ impl HomeView {
             None => return Ok(()),
         };
 
-        // Skip transient + sunk rows. Pull the snapshot details we need on
-        // the worker thread in the same borrow so we don't re-look up the
-        // instance under different conditions later. Snoozed rows only
-        // skip when the user is in Attention sort; see method doc.
+        // Skip transient + sunk rows. Snoozed rows only skip when the user is
+        // in Attention sort; see method doc.
         let in_attention = self.sort_order == crate::session::config::SortOrder::Attention;
-        let (skip, wake_snooze, title, tool) = match self.get_instance(&id) {
+        let (skip, wake_snooze) = match self.get_instance(&id) {
             Some(inst) => {
                 let snoozed = inst.is_snoozed();
                 let skip = matches!(inst.status, Status::Creating | Status::Deleting)
@@ -325,7 +323,7 @@ impl HomeView {
                     || (snoozed && in_attention)
                     || inst.pane_dead_observed;
                 let wake_snooze = snoozed && !in_attention;
-                (skip, wake_snooze, inst.title.clone(), inst.tool.clone())
+                (skip, wake_snooze)
             }
             None => return Ok(()),
         };
@@ -431,79 +429,43 @@ impl HomeView {
             }
         }
 
-        // Restart the live instance (not a detached clone) so all
-        // non-status fields restart_with_size touches are kept.
+        // The start cascade shells out to docker (image pull with no built-in
+        // timeout, container create/start) and runs the before_start host hook,
+        // any of which can block for seconds. Running it inline froze the TUI
+        // event loop, so mirror the recovery/stop paths: flip the row to
+        // Starting for immediate feedback, then run the cascade on the restart
+        // poller's worker thread. The post-cascade snapshot (and the wake-up)
+        // are handled via `apply_restart_results`.
         let size = crate::terminal::get_size();
-        self.try_mutate_instance_writeback_on_err(&id, |inst| {
-            inst.restart_with_size(size).map(|_| ())
-        })?;
 
-        // Stamp touch_last_accessed on the user's gesture (the row should
-        // visibly bump immediately). save() pushes both the restart-side
-        // mutations and the touch.
-        self.mutate_instance(&id, |inst| inst.touch_last_accessed());
+        // Status::Starting + a fresh last_start_time keeps the StatusPoller from
+        // flipping the row to Error before the worker finishes (the same grace
+        // startup recovery relies on); touch bumps the row on the user gesture.
+        self.mutate_instance(&id, |inst| {
+            inst.status = Status::Starting;
+            inst.last_error = None;
+            inst.last_start_time = Some(std::time::Instant::now());
+            inst.touch_last_accessed();
+        });
         self.save()?;
 
-        // Resolve the wake message via the moved session's profile config
-        // (already merges global + profile overrides). Empty string is the
-        // documented opt-out.
-        let profile = self
-            .get_instance(&id)
-            .map(|i| i.source_profile.clone())
-            .unwrap_or_else(|| {
-                self.active_profile
-                    .clone()
-                    .unwrap_or_else(|| "default".to_string())
-            });
-        let wake_msg = crate::session::resolve_config(&profile)
+        let Some(instance) = self.get_instance(&id).cloned() else {
+            return Ok(());
+        };
+
+        // Resolve the wake message on the main thread (config access). Empty is
+        // the documented opt-out; the worker skips the wake-up then.
+        let wake_message = crate::session::resolve_config(&instance.source_profile)
             .map(|c| c.session.restart_wake_message.clone())
             .unwrap_or_else(|_| "wake up: pick up what you were doing".to_string());
-        if wake_msg.is_empty() {
-            return Ok(());
-        }
 
-        // Background worker: wait for the pane to be live + past the boot
-        // shell, then send the wake-up keys. Failure to even spawn is
-        // logged so the user can correlate a missing wake-up with a real
-        // OS-level failure rather than silent loss.
-        let worker_session_id = id.clone();
-        let worker_title = title;
-        let worker_tool = tool;
-        let spawn_result = std::thread::Builder::new()
-            .name(format!("aoe-restart-wake/{}", id))
-            .stack_size(128 * 1024)
-            .spawn(move || {
-                let Ok(tmux_session) = crate::tmux::Session::new(&worker_session_id, &worker_title)
-                else {
-                    return;
-                };
-                let deadline = std::time::Instant::now() + std::time::Duration::from_millis(3000);
-                loop {
-                    if !tmux_session.exists() {
-                        return;
-                    }
-                    let pane_alive = !tmux_session.is_pane_dead();
-                    let hook_active = crate::hooks::read_hook_status(&worker_session_id).is_some();
-                    if pane_alive && (hook_active || !tmux_session.is_pane_running_shell()) {
-                        break;
-                    }
-                    if std::time::Instant::now() >= deadline {
-                        break;
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(50));
-                }
-
-                if !tmux_session.exists() {
-                    return;
-                }
-                let delay = crate::agents::send_keys_enter_delay(&worker_tool);
-                if let Err(e) = tmux_session.send_keys_with_delay(&wake_msg, delay) {
-                    tracing::warn!("failed to send wake-up message after restart: {}", e);
-                }
-            });
-        if let Err(err) = spawn_result {
-            tracing::warn!(?err, "failed to spawn restart wake-up worker");
-        }
+        self.restart_in_flight.insert(id.clone());
+        self.restart_poller.request_restart(RestartRequest {
+            session_id: id,
+            instance,
+            size,
+            wake_message,
+        });
         Ok(())
     }
 

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -3,7 +3,7 @@
 use crate::session::builder::{self, InstanceParams};
 use crate::session::{list_profiles, GroupTree, Item, Status, Storage};
 use crate::tui::deletion_poller::DeletionRequest;
-use crate::tui::dialogs::{DeleteOptions, GroupDeleteOptions, NewSessionData};
+use crate::tui::dialogs::{DeleteOptions, GroupDeleteOptions, InfoDialog, NewSessionData};
 use crate::tui::restart_poller::RestartRequest;
 
 use super::HomeView;
@@ -312,6 +312,16 @@ impl HomeView {
             None => return Ok(()),
         };
 
+        // A restart cascade for this row is already running on the poller
+        // worker. The cascade is off the event loop now, so the 1.5s
+        // keyboard-repeat debounce below does not cover a deliberate second
+        // press during a multi-second pull. Without this guard the worker would
+        // enqueue a duplicate request and, running serially, restart the row a
+        // second time, tearing down the container the first restart just built.
+        if self.restart_in_flight.contains(&id) {
+            return Ok(());
+        }
+
         // Skip transient + sunk rows. Snoozed rows only skip when the user is
         // in Attention sort; see method doc.
         let in_attention = self.sort_order == crate::session::config::SortOrder::Attention;
@@ -473,6 +483,20 @@ impl HomeView {
         if let Some(id) = &self.selected_session {
             let id = id.clone();
 
+            // Refuse to delete a row whose restart cascade is still running on
+            // the worker: deletion would fire docker commands against the same
+            // container the restart worker is mid-creating, orphaning resources
+            // non-deterministically. The old synchronous cascade made this race
+            // impossible (the UI thread could not accept a delete mid-restart);
+            // off-threading the cascade removed that implicit lock.
+            if self.restart_in_flight.contains(&id) {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Restart in progress",
+                    "This session is still restarting. Wait for it to finish before deleting.",
+                ));
+                return Ok(());
+            }
+
             self.set_instance_status(&id, Status::Deleting);
 
             if let Some(inst) = self.get_instance(&id) {
@@ -546,6 +570,22 @@ impl HomeView {
                 })
                 .map(|i| i.id.clone())
                 .collect();
+
+            // Refuse the whole group delete if any member is mid-restart (same
+            // concurrent-docker race as delete_selected). Restore the selection
+            // we `take()`'d above so the group stays put.
+            if sessions_to_delete
+                .iter()
+                .any(|sid| self.restart_in_flight.contains(sid))
+            {
+                self.selected_group = Some(group_path);
+                self.selected_group_profile = owning_profile;
+                self.info_dialog = Some(InfoDialog::new(
+                    "Restart in progress",
+                    "A session in this group is still restarting. Wait for it to finish before deleting the group.",
+                ));
+                return Ok(());
+            }
 
             self.bulk_apply_user_action(&sessions_to_delete, |inst| {
                 inst.status = Status::Deleting;

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -429,9 +429,9 @@ impl HomeView {
             }
         }
 
-        // The start cascade shells out to docker (image pull with no built-in
-        // timeout, container create/start) and runs the before_start host hook,
-        // any of which can block for seconds. Running it inline froze the TUI
+        // The start cascade shells out to docker (image pull, container
+        // create/start) and runs the before_start host hook, any of which can
+        // block for seconds. Running it inline froze the TUI
         // event loop, so mirror the recovery/stop paths: flip the row to
         // Starting for immediate feedback, then run the cascade on the restart
         // poller's worker thread. The post-cascade snapshot (and the wake-up)

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5948,6 +5948,58 @@ fn restart_selected_session_debounces_via_cooldown_map() {
     );
 }
 
+/// A second restart press while the first cascade is still running on the
+/// poller worker must be dropped. The cascade is off the event loop, so the
+/// 1.5s keyboard-repeat debounce does not cover a deliberate press during a
+/// multi-second pull; without the in-flight guard the worker would enqueue a
+/// duplicate request and restart the row twice.
+#[test]
+#[serial]
+fn restart_selected_session_skips_when_already_in_flight() {
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances[0].id.clone();
+    env.view.selected_session = Some(id.clone());
+    env.view.restart_in_flight.insert(id.clone());
+
+    let result = env.view.restart_selected_session(None, None, None, None);
+    assert!(result.is_ok());
+    assert!(
+        env.view.restart_cooldown_at.is_empty(),
+        "an in-flight restart must drop the press before any bookkeeping"
+    );
+    assert_ne!(
+        env.view.instances[0].status,
+        crate::session::Status::Starting,
+        "the row must not be re-flipped to Starting by a dropped duplicate press"
+    );
+}
+
+/// Deleting a row whose restart cascade is still running would fire docker
+/// commands against the container the worker is mid-creating. The delete must
+/// be refused (and surfaced) rather than racing the restart worker.
+#[test]
+#[serial]
+fn delete_selected_refused_during_restart() {
+    use crate::tui::dialogs::DeleteOptions;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances[0].id.clone();
+    env.view.selected_session = Some(id.clone());
+    env.view.restart_in_flight.insert(id.clone());
+
+    let result = env.view.delete_selected(&DeleteOptions::default());
+    assert!(result.is_ok());
+    assert_ne!(
+        env.view.instances[0].status,
+        crate::session::Status::Deleting,
+        "delete must be refused while a restart is in flight"
+    );
+    assert!(
+        env.view.info_dialog.is_some(),
+        "the refused delete must surface a dialog, not silently no-op"
+    );
+}
+
 /// Build a HomeView seeded with two distinct projects, each containing
 /// sessions with different attention statuses. Helper for the Project +
 /// Attention combination tests below.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -12,6 +12,7 @@ mod home;
 #[cfg(feature = "serve")]
 pub(crate) mod remote_home;
 pub(crate) mod responsive;
+mod restart_poller;
 pub mod settings;
 mod status_poller;
 mod stop_poller;

--- a/src/tui/restart_poller.rs
+++ b/src/tui/restart_poller.rs
@@ -24,9 +24,12 @@ impl RestartPoller {
         let (request_tx, request_rx) = mpsc::channel::<RestartRequest>();
         let (result_tx, result_rx) = mpsc::channel::<RestartResult>();
 
-        let handle = thread::spawn(move || {
-            Self::restart_loop(request_rx, result_tx);
-        });
+        let handle = thread::Builder::new()
+            .name("aoe-restart-poller".to_string())
+            .spawn(move || {
+                Self::restart_loop(request_rx, result_tx);
+            })
+            .expect("failed to spawn restart poller thread");
 
         Self {
             request_tx,
@@ -53,8 +56,13 @@ impl RestartPoller {
         }
     }
 
-    pub fn try_recv_result(&self) -> Option<RestartResult> {
-        self.result_rx.try_recv().ok()
+    /// Non-blocking poll for a completed restart. Surfaces `Disconnected`
+    /// (returned forever once the worker thread is gone, e.g. after a panic in
+    /// `perform_restart`) rather than collapsing it into `None`, so the caller
+    /// can clear stuck in-flight state instead of leaving rows pinned on
+    /// `Status::Starting` forever.
+    pub fn try_recv_result(&self) -> Result<RestartResult, mpsc::TryRecvError> {
+        self.result_rx.try_recv()
     }
 }
 
@@ -87,8 +95,8 @@ mod tests {
 
         let mut result = None;
         for _ in 0..100 {
-            result = poller.try_recv_result();
-            if result.is_some() {
+            if let Ok(r) = poller.try_recv_result() {
+                result = Some(r);
                 break;
             }
             std::thread::sleep(Duration::from_millis(20));
@@ -104,8 +112,11 @@ mod tests {
     }
 
     #[test]
-    fn restart_poller_try_recv_returns_none_when_empty() {
+    fn restart_poller_try_recv_returns_empty_when_no_result() {
         let poller = RestartPoller::new();
-        assert!(poller.try_recv_result().is_none());
+        assert!(matches!(
+            poller.try_recv_result(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
     }
 }

--- a/src/tui/restart_poller.rs
+++ b/src/tui/restart_poller.rs
@@ -1,0 +1,111 @@
+//! Background restart handler for TUI responsiveness.
+//!
+//! Restarting a sandboxed session re-runs the start cascade (docker image pull,
+//! container create/start, `before_start` host hook), which can block for
+//! seconds; a stalled registry pull has no timeout of its own. Running that on
+//! the UI event loop froze the TUI. This mirrors `StopPoller`:
+//! requests go to a worker thread, results come back over a channel the main
+//! loop polls each frame.
+
+use std::sync::mpsc;
+use std::thread;
+
+use crate::session::restart::perform_restart;
+pub use crate::session::restart::{RestartRequest, RestartResult};
+
+pub struct RestartPoller {
+    request_tx: mpsc::Sender<RestartRequest>,
+    result_rx: mpsc::Receiver<RestartResult>,
+    _handle: thread::JoinHandle<()>,
+}
+
+impl RestartPoller {
+    pub fn new() -> Self {
+        let (request_tx, request_rx) = mpsc::channel::<RestartRequest>();
+        let (result_tx, result_rx) = mpsc::channel::<RestartResult>();
+
+        let handle = thread::spawn(move || {
+            Self::restart_loop(request_rx, result_tx);
+        });
+
+        Self {
+            request_tx,
+            result_rx,
+            _handle: handle,
+        }
+    }
+
+    fn restart_loop(
+        request_rx: mpsc::Receiver<RestartRequest>,
+        result_tx: mpsc::Sender<RestartResult>,
+    ) {
+        while let Ok(request) = request_rx.recv() {
+            let result = perform_restart(request);
+            if result_tx.send(result).is_err() {
+                break;
+            }
+        }
+    }
+
+    pub fn request_restart(&self, request: RestartRequest) {
+        if let Err(e) = self.request_tx.send(request) {
+            tracing::warn!(target: "tui.restart_poller", error = %e, "restart request dropped; worker thread unavailable");
+        }
+    }
+
+    pub fn try_recv_result(&self) -> Option<RestartResult> {
+        self.result_rx.try_recv().ok()
+    }
+}
+
+impl Default for RestartPoller {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::Instance;
+    use std::time::Duration;
+
+    #[test]
+    #[serial_test::serial]
+    fn restart_poller_channel_communication() {
+        let poller = RestartPoller::new();
+        let instance = Instance::new("Test Session", "/tmp/test-project");
+        let session_id = instance.id.clone();
+        let title = instance.title.clone();
+
+        poller.request_restart(RestartRequest {
+            session_id: session_id.clone(),
+            instance,
+            size: None,
+            wake_message: String::new(),
+        });
+
+        let mut result = None;
+        for _ in 0..100 {
+            result = poller.try_recv_result();
+            if result.is_some() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        // The cascade may create a real tmux session; tear it down regardless of
+        // whether the assertions below pass.
+        if let Ok(session) = crate::tmux::Session::new(&session_id, &title) {
+            let _ = session.kill();
+        }
+        let result = result.expect("timed out waiting for restart result");
+        assert_eq!(result.session_id, session_id);
+        assert_eq!(result.instance.id, session_id);
+    }
+
+    #[test]
+    fn restart_poller_try_recv_returns_none_when_empty() {
+        let poller = RestartPoller::new();
+        assert!(poller.try_recv_result().is_none());
+    }
+}


### PR DESCRIPTION
## Description

The TUI froze during a sandboxed session restart. A user's debug log dead-ended at `pulling image ghcr.io/agent-of-empires/aoe-sandbox:latest`, with an earlier 30s stall ending in `Failed to copy dir plugins: Permission denied`.

Root cause: pressing restart (`e` / `E` / `F5`) ran the whole start cascade synchronously on the TUI event-loop thread. `restart_selected_session` -> `restart_with_size` (`operations.rs`) does a blocking `docker pull`, the `before_start` host hook, and several `docker` shellouts. The pull had no timeout, so a stalled registry connection froze the entire UI indefinitely. Recovery and the manual image-update pull were already off-thread; the restart keybind was the one start path that skipped that treatment (its doc comment even claimed "the TUI event loop never blocks", which only covered the wake-up send-keys worker).

Three fixes:

1. **`pull_image` timeout** (`containers/runtime_base.rs`): spawn the child and `wait_with_timeout`, which drains stdout/stderr on threads and kills the child after a 600s deadline. A wedged pull can no longer block the caller forever.
2. **`copy_dir_recursive` robustness** (`session/container_config.rs`): break symlink cycles with a canonical-path visited set, and skip a single unreadable/dangling entry instead of aborting the whole copy (one Permission-denied file under `~/.claude/plugins` used to fail the entire sync after a 30s churn). Also gate the `copy_dirs` (plugins/skills) push on `!has_prior_data`, matching the general file copy, so a restart no longer re-copies the whole plugins tree.
3. **`RestartPoller`** (new `session/restart.rs` + `tui/restart_poller.rs`, mirrors `StopPoller`): the restart cascade runs on a worker thread. `restart_selected_session` flips the row to `Starting` and dispatches; `apply_restart_results` writes the post-cascade snapshot back, clears the in-flight marker, and surfaces failures as `Status::Error`. The UI thread never blocks on a restart again.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

This is a responsiveness/threading fix; there is no visual change to capture (the only user-visible difference is that the row shows `Starting` and the UI stays interactive during a restart instead of freezing).

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated tests (unit/regression rather than full e2e)
- [ ] Skipped a test, because:

New regression tests:
- `wait_with_timeout_kills_child_that_outlives_deadline` / `wait_with_timeout_returns_output_for_fast_child` (timeout)
- `test_copy_dir_recursive_terminates_on_symlink_cycle`, `test_copy_dir_recursive_skips_bad_entry_inside_subdir`, `test_copy_dirs_skipped_when_prior_data` (copy)
- `perform_restart_preserves_session_id_and_returns_instance`, `restart_poller_channel_communication` (restart poller round-trip)

All existing `restart_selected_session_*` guard tests still pass. `cargo build`/`--features serve`, `cargo clippy --all-targets`, and `cargo fmt --check` are clean.

Notes for reviewers:
- Restarts are serialized on one worker (same as `StopPoller`); the 600s pull timeout bounds the worst case. Happy to switch to per-session workers if preferred.
- Gating `copy_dirs` on `has_prior_data` means a newly host-installed plugin reaches an existing sandbox only when it's recreated, consistent with how every other host file already behaves under the prior-data sentinel.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation and implementation done with Claude Code via back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784204085&installation_id=139138837&pr_number=2202&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2202&signature=d48a83537becaaa962783d6abf918f6fe17ca10daff9d201979edb8f42737edc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR fixes a critical TUI freeze when users trigger a session restart (e, E, or F5). The UI previously ran the entire restart “cascade” on the UI thread, and it could block indefinitely due to long-running/stuck operations (notably docker image pulls and hook execution). The fix keeps the UI responsive by moving restart work to a background worker and adding safety guards around the most failure-prone operations.

## What Changed

### 1. Docker pull is now time-bounded
- Added a hard timeout for `docker pull`-style operations.
- If the pull stalls beyond the deadline, the pull process is killed and the operation fails gracefully (rather than hanging the caller forever).
- Stdout/stderr draining is done safely to avoid hangs caused by pipe/grandchild behavior.

### 2. Session directory copying is more resilient and safer
- Recursive directory copy now:
  - Detects and breaks symlink cycles.
  - Becomes best-effort: unreadable/dangling/bad entries are skipped without aborting the whole sync.
  - Uses explicit “fatal vs soft” error classification (e.g., space/quota/readonly abort the operation; permission/unreadable entries are logged and skipped).
- Restart behavior is improved by avoiding re-copying seeded plugin/skill state when prior session data already exists (via a `projects/` sentinel), preventing unnecessary overwrites.

### 3. Restart execution moved off the UI thread
- Introduced a background restart worker (`RestartPoller`) and a shared restart pipeline (`session/restart.rs`).
- The UI now:
  - Marks the session row as “Starting” immediately.
  - Enqueues the restart request to the worker.
  - Applies results back to the UI during refresh.
- Restart in-flight safety was tightened:
  - Refuses duplicate restart presses for the same session while a restart is already running.
  - Refuses delete actions while restart is in flight (with an info dialog).
  - Handles worker disconnection so rows don’t get stuck in “Starting.”
- `before_start` hook execution is bounded to prevent indefinite hangs.

### 4. Updated UI refresh integration
- The main UI loop now regularly pulls restart completion results and forces redraw/update when restart state was applied.
- During shutdown, it drains any pending restart results before final persistence.

## Files Added/Updated
- **Added:** `src/session/restart.rs`, `src/tui/restart_poller.rs`
- **Updated:**  
  `src/containers/runtime_base.rs`, `src/session/container_config.rs`,  
  `src/session/mod.rs`, `src/tui/app.rs`, `src/tui/home/mod.rs`,  
  `src/tui/home/operations.rs`, `src/tui/mod.rs`, `src/tui/home/tests.rs`

## Benefits
- ✅ TUI no longer freezes during restart key presses
- ✅ Stuck docker pulls (e.g., registry stalls) can’t block the UI indefinitely
- ✅ File synchronization is more robust: one bad/unreadable entry won’t derail the whole copy
- ✅ Clearer user-facing behavior and safer concurrency (no duplicate restarts; delete blocked during restart)
- ✅ Regression tests added for timeout, in-flight restart safety, deletion refusal, and copy error discrimination
<!-- end of auto-generated comment: release notes by coderabbit.ai -->