### PR TITLE
feat(web): rework sidebar project rows, drop grab bar, hover-swap icon/chevron, add session count

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -42,7 +42,9 @@ Completing or skipping the tour records `app_state.has_seen_web_tour` on the ser
 
 ## Sidebar sort
 
-By default the sidebar shows your manually-ordered list. Drag a row (press-and-hold) to move it; the order persists across browsers and devices via `workspace-ordering.json`. To reorder whole projects, drag a project/group header by its left-side handle; this group order is per-browser (localStorage), not synced. Group drag is disabled while a filter is active or a computed sort mode is selected.
+By default the sidebar shows your manually-ordered list. Drag a row (press-and-hold) to move it; the order persists across browsers and devices via `workspace-ordering.json`. To reorder whole projects, press-and-drag the project/group header itself (there is no separate handle); this group order is per-browser (localStorage), not synced. Group drag is disabled while a filter is active or a computed sort mode is selected.
+
+Each project header shows the project icon next to its name, with a count of the sessions it holds. Hovering the header swaps the icon for a fold chevron; clicking the header collapses or expands the project's sessions.
 
 A sort picker next to the filter button offers three modes:
 

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1778,6 +1778,7 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
       <div
         data-testid="sidebar-group-header"
         data-group-id={group.id}
+        data-draggable={dragHandle ? "true" : undefined}
         tabIndex={hasMenu ? 0 : undefined}
         aria-haspopup={hasMenu ? "menu" : undefined}
         aria-label={
@@ -1810,14 +1811,20 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
           className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
         >
           <span className="relative h-4 w-4 shrink-0">
-            <span className="absolute inset-0 flex items-center justify-center transition-opacity duration-75 group-hover:opacity-0">
+            <span
+              data-testid="sidebar-group-icon"
+              className="absolute inset-0 flex items-center justify-center transition-opacity duration-75 group-hover:opacity-0"
+            >
               {group.remoteOwner ? (
                 <OwnerAvatar owner={group.remoteOwner} size={16} />
               ) : (
                 <Folder className="h-3.5 w-3.5 text-text-dim" />
               )}
             </span>
-            <span className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-75 group-hover:opacity-100">
+            <span
+              data-testid="sidebar-group-fold-chevron"
+              className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-75 group-hover:opacity-100"
+            >
               <svg
                 width="10"
                 height="10"

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1685,21 +1685,26 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
   const sessionCount = group.workspaces.reduce((n, v) => n + v.workspace.sessions.length, 0);
 
   // The whole header row is the drag activator now (no grip handle), so a
-  // drag ends with the pointer over the toggle. Suppress the trailing click
-  // for a beat after a drag so reordering a group doesn't also collapse it.
-  // Mirrors the SessionRow suppression.
+  // drag ends with the pointer over one of the row's controls. Suppress the
+  // trailing click for a beat after a drag so reordering a group doesn't also
+  // collapse it or fire the New Session button. The window stays open for the
+  // whole drag (Infinity), so even a multi-second drag can't leak the click,
+  // then closes 250ms after release. Enforced row-wide via onClickCapture so
+  // every control is covered, not just the toggle.
   const dragSuppressRef = useRef(0);
   const isDragging = dragHandle?.isDragging ?? false;
   useEffect(() => {
     if (isDragging) {
-      dragSuppressRef.current = Date.now() + 1000;
+      dragSuppressRef.current = Number.POSITIVE_INFINITY;
     } else if (dragSuppressRef.current > Date.now()) {
       dragSuppressRef.current = Date.now() + 250;
     }
   }, [isDragging]);
-  const handleToggle = () => {
-    if (dragSuppressRef.current > Date.now()) return;
-    onClick();
+  const suppressClickAfterDrag = (e: React.MouseEvent) => {
+    if (dragSuppressRef.current > Date.now()) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
   };
 
   const openMenuAt = useCallback((x: number, y: number) => {
@@ -1793,6 +1798,7 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
             : undefined
         }
         onKeyDown={hasMenu ? handleHeaderKeyDown : undefined}
+        onClickCapture={suppressClickAfterDrag}
         className={`group flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary focus:outline-none focus:ring-2 focus:ring-brand-600 ${headerHoverClass} ${
           hasActiveChild ? "border-l-2 border-brand-600" : ""
         }`}
@@ -1806,14 +1812,14 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
       >
         <span className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`} />
         <button
-          onClick={handleToggle}
+          onClick={onClick}
           aria-expanded={!group.collapsed}
           className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
         >
           <span className="relative h-4 w-4 shrink-0">
             <span
               data-testid="sidebar-group-icon"
-              className="absolute inset-0 flex items-center justify-center transition-opacity duration-75 group-hover:opacity-0"
+              className="absolute inset-0 flex items-center justify-center transition-opacity duration-75 group-hover:opacity-0 group-focus-within:opacity-0"
             >
               {group.remoteOwner ? (
                 <OwnerAvatar owner={group.remoteOwner} size={16} />
@@ -1823,7 +1829,7 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
             </span>
             <span
               data-testid="sidebar-group-fold-chevron"
-              className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-75 group-hover:opacity-100"
+              className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-75 group-hover:opacity-100 group-focus-within:opacity-100"
             >
               <svg
                 width="10"

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -16,7 +16,7 @@ import {
   Archive,
   ArrowLeftRight,
   CircleStop,
-  GripVertical,
+  Folder,
   Hourglass,
   Layers,
   Moon,
@@ -478,6 +478,7 @@ type DragHandleProps = {
   setActivatorNodeRef: (el: HTMLElement | null) => void;
   attributes: ReturnType<typeof useSortable>["attributes"];
   listeners: ReturnType<typeof useSortable>["listeners"];
+  isDragging: boolean;
 };
 
 // Sortable wrapper around an entire repo-group block (header + its rows),
@@ -509,7 +510,7 @@ function SortableRepoGroup({
       style={style}
       className={"transition-shadow duration-150 " + (isDragging ? "ring-2 ring-inset ring-brand-500 shadow-lg" : "")}
     >
-      {children({ setActivatorNodeRef, attributes, listeners })}
+      {children({ setActivatorNodeRef, attributes, listeners, isDragging })}
     </div>
   );
 }
@@ -1681,6 +1682,25 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
   const dotClass = STATUS_DOT_CLASS[group.status === "active" ? "Running" : "Idle"] ?? "bg-status-idle";
   const headerStyle = repoColorStyle(group.color);
   const headerHoverClass = group.color ? "" : "hover:bg-surface-800/50";
+  const sessionCount = group.workspaces.reduce((n, v) => n + v.workspace.sessions.length, 0);
+
+  // The whole header row is the drag activator now (no grip handle), so a
+  // drag ends with the pointer over the toggle. Suppress the trailing click
+  // for a beat after a drag so reordering a group doesn't also collapse it.
+  // Mirrors the SessionRow suppression.
+  const dragSuppressRef = useRef(0);
+  const isDragging = dragHandle?.isDragging ?? false;
+  useEffect(() => {
+    if (isDragging) {
+      dragSuppressRef.current = Date.now() + 1000;
+    } else if (dragSuppressRef.current > Date.now()) {
+      dragSuppressRef.current = Date.now() + 250;
+    }
+  }, [isDragging]);
+  const handleToggle = () => {
+    if (dragSuppressRef.current > Date.now()) return;
+    onClick();
+  };
 
   const openMenuAt = useCallback((x: number, y: number) => {
     closeOtherContextMenus();
@@ -1772,53 +1792,51 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
             : undefined
         }
         onKeyDown={hasMenu ? handleHeaderKeyDown : undefined}
-        className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary focus:outline-none focus:ring-2 focus:ring-brand-600 ${headerHoverClass} ${
+        className={`group flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary focus:outline-none focus:ring-2 focus:ring-brand-600 ${headerHoverClass} ${
           hasActiveChild ? "border-l-2 border-brand-600" : ""
         }`}
         style={headerStyle}
+        // The whole row is the drag activator (no grip). Mirrors SessionRow:
+        // spread only `listeners` (pointer-down), not dnd-kit's `attributes`,
+        // which would inject a role/tabIndex that collide with the context
+        // menu wiring. Keyboard drag isn't supported, matching session rows.
+        ref={dragHandle?.setActivatorNodeRef}
+        {...dragHandle?.listeners}
       >
-        {/* eslint-disable react-hooks/refs -- dnd-kit's DragHandleProps bundles
-            setActivatorNodeRef (a ref-setter callback) alongside plain
-            attributes/listeners objects; the rule incorrectly taints every
-            property access on the whole object as a "ref value read during
-            render". None of these touch .current, so it's a false positive. */}
-        {dragHandle && (
-          <button
-            ref={dragHandle.setActivatorNodeRef}
-            type="button"
-            aria-label={`Reorder project ${group.displayName}`}
-            data-testid="sidebar-group-drag-handle"
-            className="shrink-0 -ml-1 flex h-5 w-4 items-center justify-center text-text-dim hover:text-text-secondary cursor-grab active:cursor-grabbing touch-none"
-            {...dragHandle.attributes}
-            {...dragHandle.listeners}
-          >
-            <GripVertical className="h-3.5 w-3.5" />
-          </button>
-        )}
-        {/* eslint-enable react-hooks/refs */}
         <span className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`} />
         <button
-          onClick={onClick}
+          onClick={handleToggle}
           aria-expanded={!group.collapsed}
           className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
         >
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 10 10"
-            fill="currentColor"
-            className={`shrink-0 text-text-dim transition-transform duration-75 ${group.collapsed ? "-rotate-90" : ""}`}
-          >
-            <path
-              d="M2 3 L5 6.5 L8 3"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          <OwnerAvatar owner={group.remoteOwner} size={16} />
+          <span className="relative h-4 w-4 shrink-0">
+            <span className="absolute inset-0 flex items-center justify-center transition-opacity duration-75 group-hover:opacity-0">
+              {group.remoteOwner ? (
+                <OwnerAvatar owner={group.remoteOwner} size={16} />
+              ) : (
+                <Folder className="h-3.5 w-3.5 text-text-dim" />
+              )}
+            </span>
+            <span className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-75 group-hover:opacity-100">
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
+                fill="currentColor"
+                aria-hidden="true"
+                className={`text-text-dim transition-transform duration-75 ${group.collapsed ? "-rotate-90" : ""}`}
+              >
+                <path
+                  d="M2 3 L5 6.5 L8 3"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
+          </span>
           {group.pinned && (
             <span
               className="shrink-0 text-[10px] leading-none text-text-dim"
@@ -1831,6 +1849,9 @@ const SidebarGroupHeader = memo(function SidebarGroupHeader({
           )}
           <span className="text-[13px] md:text-[14px] font-medium truncate flex-1" title={headerTitle}>
             {group.displayName}
+          </span>
+          <span className="shrink-0 text-[12px] tabular-nums text-text-dim" data-testid="sidebar-group-session-count">
+            ({sessionCount})
           </span>
         </button>
         <Tooltip text={offline ? OFFLINE_TITLE : "New session"}>

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1626,7 +1626,7 @@ export function SnoozeModal({
   );
 }
 
-const SidebarGroupHeader = memo(function SidebarGroupHeader({
+export const SidebarGroupHeader = memo(function SidebarGroupHeader({
   group,
   hasActiveChild,
   onClick,

--- a/web/src/components/__tests__/SidebarGroupHeader.test.tsx
+++ b/web/src/components/__tests__/SidebarGroupHeader.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+//
+// RTL coverage for the reworked project header row (#2207): the per-project
+// session count, the icon (owner avatar vs Folder fallback), the data-draggable
+// hook, and the drag-release click suppression. The suppression branches
+// (window open while dragging, click swallowed row-wide) are timing/pointer
+// dependent and flaky to hit through Playwright, so they are pinned down here
+// where `dragHandle.isDragging` can be controlled directly.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { SidebarGroupHeader } from "../WorkspaceSidebar";
+import type { SidebarGroup } from "../../lib/sidebarGroups";
+import type { SessionResponse, Workspace } from "../../lib/types";
+
+function session(id: string): SessionResponse {
+  return {
+    id,
+    title: id,
+    project_path: "/p",
+    group_path: "/p",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: { delete_worktree: false, delete_branch: false, delete_sandbox: false },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+  };
+}
+
+function workspace(id: string, count: number): Workspace {
+  return {
+    id,
+    branch: null,
+    projectPath: "/p",
+    displayName: id,
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    sessions: Array.from({ length: count }, (_, i) => session(`${id}-s${i}`)),
+  };
+}
+
+function group(over: Partial<SidebarGroup> = {}): SidebarGroup {
+  const workspaces = over.workspaces ?? [{ key: "w1", workspace: workspace("w1", 3) }];
+  return {
+    id: "g1",
+    kind: "repo",
+    displayName: "my-project",
+    defaultDisplayName: "my-project",
+    alias: null,
+    color: null,
+    remoteOwner: null,
+    workspaces,
+    status: "idle",
+    collapsed: false,
+    capabilities: { appearance: true, reorder: true, create: "repo" },
+    repoPath: "/p",
+    registeredProjects: [],
+    pinned: false,
+    pinnedEmpty: false,
+    ...over,
+  };
+}
+
+function dragHandle(isDragging: boolean) {
+  return { setActivatorNodeRef: () => {}, attributes: {}, listeners: {}, isDragging };
+}
+
+function renderHeader(props: Partial<Parameters<typeof SidebarGroupHeader>[0]> = {}) {
+  const onClick = vi.fn();
+  const onNewSession = vi.fn();
+  render(
+    <SidebarGroupHeader
+      group={group()}
+      hasActiveChild={false}
+      onClick={onClick}
+      onNewSession={onNewSession}
+      onUpdateAppearance={() => {}}
+      offline={false}
+      {...props}
+    />,
+  );
+  return { onClick, onNewSession };
+}
+
+afterEach(() => cleanup());
+
+describe("SidebarGroupHeader", () => {
+  it("shows the total session count across the project's workspaces", () => {
+    renderHeader({
+      group: group({
+        workspaces: [
+          { key: "a", workspace: workspace("a", 2) },
+          { key: "b", workspace: workspace("b", 3) },
+        ],
+      }),
+    });
+    expect(screen.getByTestId("sidebar-group-session-count").textContent).toBe("(5)");
+  });
+
+  it("renders the Folder fallback icon when the project has no remote owner", () => {
+    renderHeader({ group: group({ remoteOwner: null }) });
+    // The owner avatar is an <img alt={owner}>; with no owner it is absent.
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByTestId("sidebar-group-icon")).not.toBeNull();
+  });
+
+  it("renders the owner avatar when the project has a remote owner", () => {
+    renderHeader({ group: group({ remoteOwner: "octocat" }) });
+    const img = screen.getByRole("img") as HTMLImageElement;
+    expect(img.getAttribute("alt")).toBe("octocat");
+  });
+
+  it("marks the header draggable only when a drag handle is provided", () => {
+    renderHeader({ dragHandle: dragHandle(false) });
+    expect(screen.getByTestId("sidebar-group-header").getAttribute("data-draggable")).toBe("true");
+    cleanup();
+    renderHeader();
+    expect(screen.getByTestId("sidebar-group-header").getAttribute("data-draggable")).toBeNull();
+  });
+
+  it("toggles collapse on a normal click (no drag in flight)", () => {
+    const { onClick } = renderHeader({ dragHandle: dragHandle(false) });
+    fireEvent.click(screen.getByText("my-project"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows clicks on every control while a drag is in flight", () => {
+    const { onClick, onNewSession } = renderHeader({ dragHandle: dragHandle(true) });
+    // Drag active: the row-level capture handler must suppress both the
+    // toggle and the New Session button, not just the toggle.
+    fireEvent.click(screen.getByText("my-project"));
+    fireEvent.click(screen.getByLabelText("New session in my-project"));
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onNewSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps suppressing briefly after the drag ends, then releases", () => {
+    vi.useFakeTimers();
+    try {
+      const onClick = vi.fn();
+      const { rerender } = render(
+        <SidebarGroupHeader
+          group={group()}
+          hasActiveChild={false}
+          onClick={onClick}
+          onNewSession={() => {}}
+          onUpdateAppearance={() => {}}
+          offline={false}
+          dragHandle={dragHandle(true)}
+        />,
+      );
+      // Drag ends: window collapses from Infinity to a short tail.
+      rerender(
+        <SidebarGroupHeader
+          group={group()}
+          hasActiveChild={false}
+          onClick={onClick}
+          onNewSession={() => {}}
+          onUpdateAppearance={() => {}}
+          offline={false}
+          dragHandle={dragHandle(false)}
+        />,
+      );
+      fireEvent.click(screen.getByText("my-project"));
+      expect(onClick).not.toHaveBeenCalled();
+
+      // After the tail expires a click toggles again.
+      vi.advanceTimersByTime(300);
+      fireEvent.click(screen.getByText("my-project"));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -680,6 +680,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.project-row-header",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/__tests__/SidebarGroupHeader.test.tsx"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.empty-state",
       "kind": "mocked-playwright",
       "risk": "low",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -673,6 +673,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx", "web/src/hooks/useRepoGroups.ts"]
     },
     {
+      "id": "sidebar.project-row",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["tests/sidebar-project-row.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.empty-state",
       "kind": "mocked-playwright",
       "risk": "low",

--- a/web/tests/sidebar-group-reorder.spec.ts
+++ b/web/tests/sidebar-group-reorder.spec.ts
@@ -5,14 +5,14 @@
 // server PUT to assert; the round-trip we care about is "drag, then
 // reload, order survives", which works against a fully stubbed /api.
 //
-// The grip is a dedicated drag handle on each real group header
-// (`data-testid='sidebar-group-drag-handle'`); the rest of the header
-// keeps its expand/collapse + context-menu behavior. dnd-kit's
-// MouseSensor activates on an 8px distance, so the drag is
-// mouse.down on the grip -> mouse.move past 8px in steps over the target
-// header -> mouse.up. Synthetic groups have no grip and stay pinned, and
-// group drag is disabled in last-activity sort mode (the order is
-// computed there).
+// There is no dedicated grip anymore (#2207): the whole real group header
+// is the drag activator, while the header keeps its expand/collapse +
+// context-menu behavior. A draggable header carries `data-draggable='true'`.
+// dnd-kit's MouseSensor activates on an 8px distance, so the drag is
+// mouse.down on the header -> mouse.move past 8px in steps over the target
+// header -> mouse.up. Synthetic groups are not draggable and stay pinned,
+// and group drag is disabled in last-activity sort mode (the order is
+// computed there), where the header drops `data-draggable`.
 
 import { test, expect } from "./helpers/mockedTest";
 import type { Page } from "@playwright/test";
@@ -46,20 +46,21 @@ test.describe("sidebar group-header reorder (#1644)", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
 
-    const grips = page.locator("[data-testid='sidebar-group-drag-handle']");
-    await expect(grips).toHaveCount(2);
+    const draggable = page.locator("[data-testid='sidebar-group-header'][data-draggable='true']");
+    await expect(draggable).toHaveCount(2);
 
     const before = await readGroupNames(page);
     expect(before).toHaveLength(2);
 
-    // Drag the bottom group's grip up onto the top group's header.
-    const sourceGrip = await grips.nth(1).boundingBox();
+    // Drag the bottom group's header up onto the top group's header. Grab
+    // near the left (icon/name) to stay clear of the new-session button.
+    const source = await draggable.nth(1).boundingBox();
     const targetHeader = await page.locator("[data-testid='sidebar-group-header']").nth(0).boundingBox();
-    if (!sourceGrip || !targetHeader) throw new Error("drag boxes missing");
+    if (!source || !targetHeader) throw new Error("drag boxes missing");
 
-    await page.mouse.move(sourceGrip.x + sourceGrip.width / 2, sourceGrip.y + sourceGrip.height / 2);
+    await page.mouse.move(source.x + 40, source.y + source.height / 2);
     await page.mouse.down();
-    await page.mouse.move(targetHeader.x + targetHeader.width / 2, targetHeader.y + targetHeader.height / 3, {
+    await page.mouse.move(targetHeader.x + 40, targetHeader.y + targetHeader.height / 3, {
       steps: 12,
     });
     await page.mouse.up();
@@ -69,21 +70,22 @@ test.describe("sidebar group-header reorder (#1644)", () => {
 
     // The order is client-only; a reload re-reads it from localStorage.
     await page.reload();
-    await expect(grips).toHaveCount(2);
+    await expect(draggable).toHaveCount(2);
     await expect.poll(() => readGroupNames(page), { timeout: 4_000 }).toEqual(expected);
   });
 
-  test("group drag handles are absent in last-activity sort mode", async ({ page }) => {
+  test("group headers are not draggable in last-activity sort mode", async ({ page }) => {
     await installSidebarMocks(page, { sessions: twoRepoSessions() });
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
 
-    const grips = page.locator("[data-testid='sidebar-group-drag-handle']");
-    await expect(grips).toHaveCount(2);
+    const draggable = page.locator("[data-testid='sidebar-group-header'][data-draggable='true']");
+    await expect(draggable).toHaveCount(2);
 
     // Flip to last-activity sort; the order is computed there, so the
-    // grips disappear, matching how within-group row drag is gated.
+    // headers lose their drag wiring, matching how within-group row drag
+    // is gated.
     await selectSortMode(page, "lastActivity");
-    await expect(grips).toHaveCount(0);
+    await expect(draggable).toHaveCount(0);
   });
 });

--- a/web/tests/sidebar-project-row.spec.ts
+++ b/web/tests/sidebar-project-row.spec.ts
@@ -1,0 +1,64 @@
+// Mocked coverage for the reworked sidebar project header row (#2207):
+//   - the grip grab bar is gone (`sidebar-group-drag-handle` never renders),
+//   - the project icon shows next to the name at rest while the fold chevron
+//     is hidden, and on row hover they swap (icon hides, chevron reveals),
+//   - a per-project total session count `(N)` is always visible, expanded or
+//     collapsed,
+//   - a stationary click on the header still toggles collapse.
+//
+// Opacity is driven by Tailwind `group-hover` on the header row, so the two
+// layers carry stable testids and we assert their computed opacity.
+
+import { test, expect } from "./helpers/mockedTest";
+import { installSidebarMocks, threeSessionsInOneRepo } from "./helpers/sidebarMocks";
+
+const HEADER = "[data-testid='sidebar-group-header']";
+const ICON = "[data-testid='sidebar-group-icon']";
+const CHEVRON = "[data-testid='sidebar-group-fold-chevron']";
+const COUNT = "[data-testid='sidebar-group-session-count']";
+const ROW = "[data-testid='sidebar-session-row']";
+
+test.describe("sidebar project row rework (#2207)", () => {
+  test("no grab bar; icon shown and chevron hidden at rest", async ({ page }) => {
+    await installSidebarMocks(page, { sessions: threeSessionsInOneRepo() });
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    await expect(page.locator(HEADER)).toHaveCount(1);
+    await expect(page.locator("[data-testid='sidebar-group-drag-handle']")).toHaveCount(0);
+
+    // At rest the icon layer is fully visible and the chevron is hidden.
+    await expect(page.locator(ICON)).toHaveCSS("opacity", "1");
+    await expect(page.locator(CHEVRON)).toHaveCSS("opacity", "0");
+  });
+
+  test("hovering the row swaps the icon for the fold chevron", async ({ page }) => {
+    await installSidebarMocks(page, { sessions: threeSessionsInOneRepo() });
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    await page.locator(HEADER).hover();
+
+    await expect(page.locator(ICON)).toHaveCSS("opacity", "0");
+    await expect(page.locator(CHEVRON)).toHaveCSS("opacity", "1");
+  });
+
+  test("session count is visible and survives collapse", async ({ page }) => {
+    await installSidebarMocks(page, { sessions: threeSessionsInOneRepo() });
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    // Three sessions across three branch workspaces in one project.
+    await expect(page.locator(ROW)).toHaveCount(3);
+    await expect(page.locator(COUNT)).toHaveText("(3)");
+
+    // A stationary click on the header toggles collapse; the count stays.
+    await page.locator(COUNT).click();
+    await expect(page.locator(ROW)).toHaveCount(0);
+    await expect(page.locator(COUNT)).toHaveText("(3)");
+
+    // Click again to expand; rows return.
+    await page.locator(COUNT).click();
+    await expect(page.locator(ROW)).toHaveCount(3);
+  });
+});

--- a/web/tests/sidebar-project-row.spec.ts
+++ b/web/tests/sidebar-project-row.spec.ts
@@ -61,4 +61,29 @@ test.describe("sidebar project row rework (#2207)", () => {
     await page.locator(COUNT).click();
     await expect(page.locator(ROW)).toHaveCount(3);
   });
+
+  test("a drag on the header does not collapse it (trailing click suppressed)", async ({ page }) => {
+    await installSidebarMocks(page, { sessions: threeSessionsInOneRepo() });
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    await expect(page.locator(ROW)).toHaveCount(3);
+
+    const box = await page.locator(HEADER).boundingBox();
+    if (!box) throw new Error("header box missing");
+    const x = box.x + 60;
+    const y = box.y + box.height / 2;
+
+    // Press, move past the 8px dnd activation threshold and back, then
+    // release over the header. The trailing release-click must be swallowed
+    // so the project stays expanded rather than collapsing.
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 16, y, { steps: 6 });
+    await page.mouse.move(x, y, { steps: 6 });
+    await page.mouse.up();
+
+    await expect(page.locator(ROW)).toHaveCount(3);
+    await expect(page.locator(COUNT)).toHaveText("(3)");
+  });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Reworks the web dashboard sidebar project header rows.

- Removes the `GripVertical` grab bar. The whole project header is now the drag activator (mirrors `SessionRow`: spread only dnd-kit `listeners`, not `attributes`, and suppress the trailing click after a drag so reordering a group does not also collapse it). Mouse and touch reorder are preserved; keyboard-drag a11y goes away, exactly as session rows already accept.
- Shows the project icon (the owner avatar, or a `Folder` fallback for projects with no GitHub owner) next to the name at rest, with the fold chevron hidden.
- On row hover, the icon hides and the fold chevron takes its place as the collapse control (Tailwind `group-hover` opacity swap).
- Adds an always-visible per-project total session count `(N)`, summed across the project's workspaces, styled like the snoozed/archived count.

Docs updated for the removed handle and the new chrome. The group-reorder Playwright spec is retargeted to drag the header body, and a new `sidebar-project-row.spec.ts` covers the rework.

Closes #2207

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard with at least one project that has sessions; confirm the project header shows an icon next to the name (owner avatar for GitHub projects, a folder glyph otherwise) and no grab bar.
- [ ] Hover the project header; confirm the icon hides and a fold chevron appears in its place.
- [ ] Click the project header; confirm it collapses/expands the project's sessions.
- [ ] Confirm the header shows `(N)` matching the number of sessions in the project, and that the count stays visible when the project is collapsed.
- [ ] In manual sort mode, press-and-drag a project header onto another to reorder; confirm the order changes and survives a reload, and that the drag did not collapse the dragged project.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (count semantics, hover trigger, dropping the handle), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784215787&installation_id=139138837&pr_number=2216&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2216&signature=ca0775d06ae5b3cf56c42093de2074393f692b3c8b9f894583556b1fb9f16c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR redesigns the web dashboard sidebar **project header rows** to improve reordering usability and make key project information easier to spot.

## What Changed

**Removed:**
- The `GripVertical` grab bar icon on the left of each project row (there’s no longer a separate drag handle).

**Updated:**
- **Drag-and-drop:** you now drag the **entire project header row** to reorder projects.
- **Icon/chevron layout:** the project/owner icon is shown by default; on hover it swaps into the collapse/expand **fold chevron**.
- **Keyboard + focus support:** the same icon/chevron swap behavior also works when the header is focused (not just on mouse hover).
- **Session count visibility:** adds a per-project session count badge that is **always visible** and styled alongside the snoozed/archived count.
- **Safer drag behavior:** suppresses the normal click/toggle that can happen after dragging so a project doesn’t collapse/expand accidentally during or immediately after reordering.
- **Fallback icon:** when there’s no GitHub owner, a **Folder**-style icon is shown.

**Docs/Test updates:**
- Documentation updated to explain that reordering now uses the **project/group header** itself (and to clarify when group dragging is disabled).
- Playwright: added `sidebar-project-row.spec.ts` and retargeted `sidebar-group-reorder.spec.ts` to drag headers instead of handles.
- Vitest/RTL: added focused unit coverage for session-count aggregation, icon branching, drag/click suppression behavior, and the draggable attribute wiring.

## Benefits

- **Cleaner UI:** eliminates persistent visual noise from the grab handle.
- **Easier, more reliable reordering:** larger drag target (the whole header row).
- **Improved information hierarchy:** per-project session counts stay visible and unobstructed across expanded/collapsed states.
- **Fewer accidental toggles:** drag interactions no longer unintentionally trigger collapse/expand.
- **Better accessibility:** hover behavior now also responds correctly to keyboard focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->