### PR TITLE
feat(web): move Profiles into a Settings tab, drop the sidebar button

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -84,7 +84,7 @@ With a selection active, a bulk action bar shows the count and applicable action
 
 ## Profiles
 
-The Profiles entry in the sidebar footer opens `/profiles` for managing configuration profiles: a left rail lists every profile with a **default** badge; the detail panel lets you create, rename, delete, set the default, and edit a description. **Edit configuration** buttons deep-link into the matching Settings tab scoped to that profile (`/settings/<tab>?profile=<name>`).
+The **Profiles** tab in Settings (`/settings/profiles`, the first entry in the Settings sidebar) manages configuration profiles: a left rail lists every profile with a **default** badge; the detail panel lets you create, rename, delete, set the default, and edit a description. **Edit configuration** buttons deep-link into the matching Settings tab scoped to that profile (`/settings/<tab>?profile=<name>`). The old `/profiles` URL redirects here.
 
 Lifecycle hooks are shown **read-only** here, each labeled with its source (profile override, an override disabling inherited commands, inherited global commands, or none). Hooks run arbitrary shell commands, so they are never writable from the web; edit them in your config file or the TUI. The same applies to the agent-command and environment fields. In read-only mode the create / rename / delete / set-default / description controls are hidden.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -72,7 +72,6 @@ import { MobileMainPane } from "./components/MobileMainPane";
 import { DiffFileViewer } from "./components/diff/DiffFileViewer";
 import { SettingsView } from "./components/SettingsView";
 import { ProjectsView } from "./components/ProjectsView";
-import { ProfilesPage } from "./components/profiles/ProfilesPage";
 import { HelpOverlay } from "./components/HelpOverlay";
 import { useTour } from "./hooks/useTour";
 import { useWelcomePhase } from "./hooks/useWelcomePhase";
@@ -226,7 +225,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const activeSessionId = sessionMatch?.params.sessionId ?? null;
   const showSettings = settingsRootMatch !== null || settingsTabMatch !== null;
   const showProjects = projectsMatch !== null;
-  const showProfiles = profilesMatch !== null;
   const settingsTab = settingsTabMatch?.params.tab ?? null;
 
   const {
@@ -780,18 +778,11 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     }
   }, [navigate, activeSessionId]);
 
-  const handleOpenProfiles = useCallback(() => {
-    navigate("/profiles");
-    if (window.innerWidth < 768) setSidebarOpen(false);
-  }, [navigate]);
-
-  const handleCloseProfiles = useCallback(() => {
-    if (activeSessionId) {
-      navigate(`/session/${encodeURIComponent(activeSessionId)}`);
-    } else {
-      navigate("/");
-    }
-  }, [navigate, activeSessionId]);
+  // Profiles moved into Settings as a tab; redirect the retired standalone
+  // route so old bookmarks and links still land somewhere valid.
+  useEffect(() => {
+    if (profilesMatch) navigate("/settings/profiles", { replace: true });
+  }, [profilesMatch, navigate]);
 
   const handleCloseSettings = useCallback(() => {
     if (activeSessionId) {
@@ -998,16 +989,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             next.set("profile", p);
             setSearchParams(next, { replace: true });
           }}
+          readOnly={serverAbout?.read_only}
         />
       );
     }
 
     if (showProjects) {
       return <ProjectsView onClose={handleCloseProjects} readOnly={serverAbout?.read_only} />;
-    }
-
-    if (showProfiles) {
-      return <ProfilesPage onClose={handleCloseProfiles} readOnly={serverAbout?.read_only} />;
     }
 
     // Refresh on `/session/<id>` paints once with `sessions === []` before
@@ -1246,7 +1234,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     !activeSessionId &&
     !showSettings &&
     !showProjects &&
-    !showProfiles &&
     !showSessionWizard &&
     !showHelp &&
     !showAbout &&
@@ -1291,13 +1278,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           onGoDashboard={handleGoDashboard}
           sidebarColumnVisible={!showSettings && !showProjects && sidebarOpen}
           rightColumnVisible={
-            isMdUp &&
-            !showSettings &&
-            !showProjects &&
-            !showProfiles &&
-            !!activeWorkspace &&
-            !!activeSession &&
-            !diffCollapsed
+            isMdUp && !showSettings && !showProjects && !!activeWorkspace && !!activeSession && !diffCollapsed
           }
         />
 
