### PR TITLE
fix(web): differentiate the two new-session button tooltips

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1883,7 +1883,7 @@ export const SidebarGroupHeader = memo(function SidebarGroupHeader({
             ({sessionCount})
           </span>
         </button>
-        <Tooltip text={offline ? OFFLINE_TITLE : "New session in this project"}>
+        <Tooltip text={offline ? OFFLINE_TITLE : "New session"}>
           <button
             onClick={onNewSession}
             disabled={offline}
@@ -2517,12 +2517,12 @@ export function WorkspaceSidebar({
               </svg>
             </button>
           </Tooltip>
-          <Tooltip text={offline ? OFFLINE_TITLE : "New session (choose project)"}>
+          <Tooltip text={offline ? OFFLINE_TITLE : "New project session"}>
             <button
               onClick={onNew}
               disabled={offline}
               className="w-8 h-8 flex items-center justify-center text-text-muted hover:text-text-secondary hover:bg-surface-800 cursor-pointer rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-text-muted disabled:hover:bg-transparent"
-              aria-label="New session (choose project)"
+              aria-label="New project session"
             >
               <svg
                 width="16"

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1883,7 +1883,7 @@ export const SidebarGroupHeader = memo(function SidebarGroupHeader({
             ({sessionCount})
           </span>
         </button>
-        <Tooltip text={offline ? OFFLINE_TITLE : `New session in ${group.displayName}`}>
+        <Tooltip text={offline ? OFFLINE_TITLE : "New session in this project"}>
           <button
             onClick={onNewSession}
             disabled={offline}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1883,7 +1883,7 @@ export const SidebarGroupHeader = memo(function SidebarGroupHeader({
             ({sessionCount})
           </span>
         </button>
-        <Tooltip text={offline ? OFFLINE_TITLE : "New session"}>
+        <Tooltip text={offline ? OFFLINE_TITLE : `New session in ${group.displayName}`}>
           <button
             onClick={onNewSession}
             disabled={offline}
@@ -2517,12 +2517,12 @@ export function WorkspaceSidebar({
               </svg>
             </button>
           </Tooltip>
-          <Tooltip text={offline ? OFFLINE_TITLE : "New session"}>
+          <Tooltip text={offline ? OFFLINE_TITLE : "New session (choose project)"}>
             <button
               onClick={onNew}
               disabled={offline}
               className="w-8 h-8 flex items-center justify-center text-text-muted hover:text-text-secondary hover:bg-surface-800 cursor-pointer rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-text-muted disabled:hover:bg-transparent"
-              aria-label="New session"
+              aria-label="New session (choose project)"
             >
               <svg
                 width="16"

--- a/web/tests/command-palette.spec.ts
+++ b/web/tests/command-palette.spec.ts
@@ -100,7 +100,7 @@ test.describe("Command palette", () => {
     await page.route("**/api/sessions", (r) => r.fulfill({ json: { sessions: [], workspace_ordering: [] } }));
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    await page.getByLabel("New session").first().click();
+    await page.getByLabel("New project session").first().click();
     await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
     await page.getByPlaceholder("Type to filter...").click();
     await page.keyboard.press("ControlOrMeta+k");

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -728,6 +728,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.new-session-tooltips",
+      "kind": "mocked-playwright",
+      "risk": "low",
+      "specs": ["tests/sidebar-new-session-tooltips.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.reorder-stationary-click",
       "kind": "mocked-playwright",
       "risk": "medium",

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -31,7 +31,7 @@ test.describe("Sidebar", () => {
   test("sidebar visible on desktop by default", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    await expect(page.getByLabel("New session")).toBeVisible();
+    await expect(page.getByLabel("New project session")).toBeVisible();
   });
 
   test("sidebar toggle button exists", async ({ page }) => {
@@ -56,7 +56,7 @@ test.describe("Sidebar", () => {
   test("sidebar can be toggled closed and open on desktop", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    const addBtn = page.getByLabel("New session");
+    const addBtn = page.getByLabel("New project session");
     await expect(addBtn).toBeVisible();
 
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
@@ -116,7 +116,7 @@ test.describe("Create session from home screen", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
 
-    await page.getByLabel("New session").first().click();
+    await page.getByLabel("New project session").first().click();
     await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
 
     await page.getByRole("button", { name: "Close" }).click();
@@ -192,7 +192,7 @@ test.describe("Mobile responsive", () => {
     await page.goto("/");
     // Sidebar is translated off-screen on mobile (not display:none), so
     // use toBeInViewport rather than toBeVisible.
-    await expect(page.getByLabel("New session")).not.toBeInViewport();
+    await expect(page.getByLabel("New project session")).not.toBeInViewport();
     // Home screen content visible
     await expect(page.getByText("empires", { exact: false })).toBeVisible();
   });
@@ -208,17 +208,17 @@ test.describe("Mobile responsive", () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    await expect(page.getByLabel("New session")).toBeInViewport();
+    await expect(page.getByLabel("New project session")).toBeInViewport();
   });
 
   test("sidebar closes via toggle on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    await expect(page.getByLabel("New session")).toBeInViewport();
+    await expect(page.getByLabel("New project session")).toBeInViewport();
     // Toggle the sidebar closed again
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    await expect(page.getByLabel("New session")).not.toBeInViewport();
+    await expect(page.getByLabel("New project session")).not.toBeInViewport();
   });
 
   test("settings gear accessible on mobile", async ({ page }) => {

--- a/web/tests/sidebar-new-session-tooltips.spec.ts
+++ b/web/tests/sidebar-new-session-tooltips.spec.ts
@@ -1,0 +1,24 @@
+// The sidebar has two new-session buttons: the global toolbar button (no
+// project preselected) and the per-project header button (prefills that
+// project). They used to share the literal "New session" hover tooltip, so
+// nothing distinguished them on hover. They now read differently. See #2205.
+
+import { test, expect } from "./helpers/mockedTest";
+import { installSidebarMocks } from "./helpers/sidebarMocks";
+
+test("the two new-session buttons have distinct tooltips and labels", async ({ page }) => {
+  await installSidebarMocks(page, {
+    sessions: [{ id: "s-a", title: "alpha-session", project_path: "/tmp/repo-alpha", branch: "feat/a" }],
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  // Global toolbar button: scoped to no project.
+  await expect(page.getByRole("button", { name: "New session (choose project)" })).toBeVisible();
+  await expect(page.getByText("New session (choose project)")).toBeAttached();
+
+  // Per-project header button: scoped to the repo's display name.
+  await expect(page.getByRole("button", { name: "New session in repo-alpha" })).toBeVisible();
+  await expect(page.getByText("New session in repo-alpha")).toBeAttached();
+});

--- a/web/tests/sidebar-new-session-tooltips.spec.ts
+++ b/web/tests/sidebar-new-session-tooltips.spec.ts
@@ -1,7 +1,8 @@
-// The sidebar has two new-session buttons: the global toolbar button (no
-// project preselected) and the per-project header button (prefills that
+// The sidebar has two new-session buttons: the global toolbar button (opens
+// the project-first wizard) and the per-project header button (prefills that
 // project). They used to share the literal "New session" hover tooltip, so
-// nothing distinguished them on hover. They now read differently. See #2205.
+// nothing distinguished them on hover. The global one now reads "New project
+// session"; the per-project one stays a short "New session". See #2205.
 
 import { test, expect } from "./helpers/mockedTest";
 import { installSidebarMocks } from "./helpers/sidebarMocks";
@@ -14,13 +15,14 @@ test("the two new-session buttons have distinct tooltips and labels", async ({ p
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.goto("/");
 
-  // Global toolbar button: scoped to no project.
-  await expect(page.getByRole("button", { name: "New session (choose project)" })).toBeVisible();
-  await expect(page.getByText("New session (choose project)")).toBeAttached();
+  // Global toolbar button: project-first wizard.
+  await expect(page.getByRole("button", { name: "New project session" })).toBeVisible();
+  await expect(page.getByText("New project session")).toBeAttached();
 
-  // Per-project header button: tooltip is static so the project name never
-  // leaks into the always-rendered tooltip text (which would collide with
-  // getByText(projectName) elsewhere); the accessible name stays scoped.
+  // Per-project header button: short tooltip, but its accessible name stays
+  // scoped to the project. The project name is kept out of the always-rendered
+  // tooltip text so it does not collide with getByText(projectName) elsewhere.
   await expect(page.getByRole("button", { name: "New session in repo-alpha" })).toBeVisible();
-  await expect(page.getByText("New session in this project")).toBeAttached();
+  const header = page.locator("[data-testid='sidebar-group-header']");
+  await expect(header.getByText("New session", { exact: true })).toBeAttached();
 });

--- a/web/tests/sidebar-new-session-tooltips.spec.ts
+++ b/web/tests/sidebar-new-session-tooltips.spec.ts
@@ -18,7 +18,9 @@ test("the two new-session buttons have distinct tooltips and labels", async ({ p
   await expect(page.getByRole("button", { name: "New session (choose project)" })).toBeVisible();
   await expect(page.getByText("New session (choose project)")).toBeAttached();
 
-  // Per-project header button: scoped to the repo's display name.
+  // Per-project header button: tooltip is static so the project name never
+  // leaks into the always-rendered tooltip text (which would collide with
+  // getByText(projectName) elsewhere); the accessible name stays scoped.
   await expect(page.getByRole("button", { name: "New session in repo-alpha" })).toBeVisible();
-  await expect(page.getByText("New session in repo-alpha")).toBeAttached();
+  await expect(page.getByText("New session in this project")).toBeAttached();
 });

--- a/web/tests/sidebar-new-session-tooltips.spec.ts
+++ b/web/tests/sidebar-new-session-tooltips.spec.ts
@@ -1,8 +1,13 @@
 // The sidebar has two new-session buttons: the global toolbar button (opens
-// the project-first wizard) and the per-project header button (prefills that
+// the new-session wizard) and the per-project header button (prefills that
 // project). They used to share the literal "New session" hover tooltip, so
 // nothing distinguished them on hover. The global one now reads "New project
 // session"; the per-project one stays a short "New session". See #2205.
+//
+// The shared Tooltip (Tooltip.tsx) renders its text into a portaled
+// role="tooltip" span only while the trigger is hovered/focused (#2214), so
+// each tooltip is asserted after hovering its button rather than from the
+// static DOM.
 
 import { test, expect } from "./helpers/mockedTest";
 import { installSidebarMocks } from "./helpers/sidebarMocks";
@@ -15,14 +20,18 @@ test("the two new-session buttons have distinct tooltips and labels", async ({ p
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.goto("/");
 
-  // Global toolbar button: project-first wizard.
-  await expect(page.getByRole("button", { name: "New project session" })).toBeVisible();
-  await expect(page.getByText("New project session")).toBeAttached();
+  // Global toolbar button: project-first wizard. The accessible name is always
+  // present; the visible tooltip shows on hover.
+  const globalBtn = page.getByRole("button", { name: "New project session" });
+  await expect(globalBtn).toBeVisible();
+  await globalBtn.hover();
+  await expect(page.getByRole("tooltip")).toHaveText("New project session");
 
   // Per-project header button: short tooltip, but its accessible name stays
-  // scoped to the project. The project name is kept out of the always-rendered
-  // tooltip text so it does not collide with getByText(projectName) elsewhere.
-  await expect(page.getByRole("button", { name: "New session in repo-alpha" })).toBeVisible();
-  const header = page.locator("[data-testid='sidebar-group-header']");
-  await expect(header.getByText("New session", { exact: true })).toBeAttached();
+  // scoped to the project. The project name is kept out of the tooltip text so
+  // it does not collide with getByText(projectName) elsewhere.
+  const projectBtn = page.getByRole("button", { name: "New session in repo-alpha" });
+  await expect(projectBtn).toBeVisible();
+  await projectBtn.hover();
+  await expect(page.getByRole("tooltip")).toHaveText("New session");
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web sidebar has two new-session buttons: the global one in the top toolbar (opens the project-first wizard) and the per-project one in each group header (prefills that project). Both rendered the identical `New session` hover tooltip, so nothing on hover told them apart.

This makes the tooltips distinct while keeping both short. The global toolbar button now reads `New project session` (its wizard starts on the Project step), and the per-project header button stays a plain `New session`; its aria-label remains scoped (`New session in <project>`) for screen readers. The shared offline tooltip is untouched.

Closes #2205

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] Run `aoe serve`, open the dashboard with at least one session in a repo.
- [ ] Hover the new-session button in the top sidebar toolbar; tooltip reads `New project session`.
- [ ] Hover the new-session (`+`) button in a project group header; tooltip reads `New session`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the wording call, reviewed each commit, and ran the test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784215156&installation_id=139138837&pr_number=2215&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2215&signature=be5480de22f5ac87ae3ac7fec4d7c7107998e8e7d0ed9f71a2bc615f399da062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a confusing hover/tooltip experience in the web dashboard sidebar by differentiating the two “new session” actions when the app is online—without changing what either button does (and keeping the offline state behavior intact).

## What Changed

- **`web/src/components/WorkspaceSidebar.tsx`**
  - **Global (toolbar / mobile header) “new session” button**
    - Tooltip text changed to **“New project session”**
    - Button `aria-label` updated to **“New project session”**
  - **Per-project (group header) “new session” button**
    - Tooltip text remains **“New session”** (kept short for design feedback)
    - `aria-label` remains **project-scoped** as **“New session in <project>”** for screen readers
  - **Offline**
    - Tooltip continues to use **`OFFLINE_TITLE`**
    - The button remains disabled

- **`web/tests/sidebar-new-session-tooltips.spec.ts`**
  - Added a Playwright test asserting the **two buttons have distinct visible tooltip text and distinct accessible names** (global vs per-project).

- **`web/tests/dashboard.spec.ts`**
  - Updated Playwright locators and expectations to use the **“New project session”** label where the global sidebar trigger is referenced.

- **`web/tests/coverage-matrix.json`**
  - Added coverage mapping for the new tooltip test.

## Benefits

- **Sighted usability improves:** users can visually distinguish the global vs per-project “new session” actions just by hovering.
- **Accessibility remains correct:** screen readers still get project-specific identification for the per-project button.
- **Prevents regressions:** new Playwright coverage ensures tooltip/label changes don’t accidentally revert in the future.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
