### PR TITLE
fix(web): portal the sidebar tooltip so it is not clipped at the panel edge

### DIFF
--- a/web/src/components/Tooltip.tsx
+++ b/web/src/components/Tooltip.tsx
@@ -1,17 +1,88 @@
-import type { ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { clampMenuPosition } from "../lib/menuPosition";
 
 // Shared hover tooltip used by the sidebar control row (grouping axis, filter,
 // new session) and the sort picker. Renders a custom styled span instead of
 // the native browser `title` so every control shares one look. Lives in its
 // own module so SidebarSortPicker can import it without a cycle back through
 // WorkspaceSidebar (which imports SidebarSortPicker).
+//
+// The popup is portaled to document.body and positioned `fixed`, so it escapes
+// any `overflow` ancestor that would otherwise clip it. The sidebar trigger
+// rows live inside an `overflow-x-hidden overflow-y-auto` scroller, so a span
+// nested under the trigger (the old approach) got cut off at the sidebar edge
+// regardless of z-index. See #2214.
 export function Tooltip({ text, children }: { text: string; children: ReactNode }) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const tipRef = useRef<HTMLSpanElement>(null);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+
+  const show = () => {
+    setPos(null);
+    setOpen(true);
+  };
+  const hide = () => {
+    setOpen(false);
+    setPos(null);
+  };
+
+  // Measure the trigger and the tooltip after mount, center the tooltip below
+  // the trigger, and clamp it inside the viewport. Runs before paint so the
+  // tooltip never flashes at an unclamped spot; it stays `visibility: hidden`
+  // until `pos` is set.
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current || !tipRef.current) return;
+    const anchor = triggerRef.current.getBoundingClientRect();
+    const tip = tipRef.current.getBoundingClientRect();
+    setPos(
+      clampMenuPosition({
+        x: anchor.left + anchor.width / 2 - tip.width / 2,
+        y: anchor.bottom + 6,
+        menuWidth: tip.width,
+        menuHeight: tip.height,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      }),
+    );
+  }, [open, text]);
+
+  // A fixed tooltip detaches from its trigger when an ancestor scrolls or the
+  // window resizes; dismiss it rather than tracking the moving anchor. Capture
+  // phase is needed because scroll events on the sidebar scroller do not bubble.
+  useEffect(() => {
+    if (!open) return;
+    window.addEventListener("scroll", hide, true);
+    window.addEventListener("resize", hide);
+    return () => {
+      window.removeEventListener("scroll", hide, true);
+      window.removeEventListener("resize", hide);
+    };
+  }, [open]);
+
   return (
-    <span className="relative group/tip inline-flex">
+    <span
+      ref={triggerRef}
+      className="inline-flex"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
       {children}
-      <span className="pointer-events-none absolute left-1/2 -translate-x-1/2 top-full mt-1.5 px-2 py-1 rounded bg-surface-950 border border-surface-700 text-[11px] text-text-secondary whitespace-nowrap opacity-0 scale-95 transition-all duration-100 group-hover/tip:opacity-100 group-hover/tip:scale-100 z-50">
-        {text}
-      </span>
+      {open &&
+        createPortal(
+          <span
+            ref={tipRef}
+            role="tooltip"
+            style={{ left: pos?.x ?? 0, top: pos?.y ?? 0, visibility: pos ? "visible" : "hidden" }}
+            className="pointer-events-none fixed z-50 px-2 py-1 rounded bg-surface-950 border border-surface-700 text-[11px] text-text-secondary whitespace-nowrap"
+          >
+            {text}
+          </span>,
+          document.body,
+        )}
     </span>
   );
 }

