### PR TITLE
fix(session): preserve sid on ambiguous resume failure

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -43,9 +43,12 @@ submits the whole message.
 | --- | --- | --- |
 | `200` | `{"sent": true}` | Keys delivered to the tmux pane |
 | `400` | `{"error": "message_empty"}` | `message` is empty or whitespace-only |
+| `400` | `{"error": "acp_mode_unsupported"}` | Session is structured-view/ACP mode and has no tmux pane |
 | `403` | `{"error": "read_only"}` | Server is in read-only mode |
 | `404` | `{"error": "not_found"}` | No session with that id |
 | `409` | `{"error": "session_not_running"}` | Session exists but the tmux pane is gone |
+| `409` | `{"error": "resume_failed", "message": "...", "resume_session_id": "..."}` | Auto-revive tried to resume a stored conversation, but the pane exited before AoE could prove the ID invalid. The ID is preserved for explicit retry or replacement. |
+| `409` | `{"error": "session_transient", "status": "..."}` | Session is mid-lifecycle and cannot accept input yet |
 | `500` | `{"error": "tmux_error"}` or `{"error": "internal"}` | Unexpected failure (logged server-side) |
 
 Concurrent POSTs to the same `id` are serialized server-side, so two

--- a/docs/guides/session-resume.md
+++ b/docs/guides/session-resume.md
@@ -12,7 +12,9 @@ Pin a session to a specific Claude conversation:
 aoe session set-session-id <session-name-or-id> <claude-session-uuid>
 ```
 
-The pin is sticky: every launch passes `--resume <uuid>` until you change it. If a pinned conversation becomes invalid, the next launch starts fresh automatically.
+The pin is sticky: every launch passes `--resume <uuid>` until you change it. If AoE cannot prove whether a pinned conversation is invalid and only sees the resumed pane exit, it preserves the pinned ID and reports a recoverable resume failure instead of starting fresh automatically.
+
+Retry after fixing the underlying issue, set a different conversation ID, or explicitly start fresh once with the command below.
 
 Start fresh once:
 
@@ -35,7 +37,9 @@ State lives in `sessions.json` in your AoE config directory:
 - **Linux**: `$XDG_CONFIG_HOME/agent-of-empires/profiles/<profile>/sessions.json`
 - **macOS/Windows**: `~/.agent-of-empires/profiles/<profile>/sessions.json`
 
-Two relevant fields:
+Three relevant fields:
 
 - `agent_session_id`: the observed conversation ID. Auto-managed; do not edit.
 - `resume_intent`: your intent (`Default`, `Use(uuid)`, `Cleared`). Set via the CLI above. Absent when `Default`.
+- `resume_probe_failed_sid`: the last pinned ID whose resume probe failed ambiguously.
+  This loop-breaker prevents startup recovery from retrying that same ID automatically until user action changes the resume state.

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -63,6 +63,9 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
                         stale_history_suffix(&sid),
                     );
                 }
+                Ok(EnsureReadyOutcome::ResumeFailed { sid }) => {
+                    bail!("Resume failed for sid {sid}; preserved for explicit retry")
+                }
                 Ok(EnsureReadyOutcome::AlreadyAlive) => {}
                 Err(EnsureReadyError::Transient(status)) => {
                     bail!("Session is mid-lifecycle ({status:?}); cannot send right now")

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -3,7 +3,6 @@
 use anyhow::{bail, Result};
 use clap::Args;
 
-use crate::cli::session::stale_history_suffix;
 use crate::session::{EnsureReadyError, EnsureReadyOutcome, Storage};
 
 #[derive(Args)]
@@ -41,27 +40,11 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     if !args.no_revive {
         if let Some(target) = instances.iter_mut().find(|i| i.id == session_id) {
             match target.ensure_pane_ready() {
-                Ok(EnsureReadyOutcome::Respawned { stale_sid: None }) => {
+                Ok(EnsureReadyOutcome::Respawned) => {
                     eprintln!("  (respawned dead pane before send)");
                 }
-                Ok(EnsureReadyOutcome::Respawned {
-                    stale_sid: Some(sid),
-                }) => {
-                    eprintln!(
-                        "  (respawned dead pane before send){}",
-                        stale_history_suffix(&sid),
-                    );
-                }
-                Ok(EnsureReadyOutcome::Started { stale_sid: None }) => {
+                Ok(EnsureReadyOutcome::Started) => {
                     eprintln!("  (started stopped session before send)");
-                }
-                Ok(EnsureReadyOutcome::Started {
-                    stale_sid: Some(sid),
-                }) => {
-                    eprintln!(
-                        "  (started stopped session before send){}",
-                        stale_history_suffix(&sid),
-                    );
                 }
                 Ok(EnsureReadyOutcome::ResumeFailed { sid }) => {
                     bail!("Resume failed for sid {sid}; preserved for explicit retry")

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -7,10 +7,6 @@ use std::collections::HashSet;
 
 use crate::session::{GroupTree, StartOutcome, Storage};
 
-pub(crate) fn stale_history_suffix(stale_sid: &str) -> String {
-    format!(" (resume target {stale_sid} was reset; started fresh, prior history not loaded)")
-}
-
 #[derive(Subcommand)]
 pub enum SessionCommands {
     /// Start a session's tmux process
@@ -580,28 +576,21 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         });
     }
 
-    let mut succeeded: Vec<(String, String, Option<String>)> = Vec::new();
+    let mut succeeded: Vec<(String, String)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
-    let mut restarted: Vec<(crate::session::Instance, Option<String>)> = Vec::new();
+    let mut restarted: Vec<crate::session::Instance> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
         let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
-        let stale_sid = match &result {
-            Ok(StartOutcome::Restarted { stale_sid }) => Some(stale_sid.clone()),
-            _ => None,
-        };
         let id = inst_opt.as_ref().map(|i| i.id.clone()).unwrap_or_default();
         if let Some(inst) = inst_opt {
-            restarted.push((inst, stale_sid.clone()));
+            restarted.push(inst);
         }
         match result {
-            Ok(StartOutcome::Restarted { stale_sid }) => {
-                succeeded.push((id, title, Some(stale_sid)))
-            }
             Ok(StartOutcome::ResumeFailed { sid }) => failed.push((
                 title,
                 format!("resume failed for sid {sid}; preserved for explicit retry"),
             )),
-            Ok(StartOutcome::Resumed | StartOutcome::Fresh) => succeeded.push((id, title, None)),
+            Ok(StartOutcome::Resumed | StartOutcome::Fresh) => succeeded.push((id, title)),
             Err(e) => failed.push((title, e.to_string())),
         }
     }
@@ -613,9 +602,9 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     // closure receives the latest disk state.
     let orphaned: Vec<(String, String)> = storage.update(|instances, _groups| {
         let mut orphaned = Vec::new();
-        for (restarted_inst, stale_sid) in restarted {
+        for restarted_inst in restarted {
             if let Some(stored) = instances.iter_mut().find(|i| i.id == restarted_inst.id) {
-                stored.merge_post_restart(&restarted_inst, stale_sid.as_deref());
+                stored.merge_post_restart(&restarted_inst);
             } else {
                 tracing::warn!(
                     target: "session.cli",
@@ -630,24 +619,11 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 
     // Sessions can share a title across paths; orphan filter keys on id.
     let orphaned_ids: HashSet<&String> = orphaned.iter().map(|(id, _)| id).collect();
-    succeeded.retain(|(id, _, _)| !orphaned_ids.contains(id));
+    succeeded.retain(|(id, _)| !orphaned_ids.contains(id));
 
-    let stale_count = succeeded.iter().filter(|(_, _, s)| s.is_some()).count();
-    if stale_count == 0 {
-        println!("✓ Restarted {}/{} sessions:", succeeded.len(), total);
-    } else {
-        println!(
-            "✓ Restarted {}/{} sessions ({} after explicit resume reset):",
-            succeeded.len(),
-            total,
-            stale_count,
-        );
-    }
-    for (_id, title, stale) in &succeeded {
-        match stale {
-            Some(sid) => println!("  · {}{}", title, stale_history_suffix(sid)),
-            None => println!("  · {}", title),
-        }
+    println!("✓ Restarted {}/{} sessions:", succeeded.len(), total);
+    for (_id, title) in &succeeded {
+        println!("  · {}", title);
     }
     if !orphaned.is_empty() {
         println!(
@@ -745,13 +721,9 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
     // touch_last_accessed runs on `stored`, not `working`: its fields are
     // peer-mutable and do not belong in `merge_post_restart`.
-    let stale_sid = match &outcome {
-        StartOutcome::Restarted { stale_sid } => Some(stale_sid.as_str()),
-        StartOutcome::ResumeFailed { .. } | StartOutcome::Resumed | StartOutcome::Fresh => None,
-    };
     let landed = storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
-            stored.merge_post_restart(&working, stale_sid);
+            stored.merge_post_restart(&working);
             if wake_succeeded {
                 stored.touch_last_accessed();
             }
@@ -773,13 +745,6 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     }
 
     match outcome {
-        StartOutcome::Restarted { stale_sid } => {
-            println!(
-                "✓ Restarted session: {}{}",
-                title,
-                stale_history_suffix(&stale_sid),
-            );
-        }
         StartOutcome::ResumeFailed { sid } => {
             bail!("Resume failed for sid {sid}; preserved for explicit retry");
         }
@@ -1549,35 +1514,6 @@ mod target_filter_tests {
     #[test]
     fn empty_input_yields_empty_targets() {
         assert!(pick_targets_for_restart_all(&[]).is_empty());
-    }
-}
-
-#[cfg(test)]
-mod stale_history_suffix_tests {
-    use super::stale_history_suffix;
-
-    #[test]
-    fn matches_single_session_wording() {
-        let suffix = stale_history_suffix("11111111-1111-1111-1111-111111111111");
-        assert_eq!(
-            suffix,
-            " (resume target 11111111-1111-1111-1111-111111111111 was reset; \
-             started fresh, prior history not loaded)"
-        );
-    }
-
-    #[test]
-    fn renders_inline_with_title_correctly() {
-        let line = format!(
-            "  · {}{}",
-            "alpha",
-            stale_history_suffix("22222222-2222-2222-2222-222222222222"),
-        );
-        assert_eq!(
-            line,
-            "  · alpha (resume target 22222222-2222-2222-2222-222222222222 was reset; \
-             started fresh, prior history not loaded)"
-        );
     }
 }
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -7,11 +7,8 @@ use std::collections::HashSet;
 
 use crate::session::{GroupTree, StartOutcome, Storage};
 
-/// Wording used by both single-session and `--all` restart paths when the
-/// resume-fallback cascade cleared a stale agent_session_id. Centralized so
-/// drift between the two surfaces cannot happen.
 pub(crate) fn stale_history_suffix(stale_sid: &str) -> String {
-    format!(" (resume failed for sid {stale_sid}; started fresh, prior history not loaded)")
+    format!(" (resume target {stale_sid} was reset; started fresh, prior history not loaded)")
 }
 
 #[derive(Subcommand)]
@@ -600,6 +597,10 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             Ok(StartOutcome::Restarted { stale_sid }) => {
                 succeeded.push((id, title, Some(stale_sid)))
             }
+            Ok(StartOutcome::ResumeFailed { sid }) => failed.push((
+                title,
+                format!("resume failed for sid {sid}; preserved for explicit retry"),
+            )),
             Ok(StartOutcome::Resumed | StartOutcome::Fresh) => succeeded.push((id, title, None)),
             Err(e) => failed.push((title, e.to_string())),
         }
@@ -636,7 +637,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         println!("✓ Restarted {}/{} sessions:", succeeded.len(), total);
     } else {
         println!(
-            "✓ Restarted {}/{} sessions ({} without prior history):",
+            "✓ Restarted {}/{} sessions ({} after explicit resume reset):",
             succeeded.len(),
             total,
             stale_count,
@@ -721,7 +722,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         .unwrap_or_else(|_| "wake up: pick up what you were doing".to_string());
 
     let mut wake_succeeded = false;
-    if !wake_msg.is_empty() {
+    if !wake_msg.is_empty() && !matches!(outcome, StartOutcome::ResumeFailed { .. }) {
         // Restart re-execs the agent at a blank prompt; nudge it back into
         // its prior task. Poll capture-pane for steady-state output instead
         // of a blind sleep, so the keys land as soon as the agent is at a
@@ -746,7 +747,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     // peer-mutable and do not belong in `merge_post_restart`.
     let stale_sid = match &outcome {
         StartOutcome::Restarted { stale_sid } => Some(stale_sid.as_str()),
-        StartOutcome::Resumed | StartOutcome::Fresh => None,
+        StartOutcome::ResumeFailed { .. } | StartOutcome::Resumed | StartOutcome::Fresh => None,
     };
     let landed = storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
@@ -778,6 +779,9 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
                 title,
                 stale_history_suffix(&stale_sid),
             );
+        }
+        StartOutcome::ResumeFailed { sid } => {
+            bail!("Resume failed for sid {sid}; preserved for explicit retry");
         }
         StartOutcome::Resumed | StartOutcome::Fresh => {
             println!("✓ Restarted session: {}", title);
@@ -1324,6 +1328,7 @@ async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
                 );
             }
             inst.resume_intent = new_intent.clone();
+            inst.resume_probe_failed_sid = None;
             Ok((inst.title.clone(), inst.tool.clone()))
         })
     })?;
@@ -1556,7 +1561,7 @@ mod stale_history_suffix_tests {
         let suffix = stale_history_suffix("11111111-1111-1111-1111-111111111111");
         assert_eq!(
             suffix,
-            " (resume failed for sid 11111111-1111-1111-1111-111111111111; \
+            " (resume target 11111111-1111-1111-1111-111111111111 was reset; \
              started fresh, prior history not loaded)"
         );
     }
@@ -1570,9 +1575,60 @@ mod stale_history_suffix_tests {
         );
         assert_eq!(
             line,
-            "  · alpha (resume failed for sid 22222222-2222-2222-2222-222222222222; \
+            "  · alpha (resume target 22222222-2222-2222-2222-222222222222 was reset; \
              started fresh, prior history not loaded)"
         );
+    }
+}
+
+#[cfg(test)]
+mod set_session_id_tests {
+    use super::{set_session_id, SetSessionIdArgs};
+    use crate::session::{Instance, ResumeIntent, Storage};
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    #[serial]
+    async fn set_session_id_clears_resume_probe_failed_marker() {
+        let temp = tempdir().unwrap();
+        std::env::set_var("HOME", temp.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+        let storage = Storage::new_unwatched("set-sid-clear-marker").unwrap();
+        let mut inst = Instance::new("marked_session", "/tmp/x");
+        inst.agent_session_id = Some("11111111-1111-1111-1111-111111111111".to_string());
+        inst.resume_probe_failed_sid = Some("11111111-1111-1111-1111-111111111111".to_string());
+        let id = inst.id.clone();
+        let on_disk = inst.clone();
+        storage
+            .update(|i, g| {
+                *i = vec![on_disk.clone()];
+                *g =
+                    crate::session::GroupTree::new_with_groups(std::slice::from_ref(&on_disk), &[])
+                        .get_all_groups();
+                Ok(())
+            })
+            .unwrap();
+
+        set_session_id(
+            "set-sid-clear-marker",
+            SetSessionIdArgs {
+                identifier: id.clone(),
+                session_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let loaded = storage.load().unwrap();
+        let inst_disk = loaded.iter().find(|i| i.id == id).unwrap();
+        assert_eq!(
+            inst_disk.resume_intent,
+            ResumeIntent::Use("22222222-2222-2222-2222-222222222222".to_string())
+        );
+        assert_eq!(inst_disk.resume_probe_failed_sid, None);
     }
 }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3908,7 +3908,6 @@ pub async fn ensure_session(
             }
             let resume_outcome = match &outcome {
                 crate::session::StartOutcome::Resumed => "resumed",
-                crate::session::StartOutcome::Restarted { .. } => "restarted",
                 crate::session::StartOutcome::ResumeFailed { .. } => "resume_failed",
                 crate::session::StartOutcome::Fresh => "fresh",
             };
@@ -3916,9 +3915,6 @@ pub async fn ensure_session(
                 "status": "restarted",
                 "resume_outcome": resume_outcome,
             });
-            if let crate::session::StartOutcome::Restarted { stale_sid } = &outcome {
-                body["stale_session_id"] = serde_json::Value::String(stale_sid.clone());
-            }
             if let crate::session::StartOutcome::ResumeFailed { sid } = &outcome {
                 body["status"] = serde_json::Value::String("resume_failed".to_string());
                 body["error"] = serde_json::Value::String("resume_failed".to_string());
@@ -6246,29 +6242,14 @@ pub async fn send_message(
                     }
                 }
             });
-            let mut body = serde_json::json!({"sent": true});
-            let stale_sid = match &outcome {
-                EnsureReadyOutcome::Respawned {
-                    stale_sid: Some(sid),
-                }
-                | EnsureReadyOutcome::Started {
-                    stale_sid: Some(sid),
-                } => Some(sid.clone()),
-                _ => None,
-            };
-            if let Some(sid) = stale_sid {
-                body["stale_session_id"] = serde_json::Value::String(sid);
-            }
-            (StatusCode::OK, Json(body)).into_response()
+            (StatusCode::OK, Json(serde_json::json!({"sent": true}))).into_response()
         }
         Ok(Err(boxed)) => {
             let (started, outcome, send_err) = *boxed;
             // ensure_pane_ready did mutate state when the outcome is
-            // anything other than AlreadyAlive. The cascade itself only
-            // runs in `Respawned { stale_sid: Some(_) }`, but `Started`
-            // and `Respawned { stale_sid: None }` also touch fields the
-            // live entry needs to reflect (fresh sid from acquire,
-            // last_start_time, etc.). Sync only when work happened.
+            // anything other than AlreadyAlive. `Started` and `Respawned`
+            // touch fields the live entry needs to reflect (fresh sid from
+            // acquire, last_start_time, etc.). Sync only when work happened.
             let did_work = !matches!(outcome, EnsureReadyOutcome::AlreadyAlive);
             match send_err {
                 SendKeysError::NotRunning => {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2291,7 +2291,11 @@ pub async fn start_session(
     .await;
 
     match restart_result {
-        Ok(Ok((started, _outcome))) => {
+        Ok(Ok((started, outcome))) => {
+            let resume_failed_sid = match &outcome {
+                crate::session::StartOutcome::ResumeFailed { sid } => Some(sid.clone()),
+                _ => None,
+            };
             let mut instances = state.instances.write().await;
             let response = match instances.iter_mut().find(|i| i.id == id) {
                 Some(inst) => {
@@ -2309,6 +2313,17 @@ pub async fn start_session(
                         .into_response();
                 }
             };
+            if let Some(sid) = resume_failed_sid {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": "resume_failed",
+                        "message": format!("Resume failed for sid {sid}; preserved for explicit retry"),
+                        "resume_session_id": sid,
+                    })),
+                )
+                    .into_response();
+            }
             (StatusCode::OK, Json(serde_json::json!(response))).into_response()
         }
         Ok(Err(boxed)) => {
@@ -3707,17 +3722,22 @@ fn public_create_session_error(e: &anyhow::Error) -> String {
 /// silently orphaning the previous Claude conversation.
 fn apply_post_restart_sync(live: &mut Instance, started: &Instance) {
     live.status = started.status;
-    live.last_error = None;
+    live.last_error = if started.status == Status::Error {
+        started.last_error.clone()
+    } else {
+        None
+    };
+    live.last_error_check = started.last_error_check;
     live.agent_session_id = started.agent_session_id.clone();
+    live.resume_probe_failed_sid = started.resume_probe_failed_sid.clone();
     live.last_start_time = started.last_start_time;
     live.retroactive_capture_excludes = started.retroactive_capture_excludes.clone();
 }
 
 /// Narrow sibling of [`apply_post_restart_sync`] that propagates only the
-/// fields the resume-fallback cascade is responsible for: the post-cascade
-/// `agent_session_id` (either `None` after a bailed Tier-1 cleanup, or a
-/// fresh UUID acquired by Tier-2's `start_with_size_opts` ->
-/// `acquire_session_id`) and the updated `retroactive_capture_excludes`.
+/// fields the resume path is responsible for: the post-probe
+/// `agent_session_id`, the `resume_probe_failed_sid` marker, and the updated
+/// `retroactive_capture_excludes`.
 ///
 /// Intended for error paths where the cascade may have run but the caller
 /// does not want to touch user-visible status fields. `NotRunning` is the
@@ -3727,6 +3747,7 @@ fn apply_post_restart_sync(live: &mut Instance, started: &Instance) {
 /// as `Starting` until the 2s status poll loop reconciles.
 fn apply_cascade_state_sync(live: &mut Instance, started: &Instance) {
     live.agent_session_id = started.agent_session_id.clone();
+    live.resume_probe_failed_sid = started.resume_probe_failed_sid.clone();
     live.retroactive_capture_excludes = started.retroactive_capture_excludes.clone();
 }
 
@@ -3750,13 +3771,12 @@ fn apply_cascade_state_sync(live: &mut Instance, started: &Instance) {
 ///     `RESUME_PROBE_POST_SHELL_GRACE` (~2s) shortcut. Shell-wrapper
 ///     overrides charitably burn the full ~3s instead (see
 ///     `Instance::probe_settle`).
-///   * Cascade fires (Tier-1 detects a dead pane): Tier-1 returns Dead
-///     fast (`pane_dead`/`!exists` is unambiguous), then `kill_clean`
-///     (~100ms macOS grace) + Tier-2 tmux spawn + up to another
-///     `RESUME_PROBE_MAX`.
+///   * Probe failure (resume pane dies): Tier-1 returns Dead fast
+///     (`pane_dead`/`!exists` is unambiguous), then `kill_clean` (~100ms
+///     macOS grace) and a typed 409 response preserving the sid.
 ///
-/// HTTP clients should budget ~6-7s worst-case for the full Tier-1 +
-/// Tier-2 cascade and configure timeouts accordingly.
+/// HTTP clients should budget ~3-4s worst-case for the resume probe and
+/// configure timeouts accordingly.
 pub async fn ensure_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -3868,12 +3888,10 @@ pub async fn ensure_session(
                 return Err(Box::new((inst, e)));
             }
             // Surface the moved Instance on the Err arm so the caller can
-            // sync the cascade-cleared `agent_session_id` and updated
-            // `retroactive_capture_excludes` back to live state. Otherwise
-            // the live entry retains the stale sid in memory while disk has
-            // already been cleared, and subsequent calls within the
-            // `status_poll_loop` reload window (~2s) keep re-attempting
-            // resume with the bad sid. See `apply_post_restart_sync`.
+            // sync resume-path mutations back to live state. Otherwise the
+            // live entry can retain stale marker/sid state until the next
+            // `status_poll_loop` reload window (~2s). See
+            // `apply_post_restart_sync`.
             match inst.start_with_resume_fallback(None, false) {
                 Ok(outcome) => Ok((inst, outcome)),
                 Err(e) => Err(Box::new((inst, e))),
@@ -3891,6 +3909,7 @@ pub async fn ensure_session(
             let resume_outcome = match &outcome {
                 crate::session::StartOutcome::Resumed => "resumed",
                 crate::session::StartOutcome::Restarted { .. } => "restarted",
+                crate::session::StartOutcome::ResumeFailed { .. } => "resume_failed",
                 crate::session::StartOutcome::Fresh => "fresh",
             };
             let mut body = serde_json::json!({
@@ -3899,6 +3918,15 @@ pub async fn ensure_session(
             });
             if let crate::session::StartOutcome::Restarted { stale_sid } = &outcome {
                 body["stale_session_id"] = serde_json::Value::String(stale_sid.clone());
+            }
+            if let crate::session::StartOutcome::ResumeFailed { sid } = &outcome {
+                body["status"] = serde_json::Value::String("resume_failed".to_string());
+                body["error"] = serde_json::Value::String("resume_failed".to_string());
+                body["message"] = serde_json::Value::String(format!(
+                    "Resume failed for sid {sid}; preserved for explicit retry"
+                ));
+                body["resume_session_id"] = serde_json::Value::String(sid.clone());
+                return (StatusCode::CONFLICT, Json(body)).into_response();
             }
             (StatusCode::OK, Json(body)).into_response()
         }
@@ -5208,6 +5236,56 @@ mod tests {
         assert_eq!(live.agent_session_id.as_deref(), Some("fresh-id"));
     }
 
+    #[test]
+    fn apply_post_restart_sync_propagates_resume_failed_marker_and_error() {
+        let mut live = make_test_instance();
+        live.status = Status::Running;
+        live.last_error = Some("prior failure".to_string());
+        live.agent_session_id = Some("sid-before".to_string());
+        live.resume_probe_failed_sid = None;
+
+        let mut started = make_test_instance();
+        started.status = Status::Error;
+        started.agent_session_id = Some("sid-after".to_string());
+        started.resume_probe_failed_sid = Some("sid-after".to_string());
+        started.last_error =
+            Some("resume failed for sid sid-after; preserved for explicit retry".to_string());
+        started.last_error_check = Some(std::time::Instant::now());
+
+        apply_post_restart_sync(&mut live, &started);
+
+        assert_eq!(live.status, Status::Error);
+        assert_eq!(
+            live.last_error.as_deref(),
+            Some("resume failed for sid sid-after; preserved for explicit retry")
+        );
+        assert!(live.last_error_check.is_some());
+        assert_eq!(live.agent_session_id.as_deref(), Some("sid-after"));
+        assert_eq!(live.resume_probe_failed_sid.as_deref(), Some("sid-after"));
+    }
+
+    #[test]
+    fn apply_cascade_state_sync_propagates_marker_without_status() {
+        let mut live = make_test_instance();
+        live.status = Status::Running;
+        live.last_error = Some("keep me".to_string());
+        live.agent_session_id = Some("sid-before".to_string());
+        live.resume_probe_failed_sid = None;
+
+        let mut started = make_test_instance();
+        started.status = Status::Error;
+        started.last_error = Some("resume failed".to_string());
+        started.agent_session_id = Some("sid-after".to_string());
+        started.resume_probe_failed_sid = Some("sid-after".to_string());
+
+        apply_cascade_state_sync(&mut live, &started);
+
+        assert_eq!(live.status, Status::Running);
+        assert_eq!(live.last_error.as_deref(), Some("keep me"));
+        assert_eq!(live.agent_session_id.as_deref(), Some("sid-after"));
+        assert_eq!(live.resume_probe_failed_sid.as_deref(), Some("sid-after"));
+    }
+
     fn isolated_app_dir(temp_home: &std::path::Path) -> std::path::PathBuf {
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
@@ -6006,6 +6084,7 @@ fn default_revive() -> bool {
 
 enum SendKeysError {
     NotRunning,
+    ResumeFailed(String),
     Transient(Status),
     StructuredView,
     Tmux(anyhow::Error),
@@ -6066,10 +6145,9 @@ pub async fn send_message(
         //
         // The closure surfaces both `inst_owned` AND the
         // `EnsureReadyOutcome` on the Err arm so the caller can sync
-        // the post-cascade `agent_session_id` (None after Tier-1
-        // cleanup, or the fresh UUID acquired by Tier-2) and the
-        // updated `retroactive_capture_excludes` back to live state
-        // regardless of which post-cascade failure path fires. The
+        // post-resume-path mutations (`agent_session_id`, failure marker,
+        // and `retroactive_capture_excludes`) back to live state regardless
+        // of which failure path fires. The
         // outcome lets the caller distinguish cascade-fired
         // (`Respawned`/`Started`) from the no-op `AlreadyAlive` path
         // so a sync only happens when there's actual cascade state to
@@ -6092,7 +6170,7 @@ pub async fn send_message(
                     // false. `EnsureReadyError::Tmux` may be either
                     // pre-cascade (tmux_session() / start_with_size
                     // subprocess failure: `inst_owned` unmutated) or
-                    // post-cascade (Tier-2 bail: mutations committed).
+                    // post-resume-path (mutations committed).
                     // The Tmux outer arm syncs unconditionally and
                     // covers both shapes; the others (Transient /
                     // StructuredView) bail before any mutation.
@@ -6106,6 +6184,13 @@ pub async fn send_message(
         } else {
             EnsureReadyOutcome::AlreadyAlive
         };
+        if let EnsureReadyOutcome::ResumeFailed { sid } = &outcome {
+            return Err(Box::new((
+                inst_owned,
+                outcome.clone(),
+                SendKeysError::ResumeFailed(sid.clone()),
+            )));
+        }
         let tmux_session = match inst_owned.tmux_session() {
             Ok(s) => s,
             Err(e) => return Err(Box::new((inst_owned, outcome, SendKeysError::Tmux(e)))),
@@ -6187,18 +6272,13 @@ pub async fn send_message(
             let did_work = !matches!(outcome, EnsureReadyOutcome::AlreadyAlive);
             match send_err {
                 SendKeysError::NotRunning => {
-                    // External kill or remain-on-exit-off Tier-2 crash can
-                    // race ensure_pane_ready's Alive decision against the
-                    // tmux_session.exists() check. Propagate the
-                    // post-cascade agent_session_id (fresh UUID acquired
-                    // in place of the stale, or None for Tier-1 cleanup)
-                    // and the updated excludes when applicable so the
-                    // next call won't orphan or re-attempt resume with
-                    // the bad sid; use the narrow sync helper to leave
-                    // status and last_error untouched (NotRunning is
+                    // External kill or remain-on-exit-off crash can race
+                    // ensure_pane_ready's Alive decision against the
+                    // tmux_session.exists() check. Propagate resume-path
+                    // state when applicable; use the narrow sync helper to
+                    // leave status and last_error untouched (NotRunning is
                     // recoverable; `started.status = Starting` from
-                    // finalize_launch would briefly mis-paint a broken
-                    // pane).
+                    // finalize_launch would briefly mis-paint a broken pane).
                     if did_work {
                         let mut instances = state.instances.write().await;
                         if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
@@ -6208,6 +6288,21 @@ pub async fn send_message(
                     (
                         StatusCode::CONFLICT,
                         Json(serde_json::json!({"error": "session_not_running"})),
+                    )
+                        .into_response()
+                }
+                SendKeysError::ResumeFailed(sid) => {
+                    let mut instances = state.instances.write().await;
+                    if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
+                        apply_post_restart_sync(i, &started);
+                    }
+                    (
+                        StatusCode::CONFLICT,
+                        Json(serde_json::json!({
+                            "error": "resume_failed",
+                            "message": format!("Resume failed for sid {sid}; preserved for explicit retry"),
+                            "resume_session_id": sid,
+                        })),
                     )
                         .into_response()
                 }
@@ -6230,12 +6325,12 @@ pub async fn send_message(
                     // Sync cascade-mutated fields back to live state. Mirror
                     // `ensure_session`'s Err arm: full sync, then override
                     // `status` and `last_error` so observers don't see
-                    // `Status::Starting` (set by `finalize_launch` before
-                    // Tier-2 bail) on a broken session. Tmux Err is the
+                    // `Status::Starting` (set by `finalize_launch`) on a
+                    // broken session. Tmux Err is the
                     // catch-all for both pre-cascade tmux failures (where
                     // `started` is unmutated and the sync is a no-op) and
-                    // post-cascade Tier-2 bails (where the sync propagates
-                    // the cleared sid + updated excludes).
+                    // post-resume-path failures (where durable resume state
+                    // must be copied back from the clone).
                     let mut instances = state.instances.write().await;
                     if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
                         apply_post_restart_sync(i, &started);

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2276,6 +2276,7 @@ pub async fn start_session(
         }
     }
 
+    let sync_base = instance.clone();
     let restart_result = tokio::task::spawn_blocking(
         move || -> Result<(Instance, crate::session::StartOutcome), Box<(Instance, anyhow::Error)>> {
             let mut inst = instance;
@@ -2299,7 +2300,7 @@ pub async fn start_session(
             let mut instances = state.instances.write().await;
             let response = match instances.iter_mut().find(|i| i.id == id) {
                 Some(inst) => {
-                    apply_post_restart_sync(inst, &started);
+                    apply_post_restart_sync(inst, &sync_base, &started);
                     SessionResponse::from_instance(
                         inst,
                         crate::claude_settings::read_tui_fullscreen(),
@@ -2332,7 +2333,7 @@ pub async fn start_session(
             tracing::warn!(target: "http.api.sessions", "start_session restart failed for {id}: {msg}");
             let mut instances = state.instances.write().await;
             if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
-                apply_post_restart_sync(inst, &started);
+                apply_post_restart_sync(inst, &sync_base, &started);
                 inst.status = Status::Error;
                 inst.last_error = Some(msg.clone());
             }
@@ -3720,7 +3721,22 @@ fn public_create_session_error(e: &anyhow::Error) -> String {
 /// a rapid second restart inside that window would see a stale
 /// `agent_session_id = None` and generate (and persist) a new UUID,
 /// silently orphaning the previous Claude conversation.
-fn apply_post_restart_sync(live: &mut Instance, started: &Instance) {
+fn apply_post_restart_identity_sync(live: &mut Instance, before: &Instance, started: &Instance) {
+    // Treat the pre-restart snapshot as a CAS baseline for peer-writable
+    // identity fields. If a poller/CLI/TUI peer changed the sid while the
+    // restart clone was blocking, that newer sid and its marker stay
+    // authoritative.
+    let sid_unchanged = live.agent_session_id == before.agent_session_id;
+    let marker_unchanged = live.resume_probe_failed_sid == before.resume_probe_failed_sid;
+    if sid_unchanged {
+        live.agent_session_id = started.agent_session_id.clone();
+    }
+    if marker_unchanged && live.agent_session_id == started.agent_session_id {
+        live.resume_probe_failed_sid = started.resume_probe_failed_sid.clone();
+    }
+}
+
+fn apply_post_restart_sync(live: &mut Instance, before: &Instance, started: &Instance) {
     live.status = started.status;
     live.last_error = if started.status == Status::Error {
         started.last_error.clone()
@@ -3728,8 +3744,7 @@ fn apply_post_restart_sync(live: &mut Instance, started: &Instance) {
         None
     };
     live.last_error_check = started.last_error_check;
-    live.agent_session_id = started.agent_session_id.clone();
-    live.resume_probe_failed_sid = started.resume_probe_failed_sid.clone();
+    apply_post_restart_identity_sync(live, before, started);
     live.last_start_time = started.last_start_time;
     live.retroactive_capture_excludes = started.retroactive_capture_excludes.clone();
 }
@@ -3745,9 +3760,8 @@ fn apply_post_restart_sync(live: &mut Instance, started: &Instance) {
 /// `live.status` with `started.status` (typically `Starting` from the
 /// post-cascade `finalize_launch`) would briefly mis-paint a broken pane
 /// as `Starting` until the 2s status poll loop reconciles.
-fn apply_cascade_state_sync(live: &mut Instance, started: &Instance) {
-    live.agent_session_id = started.agent_session_id.clone();
-    live.resume_probe_failed_sid = started.resume_probe_failed_sid.clone();
+fn apply_cascade_state_sync(live: &mut Instance, before: &Instance, started: &Instance) {
+    apply_post_restart_identity_sync(live, before, started);
     live.retroactive_capture_excludes = started.retroactive_capture_excludes.clone();
 }
 
@@ -3876,6 +3890,7 @@ pub async fn ensure_session(
         }
     }
 
+    let sync_base = instance.clone();
     let restart_result = tokio::task::spawn_blocking(
         move || -> Result<(Instance, crate::session::StartOutcome), Box<(Instance, anyhow::Error)>> {
             let mut inst = instance;
@@ -3904,7 +3919,7 @@ pub async fn ensure_session(
         Ok(Ok((started, outcome))) => {
             let mut instances = state.instances.write().await;
             if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
-                apply_post_restart_sync(inst, &started);
+                apply_post_restart_sync(inst, &sync_base, &started);
             }
             let resume_outcome = match &outcome {
                 crate::session::StartOutcome::Resumed => "resumed",
@@ -3932,7 +3947,7 @@ pub async fn ensure_session(
             tracing::warn!(target: "http.api.sessions", "ensure_session restart failed for {id}: {msg}");
             let mut instances = state.instances.write().await;
             if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
-                apply_post_restart_sync(inst, &started);
+                apply_post_restart_sync(inst, &sync_base, &started);
                 inst.status = crate::session::Status::Error;
                 inst.last_error = Some(msg.clone());
             }
@@ -5198,13 +5213,14 @@ mod tests {
         live.last_error = Some("prior failure".to_string());
         live.agent_session_id = None;
         live.last_start_time = None;
+        let before = live.clone();
 
         let mut started = make_test_instance();
         started.status = Status::Starting;
         started.agent_session_id = Some("claude-uuid-restart".to_string());
         started.last_start_time = Some(std::time::Instant::now());
 
-        apply_post_restart_sync(&mut live, &started);
+        apply_post_restart_sync(&mut live, &before, &started);
 
         assert_eq!(live.status, Status::Starting);
         assert!(live.last_error.is_none());
@@ -5223,11 +5239,12 @@ mod tests {
         // existing ID, but the contract here is "started wins."
         let mut live = make_test_instance();
         live.agent_session_id = Some("stale-id".to_string());
+        let before = live.clone();
 
         let mut started = make_test_instance();
         started.agent_session_id = Some("fresh-id".to_string());
 
-        apply_post_restart_sync(&mut live, &started);
+        apply_post_restart_sync(&mut live, &before, &started);
 
         assert_eq!(live.agent_session_id.as_deref(), Some("fresh-id"));
     }
@@ -5239,6 +5256,7 @@ mod tests {
         live.last_error = Some("prior failure".to_string());
         live.agent_session_id = Some("sid-before".to_string());
         live.resume_probe_failed_sid = None;
+        let before = live.clone();
 
         let mut started = make_test_instance();
         started.status = Status::Error;
@@ -5248,7 +5266,7 @@ mod tests {
             Some("resume failed for sid sid-after; preserved for explicit retry".to_string());
         started.last_error_check = Some(std::time::Instant::now());
 
-        apply_post_restart_sync(&mut live, &started);
+        apply_post_restart_sync(&mut live, &before, &started);
 
         assert_eq!(live.status, Status::Error);
         assert_eq!(
@@ -5267,6 +5285,7 @@ mod tests {
         live.last_error = Some("keep me".to_string());
         live.agent_session_id = Some("sid-before".to_string());
         live.resume_probe_failed_sid = None;
+        let before = live.clone();
 
         let mut started = make_test_instance();
         started.status = Status::Error;
@@ -5274,12 +5293,140 @@ mod tests {
         started.agent_session_id = Some("sid-after".to_string());
         started.resume_probe_failed_sid = Some("sid-after".to_string());
 
-        apply_cascade_state_sync(&mut live, &started);
+        apply_cascade_state_sync(&mut live, &before, &started);
 
         assert_eq!(live.status, Status::Running);
         assert_eq!(live.last_error.as_deref(), Some("keep me"));
         assert_eq!(live.agent_session_id.as_deref(), Some("sid-after"));
         assert_eq!(live.resume_probe_failed_sid.as_deref(), Some("sid-after"));
+    }
+
+    #[test]
+    fn apply_post_restart_sync_preserves_peer_sid_write() {
+        let mut before = make_test_instance();
+        before.agent_session_id = Some("stale-restart-sid".to_string());
+        before.resume_probe_failed_sid = None;
+
+        let mut live = make_test_instance();
+        live.agent_session_id = Some("peer-fresh-sid".to_string());
+        live.resume_probe_failed_sid = Some("peer-fresh-sid".to_string());
+
+        let mut started = make_test_instance();
+        started.status = Status::Error;
+        started.agent_session_id = Some("stale-restart-sid".to_string());
+        started.resume_probe_failed_sid = Some("stale-restart-sid".to_string());
+        started.last_error = Some("resume failed".to_string());
+
+        apply_post_restart_sync(&mut live, &before, &started);
+
+        assert_eq!(live.status, Status::Error);
+        assert_eq!(live.last_error.as_deref(), Some("resume failed"));
+        assert_eq!(live.agent_session_id.as_deref(), Some("peer-fresh-sid"));
+        assert_eq!(
+            live.resume_probe_failed_sid.as_deref(),
+            Some("peer-fresh-sid")
+        );
+    }
+
+    #[test]
+    fn apply_post_restart_sync_preserves_peer_marker_for_same_sid() {
+        let mut before = make_test_instance();
+        before.agent_session_id = Some("same-sid".to_string());
+        before.resume_probe_failed_sid = None;
+
+        let mut live = before.clone();
+        live.resume_probe_failed_sid = Some("same-sid".to_string());
+
+        let mut started = before.clone();
+        started.status = Status::Starting;
+        started.resume_probe_failed_sid = None;
+
+        apply_post_restart_sync(&mut live, &before, &started);
+
+        assert_eq!(live.status, Status::Starting);
+        assert_eq!(live.agent_session_id.as_deref(), Some("same-sid"));
+        assert_eq!(live.resume_probe_failed_sid.as_deref(), Some("same-sid"));
+    }
+
+    #[test]
+    fn apply_cascade_state_sync_preserves_peer_sid_write() {
+        let mut before = make_test_instance();
+        before.agent_session_id = Some("stale-restart-sid".to_string());
+        before.resume_probe_failed_sid = None;
+
+        let mut live = make_test_instance();
+        live.status = Status::Running;
+        live.last_error = Some("keep me".to_string());
+        live.agent_session_id = Some("peer-fresh-sid".to_string());
+        live.resume_probe_failed_sid = Some("peer-fresh-sid".to_string());
+
+        let mut started = make_test_instance();
+        started.status = Status::Error;
+        started.last_error = Some("resume failed".to_string());
+        started.agent_session_id = Some("stale-restart-sid".to_string());
+        started.resume_probe_failed_sid = Some("stale-restart-sid".to_string());
+
+        apply_cascade_state_sync(&mut live, &before, &started);
+
+        assert_eq!(live.status, Status::Running);
+        assert_eq!(live.last_error.as_deref(), Some("keep me"));
+        assert_eq!(live.agent_session_id.as_deref(), Some("peer-fresh-sid"));
+        assert_eq!(
+            live.resume_probe_failed_sid.as_deref(),
+            Some("peer-fresh-sid")
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn send_message_post_restart_save_preserves_peer_sid_write() {
+        let temp_home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        let _ = isolated_app_dir(temp_home.path());
+
+        let profile = "send-post-restart-peer-sid";
+        let storage = Storage::new_unwatched(profile).unwrap();
+        let mut seed = make_test_instance();
+        let id = seed.id.clone();
+        seed.agent_session_id = Some("peer-fresh-sid".to_string());
+        seed.resume_probe_failed_sid = Some("peer-fresh-sid".to_string());
+        storage
+            .update(|instances, _groups| {
+                instances.push(seed.clone());
+                Ok(())
+            })
+            .unwrap();
+
+        let mut sync_base_for_save = make_test_instance();
+        sync_base_for_save.id = id.clone();
+        sync_base_for_save.agent_session_id = Some("stale-restart-sid".to_string());
+        sync_base_for_save.resume_probe_failed_sid = None;
+
+        let mut started_for_save = make_test_instance();
+        started_for_save.id = id.clone();
+        started_for_save.status = Status::Starting;
+        started_for_save.agent_session_id = Some("stale-restart-sid".to_string());
+        started_for_save.resume_probe_failed_sid = None;
+
+        storage
+            .update(|all, _groups| {
+                if let Some(disk_inst) = all.iter_mut().find(|i| i.id == id) {
+                    apply_post_restart_sync(disk_inst, &sync_base_for_save, &started_for_save);
+                    disk_inst.touch_last_accessed();
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        let reloaded = storage.load().unwrap();
+        let disk = reloaded.iter().find(|i| i.id == seed.id).unwrap();
+        assert_eq!(disk.status, Status::Starting);
+        assert_eq!(disk.agent_session_id.as_deref(), Some("peer-fresh-sid"));
+        assert_eq!(
+            disk.resume_probe_failed_sid.as_deref(),
+            Some("peer-fresh-sid")
+        );
+        assert!(disk.last_accessed_at.is_some());
     }
 
     fn isolated_app_dir(temp_home: &std::path::Path) -> std::path::PathBuf {
@@ -6131,6 +6278,7 @@ pub async fn send_message(
     let inst_lock = state.instance_lock(&id).await;
     let _guard = inst_lock.lock().await;
 
+    let sync_base = instance.clone();
     let tool = instance.tool.clone();
     let message = req.message;
     let revive = req.revive;
@@ -6214,7 +6362,7 @@ pub async fn send_message(
             let mut instances = state.instances.write().await;
             let profile = if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
                 if !matches!(outcome, EnsureReadyOutcome::AlreadyAlive) {
-                    apply_post_restart_sync(i, &started);
+                    apply_post_restart_sync(i, &sync_base, &started);
                 }
                 i.touch_last_accessed();
                 i.source_profile.clone()
@@ -6225,6 +6373,7 @@ pub async fn send_message(
             };
             drop(instances);
             let id_for_save = id.clone();
+            let sync_base_for_save = sync_base.clone();
             let started_for_save = started.clone();
             let outcome_already_alive = matches!(outcome, EnsureReadyOutcome::AlreadyAlive);
             tokio::task::spawn_blocking(move || {
@@ -6232,7 +6381,11 @@ pub async fn send_message(
                     if let Err(e) = storage.update(|all, _groups| {
                         if let Some(disk_inst) = all.iter_mut().find(|i| i.id == id_for_save) {
                             if !outcome_already_alive {
-                                apply_post_restart_sync(disk_inst, &started_for_save);
+                                apply_post_restart_sync(
+                                    disk_inst,
+                                    &sync_base_for_save,
+                                    &started_for_save,
+                                );
                             }
                             disk_inst.touch_last_accessed();
                         }
@@ -6263,7 +6416,7 @@ pub async fn send_message(
                     if did_work {
                         let mut instances = state.instances.write().await;
                         if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
-                            apply_cascade_state_sync(i, &started);
+                            apply_cascade_state_sync(i, &sync_base, &started);
                         }
                     }
                     (
@@ -6275,7 +6428,7 @@ pub async fn send_message(
                 SendKeysError::ResumeFailed(sid) => {
                     let mut instances = state.instances.write().await;
                     if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
-                        apply_post_restart_sync(i, &started);
+                        apply_post_restart_sync(i, &sync_base, &started);
                     }
                     (
                         StatusCode::CONFLICT,
@@ -6314,7 +6467,7 @@ pub async fn send_message(
                     // must be copied back from the clone).
                     let mut instances = state.instances.write().await;
                     if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
-                        apply_post_restart_sync(i, &started);
+                        apply_post_restart_sync(i, &sync_base, &started);
                         i.status = crate::session::Status::Error;
                         i.last_error = Some(msg);
                     }

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3795,6 +3795,12 @@ pub async fn ensure_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    // Serialize concurrent ensure calls for the same session. The decision
+    // phase reads tmux state and the restart phase mutates it; any other
+    // ensure for this id must wait so both see a consistent view.
+    let inst_lock = state.instance_lock(&id).await;
+    let _guard = inst_lock.lock().await;
+
     let instances = state.instances.read().await;
     let Some(instance) = instances.iter().find(|i| i.id == id).cloned() else {
         return (
@@ -3804,12 +3810,6 @@ pub async fn ensure_session(
             .into_response();
     };
     drop(instances);
-
-    // Serialize concurrent ensure calls for the same session. The decision
-    // phase reads tmux state and the restart phase mutates it; any other
-    // ensure for this id must wait so both see a consistent view.
-    let inst_lock = state.instance_lock(&id).await;
-    let _guard = inst_lock.lock().await;
 
     // Inspect tmux + make the restart decision on a blocking thread. Refresh
     // the cache first so rapid re-calls see the true current state (the
@@ -5621,6 +5621,51 @@ mod tests {
         assert!(create_source.contains("std::path::Path::new(&body.path)"));
         assert!(!create_source[validation..spawn_blocking].contains("command_override"));
     }
+
+    #[test]
+    fn ensure_session_refreshes_instance_after_instance_lock() {
+        let source = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/server/api/sessions.rs"),
+        )
+        .unwrap();
+        let start = source.find("pub async fn ensure_session").unwrap();
+        let end = source.find("pub async fn ensure_terminal").unwrap();
+        let ensure_source = &source[start..end];
+        let lock = ensure_source
+            .find("let inst_lock = state.instance_lock(&id).await")
+            .unwrap();
+        let read = ensure_source
+            .find("let instances = state.instances.read().await")
+            .unwrap();
+        let sync_base = ensure_source
+            .find("let sync_base = instance.clone()")
+            .unwrap();
+
+        assert!(lock < read);
+        assert!(read < sync_base);
+    }
+
+    #[test]
+    fn send_message_refreshes_instance_after_instance_lock() {
+        let source = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/server/api/sessions.rs"),
+        )
+        .unwrap();
+        let start = source.find("pub async fn send_message").unwrap();
+        let send_source = &source[start..];
+        let lock = send_source
+            .find("let inst_lock = state.instance_lock(&id).await")
+            .unwrap();
+        let read = send_source
+            .find("let instances = state.instances.read().await")
+            .unwrap();
+        let sync_base = send_source
+            .find("let sync_base = instance.clone()")
+            .unwrap();
+
+        assert!(lock < read);
+        assert!(read < sync_base);
+    }
     // ── validate_diff_path: security regression tests ──────────────────────────
     //
     // Regression for a path-traversal vulnerability in the first cut of the
@@ -6261,6 +6306,13 @@ pub async fn send_message(
             .into_response();
     }
 
+    // Serialize concurrent sends (and other tmux mutations) for this id.
+    // Without this, two POSTs racing against the same session would issue
+    // overlapping `tmux send-keys -l` invocations and the bytes can interleave
+    // inside the pane.
+    let inst_lock = state.instance_lock(&id).await;
+    let _guard = inst_lock.lock().await;
+
     let instances = state.instances.read().await;
     let Some(instance) = instances.iter().find(|i| i.id == id).cloned() else {
         return (
@@ -6270,13 +6322,6 @@ pub async fn send_message(
             .into_response();
     };
     drop(instances);
-
-    // Serialize concurrent sends (and other tmux mutations) for this id.
-    // Without this, two POSTs racing against the same session would issue
-    // overlapping `tmux send-keys -l` invocations and the bytes can interleave
-    // inside the pane.
-    let inst_lock = state.instance_lock(&id).await;
-    let _guard = inst_lock.lock().await;
 
     let sync_base = instance.clone();
     let tool = instance.tool.clone();

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -914,6 +914,24 @@ impl Instance {
         }
     }
 
+    /// Baseline-aware sibling for async restart workers. Copies worker-produced
+    /// identity only when the live row still matches the pre-restart snapshot;
+    /// peer writes that land while the worker is blocked remain authoritative.
+    pub fn merge_post_restart_with_baseline(&mut self, before: &Self, src: &Self) {
+        self.merge_post_start(src);
+        let sid_unchanged = self.agent_session_id == before.agent_session_id;
+        let marker_unchanged = self.resume_probe_failed_sid == before.resume_probe_failed_sid;
+
+        if sid_unchanged {
+            self.agent_session_id = src.agent_session_id.clone();
+            self.session_id_poller = src.session_id_poller.clone();
+        }
+
+        if marker_unchanged && self.agent_session_id == src.agent_session_id {
+            self.resume_probe_failed_sid = src.resume_probe_failed_sid.clone();
+        }
+    }
+
     /// Reload this instance from disk before a launch that would re-persist
     /// peer-writable fields. Refreshes `agent_session_id` (poller-observed)
     /// and `resume_intent` (user-set) from disk; carries runtime-only fields

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -102,10 +102,6 @@ pub enum StartOutcome {
     /// observed an explicit invalid-resume signal. The sid was preserved and
     /// marked so startup recovery does not retry it automatically.
     ResumeFailed { sid: String },
-    /// Resume was explicitly invalidated, the bad sid was cleared, and a
-    /// fresh start succeeded. Caller should surface this: the user's prior
-    /// conversation is gone. `stale_sid` is the sid that was cleared.
-    Restarted { stale_sid: String },
     /// No resume cascade ran. Either no prior sid, the agent doesn't support
     /// resume, the sid was invalid, the session is structured view-mode (no tmux
     /// pane), or the tmux session was already alive when entered (so
@@ -177,15 +173,11 @@ pub enum EnsureReadyOutcome {
     /// Pane was already alive; no action taken.
     AlreadyAlive,
     /// Pane was dead (`#{pane_dead}=1`) and was respawned via the restart path.
