### PR TITLE
feat(settings): full-text settings search on the web, fuzzy matching on both surfaces

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -32,6 +32,10 @@ The command palette (top-bar button or keyboard shortcut) is a fuzzy launcher fo
 
 Individual settings also appear in the palette under `Settings`. A writable toggle flips inline from the palette (a toast confirms, and the subtitle shows its current state and scope); every other setting opens the settings view on its tab. Read-only servers and settings that need elevation jump to the settings view instead of writing.
 
+## Settings search
+
+The search box in the Settings header filters every setting by name and description as you type, with the same fuzzy matching as the command palette (so `mcw` finds **Max Concurrent Workers**). Picking a result jumps to that setting's tab, scrolls the field into view, and briefly highlights it, opening the **Advanced** fold when the setting lives inside it. Search spans every tab, so you can find a setting without knowing which tab it is on. The TUI settings screen has the same fuzzy search behind the `/` key.
+
 ## First-run onboarding
 
 The first time you open the dashboard in a browser, a **Choose your theme** card appears before anything else. Picking a theme applies it live and saves it to your default profile; you can switch freely, then click **Continue**. Change it later in Settings > Appearance. The card is skipped in read-only mode and for anyone who already finished the tutorial.

--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -30,11 +30,7 @@ Choosing a profile seeds the agent-step defaults. If you have already edited a f
 
 The command palette (top-bar button or keyboard shortcut) is a fuzzy launcher for global actions: jump to a session, open settings, start a new session, toggle the right panel.
 
-Individual settings also appear in the palette under `Settings`. A writable toggle flips inline from the palette (a toast confirms, and the subtitle shows its current state and scope); every other setting opens the settings view on its tab. Read-only servers and settings that need elevation jump to the settings view instead of writing.
-
-## Settings search
-
-The search box in the Settings header filters schema-backed settings by name and description as you type, with the same fuzzy matching as the command palette (so `mcw` finds **Max Concurrent Workers**). Picking a result jumps to that setting's tab, scrolls the field into view, and briefly highlights it, opening the **Advanced** fold when the setting lives inside it. Search spans schema-backed settings tabs, so you can find a setting without knowing its tab first. The TUI settings screen has the same fuzzy search behind the `/` key.
+Individual settings also appear in the palette under `Settings`. A writable toggle flips inline from the palette (a toast confirms, and the subtitle shows its current state and scope); every other setting opens the settings view on its tab. Read-only servers and settings that need elevation jump to the settings view instead of writing. The Settings header also has its own search box (and the TUI settings screen the `/` key) that filters settings across every tab and jumps to the one you pick.
 
 ## First-run onboarding
 

--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -34,7 +34,7 @@ Individual settings also appear in the palette under `Settings`. A writable togg
 
 ## Settings search
 
-The search box in the Settings header filters every setting by name and description as you type, with the same fuzzy matching as the command palette (so `mcw` finds **Max Concurrent Workers**). Picking a result jumps to that setting's tab, scrolls the field into view, and briefly highlights it, opening the **Advanced** fold when the setting lives inside it. Search spans every tab, so you can find a setting without knowing which tab it is on. The TUI settings screen has the same fuzzy search behind the `/` key.
+The search box in the Settings header filters schema-backed settings by name and description as you type, with the same fuzzy matching as the command palette (so `mcw` finds **Max Concurrent Workers**). Picking a result jumps to that setting's tab, scrolls the field into view, and briefly highlights it, opening the **Advanced** fold when the setting lives inside it. Search spans schema-backed settings tabs, so you can find a setting without knowing its tab first. The TUI settings screen has the same fuzzy search behind the `/` key.
 
 ## First-run onboarding
 

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -29,6 +29,41 @@ fn config_to_json<T: serde::Serialize>(value: &T) -> serde_json::Value {
     serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
 }
 