--- a/web/src/components/Tooltip.tsx
+++ b/web/src/components/Tooltip.tsx
@@ -62,14 +62,7 @@ export function Tooltip({ text, children }: { text: string; children: ReactNode 
   }, [open]);
 
   return (
-    <span
-      ref={triggerRef}
-      className="inline-flex"
-      onMouseEnter={show}
-      onMouseLeave={hide}
-      onFocus={show}
-      onBlur={hide}
-    >
+    <span ref={triggerRef} className="inline-flex" onMouseEnter={show} onMouseLeave={hide} onFocus={show} onBlur={hide}>
       {children}
       {open &&
         createPortal(

--- a/web/src/components/__tests__/Tooltip.test.tsx
+++ b/web/src/components/__tests__/Tooltip.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+//
+// Coverage for Tooltip (#2214): the popup must portal out to document.body so
+// it escapes the sidebar scroller's `overflow-x-hidden` clip, rather than
+// rendering as a nested span that gets cut off at the sidebar edge. jsdom
+// cannot measure layout, so this asserts the structural fix (portaled, fixed,
+// role=tooltip, shown/hidden on hover and focus) rather than geometry.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { Tooltip } from "../Tooltip";
+
+afterEach(cleanup);
+
+describe("Tooltip", () => {
+  it("renders no tooltip until hovered", () => {
+    render(
+      <Tooltip text="New session">
+        <button type="button">+</button>
+      </Tooltip>,
+    );
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("portals the popup to document.body on hover and removes it on leave", () => {
+    const { container } = render(
+      <Tooltip text="New session">
+        <button type="button">+</button>
+      </Tooltip>,
+    );
+    const trigger = screen.getByRole("button").parentElement!;
+
+    fireEvent.mouseEnter(trigger);
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip.textContent).toBe("New session");
+    // Portaled directly under body, not nested inside the trigger / render tree.
+    expect(tooltip.parentElement).toBe(document.body);
+    expect(container.contains(tooltip)).toBe(false);
+    // Fixed positioning is what lets it escape the overflow ancestor.
+    expect(tooltip.classList.contains("fixed")).toBe(true);
+
+    fireEvent.mouseLeave(trigger);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("opens on focus and closes on blur", () => {
+    render(
+      <Tooltip text="New session">
+        <button type="button">+</button>
+      </Tooltip>,
+    );
+    const button = screen.getByRole("button");
+
+    fireEvent.focus(button);
+    expect(screen.queryByRole("tooltip")).not.toBeNull();
+
+    fireEvent.blur(button);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+});

--- a/web/tests/sidebar-sort-mode.spec.ts
+++ b/web/tests/sidebar-sort-mode.spec.ts
@@ -381,11 +381,13 @@ test.describe("Sidebar sort picker (#1418, #1640)", () => {
     // No native browser tooltip on the trigger any more.
     await expect(toggle).not.toHaveAttribute("title", /.+/);
 
-    // The active-mode label now lives in the shared Tooltip span, carrying
-    // the same surface-950 styling the group/filter tooltips use.
-    const tip = page.getByText("Sort: manual, drag enabled", { exact: true });
+    // The active-mode label lives in the shared Tooltip, which now portals its
+    // popup to document.body on hover with `position: fixed`, carrying the same
+    // surface-950 styling the group/filter tooltips use (#2214).
+    await toggle.hover();
+    const tip = page.getByRole("tooltip").filter({ hasText: "Sort: manual, drag enabled" });
     await expect(tip).toHaveClass(/bg-surface-950/);
-    await expect(tip).toHaveClass(/group-hover\/tip:opacity-100/);
+    await expect(tip).toHaveClass(/fixed/);
 
     // The scrollable session list is separated from the control row by a top
     // border (the explicit ask in #1836).


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The shared sidebar `Tooltip` rendered its popup as a span nested under the trigger, absolutely positioned. The sidebar's session list is an `overflow-x-hidden overflow-y-auto` scroller, so the per-project new-session "+" tooltip, centered on a button sitting flush at the sidebar's right edge, spilled past that edge and was clipped where the center content panel begins. `z-index` does not help: an element cannot escape an overflow-clipping ancestor.

This renders the popup through a React portal into `document.body` with `position: fixed`, anchored from the trigger's bounding rect and clamped to the viewport with the existing `clampMenuPosition` helper, the same pattern `CopyPathContextMenu` already uses. A fixed popup has the viewport as its containing block, so no `overflow` ancestor can clip it. It shows on hover and keyboard focus, and dismisses on scroll or resize since a fixed popup would otherwise detach from a scrolling trigger. Adds `role="tooltip"` for assistive tech.

All five sidebar `Tooltip` call sites (per-project and global new-session buttons, filter, grouping-axis toggle, sort picker) keep working through the same component.

Closes #2214

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe serve`, open the dashboard with at least one project group in the sidebar.
- [ ] Hover the per-project "+" (new session) button in a group header; the full "New session" tooltip is visible, not cut off at the sidebar / center-panel boundary.
- [ ] Hover the other sidebar controls (global "+", filter, grouping axis, sort) and confirm their tooltips still appear correctly below each control.
- [ ] Tab to the "+" button with the keyboard; the tooltip appears on focus and clears on blur.
- [ ] Hover a "+" near the bottom of a long, scrolled session list, then scroll; the tooltip dismisses rather than floating detached.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the bug is a paint-level overflow clip that a Playwright geometry / bounding-box assertion cannot detect in jsdom or reliably in a browser. Covered instead by a Vitest + RTL structural test (`web/src/components/__tests__/Tooltip.test.tsx`) asserting the popup portals out to `document.body`, carries `role="tooltip"` and the `fixed` class, and mounts on hover/focus and unmounts on leave/blur. `Tooltip.tsx` is already mapped in `coverage-matrix.json` under `sidebar.sort-toggle-ui`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a multi-model design debate, plan, and implementation drafted by Claude under my direction. I made the design calls (portal rewrite over a scoped CSS patch, dismiss-on-scroll, Vitest structural test) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784215922&installation_id=139138837&pr_number=2217&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2217&signature=3b41c43f1864b101d695a4504390188b1eb3e1665bad2e106a413384cc0a8cde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

### Visual Bug Fix (Sidebar Tooltip Clipping)
- Reworked the shared `Tooltip` so tooltips near the sidebar’s right edge are no longer cut off by the sidebar’s overflow/scroll container.
- The tooltip is now rendered outside the sidebar’s DOM flow to avoid being constrained by overflow boundaries.

### Implementation Updates
- **`Tooltip.tsx`**
  - Tooltip content is now **portaled to `document.body`** and positioned using **`fixed`** layout.
  - It calculates placement from the trigger and **keeps the tooltip within the viewport**.
  - Tooltip behavior now supports both **hover and keyboard focus**, and it includes **`role="tooltip"`** for accessibility.
  - It automatically dismisses on **scroll** and **resize** to prevent misplacement.

### Tests
- **`web/src/components/__tests__/Tooltip.test.tsx`**
  - Added Vitest + RTL coverage to confirm:
    - tooltip doesn’t appear until triggered
    - the popup **portals to `document.body`**
    - it uses **fixed-position** behavior
    - it has `role="tooltip"`
    - it mounts/unmounts correctly on hover and focus/blur
- **`web/tests/sidebar-sort-mode.spec.ts`**
  - Updated the Playwright test to validate the sort toggle tooltip using the shared tooltip/portal behavior.

## Scope
- All existing sidebar tooltip instances continue using the same component (no call-site changes): per-project new-session button, global new-session button, filter, grouping-axis toggle, and sort picker.

## Benefits
- Fixes the reported sidebar-edge tooltip clipping issue once, centrally, for all shared tooltip usages.
- Improves accessibility and reliability by supporting keyboard interaction and clearing on scroll/resize.
- Adds regression protection specifically around the portal-based rendering that prevents overflow clipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->