-    /// `stale_sid` is `Some` only when a resume target was explicitly reset
-    /// before a fresh launch; ambiguous probe failures use `ResumeFailed`.
-    Respawned { stale_sid: Option<String> },
+    Respawned,
     /// Tmux session did not exist and was started via the resume-fallback
-    /// path. `stale_sid` is `Some` only when a resume target was explicitly
-    /// invalidated before a fresh launch; ambiguous probe failures use
-    /// `ResumeFailed` instead. `None` means healthy resume or fresh launch
-    /// without resume. Same surface-to-user contract as `Respawned`.
-    Started { stale_sid: Option<String> },
+    /// path. Healthy resume and fresh launch both use this outcome;
+    /// ambiguous probe failures use `ResumeFailed` instead.
+    Started,
     /// Resume failed ambiguously while trying to start or respawn the pane.
     /// The durable sid remains stored for an explicit retry.
     ResumeFailed { sid: String },
@@ -912,20 +904,13 @@ impl Instance {
         self.sandbox_info = src.sandbox_info.clone();
     }
 
-    /// Same fields as `merge_post_start`. When `stale_sid` is `Some`, an
-    /// explicit resume reset just invalidated that exact sid; replace
-    /// `self.agent_session_id` only if it still matches the stale value, so
-    /// a peer poller's freshly-discovered sid (landed between phase 2 and
-    /// phase 3 of the restart) survives intact.
-    pub fn merge_post_restart(&mut self, src: &Self, stale_sid: Option<&str>) {
+    /// Same fields as `merge_post_start`. Resume-probe failure markers are
+    /// copied only when the sid still matches so peer poller writes that land
+    /// between phase 2 and phase 3 of the restart remain authoritative.
+    pub fn merge_post_restart(&mut self, src: &Self) {
         self.merge_post_start(src);
         if self.agent_session_id == src.agent_session_id {
             self.resume_probe_failed_sid = src.resume_probe_failed_sid.clone();
-        }
-        if let Some(stale) = stale_sid {
-            if self.agent_session_id.as_deref() == Some(stale) {
-                self.agent_session_id = src.agent_session_id.clone();
-            }
         }
     }
 
@@ -3100,29 +3085,27 @@ impl Instance {
             let outcome = self
                 .start_with_resume_fallback(size, false)
                 .map_err(EnsureReadyError::Tmux)?;
-            let stale_sid = match outcome {
-                StartOutcome::Restarted { stale_sid } => Some(stale_sid),
+            match outcome {
                 StartOutcome::ResumeFailed { sid } => {
                     return Ok(EnsureReadyOutcome::ResumeFailed { sid });
                 }
-                StartOutcome::Resumed | StartOutcome::Fresh => None,
-            };
+                StartOutcome::Resumed | StartOutcome::Fresh => {}
+            }
             self.wait_for_pane_ready(&session);
-            return Ok(EnsureReadyOutcome::Started { stale_sid });
+            return Ok(EnsureReadyOutcome::Started);
         }
         if session.is_pane_dead() {
             let outcome = self
                 .restart_with_size(size)
                 .map_err(EnsureReadyError::Tmux)?;
-            let stale_sid = match outcome {
-                StartOutcome::Restarted { stale_sid } => Some(stale_sid),
+            match outcome {
                 StartOutcome::ResumeFailed { sid } => {
                     return Ok(EnsureReadyOutcome::ResumeFailed { sid });
                 }
-                StartOutcome::Resumed | StartOutcome::Fresh => None,
-            };
+                StartOutcome::Resumed | StartOutcome::Fresh => {}
+            }
             self.wait_for_pane_ready(&session);
-            return Ok(EnsureReadyOutcome::Respawned { stale_sid });
+            return Ok(EnsureReadyOutcome::Respawned);
         }
         Ok(EnsureReadyOutcome::AlreadyAlive)
     }