+/// Fuzzy-score a field's searchable text against a settings-search query.
+/// The query is split on whitespace and every token must fuzzy-match the
+/// haystack (AND semantics, preserving the old substring search's behavior so
+/// "max workers" still matches "Max Concurrent Workers"); the per-token scores
+/// are summed so closer matches rank higher. An empty query scores every field
+/// 0, which keeps the overlay listing all fields in their natural order. The
+/// fuzzy match also covers acronyms, so "mcw" finds "Max Concurrent Workers".
+/// Reuses the same nucleo pattern as the command palette.
+fn fuzzy_settings_score(query: &str, haystack: &str) -> Option<u32> {
+    use nucleo_matcher::pattern::{Atom, AtomKind, CaseMatching, Normalization};
+    use nucleo_matcher::{Config, Matcher, Utf32Str};
+
+    let tokens: Vec<&str> = query.split_whitespace().collect();
+    if tokens.is_empty() {
+        return Some(0);
+    }
+
+    let mut matcher = Matcher::new(Config::DEFAULT);
+    let mut buf = Vec::new();
+    let mut total: u32 = 0;
+    for token in tokens {
+        let atom = Atom::new(
+            token,
+            CaseMatching::Ignore,
+            Normalization::Smart,
+            AtomKind::Fuzzy,
+            false,
+        );
+        let h = Utf32Str::new(haystack, &mut buf);
+        let score = atom.score(h, &mut matcher)?;
+        total += score as u32;
+    }
+    Some(total)
+}
+
 /// Which scope of settings is being edited
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SettingsScope {
@@ -689,7 +724,6 @@ impl SettingsView {
             .as_ref()
             .map(|i| i.value().to_string())
             .unwrap_or_default();
-        let tokens: Vec<String> = query.split_whitespace().map(|t| t.to_lowercase()).collect();
 
         let (scope_for_fields, global_ref, profile_ref) = match self.scope {
             SettingsScope::Global => (
@@ -709,7 +743,7 @@ impl SettingsView {
             ),
         };
 
-        let mut hits: Vec<SearchHit> = Vec::new();
+        let mut scored: Vec<(SearchHit, u32)> = Vec::new();
         for category in self.categories.iter().filter_map(|r| r.as_tab()) {
             let fields = fields::build_fields_for_category(
                 category,
@@ -721,24 +755,26 @@ impl SettingsView {
                 if field.is_section_header() {
                     continue;
                 }
-                let label_lower = field.label.to_lowercase();
-                let desc_lower = field.description.to_lowercase();
-                let matches_all = tokens
-                    .iter()
-                    .all(|t| label_lower.contains(t) || desc_lower.contains(t));
-                if !matches_all {
+                let haystack = format!("{} {}", field.label, field.description);
+                let Some(score) = fuzzy_settings_score(&query, &haystack) else {
                     continue;
-                }
-                hits.push(SearchHit {
-                    category,
-                    field_ident: field.ident(),
-                    field_label: field.label.clone(),
-                    category_label: category.label(),
-                });
+                };
+                scored.push((
+                    SearchHit {
+                        category,
+                        field_ident: field.ident(),
+                        field_label: field.label.clone(),
+                        category_label: category.label(),
+                    },
+                    score,
+                ));
             }
         }
 
-        self.search_hits = hits;
+        // Stable sort by score descending: ties (and the empty-query case where
+        // every field scores 0) keep their natural (category, field) order.
+        scored.sort_by_key(|(_, score)| std::cmp::Reverse(*score));
+        self.search_hits = scored.into_iter().map(|(hit, _)| hit).collect();
         if self.search_selected >= self.search_hits.len() {
             self.search_selected = self.search_hits.len().saturating_sub(1);
         }
@@ -835,6 +871,49 @@ mod dirty_tracking_tests {
         assert!(
             view.has_changes,
             "the post-save baseline tracks the saved value"
+        );
+    }
+}
+
+#[cfg(test)]
+mod search_tests {
+    use super::fuzzy_settings_score;
+
+    const HAYSTACK: &str = "Max Concurrent Workers How many agents run at once";
+
+    /// An empty query scores every field 0 so the overlay lists all of them.
+    #[test]
+    fn empty_query_matches_everything() {
+        assert_eq!(fuzzy_settings_score("", HAYSTACK), Some(0));
+        assert_eq!(fuzzy_settings_score("   ", HAYSTACK), Some(0));
+    }
+
+    /// The acronym story: "mcw" must fuzzy-match "Max Concurrent Workers" and
+    /// rank above a weaker match, which the old substring search could not do.
+    #[test]
+    fn acronym_matches_and_ranks_top() {
+        let target = fuzzy_settings_score("mcw", HAYSTACK);
+        assert!(
+            target.is_some(),
+            "'mcw' should match Max Concurrent Workers"
+        );
+
+        let weaker = fuzzy_settings_score("mcw", "Theme How the dashboard looks");
+        assert!(
+            weaker.is_none(),
+            "'mcw' should not match an unrelated field"
+        );
+    }
+
+    /// Multi-token queries keep AND semantics: every whitespace token must
+    /// match, so "max workers" still finds the field even out of order.
+    #[test]
+    fn multi_token_requires_all_tokens() {
+        assert!(fuzzy_settings_score("max workers", HAYSTACK).is_some());
+        assert!(fuzzy_settings_score("workers max", HAYSTACK).is_some());
+        assert!(
+            fuzzy_settings_score("max banana", HAYSTACK).is_none(),
+            "a token with no match drops the field"
         );
     }
 }

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -21,8 +21,10 @@ import { DiffSettings } from "./settings/DiffSettings";
 import { TelemetrySettings } from "./settings/TelemetrySettings";
 import { SettingsHeader } from "./settings/SettingsHeader";
 import { ProfilesSection } from "./profiles/ProfilesSection";
+import { SettingsSearch } from "./settings/SettingsSearch";
+import type { SettingsSearchHit } from "./settings/settingsSearchIndex";
 
-type TabId =
+export type TabId =
   | "profiles"
   | "session"
   | "sandbox"
@@ -226,6 +228,19 @@ export function SettingsView({
   const [schema, setSchema] = useState<SettingsFieldDescriptor[]>([]);
   const [schemaLoading, setSchemaLoading] = useState(true);
   const [schemaError, setSchemaError] = useState<string | null>(null);
+  // Set when a settings-search hit is chosen: switch to the hit's tab and ask
+  // the matching SchemaSection to scroll the field into view and highlight it.
+  // The nonce bumps on every jump so re-selecting the same field (or jumping to
+  // an advanced field on the current tab) re-triggers the scroll and reopens
+  // the Advanced fold via the content-subtree remount key.
+  const [focusRequest, setFocusRequest] = useState<{ section: string; field: string; nonce: number } | null>(null);
+  const handleSearchJump = useCallback(
+    (hit: SettingsSearchHit) => {
+      setFocusRequest((prev) => ({ section: hit.section, field: hit.field, nonce: (prev?.nonce ?? 0) + 1 }));
+      onSelectTab(hit.tab);
+    },
+    [onSelectTab],
+  );
 
   useEffect(() => {
     fetchProfiles().then((p) => {
@@ -436,6 +451,7 @@ export function SettingsView({
               <SchemaSection
                 section="session"
                 schema={schema}
+                focusRequest={focusRequest}
                 values={session}
                 onSaveField={saveSubField}
                 advancedSubtitle="Idle auto-stop, attach modes, live-send, and other session tuning."
@@ -449,6 +465,7 @@ export function SettingsView({
           <SchemaSection
             section="sandbox"
             schema={schema}
+            focusRequest={focusRequest}
             values={sandbox}
             onSaveField={saveSubField}
             advancedSubtitle="Resource limits, custom instructions, environment, volumes, and ports."
@@ -460,6 +477,7 @@ export function SettingsView({
           <SchemaSection
             section="worktree"
             schema={schema}
+            focusRequest={focusRequest}
             values={worktree}
             onSaveField={saveSubField}
             advancedSubtitle="Bare-repo and workspace path templates, branch cleanup, and submodules."
@@ -471,6 +489,7 @@ export function SettingsView({
           <SchemaSection
             section="theme"
             schema={schema}
+            focusRequest={focusRequest}
             values={(settings?.theme ?? {}) as Record<string, unknown>}
             onSaveField={saveThemeField}
           />
@@ -482,6 +501,7 @@ export function SettingsView({
           <SchemaSection
             section="sound"
             schema={schema}
+            focusRequest={focusRequest}
             values={(settings?.sound ?? {}) as Record<string, unknown>}
             onSaveField={saveSubField}
           />
@@ -491,6 +511,7 @@ export function SettingsView({
           <SchemaSection
             section="tmux"
             schema={schema}
+            focusRequest={focusRequest}
             values={(settings?.tmux ?? {}) as Record<string, unknown>}
             onSaveField={saveSubField}
           />
@@ -500,6 +521,7 @@ export function SettingsView({
           <SchemaSection
             section="updates"
             schema={schema}
+            focusRequest={focusRequest}
             values={(settings?.updates ?? {}) as Record<string, unknown>}
             onSaveField={saveSubField}
           />
@@ -511,6 +533,7 @@ export function SettingsView({
           <SchemaSection
             section="logging"
             schema={schema}
+            focusRequest={focusRequest}
             values={(settings?.logging ?? {}) as Record<string, unknown>}
             onSaveField={saveSubField}
             advancedSubtitle="Sink and rotation; some fields require restarting aoe to take effect."
@@ -528,7 +551,15 @@ export function SettingsView({
                 Controls which session events trigger push notifications on the server.
               </p>
               {schemaGuard() ??
-                (settings && <SchemaSection section="web" schema={schema} values={web} onSaveField={saveSubField} />)}
+                (settings && (
+                  <SchemaSection
+                    section="web"
+                    schema={schema}
+                    focusRequest={focusRequest}
+                    values={web}
+                    onSaveField={saveSubField}
+                  />
+                ))}
             </div>
           </div>
         );
@@ -556,6 +587,7 @@ export function SettingsView({
             <SchemaSection
               section="acp"
               schema={schema}
+              focusRequest={focusRequest}
               values={acp}
               onSaveField={saveSubField}
               // The acp section mirrors three fields into serverAbout, which
@@ -640,6 +672,8 @@ export function SettingsView({
           <div className="p-6 max-w-2xl mx-auto space-y-5">
             <h2 className="text-lg font-semibold text-text-bright">{currentTabLabel}</h2>
 
+            <SettingsSearch schema={schema} loading={schemaLoading} onJump={handleSearchJump} />
+
             {offline && (
               <div className="text-sm text-status-error bg-status-error/10 rounded-lg p-3">
                 {OFFLINE_TITLE}: toggles will not save while disconnected.
@@ -657,7 +691,7 @@ export function SettingsView({
                 selectedProfile from its "" seed to the default does not remount
                 mid-interaction and collapse a just-expanded fold. */}
             <fieldset
-              key={`${activeTab}-${profileEpoch}`}
+              key={`${activeTab}-${profileEpoch}-${focusRequest?.nonce ?? 0}`}
               disabled={offline}
               className="space-y-5 disabled:opacity-50 border-0 m-0 p-0 min-w-0"
             >

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -21,7 +21,6 @@ import { DiffSettings } from "./settings/DiffSettings";
 import { TelemetrySettings } from "./settings/TelemetrySettings";
 import { SettingsHeader } from "./settings/SettingsHeader";
 import { ProfilesSection } from "./profiles/ProfilesSection";
-import { SettingsSearch } from "./settings/SettingsSearch";
 import type { SettingsSearchHit } from "./settings/settingsSearchIndex";
 
 export type TabId =
@@ -612,6 +611,9 @@ export function SettingsView({
         saveError={saveError}
         selectedProfile={selectedProfile}
         onSelectProfile={handleSelectProfile}
+        schema={schema}
+        schemaLoading={schemaLoading}
+        onSearchJump={handleSearchJump}
       />
 
       {/* Mobile tabs (horizontal scroll) */}
@@ -671,8 +673,6 @@ export function SettingsView({
         <div className="flex-1 overflow-y-auto">
           <div className="p-6 max-w-2xl mx-auto space-y-5">
             <h2 className="text-lg font-semibold text-text-bright">{currentTabLabel}</h2>
-
-            <SettingsSearch schema={schema} loading={schemaLoading} onJump={handleSearchJump} />
 
             {offline && (
               <div className="text-sm text-status-error bg-status-error/10 rounded-lg p-3">

--- a/web/src/components/settings/SchemaSection.tsx
+++ b/web/src/components/settings/SchemaSection.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { SettingsFieldDescriptor, SettingsValidation } from "../../lib/types";
 import {
   CollapsibleSection,
@@ -28,6 +29,12 @@ interface Props {
    *  (consumed live by ToolCards / the composer); widget-specific effects
    *  (e.g. theme repaint) live in the custom widget itself, not here. */
   onAfterSave?: (descriptor: SettingsFieldDescriptor, value: unknown) => Promise<void> | void;
+  /** Set by a settings-search jump. When `section` matches this section, the
+   *  named field is scrolled into view and briefly highlighted, and the
+   *  Advanced fold opens if the target lives inside it. The `nonce` only
+   *  participates in the SettingsView remount key; this component reacts to the
+   *  fresh mount. */
+  focusRequest?: { section: string; field: string; nonce: number } | null;
 }
 
 /** Client-side list-entry validator derived from the server's validation rule,
@@ -176,10 +183,50 @@ function renderField(
  * grouped under an "Advanced" fold to match the TUI. `custom` widgets render
  * via the custom-widget registry (`customWidgets.tsx`).
  */
-export function SchemaSection({ section, schema, values, onSaveField, advancedSubtitle, onAfterSave }: Props) {
+export function SchemaSection({
+  section,
+  schema,
+  values,
+  onSaveField,
+  advancedSubtitle,
+  onAfterSave,
+  focusRequest,
+}: Props) {
   const fields = schema.filter((d) => d.section === section && d.web_write.policy !== "local_only");
   const primary = fields.filter((d) => !d.advanced);
   const advanced = fields.filter((d) => d.advanced);
+
+  // A settings-search jump targeting this section: scroll the field into view
+  // (effect below) and open the Advanced fold if the field lives there. The
+  // flash is a one-shot CSS animation on the target wrapper, which replays on
+  // every jump because SettingsView remounts this subtree on the focus nonce.
+  const targetField = focusRequest && focusRequest.section === section ? focusRequest.field : null;
+  const targetAdvanced = !!targetField && advanced.some((d) => d.field === targetField);
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!targetField || !targetRef.current) return;
+    const el = targetRef.current;
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    const raf = requestAnimationFrame(() =>
+      el.scrollIntoView({ block: "center", behavior: reduce ? "auto" : "smooth" }),
+    );
+    return () => cancelAnimationFrame(raf);
+  }, [targetField]);
+
+  const wrap = (d: SettingsFieldDescriptor, node: React.ReactNode) => {
+    const isTarget = d.field === targetField;
+    return (
+      <div
+        key={d.field}
+        ref={isTarget ? targetRef : undefined}
+        data-settings-field={`${d.section}.${d.field}`}
+        className={isTarget ? "animate-settings-highlight" : undefined}
+      >
+        {node}
+      </div>
+    );
+  };
 
   // Wrap onSaveField so a successful save in this section runs the optional
   // section-level hook once. Custom widgets receive this same `save`, so their
@@ -204,10 +251,10 @@ export function SchemaSection({ section, schema, values, onSaveField, advancedSu
 
   return (
     <div className="space-y-4">
-      {primary.map((d) => renderField(d, values, makeSave(d)))}
+      {primary.map((d) => wrap(d, renderField(d, values, makeSave(d))))}
       {advanced.length > 0 && (
-        <CollapsibleSection title="Advanced" subtitle={advancedSubtitle}>
-          {advanced.map((d) => renderField(d, values, makeSave(d)))}
+        <CollapsibleSection title="Advanced" subtitle={advancedSubtitle} defaultOpen={targetAdvanced}>
+          {advanced.map((d) => wrap(d, renderField(d, values, makeSave(d))))}
         </CollapsibleSection>
       )}
     </div>

--- a/web/src/components/settings/SchemaSection.tsx
+++ b/web/src/components/settings/SchemaSection.tsx
@@ -207,7 +207,7 @@ export function SchemaSection({
   useEffect(() => {
     if (!targetField || !targetRef.current) return;
     const el = targetRef.current;
-    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
     const raf = requestAnimationFrame(() =>
       el.scrollIntoView({ block: "center", behavior: reduce ? "auto" : "smooth" }),
     );

--- a/web/src/components/settings/SettingsHeader.tsx
+++ b/web/src/components/settings/SettingsHeader.tsx
@@ -1,4 +1,7 @@
 import { ProfileSelector } from "./ProfileSelector";
+import { SettingsSearch } from "./SettingsSearch";
+import type { SettingsFieldDescriptor } from "../../lib/types";
+import type { SettingsSearchHit } from "./settingsSearchIndex";
 
 interface Props {
   onClose: () => void;
@@ -6,13 +9,25 @@ interface Props {
   saveError: string | null;
   selectedProfile: string;
   onSelectProfile: (profile: string) => void;
+  schema: SettingsFieldDescriptor[];
+  schemaLoading: boolean;
+  onSearchJump: (hit: SettingsSearchHit) => void;
 }
 
-// Settings header. ProfileSelector wraps onto its own row on mobile via
-// `basis-full` so the Back affordance and title keep their space; on md+
-// the wrapper switches to `basis-auto ml-auto` for a single-row layout
-// with the picker aligned right.
-export function SettingsHeader({ onClose, saving, saveError, selectedProfile, onSelectProfile }: Props) {
+// Settings header. The search box takes the flexible middle (full-width row on
+// mobile); ProfileSelector wraps onto its own row on mobile via `basis-full`
+// so the Back affordance and title keep their space; on md+ both sit on a
+// single row with the picker aligned right.
+export function SettingsHeader({
+  onClose,
+  saving,
+  saveError,
+  selectedProfile,
+  onSelectProfile,
+  schema,
+  schemaLoading,
+  onSearchJump,
+}: Props) {
   return (
     <div
       data-testid="settings-header"
@@ -31,7 +46,10 @@ export function SettingsHeader({ onClose, saving, saveError, selectedProfile, on
           {saveError}
         </span>
       )}
-      <div className="basis-full flex justify-center overflow-x-auto md:basis-auto md:ml-auto md:overflow-visible md:justify-end shrink-0">
+      <div className="basis-full md:basis-auto md:flex-1 md:min-w-0 md:max-w-sm md:ml-auto">
+        <SettingsSearch schema={schema} loading={schemaLoading} onJump={onSearchJump} />
+      </div>
+      <div className="basis-full flex justify-center overflow-x-auto md:basis-auto md:overflow-visible md:justify-end shrink-0">
         <ProfileSelector selectedProfile={selectedProfile} onSelect={onSelectProfile} />
       </div>
     </div>

--- a/web/src/components/settings/SettingsSearch.tsx
+++ b/web/src/components/settings/SettingsSearch.tsx
@@ -1,0 +1,64 @@
+import { useMemo, useState } from "react";
+import { Command } from "cmdk";
+import type { SettingsFieldDescriptor } from "../../lib/types";
+import { buildSettingsSearchIndex, type SettingsSearchHit } from "./settingsSearchIndex";
+
+interface Props {
+  schema: SettingsFieldDescriptor[];
+  loading: boolean;
+  onJump: (hit: SettingsSearchHit) => void;
+}
+
+// Full-text settings search. Sits above the tab content and filters the
+// schema-backed settings as you type, mirroring the TUI `/` overlay: selecting
+// a hit jumps to that field's tab (SettingsView scrolls it into view). cmdk
+// provides the fuzzy filtering and arrow/Enter keyboard navigation; the index
+// is built once from the cached schema.
+export function SettingsSearch({ schema, loading, onJump }: Props) {
+  const [query, setQuery] = useState("");
+  const index = useMemo(() => buildSettingsSearchIndex(schema), [schema]);
+  const open = query.trim().length > 0;
+
+  const jump = (hit: SettingsSearchHit) => {
+    onJump(hit);
+    setQuery("");
+  };
+
+  return (
+    <Command
+      label="Search settings"
+      data-testid="settings-search"
+      className="relative"
+      // Let the click on a result fire before the list unmounts on blur.
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Command.Input
+        value={query}
+        onValueChange={setQuery}
+        placeholder={loading ? "Loading settings..." : "Search settings..."}
+        disabled={loading}
+        className="w-full rounded-md bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-text-primary outline-none placeholder:text-text-muted focus:border-brand-500 disabled:opacity-50"
+      />
+      {open && (
+        <Command.List className="absolute left-0 right-0 top-full mt-1 z-20 max-h-[40vh] overflow-y-auto rounded-md border border-surface-700 bg-surface-800 p-1 shadow-2xl">
+          <Command.Empty className="px-3 py-4 text-center text-sm text-text-muted">No matching settings</Command.Empty>
+          {index.map((hit) => (
+            <Command.Item
+              key={`${hit.section}.${hit.field}`}
+              value={`${hit.section}.${hit.field} ${hit.searchText}`}
+              onSelect={() => jump(hit)}
+              data-testid={`settings-search-hit-${hit.section}-${hit.field}`}
+              className="flex items-center gap-2 px-3 py-2 rounded-md cursor-pointer text-sm text-text-primary data-[selected=true]:bg-surface-700 data-[selected=true]:text-text-bright"
+            >
+              <span className="truncate">{hit.label}</span>
+              <span className="flex-1" />
+              <span className="shrink-0 text-[10px] font-mono uppercase tracking-wider text-text-muted">
+                {hit.category}
+              </span>
+            </Command.Item>
+          ))}
+        </Command.List>
+      )}
+    </Command>
+  );
+}

--- a/web/src/components/settings/SettingsSearch.tsx
+++ b/web/src/components/settings/SettingsSearch.tsx
@@ -9,7 +9,7 @@ interface Props {
   onJump: (hit: SettingsSearchHit) => void;
 }
 
-// Full-text settings search. Sits above the tab content and filters the
+// Full-text settings search. Sits in the settings header and filters the
 // schema-backed settings as you type, mirroring the TUI `/` overlay: selecting
 // a hit jumps to that field's tab (SettingsView scrolls it into view). cmdk
 // provides the fuzzy filtering and arrow/Enter keyboard navigation; the index

--- a/web/src/components/settings/__tests__/SettingsHeader.test.tsx
+++ b/web/src/components/settings/__tests__/SettingsHeader.test.tsx
@@ -29,6 +29,9 @@ describe("SettingsHeader", () => {
     saveError: null as string | null,
     selectedProfile: "default",
     onSelectProfile: () => {},
+    schema: [],
+    schemaLoading: false,
+    onSearchJump: () => {},
   };
 
   it("renders Back button and Settings title", () => {

--- a/web/src/components/settings/__tests__/SettingsSearch.test.tsx
+++ b/web/src/components/settings/__tests__/SettingsSearch.test.tsx
@@ -29,7 +29,12 @@ function descriptor(
 
 const SCHEMA: SettingsFieldDescriptor[] = [
   descriptor({ section: "theme", field: "name", label: "Theme", category: "Theme" }),
-  descriptor({ section: "acp", field: "show_tool_durations", label: "Show tool-call durations", category: "Structured view" }),
+  descriptor({
+    section: "acp",
+    field: "show_tool_durations",
+    label: "Show tool-call durations",
+    category: "Structured view",
+  }),
 ];
 
 describe("SettingsSearch", () => {

--- a/web/src/components/settings/__tests__/SettingsSearch.test.tsx
+++ b/web/src/components/settings/__tests__/SettingsSearch.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+//
+// Pins the web settings search box: it stays closed until you type, filters
+// the schema-backed settings, and emits the chosen hit (with its resolved jump
+// tab) through onJump so SettingsView can switch tabs and scroll to the field.
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SettingsSearch } from "../SettingsSearch";
+import type { SettingsFieldDescriptor } from "../../../lib/types";
+
+const ALLOW = { policy: "allow" } as const;
+const NONE = { rule: "none" } as const;
+
+function descriptor(
+  over: Partial<SettingsFieldDescriptor> & Pick<SettingsFieldDescriptor, "section" | "field" | "label">,
+): SettingsFieldDescriptor {
+  return {
+    category: "Sandbox",
+    description: "",
+    widget: { kind: "toggle" },
+    web_write: ALLOW,
+    profile_overridable: true,
+    validation: NONE,
+    advanced: false,
+    ...over,
+  };
+}
+
+const SCHEMA: SettingsFieldDescriptor[] = [
+  descriptor({ section: "theme", field: "name", label: "Theme", category: "Theme" }),
+  descriptor({ section: "acp", field: "show_tool_durations", label: "Show tool-call durations", category: "Structured view" }),
+];
+
+describe("SettingsSearch", () => {
+  // This repo's component tests do not load jest-dom, so assertions use plain
+  // DOM presence (queryBy -> null) instead of toBeInTheDocument.
+  it("shows no result list until the user types", () => {
+    render(<SettingsSearch schema={SCHEMA} loading={false} onJump={vi.fn()} />);
+    expect(screen.queryByText("Theme")).toBeNull();
+    expect(screen.queryByText("No matching settings")).toBeNull();
+  });
+
+  it("filters to matching settings and jumps with the resolved tab on select", () => {
+    const onJump = vi.fn();
+    render(<SettingsSearch schema={SCHEMA} loading={false} onJump={onJump} />);
+
+    const input = screen.getByPlaceholderText("Search settings...");
+    fireEvent.change(input, { target: { value: "tool" } });
+
+    // The matching hit shows; the unrelated one is filtered out.
+    const hit = screen.getByTestId("settings-search-hit-acp-show_tool_durations");
+    expect(hit).toBeTruthy();
+    expect(screen.queryByTestId("settings-search-hit-theme-name")).toBeNull();
+
+    fireEvent.click(hit);
+    expect(onJump).toHaveBeenCalledTimes(1);
+    expect(onJump).toHaveBeenCalledWith(
+      expect.objectContaining({ section: "acp", field: "show_tool_durations", tab: "structured-view" }),
+    );
+  });
+
+  it("disables the input while the schema is loading", () => {
+    render(<SettingsSearch schema={[]} loading={true} onJump={vi.fn()} />);
+    expect((screen.getByPlaceholderText("Loading settings...") as HTMLInputElement).disabled).toBe(true);
+  });
+});

--- a/web/src/components/settings/__tests__/settingsSearchIndex.test.ts
+++ b/web/src/components/settings/__tests__/settingsSearchIndex.test.ts
@@ -1,0 +1,85 @@
+// Unit test for the settings-search index builder. The index is what the
+// web search box filters over, so this pins the inclusion rules: skip fields
+// the dashboard cannot write, skip sections with no web tab (a hit must be
+// able to jump somewhere), and map web/acp to their non-identity tabs.
+
+import { describe, expect, it } from "vitest";
+import { buildSettingsSearchIndex, SECTION_TO_TAB } from "../settingsSearchIndex";
+import type { SettingsFieldDescriptor } from "../../../lib/types";
+
+const ALLOW = { policy: "allow" } as const;
+const NONE = { rule: "none" } as const;
+
+function descriptor(
+  over: Partial<SettingsFieldDescriptor> & Pick<SettingsFieldDescriptor, "section" | "field" | "label">,
+): SettingsFieldDescriptor {
+  return {
+    category: "Sandbox",
+    description: "",
+    widget: { kind: "toggle" },
+    web_write: ALLOW,
+    profile_overridable: true,
+    validation: NONE,
+    advanced: false,
+    ...over,
+  };
+}
+
+describe("buildSettingsSearchIndex", () => {
+  it("includes schema-backed writable fields and resolves the jump tab", () => {
+    const index = buildSettingsSearchIndex([
+      descriptor({ section: "sandbox", field: "enabled_by_default", label: "Enabled by Default" }),
+      descriptor({ section: "acp", field: "show_tool_durations", label: "Show tool-call durations" }),
+      descriptor({ section: "web", field: "notify_on_idle", label: "Notify on idle" }),
+    ]);
+
+    expect(index.map((h) => `${h.section}.${h.field}`)).toEqual([
+      "sandbox.enabled_by_default",
+      "acp.show_tool_durations",
+      "web.notify_on_idle",
+    ]);
+    // acp and web are the non-identity mappings.
+    expect(index.find((h) => h.section === "acp")?.tab).toBe("structured-view");
+    expect(index.find((h) => h.section === "web")?.tab).toBe("notifications");
+    expect(index.find((h) => h.section === "sandbox")?.tab).toBe("sandbox");
+  });
+
+  it("skips local_only fields the server rejects", () => {
+    const index = buildSettingsSearchIndex([
+      descriptor({
+        section: "sandbox",
+        field: "node_path",
+        label: "Node path",
+        web_write: { policy: "local_only", reason: "host binary" },
+      }),
+    ]);
+    expect(index).toHaveLength(0);
+  });
+
+  it("skips sections with no web tab so every hit can jump", () => {
+    const index = buildSettingsSearchIndex([
+      descriptor({ section: "diff", field: "context_lines", label: "Context lines" }),
+      descriptor({ section: "made_up", field: "x", label: "X" }),
+      descriptor({ section: "tmux", field: "prefix", label: "Prefix" }),
+    ]);
+    expect(index.map((h) => h.section)).toEqual(["tmux"]);
+  });
+
+  it("packs label, description, section, and field into the searchable text", () => {
+    const [hit] = buildSettingsSearchIndex([
+      descriptor({
+        section: "session",
+        field: "max_concurrent_workers",
+        label: "Max Concurrent Workers",
+        description: "How many agents run at once",
+      }),
+    ]);
+    expect(hit.searchText).toBe("Max Concurrent Workers How many agents run at once session max_concurrent_workers");
+  });
+
+  it("maps every section in SECTION_TO_TAB to a real tab id", () => {
+    // Drift guard: a section listed here but pointing at a tab that no longer
+    // exists would silently swallow its fields' search hits.
+    expect(Object.values(SECTION_TO_TAB).every((tab) => typeof tab === "string" && tab.length > 0)).toBe(true);
+  });
+});

--- a/web/src/components/settings/settingsSearchIndex.ts
+++ b/web/src/components/settings/settingsSearchIndex.ts
@@ -1,0 +1,56 @@
+import type { SettingsFieldDescriptor } from "../../lib/types";
+import type { TabId } from "../SettingsView";
+
+// Maps a schema section to the settings tab that renders it. Identity for most
+// sections; `web` lives under the Notifications tab and `acp` under the
+// Structured view tab (see renderTabContent in SettingsView). Sections absent
+// here have no web tab, so their fields are excluded from search: a hit must be
+// able to jump somewhere.
+export const SECTION_TO_TAB: Record<string, TabId> = {
+  session: "session",
+  sandbox: "sandbox",
+  worktree: "worktree",
+  theme: "theme",
+  sound: "sound",
+  tmux: "tmux",
+  updates: "updates",
+  logging: "logging",
+  web: "notifications",
+  acp: "structured-view",
+};
+
+export interface SettingsSearchHit {
+  section: string;
+  field: string;
+  tab: TabId;
+  label: string;
+  description: string;
+  /** Settings tab label shown as a badge next to the hit. */
+  category: string;
+  advanced: boolean;
+  /** Text the fuzzy filter matches against: label, description, section, field. */
+  searchText: string;
+}
+
+// Build the searchable settings index from the schema. Skips fields the
+// dashboard cannot write (`local_only`, rejected by the server PATCH) and
+// sections with no web tab, mirroring what SchemaSection actually renders.
+export function buildSettingsSearchIndex(schema: SettingsFieldDescriptor[]): SettingsSearchHit[] {
+  const hits: SettingsSearchHit[] = [];
+  for (const d of schema) {
+    if (d.web_write.policy === "local_only") continue;
+    const tab = SECTION_TO_TAB[d.section];
+    if (!tab) continue;
+    hits.push({
+      section: d.section,
+      field: d.field,
+      tab,
+      label: d.label,
+      description: d.description,
+      category: d.category,
+      advanced: d.advanced,
+      searchText: `${d.label} ${d.description} ${d.section} ${d.field}`,
+    });
+  }
+  return hits;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -400,7 +400,7 @@ body {
   }
 }
 .animate-settings-highlight {
-  animation: settings-search-highlight 1.6s ease-out;
+  animation: settings-search-highlight 300ms cubic-bezier(0.16, 1, 0.3, 1);
   border-radius: 0.5rem;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -387,6 +387,28 @@ body {
   animation: slide-in-right 0.2s ease-out;
 }
 
+/* One-shot flash for the field a settings-search jump lands on. The target
+   wrapper remounts on each jump (SettingsView keys the content subtree on the
+   focus nonce), so the animation replays without any JS timer or state. */
+@keyframes settings-search-highlight {
+  0%,
+  60% {
+    box-shadow: 0 0 0 2px var(--color-brand-500);
+  }
+  100% {
+    box-shadow: 0 0 0 2px transparent;
+  }
+}
+.animate-settings-highlight {
+  animation: settings-search-highlight 1.6s ease-out;
+  border-radius: 0.5rem;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-settings-highlight {
+    animation: none;
+  }
+}
+
 /* Focus indicators for keyboard navigation */
 button:focus-visible,
 a:focus-visible,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -275,6 +275,28 @@
       "components": ["web/src/components/SettingsView.tsx"]
     },
     {
+      "id": "settings.search",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["tests/settings-search.spec.ts"],
+      "components": [
+        "web/src/components/settings/SettingsSearch.tsx",
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/SchemaSection.tsx",
+        "web/src/index.css"
+      ]
+    },
+    {
+      "id": "settings.search.index",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/settings/__tests__/settingsSearchIndex.test.ts",
+        "src/components/settings/__tests__/SettingsSearch.test.tsx"
+      ],
+      "components": ["web/src/components/settings/SettingsSearch.tsx"]
+    },
+    {
       "id": "settings.advanced-fold",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -294,7 +294,10 @@
         "src/components/settings/__tests__/settingsSearchIndex.test.ts",
         "src/components/settings/__tests__/SettingsSearch.test.tsx"
       ],
-      "components": ["web/src/components/settings/SettingsSearch.tsx"]
+      "components": [
+        "web/src/components/settings/SettingsSearch.tsx",
+        "web/src/components/settings/settingsSearchIndex.ts"
+      ]
     },
     {
       "id": "settings.advanced-fold",

--- a/web/tests/settings-search.spec.ts
+++ b/web/tests/settings-search.spec.ts
@@ -11,10 +11,35 @@ const ALLOW = { policy: "allow" };
 const NONE = { rule: "none" };
 
 const SCHEMA = [
-  { section: "sandbox", field: "enabled_by_default", label: "Enabled by Default", widget: { kind: "toggle" }, advanced: false },
-  { section: "acp", field: "show_tool_durations", label: "Show tool-call durations", widget: { kind: "toggle" }, advanced: false },
-  { section: "acp", field: "replay_bytes", label: "Replay buffer bytes", widget: { kind: "number", min: 0 }, advanced: true },
-].map((d) => ({ category: d.section, description: "", profile_overridable: true, validation: NONE, web_write: ALLOW, ...d }));
+  {
+    section: "sandbox",
+    field: "enabled_by_default",
+    label: "Enabled by Default",
+    widget: { kind: "toggle" },
+    advanced: false,
+  },
+  {
+    section: "acp",
+    field: "show_tool_durations",
+    label: "Show tool-call durations",
+    widget: { kind: "toggle" },
+    advanced: false,
+  },
+  {
+    section: "acp",
+    field: "replay_bytes",
+    label: "Replay buffer bytes",
+    widget: { kind: "number", min: 0 },
+    advanced: true,
+  },
+].map((d) => ({
+  category: d.section,
+  description: "",
+  profile_overridable: true,
+  validation: NONE,
+  web_write: ALLOW,
+  ...d,
+}));
 
 async function installMocks(page: Page) {
   await page.route(

--- a/web/tests/settings-search.spec.ts
+++ b/web/tests/settings-search.spec.ts
@@ -1,0 +1,78 @@
+// Full-text settings search (#2213): typing in the settings search box filters
+// the schema-backed settings to a hit list, and selecting a hit jumps to that
+// field's tab and scrolls/highlights the field, opening the Advanced fold when
+// the target lives inside it. The RTL suites pin the index and the box in
+// isolation; this spec is the real-DOM cross-tab jump.
+
+import { test, expect } from "./helpers/mockedTest";
+import type { Page } from "@playwright/test";
+
+const ALLOW = { policy: "allow" };
+const NONE = { rule: "none" };
+
+const SCHEMA = [
+  { section: "sandbox", field: "enabled_by_default", label: "Enabled by Default", widget: { kind: "toggle" }, advanced: false },
+  { section: "acp", field: "show_tool_durations", label: "Show tool-call durations", widget: { kind: "toggle" }, advanced: false },
+  { section: "acp", field: "replay_bytes", label: "Replay buffer bytes", widget: { kind: "number", min: 0 }, advanced: true },
+].map((d) => ({ category: d.section, description: "", profile_overridable: true, validation: NONE, web_write: ALLOW, ...d }));
+
+async function installMocks(page: Page) {
+  await page.route(
+    (url) => url.pathname === "/api/sessions",
+    (r) => r.fulfill({ json: { sessions: [], workspace_ordering: [] } }),
+  );
+  await page.route(
+    (url) => url.pathname === "/api/about",
+    (r) => r.fulfill({ json: { read_only: false, auth_mode: "none", behind_tunnel: false, profile: "main" } }),
+  );
+  await page.route(
+    (url) => url.pathname === "/api/profiles",
+    (r) => r.fulfill({ json: [{ name: "main", is_default: true }] }),
+  );
+  await page.route(
+    (url) => url.pathname === "/api/settings/schema",
+    (r) => r.fulfill({ json: SCHEMA }),
+  );
+  await page.route(
+    (url) => url.pathname === "/api/settings",
+    (r) => r.fulfill({ json: { sandbox: {}, acp: {} } }),
+  );
+  await page.route(
+    (url) => /^\/api\/profiles\/[^/]+\/settings$/.test(url.pathname),
+    (route) => route.fulfill({ json: { ok: true } }),
+  );
+}
+
+test("search jumps to a primary field on another tab and highlights it", async ({ page }) => {
+  await installMocks(page);
+  await page.goto("/settings/sandbox");
+
+  await expect(page.getByText("Enabled by Default")).toBeVisible();
+
+  await page.getByPlaceholder("Search settings...").fill("durations");
+
+  // The matching hit is listed; the unrelated sandbox field is filtered out.
+  const hit = page.getByTestId("settings-search-hit-acp-show_tool_durations");
+  await expect(hit).toBeVisible();
+  await expect(page.getByTestId("settings-search-hit-sandbox-enabled_by_default")).toHaveCount(0);
+
+  await hit.click();
+
+  // Jumped to the Structured view tab and the field is scrolled in + flashed.
+  await expect(page.getByRole("heading", { name: "Structured view" })).toBeVisible();
+  const target = page.locator('[data-settings-field="acp.show_tool_durations"]');
+  await expect(target).toBeVisible();
+  await expect(target).toHaveClass(/animate-settings-highlight/);
+});
+
+test("search opens the Advanced fold when the target field lives inside it", async ({ page }) => {
+  await installMocks(page);
+  await page.goto("/settings/sandbox");
+
+  await page.getByPlaceholder("Search settings...").fill("replay");
+  await page.getByTestId("settings-search-hit-acp-replay_bytes").click();
+
+  // The advanced field is visible without manually expanding the fold.
+  await expect(page.getByRole("heading", { name: "Structured view" })).toBeVisible();
+  await expect(page.locator('[data-settings-field="acp.replay_bytes"]')).toBeVisible();
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a full-text settings search to the web dashboard and upgrades both surfaces to fuzzy matching, closing the gap where the web Settings view had no search at all (16 hardcoded tabs) and the TUI `/` overlay only did plain substring matching.

Web: a search box sits above the settings tab content. Typing fuzzy-filters every schema-backed setting (via cmdk) into a hit list; selecting a hit jumps to that setting's tab, scrolls the field into view, briefly highlights it, and opens the **Advanced** fold when the setting lives inside it. The index covers all schema-backed sections (skipping `local_only` fields and sections with no web tab), so you can find a setting without knowing its tab.

TUI: `recompute_search_hits` swaps the substring AND-token test for a per-token nucleo fuzzy score (the same matcher the command palette uses), summed and ranked. Acronyms like `mcw` now find "Max Concurrent Workers"; multi-token queries keep AND semantics; an empty query still lists every field in natural order.

No new dependencies (reuses `nucleo-matcher` and `cmdk`) and no backend changes (the schema is already fetched and cached).

Closes #2213

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the web dashboard, open Settings and type `worker` in the search box; confirm only matching settings show in the hit list.
- [ ] Click a hit that lives on a different tab; confirm the tab switches, the field scrolls into view, and it flashes briefly.
- [ ] Search for a setting that lives under an **Advanced** fold and select it; confirm the fold opens with the field visible.
- [ ] In the TUI settings screen, press `/` and type `mcw`; confirm "Max Concurrent Workers" matches and ranks at the top.
- [ ] In the TUI search, type `max workers`; confirm it still matches (multi-token AND), and an empty query lists every field.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: the TUI change is a pure scoring helper covered by unit tests (`src/tui/settings/mod.rs`), not a rendering or lifecycle change

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult on the design. I made the design calls (web + TUI fuzzy, schema-backed only, filter-in-place + jump list), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784223024&installation_id=139138837&pr_number=2223&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2223&signature=3e214f4f01face01fa2bc4bcedf4684df94c707664942379cce46b0c1ea38df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds ranked, full-text fuzzy search for Settings on both the web dashboard and the TUI, making it much easier to find the right setting and jump to it directly.

## What Changed

### Web Dashboard
- Added a **Settings search box** in the Settings header that fuzzy-filters all schema-backed settings as you type.
- Implemented **click-to-jump focus**: selecting a result switches to the right tab, scrolls the matched field into view, and briefly highlights it.
- Added **automatic “Advanced” expansion** when the matched setting lives inside the Advanced section.
- Limited results to what the UI can actually navigate to (skips `local_only` fields and sections without a web tab).
- Added a dedicated search component and **indexing helper** to build searchable text and tab targets.
- Updated and expanded **end-to-end and unit tests**, plus coverage configuration.

### TUI
- Upgraded the `/` settings search from simple substring filtering to **per-token fuzzy scoring**, then ranked results.
- Preserved multi-token “AND” behavior while enabling abbreviation-style matches (e.g., `mcw` → “Max Concurrent Workers”).
- Added **unit tests** for the fuzzy scoring logic.

### Docs
- Updated the web dashboard guide to mention that **Settings includes its own search**.

## Benefits
- Faster settings discovery across many tabs with **better matching** (fuzzy + abbreviations).
- Stronger “search to location” flow: results take you directly to the exact field with **scroll + highlight**, and Advanced is opened when needed.
- Reuses existing dependencies (web: `cmdk`, TUI: `nucleo-matcher`) and works without backend changes since the schema is already available.

## Potential Areas for Further Enhancement
- The new web search indexing/focus plumbing is designed to be reusable, supporting future flows such as command palette adjustments (mentioned in the objectives).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->