### PR TITLE
fix(projects): unpin keeps the saved project; decouple pin from the registry

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,6 +154,8 @@ jobs:
           fail_ci_if_error: false
       - name: Upload test results to Codecov (vitest)
         if: ${{ !cancelled() }}
+        # Test-analytics upload only; a Codecov network blip must not fail the job.
+        continue-on-error: true
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -252,6 +254,8 @@ jobs:
           fail_ci_if_error: false
       - name: Upload test results to Codecov (playwright-mocked)
         if: ${{ !cancelled() }}
+        # Test-analytics upload only; a Codecov network blip must not fail the job.
+        continue-on-error: true
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -357,6 +361,8 @@ jobs:
           fail_ci_if_error: false
       - name: Upload test results to Codecov (playwright-live)
         if: ${{ !cancelled() }}
+        # Test-analytics upload only; a Codecov network blip must not fail the job.
+        continue-on-error: true
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/guides/multi-repo-workspaces.md
+++ b/docs/guides/multi-repo-workspaces.md
@@ -76,13 +76,17 @@ aoe project add /repo/foo                              # global
 aoe -p other project add /repo/foo --allow-override    # profile shadows global
 ```
 
+### Saved projects versus pinned projects
+
+A registered (saved) project is a registry entry: it shows in the Projects view and the new-session wizard's multi-select picker, whether or not it has any sessions. Pinning is a separate decision: it keeps the project's header visible in the sidebar / project view even with zero sessions. So a saved project is not forced into the sidebar, and unpinning a project does not delete it; it stays saved and only its sessionless header goes away. Removing a project (the Projects view's "Remove", or `aoe project remove`) is the one action that deletes the registry entry.
+
 ### Pinning a project from the TUI
 
-In the TUI's project view (press `g` and pick Project grouping), a project header normally disappears once its last session is gone. Press `p` on a project header, or pick "Pin project" from its right-click menu, to register that repo in the global registry. A pinned project keeps its header (marked with a `◆`) even with zero sessions, so you can launch new work under it later, mirroring the web dashboard, where a project is a registry entry independent of any session. Press `p` again to unpin; an unpinned project drops from the view once it has no sessions.
+In the TUI's project view (press `g` and pick Project grouping), a project header normally disappears once its last session is gone. Press `p` on a project header, or pick "Pin project" from its right-click menu, to pin it (registering the repo in the global registry if it is not already saved). A pinned project keeps its header (marked with a `◆`) even with zero sessions, so you can launch new work under it later. Press `p` again to unpin; the project stays saved (still in the picker), and its header drops from the view once it has no sessions.
 
 ### Pinning a project from the web dashboard
 
-The web sidebar's project (repository) grouping mirrors the TUI. A pinned project shows a `◆` next to its name and keeps its header even with zero sessions; its `+` New session button launches work under that repo. Open a project header's actions menu (right-click, or the menu on the header) and choose "Pin project" to register the repo (global scope) or "Unpin project" to remove every registry entry for it. Pinned-but-empty projects sort below your active repositories. A pin made in the TUI shows up here when the dashboard regains focus, and vice versa.
+The web sidebar's project (repository) grouping mirrors the TUI. A pinned project shows a `◆` next to its name and keeps its header even with zero sessions; its `+` New session button launches work under that repo. Open a project header's actions menu (right-click, or the menu on the header) and choose "Pin project" to pin it (registering the repo, global scope, if needed) or "Unpin project" to clear the pin while keeping the saved project. Pinned-but-empty projects sort below your active repositories. The pin is stored in the registry, so a pin made in the TUI shows up here when the dashboard regains focus, and vice versa.
 
 ## CLI Reference
 

--- a/src/server/api/projects.rs
+++ b/src/server/api/projects.rs
@@ -23,6 +23,9 @@ pub struct ProjectResponse {
     pub scope: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_base_branch: Option<String>,
+    /// Whether the project shows as a sessionless sidebar header. The web
+    /// derives the pin marker and empty-header visibility from this. See #2208.
+    pub pinned: bool,
 }
 
 impl From<Project> for ProjectResponse {
@@ -32,6 +35,7 @@ impl From<Project> for ProjectResponse {
             path: p.path,
             scope: p.scope.as_str().to_string(),
             default_base_branch: p.default_base_branch,
+            pinned: p.pinned,
         }
     }
 }
@@ -104,6 +108,11 @@ pub struct CreateProjectBody {
     /// workspace. Empty/whitespace is treated as unset.
     #[serde(default)]
     pub default_base_branch: Option<String>,
+    /// Whether to pin the project (show it as a sessionless sidebar header).
+    /// Defaults to false: the Projects view just saves a project, while the
+    /// sidebar "Pin project" action sends `true`. See #2208.
+    #[serde(default)]
+    pub pinned: bool,
 }
 
 #[tracing::instrument(
@@ -180,7 +189,8 @@ pub async fn create_project(
     }
 
     let project = Project::new(name, canonical.to_string_lossy(), scope)
-        .with_base_branch(body.default_base_branch);
+        .with_base_branch(body.default_base_branch)
+        .with_pinned(body.pinned);
     match projects::add(&state.profile, scope, project, body.allow_override) {
         Ok(saved) => {
             tracing::info!(target: "http.api.projects", name = %saved.name, path = %saved.path, scope = saved.scope.as_str(), "created project");
@@ -285,24 +295,45 @@ pub async fn delete_project(
     }
 }
 
-/// Extract the new `default_base_branch` from a PATCH body. The key is
-/// required: a plain `Option<String>` field can't enforce that because serde
-/// deserializes a missing field to `None`, indistinguishable from an explicit
-/// `null`, so a `{}` body would silently clear the stored value. Inspect the
-/// raw JSON instead. `Ok(None)` clears, `Ok(Some(_))` sets, `Err((code, msg))`
-/// is a malformed request. Empty/whitespace is normalized to unset downstream.
-fn parse_base_branch_update(
+/// Parsed PATCH body for a project. Each field is `None` when its key is
+/// absent (leave that attribute untouched), `Some(_)` when present. The raw
+/// JSON is inspected rather than deserialized into a struct because a missing
+/// `default_base_branch` key must be distinguishable from an explicit `null`
+/// (which clears the value); serde would fold both to `None`. At least one
+/// recognized key must be present, else the request is a no-op.
+#[derive(Debug, PartialEq)]
+struct ProjectPatch {
+    /// `None`: key absent. `Some(None)`: clear. `Some(Some(s))`: set to `s`
+    /// (empty/whitespace normalized to unset downstream).
+    base_branch: Option<Option<String>>,
+    /// `None`: key absent. `Some(b)`: set the pin flag to `b`.
+    pinned: Option<bool>,
+}
+
+fn parse_project_patch(
     body: &serde_json::Value,
-) -> Result<Option<String>, (&'static str, &'static str)> {
-    match body.get("default_base_branch") {
-        None => Err((
-            "missing_field",
-            "default_base_branch is required (use null to clear)",
-        )),
-        Some(serde_json::Value::Null) => Ok(None),
-        Some(serde_json::Value::String(s)) => Ok(Some(s.clone())),
-        Some(_) => Err(("bad_field", "default_base_branch must be a string or null")),
+) -> Result<ProjectPatch, (&'static str, &'static str)> {
+    let base_branch = match body.get("default_base_branch") {
+        None => None,
+        Some(serde_json::Value::Null) => Some(None),
+        Some(serde_json::Value::String(s)) => Some(Some(s.clone())),
+        Some(_) => return Err(("bad_field", "default_base_branch must be a string or null")),
+    };
+    let pinned = match body.get("pinned") {
+        None => None,
+        Some(serde_json::Value::Bool(b)) => Some(*b),
+        Some(_) => return Err(("bad_field", "pinned must be a boolean")),
+    };
+    if base_branch.is_none() && pinned.is_none() {
+        return Err((
+            "no_fields",
+            "provide at least one of: default_base_branch, pinned",
+        ));
     }
+    Ok(ProjectPatch {
+        base_branch,
+        pinned,
+    })
 }
 
 #[tracing::instrument(target = "http.api.projects", skip_all, fields(name = %name, scope = q.scope.as_deref().unwrap_or("global")))]
@@ -344,8 +375,8 @@ pub async fn update_project(
         }
     };
 
-    let base = match parse_base_branch_update(&body) {
-        Ok(base) => base,
+    let patch = match parse_project_patch(&body) {
+        Ok(patch) => patch,
         Err((err, msg)) => {
             tracing::warn!(target: "http.api.projects", reason = err, "rejected update");
             return (
@@ -356,7 +387,27 @@ pub async fn update_project(
         }
     };
 
-    match projects::update_base_branch(&state.profile, scope, &name, base) {
+    // Apply each present field in turn. Both are read-modify-write over the
+    // same registry file, so the last call's returned project reflects every
+    // applied change. `parse_project_patch` guarantees at least one field.
+    let mut result: Option<std::result::Result<Project, RegistryError>> = None;
+    if let Some(base) = patch.base_branch {
+        result = Some(projects::update_base_branch(
+            &state.profile,
+            scope,
+            &name,
+            base,
+        ));
+    }
+    if let Some(pinned) = patch.pinned {
+        // Don't run the pinned write if a prior base-branch write already
+        // failed (e.g. NotFound), so its error is surfaced rather than masked.
+        if !matches!(&result, Some(Err(_))) {
+            result = Some(projects::set_pinned(&state.profile, scope, &name, pinned));
+        }
+    }
+
+    match result.expect("parse_project_patch guarantees at least one field") {
         Ok(updated) => {
             tracing::info!(target: "http.api.projects", name = %updated.name, path = %updated.path, scope = updated.scope.as_str(), "updated project");
             (StatusCode::OK, Json(ProjectResponse::from(updated))).into_response()
@@ -390,33 +441,60 @@ pub async fn update_project(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_base_branch_update;
+    use super::{parse_project_patch, ProjectPatch};
     use serde_json::json;
 
     #[test]
-    fn base_branch_update_requires_the_key() {
-        // A missing key is a malformed request, not an intent to clear: this is
-        // the guard that stops a `{}` body from silently wiping the default.
+    fn project_patch_requires_at_least_one_field() {
+        // An empty body is a no-op, not an intent to clear: this guard stops a
+        // `{}` body from silently wiping the default base branch (#2208 made
+        // the base-branch key optional, so the old "missing_field" guard moved
+        // here as "no_fields").
         assert_eq!(
-            parse_base_branch_update(&json!({})),
+            parse_project_patch(&json!({})),
             Err((
-                "missing_field",
-                "default_base_branch is required (use null to clear)"
+                "no_fields",
+                "provide at least one of: default_base_branch, pinned"
             ))
         );
-        // null and string both parse; null/empty clears downstream, a value sets.
+    }
+
+    #[test]
+    fn project_patch_parses_base_branch() {
+        // null clears, a string sets; the key being present is what matters.
         assert_eq!(
-            parse_base_branch_update(&json!({"default_base_branch": null})),
-            Ok(None)
+            parse_project_patch(&json!({"default_base_branch": null})),
+            Ok(ProjectPatch {
+                base_branch: Some(None),
+                pinned: None
+            })
         );
         assert_eq!(
-            parse_base_branch_update(&json!({"default_base_branch": "develop"})),
-            Ok(Some("develop".to_string()))
+            parse_project_patch(&json!({"default_base_branch": "develop"})),
+            Ok(ProjectPatch {
+                base_branch: Some(Some("develop".to_string())),
+                pinned: None
+            })
         );
-        // Wrong type is rejected.
         assert_eq!(
-            parse_base_branch_update(&json!({"default_base_branch": 42})),
+            parse_project_patch(&json!({"default_base_branch": 42})),
             Err(("bad_field", "default_base_branch must be a string or null"))
+        );
+    }
+
+    #[test]
+    fn project_patch_parses_pinned_alone() {
+        // The unpin path sends only `pinned`, with no base-branch key.
+        assert_eq!(
+            parse_project_patch(&json!({"pinned": false})),
+            Ok(ProjectPatch {
+                base_branch: None,
+                pinned: Some(false)
+            })
+        );
+        assert_eq!(
+            parse_project_patch(&json!({"pinned": "yes"})),
+            Err(("bad_field", "pinned must be a boolean"))
         );
     }
 }

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -72,6 +72,20 @@ pub struct Project {
     /// then the repo's detected default branch.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_base_branch: Option<String>,
+    /// Whether this project shows as an empty (sessionless) header in the
+    /// sidebar / project view. A registry entry is the "saved project" (it
+    /// feeds the Projects view and the new-session wizard); the pin is the
+    /// separate decision to keep its header visible without sessions. Unpin
+    /// clears this flag but keeps the entry; only an explicit remove deletes
+    /// the entry. See #2208.
+    ///
+    /// Missing in JSON written before #2208 deserializes to `true`: every
+    /// registered project was implicitly pinned then, so an upgrade preserves
+    /// the existing headers rather than silently hiding them. New entries
+    /// (`Project::new`, the create API, `aoe project add`) default to `false`,
+    /// so saving a project no longer forces a sidebar header.
+    #[serde(default = "default_pinned")]
+    pub pinned: bool,
     /// Populated by the loader; not persisted.
     #[serde(skip, default = "default_scope")]
     pub scope: ProjectScope,
@@ -81,12 +95,17 @@ fn default_scope() -> ProjectScope {
     ProjectScope::Global
 }
 
+fn default_pinned() -> bool {
+    true
+}
+
 impl Project {
     pub fn new(name: impl Into<String>, path: impl Into<String>, scope: ProjectScope) -> Self {
         Self {
             name: name.into(),
             path: path.into(),
             default_base_branch: None,
+            pinned: false,
             scope,
         }
     }
@@ -95,6 +114,12 @@ impl Project {
     /// string as "unset".
     pub fn with_base_branch(mut self, base: Option<String>) -> Self {
         self.default_base_branch = base.map(|b| b.trim().to_string()).filter(|b| !b.is_empty());
+        self
+    }
+
+    /// Set the pin flag (whether the project shows as a sessionless header).
+    pub fn with_pinned(mut self, pinned: bool) -> Self {
+        self.pinned = pinned;
         self
     }
 
@@ -239,6 +264,13 @@ pub fn unpopulated_projects(
     let mut out = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
     for p in registered {
+        // Only pinned projects surface as empty headers. An unpinned entry is
+        // saved (Projects view / wizard) but not forced into the sidebar; check
+        // it before `seen.insert` so an unpinned entry never consumes the slot
+        // a pinned entry for the same path would. See #2208.
+        if !p.pinned {
+            continue;
+        }
         let label = repo_label(&p.path);
         if populated_labels.contains(&label) || !seen.insert(canonical_key(&p.path)) {
             continue;
@@ -402,6 +434,42 @@ pub fn update_base_branch(
     Ok(updated)
 }
 
+/// Set the pin flag on the entry matching `name_or_path` in the given scope.
+/// Unpinning (`pinned = false`) keeps the registry entry, so the project stays
+/// in the Projects view and the new-session wizard; only [`remove`] deletes it.
+/// Returns the updated project, or `NotFound` if no entry matches. Same
+/// read-modify-write, last-writer-wins semantics as [`update_base_branch`].
+pub fn set_pinned(
+    profile: &str,
+    scope: ProjectScope,
+    name_or_path: &str,
+    pinned: bool,
+) -> std::result::Result<Project, RegistryError> {
+    let mut existing = match scope {
+        ProjectScope::Global => load_global().map_err(RegistryError::Other)?,
+        ProjectScope::Profile => load_profile(profile).map_err(RegistryError::Other)?,
+    };
+
+    let canonical_target = canonical_key(name_or_path);
+    let idx = existing
+        .iter()
+        .position(|p| {
+            p.name.eq_ignore_ascii_case(name_or_path) || canonical_key(&p.path) == canonical_target
+        })
+        .ok_or_else(|| {
+            RegistryError::NotFound(format!(
+                "No project '{}' in {} scope",
+                name_or_path,
+                scope.as_str()
+            ))
+        })?;
+
+    existing[idx].pinned = pinned;
+    let updated = existing[idx].clone();
+    save_scope(profile, scope, &existing).map_err(RegistryError::Other)?;
+    Ok(updated)
+}
+
 /// Resolve a list of project names against the merged registry. Errors on the
 /// first unknown name with the available names listed.
 pub fn resolve_names(profile: &str, names: &[String]) -> Result<Vec<Project>> {
@@ -454,12 +522,12 @@ mod tests {
     #[test]
     fn unpopulated_projects_skips_populated_and_keys_on_path() {
         let registered = vec![
-            Project::new("alpha", "/work/alpha", ProjectScope::Global),
-            Project::new("beta", "/work/beta", ProjectScope::Global),
+            Project::new("alpha", "/work/alpha", ProjectScope::Global).with_pinned(true),
+            Project::new("beta", "/work/beta", ProjectScope::Global).with_pinned(true),
             // Same basename as the first beta entry but a distinct repo: it
             // must NOT be folded away by the shared basename, the identity is
             // the path.
-            Project::new("beta-other", "/other/beta", ProjectScope::Profile),
+            Project::new("beta-other", "/other/beta", ProjectScope::Profile).with_pinned(true),
         ];
         // `alpha` has a live session keeping its header alive, so only the
         // two distinct beta repos surface as empty headers.
@@ -474,10 +542,10 @@ mod tests {
     #[test]
     fn unpopulated_projects_dedupes_same_path() {
         let registered = vec![
-            Project::new("beta", "/work/beta", ProjectScope::Global),
+            Project::new("beta", "/work/beta", ProjectScope::Global).with_pinned(true),
             // Same canonical path registered again (e.g. global + profile
             // shadow): collapse to a single header.
-            Project::new("beta", "/work/beta", ProjectScope::Profile),
+            Project::new("beta", "/work/beta", ProjectScope::Profile).with_pinned(true),
         ];
         let populated: HashSet<String> = HashSet::new();
         let empties = unpopulated_projects(&populated, &registered);
@@ -487,9 +555,35 @@ mod tests {
 
     #[test]
     fn unpopulated_projects_empty_when_all_populated() {
-        let registered = vec![Project::new("alpha", "/work/alpha", ProjectScope::Global)];
+        let registered =
+            vec![Project::new("alpha", "/work/alpha", ProjectScope::Global).with_pinned(true)];
         let populated: HashSet<String> = ["alpha".to_string()].into_iter().collect();
         assert!(unpopulated_projects(&populated, &registered).is_empty());
+    }
+
+    #[test]
+    fn unpopulated_projects_skips_unpinned() {
+        // A saved-but-unpinned project (the new default) is not forced into the
+        // sidebar; only pinned ones surface as empty headers. See #2208.
+        let registered = vec![
+            Project::new("pinned", "/work/pinned", ProjectScope::Global).with_pinned(true),
+            Project::new("saved", "/work/saved", ProjectScope::Global),
+        ];
+        let populated: HashSet<String> = HashSet::new();
+        let empties = unpopulated_projects(&populated, &registered);
+        let paths: Vec<&str> = empties.iter().map(|p| p.path.as_str()).collect();
+        assert_eq!(paths, vec!["/work/pinned"]);
+    }
+
+    #[test]
+    fn new_project_defaults_unpinned_legacy_json_defaults_pinned() {
+        // New entries are saved-but-not-pinned.
+        assert!(!Project::new("r", "/tmp/r", ProjectScope::Global).pinned);
+        // JSON written before #2208 has no `pinned` key: it must deserialize to
+        // pinned so an upgrade keeps existing empty headers visible.
+        let legacy = r#"[{"name":"r","path":"/tmp/r"}]"#;
+        let parsed: Vec<Project> = serde_json::from_str(legacy).unwrap();
+        assert!(parsed[0].pinned);
     }
 
     #[test]
@@ -589,6 +683,47 @@ mod tests {
         // Unknown project is a NotFound.
         assert!(matches!(
             update_base_branch("default", ProjectScope::Global, "nope", Some("x".into())),
+            Err(RegistryError::NotFound(_))
+        ));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn set_pinned_toggles_without_removing_entry() -> Result<()> {
+        let temp = tempdir()?;
+        setup(temp.path());
+        let repo = temp.path().join("repoPin");
+        let _ = git2::Repository::init(&repo);
+
+        // Pin on create, then unpin: the row must survive (the #2208 fix).
+        add(
+            "default",
+            ProjectScope::Global,
+            Project::new("repoPin", repo.to_string_lossy(), ProjectScope::Global).with_pinned(true),
+            false,
+        )?;
+        assert!(load_global()?[0].pinned);
+
+        let unpinned = set_pinned("default", ProjectScope::Global, "repoPin", false)?;
+        assert!(!unpinned.pinned);
+        // Unpin keeps the saved project rather than deleting it.
+        let loaded = load_global()?;
+        assert_eq!(loaded.len(), 1);
+        assert!(!loaded[0].pinned);
+
+        // Re-pin by canonical path.
+        let repinned = set_pinned(
+            "default",
+            ProjectScope::Global,
+            &repo.to_string_lossy(),
+            true,
+        )?;
+        assert!(repinned.pinned);
+        assert!(load_global()?[0].pinned);
+
+        assert!(matches!(
+            set_pinned("default", ProjectScope::Global, "nope", true),
             Err(RegistryError::NotFound(_))
         ));
         Ok(())

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -5163,22 +5163,25 @@ impl HomeView {
             .map(|i| crate::session::projects::canonical_key(i.repo_path()))
     }
 
-    /// Whether the project-view header `label` is backed by a registered
-    /// (pinned) project. A header with live sessions is pinned iff its own repo
-    /// path is in the registry, so two repos sharing a basename are judged
-    /// independently. An empty header exists only because a registered project
-    /// carries that basename, so it is pinned by construction (matched by
-    /// label). Used for the pin indicator and the pin toggle.
+    /// Whether the project-view header `label` is backed by a registered AND
+    /// pinned project. A registry entry is the "saved project"; the `pinned`
+    /// flag is the separate decision to keep its header visible (#2208), so a
+    /// saved-but-unpinned repo reads as not pinned (no glyph; the toggle pins
+    /// it). A header with live sessions is pinned iff its own repo path is a
+    /// pinned entry, so two repos sharing a basename are judged independently.
+    /// An empty header exists only because a pinned project carries that
+    /// basename, so the label match still requires the flag. Used for the pin
+    /// indicator and the pin toggle.
     pub(super) fn is_project_label_pinned(&self, label: &str) -> bool {
         match self.project_header_repo_path(label) {
             Some(path) => self
                 .registered_projects
                 .iter()
-                .any(|p| crate::session::projects::canonical_key(&p.path) == path),
+                .any(|p| p.pinned && crate::session::projects::canonical_key(&p.path) == path),
             None => self
                 .registered_projects
                 .iter()
-                .any(|p| crate::session::projects::repo_label(&p.path) == label),
+                .any(|p| p.pinned && crate::session::projects::repo_label(&p.path) == label),
         }
     }
 

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -57,14 +57,18 @@ fn worktree_rename_block(
 impl HomeView {
     /// Pin or unpin the project header under the cursor (project view only).
     ///
-    /// Pinning registers the repo in the global project registry (the same
-    /// store the WebUI writes), so the project keeps its header in project
-    /// view even after its last session is deleted. Unpinning removes the
-    /// registry entry; a project with no remaining sessions then disappears.
+    /// Pinning keeps the repo's header in project view even after its last
+    /// session is gone: it registers the repo if needed (the same global
+    /// registry the WebUI writes) and sets its `pinned` flag. Unpinning clears
+    /// the flag but KEEPS the registry entry, so the project stays a saved
+    /// project (still in the Projects view and the new-session wizard); its
+    /// header just drops once it has no sessions. Only an explicit remove (the
+    /// projects dialog) deletes the entry. See #2208.
     ///
-    /// The registry is the shared persistence layer: this goes through the
-    /// same `projects::add` / `projects::remove` the web API and the projects
-    /// dialog use, so canonicalization and conflict rules stay in one place.
+    /// The registry is the shared persistence layer, so this goes through the
+    /// same `projects::add` / `projects::set_pinned` the web API and the
+    /// projects dialog use; canonicalization and conflict rules stay in one
+    /// place.
     pub(super) fn toggle_project_pin_at_cursor(&mut self) {
         use crate::session::{projects, Project, ProjectScope};
         use crate::tui::dialogs::InfoDialog;
@@ -81,7 +85,7 @@ impl HomeView {
         if self.is_project_label_pinned(&label) {
             // Unpin. Prefer the registry entry whose canonical path matches the
             // header's own repo. An empty header has no session path, so fall
-            // back to the basename match (it exists only because a registered
+            // back to the basename match (it exists only because a pinned
             // project carries that basename; two such empties share one header
             // and clear one per press).
             let existing = match &header_path {
@@ -98,50 +102,13 @@ impl HomeView {
             let Some(existing) = existing else {
                 return;
             };
-            // Unpin means "this repo is no longer pinned anywhere", so clear
-            // every registry entry for its canonical path rather than just the
-            // one `load_merged` happened to surface. A path can sit in more than
-            // one scope at once (`--allow-override` lets a profile entry shadow
-            // a global one); removing only the visible entry would re-surface
-            // the shadowed one and leave the header pinned after a "success"
-            // dialog. `registered_projects` also drops which profile each entry
-            // came from in all-profiles mode, and `config_profile()` is only
-            // the default, so sweep the global file plus every loaded profile.
             let target = existing.path.clone();
-            let mut profiles: Vec<String> = self.storages.keys().cloned().collect();
-            if !profiles.contains(&profile) {
-                profiles.push(profile.clone());
-            }
-            // Global lives in one shared file, so the profile arg is irrelevant.
-            let mut removals = vec![projects::remove(&profile, ProjectScope::Global, &target)];
-            for p in &profiles {
-                removals.push(projects::remove(p, ProjectScope::Profile, &target));
-            }
-            let mut removed_any = false;
-            let mut hard_err: Option<projects::RegistryError> = None;
-            for res in removals {
-                match res {
-                    Ok(_) => removed_any = true,
-                    Err(projects::RegistryError::NotFound(_)) => {}
-                    Err(e) => hard_err = Some(e),
-                }
-            }
-            // Surface a real I/O/parse failure even if some entry was removed;
-            // a partial unpin the user can't see is worse than a visible error.
-            let result: Result<(), projects::RegistryError> = match (hard_err, removed_any) {
-                (Some(e), _) => Err(e),
-                (None, true) => Ok(()),
-                (None, false) => Err(projects::RegistryError::NotFound(format!(
-                    "No pinned project '{}' found in any loaded scope",
-                    label
-                ))),
-            };
-            match result {
+            match self.set_project_pinned_all_scopes(&target, &profile, false) {
                 Ok(_) => {
                     self.info_dialog = Some(InfoDialog::new(
                         "Project Unpinned",
                         &format!(
-                            "'{}' is no longer pinned. It will drop from project view once it has no sessions.",
+                            "'{}' is no longer pinned. It stays a saved project; its header drops from project view once it has no sessions.",
                             label
                         ),
                     ));
@@ -156,12 +123,28 @@ impl HomeView {
         } else {
             // Pin the repo backing this header. An unpinned header always has at
             // least one live session (an empty header is pinned by
-            // construction), so its repo path is known.
+            // construction), so its repo path is known. If the repo is already
+            // saved (registered but not pinned), flip its flag; otherwise
+            // register it pinned.
             let Some(repo_path) = header_path else {
                 return;
             };
-            let project = Project::new(label.clone(), repo_path, ProjectScope::Global);
-            match projects::add(&profile, ProjectScope::Global, project, false) {
+            let already_registered = self
+                .registered_projects
+                .iter()
+                .any(|p| projects::canonical_key(&p.path) == repo_path);
+            let result = if already_registered {
+                self.set_project_pinned_all_scopes(&repo_path, &profile, true)
+            } else {
+                projects::add(
+                    &profile,
+                    ProjectScope::Global,
+                    Project::new(label.clone(), repo_path, ProjectScope::Global).with_pinned(true),
+                    false,
+                )
+                .map(|_| ())
+            };
+            match result {
                 Ok(_) => {
                     self.info_dialog = Some(InfoDialog::new(
                         "Project Pinned",
@@ -183,6 +166,60 @@ impl HomeView {
         self.refresh_registered_projects();
         self.flat_items = self.build_flat_items();
         self.update_selected();
+    }
+
+    /// Set the `pinned` flag on every registry entry for `target_path`'s
+    /// canonical path, across the global file and every loaded profile (plus
+    /// the default profile). A path can be registered in more than one scope at
+    /// once (`--allow-override` lets a profile entry shadow a global one), and
+    /// `registered_projects` drops which profile each entry came from in
+    /// all-profiles mode, so a single visible entry is not enough. `NotFound`
+    /// per scope is ignored; a real I/O/parse failure is surfaced even if
+    /// another scope updated, since a partial toggle the user can't see is
+    /// worse than a visible error; no match anywhere is `NotFound`. See #2208.
+    fn set_project_pinned_all_scopes(
+        &self,
+        target_path: &str,
+        profile: &str,
+        pinned: bool,
+    ) -> Result<(), crate::session::projects::RegistryError> {
+        use crate::session::{projects, ProjectScope};
+        let mut profiles: Vec<String> = self.storages.keys().cloned().collect();
+        if !profiles.iter().any(|p| p == profile) {
+            profiles.push(profile.to_string());
+        }
+        // Global lives in one shared file, so the profile arg is irrelevant.
+        let mut updates = vec![projects::set_pinned(
+            profile,
+            ProjectScope::Global,
+            target_path,
+            pinned,
+        )];
+        for p in &profiles {
+            updates.push(projects::set_pinned(
+                p,
+                ProjectScope::Profile,
+                target_path,
+                pinned,
+            ));
+        }
+        let mut updated_any = false;
+        let mut hard_err: Option<projects::RegistryError> = None;
+        for res in updates {
+            match res {
+                Ok(_) => updated_any = true,
+                Err(projects::RegistryError::NotFound(_)) => {}
+                Err(e) => hard_err = Some(e),
+            }
+        }
+        match (hard_err, updated_any) {
+            (Some(e), _) => Err(e),
+            (None, true) => Ok(()),
+            (None, false) => Err(projects::RegistryError::NotFound(format!(
+                "No project for path '{}' found in any loaded scope",
+                target_path
+            ))),
+        }
     }
 
     pub(super) fn create_session(&mut self, data: NewSessionData) -> anyhow::Result<String> {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6287,10 +6287,12 @@ fn p_key_pins_project_on_header() {
     // See #2208.
     env.view.toggle_project_pin_at_cursor();
     assert!(!env.view.is_project_label_pinned("alpha"));
-    assert!(
-        !crate::session::projects::load_global().unwrap().is_empty(),
-        "unpin must keep the registry entry, not delete it"
-    );
+    // The specific entry is kept (not just "registry non-empty") with its pin
+    // flag cleared: unpin keeps the saved project, only Remove deletes it.
+    let after = crate::session::projects::load_global().unwrap();
+    assert_eq!(after.len(), 1, "unpin must keep the registry entry");
+    assert_eq!(after[0].name, "alpha");
+    assert!(!after[0].pinned, "unpin must clear the pin flag");
 }
 
 /// Off a project header (here: in Manual grouping), `p` keeps its original

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6656,7 +6656,7 @@ fn all_profiles_view_includes_profile_scoped_pins() {
     projects::add(
         "beta",
         ProjectScope::Profile,
-        Project::new("lonely", "/repos/lonely", ProjectScope::Profile),
+        Project::new("lonely", "/repos/lonely", ProjectScope::Profile).with_pinned(true),
         false,
     )
     .unwrap();
@@ -6715,7 +6715,7 @@ fn unpin_profile_scoped_pin_from_all_profiles_clears_header() {
     projects::add(
         "beta",
         ProjectScope::Profile,
-        Project::new("lonely", "/repos/lonely", ProjectScope::Profile),
+        Project::new("lonely", "/repos/lonely", ProjectScope::Profile).with_pinned(true),
         false,
     )
     .unwrap();
@@ -6738,10 +6738,13 @@ fn unpin_profile_scoped_pin_from_all_profiles_clears_header() {
         !view.is_project_label_pinned("lonely"),
         "lonely must read as unpinned after the toggle"
     );
-    // The entry is gone from beta's on-disk registry, not just the in-memory view.
+    // The unpin must clear the flag on beta's on-disk entry (not the default
+    // profile's), but KEEP the entry: it stays a saved project. See #2208.
+    let beta_after = projects::load_profile("beta").unwrap();
+    assert_eq!(beta_after.len(), 1, "the profile-scoped entry must be kept");
     assert!(
-        projects::load_profile("beta").unwrap().is_empty(),
-        "the profile-scoped registry entry must be removed from disk"
+        !beta_after[0].pinned,
+        "its pin flag must be cleared on disk"
     );
     let still: Vec<String> = view
         .flat_items
@@ -6759,9 +6762,10 @@ fn unpin_profile_scoped_pin_from_all_profiles_clears_header() {
 
 /// A repo pinned in BOTH scopes (a profile entry shadowing a global one via
 /// `--allow-override`) must fully unpin in a single press. `load_merged` only
-/// surfaces the shadowing profile entry, so removing just that one would
-/// re-surface the global entry and leave the header pinned after a "success"
-/// dialog. Unpin sweeps every scope for the path.
+/// surfaces the shadowing profile entry, so clearing just that one would
+/// re-surface the global pin and leave the header pinned after a "success"
+/// dialog. Unpin sweeps every scope for the path, clearing the flag while
+/// keeping each entry. See #2208.
 #[test]
 #[serial]
 fn unpin_clears_both_global_and_profile_entries_for_a_path() {
@@ -6773,14 +6777,14 @@ fn unpin_clears_both_global_and_profile_entries_for_a_path() {
     projects::add(
         "test",
         ProjectScope::Global,
-        Project::new("dual-global", "/repos/dual", ProjectScope::Global),
+        Project::new("dual-global", "/repos/dual", ProjectScope::Global).with_pinned(true),
         false,
     )
     .unwrap();
     projects::add(
         "test",
         ProjectScope::Profile,
-        Project::new("dual-profile", "/repos/dual", ProjectScope::Profile),
+        Project::new("dual-profile", "/repos/dual", ProjectScope::Profile).with_pinned(true),
         true,
     )
     .unwrap();
@@ -6805,14 +6809,14 @@ fn unpin_clears_both_global_and_profile_entries_for_a_path() {
         !env.view.is_project_label_pinned("dual"),
         "dual must read as unpinned after a single press"
     );
-    assert!(
-        projects::load_global().unwrap().is_empty(),
-        "global entry must be removed"
-    );
-    assert!(
-        projects::load_profile("test").unwrap().is_empty(),
-        "profile entry must be removed"
-    );
+    // Both entries are kept (saved projects), with the pin flag cleared in
+    // each scope so the merged view no longer shows a pinned header. See #2208.
+    let global_after = projects::load_global().unwrap();
+    assert_eq!(global_after.len(), 1, "global entry must be kept");
+    assert!(!global_after[0].pinned, "global pin flag must be cleared");
+    let profile_after = projects::load_profile("test").unwrap();
+    assert_eq!(profile_after.len(), 1, "profile entry must be kept");
+    assert!(!profile_after[0].pinned, "profile pin flag must be cleared");
     let names: Vec<String> = env
         .view
         .flat_items

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6227,7 +6227,7 @@ fn pinned_project_without_sessions_shows_empty_header() {
     projects::add(
         "test",
         ProjectScope::Global,
-        Project::new("gamma", "/repos/gamma", ProjectScope::Global),
+        Project::new("gamma", "/repos/gamma", ProjectScope::Global).with_pinned(true),
         false,
     )
     .unwrap();
@@ -6282,9 +6282,15 @@ fn p_key_pins_project_on_header() {
     // The pin path must not open the projects dialog (the chord is shared).
     assert!(env.view.projects_dialog.is_none());
 
-    // Unpinning (a second toggle) drops the registry entry.
+    // Unpinning (a second toggle) clears the pin but KEEPS the saved project,
+    // so the entry stays in the registry (only an explicit remove deletes it).
+    // See #2208.
     env.view.toggle_project_pin_at_cursor();
     assert!(!env.view.is_project_label_pinned("alpha"));
+    assert!(
+        !crate::session::projects::load_global().unwrap().is_empty(),
+        "unpin must keep the registry entry, not delete it"
+    );
 }
 
 /// Off a project header (here: in Manual grouping), `p` keeps its original
@@ -6421,10 +6427,11 @@ fn stale_registry_entry_with_mismatched_archived_path_stays_pinned_and_unpinnabl
         .unwrap();
 
     // Stale registry entry: same basename, different (nonexistent) path.
+    // Pinned, so it surfaces as an empty header (#2208).
     projects::add(
         "test",
         ProjectScope::Global,
-        Project::new("otari", "/repos/otari", ProjectScope::Global),
+        Project::new("otari", "/repos/otari", ProjectScope::Global).with_pinned(true),
         false,
     )
     .unwrap();
@@ -6474,10 +6481,11 @@ fn stale_registry_entry_with_mismatched_archived_path_stays_pinned_and_unpinnabl
         "unpin must drop the empty header from the main flow; got {:?}",
         view.flat_items
     );
-    assert!(
-        projects::load_global().unwrap().is_empty(),
-        "unpin must remove the stale registry entry"
-    );
+    // Unpin clears the flag but KEEPS the saved project (#2208): the entry
+    // survives, now unpinned, so it stays in the Projects view / wizard.
+    let after = projects::load_global().unwrap();
+    assert_eq!(after.len(), 1, "unpin must keep the registry entry");
+    assert!(!after[0].pinned, "unpin must clear the pin flag");
     // The archived session itself is untouched; it stays under Archived.
     assert!(
         view.flat_items

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,9 +43,10 @@ import {
   markWebTourSeen,
   updateWorkspaceOrdering,
   createProject,
-  deleteProject,
+  setProjectPinned,
 } from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
+import { normalizeProjectPathKey } from "./lib/registeredProjects";
 import { IdleDecayWindowContext, parseIdleDecayWindowMs, useIdleDecayWindowMs } from "./lib/idleDecay";
 import { toastBus } from "./lib/toastBus";
 import { resolveToRepoRelative, type FileRef } from "./lib/fileRef";
@@ -688,26 +689,39 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     [sessions],
   );
 
-  // Pin a repo: register it (scope global, matching the TUI's global
-  // registry) so its header persists with zero sessions, then refresh so the
-  // diamond / empty header reflects it. See #2047.
+  // Pin a repo so its header persists with zero sessions. If the repo is
+  // already a saved project, just set its pin flag (PATCH); otherwise register
+  // it pinned (scope global, matching the TUI's global registry). Then refresh
+  // so the diamond / empty header reflects it. See #2047, #2208.
   const handlePinProject = useCallback(
     async (repoPath: string) => {
-      const res = await createProject({ path: repoPath, scope: "global" });
-      if (!res.ok) {
-        toastBus.handler?.error(res.error ?? "Failed to pin project");
+      const key = normalizeProjectPathKey(repoPath);
+      const existing = projects.filter((p) => normalizeProjectPathKey(p.path) === key);
+      let failed: { error?: string } | undefined;
+      if (existing.length > 0) {
+        const results = await Promise.all(existing.map((p) => setProjectPinned(p.name, p.scope, true)));
+        failed = results.find((r) => !r.ok);
+      } else {
+        const res = await createProject({ path: repoPath, scope: "global", pinned: true });
+        if (!res.ok) failed = res;
+      }
+      if (failed) {
+        toastBus.handler?.error(failed.error ?? "Failed to pin project");
         return;
       }
       await refreshProjects();
     },
-    [refreshProjects],
+    [projects, refreshProjects],
   );
 
-  // Unpin a repo: remove every registry entry for its path (a path can be
-  // registered under both global and profile scope), then refresh. See #2047.
+  // Unpin a repo: clear the pin flag on every pinned registry entry for its
+  // path (a path can be registered under both global and profile scope),
+  // keeping the saved project so it stays in the Projects view and the wizard.
+  // Only the Projects view's Remove deletes the entry. See #2208.
   const handleUnpinProject = useCallback(
     async (group: SidebarGroup) => {
-      const results = await Promise.all(group.registeredProjects.map((p) => deleteProject(p.name, p.scope)));
+      const pinned = group.registeredProjects.filter((p) => p.pinned);
+      const results = await Promise.all(pinned.map((p) => setProjectPinned(p.name, p.scope, false)));
       const failed = results.find((r) => !r.ok);
       if (failed) {
         toastBus.handler?.error(failed.error ?? "Failed to unpin project");

--- a/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
+++ b/web/src/components/session-wizard/__tests__/ProjectStep.saved-projects.test.tsx
@@ -43,6 +43,7 @@ function savedProject(overrides: Partial<ProjectInfo> = {}): ProjectInfo {
     path: overrides.path ?? "/repo/alpha",
     scope: overrides.scope ?? "global",
     default_base_branch: overrides.default_base_branch,
+    pinned: overrides.pinned ?? false,
   };
 }
 

--- a/web/src/components/session-wizard/steps/__tests__/ExtraReposPicker.test.tsx
+++ b/web/src/components/session-wizard/steps/__tests__/ExtraReposPicker.test.tsx
@@ -18,9 +18,9 @@ vi.mock("../../../../lib/api", () => ({
 }));
 
 const PROJECTS: ProjectInfo[] = [
-  { name: "primary", path: "/repos/primary", scope: "global" },
-  { name: "alpha", path: "/repos/alpha", scope: "global" },
-  { name: "beta", path: "/repos/beta", scope: "profile" },
+  { name: "primary", path: "/repos/primary", scope: "global", pinned: false },
+  { name: "alpha", path: "/repos/alpha", scope: "global", pinned: false },
+  { name: "beta", path: "/repos/beta", scope: "profile", pinned: false },
 ];
 
 function setup(overrides?: { selectedPaths?: string[]; primaryPath?: string }) {

--- a/web/src/lib/__tests__/registeredProjects.test.ts
+++ b/web/src/lib/__tests__/registeredProjects.test.ts
@@ -42,8 +42,10 @@ function repoGroup(repoPath: string, over: Partial<RepoGroup> = {}): RepoGroup {
   };
 }
 
+// Defaults to pinned: most of these cases assert the empty-header behavior,
+// which only pinned projects get (#2208). Unpinned cases pass `{ pinned: false }`.
 function project(path: string, over: Partial<ProjectInfo> = {}): ProjectInfo {
-  return { name: path.split("/").pop() ?? path, path, scope: "global", ...over };
+  return { name: path.split("/").pop() ?? path, path, scope: "global", pinned: true, ...over };
 }
 
 describe("normalizeProjectPathKey", () => {
@@ -78,6 +80,32 @@ describe("mergeRegisteredProjects", () => {
     expect(merged[0]!.repoPath).toBe("/work/beta");
     expect(merged[0]!.displayName).toBe("beta");
     expect(merged[0]!.workspaces).toHaveLength(0);
+    expect(merged[0]!.registeredProjects).toHaveLength(1);
+  });
+
+  it("does NOT append a header for a saved-but-unpinned repo with no live group", () => {
+    // A project added via the Projects view defaults to unpinned: saved, but
+    // not forced into the sidebar. See #2208.
+    const merged = mergeRegisteredProjects([], [project("/work/saved", { pinned: false })]);
+    expect(merged).toHaveLength(0);
+  });
+
+  it("appends the header when at least one registration for the path is pinned", () => {
+    // Same path saved unpinned in one scope and pinned in another: the pin wins.
+    const merged = mergeRegisteredProjects(
+      [],
+      [
+        project("/work/beta", { scope: "global", pinned: false }),
+        project("/work/beta", { scope: "profile", pinned: true }),
+      ],
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.repoPath).toBe("/work/beta");
+  });
+
+  it("attaches a saved-but-unpinned entry to a populated group (for the context menu)", () => {
+    const merged = mergeRegisteredProjects([repoGroup("/work/alpha")], [project("/work/alpha", { pinned: false })]);
+    expect(merged).toHaveLength(1);
     expect(merged[0]!.registeredProjects).toHaveLength(1);
   });
 
@@ -135,6 +163,15 @@ describe("SidebarGroup pin derivation + render gating", () => {
 
   it("leaves an unregistered repo unpinned", () => {
     const sg = repoGroupToSidebarGroup(repoGroup("/work/gamma"));
+    expect(sg.pinned).toBe(false);
+    expect(sg.pinnedEmpty).toBe(false);
+  });
+
+  it("treats a populated saved-but-unpinned repo as not pinned (#2208)", () => {
+    const [g] = mergeRegisteredProjects([repoGroup("/work/alpha")], [project("/work/alpha", { pinned: false })]);
+    const sg = repoGroupToSidebarGroup(g!);
+    // The entry is attached (so the menu can offer Pin) but there is no marker.
+    expect(sg.registeredProjects).toHaveLength(1);
     expect(sg.pinned).toBe(false);
     expect(sg.pinnedEmpty).toBe(false);
   });

--- a/web/src/lib/api.coverage.test.ts
+++ b/web/src/lib/api.coverage.test.ts
@@ -52,6 +52,7 @@ import {
   createProject,
   deleteProject,
   updateProject,
+  setProjectPinned,
   fetchDockerStatus,
   createSession,
   cloneRepo,
@@ -900,6 +901,45 @@ describe("updateProject", () => {
   it("returns a network error on a thrown fetch", async () => {
     fetchSpy.mockRejectedValueOnce(new Error("offline"));
     const result = await updateProject("p", "global", "x");
+    expect(result).toEqual({ ok: false, error: "offline" });
+  });
+});
+
+describe("setProjectPinned", () => {
+  it("PATCHes the pinned flag and returns the project on 200", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ name: "p", pinned: false }));
+    const result = await setProjectPinned("p", "global", false);
+    expect(result.ok).toBe(true);
+    expect(result.project).toEqual({ name: "p", pinned: false });
+    const [url, init] = lastCall();
+    expect(url).toBe("/api/projects/p?scope=global");
+    expect(init?.method).toBe("PATCH");
+    expect(bodyOf(init)).toEqual({ pinned: false });
+  });
+
+  it("encodes the name and forwards the profile scope", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ name: "a b", pinned: true }));
+    await setProjectPinned("a b", "profile", true);
+    expect(lastCall()[0]).toBe("/api/projects/a%20b?scope=profile");
+    expect(bodyOf(lastCall()[1])).toEqual({ pinned: true });
+  });
+
+  it("returns a parsed error on a JSON error body", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ message: "nope" }), { status: 404 }));
+    const result = await setProjectPinned("p", "global", true);
+    expect(result).toEqual({ ok: false, error: "nope" });
+  });
+
+  it("falls back to the raw text on a non-JSON error body", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("boom", { status: 500 }));
+    const result = await setProjectPinned("p", "global", true);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("boom");
+  });
+
+  it("returns a network error on a thrown fetch", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    const result = await setProjectPinned("p", "global", true);
     expect(result).toEqual({ ok: false, error: "offline" });
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -813,6 +813,10 @@ export async function createProject(body: {
   scope?: "global" | "profile";
   allow_override?: boolean;
   default_base_branch?: string;
+  /** Pin the project on create (show it as a sessionless sidebar header).
+   *  Defaults to false server-side: the Projects view just saves, the sidebar
+   *  "Pin project" action sends true. See #2208. */
+  pinned?: boolean;
 }): Promise<{ ok: boolean; error?: string; project?: ProjectInfo }> {
   try {
     const res = await fetch("/api/projects", {
@@ -874,6 +878,39 @@ export async function updateProject(
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ default_base_branch: defaultBaseBranch }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      try {
+        const data = JSON.parse(text);
+        return {
+          ok: false,
+          error: data.message || `Server error (${res.status})`,
+        };
+      } catch {
+        return { ok: false, error: text || `Server error (${res.status})` };
+      }
+    }
+    const project = (await res.json()) as ProjectInfo;
+    return { ok: true, project };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Pin or unpin a saved project. Unpinning (pinned=false) keeps the registry
+ *  entry, so the project stays in the Projects view and the wizard; it just
+ *  drops from the sidebar. See #2208. */
+export async function setProjectPinned(
+  name: string,
+  scope: "global" | "profile",
+  pinned: boolean,
+): Promise<{ ok: boolean; error?: string; project?: ProjectInfo }> {
+  try {
+    const res = await fetch(`/api/projects/${encodeURIComponent(name)}?scope=${scope}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pinned }),
     });
     if (!res.ok) {
       const text = await res.text();

--- a/web/src/lib/registeredProjects.ts
+++ b/web/src/lib/registeredProjects.ts
@@ -21,12 +21,14 @@ function isSyntheticRepoGroup(id: string): boolean {
 }
 
 // Attach registry metadata to the session-derived repo groups and append a
-// zero-workspace group for every registered project that has no live group
-// (a pinned-but-empty project). Pure so it can be unit-tested directly and
-// memoized in `useRepoGroups`.
+// zero-workspace group for every PINNED registered project that has no live
+// group. Saved-but-unpinned projects attach to a populated group if one
+// exists, but never produce a standalone empty header (#2208). Pure so it can
+// be unit-tested directly and memoized in `useRepoGroups`.
 //
 // A registered path that matches a populated group attaches to it (so the
-// group renders a pin marker) instead of producing a second empty header.
+// group renders a pin marker when pinned) instead of producing a second empty
+// header.
 // Registrations are grouped by normalized path, so the same repo registered
 // under both global and profile scope collapses into one group carrying both
 // (unpin removes every registration for the path). Synthetic Multi-repo /
@@ -65,6 +67,11 @@ export function mergeRegisteredProjects(
 
   for (const [key, registrations] of byKey) {
     if (seen.has(key)) continue;
+    // Only a pinned registration earns a sessionless sidebar header. A
+    // saved-but-unpinned project (the default for a project added via the
+    // Projects view / CLI) stays in the Projects view and the wizard but is
+    // not forced into the sidebar. See #2208.
+    if (!registrations.some((p) => p.pinned)) continue;
     const primary = registrations[0];
     if (!primary) continue;
     const defaultDisplayName = primary.path.split("/").pop() || primary.path;

--- a/web/src/lib/sidebarGroups.ts
+++ b/web/src/lib/sidebarGroups.ts
@@ -50,13 +50,14 @@ export interface SidebarGroup {
   repoPath?: string;
   /** Set when `kind === "sessionGroup"`. Empty string for Ungrouped. */
   groupPath?: string;
-  /** Registry entries for this repo path (the "pin"); empty when unpinned.
-   *  Repo axis only. See #2047. */
+  /** Registry entries (saved projects) for this repo path; empty when the
+   *  repo is not saved. Present regardless of pin state, so the context menu
+   *  can offer Pin/Unpin. Repo axis only. See #2047, #2208. */
   registeredProjects: ProjectInfo[];
-  /** Derived: the repo is registered (pinned). */
+  /** Derived: a saved entry for this repo has `pinned === true`. */
   pinned: boolean;
-  /** Derived: registered with no live workspace, so it shows as an empty
-   *  header that only the pin keeps visible. */
+  /** Derived: pinned with no live workspace, so it shows as an empty header
+   *  that only the pin keeps visible. */
   pinnedEmpty: boolean;
 }
 
@@ -70,7 +71,10 @@ function isSyntheticRepoGroup(id: string): boolean {
 // repo path); real repos create directly in their repo.
 export function repoGroupToSidebarGroup(group: RepoGroup): SidebarGroup {
   const synthetic = isSyntheticRepoGroup(group.id);
-  const pinned = !synthetic && group.registeredProjects.length > 0;
+  // Pinned is the per-project flag, not mere registry membership: a
+  // saved-but-unpinned project attaches its entry for the context menu but
+  // shows no marker and no sessionless header. See #2208.
+  const pinned = !synthetic && group.registeredProjects.some((p) => p.pinned);
   return {
     id: group.id,
     kind: "repo",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -392,6 +392,10 @@ export interface ProjectInfo {
   scope: "global" | "profile";
   /** Default base branch for new worktree branches against this project's repo. */
   default_base_branch?: string;
+  /** Whether the project is pinned: shown as a sessionless sidebar header. A
+   *  registry entry is the saved project; the pin is the separate decision to
+   *  keep its header visible without sessions. See #2208. */
+  pinned: boolean;
 }
 
 /** Docker status returned by /api/docker/status */

--- a/web/tests/acp-transcript-render.spec.ts
+++ b/web/tests/acp-transcript-render.spec.ts
@@ -86,8 +86,14 @@ test.describe("chat bubble overflow", () => {
     // targets p/li/blockquote/a only, so the code container is untouched).
     const codeScroller: Locator = viewport.locator(".acp-markdown .overflow-x-auto").first();
     await expect(codeScroller).toBeVisible();
-    const codeOverflowX = await codeScroller.evaluate((el) => getComputedStyle(el).overflowX);
-    expect(["auto", "scroll"]).toContain(codeOverflowX);
+    // Poll rather than read once: the code block renders as a plain <pre> first,
+    // then shiki async-swaps in a highlighted <div>. In the transient pre state
+    // the bubble's `pre { overflow: hidden }` clobbers the overflow-x-auto
+    // utility, so a single read can catch "hidden" before the swap settles
+    // (CI-only flake). Poll until the settled scroll container reports auto/scroll.
+    await expect
+      .poll(async () => codeScroller.evaluate((el) => getComputedStyle(el).overflowX))
+      .toMatch(/^(auto|scroll)$/);
 
     // The wrap rule must NOT leak into code: the long line stays a single
     // unwrapped line, so the code <pre>'s content is wider than its box.
@@ -95,10 +101,9 @@ test.describe("chat bubble overflow", () => {
     // `pre { overflow: hidden }` clips it.) If overflow-wrap leaked here the
     // line would wrap and scrollWidth would collapse to clientWidth.
     const codePre: Locator = codeScroller.locator("pre").first();
-    const codeLineUnwrapped = await codePre.evaluate(
-      (el) => (el as HTMLElement).scrollWidth > (el as HTMLElement).clientWidth,
-    );
-    expect(codeLineUnwrapped).toBe(true);
+    await expect
+      .poll(async () => codePre.evaluate((el) => (el as HTMLElement).scrollWidth > (el as HTMLElement).clientWidth))
+      .toBe(true);
   });
 });
 

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2243,9 +2243,17 @@
       "components": [
         "web/src/components/WorkspaceSidebar.tsx",
         "web/src/lib/registeredProjects.ts",
+        "web/src/lib/sidebarGroups.ts",
         "web/src/hooks/useRepoGroups.ts",
         "web/src/hooks/useProjects.ts"
       ]
+    },
+    {
+      "id": "sidebar.project-pin-handlers",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": ["tests/sidebar-project-pin.spec.ts"],
+      "components": ["web/src/App.tsx", "web/src/lib/api.ts"]
     },
     {
       "id": "triage.archive-toggle",

--- a/web/tests/live/project-pin.spec.ts
+++ b/web/tests/live/project-pin.spec.ts
@@ -128,7 +128,7 @@ base.describe("pin a project from the web sidebar (#2047, #2208)", () => {
       // The #2208 regression: unpin must NOT delete the saved project. The
       // registry still lists projectA (it would be in the Projects view / wizard).
       const afterUnpin = await (await page.request.get(`${serve.baseUrl}/api/projects`)).json();
-      expect(afterUnpin.some((p: { name: string }) => p.path === repoA)).toBe(true);
+      expect(afterUnpin.some((p: { path: string }) => p.path === repoA)).toBe(true);
     } finally {
       await serve.stop();
     }

--- a/web/tests/live/project-pin.spec.ts
+++ b/web/tests/live/project-pin.spec.ts
@@ -1,13 +1,14 @@
-// Live coverage for pinning a project from the web sidebar (#2047):
-//   - A registered project with no sessions shows as an empty header in the
-//     sidebar (the ◆ marker + a New session button), parity with the TUI.
-//   - "Pin project" on a populated repo header POSTs /api/projects and the
-//     ◆ marker appears and survives a reload (registry persistence).
-//   - "Unpin project" on the empty project DELETEs /api/projects and its
-//     header drops from the sidebar (it had no sessions keeping it alive).
+// Live coverage for pinning a project from the web sidebar (#2047, #2208):
+//   - A saved (registered) but UNPINNED project with no sessions does NOT show
+//     as a sidebar empty header, yet stays in the registry (Projects view /
+//     wizard). Saving a project no longer forces a sidebar header (#2208).
+//   - "Pin project" on a populated repo header POSTs /api/projects with
+//     pinned:true; the ◆ marker appears and survives a reload.
+//   - "Unpin project" PATCHes pinned:false (NOT DELETE): the empty header drops,
+//     but the project remains a saved registry entry (the #2208 regression).
 //
-// The render path is in web/src/components/WorkspaceSidebar.tsx + the merge
-// in web/src/lib/registeredProjects.ts; the registry CRUD is
+// The render path is in web/src/components/WorkspaceSidebar.tsx + the merge in
+// web/src/lib/registeredProjects.ts; the registry CRUD is
 // src/server/api/projects.rs. Live coverage catches wire-format drift the
 // mocked specs miss.
 
@@ -18,9 +19,9 @@ import { spawnSync } from "node:child_process";
 import { spawnAoeServe, listSessions, resolveAoeBinary } from "../helpers/aoeServe";
 
 // Seed a session in `projectA` and register `projectB` (a git repo with no
-// session) so the sidebar shows one populated header and one pinned-but-empty
-// header. Runs before serve spawns so the in-memory caches pick both up.
-function seedSessionAndEmptyProject(opts: {
+// session). projectB is registered UNPINNED (the `aoe project add` default
+// since #2208), so it is a saved project that does NOT show in the sidebar.
+function seedSessionAndSavedProject(opts: {
   title: string;
 }): (seedEnv: { home: string; shimBin: string; env: NodeJS.ProcessEnv }) => void {
   return ({ home, env }) => {
@@ -54,7 +55,7 @@ function seedSessionAndEmptyProject(opts: {
     if (add.status !== 0) {
       throw new Error(`aoe add failed: status=${add.status} stderr=${add.stderr?.toString() ?? "<none>"}`);
     }
-    // Register projectB with no session: the pinned-but-empty case.
+    // Register projectB with no session: saved but unpinned by default.
     const reg = spawnSync(resolveAoeBinary(), ["project", "add", projectB, "--scope", "global"], { env });
     if (reg.status !== 0) {
       throw new Error(`aoe project add failed: status=${reg.status} stderr=${reg.stderr?.toString() ?? "<none>"}`);
@@ -62,13 +63,13 @@ function seedSessionAndEmptyProject(opts: {
   };
 }
 
-base.describe("pin a project from the web sidebar (#2047)", () => {
-  base("empty project shows, pin persists, unpin removes", async ({ page }, testInfo) => {
+base.describe("pin a project from the web sidebar (#2047, #2208)", () => {
+  base("saved-unpinned hidden; pin POSTs; unpin keeps the saved project", async ({ page }, testInfo) => {
     const serve = await spawnAoeServe({
       authMode: "none",
       workerIndex: testInfo.workerIndex,
       parallelIndex: testInfo.parallelIndex,
-      seedFn: seedSessionAndEmptyProject({ title: "pin-session" }),
+      seedFn: seedSessionAndSavedProject({ title: "pin-session" }),
     });
 
     try {
@@ -82,14 +83,15 @@ base.describe("pin a project from the web sidebar (#2047)", () => {
       const headerA = page.locator(`[data-testid='sidebar-group-header'][data-group-id='${repoA}']`);
       await expect(headerA).toBeVisible({ timeout: 10_000 });
 
-      // The pinned-but-empty project (projectB) renders despite no sessions,
-      // with the ◆ marker and a New session button.
-      const headerB = page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "projectB" });
-      await expect(headerB).toBeVisible({ timeout: 10_000 });
-      await expect(headerB.locator("[data-testid='sidebar-group-pinned-marker']")).toBeVisible();
-      await expect(headerB.locator("[aria-label='New session in projectB']")).toBeVisible();
+      // projectB is saved but unpinned: it must NOT show as a sidebar header,
+      // even though it has no sessions and is in the registry (#2208 story 2).
+      await expect(page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "projectB" })).toHaveCount(0);
 
-      // ---- Pin projectA from its header menu ----
+      // ...but it IS a saved project: the registry still lists it.
+      const savedList = await (await page.request.get(`${serve.baseUrl}/api/projects`)).json();
+      expect(savedList.some((p: { name: string }) => p.name === "projectB")).toBe(true);
+
+      // ---- Pin projectA from its header menu (POST with pinned:true) ----
       await headerA.click({ button: "right" });
       const pinPost = page.waitForResponse(
         (res) => res.url().endsWith("/api/projects") && res.request().method() === "POST",
@@ -97,7 +99,7 @@ base.describe("pin a project from the web sidebar (#2047)", () => {
       await page.locator("[data-testid='sidebar-group-context-menu-pin']").click();
       const pinRes = await pinPost;
       expect(pinRes.ok()).toBe(true);
-      expect(pinRes.request().postDataJSON()).toMatchObject({ path: repoA, scope: "global" });
+      expect(pinRes.request().postDataJSON()).toMatchObject({ path: repoA, scope: "global", pinned: true });
 
       await expect(headerA.locator("[data-testid='sidebar-group-pinned-marker']")).toBeVisible({ timeout: 5_000 });
 
@@ -108,20 +110,25 @@ base.describe("pin a project from the web sidebar (#2047)", () => {
         timeout: 10_000,
       });
 
-      // ---- Unpin the empty projectB: its header drops (no sessions) ----
-      const headerBReloaded = page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "projectB" });
-      await headerBReloaded.click({ button: "right" });
-      const unpinDelete = page.waitForResponse(
-        (res) => res.url().includes("/api/projects/") && res.request().method() === "DELETE",
+      // ---- Unpin projectA: PATCH pinned:false, NOT a DELETE ----
+      await headerAReloaded.click({ button: "right" });
+      const unpinPatch = page.waitForResponse(
+        (res) => res.url().includes("/api/projects/") && res.request().method() === "PATCH",
       );
       await page.locator("[data-testid='sidebar-group-context-menu-unpin']").click();
-      const unpinRes = await unpinDelete;
+      const unpinRes = await unpinPatch;
       expect(unpinRes.ok()).toBe(true);
+      expect(unpinRes.request().postDataJSON()).toMatchObject({ pinned: false });
 
-      await expect(page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "projectB" })).toHaveCount(
-        0,
-        { timeout: 10_000 },
-      );
+      // Marker gone (projectA still has a session, so the header stays).
+      await expect(headerAReloaded.locator("[data-testid='sidebar-group-pinned-marker']")).toHaveCount(0, {
+        timeout: 5_000,
+      });
+
+      // The #2208 regression: unpin must NOT delete the saved project. The
+      // registry still lists projectA (it would be in the Projects view / wizard).
+      const afterUnpin = await (await page.request.get(`${serve.baseUrl}/api/projects`)).json();
+      expect(afterUnpin.some((p: { name: string }) => p.path === repoA)).toBe(true);
     } finally {
       await serve.stop();
     }

--- a/web/tests/sidebar-project-pin.spec.ts
+++ b/web/tests/sidebar-project-pin.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+
+// Mocked coverage for the web sidebar pin/unpin handlers (#2208). The live
+// spec (web/tests/live/project-pin.spec.ts) proves the real wire round-trip;
+// this mocked spec drives the same App handlers under the instrumented build
+// so handlePinProject (POST + PATCH-existing branches) and handleUnpinProject
+// (PATCH, never DELETE) are exercised. Unpin must PATCH pinned:false, keeping
+// the saved project rather than deleting it.
+
+interface MockSession {
+  id: string;
+  title: string;
+  project_path: string;
+}
+
+interface MockProject {
+  name: string;
+  path: string;
+  scope: "global" | "profile";
+  pinned: boolean;
+}
+
+async function mockApis(page: Page, sessions: MockSession[], projects: MockProject[]) {
+  await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: sessions.map((s) => ({
+          id: s.id,
+          title: s.title,
+          project_path: s.project_path,
+          group_path: s.project_path,
+          tool: "claude",
+          status: "Idle",
+          yolo_mode: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: null,
+          last_error: null,
+          branch: null,
+          main_repo_path: null,
+          is_sandboxed: false,
+          has_terminal: true,
+          profile: "default",
+          workspace_repos: [],
+        })),
+        workspace_ordering: [],
+      },
+    });
+  });
+  // GET lists the registry; POST registers (returns the created project).
+  await page.route("**/api/projects", (r) => {
+    const method = r.request().method();
+    if (method === "GET") return r.fulfill({ json: projects });
+    if (method === "POST") {
+      const body = r.request().postDataJSON() as { path: string; pinned?: boolean };
+      return r.fulfill({
+        status: 201,
+        json: { name: body.path.split("/").pop(), path: body.path, scope: "global", pinned: body.pinned ?? false },
+      });
+    }
+    return r.fulfill({ status: 400 });
+  });
+  // PATCH toggles the pin flag (the unpin / pin-existing path).
+  await page.route("**/api/projects/*", (r) => {
+    if (r.request().method() !== "PATCH") return r.fulfill({ status: 400 });
+    return r.fulfill({ json: { name: "p", path: "/tmp/p", scope: "global", pinned: false } });
+  });
+  for (const path of ["settings", "themes", "agents", "profiles", "groups", "devices", "docker/status", "about"]) {
+    await page.route(`**/api/${path}`, (r) => r.fulfill({ json: path === "docker/status" ? {} : [] }));
+  }
+}
+
+test.describe("Sidebar project pin/unpin (#2208)", () => {
+  test("Pin on an unregistered populated repo POSTs pinned:true", async ({ page }) => {
+    await mockApis(page, [{ id: "s-1", title: "Mongols", project_path: "/tmp/repo-a" }], []);
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const header = page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "repo-a" });
+    await expect(header).toBeVisible();
+    await header.click({ button: "right" });
+
+    const post = page.waitForRequest((req) => req.url().endsWith("/api/projects") && req.method() === "POST");
+    await page.locator("[data-testid='sidebar-group-context-menu-pin']").click();
+    const req = await post;
+    expect(req.postDataJSON()).toMatchObject({ path: "/tmp/repo-a", scope: "global", pinned: true });
+  });
+
+  test("Pin on a registered-but-unpinned repo PATCHes pinned:true", async ({ page }) => {
+    await mockApis(
+      page,
+      [{ id: "s-1", title: "Mongols", project_path: "/tmp/repo-a" }],
+      [{ name: "repo-a", path: "/tmp/repo-a", scope: "global", pinned: false }],
+    );
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const header = page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "repo-a" });
+    await expect(header).toBeVisible();
+    await header.click({ button: "right" });
+
+    const patch = page.waitForRequest((req) => req.url().includes("/api/projects/") && req.method() === "PATCH");
+    await page.locator("[data-testid='sidebar-group-context-menu-pin']").click();
+    const req = await patch;
+    expect(req.postDataJSON()).toMatchObject({ pinned: true });
+  });
+
+  test("Unpin a pinned-empty project PATCHes pinned:false (not DELETE)", async ({ page }) => {
+    await mockApis(page, [], [{ name: "repo-b", path: "/tmp/repo-b", scope: "global", pinned: true }]);
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const header = page.locator("[data-testid='sidebar-group-header']").filter({ hasText: "repo-b" });
+    await expect(header).toBeVisible();
+    await header.click({ button: "right" });
+
+    const patch = page.waitForRequest((req) => req.url().includes("/api/projects/") && req.method() === "PATCH");
+    await page.locator("[data-testid='sidebar-group-context-menu-unpin']").click();
+    const req = await patch;
+    expect(req.postDataJSON()).toMatchObject({ pinned: false });
+    expect(req.method()).not.toBe("DELETE");
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Unpinning a project from the web sidebar used to call `DELETE /api/projects`, which deleted the registry entry outright. The project then also vanished from the Projects view ("Saved repositories you can multi-select when creating sessions") and the new-session wizard picker. The TUI had the identical data-loss bug: its unpin removed the registry entry too.

Root cause: "pinned in the sidebar" and "registered/saved project" were the same thing. There was no separate pin signal, so the only way unpin could hide a sessionless header was to delete the saved project other surfaces depend on.

This decouples the two. A registry entry now carries a `pinned` flag: the entry is the saved project (Projects view + wizard), and `pinned` is the separate decision to keep its sessionless header visible in the sidebar / project view.

- Unpinning clears the flag and keeps the entry, on both web and TUI. Only the Projects view's Remove (`DELETE`) deletes a saved project.
- Pinning sets the flag, registering the repo first if it is not already saved.
- A saved-but-unpinned project (the new default for a project added via the Projects view or `aoe project add`) no longer forces a sidebar header; it shows only after it is explicitly pinned.

Cross-surface sync is preserved because the flag lives in the registry. Migration is handled by serde: a registry entry written before this change has no `pinned` key and deserializes to `true`, so existing headers survive an upgrade; new entries default to `false`.

Closes #2208

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Web: with a project that has no live sessions saved via the Projects view (or `aoe project add <repo>`), confirm it appears in the Projects view and the new-session wizard but does NOT show as a sidebar header.
- [ ] Web: right-click a populated repo header, choose "Pin project", confirm the ◆ marker appears and survives a page reload.
- [ ] Web: "Unpin project" on a pinned project, confirm its sessionless header disappears (or the marker clears if it still has sessions) AND the project is still listed in the Projects view and the wizard.
- [ ] TUI: in project grouping, press `p` on a header to pin, `p` again to unpin, confirm the unpinned project stays available in the project picker (it is not deleted).
- [ ] Upgrade check: with a pre-existing `projects.json` (no `pinned` key), confirm those projects still render as pinned headers after the update.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Rewrote `web/tests/live/project-pin.spec.ts`: a saved-unpinned project is hidden from the sidebar but present in the registry; pin POSTs `pinned:true`; unpin PATCHes `pinned:false` (not DELETE) and the project survives in `/api/projects`. Also extended the `registeredProjects` Vitest for the pinned-only empty-header derivation.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the TUI pin/unpin behavior change is covered by updated unit tests in `src/tui/home/tests.rs` (unpin keeps the registry entry; saved-but-unpinned reads as unpinned), and registry-level behavior by `src/session/projects.rs` tests. No new rendering path warranted a full-binary e2e.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (cross-checked with a two-model design debate), and implementation drafted by Claude under my direction. I made the design calls (server-side `pinned` flag over a web-local approach, default true for legacy entries and false for new ones, full TUI parity in scope), reviewed each commit, and ran the test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784223273&installation_id=139138837&pr_number=2225&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2225&signature=c57855150a7f2a9f3873f05d383e168bcf52cd266dfc60d971ada1089d8d5474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a data-loss bug in both the web sidebar and TUI: unpinning a project used to delete it from the server registry, making it disappear from the Projects view and the new-session wizard. The fix introduces a clear separation between **saved projects** (always kept) and **pinned projects** (only control whether the sidebar shows a header).

## What changed

- **Registry now tracks pin state with a `pinned` flag**
  - Existing/legacy entries remain compatible by treating a missing flag as “pinned”.
- **Unpin is no longer destructive**
  - Unpin now updates the registry to set `pinned: false` rather than deleting the project entry.
- **Pin/unpin behavior is aligned across web and TUI**
  - Both surfaces now toggle the same server-side `pinned` flag via **PATCH**.
- **Sidebar rendering depends only on explicit pinning**
  - “Empty” sidebar headers appear only for **pinned-but-no-active-sessions** projects, not merely for saved ones.
  - Pinned-but-empty projects are ordered below active repositories.
- **Project addition no longer forces sidebar headers**
  - Saving/adding a project doesn’t automatically make it visible in the sidebar as a header; pinning must be explicit.
- **API and UI updates to support partial updates**
  - The server PATCH endpoint now supports updating `pinned` and (as before) `default_base_branch`, including correct “null vs unchanged” handling.
- **Docs and test coverage updated**
  - Guidance was updated to explain saved vs pinned behavior.
  - Existing and new tests were updated for the new contract.

## Benefits

- **Prevents irreversible loss of saved project entries** when users unpin.
- **More predictable UX**: Projects view/wizard reflect saved projects; sidebar headers reflect pinned state only.
- **State consistency across devices and reloads** because pin state is stored server-side.

## Tests updated

- Rewrote/extended Playwright coverage for the “saved but unpinned” sidebar behavior.
- Expanded backend/unit tests around parsing, registry derivation, and the new pin-toggle behavior.
- Updated TUI unit tests to assert registry entries remain after unpin.
- Added/extended web API tests for the new `setProjectPinned` helper.
- No new full e2e test was added (covered by lower-level tests).

## Potential areas for further enhancement

- Add a targeted end-to-end scenario (if desired) to validate the full web-to-server-to-sidebar flow end-to-end for unpin/pin across reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->