@@ -3967,7 +3950,7 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_post_restart_no_fallback_preserves_sid() {
+    fn test_merge_post_restart_preserves_peer_sid() {
         let mut stored = Instance::new("session", "/tmp/test");
         stored.agent_session_id = Some("peer-fresh-sid".to_string());
         stored.snooze(15);
@@ -3977,51 +3960,62 @@ mod tests {
         working.status = Status::Idle;
         working.agent_session_id = Some("phase1-stale-sid".to_string());
 
-        stored.merge_post_restart(&working, None);
+        stored.merge_post_restart(&working);
 
         assert_eq!(stored.status, Status::Idle);
         assert_eq!(
             stored.agent_session_id.as_deref(),
             Some("peer-fresh-sid"),
-            "no-fallback restart must not clobber peer sid write"
+            "restart merge must not clobber peer sid write"
         );
         assert!(stored.is_snoozed(), "peer snooze must survive merge");
     }
 
     #[test]
-    fn test_merge_post_restart_fallback_clears_matching_sid() {
+    fn test_merge_post_restart_copies_resume_failed_marker_when_sid_matches() {
         let mut stored = Instance::new("session", "/tmp/test");
-        stored.agent_session_id = Some("phase1-stale-sid".to_string());
+        stored.agent_session_id = Some("failed-sid".to_string());
+        stored.resume_probe_failed_sid = None;
 
         let mut working = Instance::new("session", "/tmp/test");
         working.id = stored.id.clone();
-        working.status = Status::Starting;
-        working.agent_session_id = None;
+        working.status = Status::Error;
+        working.agent_session_id = Some("failed-sid".to_string());
+        working.resume_probe_failed_sid = Some("failed-sid".to_string());
 
-        stored.merge_post_restart(&working, Some("phase1-stale-sid"));
+        stored.merge_post_restart(&working);
 
-        assert!(
-            stored.agent_session_id.is_none(),
-            "stored sid still equals stale; cascade invalidation propagates"
+        assert_eq!(stored.status, Status::Error);
+        assert_eq!(stored.agent_session_id.as_deref(), Some("failed-sid"));
+        assert_eq!(
+            stored.resume_probe_failed_sid.as_deref(),
+            Some("failed-sid")
         );
     }
 
     #[test]
-    fn test_merge_post_restart_preserves_poller_sid_landed_during_phase_2() {
+    fn test_merge_post_restart_preserves_peer_marker_when_sid_mismatches() {
         let mut stored = Instance::new("session", "/tmp/test");
         stored.agent_session_id = Some("poller-fresh-sid".to_string());
+        stored.resume_probe_failed_sid = Some("poller-fresh-sid".to_string());
 
         let mut working = Instance::new("session", "/tmp/test");
         working.id = stored.id.clone();
         working.status = Status::Starting;
-        working.agent_session_id = None;
+        working.agent_session_id = Some("phase1-stale-sid".to_string());
+        working.resume_probe_failed_sid = Some("phase1-stale-sid".to_string());
 
-        stored.merge_post_restart(&working, Some("phase1-stale-sid"));
+        stored.merge_post_restart(&working);
 
         assert_eq!(
             stored.agent_session_id.as_deref(),
             Some("poller-fresh-sid"),
-            "poller wrote a fresh sid between phase 2 and phase 3; CAS preserves it"
+            "poller wrote a fresh sid between phase 2 and phase 3; merge preserves it"
+        );
+        assert_eq!(
+            stored.resume_probe_failed_sid.as_deref(),
+            Some("poller-fresh-sid"),
+            "marker for peer sid remains authoritative"
         );
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -82,11 +82,11 @@ impl Status {
     }
 }
 
-/// Outcome of a `start_with_resume_fallback` cascade.
+/// Outcome of `start_with_resume_fallback`.
 ///
-/// Failures (both tiers) propagate as `Err` so callers keep the existing
-/// `Status::Error` + `last_error` path. Only successful outcomes are
-/// enumerated; mirrors the `EnsureReadyOutcome` shape.
+/// Tmux/process failures propagate as `Err` so callers keep the existing
+/// `Status::Error` + `last_error` path. Resume-probe death is represented
+/// explicitly as `ResumeFailed` because it preserves durable state.
 /// `last_error` the status poller stamps when a session's tmux pane is simply
 /// absent (killed, exited, server reboot) and nothing more specific was
 /// captured from the pane. The preview treats this as the calm "Stopped" case
@@ -98,7 +98,11 @@ pub const TMUX_SESSION_GONE_ERROR: &str =
 pub enum StartOutcome {
     /// Session ID was set and resume succeeded; pane is alive.
     Resumed,
-    /// Resume attempt crashed the pane fast; the bad sid was cleared and a
+    /// Resume was attempted, but the pane died during the probe before AoE
+    /// observed an explicit invalid-resume signal. The sid was preserved and
+    /// marked so startup recovery does not retry it automatically.
+    ResumeFailed { sid: String },
+    /// Resume was explicitly invalidated, the bad sid was cleared, and a
     /// fresh start succeeded. Caller should surface this: the user's prior
     /// conversation is gone. `stale_sid` is the sid that was cleared.
     Restarted { stale_sid: String },
@@ -147,15 +151,14 @@ const RESUME_PROBE_POLL: std::time::Duration = std::time::Duration::from_millis(
 /// opencode (bun-compiled native binary that loads JS, parses argv, and
 /// hits the session-not-found path) reaches `pane_dead = true` between
 /// ~900ms and ~1100ms after spawn on a warm cache, longer on cold or
-/// heavy projects. Healthy resumes pay this entire window once on Tier-1
-/// (and again on Tier-2 if it fires); the pane is fully attachable for
-/// the duration so the cost is purely in the synchronous restart path's
-/// latency, not in agent responsiveness afterward.
+/// heavy projects. Healthy resumes pay this entire window once; the pane is
+/// fully attachable for the duration so the cost is purely in the synchronous
+/// restart path's latency, not in agent responsiveness afterward.
 const RESUME_PROBE_POST_SHELL_GRACE: std::time::Duration = std::time::Duration::from_millis(2000);
 
-/// Pure decision: should the resume-fallback cascade probe and potentially
-/// retry without resume after the initial start? Extracted for unit-testability:
-/// the cascade itself needs a real tmux session to test end-to-end.
+/// Pure decision: should a launch with this sid/tool use the resume probe?
+/// Extracted for unit-testability: the probe path itself needs a real tmux
+/// session to test end-to-end.
 pub(crate) fn should_attempt_resume(agent_session_id: Option<&str>, tool: &str) -> bool {
     let valid = agent_session_id.map(is_valid_session_id).unwrap_or(false);
     if !valid {
@@ -174,16 +177,18 @@ pub enum EnsureReadyOutcome {
     /// Pane was already alive; no action taken.
     AlreadyAlive,
     /// Pane was dead (`#{pane_dead}=1`) and was respawned via the restart path.
-    /// `stale_sid` is `Some` when the resume-fallback cascade fired during the
-    /// respawn, meaning the agent's prior conversation is gone; callers should
-    /// surface this so the user understands why history disappeared.
+    /// `stale_sid` is `Some` only when a resume target was explicitly reset
+    /// before a fresh launch; ambiguous probe failures use `ResumeFailed`.
     Respawned { stale_sid: Option<String> },
     /// Tmux session did not exist and was started via the resume-fallback
-    /// cascade. `stale_sid` is `Some` when the cascade fired (sid was on
-    /// disk from a prior run, the agent crashed on it, and we cleared it
-    /// before retrying), `None` for a healthy resume or fresh launch
+    /// path. `stale_sid` is `Some` only when a resume target was explicitly
+    /// invalidated before a fresh launch; ambiguous probe failures use
+    /// `ResumeFailed` instead. `None` means healthy resume or fresh launch
     /// without resume. Same surface-to-user contract as `Respawned`.
     Started { stale_sid: Option<String> },
+    /// Resume failed ambiguously while trying to start or respawn the pane.
+    /// The durable sid remains stored for an explicit retry.
+    ResumeFailed { sid: String },
 }
 
 /// How a session is rendered. `Structured` uses the ACP-based native
@@ -477,6 +482,13 @@ pub struct Instance {
     )]
     pub agent_session_id: Option<String>,
 
+    /// Durable loop-breaker for ambiguous resume-probe failures. When this
+    /// equals `agent_session_id`, startup recovery skips automatic resume so a
+    /// transient pane crash does not repeatedly re-run the same failed probe.
+    /// Explicit user actions can still retry the preserved sid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) resume_probe_failed_sid: Option<String>,
+
     /// User intent gating `acquire_session_id`. See `ResumeIntent` for
     /// semantics. Non-`Default` values (`Use`, `Cleared`) are written only
     /// by user-initiated CLI commands; daemon-internal paths demote to
@@ -554,17 +566,15 @@ pub struct Instance {
     pub session_id_poller: Option<Arc<Mutex<SessionPoller>>>,
 
     /// Runtime-only set of session IDs that retroactive capture must NOT
-    /// re-discover from on-disk artifacts. Populated by the resume-fallback
-    /// cascade with the just-crashed session ID so the Tier-2 fresh start
-    /// doesn't re-import the same bad sid via filesystem scan (opencode db,
-    /// vibe meta.json, codex state, etc., all keep the bad session's row
-    /// after the crash for several minutes).
+    /// re-discover from on-disk artifacts after an explicit resume-target
+    /// invalidation. On-disk artifacts (opencode db, vibe meta.json, codex
+    /// state, etc.) can retain the old row for several minutes.
     ///
     /// `#[serde(skip)]` is intentional. If the daemon dies between the
-    /// cascade clearing the on-disk sid and the on-disk artifact decaying
+    /// explicit invalidation clearing the on-disk sid and the artifact decaying
     /// (~5-10 min), the next launch starts with this set empty and the
     /// freshly-spawned poller can re-import the bad sid once. The next
-    /// `start_with_resume_fallback` then re-runs the cascade and clears it
+    /// `start_with_resume_fallback` then re-runs the invalidation and clears it
     /// again. Self-healing within one cycle; persisting a TTL set isn't
     /// worth the schema cost.
     #[serde(skip)]
@@ -739,6 +749,7 @@ pub(crate) fn persist_session_to_storage(
                 return Ok(SidWrite::Skipped);
             }
             inst.agent_session_id = Some(session_id.to_string());
+            inst.resume_probe_failed_sid = None;
             Ok(SidWrite::Applied)
         } else {
             Ok(SidWrite::Failed)
@@ -801,6 +812,7 @@ impl Instance {
             sandbox_info: None,
             terminal_info: None,
             agent_session_id: None,
+            resume_probe_failed_sid: None,
             resume_intent: ResumeIntent::Default,
             source_profile: String::new(),
             notify_on_waiting: None,
@@ -900,13 +912,16 @@ impl Instance {
         self.sandbox_info = src.sandbox_info.clone();
     }
 
-    /// Same fields as `merge_post_start`. When `stale_sid` is `Some`, the
-    /// resume-fallback cascade just invalidated that exact sid; clear
+    /// Same fields as `merge_post_start`. When `stale_sid` is `Some`, an
+    /// explicit resume reset just invalidated that exact sid; replace
     /// `self.agent_session_id` only if it still matches the stale value, so
     /// a peer poller's freshly-discovered sid (landed between phase 2 and
     /// phase 3 of the restart) survives intact.
     pub fn merge_post_restart(&mut self, src: &Self, stale_sid: Option<&str>) {
         self.merge_post_start(src);
+        if self.agent_session_id == src.agent_session_id {
+            self.resume_probe_failed_sid = src.resume_probe_failed_sid.clone();
+        }
         if let Some(stale) = stale_sid {
             if self.agent_session_id.as_deref() == Some(stale) {
                 self.agent_session_id = src.agent_session_id.clone();
@@ -1354,6 +1369,7 @@ impl Instance {
             }
             ResumeIntent::Cleared => {
                 self.agent_session_id = None;
+                self.resume_probe_failed_sid = None;
                 let session_id = match self.tool.as_str() {
                     "claude" => Some(generate_claude_session_id()),
                     _ => None,
@@ -1753,8 +1769,8 @@ impl Instance {
         // `resume_intent`) from disk before the launch decision. Closes the
         // status-poll lag window for both the read side
         // (`acquire_session_id`) and the write side (`persist_session_id`'s
-        // CAS baseline). Covers Tier-1 and Tier-2 of the resume-fallback
-        // cascade since both call this function.
+        // CAS baseline). Covers resume-probe launches and explicit fresh
+        // launches since both call this function.
         self.reconcile_from_disk();
 
         self.reconcile_sidecar_into_disk();
@@ -2254,6 +2270,7 @@ impl Instance {
             }
 
             inst.agent_session_id = new_sid_for_closure.clone();
+            inst.resume_probe_failed_sid = None;
 
             if promote_cleared {
                 if inst.resume_intent == expected_prior_intent_for_closure {
@@ -2273,10 +2290,12 @@ impl Instance {
 
         match outcome {
             Ok(SidWrite::Applied) => {
+                self.resume_probe_failed_sid = None;
                 if promote_cleared {
                     if let Ok(insts) = storage.load() {
                         if let Some(disk) = insts.into_iter().find(|i| i.id == self.id) {
                             self.resume_intent = disk.resume_intent;
+                            self.resume_probe_failed_sid = disk.resume_probe_failed_sid;
                         }
                     }
                 }
@@ -2287,6 +2306,7 @@ impl Instance {
                     Some(disk) => {
                         self.agent_session_id = disk.agent_session_id;
                         self.resume_intent = disk.resume_intent;
+                        self.resume_probe_failed_sid = disk.resume_probe_failed_sid;
                         SidPersistOutcome::Published
                     }
                     None => {
@@ -2323,31 +2343,14 @@ impl Instance {
         }
     }
 
-    /// Atomic single-flock CAS+clear of `agent_session_id` and (when
-    /// disk still pins `Use(stale_sid)`) downgrade of `resume_intent`
-    /// to `Default`. A split would let a daemon crash freeze disk at
-    /// `(None, Use(stale_sid))`, forcing one extra cascade cycle on
-    /// the next launch.
-    ///
-    /// Intent downgrade is gated on disk's `resume_intent` (read under
-    /// the flock), not the caller's memory: a user repin landing
-    /// between the probe and the clear keeps its fresh pin.
-    ///
-    /// Also heals the legacy `(None, Use(stale_sid))` shape that the
-    /// previous two-flock implementation could persist after a daemon
-    /// crash mid-cascade: when disk's sid is already `None` but intent
-    /// still pins the dead sid, downgrade intent to `Default` and
-    /// return `Applied`.
-    ///
-    /// On sid CAS skip: skip both writes. On Applied or Skipped:
-    /// reload both fields from disk so memory matches whatever the
-    /// closure committed (or the peer's state on Skipped).
-    fn clear_session_for_resume_fallback(&mut self, profile: &str, stale_sid: &str) -> SidWrite {
+    /// Persist an ambiguous resume-probe failure without clearing the durable
+    /// resume sid. The CAS guard keeps peer sid changes authoritative.
+    fn mark_resume_probe_failed(&mut self, profile: &str, sid: &str) -> SidWrite {
         let storage = match super::storage::Storage::new(profile, self.resolve_file_watch()) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(target: "session.store",
-                    "Failed to create storage for resume-fallback clear for {}: {}",
+                    "Failed to create storage for resume-probe failure marker for {}: {}",
                     self.id,
                     e
                 );
@@ -2356,46 +2359,23 @@ impl Instance {
         };
 
         let instance_id = self.id.clone();
-        let stale_for_closure = stale_sid.to_string();
+        let sid_for_closure = sid.to_string();
         let outcome = storage.update(|instances, _groups| {
             let Some(inst) = instances.iter_mut().find(|i| i.id == instance_id) else {
                 return Ok(SidWrite::Failed);
             };
 
-            // Heal legacy `(None, Use(stale_sid))` stuck state from a
-            // pre-flock daemon crash between the two writes. Rare
-            // post-migration; tracing is for forensic visibility.
-            if inst.agent_session_id.is_none()
-                && matches!(&inst.resume_intent, ResumeIntent::Use(p) if p == &stale_for_closure)
-            {
-                tracing::info!(target: "session.store",
-                    instance_id = %instance_id,
-                    stale_sid = %stale_for_closure,
-                    "healing legacy (None, Use(stale)) stuck state in resume-fallback clear"
-                );
-                inst.resume_intent = ResumeIntent::Default;
-                return Ok(SidWrite::Applied);
-            }
-
-            if inst.agent_session_id.as_deref() != Some(stale_for_closure.as_str()) {
+            if inst.agent_session_id.as_deref() != Some(sid_for_closure.as_str()) {
                 tracing::warn!(target: "session.store",
                     instance_id = %instance_id,
-                    expected_sid = %stale_for_closure,
+                    expected_sid = %sid_for_closure,
                     disk_sid = ?inst.agent_session_id,
-                    "sid CAS mismatch in resume-fallback clear; skipping both writes"
+                    "sid CAS mismatch in resume-probe failure marker; skipping write"
                 );
                 return Ok(SidWrite::Skipped);
             }
 
-            inst.agent_session_id = None;
-
-            // Downgrade only when the pin still names the dead sid. The
-            // "user repinned to fresh-sid mid-cascade" and "intent was
-            // already Default/Cleared" paths are legitimate, no warn.
-            if matches!(&inst.resume_intent, ResumeIntent::Use(p) if p == &stale_for_closure) {
-                inst.resume_intent = ResumeIntent::Default;
-            }
-
+            inst.resume_probe_failed_sid = Some(sid_for_closure.clone());
             Ok(SidWrite::Applied)
         });
 
@@ -2405,20 +2385,21 @@ impl Instance {
                     if let Some(disk) = insts.into_iter().find(|i| i.id == self.id) {
                         self.agent_session_id = disk.agent_session_id;
                         self.resume_intent = disk.resume_intent;
+                        self.resume_probe_failed_sid = disk.resume_probe_failed_sid;
                     }
                 }
                 write
             }
             Ok(SidWrite::Failed) => {
                 tracing::warn!(target: "session.store",
-                    "Resume-fallback clear found no instance row for {}",
+                    "Resume-probe failure marker found no instance row for {}",
                     self.id
                 );
                 SidWrite::Failed
             }
             Err(e) => {
                 tracing::warn!(target: "session.store",
-                    "Failed to clear sid for resume fallback for {}: {}",
+                    "Failed to mark resume-probe failure for {}: {}",
                     self.id,
                     e
                 );
@@ -2569,12 +2550,10 @@ impl Instance {
         let mut poller = SessionPoller::new(tmux_session_name.clone());
         let instance_id = self.id.clone();
         let initial_known = self.agent_session_id.clone();
-        // Snapshot per-instance excludes (sids cleared by the resume-fallback
-        // cascade) at poller-spawn time. The cascade always tears down the
-        // existing poller and re-enters this function AFTER inserting into
-        // `retroactive_capture_excludes` (see start_with_resume_fallback),
-        // so the freshly-spawned poller's first immediate poll sees the
-        // populated set and won't re-import the bad sid.
+        // Snapshot per-instance excludes at poller-spawn time. Explicit sid
+        // invalidation inserts into `retroactive_capture_excludes` before any
+        // fresh poller starts, so the first immediate poll won't re-import the
+        // invalidated sid.
         let extra_excludes = self.retroactive_capture_excludes.clone();
 
         let poll_fn: Box<dyn Fn() -> Option<String> + Send + 'static> = match tool {
@@ -2875,18 +2854,11 @@ impl Instance {
     ///   1. If a valid `agent_session_id` is set and the agent supports
     ///      resume, attempt the start (which appends `--resume <sid>` or
     ///      equivalent). Probe the pane via `probe_settle`.
-    ///   2. If the pane went dead within the probe window, stop the Tier-1
-    ///      poller, tear down the dead tmux session, clear the bad sid
-    ///      (in memory, on disk, and from retroactive-capture re-discovery),
-    ///      and retry the start with `skip_on_launch=true` so on_launch
-    ///      hooks do not run twice. Probe the second pane the same way:
-    ///      `start_with_size_opts` only fails on tmux-subprocess errors, so
-    ///      an in-pane crash (missing binary, broken `docker exec`, agent
-    ///      panic on first run) would otherwise masquerade as
-    ///      `StartOutcome::Restarted` over a corpse pane.
-    ///   3. If the Tier-2 start fails at the tmux level *or* its pane crashes
-    ///      within the probe window, propagate `Err` so the caller's existing
-    ///      `Status::Error` + `last_error` path takes over.
+    ///   2. If the pane went dead within the probe window, stop the poller,
+    ///      tear down the dead tmux session, preserve the sid, persist a
+    ///      `resume_probe_failed_sid` loop-breaker, and return
+    ///      `StartOutcome::ResumeFailed`. A dead pane is not proof that the
+    ///      sid is invalid, so this path must not clear it or launch fresh.
     ///
     /// Latency: only fires the probe when `--resume <sid>` is being passed
     /// to a freshly-created tmux session. Healthy resumes on real agents
@@ -2894,9 +2866,8 @@ impl Instance {
     /// warm sessions and non-resume launches pay nothing. Shell-wrapper
     /// command overrides pay the full `RESUME_PROBE_MAX` (~3s) on every
     /// healthy resume because `is_pane_running_shell` never clears for
-    /// them; see `probe_settle`. When the cascade fires, add `kill_clean`
-    /// (~100ms macOS grace) + Tier-2 spawn + a second `RESUME_PROBE_MAX`
-    /// window: ~6-7s total worst-case.
+    /// them; see `probe_settle`. When the failure path fires, add
+    /// `kill_clean` (~100ms macOS grace) before returning.
     ///
     /// Acp-mode sessions short-circuit (no tmux pane to probe).
     /// `StartOutcome::Fresh` is honest there: structured view's resume concept lives
@@ -3027,7 +2998,7 @@ impl Instance {
         tracing::warn!(
             target: "session.store",
             "start: resume with sid {} for session {} crashed pane within probe; \
-             clearing sid and retrying without resume",
+             preserving sid and marking resume failure",
             stale_sid,
             self.id,
         );
@@ -3037,74 +3008,25 @@ impl Instance {
         self.kill_clean()
             .with_context(|| format!("kill_clean before resume fallback for {}", self.id))?;
 
-        self.agent_session_id = None;
-        if let Ok(dir) = crate::hooks::hook_status_dir(&self.id) {
-            let _ = std::fs::remove_file(dir.join("session_id"));
-        }
-        // Populate the poller exclusion before calling
-        // `clear_session_for_resume_fallback` so its `Failed` bail
-        // still keeps the bad sid out of the next retroactive capture
-        // cycle. Must stay before that call for the bail to win.
-        self.retroactive_capture_excludes.insert(stale_sid.clone());
-        match self.clear_session_for_resume_fallback(&profile, &stale_sid) {
+        self.resume_probe_failed_sid = Some(stale_sid.clone());
+        match self.mark_resume_probe_failed(&profile, &stale_sid) {
             SidWrite::Applied | SidWrite::Skipped => {}
-            // `Failed` is unit-tested via
-            // `clear_for_resume_fallback_returns_failed_on_missing_row`;
-            // bail rather than launch Tier-2 against a disk we know
-            // could not be cleaned, which would re-pin the dead sid.
             SidWrite::Failed => {
                 anyhow::bail!(
-                    "resume-fallback could not clear stale sid {} for {}",
+                    "resume probe failed for sid {} for {}, but marker could not be persisted",
                     stale_sid,
                     self.id,
                 );
             }
         }
+        self.status = Status::Error;
+        self.last_error = Some(format!(
+            "resume failed for sid {}; preserved for explicit retry",
+            stale_sid
+        ));
+        self.last_error_check = Some(std::time::Instant::now());
 
-        let _ = self.start_with_size_opts(size, true).with_context(|| {
-            format!(
-                "fresh restart after resume fallback failed for {} (stale sid {} was cleared)",
-                self.id, stale_sid,
-            )
-        })?;
-
-        // Tier-2 needs the same settle-probe as Tier-1: tmux can spawn the
-        // pane successfully while the agent inside crashes immediately
-        // (missing binary, gone docker image, agent panic on first run).
-        // Without this, the in-pane crash class - the very class the cascade
-        // exists to surface - would silently report `StartOutcome::Restarted`.
-        // The dead pane is left in tmux; the next user-initiated restart
-        // goes through `restart_with_size_opts` -> `kill_clean` and self-heals.
-        // Tier-2 settle probe. On Err (same rare condition as Tier-1),
-        // tear down the Tier-2 poller spawned by the second
-        // start_with_size_opts before propagating.
-        let probe = match self.probe_settle(RESUME_PROBE_MAX, RESUME_PROBE_POLL) {
-            Ok(p) => p,
-            Err(e) => {
-                self.stop_poller();
-                self.session_id_poller = None;
-                return Err(e);
-            }
-        };
-        if matches!(probe, ProbeResult::Dead) {
-            // Symmetric teardown with the Tier-1->Tier-2 transition above:
-            // the Tier-2 spawn already started a fresh poller via
-            // `finalize_launch`, and bailing without stopping it leaves an
-            // orphan thread polling a dead pane. The pane stays in tmux
-            // (intentional, for `tmux attach` diagnostic on the crash),
-            // but the poller handle must be torn down so callers see a
-            // consistent post-error state.
-            self.stop_poller();
-            self.session_id_poller = None;
-            anyhow::bail!(
-                "fresh restart after resume fallback crashed within probe for {} \
-                 (stale sid {} was cleared; underlying issue persists)",
-                self.id,
-                stale_sid,
-            );
-        }
-
-        Ok(StartOutcome::Restarted { stale_sid })
+        Ok(StartOutcome::ResumeFailed { sid: stale_sid })
     }
 
     /// Smart-send precondition: bring this session's tmux pane to a state
@@ -3128,9 +3050,9 @@ impl Instance {
     ///
     /// Latency: `AlreadyAlive` is ~tmux RTT. The `Respawned` path routes
     /// through `restart_with_size` -> `start_with_resume_fallback`, which
-    /// on a dead resume-eligible pane can block for the full Tier-1 +
-    /// Tier-2 cascade window (~6-7s; see `start_with_resume_fallback` for
-    /// the breakdown) plus up to 3s of `wait_for_pane_ready` polling.
+    /// on a dead resume-eligible pane can block for the resume probe window
+    /// (~3s; see `start_with_resume_fallback` for the breakdown) plus up to
+    /// 3s of `wait_for_pane_ready` polling.
     /// Smart-send, TUI Enter, and `aoe send` callers should size timeouts
     /// and spinner copy accordingly.
     ///
@@ -3171,30 +3093,35 @@ impl Instance {
         }
         let session = self.tmux_session().map_err(EnsureReadyError::Tmux)?;
         if !session.exists() {
-            // Route fresh starts through the cascade so a stale sid loaded
-            // from disk that crashes the agent on launch is detected,
-            // cleared, and retried. Without this, `aoe send` after a tmux
-            // server kill or reboot resurrects the same bad sid the
-            // restart paths exist to recover from.
+            // Route fresh starts through the resume probe so a sid loaded
+            // from disk that crashes the agent on launch is detected and
+            // preserved with a loop-breaker instead of being retried
+            // automatically.
             let outcome = self
                 .start_with_resume_fallback(size, false)
                 .map_err(EnsureReadyError::Tmux)?;
-            self.wait_for_pane_ready(&session);
             let stale_sid = match outcome {
                 StartOutcome::Restarted { stale_sid } => Some(stale_sid),
+                StartOutcome::ResumeFailed { sid } => {
+                    return Ok(EnsureReadyOutcome::ResumeFailed { sid });
+                }
                 StartOutcome::Resumed | StartOutcome::Fresh => None,
             };
+            self.wait_for_pane_ready(&session);
             return Ok(EnsureReadyOutcome::Started { stale_sid });
         }
         if session.is_pane_dead() {
             let outcome = self
                 .restart_with_size(size)
                 .map_err(EnsureReadyError::Tmux)?;
-            self.wait_for_pane_ready(&session);
             let stale_sid = match outcome {
                 StartOutcome::Restarted { stale_sid } => Some(stale_sid),
+                StartOutcome::ResumeFailed { sid } => {
+                    return Ok(EnsureReadyOutcome::ResumeFailed { sid });
+                }
                 StartOutcome::Resumed | StartOutcome::Fresh => None,
             };
+            self.wait_for_pane_ready(&session);
             return Ok(EnsureReadyOutcome::Respawned { stale_sid });
         }
         Ok(EnsureReadyOutcome::AlreadyAlive)
@@ -6702,6 +6629,50 @@ mod tests {
 
         #[test]
         #[serial]
+        fn persist_session_id_clears_resume_probe_failed_marker() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let storage =
+                crate::session::storage::Storage::new_unwatched("persist-clear-resume-marker")
+                    .unwrap();
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = "persist-clear-resume-marker".to_string();
+            inst.agent_session_id = Some("019342aa-2222-7eee-8fff-aaaabbbbcccc".to_string());
+            inst.resume_probe_failed_sid = Some("019342aa-2222-7eee-8fff-aaaabbbbcccc".to_string());
+            let on_disk = inst.clone();
+            storage
+                .update(|i, g| {
+                    *i = vec![on_disk.clone()];
+                    *g = crate::session::GroupTree::new_with_groups(
+                        std::slice::from_ref(&on_disk),
+                        &[],
+                    )
+                    .get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
+            inst.agent_session_id = Some("019342ab-1234-7def-8901-abcdef012345".to_string());
+            let _ = inst.persist_session_id(
+                "persist-clear-resume-marker",
+                Some("019342aa-2222-7eee-8fff-aaaabbbbcccc"),
+                ResumeIntent::Default,
+            );
+
+            let loaded = storage.load().unwrap();
+            assert_eq!(
+                loaded[0].agent_session_id.as_deref(),
+                Some("019342ab-1234-7def-8901-abcdef012345"),
+            );
+            assert_eq!(loaded[0].resume_probe_failed_sid, None);
+            assert_eq!(inst.resume_probe_failed_sid, None);
+        }
+
+        #[test]
+        #[serial]
         fn persist_session_id_persists_sid_when_intent_cas_mismatches() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());
@@ -6799,289 +6770,6 @@ mod tests {
             );
         }
 
-        fn seed_disk(profile: &str, inst: &Instance) {
-            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
-            let on_disk = inst.clone();
-            storage
-                .update(|i, g| {
-                    *i = vec![on_disk.clone()];
-                    *g = crate::session::GroupTree::new_with_groups(
-                        std::slice::from_ref(&on_disk),
-                        &[],
-                    )
-                    .get_all_groups();
-                    Ok(())
-                })
-                .unwrap();
-        }
-
-        #[test]
-        #[serial]
-        fn clear_for_resume_fallback_atomically_clears_and_downgrades() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let profile = "fallback-clear-happy";
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = profile.to_string();
-            inst.agent_session_id = Some("stale".to_string());
-            inst.resume_intent = ResumeIntent::Use("stale".to_string());
-            seed_disk(profile, &inst);
-
-            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
-            assert_eq!(outcome, super::SidWrite::Applied);
-
-            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].agent_session_id, None);
-            assert_eq!(loaded[0].resume_intent, ResumeIntent::Default);
-            assert_eq!(inst.agent_session_id, None);
-            assert_eq!(inst.resume_intent, ResumeIntent::Default);
-        }
-
-        #[test]
-        #[serial]
-        fn clear_for_resume_fallback_intent_already_default() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let profile = "fallback-clear-default";
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = profile.to_string();
-            inst.agent_session_id = Some("stale".to_string());
-            inst.resume_intent = ResumeIntent::Default;
-            seed_disk(profile, &inst);
-
-            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
-            assert_eq!(outcome, super::SidWrite::Applied);
-
-            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].agent_session_id, None);
-            assert_eq!(loaded[0].resume_intent, ResumeIntent::Default);
-            assert_eq!(inst.resume_intent, ResumeIntent::Default);
-        }
-
-        #[test]
-        #[serial]
-        fn clear_for_resume_fallback_preserves_user_repin() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let profile = "fallback-clear-repin";
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = profile.to_string();
-            inst.agent_session_id = Some("stale".to_string());
-            inst.resume_intent = ResumeIntent::Use("stale".to_string());
-            seed_disk(profile, &inst);
-
-            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
-            storage
-                .update(|i, _g| {
-                    i[0].resume_intent = ResumeIntent::Use("fresh".to_string());
-                    Ok(())
-                })
-                .unwrap();
-
-            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
-            assert_eq!(outcome, super::SidWrite::Applied);
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].agent_session_id, None);
-            assert_eq!(
-                loaded[0].resume_intent,
-                ResumeIntent::Use("fresh".to_string()),
-                "user's repin must survive the cascade clear",
-            );
-            assert_eq!(
-                inst.resume_intent,
-                ResumeIntent::Use("fresh".to_string()),
-                "memory must reload to honor the repin so Tier-2 picks it up",
-            );
-        }
-
-        #[test]
-        #[serial]
-        fn clear_for_resume_fallback_skips_on_sid_cas_mismatch() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let profile = "fallback-clear-sid-mismatch";
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = profile.to_string();
-            inst.agent_session_id = Some("stale".to_string());
-            inst.resume_intent = ResumeIntent::Use("stale".to_string());
-            seed_disk(profile, &inst);
-
-            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
-            storage
-                .update(|i, _g| {
-                    i[0].agent_session_id = Some("peer-fresh".to_string());
-                    i[0].resume_intent = ResumeIntent::Use("peer-fresh".to_string());
-                    Ok(())
-                })
-                .unwrap();
-
-            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
-            assert_eq!(outcome, super::SidWrite::Skipped);
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].agent_session_id.as_deref(), Some("peer-fresh"));
-            assert_eq!(
-                loaded[0].resume_intent,
-                ResumeIntent::Use("peer-fresh".to_string()),
-            );
-            assert_eq!(
-                inst.agent_session_id.as_deref(),
-                Some("peer-fresh"),
-                "memory must reload sid to converge on peer",
-            );
-            assert_eq!(
-                inst.resume_intent,
-                ResumeIntent::Use("peer-fresh".to_string()),
-                "memory must reload intent to converge on peer",
-            );
-        }
-
-        #[test]
-        #[serial]
-        fn clear_for_resume_fallback_heals_legacy_stuck_state() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let profile = "fallback-clear-heal-legacy";
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = profile.to_string();
-            inst.agent_session_id = Some("stale".to_string());
-            inst.resume_intent = ResumeIntent::Use("stale".to_string());
-            seed_disk(profile, &inst);
-
-            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
-            storage
-                .update(|i, _g| {
-                    i[0].agent_session_id = None;
-                    Ok(())
-                })
-                .unwrap();
-
-            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
-            assert_eq!(outcome, super::SidWrite::Applied);
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].agent_session_id, None);
-            assert_eq!(
-                loaded[0].resume_intent,
-                ResumeIntent::Default,
-                "legacy (None, Use(stale)) state must heal to Default",
-            );
-            assert_eq!(inst.agent_session_id, None);
-            assert_eq!(inst.resume_intent, ResumeIntent::Default);
-        }
-
-        #[test]
-        #[serial]
-        fn clear_for_resume_fallback_skips_on_user_repin_with_none_sid() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let profile = "fallback-clear-repin-none-sid";
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = profile.to_string();
-            inst.agent_session_id = Some("stale".to_string());
-            inst.resume_intent = ResumeIntent::Use("stale".to_string());
-            seed_disk(profile, &inst);
-
-            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
-            storage
-                .update(|i, _g| {
-                    i[0].agent_session_id = None;
-                    i[0].resume_intent = ResumeIntent::Use("other".to_string());
-                    Ok(())
-                })
-                .unwrap();
-
-            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
-            assert_eq!(outcome, super::SidWrite::Skipped);
-
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].agent_session_id, None);
-            assert_eq!(
-                loaded[0].resume_intent,
-                ResumeIntent::Use("other".to_string()),
-                "pin to a different sid must not be healed",
-            );
-            assert_eq!(
-                inst.resume_intent,
-                ResumeIntent::Use("other".to_string()),
-                "memory must reload the user's repin",
-            );
-        }
-
-        #[test]
-        #[serial]
-        fn clear_for_resume_fallback_intent_cleared_not_downgraded() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let profile = "fallback-clear-intent-cleared";
-            let mut inst = Instance::new("title", "/tmp/x");
-            inst.source_profile = profile.to_string();
-            inst.agent_session_id = Some("stale".to_string());
-            inst.resume_intent = ResumeIntent::Cleared;
-            seed_disk(profile, &inst);
-
-            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
-            assert_eq!(outcome, super::SidWrite::Applied);
-
-            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
-            let loaded = storage.load().unwrap();
-            assert_eq!(loaded[0].agent_session_id, None);
-            assert_eq!(
-                loaded[0].resume_intent,
-                ResumeIntent::Cleared,
-                "Cleared is not Use(stale_sid); downgrade must not fire",
-            );
-            assert_eq!(inst.resume_intent, ResumeIntent::Cleared);
-        }
-
-        #[test]
-        #[serial]
-        fn clear_for_resume_fallback_returns_failed_on_missing_row() {
-            let temp = tempdir().unwrap();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-
-            let profile = "fallback-clear-missing";
-            let other = Instance::new("other", "/tmp/x");
-            seed_disk(profile, &other);
-
-            let mut inst = Instance::new("missing", "/tmp/x");
-            inst.source_profile = profile.to_string();
-            inst.agent_session_id = Some("stale".to_string());
-            inst.resume_intent = ResumeIntent::Use("stale".to_string());
-
-            let outcome = inst.clear_session_for_resume_fallback(profile, "stale");
-            assert_eq!(outcome, super::SidWrite::Failed);
-
-            assert_eq!(inst.agent_session_id.as_deref(), Some("stale"));
-            assert_eq!(inst.resume_intent, ResumeIntent::Use("stale".to_string()));
-        }
-
         #[cfg(feature = "serve")]
         #[test]
         #[serial]
@@ -7102,7 +6790,7 @@ mod tests {
 
         #[test]
         #[serial]
-        fn fallback_clears_sid_in_memory_and_on_disk_when_pane_dies() {
+        fn fallback_marks_resume_failed_and_preserves_sid_when_pane_dies() {
             if std::process::Command::new("tmux")
                 .arg("-V")
                 .output()
@@ -7147,36 +6835,38 @@ mod tests {
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
-            let err = outcome
-                .expect_err("Tier-2 with /bin/false must crash within probe and propagate Err");
-            let chain = format!("{:#}", err);
-            assert!(
-                chain.contains("crashed within probe") && chain.contains(&stale_sid),
-                "Tier-2 probe failure must surface the stale sid in its error chain, got: {chain}",
+            assert_eq!(
+                outcome.unwrap(),
+                StartOutcome::ResumeFailed {
+                    sid: stale_sid.clone(),
+                }
             );
-
-            assert!(
-                inst.retroactive_capture_excludes.contains(&stale_sid),
-                "stale sid must be in exclusion set even when Tier-2 ultimately fails: \
-                 the cleanup happens before the Tier-2 attempt and must survive the bail",
+            assert_eq!(inst.agent_session_id.as_deref(), Some(stale_sid.as_str()));
+            assert_eq!(
+                inst.resume_probe_failed_sid.as_deref(),
+                Some(stale_sid.as_str())
             );
-            assert_ne!(
-                inst.agent_session_id.as_deref(),
-                Some(stale_sid.as_str()),
-                "stale sid must not survive in memory after fallback, even on Tier-2 failure",
+            assert_eq!(inst.status, Status::Error);
+            assert_eq!(
+                inst.last_error.as_deref(),
+                Some(
+                    format!("resume failed for sid {stale_sid}; preserved for explicit retry")
+                        .as_str()
+                )
             );
+            assert!(inst.last_error_check.is_some());
             let loaded = storage.load().unwrap();
             let row = loaded.iter().find(|i| i.id == id).expect("instance");
-            assert_ne!(
-                row.agent_session_id.as_deref(),
-                Some(stale_sid.as_str()),
-                "stale sid must not survive on disk after fallback, even on Tier-2 failure",
+            assert_eq!(row.agent_session_id.as_deref(), Some(stale_sid.as_str()));
+            assert_eq!(
+                row.resume_probe_failed_sid.as_deref(),
+                Some(stale_sid.as_str())
             );
         }
 
         #[test]
         #[serial]
-        fn fallback_returns_restarted_when_tier2_pane_lives() {
+        fn fallback_does_not_launch_fresh_when_command_would_live_without_stale_sid() {
             if std::process::Command::new("tmux")
                 .arg("-V")
                 .output()
@@ -7190,25 +6880,12 @@ mod tests {
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
-            let _storage = crate::session::storage::Storage::new_unwatched("fb-test-live").unwrap();
+            let storage = crate::session::storage::Storage::new_unwatched("fb-test-live").unwrap();
 
             let stale_sid = "22222222-2222-2222-2222-222222222222".to_string();
             let mut inst = Instance::new("fallback_lives_test", "/tmp/x");
             inst.tool = "claude".to_string();
             inst.source_profile = "fb-test-live".to_string();
-            // Claude regenerates a fresh UUID on Tier-2 (acquire_session_id
-            // emits `--session-id <new_uuid>`), so we cannot just count argv.
-            // Match the *stale* sid specifically: Tier-1 appends `--resume
-            // <stale_sid>` and the script exits, firing the cascade. Tier-2
-            // appends `--session-id <new_uuid>` (different value), so the
-            // pattern does not match and `sleep 30` keeps the pane alive
-            // past RESUME_PROBE_MAX (3s).
-            //
-            // Pinned: this discriminator relies on
-            // `ResumeStrategy::FlagPair` appending the sid to argv (see
-            // `src/agents.rs`). If a future variant ever passes the sid
-            // out of band (env var, stdin, file), update the wrapper to
-            // observe the new channel instead of `$*`.
             inst.command = format!(
                 "/bin/sh -c 'case \"$*\" in *{stale}*) exit 1 ;; esac; exec sleep 30' --",
                 stale = stale_sid,
@@ -7216,11 +6893,8 @@ mod tests {
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
 
-            // Seed required: clear_session_for_resume_fallback bails on
-            // missing-row Failed before reaching Tier-2, so the row must
-            // exist on disk for the cascade to reach the probe assertions.
             let xs = vec![inst.clone()];
-            _storage
+            storage
                 .update(|i, g| {
                     *i = xs.to_vec();
                     *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
@@ -7239,26 +6913,29 @@ mod tests {
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
-            match outcome {
-                Ok(StartOutcome::Restarted { stale_sid: cleared }) => {
-                    assert_eq!(cleared, stale_sid);
+            assert_eq!(
+                outcome.unwrap(),
+                StartOutcome::ResumeFailed {
+                    sid: stale_sid.clone(),
                 }
-                Ok(other) => panic!(
-                    "Tier-2 success path must return Restarted, got {other:?}; \
-                     a different variant indicates the probe misfires"
-                ),
-                Err(e) => panic!(
-                    "Tier-2 with a live binary must succeed: {e:#}; \
-                     check probe_settle behavior on long-running shells"
-                ),
-            }
-            assert!(inst.retroactive_capture_excludes.contains(&stale_sid));
-            assert!(inst.agent_session_id.as_deref() != Some(stale_sid.as_str()));
+            );
+            assert_eq!(inst.agent_session_id.as_deref(), Some(stale_sid.as_str()));
+            assert_eq!(
+                inst.resume_probe_failed_sid.as_deref(),
+                Some(stale_sid.as_str())
+            );
+            let loaded = storage.load().unwrap();
+            let row = loaded.iter().find(|i| i.id == inst.id).expect("instance");
+            assert_eq!(row.agent_session_id.as_deref(), Some(stale_sid.as_str()));
+            assert_eq!(
+                row.resume_probe_failed_sid.as_deref(),
+                Some(stale_sid.as_str())
+            );
         }
 
         #[test]
         #[serial]
-        fn cascade_fires_when_pane_dies_inside_post_shell_grace_window() {
+        fn resume_failed_fires_when_pane_dies_inside_post_shell_grace_window() {
             if std::process::Command::new("tmux")
                 .arg("-V")
                 .output()
@@ -7272,35 +6949,12 @@ mod tests {
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
-            let _storage =
-                crate::session::storage::Storage::new_unwatched("fb-test-grace").unwrap();
+            let storage = crate::session::storage::Storage::new_unwatched("fb-test-grace").unwrap();
 
             let stale_sid = "33333333-3333-3333-3333-333333333333".to_string();
             let mut inst = Instance::new("fallback_grace_test", "/tmp/x");
             inst.tool = "claude".to_string();
             inst.source_profile = "fb-test-grace".to_string();
-            // Regression guard for RESUME_PROBE_POST_SHELL_GRACE.
-            //
-            // The Tier-1 wrapper exits its boot shell immediately via `exec
-            // sleep N`, then the replacement process exits; tmux observes
-            // pane_dead at roughly t = N seconds. We pick N inside the
-            // window (current grace 2000ms, sleep 1.2s) so:
-            //   * with grace = 500ms, probe_settle returns Alive at t=500ms
-            //     before the death at t=1200ms; cascade misses it; the test
-            //     observes Resumed; assertion FAILS (regression caught).
-            //   * with grace >= ~1300ms, the grace timer is still open when
-            //     pane_dead fires; probe_settle returns Dead; cascade fires;
-            //     the test observes Restarted; assertion PASSES.
-            //
-            // This pins the LOWER bound of grace; the upper bound is
-            // implicitly RESUME_PROBE_MAX (3000ms) since deadline charity
-            // would otherwise mask future regressions.
-            //
-            // Tier-2 reuses the same wrapper but its sid differs from the
-            // stale one (cascade clears agent_session_id; Claude's FlagPair
-            // strategy regenerates a fresh UUID), so the case match misses
-            // and `exec sleep 30` keeps the pane alive past the second
-            // probe window.
             inst.command = format!(
                 "/bin/sh -c 'case \"$*\" in *{stale}*) exec sleep 1.2 ;; esac; exec sleep 30' --",
                 stale = stale_sid,
@@ -7308,11 +6962,8 @@ mod tests {
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
 
-            // Seed required: clear_session_for_resume_fallback bails on
-            // missing-row Failed before reaching Tier-2, so the row must
-            // exist on disk for the cascade to reach the probe assertions.
             let xs = vec![inst.clone()];
-            _storage
+            storage
                 .update(|i, g| {
                     *i = xs.to_vec();
                     *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
@@ -7332,24 +6983,22 @@ mod tests {
                 .output();
 
             match outcome {
-                Ok(StartOutcome::Restarted { stale_sid: cleared }) => {
-                    assert_eq!(cleared, stale_sid);
-                }
+                Ok(StartOutcome::ResumeFailed { sid }) => assert_eq!(sid, stale_sid),
                 Ok(StartOutcome::Resumed) => panic!(
                     "Tier-1 grace shortcut returned Alive before the t=1200ms pane_dead: \
                      RESUME_PROBE_POST_SHELL_GRACE is too short. \
                      Real opencode crashes at ~1000ms; raise the grace constant."
                 ),
                 Ok(other) => panic!(
-                    "Expected Restarted or Resumed; got {other:?} (probe path is taking an unexpected branch)"
+                    "Expected ResumeFailed or Resumed; got {other:?} (probe path is taking an unexpected branch)"
                 ),
-                Err(e) => panic!(
-                    "Tier-2 must succeed because its wrapper does not match the stale sid: {e:#}; \
-                     either the cascade is misrouting the sid or Tier-2 spawn is failing"
-                ),
+                Err(e) => panic!("resume failure should be a typed outcome, got: {e:#}"),
             }
-            assert!(inst.retroactive_capture_excludes.contains(&stale_sid));
-            assert!(inst.agent_session_id.as_deref() != Some(stale_sid.as_str()));
+            assert_eq!(inst.agent_session_id.as_deref(), Some(stale_sid.as_str()));
+            assert_eq!(
+                inst.resume_probe_failed_sid.as_deref(),
+                Some(stale_sid.as_str())
+            );
         }
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -82,11 +82,6 @@ impl Status {
     }
 }
 
-/// Outcome of `start_with_resume_fallback`.
-///
-/// Tmux/process failures propagate as `Err` so callers keep the existing
-/// `Status::Error` + `last_error` path. Resume-probe death is represented
-/// explicitly as `ResumeFailed` because it preserves durable state.
 /// `last_error` the status poller stamps when a session's tmux pane is simply
 /// absent (killed, exited, server reboot) and nothing more specific was
 /// captured from the pane. The preview treats this as the calm "Stopped" case
@@ -94,6 +89,11 @@ impl Status {
 pub const TMUX_SESSION_GONE_ERROR: &str =
     "tmux session is gone. The agent process may have exited or been killed.";
 
+/// Outcome of `start_with_resume_fallback`.
+///
+/// Tmux/process failures propagate as `Err` so callers keep the existing
+/// `Status::Error` + `last_error` path. Resume-probe death is represented
+/// explicitly as `ResumeFailed` because it preserves durable state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StartOutcome {
     /// Session ID was set and resume succeeded; pane is alive.
@@ -118,12 +118,12 @@ pub enum StartOutcome {
 /// `StartOutcome::Resumed` because `acquire_session_id` always assigns a
 /// UUID for Claude.
 #[must_use]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LaunchSidOutcome {
     /// `acquire_session_id` reused a prior sid: `ResumeIntent::Use(sid)`,
     /// observed `agent_session_id`, or retroactive-capture hit. The launch
     /// command embedded the agent's resume flag.
-    Existing,
+    Existing { sid: String },
     /// `acquire_session_id` returned a fresh sid (Claude UUID generation)
     /// or `None`. No prior conversation continued.
     Fresh,
@@ -1786,6 +1786,15 @@ impl Instance {
 
         let profile = self.effective_profile();
         let (cmd, is_existing) = self.build_launch_command(skip_on_launch, &profile)?;
+        let launch_sid = if is_existing {
+            Some(
+                self.agent_session_id
+                    .clone()
+                    .expect("existing launch command carries agent_session_id"),
+            )
+        } else {
+            None
+        };
 
         tracing::debug!(target: "session.store",
             "container cmd: {}",
@@ -1809,10 +1818,9 @@ impl Instance {
             expected_prior_intent,
         );
 
-        Ok(if is_existing {
-            LaunchSidOutcome::Existing
-        } else {
-            LaunchSidOutcome::Fresh
+        Ok(match launch_sid {
+            Some(sid) => LaunchSidOutcome::Existing { sid },
+            None => LaunchSidOutcome::Fresh,
         })
     }
 
@@ -2936,8 +2944,13 @@ impl Instance {
         // honestly report `Fresh`. Without this gate, every Claude launch
         // would probe (~2s) and return `Resumed` because acquire always
         // assigns a UUID, even when no `--resume` was passed.
-        let attempting_resume = matches!(outcome, LaunchSidOutcome::Existing)
-            && should_attempt_resume(self.agent_session_id.as_deref(), &self.tool);
+        let attempted_sid = match &outcome {
+            LaunchSidOutcome::Existing { sid } if should_attempt_resume(Some(sid), &self.tool) => {
+                Some(sid.clone())
+            }
+            _ => None,
+        };
+        let attempting_resume = attempted_sid.is_some();
 
         if pane_was_preexisting {
             if attempting_resume {
@@ -2993,10 +3006,7 @@ impl Instance {
             ProbeResult::Dead => {}
         }
 
-        let stale_sid = self
-            .agent_session_id
-            .clone()
-            .expect("attempting_resume guarantees agent_session_id is Some");
+        let stale_sid = attempted_sid.expect("attempting_resume guarantees launch sid is Some");
         let profile = self.effective_profile();
         tracing::warn!(
             target: "session.store",
@@ -3008,9 +3018,6 @@ impl Instance {
 
         self.stop_poller();
         self.session_id_poller = None;
-        self.kill_clean()
-            .with_context(|| format!("kill_clean before resume fallback for {}", self.id))?;
-
         self.resume_probe_failed_sid = Some(stale_sid.clone());
         match self.mark_resume_probe_failed(&profile, &stale_sid) {
             SidWrite::Applied | SidWrite::Skipped => {}
@@ -3022,6 +3029,8 @@ impl Instance {
                 );
             }
         }
+        self.kill_clean()
+            .with_context(|| format!("kill_clean before resume fallback for {}", self.id))?;
         self.status = Status::Error;
         self.last_error = Some(format!(
             "resume failed for sid {}; preserved for explicit retry",
@@ -5767,7 +5776,9 @@ mod tests {
     }
 
     mod resume_fallback {
-        use super::super::{should_attempt_resume, Instance, ResumeIntent, StartOutcome, Status};
+        use super::super::{
+            should_attempt_resume, Instance, LaunchSidOutcome, ResumeIntent, StartOutcome, Status,
+        };
         use serial_test::serial;
         use tempfile::tempdir;
 
@@ -5811,6 +5822,65 @@ mod tests {
         #[test]
         fn unknown_tool_does_not_attempt_resume() {
             assert!(!should_attempt_resume(Some("uuid-abc-123"), "nonexistent"));
+        }
+
+        #[test]
+        fn launch_sid_outcome_carries_emitted_sid() {
+            let outcome = LaunchSidOutcome::Existing {
+                sid: "11111111-1111-1111-1111-111111111111".to_string(),
+            };
+
+            match outcome {
+                LaunchSidOutcome::Existing { sid } => {
+                    assert_eq!(sid, "11111111-1111-1111-1111-111111111111");
+                }
+                other => panic!("expected Existing, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn start_with_resume_fallback_uses_launch_sid_for_probe_decision() {
+            let source = std::fs::read_to_string(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/session/instance.rs"),
+            )
+            .unwrap();
+            let start = source
+                .find("pub(crate) fn start_with_resume_fallback")
+                .unwrap();
+            let end = source.find("pub fn ensure_pane_ready").unwrap();
+            let fallback_source = &source[start..end];
+
+            assert!(fallback_source.contains("let attempted_sid = match &outcome"));
+            assert!(fallback_source.contains("LaunchSidOutcome::Existing { sid }"));
+            assert!(
+                !fallback_source.contains("should_attempt_resume(self.agent_session_id.as_deref()")
+            );
+            assert!(
+                !fallback_source.contains("let stale_sid = self\n            .agent_session_id")
+            );
+        }
+
+        #[test]
+        fn resume_probe_failure_marks_before_cleanup() {
+            let source = std::fs::read_to_string(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/session/instance.rs"),
+            )
+            .unwrap();
+            let start = source
+                .find("pub(crate) fn start_with_resume_fallback")
+                .unwrap();
+            let end = source.find("pub fn ensure_pane_ready").unwrap();
+            let fallback_source = &source[start..end];
+            let local_marker = fallback_source
+                .find("self.resume_probe_failed_sid = Some(stale_sid.clone())")
+                .unwrap();
+            let persisted_marker = fallback_source
+                .find("self.mark_resume_probe_failed(&profile, &stale_sid)")
+                .unwrap();
+            let cleanup = fallback_source.find("self.kill_clean()").unwrap();
+
+            assert!(local_marker < cleanup);
+            assert!(persisted_marker < cleanup);
         }
 
         #[test]

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -129,6 +129,7 @@ pub fn is_recovery_candidate(inst: &Instance) -> bool {
         && !inst.is_archived()
         && !inst.is_snoozed()
         && inst.status != super::Status::Stopped
+        && inst.agent_session_id != inst.resume_probe_failed_sid
         && should_attempt_resume(inst.agent_session_id.as_deref(), &inst.tool)
 }
 
@@ -323,8 +324,8 @@ pub fn drain_recovery_pending(
 /// hung `on_launch` hook cannot pin the recovery lock (#1265).
 ///
 /// `skip_on_launch=false` is mandatory: hooks must run on the first start
-/// after a reboot. The Tier-2 retry in `start_with_resume_fallback`
-/// hardcodes `true` internally to prevent double-firing.
+/// after a reboot. Ambiguous resume-probe failures return `ResumeFailed`
+/// instead of launching fresh, so hooks are not double-fired on that path.
 ///
 /// On failure, stamps `Status::Error`, `last_error`, and `last_error_check`
 /// on the instance before propagating the error so daemon and TUI workers
@@ -333,7 +334,7 @@ pub fn drain_recovery_pending(
 /// failures keep the historical `"recovery cascade: <e>"` shape.
 ///
 /// Blocks; callers must invoke it off the main event-loop thread. Worst
-/// case is `N_hooks * RECOVERY_HOOK_TIMEOUT + ~7 s` fallback latency.
+/// case is `N_hooks * RECOVERY_HOOK_TIMEOUT + ~4 s` resume-probe latency.
 pub fn run_recovery_for_instance(inst: &mut Instance) -> Result<StartOutcome> {
     let _scope = HookTimeoutScope::new(recovery_hook_timeout());
     let result = inst.restart_with_size_opts(None, false);
@@ -671,6 +672,25 @@ mod tests {
         assert!(
             is_recovery_candidate(&inst),
             "expired snooze must restore recovery eligibility"
+        );
+    }
+
+    #[test]
+    fn resume_probe_failed_sid_is_not_recovery_candidate_until_user_action_changes_state() {
+        let sid = "44444444-4444-4444-8444-444444444444".to_string();
+        let mut inst = Instance::new("resume-failed", "/tmp/test");
+        inst.agent_session_id = Some(sid.clone());
+        inst.resume_probe_failed_sid = Some(sid.clone());
+
+        assert!(
+            !is_recovery_candidate(&inst),
+            "startup recovery must not loop on an ambiguously failed resume sid"
+        );
+
+        inst.resume_probe_failed_sid = None;
+        assert!(
+            is_recovery_candidate(&inst),
+            "clearing the marker through an explicit path restores recovery eligibility"
         );
     }
 

--- a/src/session/restart.rs
+++ b/src/session/restart.rs
@@ -59,10 +59,7 @@ pub fn perform_restart(request: RestartRequest) -> RestartResult {
     // On a successful restart, send the wake-up keys on a detached thread so
     // the result (and the row's status update) propagate back immediately
     // rather than waiting out the up-to-3s pane-readiness probe.
-    let should_wake = match &outcome {
-        Ok(StartOutcome::Fresh | StartOutcome::Resumed) => true,
-        Ok(StartOutcome::ResumeFailed { .. }) | Err(_) => false,
-    };
+    let should_wake = should_send_restart_wake(&outcome);
     if should_wake && !wake_message.is_empty() {
         spawn_wake_worker(session_id.clone(), title, tool, wake_message);
     }
@@ -73,6 +70,10 @@ pub fn perform_restart(request: RestartRequest) -> RestartResult {
         instance: Box::new(instance),
         outcome,
     }
+}
+
+fn should_send_restart_wake(outcome: &Result<StartOutcome, String>) -> bool {
+    matches!(outcome, Ok(StartOutcome::Fresh | StartOutcome::Resumed))
 }
 
 /// Wait for the restarted pane to become live and past its boot shell, then
@@ -142,5 +143,14 @@ mod tests {
         }
         assert_eq!(result.session_id, id);
         assert_eq!(result.instance.id, id);
+    }
+
+    #[test]
+    fn restart_wake_is_suppressed_for_resume_failed() {
+        let outcome = Ok(StartOutcome::ResumeFailed {
+            sid: "11111111-2222-3333-4444-555555555555".to_string(),
+        });
+
+        assert!(!should_send_restart_wake(&outcome));
     }
 }

--- a/src/session/restart.rs
+++ b/src/session/restart.rs
@@ -21,6 +21,9 @@ pub struct RestartRequest {
 
 pub struct RestartResult {
     pub session_id: String,
+    /// Pre-cascade snapshot used as a compare-and-swap baseline when merging
+    /// peer-writable identity fields back into a live row.
+    pub before: Box<Instance>,
     /// Post-cascade instance snapshot. Written back into the TUI's in-memory
     /// copy so `#[serde(skip)]` fields (e.g. `last_start_time`) and the
     /// cascade's mutations (cleared stale `agent_session_id`, container id)
@@ -39,6 +42,7 @@ pub fn perform_restart(request: RestartRequest) -> RestartResult {
 
     let title = instance.title.clone();
     let tool = instance.tool.clone();
+    let before = instance.clone();
 
     // Honor the same on_launch / before_start hook timeout the startup-recovery
     // worker installs (`run_recovery_for_instance`). Without it, a hanging
@@ -65,6 +69,7 @@ pub fn perform_restart(request: RestartRequest) -> RestartResult {
 
     RestartResult {
         session_id,
+        before: Box::new(before),
         instance: Box::new(instance),
         outcome,
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2470,17 +2470,8 @@ impl App {
                     .set_instance_status(&id, crate::session::Status::Starting);
                 self.update_status = Some(UpdateStatus::transient("Reviving session...".into()));
                 self.draw(terminal)?;
-                let stale_sid = self.home.execute_send_message(&id, &message);
-                match stale_sid {
-                    Some(sid) => {
-                        self.update_status = Some(UpdateStatus::transient(format!(
-                            "Resume target {sid} was reset; sent to fresh session (history not loaded)"
-                        )));
-                    }
-                    None => {
-                        self.update_status = None;
-                    }
-                }
+                self.home.execute_send_message(&id, &message);
+                self.update_status = None;
             }
             Action::EnterLiveSend(id) => {
                 // Same revive flow as SendMessage so cold-start (Docker,
@@ -2502,13 +2493,10 @@ impl App {
                 // the smaller pane, and the first capture would render
                 // shifted up.
                 self.update_status = match &outcome {
-                    Ok(Some(sid)) => Some(UpdateStatus::transient(format!(
-                        "Resume target {sid} was reset; live-send used a fresh pane (history not loaded)"
-                    ))),
                     // On clean ready, drop the toast entirely. On Err the
                     // info_dialog already carries the failure detail, so the
                     // transient toast just gets in the way.
-                    Ok(None) | Err(()) => None,
+                    Ok(()) | Err(()) => None,
                 };
                 if outcome.is_ok() {
                     self.draw(terminal)?;
@@ -2678,11 +2666,6 @@ impl App {
                         "restart failed: {err_str}"
                     )));
                     return Ok(());
-                }
-                Ok(crate::session::StartOutcome::Restarted { stale_sid }) => {
-                    self.update_status = Some(UpdateStatus::transient(format!(
-                        "Resume target {stale_sid} was reset; started fresh (history not loaded)"
-                    )));
                 }
                 Ok(crate::session::StartOutcome::ResumeFailed { sid }) => {
                     self.update_status = Some(UpdateStatus::transient(format!(

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2474,7 +2474,7 @@ impl App {
                 match stale_sid {
                     Some(sid) => {
                         self.update_status = Some(UpdateStatus::transient(format!(
-                            "Resume failed for sid {sid}; sent to fresh session (history not loaded)"
+                            "Resume target {sid} was reset; sent to fresh session (history not loaded)"
                         )));
                     }
                     None => {
@@ -2503,7 +2503,7 @@ impl App {
                 // shifted up.
                 self.update_status = match &outcome {
                     Ok(Some(sid)) => Some(UpdateStatus::transient(format!(
-                        "Resume failed for sid {sid}; live-send sent to a fresh pane (history not loaded)"
+                        "Resume target {sid} was reset; live-send used a fresh pane (history not loaded)"
                     ))),
                     // On clean ready, drop the toast entirely. On Err the
                     // info_dialog already carries the failure detail, so the

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2681,8 +2681,14 @@ impl App {
                 }
                 Ok(crate::session::StartOutcome::Restarted { stale_sid }) => {
                     self.update_status = Some(UpdateStatus::transient(format!(
-                        "Resume failed for sid {stale_sid}; started fresh (history not loaded)"
+                        "Resume target {stale_sid} was reset; started fresh (history not loaded)"
                     )));
+                }
+                Ok(crate::session::StartOutcome::ResumeFailed { sid }) => {
+                    self.update_status = Some(UpdateStatus::transient(format!(
+                        "Resume failed for sid {sid}; preserved for retry"
+                    )));
+                    return Ok(());
                 }
                 Ok(_) => {}
             }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2577,13 +2577,12 @@ impl HomeView {
                     filtered_ids.insert(inst.id.clone());
                     continue;
                 };
-                // Defense-in-depth against the resume-fallback cascade: a sid
-                // the cascade just cleared can still live on disk for several
-                // minutes (opencode db, vibe meta.json, codex/gemini/pi/hermes
-                // state). The poller closures filter via `compose_exclusion`,
-                // but if a closure factory ever forgets to thread the per-
-                // instance excludes, this guard prevents the cleared sid from
-                // being re-imported into memory and disk.
+                // Defense-in-depth against explicit resume-target invalidation:
+                // an invalidated sid can still live on disk for several minutes
+                // (opencode db, vibe meta.json, codex/gemini/pi/hermes state).
+                // The poller closures filter via `compose_exclusion`, but if a
+                // closure factory ever forgets to thread the per-instance
+                // excludes, this guard prevents the sid from being re-imported.
                 if inst.retroactive_capture_excludes.contains(&session_id) {
                     tracing::debug!(
                         target: "tui.home",
@@ -2607,7 +2606,7 @@ impl HomeView {
         }
 
         let mut to_apply: Vec<(String, String)> = Vec::new();
-        let mut to_rollback: Vec<(String, Option<String>)> = Vec::new();
+        let mut to_rollback: Vec<(String, Option<String>, Option<String>)> = Vec::new();
 
         for (id, session_id, expected_prior) in &updates {
             let Some(profile) = self.instance_map.get(id).map(|i| i.source_profile.clone()) else {
@@ -2630,7 +2629,11 @@ impl HomeView {
                     {
                         if let Ok(disk_insts) = storage.load() {
                             if let Some(disk_inst) = disk_insts.iter().find(|i| i.id == *id) {
-                                to_rollback.push((id.clone(), disk_inst.agent_session_id.clone()));
+                                to_rollback.push((
+                                    id.clone(),
+                                    disk_inst.agent_session_id.clone(),
+                                    disk_inst.resume_probe_failed_sid.clone(),
+                                ));
                                 reloaded = true;
                             }
                         }
@@ -2655,19 +2658,22 @@ impl HomeView {
         for (id, session_id) in &to_apply {
             self.mutate_instance(id, |inst| {
                 inst.agent_session_id = Some(session_id.clone());
+                inst.resume_probe_failed_sid = None;
             });
         }
-        for (id, disk_sid) in &to_rollback {
+        for (id, disk_sid, disk_failed_sid) in &to_rollback {
             let disk_sid = disk_sid.clone();
+            let disk_failed_sid = disk_failed_sid.clone();
             self.mutate_instance(id, |inst| {
                 inst.agent_session_id = disk_sid.clone();
+                inst.resume_probe_failed_sid = disk_failed_sid.clone();
             });
         }
 
         let touched_ids: Vec<&str> = to_apply
             .iter()
             .map(|(id, _)| id.as_str())
-            .chain(to_rollback.iter().map(|(id, _)| id.as_str()))
+            .chain(to_rollback.iter().map(|(id, _, _)| id.as_str()))
             .chain(filtered_ids.iter().map(|s| s.as_str()))
             .collect();
         let mut set_batch: Vec<(String, String, String)> = Vec::new();
@@ -2759,7 +2765,16 @@ impl HomeView {
                                 id = %instance_id,
                                 %title,
                                 %stale_sid,
-                                "restarted fresh after resume failure",
+                                "restarted fresh after explicit resume reset",
+                            );
+                        }
+                        Ok(crate::session::StartOutcome::ResumeFailed { sid }) => {
+                            tracing::warn!(
+                                target: "session.startup_recovery",
+                                id = %instance_id,
+                                %title,
+                                %sid,
+                                "resume failed; sid preserved for explicit retry",
                             );
                         }
                         Ok(crate::session::StartOutcome::Fresh) => {}
@@ -4092,6 +4107,13 @@ impl HomeView {
                     | Ok(Some(EnsureReadyOutcome::Started {
                         stale_sid: Some(sid),
                     })) => Some(sid),
+                    Ok(Some(EnsureReadyOutcome::ResumeFailed { sid })) => {
+                        self.info_dialog = Some(InfoDialog::new(
+                            "Send Failed",
+                            &format!("Resume failed for sid {sid}; preserved for explicit retry"),
+                        ));
+                        return None;
+                    }
                     Ok(_) => None,
                     Err(err) => {
                         self.info_dialog = Some(InfoDialog::new(
@@ -4239,6 +4261,13 @@ impl HomeView {
                     | Ok(Some(EnsureReadyOutcome::Started {
                         stale_sid: Some(sid),
                     })) => Some(sid),
+                    Ok(Some(EnsureReadyOutcome::ResumeFailed { sid })) => {
+                        self.info_dialog = Some(InfoDialog::new(
+                            "Live send failed",
+                            &format!("Resume failed for sid {sid}; preserved for explicit retry"),
+                        ));
+                        return Err(());
+                    }
                     Ok(_) => None,
                     Err(err) => {
                         self.info_dialog = Some(InfoDialog::new(
@@ -4957,15 +4986,12 @@ impl HomeView {
     /// when `f` returns `Err`.
     ///
     /// Required for callers of `Instance::restart_with_size_opts` /
-    /// `ensure_pane_ready`, because the resume-fallback cascade mutates
-    /// `agent_session_id` and `retroactive_capture_excludes` BEFORE
-    /// returning `Err` on Tier-2 failure. The default `try_mutate_instance`
-    /// drops the mutated clone on `Err`, leaving the live entry with the
-    /// stale sid in memory while disk has been cleared. Subsequent restarts
-    /// then loop indefinitely on the same bad sid (the TUI's `reload()`
-    /// merge prefers in-memory, so even the 5s disk refresh does not
-    /// recover). This helper preserves the cascade's partial mutations so
-    /// the live state stays consistent with disk.
+    /// `ensure_pane_ready`, because the resume path can mutate
+    /// `agent_session_id`, `resume_probe_failed_sid`, and
+    /// `retroactive_capture_excludes` before returning `Err`. The default
+    /// `try_mutate_instance` drops the mutated clone on `Err`, leaving live
+    /// state inconsistent with disk until a later reload. This helper keeps
+    /// the live state consistent with the attempted restart.
     pub(super) fn try_mutate_instance_writeback_on_err<T>(
         &mut self,
         id: &str,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2893,6 +2893,7 @@ impl HomeView {
                 Ok(result) => {
                     let crate::session::restart::RestartResult {
                         session_id,
+                        before,
                         mut instance,
                         outcome,
                     } = result;
@@ -2936,7 +2937,16 @@ impl HomeView {
                     }
 
                     if let Some(slot) = self.instances.iter_mut().find(|i| i.id == session_id) {
-                        *slot = *instance;
+                        slot.merge_post_restart_with_baseline(&before, &instance);
+                        slot.last_error = if instance.status == Status::Error {
+                            instance.last_error.clone()
+                        } else {
+                            None
+                        };
+                        slot.last_error_check = instance.last_error_check;
+                        slot.last_start_time = instance.last_start_time;
+                        slot.retroactive_capture_excludes =
+                            instance.retroactive_capture_excludes.clone();
                         touched = true;
                     }
                 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4246,6 +4246,10 @@ impl HomeView {
             }
         };
         let Some(inst) = self.get_instance(session_id) else {
+            self.info_dialog = Some(InfoDialog::new(
+                "Send Failed",
+                "Session disappeared before the message could be sent.",
+            ));
             return;
         };
         let tmux_session = match target {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2759,15 +2759,6 @@ impl HomeView {
                                 "resumed",
                             );
                         }
-                        Ok(crate::session::StartOutcome::Restarted { stale_sid }) => {
-                            tracing::warn!(
-                                target: "session.startup_recovery",
-                                id = %instance_id,
-                                %title,
-                                %stale_sid,
-                                "restarted fresh after explicit resume reset",
-                            );
-                        }
                         Ok(crate::session::StartOutcome::ResumeFailed { sid }) => {
                             tracing::warn!(
                                 target: "session.startup_recovery",
@@ -4079,10 +4070,7 @@ impl HomeView {
     /// the keystrokes. Errors are surfaced via `info_dialog` so the caller
     /// (`execute_action`) only has to clear its transient status.
     ///
-    /// Returns `Some(stale_sid)` when the resume-fallback cascade fired
-    /// during the implicit respawn so the caller can toast the user about
-    /// the lost history; `None` otherwise.
-    pub fn execute_send_message(&mut self, session_id: &str, message: &str) -> Option<String> {
+    pub fn execute_send_message(&mut self, session_id: &str, message: &str) {
         let target = std::mem::replace(
             &mut self.pending_send_target,
             live_send::LiveSendTarget::Agent,
@@ -4095,32 +4083,26 @@ impl HomeView {
         // live-send does (see `ensure_pane_ready_with_size`): otherwise it
         // boots at tmux's 80x24 default and runs narrow until something
         // resizes it.
-        let stale_sid = match target {
+        match target {
             live_send::LiveSendTarget::Agent => {
                 let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
                     inst.ensure_pane_ready_with_size(size).map_err(Into::into)
                 });
                 match outcome {
-                    Ok(Some(EnsureReadyOutcome::Respawned {
-                        stale_sid: Some(sid),
-                    }))
-                    | Ok(Some(EnsureReadyOutcome::Started {
-                        stale_sid: Some(sid),
-                    })) => Some(sid),
                     Ok(Some(EnsureReadyOutcome::ResumeFailed { sid })) => {
                         self.info_dialog = Some(InfoDialog::new(
                             "Send Failed",
                             &format!("Resume failed for sid {sid}; preserved for explicit retry"),
                         ));
-                        return None;
+                        return;
                     }
-                    Ok(_) => None,
+                    Ok(_) => {}
                     Err(err) => {
                         self.info_dialog = Some(InfoDialog::new(
                             "Send Failed",
                             &format!("Cannot prepare session: {}", err),
                         ));
-                        return None;
+                        return;
                     }
                 }
             }
@@ -4130,9 +4112,8 @@ impl HomeView {
                         "Send Failed",
                         &format!("Cannot prepare terminal: {}", e),
                     ));
-                    return None;
+                    return;
                 }
-                None
             }
             live_send::LiveSendTarget::ContainerTerminal => {
                 if let Err(e) = self.ensure_container_terminal_pane_ready(session_id, size) {
@@ -4140,12 +4121,13 @@ impl HomeView {
                         "Send Failed",
                         &format!("Cannot prepare container terminal: {}", e),
                     ));
-                    return None;
+                    return;
                 }
-                None
             }
         };
-        let inst = self.get_instance(session_id)?;
+        let Some(inst) = self.get_instance(session_id) else {
+            return;
+        };
         let tmux_session = match target {
             live_send::LiveSendTarget::Agent => {
                 match crate::tmux::Session::new(&inst.id, &inst.title) {
@@ -4155,7 +4137,7 @@ impl HomeView {
                             "Send Failed",
                             &format!("Failed to resolve session: {}", e),
                         ));
-                        return None;
+                        return;
                     }
                 }
             }
@@ -4178,7 +4160,7 @@ impl HomeView {
                 "Send Failed",
                 &format!("Failed to send message: {}", e),
             ));
-            return None;
+            return;
         }
         self.stamp_last_accessed(session_id);
         if let Err(e) = self.save() {
@@ -4188,7 +4170,6 @@ impl HomeView {
             self.select_top_attention(None);
             self.selected_session = None;
         }
-        stale_sid
     }
 
     /// Size to boot a cold/dead agent pane at on live-send entry: the visible
@@ -4227,11 +4208,9 @@ impl HomeView {
     /// the post-toast frame, and the agent's first capture rendered
     /// shifted up.
     ///
-    /// Returns `Ok(Some(stale_sid))` when the resume-fallback cascade
-    /// fired during respawn, `Ok(None)` on a clean ready, and `Err(())`
-    /// if the pane could not be readied (`info_dialog` is set with the
-    /// underlying error so the caller only has to clear its toast).
-    pub fn prepare_live_send(&mut self, session_id: &str) -> Result<Option<String>, ()> {
+    /// Returns `Err(())` if the pane could not be readied (`info_dialog` is
+    /// set with the underlying error so the caller only has to clear its toast).
+    pub fn prepare_live_send(&mut self, session_id: &str) -> Result<(), ()> {
         let target = self.pending_live_send_target;
         self.pending_live_send_target = live_send::LiveSendTarget::Agent;
         let size = crate::terminal::get_size();
@@ -4248,19 +4227,13 @@ impl HomeView {
         // lost, leaves the pane pinned at ~50% width until live mode is
         // re-entered. See `Instance::ensure_pane_ready_with_size`.
         let agent_boot_size = self.live_send_boot_size();
-        let stale_sid = match target {
+        match target {
             live_send::LiveSendTarget::Agent => {
                 let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
                     inst.ensure_pane_ready_with_size(agent_boot_size)
                         .map_err(Into::into)
                 });
                 match outcome {
-                    Ok(Some(EnsureReadyOutcome::Respawned {
-                        stale_sid: Some(sid),
-                    }))
-                    | Ok(Some(EnsureReadyOutcome::Started {
-                        stale_sid: Some(sid),
-                    })) => Some(sid),
                     Ok(Some(EnsureReadyOutcome::ResumeFailed { sid })) => {
                         self.info_dialog = Some(InfoDialog::new(
                             "Live send failed",
@@ -4268,7 +4241,7 @@ impl HomeView {
                         ));
                         return Err(());
                     }
-                    Ok(_) => None,
+                    Ok(_) => {}
                     Err(err) => {
                         self.info_dialog = Some(InfoDialog::new(
                             "Live send failed",
@@ -4286,7 +4259,6 @@ impl HomeView {
                     ));
                     return Err(());
                 }
-                None
             }
             live_send::LiveSendTarget::ContainerTerminal => {
                 if let Err(e) = self.ensure_container_terminal_pane_ready(session_id, size) {
@@ -4296,7 +4268,6 @@ impl HomeView {
                     ));
                     return Err(());
                 }
-                None
             }
         };
         let inst = match self.get_instance(session_id) {
@@ -4443,7 +4414,7 @@ impl HomeView {
         // preview dedup so exiting re-asserts the preview geometry cleanly.
         self.preview_pane_synced = None;
         self.stamp_last_accessed(session_id);
-        Ok(stale_sid)
+        Ok(())
     }
 
     /// Synchronously resize the live-send pane to match `self.preview_pane_area`,

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -3,7 +3,7 @@
 use crate::session::builder::{self, InstanceParams};
 use crate::session::{list_profiles, GroupTree, Item, Status, Storage};
 use crate::tui::deletion_poller::DeletionRequest;
-use crate::tui::dialogs::{DeleteOptions, GroupDeleteOptions, NewSessionData};
+use crate::tui::dialogs::{DeleteOptions, GroupDeleteOptions, InfoDialog, NewSessionData};
 
 use super::HomeView;
 
@@ -290,9 +290,8 @@ impl HomeView {
     /// on the next launch.
     ///
     /// Restart goes through `try_mutate_instance_writeback_on_err` so all
-    /// of `restart_with_size`'s mutations (cleared stale `agent_session_id`
-    /// on Tier-2 resume fallback, `last_accessed_at` bumps, etc.) are
-    /// preserved on the live instance.
+    /// of `restart_with_size`'s mutations (`resume_probe_failed_sid`,
+    /// `last_error`, etc.) are preserved on the live instance.
     ///
     /// The wake-up message is read from the resolved config
     /// (`session.restart_wake_message`); an empty value disables the
@@ -434,9 +433,19 @@ impl HomeView {
         // Restart the live instance (not a detached clone) so all
         // non-status fields restart_with_size touches are kept.
         let size = crate::terminal::get_size();
-        self.try_mutate_instance_writeback_on_err(&id, |inst| {
-            inst.restart_with_size(size).map(|_| ())
-        })?;
+        let restart_outcome =
+            self.try_mutate_instance_writeback_on_err(&id, |inst| inst.restart_with_size(size))?;
+        let Some(restart_outcome) = restart_outcome else {
+            return Ok(());
+        };
+        if let crate::session::StartOutcome::ResumeFailed { sid } = restart_outcome {
+            self.info_dialog = Some(InfoDialog::new(
+                "Restart Failed",
+                &format!("Resume failed for sid {sid}; preserved for explicit retry"),
+            ));
+            self.save()?;
+            return Ok(());
+        }
 
         // Stamp touch_last_accessed on the user's gesture (the row should
         // visibly bump immediately). save() pushes both the restart-side

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6064,6 +6064,69 @@ fn restart_selected_session_debounces_via_cooldown_map() {
     );
 }
 
+#[test]
+#[serial]
+fn restart_selected_session_surfaces_resume_failed_without_touching_last_accessed() {
+    if std::process::Command::new("tmux")
+        .arg("-V")
+        .output()
+        .is_err()
+    {
+        eprintln!("Skipping: tmux not available");
+        return;
+    }
+
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let profile = "restart-resume-failed";
+    let storage = Storage::new_unwatched(profile).unwrap();
+    let stale_sid = "11111111-2222-3333-4444-555555555555";
+
+    let mut inst = Instance::new("restart-resume-failed", "/tmp/x");
+    inst.source_profile = profile.to_string();
+    inst.tool = "claude".to_string();
+    inst.command = "/bin/false".to_string();
+    inst.agent_session_id = Some(stale_sid.to_string());
+    let id = inst.id.clone();
+    let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+    let _ = std::process::Command::new("tmux")
+        .args(["kill-session", "-t", &tmux_name])
+        .output();
+
+    storage
+        .update(|instances, groups| {
+            *instances = vec![inst.clone()];
+            *groups = GroupTree::new_with_groups(std::slice::from_ref(&inst), &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(
+        Some(profile.to_string()),
+        tools,
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    view.update_selected();
+    view.selected_session = Some(id.clone());
+
+    let result = view.restart_selected_session(None, None, None, None);
+    let _ = std::process::Command::new("tmux")
+        .args(["kill-session", "-t", &tmux_name])
+        .output();
+
+    assert!(result.is_ok());
+    let dialog = view.info_dialog.as_ref().expect("resume failure dialog");
+    assert_eq!(dialog.title(), "Restart Failed");
+    assert!(dialog.message().contains(stale_sid));
+    let row = view.get_instance(&id).expect("instance remains visible");
+    assert_eq!(row.agent_session_id.as_deref(), Some(stale_sid));
+    assert_eq!(row.resume_probe_failed_sid.as_deref(), Some(stale_sid));
+    assert_eq!(row.status, crate::session::Status::Error);
+    assert!(row.last_accessed_at.is_none());
+}
+
 /// Build a HomeView seeded with two distinct projects, each containing
 /// sessions with different attention statuses. Helper for the Project +
 /// Attention combination tests below.

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6224,6 +6224,24 @@ fn apply_restart_results_propagates_worker_sid_without_peer_write() {
     assert!(env.view.restart_in_flight.is_empty());
 }
 
+#[test]
+#[serial]
+fn execute_send_message_missing_session_shows_send_failed() {
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances[0].id.clone();
+    env.view.instances.retain(|inst| inst.id != id);
+    env.view.instance_map.remove(&id);
+
+    env.view.execute_send_message(&id, "hello");
+
+    let dialog = env.view.info_dialog.as_ref().expect("send failure dialog");
+    assert_eq!(dialog.title(), "Send Failed");
+    assert_eq!(
+        dialog.message(),
+        "Session disappeared before the message could be sent."
+    );
+}
+
 /// A second restart press while the first cascade is still running on the
 /// poller worker must be dropped. The cascade is off the event loop, so the
 /// 1.5s keyboard-repeat debounce does not cover a deliberate press during a

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6138,6 +6138,92 @@ fn restart_selected_session_surfaces_resume_failed_after_async_restart() {
     assert!(row.last_accessed_at.is_some());
 }
 
+#[test]
+#[serial]
+fn apply_restart_results_preserves_peer_sid_and_marker() {
+    use crate::session::StartOutcome;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances[0].id.clone();
+    env.view.restart_in_flight.insert(id.clone());
+    env.view.instances[0].agent_session_id = Some("peer-fresh-sid".to_string());
+    env.view.instances[0].resume_probe_failed_sid = Some("peer-fresh-sid".to_string());
+
+    let mut worker = env.view.instances[0].clone();
+    worker.status = crate::session::Status::Error;
+    worker.agent_session_id = Some("phase1-stale-sid".to_string());
+    worker.resume_probe_failed_sid = Some("phase1-stale-sid".to_string());
+    worker.last_error =
+        Some("resume failed for sid phase1-stale-sid; preserved for explicit retry".to_string());
+
+    env.view.restart_poller = crate::tui::restart_poller::RestartPoller::with_result_for_test(
+        crate::session::restart::RestartResult {
+            session_id: id.clone(),
+            before: Box::new(worker.clone()),
+            instance: Box::new(worker),
+            outcome: Ok(StartOutcome::ResumeFailed {
+                sid: "phase1-stale-sid".to_string(),
+            }),
+        },
+    );
+
+    assert!(env.view.apply_restart_results());
+
+    let row = env
+        .view
+        .get_instance(&id)
+        .expect("instance remains visible");
+    assert_eq!(row.status, crate::session::Status::Error);
+    assert_eq!(row.agent_session_id.as_deref(), Some("peer-fresh-sid"));
+    assert_eq!(
+        row.resume_probe_failed_sid.as_deref(),
+        Some("peer-fresh-sid")
+    );
+    assert!(env.view.restart_in_flight.is_empty());
+    let dialog = env
+        .view
+        .info_dialog
+        .as_ref()
+        .expect("resume failure dialog");
+    assert!(dialog.message().contains("phase1-stale-sid"));
+}
+
+#[test]
+#[serial]
+fn apply_restart_results_propagates_worker_sid_without_peer_write() {
+    use crate::session::StartOutcome;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances[0].id.clone();
+    env.view.restart_in_flight.insert(id.clone());
+    env.view.instances[0].agent_session_id = Some("sid-before".to_string());
+
+    let before = env.view.instances[0].clone();
+    let mut worker = before.clone();
+    worker.agent_session_id = Some("sid-after".to_string());
+    worker.status = crate::session::Status::Running;
+
+    env.view.restart_poller = crate::tui::restart_poller::RestartPoller::with_result_for_test(
+        crate::session::restart::RestartResult {
+            session_id: id.clone(),
+            before: Box::new(before),
+            instance: Box::new(worker),
+            outcome: Ok(StartOutcome::Resumed),
+        },
+    );
+
+    assert!(env.view.apply_restart_results());
+
+    let row = env
+        .view
+        .get_instance(&id)
+        .expect("instance remains visible");
+    assert_eq!(row.status, crate::session::Status::Running);
+    assert_eq!(row.agent_session_id.as_deref(), Some("sid-after"));
+    assert_eq!(row.resume_probe_failed_sid, None);
+    assert!(env.view.restart_in_flight.is_empty());
+}
+
 /// A second restart press while the first cascade is still running on the
 /// poller worker must be dropped. The cascade is off the event loop, so the
 /// 1.5s keyboard-repeat debounce does not cover a deliberate press during a

--- a/src/tui/restart_poller.rs
+++ b/src/tui/restart_poller.rs
@@ -64,6 +64,27 @@ impl RestartPoller {
     pub fn try_recv_result(&self) -> Result<RestartResult, mpsc::TryRecvError> {
         self.result_rx.try_recv()
     }
+
+    #[cfg(test)]
+    pub(crate) fn with_result_for_test(result: RestartResult) -> Self {
+        let (request_tx, request_rx) = mpsc::channel::<RestartRequest>();
+        let (result_tx, result_rx) = mpsc::channel::<RestartResult>();
+        result_tx.send(result).expect("seed restart result");
+
+        let handle = thread::Builder::new()
+            .name("aoe-restart-poller-test".to_string())
+            .spawn(move || {
+                while request_rx.recv().is_ok() {}
+                drop(result_tx);
+            })
+            .expect("failed to spawn test restart poller thread");
+
+        Self {
+            request_tx,
+            result_rx,
+            _handle: handle,
+        }
+    }
 }
 
 impl Default for RestartPoller {


### PR DESCRIPTION
## Description
Fixes #2153.

This makes ambiguous resume-probe failures deterministic and non-destructive:

- Preserve the durable `agent_session_id` when the resume probe pane dies.
- Persist `resume_probe_failed_sid` as a startup-recovery loop-breaker.
- Return and propagate typed `ResumeFailed` outcomes instead of launching a fresh pane automatically.
- Surface the recoverable failure through CLI, TUI, and serve/API paths.
- Clear the marker on explicit sid changes or successful sid persistence.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [ ] New and existing tests pass
  - Focused checks pass; full `cargo test -q` has unrelated local failures listed below.
- [x] Documentation was updated where necessary
  - No user docs change needed; this is a lifecycle recovery behavior fix with covered user-facing surfaces.
- [ ] For UI changes: included screenshot or recording
  - No layout/visual rendering change; TUI dialog/toast behavior is covered by a regression test.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: added focused Rust/tmux regression coverage for the resume-failed TUI restart path plus session/API/CLI unit tests; no visual layout change, and the broad local tmux environment currently has unrelated capture-test failures.

## Testing

Passed:

- `cargo fmt -- --check`
- `cargo check -q`
- `cargo check -q --features serve`
- `cargo clippy -- -D warnings`
- `cargo clippy --features serve -- -D warnings`
- `GIT_MASTER=1 git diff --check upstream/main..HEAD`
- `cargo test -q resume_failed -- --nocapture`
- `cargo test -q resume_probe_failed -- --nocapture`
- `cargo test -q restart_selected_session -- --nocapture`
- `cargo test -q --features serve apply_post_restart_sync -- --nocapture`
- `cargo test -q --features serve apply_cascade_state_sync -- --nocapture`
- `cargo test -q --features serve resume_failed -- --nocapture`
- `cargo test -q --features serve resume_probe_failed -- --nocapture`
- `cargo test -q stale_history_suffix -- --nocapture`
- `cargo test -q set_session_id_clears_resume_probe_failed_marker -- --nocapture`

Known local broad-suite result:

- `cargo test -q` failed locally with 3126 passed, 7 failed, 2 ignored.
- The failures are outside this diff and match previously qualified environment/pre-existing failures:
  - `git::worktree::tests::test_create_worktree_returns_error_on_git_failure`
  - `git::worktree::tests::test_create_worktree_skips_blocked_local_submodules`
  - `git::worktree::tests::test_delete_branch_idempotent_for_branch_with_spaces_in_name`
  - `git::worktree::tests::test_delete_branch_is_idempotent_for_nonexistent_branch`
  - `session::instance::tests::update_status_reconciles_running_hook_to_waiting_on_claude_approval_prompt`
  - `tmux::session::tests::capture_pane_with_cursor_returns_content_and_cursor`
  - `tmux::session::tests::capture_with_cursor_stays_consistent_under_streaming_load`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Sisyphus via OhMyOpenCode, powered by GPT-5.5.

**Any Additional AI Details you'd like to share:**

AI assisted with implementation, review orchestration, and validation. The PR is intentionally draft because the broad local `cargo test -q` run still has unrelated local failures documented above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784223186&installation_id=139138837&pr_number=2224&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2224&signature=699a86a4c03b21edcb2d0792ebcadca617364f3884aea3e669d6e9b9c41e2e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR fixes a session recovery data-loss bug (issue `#2153`) by making “ambiguous resume probe” failures deterministic and non-destructive. When a resumed agent pane exits during the startup probe window, the system no longer clears the stored durable session identity and silently starts over. Instead, it preserves the existing identity and treats the situation as a recoverable “resume failed” state.

### What Changed
- **Preserve identity on ambiguous failures:** The durable `agent_session_id` is kept when the resume probe fails in a way that previously caused it to be wiped and replaced with a fresh session.
- **Add a loop-breaker marker:** A new persisted `resume_probe_failed_sid` marker is written on these ambiguous failures to prevent infinite startup recovery retries until the session state changes.
- **Make outcomes explicit end-to-end:** A typed **`ResumeFailed`** outcome is propagated instead of falling back into restart/respawn behavior.
- **Surface recoverable failures to users:**  
  - **API:** Returns a `409` with `error/message: "resume_failed"` and the preserved `resume_session_id`.
  - **CLI & TUI:** Show clear “preserved for retry” messaging and avoid automatically launching a fresh pane.
- **Cleanup/marker management:** The marker is cleared when the user explicitly changes the session resume target (or when the system successfully persists/locks in the new identity), preventing stale “resume failed” suppression from lasting forever.
- **Remove stale-id handling artifacts:** The older “stale history” suffix approach was removed, and restart logic was adjusted to avoid propagating stale session IDs through the system.

### Benefits
- **No more accidental conversation loss** during transient startup/resume timing issues.
- **Predictable behavior** across CLI, TUI, and API paths when resume is ambiguous.
- **User control and clearer recovery:** users see what happened and can retry intentionally rather than being forced into a fresh session.

### Documentation Updates
- Expanded API documentation for new/updated error response cases.
- Updated session resume guidance to reflect the new “pinned/resume probe failure” behavior and the new persisted marker (`resume_probe_failed_sid`).

### Testing
- Added/updated focused unit and UI/API tests around resume-failed wake suppression, marker persistence, restart/resume handling, and marker clearing behavior.

### Technical Enhancements (for reviewers)
- Introduced durable marker persistence/rollback behavior and new typed `ResumeFailed` outcomes across session instance, restart, recovery, server API, and TUI.
- Refactored restart sync to snapshot-before/merge-after while carefully preserving identity fields (`agent_session_id`, `resume_probe_failed_sid`) without overwriting status/last-error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->