@@ -1328,7 +1309,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
               onUnpinProject={handleUnpinProject}
               onSettings={handleOpenSettings}
               onProjects={handleOpenProjects}
-              onProfiles={handleOpenProfiles}
               onDeleteSession={handleDeleteSession}
               onStopSession={handleStopSession}
               onStartSession={handleStartSession}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -781,7 +781,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // Profiles moved into Settings as a tab; redirect the retired standalone
   // route so old bookmarks and links still land somewhere valid.
   useEffect(() => {
-    if (profilesMatch) navigate("/settings/profiles", { replace: true });
+    if (profilesMatch) navigate(`/settings/profiles${window.location.search}`, { replace: true });
   }, [profilesMatch, navigate]);
 
   const handleCloseSettings = useCallback(() => {

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { ConnectedDevices } from "./ConnectedDevices";
 import { McpServers } from "./McpServers";
@@ -20,8 +20,10 @@ import { SelectField } from "./settings/FormFields";
 import { DiffSettings } from "./settings/DiffSettings";
 import { TelemetrySettings } from "./settings/TelemetrySettings";
 import { SettingsHeader } from "./settings/SettingsHeader";
+import { ProfilesSection } from "./profiles/ProfilesSection";
 
 type TabId =
+  | "profiles"
   | "session"
   | "sandbox"
   | "worktree"
@@ -39,7 +41,31 @@ type TabId =
   | "mcp"
   | "logging";
 
-type SidebarItem = { kind: "tab"; id: TabId; label: string } | { kind: "divider"; label: string };
+type SidebarItem = { kind: "tab"; id: TabId; label: string; icon?: ReactNode } | { kind: "divider"; label: string };
+
+// ID-card / badge glyph for the Profiles tab. Profiles is the only Settings
+// tab that carries an icon; it sits at the top as a meta-section over the
+// config tabs below it.
+const PROFILES_ICON = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    className="shrink-0"
+  >
+    <rect x="3" y="4" width="18" height="16" rx="2" />
+    <circle cx="9" cy="10" r="2" />
+    <path d="M6 16a3 3 0 0 1 6 0" />
+    <path d="M15 9h3" />
+    <path d="M15 13h3" />
+  </svg>
+);
 
 // Sidebar groups mirror the TUI Settings layout (Appearance / Sessions /
 // Environment / Notifications / Web Dashboard / System) so muscle memory
@@ -52,6 +78,7 @@ type SidebarItem = { kind: "tab"; id: TabId; label: string } | { kind: "divider"
 // tab strips in the DOM.
 export function buildSidebar(): SidebarItem[] {
   return [
+    { kind: "tab", id: "profiles", label: "Profiles", icon: PROFILES_ICON },
     { kind: "divider", label: "Appearance" },
     { kind: "tab", id: "theme", label: "Theme" },
     { kind: "tab", id: "diff", label: "Diff" },
@@ -88,9 +115,12 @@ interface Props {
   /** Notifies the host when the profile changes via the header dropdown,
    *  so it can keep `?profile=` in sync for shareable/refreshable URLs. */
   onSelectProfile?: (profile: string) => void;
+  /** Read-only server: the Profiles tab hides its create/edit controls. */
+  readOnly?: boolean;
 }
 
 const ALL_TAB_IDS = new Set<TabId>([
+  "profiles",
   "session",
   "sandbox",
   "worktree",
@@ -143,7 +173,15 @@ export function resolveSelectedProfile(current: string, profiles: ProfileInfo[])
   return profiles.find((p) => p.is_default)?.name ?? "default";
 }
 
-export function SettingsView({ onClose, tab, onSelectTab, onServerAboutRefresh, profile, onSelectProfile }: Props) {
+export function SettingsView({
+  onClose,
+  tab,
+  onSelectTab,
+  onServerAboutRefresh,
+  profile,
+  onSelectProfile,
+  readOnly,
+}: Props) {
   const offline = useServerDown();
   const [settings, setSettings] = useState<Record<string, unknown> | null>(null);
   const [saving, setSaving] = useState(false);
@@ -329,6 +367,7 @@ export function SettingsView({ onClose, tab, onSelectTab, onServerAboutRefresh, 
   const renderTabContent = () => {
     if (
       !settings &&
+      activeTab !== "profiles" &&
       activeTab !== "notifications" &&
       activeTab !== "terminal" &&
       activeTab !== "security" &&
@@ -373,6 +412,9 @@ export function SettingsView({ onClose, tab, onSelectTab, onServerAboutRefresh, 
     }
 
     switch (activeTab) {
+      case "profiles":
+        return <ProfilesSection readOnly={readOnly} />;
+
       case "session":
         return (
           <div className="space-y-4">
@@ -543,12 +585,13 @@ export function SettingsView({ onClose, tab, onSelectTab, onServerAboutRefresh, 
               <button
                 key={item.id}
                 onClick={() => onSelectTab(item.id)}
-                className={`px-4 py-2.5 text-xs font-medium whitespace-nowrap cursor-pointer transition-colors ${
+                className={`flex items-center gap-1.5 px-4 py-2.5 text-xs font-medium whitespace-nowrap cursor-pointer transition-colors ${
                   activeTab === item.id
                     ? "text-brand-500 border-b-2 border-brand-500"
                     : "text-text-secondary hover:text-text-primary"
                 }`}
               >
+                {item.icon}
                 {item.label}
               </button>
             ),
@@ -572,12 +615,13 @@ export function SettingsView({ onClose, tab, onSelectTab, onServerAboutRefresh, 
               <button
                 key={item.id}
                 onClick={() => onSelectTab(item.id)}
-                className={`px-4 py-2 text-sm text-left cursor-pointer transition-colors ${
+                className={`flex items-center gap-2 px-4 py-2 text-sm text-left cursor-pointer transition-colors ${
                   activeTab === item.id
                     ? "text-brand-500 bg-surface-800 border-r-2 border-brand-500"
                     : "text-text-secondary hover:text-text-primary hover:bg-surface-800/50"
                 }`}
               >
+                {item.icon}
                 {item.label}
               </button>
             ),

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -158,7 +158,6 @@ interface Props {
   onUnpinProject?: (group: SidebarGroup) => void;
   onSettings: () => void;
   onProjects: () => void;
-  onProfiles: () => void;
   onDeleteSession?: (workspaceId: string) => void;
   onStopSession?: (workspaceId: string) => void;
   onStartSession?: (workspaceId: string) => void;
@@ -2011,7 +2010,6 @@ export function WorkspaceSidebar({
   onUnpinProject,
   onSettings,
   onProjects,
-  onProfiles,
   onDeleteSession,
   onStopSession,
   onStartSession,
@@ -2816,28 +2814,6 @@ export function WorkspaceSidebar({
               strokeLinejoin="round"
             >
               <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-            </svg>
-          </button>
-          <button
-            onClick={onProfiles}
-            className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
-            title="Profiles"
-            aria-label="Profiles"
-          >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-              <circle cx="9" cy="7" r="4" />
-              <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
             </svg>
           </button>
           <button

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -17,8 +17,14 @@ import { buildSidebar, resolveSelectedProfile } from "../SettingsView";
 // across surfaces. Asserting the pure config is more robust than querying the
 // DOM, which renders the same list twice (mobile strip + desktop nav).
 describe("buildSidebar", () => {
-  it("matches the TUI grouping order", () => {
-    expect(buildSidebar()).toEqual([
+  it("matches the TUI grouping order, with Profiles pinned first", () => {
+    // Strip the Profiles tab's icon (a ReactNode) so the order assertion stays
+    // a plain structural compare; the icon presence is asserted separately.
+    const order = buildSidebar().map((item) =>
+      item.kind === "tab" ? { kind: item.kind, id: item.id, label: item.label } : item,
+    );
+    expect(order).toEqual([
+      { kind: "tab", id: "profiles", label: "Profiles" },
       { kind: "divider", label: "Appearance" },
       { kind: "tab", id: "theme", label: "Theme" },
       { kind: "tab", id: "diff", label: "Diff" },
@@ -42,6 +48,11 @@ describe("buildSidebar", () => {
       { kind: "tab", id: "telemetry", label: "Telemetry" },
       { kind: "tab", id: "logging", label: "Logging" },
     ]);
+  });
+
+  it("gives the Profiles tab an icon", () => {
+    const profiles = buildSidebar().find((item) => item.kind === "tab" && item.id === "profiles");
+    expect(profiles && "icon" in profiles && profiles.icon).toBeTruthy();
   });
 });
 

--- a/web/src/components/profiles/ProfilesSection.tsx
+++ b/web/src/components/profiles/ProfilesSection.tsx
@@ -15,13 +15,12 @@ import { buildEffectiveHooks } from "../../lib/profileHooks";
 import { HooksReadOnlyPanel } from "./HooksReadOnlyPanel";
 
 interface Props {
-  onClose: () => void;
   readOnly?: boolean;
 }
 
-// Sections deep-linked into the existing Settings page (scoped to the
+// Sections deep-linked into the rest of the Settings tabs (scoped to the
 // selected profile via ?profile=). Per-section editing, including the
-// passphrase-gated sandbox/worktree saves, stays in SettingsView; this page
+// passphrase-gated sandbox/worktree saves, stays in those tabs; this section
 // owns profile-management metadata only.
 const EDIT_SECTIONS: ReadonlyArray<{ tab: string; label: string }> = [
   { tab: "session", label: "Session" },
@@ -36,7 +35,7 @@ function validateName(name: string): string | null {
   return null;
 }
 
-export function ProfilesPage({ onClose, readOnly }: Props) {
+export function ProfilesSection({ readOnly }: Props) {
   const navigate = useNavigate();
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   const [selected, setSelected] = useState<string>("");
@@ -189,83 +188,68 @@ export function ProfilesPage({ onClose, readOnly }: Props) {
   const hookGroups = buildEffectiveHooks(profileSettings?.hooks, globalHooks);
 
   return (
-    <div className="flex flex-col h-full bg-surface-900">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-surface-700/30">
-        <div>
-          <h1 className="text-lg font-semibold text-text-primary">Profiles</h1>
-          <p className="text-xs text-text-dim">Manage configuration profiles and inspect their lifecycle hooks.</p>
-        </div>
-        <div className="flex gap-2">
-          {!readOnly && !creating && !renaming && (
-            <button
-              type="button"
-              onClick={() => {
-                setCreating(true);
-                setInputValue("");
-                setError(null);
-              }}
-              className="px-3 py-1.5 text-sm bg-brand-600 hover:bg-brand-700 text-surface-900 rounded-md cursor-pointer font-medium"
-            >
-              + New profile
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-3 py-1.5 text-sm border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer"
-          >
-            Close
-          </button>
-        </div>
-      </div>
+    <div className="space-y-3" data-testid="profiles-section">
+      <p className="text-xs text-text-dim">Manage configuration profiles and inspect their lifecycle hooks.</p>
+
+      {!readOnly && !creating && !renaming && (
+        <button
+          type="button"
+          onClick={() => {
+            setCreating(true);
+            setInputValue("");
+            setError(null);
+          }}
+          className="px-3 py-1.5 text-sm bg-brand-600 hover:bg-brand-700 text-surface-900 rounded-md cursor-pointer font-medium"
+        >
+          + New profile
+        </button>
+      )}
 
       {error && (
-        <div className="mx-4 mt-3 px-3 py-2 bg-red-900/20 border border-red-700/30 rounded-md">
+        <div className="px-3 py-2 bg-red-900/20 border border-red-700/30 rounded-md">
           <p className="text-sm text-red-400">{error}</p>
         </div>
       )}
 
       {(creating || renaming) && (
-        <div className="px-4 pt-3">
-          <div className="flex gap-2 bg-surface-850 border border-surface-700 rounded-lg p-3">
-            <input
-              type="text"
-              value={inputValue}
-              autoFocus
-              onChange={(e) => {
-                setInputValue(e.target.value);
-                setError(null);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  if (creating) handleCreate();
-                  else handleRename();
-                }
-                if (e.key === "Escape") closeInput();
-              }}
-              placeholder={creating ? "Profile name" : "New name"}
-              className="flex-1 bg-surface-900 border border-surface-700 rounded-md px-2 py-1.5 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
-            />
-            <button
-              type="button"
-              onClick={creating ? handleCreate : handleRename}
-              className="px-3 py-1.5 rounded-md bg-brand-600 hover:bg-brand-500 text-xs font-medium text-surface-950 cursor-pointer"
-            >
-              {creating ? "Create" : "Rename"}
-            </button>
-            <button
-              type="button"
-              onClick={closeInput}
-              className="px-3 py-1.5 rounded-md border border-surface-700 text-xs text-text-secondary hover:bg-surface-800 cursor-pointer"
-            >
-              Cancel
-            </button>
-          </div>
+        <div className="flex gap-2 bg-surface-850 border border-surface-700 rounded-lg p-3">
+          <input
+            type="text"
+            value={inputValue}
+            autoFocus
+            onChange={(e) => {
+              setInputValue(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                if (creating) handleCreate();
+                else handleRename();
+              }
+              if (e.key === "Escape") closeInput();
+            }}
+            placeholder={creating ? "Profile name" : "New name"}
+            className="flex-1 bg-surface-900 border border-surface-700 rounded-md px-2 py-1.5 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={creating ? handleCreate : handleRename}
+            className="px-3 py-1.5 rounded-md bg-brand-600 hover:bg-brand-500 text-xs font-medium text-surface-950 cursor-pointer"
+          >
+            {creating ? "Create" : "Rename"}
+          </button>
+          <button
+            type="button"
+            onClick={closeInput}
+            className="px-3 py-1.5 rounded-md border border-surface-700 text-xs text-text-secondary hover:bg-surface-800 cursor-pointer"
+          >
+            Cancel
+          </button>
         </div>
       )}
 
-      <div className="flex flex-1 min-h-0 gap-4 p-4">
-        <nav className="w-56 shrink-0 flex flex-col gap-1 overflow-y-auto">
+      <div className="flex gap-4">
+        <nav className="w-44 shrink-0 flex flex-col gap-1">
           {profiles.map((p) => (
             <button
               key={p.name}
@@ -288,7 +272,7 @@ export function ProfilesPage({ onClose, readOnly }: Props) {
           ))}
         </nav>
 
-        <div className="flex-1 min-w-0 overflow-y-auto">
+        <div className="flex-1 min-w-0">
           {selectedInfo ? (
             <div className="flex flex-col gap-4">
               <div className="flex items-center gap-2">

--- a/web/src/components/profiles/__tests__/ProfilesSection.test.tsx
+++ b/web/src/components/profiles/__tests__/ProfilesSection.test.tsx
@@ -1,15 +1,15 @@
 // @vitest-environment jsdom
 //
-// Contract + interaction tests for the Profiles page. The security-critical
-// invariant: even though the profile settings GET returns a `hooks` section
-// (unfiltered on reads), no PATCH the page issues may ever carry it. Also
-// exercises the CRUD / set-default / deep-link / read-only paths so the
-// page's handlers are covered without a live backend.
+// Contract + interaction tests for the Profiles settings section. The
+// security-critical invariant: even though the profile settings GET returns a
+// `hooks` section (unfiltered on reads), no PATCH the section issues may ever
+// carry it. Also exercises the CRUD / set-default / deep-link / read-only
+// paths so the section's handlers are covered without a live backend.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
-import { ProfilesPage } from "../ProfilesPage";
+import { ProfilesSection } from "../ProfilesSection";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -79,8 +79,8 @@ function LocationProbe() {
 
 function mount(props: { readOnly?: boolean } = {}) {
   return render(
-    <MemoryRouter initialEntries={["/profiles"]}>
-      <ProfilesPage onClose={() => {}} readOnly={props.readOnly} />
+    <MemoryRouter initialEntries={["/settings/profiles"]}>
+      <ProfilesSection readOnly={props.readOnly} />
       <LocationProbe />
     </MemoryRouter>,
   );
@@ -93,7 +93,7 @@ async function selectWork(api: ReturnType<typeof mount>) {
   fireEvent.click(api.getByRole("button", { name: "work", exact: true }));
 }
 
-describe("ProfilesPage", () => {
+describe("ProfilesSection", () => {
   it("lists profiles with a default badge", async () => {
     const api = mount();
     await waitFor(() => api.getByRole("button", { name: "work", exact: true }));

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -368,7 +368,12 @@
       "kind": "mocked-playwright",
       "risk": "high",
       "specs": ["tests/profiles-page.spec.ts"],
-      "components": ["web/src/components/profiles/ProfilesPage.tsx"]
+      "components": [
+        "web/src/components/profiles/ProfilesSection.tsx",
+        "web/src/components/SettingsView.tsx",
+        "web/src/App.tsx",
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
     },
     {
       "id": "profiles.hooks-readonly",
@@ -381,15 +386,15 @@
       "id": "profiles.write-guard",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/lib/api.test.ts", "src/components/profiles/__tests__/ProfilesPage.test.tsx"],
-      "components": ["web/src/components/profiles/ProfilesPage.tsx"]
+      "specs": ["src/lib/api.test.ts", "src/components/profiles/__tests__/ProfilesSection.test.tsx"],
+      "components": ["web/src/components/profiles/ProfilesSection.tsx"]
     },
     {
       "id": "profiles.description-edit-race",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/profiles/__tests__/ProfilesPage.test.tsx"],
-      "components": ["web/src/components/profiles/ProfilesPage.tsx"]
+      "specs": ["src/components/profiles/__tests__/ProfilesSection.test.tsx"],
+      "components": ["web/src/components/profiles/ProfilesSection.tsx"]
     },
     {
       "id": "profiles.override",

--- a/web/tests/profiles-page.spec.ts
+++ b/web/tests/profiles-page.spec.ts
@@ -1,13 +1,14 @@
-// Dedicated Profiles page (/profiles): CRUD + set-default + description
-// round-trips, the deep-link into Settings (?profile=), the sidebar-footer
-// entry point, the read-only mode, and the hooks panel invariant. Ported from
-// live to the mocked suite: a stateful in-route profile store stands in for
-// the backend, so "persists" assertions check the store and the post-reload
-// UI rather than a real config file.
+// Profiles settings tab (/settings/profiles): CRUD + set-default + description
+// round-trips, the deep-link into other Settings tabs (?profile=), the retired
+// /profiles redirect, the absence of the old sidebar button, the read-only
+// mode, and the hooks panel invariant. Ported from live to the mocked suite: a
+// stateful in-route profile store stands in for the backend, so "persists"
+// assertions check the store and the post-reload UI rather than a real config
+// file.
 //
 // Component-level handler details (the hooks-never-PATCHed invariant across
 // every interaction, the in-flight description edit race) are pinned in
-// ProfilesPage.test.tsx; this spec covers the app-level wiring: routing,
+// ProfilesSection.test.tsx; this spec covers the app-level wiring: routing,
 // the /api/about read_only flag, and the dropdown/rail refresh loops.
 
 import { test, expect } from "./helpers/mockedTest";
@@ -112,7 +113,7 @@ async function installProfilesPageMocks(
 }
 
 async function openProfiles(page: Page) {
-  await page.goto("/profiles");
+  await page.goto("/settings/profiles");
   await expect(page.getByRole("heading", { name: "Profiles" })).toBeVisible();
 }
 
@@ -164,7 +165,8 @@ test("Edit configuration deep-links into Settings scoped to the profile", async 
   await openProfiles(page);
 
   await page.getByRole("button", { name: "work", exact: true }).click();
-  await page.getByRole("button", { name: /^Session/ }).click();
+  // The arrow disambiguates the "Session ->" deep-link from the "Session" nav tab.
+  await page.getByRole("button", { name: "Session →" }).click();
 
   await expect(page).toHaveURL(/\/settings\/session\?profile=work/);
   const profileSelect = page
@@ -174,15 +176,18 @@ test("Edit configuration deep-links into Settings scoped to the profile", async 
   await expect(profileSelect).toHaveValue("work");
 });
 
-test("opens from the sidebar footer and closes back to the dashboard", async ({ page }) => {
+test("the retired /profiles route redirects into the Settings Profiles tab", async ({ page }) => {
+  await installProfilesPageMocks(page);
+  await page.goto("/profiles");
+  await expect(page).toHaveURL(/\/settings\/profiles$/);
+  await expect(page.getByRole("heading", { name: "Profiles" })).toBeVisible();
+});
+
+test("the dashboard sidebar footer no longer has a Profiles button", async ({ page }) => {
   await installProfilesPageMocks(page);
   await page.goto("/");
-  await page.getByRole("button", { name: "Profiles", exact: true }).click();
-  await expect(page).toHaveURL(/\/profiles$/);
-  await expect(page.getByRole("heading", { name: "Profiles" })).toBeVisible();
-
-  await page.getByRole("button", { name: "Close" }).click();
-  await expect(page).not.toHaveURL(/\/profiles/);
+  await expect(page.getByRole("button", { name: "Settings", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Profiles", exact: true })).toHaveCount(0);
 });
 
 test("read-only mode hides every mutation control", async ({ page }) => {
@@ -190,11 +195,14 @@ test("read-only mode hides every mutation control", async ({ page }) => {
   await openProfiles(page);
   await page.getByRole("button", { name: "work", exact: true }).click();
 
-  await expect(page.getByPlaceholder("What this profile is for")).toBeVisible();
-  await expect(page.getByRole("button", { name: "+ New profile" })).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "Set as default" })).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "Rename" })).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0);
+  // Scope to the section: the Settings header's ProfileSelector has its own
+  // create/rename/delete controls (tracked separately) that we are not asserting here.
+  const section = page.getByTestId("profiles-section");
+  await expect(section.getByPlaceholder("What this profile is for")).toBeVisible();
+  await expect(section.getByRole("button", { name: "+ New profile" })).toHaveCount(0);
+  await expect(section.getByRole("button", { name: "Set as default" })).toHaveCount(0);
+  await expect(section.getByRole("button", { name: "Rename" })).toHaveCount(0);
+  await expect(section.getByRole("button", { name: "Save" })).toHaveCount(0);
 });
 
 test("lifecycle hooks render read-only with the explain-why note", async ({ page }) => {

--- a/web/tests/profiles-page.spec.ts
+++ b/web/tests/profiles-page.spec.ts
@@ -181,6 +181,10 @@ test("the retired /profiles route redirects into the Settings Profiles tab", asy
   await page.goto("/profiles");
   await expect(page).toHaveURL(/\/settings\/profiles$/);
   await expect(page.getByRole("heading", { name: "Profiles" })).toBeVisible();
+
+  // The redirect preserves any query string (e.g. a ?profile= deep link).
+  await page.goto("/profiles?profile=work");
+  await expect(page).toHaveURL(/\/settings\/profiles\?profile=work$/);
 });
 
 test("the dashboard sidebar footer no longer has a Profiles button", async ({ page }) => {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Profiles used to live on their own top-level route (`/profiles`), reached from a button in the bottom-sidebar icon strip next to Projects and Settings. That split configuration across two places, and the page did not even edit profile settings itself: its "Edit configuration" buttons deep-linked back into Settings tabs, and Settings already had a `ProfileSelector` in its header.

This PR finishes the move. Profiles is now the first tab in the Settings sidebar, marked with an ID-card icon, rendering the same profile list, details, description editor, deep-links, and read-only hooks panel as before. The standalone `ProfilesPage` is refactored into `ProfilesSection` (the page header and Close chrome are dropped, since the Settings shell owns them). The bottom-sidebar Profiles button is removed, and the retired `/profiles` URL redirects to `/settings/profiles`, preserving any query string so existing `?profile=` deep links keep working.

User-observable impact: Profiles is reached only through Settings now; the bottom sidebar has one fewer button.

Closes #2211

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, click the Settings (gear) button, confirm "Profiles" is the first tab in the Settings sidebar and shows an ID-card icon.
- [ ] On the Profiles tab, create / rename / delete a profile and set a default; confirm each change sticks and the header profile selector reflects it.
- [ ] Click an "Edit configuration" button (e.g. Session); confirm it opens that Settings tab scoped to the profile (`/settings/session?profile=<name>`).
- [ ] Confirm the bottom sidebar no longer has a Profiles button.
- [ ] Visit `/profiles` directly; confirm it redirects to `/settings/profiles`. Visit `/profiles?profile=work`; confirm it lands on `/settings/profiles?profile=work`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (remove the sidebar button, Profiles tab with an ID-card icon, redirect rather than delete the old route), reviewed each commit, and ran the test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784216152&installation_id=139138837&pr_number=2218&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2218&signature=d44adb3601cda3f927f1a4236f27153abb4fb9af0ab13318b18a22b87b7aaa60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR consolidates Profiles configuration from a standalone page into the Settings view, eliminating duplication and confusion around profile management. Previously, profiles could be accessed in two separate locations—a standalone `/profiles` page and through the Settings view—which created fragmented user experience. This change unifies profile management into a single, integrated tab within Settings.

## What Moved
- **Profiles configuration**: Moved from a standalone `/profiles` page to the first tab in the Settings sidebar (marked with an ID-card icon)
- **Profile management controls**: Now accessed exclusively through the Settings interface

## What Was Removed
- Standalone `/profiles` route and its associated page component
- Bottom-sidebar "Profiles" button for navigation
- Page-level chrome (header, close button) from the Profiles view—now owned by the Settings shell

## What Was Added
- **Profiles tab**: Added as the first tab in the Settings sidebar with appropriate icon styling
- **Redirect mechanism**: The old `/profiles` URL now redirects to `/settings/profiles`, preserving query string parameters to maintain compatibility with existing deep-links (e.g., `?profile=work`)
- **Read-only support**: Added `readOnly` prop to ProfilesSection to hide create/edit controls in restricted environments

## What Changed
- **Component refactoring**: `ProfilesPage` component renamed to `ProfilesSection` with simplified props (removed `onClose`)
- **Settings enhancements**: Updated SettingsView to handle Profiles as a dedicated tab with icon support
- **Sidebar updates**: WorkspaceSidebar now exposes `onProjects` callback instead of `onProfiles`
- **Test coverage**: Updated tests to target the new `/settings/profiles` path and verify redirect behavior

## Benefits
- **Single source of truth**: All profile configuration is now in one place, reducing user confusion
- **Better information architecture**: Profiles tab logically grouped with other settings
- **Backward compatibility**: Existing bookmarks and deep-links continue to work through automatic redirects
- **Cleaner navigation**: Eliminated the sidebar button clutter and simplified navigation patterns
- **Improved UX**: No need to toggle between different pages for profile-related tasks

---

## Technical Details

**Component Structure:**
- `ProfilesPage` → `ProfilesSection`: Component refactored to work as a Settings tab rather than a standalone page
- Props changed from `{ onClose, readOnly }` to `{ readOnly }` only
- Removed overflow-auto behavior from right-side content container
- JSX restructured to remove header and close button chrome

**Router and Navigation:**
- Removed `ProfilesPage` import and rendering from App.tsx
- Added effect to watch `profilesMatch` and redirect to `/settings/profiles` using `window.location.search` to preserve query parameters
- Removed `showProfiles` router state and simplified UI gating conditions

**Component Updates:**
- `SettingsView`: Added PROFILES_ICON glyph, extended sidebar tab shape to support icons, updated `buildSidebar()` to include profiles tab, simplified settings-loading fallback guard
- `WorkspaceSidebar`: Replaced `onProfiles` prop with `onProjects` prop, swapped Profiles button with Projects button in bottom navigation

**Test Coverage:**
- Updated test paths from `/profiles` to `/settings/profiles`
- Added coverage for `/profiles` redirect behavior with query string preservation
- Added assertions for Profiles tab icon presence
- Verified sidebar Profiles button removal
- Updated scope of read-only assertions to target `profiles-section` specifically

**Documentation:**
- Updated dashboard guide to reference `/settings/profiles` instead of `/profiles`
- Noted redirect behavior for existing users
- Updated coverage-matrix.json to reflect new component dependencies (ProfilesSection, SettingsView, App, WorkspaceSidebar)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->