### PR TITLE
fix(session): keep archived sessions out of Error when their tmux is gone

### DIFF
--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -23,13 +23,14 @@ mod v012_acp_rename;
 mod v013_strip_profile_theme;
 mod v014_rename_default_theme;
 mod v015_rewrite_hook_strings;
+mod v016_clear_archived_tmux_gone_error;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 15;
+const CURRENT_VERSION: u32 = 16;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -113,6 +114,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 15,
         name: "rewrite_hook_strings",
         run: v015_rewrite_hook_strings::run,
+    },
+    Migration {
+        version: 16,
+        name: "clear_archived_tmux_gone_error",
+        run: v016_clear_archived_tmux_gone_error::run,
     },
 ];
 

--- a/src/migrations/v016_clear_archived_tmux_gone_error.rs
+++ b/src/migrations/v016_clear_archived_tmux_gone_error.rs
@@ -1,0 +1,140 @@
+//! Migration v016: clear the spurious tmux-gone Error left on archived
+//! sessions by builds shipped between #1868 (tear down tmux on archive) and
+//! #2206 (stop the status poller flipping archived rows to Error).
+//!
+//! Those builds archived a session, killed its tmux, then let the status
+//! poller observe the missing tmux and stamp `status = "error"` with a
+//! "tmux session is gone" message. `last_error` is not persisted
+//! (`#[serde(skip)]`), so on reload the row carries only `status = "error"`
+//! and the message is gone; the in-process #2206 guard cannot recognize it.
+//! This one-shot migration walks every sessions.json and demotes any archived
+//! row still sitting at Error back to Idle. An archived row has no live tmux
+//! by design, so an Error status on one can only be that spurious transition.
+//!
+//! ## Failure policy
+//!
+//! Per `AGENTS.md > Data Migrations`, a returned `Err` aborts boot. A
+//! sessions.json that fails to parse is logged and skipped (a corrupt file
+//! must not block boot or spam every launch). Only `get_app_dir` and
+//! directory-read failures propagate.
+
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+use tracing::{debug, info};
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    run_in(&app_dir)
+}
+
+pub(crate) fn run_in(app_dir: &Path) -> Result<()> {
+    let profiles_dir = app_dir.join("profiles");
+    if profiles_dir.exists() {
+        for entry in fs::read_dir(&profiles_dir)? {
+            let entry = entry?;
+            if entry.path().is_dir() {
+                clear_archived_error(&entry.path().join("sessions.json"))?;
+            }
+        }
+    }
+    // Legacy top-level sessions.json (pre-profiles layout).
+    clear_archived_error(&app_dir.join("sessions.json"))?;
+    Ok(())
+}
+
+/// Demote any archived session still persisted at `status = "error"` back to
+/// `"idle"`. Leaves non-archived rows and archived rows in any other status
+/// untouched.
+fn clear_archived_error(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let content = fs::read_to_string(path)?;
+    let mut value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            debug!("v016: failed to parse {}: {e}, skipping", path.display());
+            return Ok(());
+        }
+    };
+
+    let mut healed = 0usize;
+    if let Some(array) = value.as_array_mut() {
+        for instance in array.iter_mut() {
+            if let Some(obj) = instance.as_object_mut() {
+                let archived = obj.get("archived_at").is_some_and(|v| !v.is_null());
+                let errored = obj.get("status").and_then(|v| v.as_str()) == Some("error");
+                if archived && errored {
+                    obj.insert(
+                        "status".to_string(),
+                        serde_json::Value::String("idle".to_string()),
+                    );
+                    healed += 1;
+                }
+            }
+        }
+    }
+
+    if healed > 0 {
+        fs::write(path, serde_json::to_string_pretty(&value)?)?;
+        info!(
+            "v016: cleared spurious archived Error on {healed} session(s) in {} (#2206)",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clears_only_archived_error_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        fs::write(
+            &path,
+            r#"[
+                {"id":"a","status":"error","archived_at":"2026-06-05T16:04:12Z"},
+                {"id":"b","status":"error"},
+                {"id":"c","status":"idle","archived_at":"2026-06-05T16:04:12Z"},
+                {"id":"d","status":"stopped","archived_at":"2026-06-05T16:04:12Z"},
+                {"id":"e","status":"error","archived_at":null}
+            ]"#,
+        )
+        .unwrap();
+
+        clear_archived_error(&path).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let arr = v.as_array().unwrap();
+        // archived + error -> idle (the bug footprint)
+        assert_eq!(arr[0]["status"], "idle");
+        // non-archived error -> untouched
+        assert_eq!(arr[1]["status"], "error");
+        // archived non-error -> untouched
+        assert_eq!(arr[2]["status"], "idle");
+        assert_eq!(arr[3]["status"], "stopped");
+        // explicit null archived_at counts as non-archived -> untouched
+        assert_eq!(arr[4]["status"], "error");
+    }
+
+    #[test]
+    fn missing_file_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        clear_archived_error(&dir.path().join("does-not-exist.json")).unwrap();
+    }
+
+    #[test]
+    fn corrupt_file_is_skipped_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        fs::write(&path, "{ not valid json").unwrap();
+        // Must not error; a corrupt file is left untouched.
+        clear_archived_error(&path).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{ not valid json");
+    }
+}

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1144,6 +1144,11 @@ impl Instance {
         self.favorited_at = None;
         self.snoozed_until = None;
         self.pinned_at = None;
+        // Archiving tears down the session's tmux on purpose (#1868), so its
+        // resting state is Stopped, not whatever it was running as. Stopped is
+        // polling tier 0, so the status poller stops re-probing the row and
+        // can never flip it to Error for a tmux that is gone by design (#2206).
+        self.status = Status::Stopped;
     }
 
     pub fn unarchive(&mut self) {
@@ -3330,6 +3335,21 @@ impl Instance {
             return;
         }
 
+        // Archived sessions have their tmux torn down on purpose (#1868), so
+        // probing tmux here only ever produces a spurious "tmux session is
+        // gone" Error transition (#2206). Heal a session that was already
+        // persisted as Error before this guard existed, then short-circuit so
+        // the poller never re-probes a row whose tmux is gone by design.
+        if self.is_archived() {
+            if self.last_error.as_deref() == Some(TMUX_SESSION_GONE_ERROR) {
+                self.last_error = None;
+            }
+            if self.status == Status::Error {
+                self.status = Status::Stopped;
+            }
+            return;
+        }
+
         // Acp-mode sessions are not backed by a tmux pane; the structured view
         // worker supervisor owns their lifecycle and emits typed health
         // events over the broadcast. Probing tmux here only ever produces
@@ -3978,6 +3998,36 @@ mod tests {
         inst.touch_last_accessed();
         assert!(!inst.is_archived());
         assert!(inst.last_accessed_at.is_some());
+    }
+
+    #[test]
+    fn test_archived_session_not_marked_error_when_tmux_gone() {
+        // #2206: archiving kills the session's tmux on purpose. A subsequent
+        // status poll must not flip the archived row to Error for the missing
+        // tmux; it should rest at Stopped with no tmux-gone error recorded.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.archive();
+        inst.update_status_with_metadata(None);
+        assert_ne!(inst.status, Status::Error);
+        assert_eq!(inst.status, Status::Stopped);
+        assert_eq!(inst.last_error, None);
+    }
+
+    #[test]
+    fn test_archived_session_heals_stale_tmux_gone_error() {
+        // #2206: a session archived before this guard existed may already be
+        // persisted as Error with a tmux-gone message. The next poll heals it
+        // to Stopped and clears the stale error.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Error;
+        inst.last_error = Some(TMUX_SESSION_GONE_ERROR.to_string());
+        inst.archive();
+        // archive() resets status to Stopped, but force Error back to simulate
+        // a row loaded from disk that predates the archive() status reset.
+        inst.status = Status::Error;
+        inst.update_status_with_metadata(None);
+        assert_eq!(inst.status, Status::Stopped);
+        assert_eq!(inst.last_error, None);
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3333,16 +3333,10 @@ impl Instance {
         // Archived sessions have their tmux torn down on purpose (#1868), so
         // probing tmux here only ever produces a spurious "tmux session is
         // gone" Error transition (#2206). Short-circuit so the poller never
-        // re-probes a row whose tmux is gone by design; archive/unarchive must
-        // stay status-preserving, so only the bug's own footprint (Error with
-        // the tmux-gone message) is healed back to Idle.
+        // re-probes a row whose tmux is gone by design; this keeps
+        // archive/unarchive status-preserving. Rows already persisted as Error
+        // by a pre-fix build are cleaned up once by the v016 migration.
         if self.is_archived() {
-            if self.status == Status::Error
-                && self.last_error.as_deref() == Some(TMUX_SESSION_GONE_ERROR)
-            {
-                self.status = Status::Idle;
-                self.last_error = None;
-            }
             return;
         }
 
@@ -4000,8 +3994,8 @@ mod tests {
     fn test_archived_session_not_marked_error_when_tmux_gone() {
         // #2206: archiving kills the session's tmux on purpose. A subsequent
         // status poll must not flip the archived row to Error for the missing
-        // tmux; archive is status-preserving, so an idle row stays Idle with
-        // no tmux-gone error recorded.
+        // tmux; the archived guard short-circuits, so an idle row stays Idle.
+        // Red on the pre-fix tree, where the tmux probe stamps Error.
         let mut inst = Instance::new("test", "/tmp/test");
         inst.archive();
         inst.update_status_with_metadata(None);
@@ -4011,28 +4005,32 @@ mod tests {
     }
 
     #[test]
-    fn test_archived_session_heals_stale_tmux_gone_error() {
-        // #2206: a session archived by an older build may already be persisted
-        // as Error with the tmux-gone message. The next poll heals exactly
-        // that footprint back to Idle and clears the stale error.
-        let mut inst = Instance::new("test", "/tmp/test");
-        inst.archive();
-        inst.status = Status::Error;
-        inst.last_error = Some(TMUX_SESSION_GONE_ERROR.to_string());
-        inst.update_status_with_metadata(None);
-        assert_eq!(inst.status, Status::Idle);
-        assert_eq!(inst.last_error, None);
-    }
-
-    #[test]
     fn test_archived_session_preserves_genuine_error() {
-        // #2206: a session that genuinely errored (a non-tmux-gone message)
-        // and was then archived must keep its Error status, so archive then
-        // unarchive stays status-preserving for real failures.
+        // #2206 regression guard (passes on both trees): the archived guard
+        // never mutates status, so a genuinely errored session keeps its Error
+        // state while archived. The legacy on-disk footprint is cleaned up by
+        // the v016 migration, not by the poller.
         let mut inst = Instance::new("test", "/tmp/test");
         inst.archive();
         inst.status = Status::Error;
         inst.last_error = Some("agent crashed".to_string());
+        inst.update_status_with_metadata(None);
+        assert_eq!(inst.status, Status::Error);
+        assert_eq!(inst.last_error.as_deref(), Some("agent crashed"));
+    }
+
+    #[test]
+    fn test_archived_unarchived_genuine_error_roundtrips() {
+        // #2206: archive then unarchive must stay status-preserving for a real
+        // failure. The archived guard leaves Error untouched; after unarchive
+        // the tmux probe re-stamps Error and its is_none() guard preserves the
+        // original message regardless of whether tmux is installed on the box.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.archive();
+        inst.status = Status::Error;
+        inst.last_error = Some("agent crashed".to_string());
+        inst.update_status_with_metadata(None);
+        inst.unarchive();
         inst.update_status_with_metadata(None);
         assert_eq!(inst.status, Status::Error);
         assert_eq!(inst.last_error.as_deref(), Some("agent crashed"));

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1144,11 +1144,6 @@ impl Instance {
         self.favorited_at = None;
         self.snoozed_until = None;
         self.pinned_at = None;
-        // Archiving tears down the session's tmux on purpose (#1868), so its
-        // resting state is Stopped, not whatever it was running as. Stopped is
-        // polling tier 0, so the status poller stops re-probing the row and
-        // can never flip it to Error for a tmux that is gone by design (#2206).
-        self.status = Status::Stopped;
     }
 
     pub fn unarchive(&mut self) {
@@ -3337,15 +3332,16 @@ impl Instance {
 
         // Archived sessions have their tmux torn down on purpose (#1868), so
         // probing tmux here only ever produces a spurious "tmux session is
-        // gone" Error transition (#2206). Heal a session that was already
-        // persisted as Error before this guard existed, then short-circuit so
-        // the poller never re-probes a row whose tmux is gone by design.
+        // gone" Error transition (#2206). Short-circuit so the poller never
+        // re-probes a row whose tmux is gone by design; archive/unarchive must
+        // stay status-preserving, so only the bug's own footprint (Error with
+        // the tmux-gone message) is healed back to Idle.
         if self.is_archived() {
-            if self.last_error.as_deref() == Some(TMUX_SESSION_GONE_ERROR) {
+            if self.status == Status::Error
+                && self.last_error.as_deref() == Some(TMUX_SESSION_GONE_ERROR)
+            {
+                self.status = Status::Idle;
                 self.last_error = None;
-            }
-            if self.status == Status::Error {
-                self.status = Status::Stopped;
             }
             return;
         }
@@ -4004,30 +4000,42 @@ mod tests {
     fn test_archived_session_not_marked_error_when_tmux_gone() {
         // #2206: archiving kills the session's tmux on purpose. A subsequent
         // status poll must not flip the archived row to Error for the missing
-        // tmux; it should rest at Stopped with no tmux-gone error recorded.
+        // tmux; archive is status-preserving, so an idle row stays Idle with
+        // no tmux-gone error recorded.
         let mut inst = Instance::new("test", "/tmp/test");
         inst.archive();
         inst.update_status_with_metadata(None);
         assert_ne!(inst.status, Status::Error);
-        assert_eq!(inst.status, Status::Stopped);
+        assert_eq!(inst.status, Status::Idle);
         assert_eq!(inst.last_error, None);
     }
 
     #[test]
     fn test_archived_session_heals_stale_tmux_gone_error() {
-        // #2206: a session archived before this guard existed may already be
-        // persisted as Error with a tmux-gone message. The next poll heals it
-        // to Stopped and clears the stale error.
+        // #2206: a session archived by an older build may already be persisted
+        // as Error with the tmux-gone message. The next poll heals exactly
+        // that footprint back to Idle and clears the stale error.
         let mut inst = Instance::new("test", "/tmp/test");
+        inst.archive();
         inst.status = Status::Error;
         inst.last_error = Some(TMUX_SESSION_GONE_ERROR.to_string());
-        inst.archive();
-        // archive() resets status to Stopped, but force Error back to simulate
-        // a row loaded from disk that predates the archive() status reset.
-        inst.status = Status::Error;
         inst.update_status_with_metadata(None);
-        assert_eq!(inst.status, Status::Stopped);
+        assert_eq!(inst.status, Status::Idle);
         assert_eq!(inst.last_error, None);
+    }
+
+    #[test]
+    fn test_archived_session_preserves_genuine_error() {
+        // #2206: a session that genuinely errored (a non-tmux-gone message)
+        // and was then archived must keep its Error status, so archive then
+        // unarchive stays status-preserving for real failures.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.archive();
+        inst.status = Status::Error;
+        inst.last_error = Some("agent crashed".to_string());
+        inst.update_status_with_metadata(None);
+        assert_eq!(inst.status, Status::Error);
+        assert_eq!(inst.last_error.as_deref(), Some("agent crashed"));
     }
 
     #[test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Archiving a session from the TUI tears down its tmux on purpose (#1868). But `archive()` left `status` untouched, and the status poller then probed the now-missing tmux and flipped the row to `Error` with a "tmux session is gone" message. The web dashboard serializes that status verbatim, so an archived session rendered as **errored** in the Archived list even though nothing failed.

The fix adds an archived guard in `update_status_with_metadata_inner` (`src/session/instance.rs`), mirroring the existing structured-session guard right above it: an archived session has no tmux by design, so the poller short-circuits with `if self.is_archived() { return; }` and never re-probes it into `Error`. `archive()` only stamps `archived_at`, so the guard keeps archive/unarchive status-preserving (a genuinely errored session keeps its `Error` status), which the attention-tier and recovery-eligibility logic depend on.

Rows already persisted as `Error` by a pre-fix build cannot be healed in the poller: `last_error` is `#[serde(skip)]`, so on reload such a row carries only `status = "error"` with no message to match on. A one-shot `v016` migration (`src/migrations/v016_clear_archived_tmux_gone_error.rs`) walks every sessions.json on boot and demotes any archived row still at `error` to `idle`. This follows the AGENTS.md rule of using a migration rather than an inline compat shim.

Closes #2206

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the TUI, create a session, then archive it (`a`).
- [ ] Open the web dashboard, expand the Archived list, confirm the session does not show as errored.
- [ ] In the TUI, let a session genuinely error (kill its agent), then archive it; confirm it still shows its error state, not a healed/idle state.
- [ ] Archive a session, leave and re-enter the TUI; confirm the archived row is not flipped to errored after the status poller runs.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

<!-- The web renders whatever status the server sends; no web/src code changed. The fix and its coverage live entirely in Rust session-status logic. -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the bug is pure status-computation plus a data migration, covered by deterministic Rust unit tests. In `src/session/instance.rs`: `test_archived_session_not_marked_error_when_tmux_gone` is genuinely red on the pre-fix tree; `test_archived_session_preserves_genuine_error` and `test_archived_unarchived_genuine_error_roundtrips` are regression guards for the status-preserving contract. In `src/migrations/v016_clear_archived_tmux_gone_error.rs`: tests cover the heal, leaving non-archived and non-error rows untouched, a missing file, and a corrupt file. An e2e through tmux adds no signal these lack.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (dropping the status-mutation approach once it broke archive/unarchive symmetry, then switching from an inline heal to a v016 migration after review), reviewed each commit, and ran the test steps above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a web dashboard issue where sessions that were archived from the TUI could incorrectly show up as “errored.” The root cause was that the background status poller kept checking tmux for sessions that had already been intentionally torn down when archived, and then persisted the “tmux session is gone” error footprint.

## What Changed

### Core behavior
- **`src/session/instance.rs`**: Added an **archived-session guard** to stop the status update logic from re-probing archived instances (so they don’t get flipped into `Error` just because tmux is gone).
- Added **targeted healing** so the specific persisted “tmux session is gone” error footprint on archived rows is corrected back to a non-error state rather than treated as a real failure.

### Data migration
- **Migration v016 (`src/migrations/v016_clear_archived_tmux_gone_error.rs`)**:
  - Scans session state files (both per-profile and legacy top-level).
  - For any session marked `error` **only when `archived_at` is present**, it demotes it back to `idle`.
  - Includes safe handling for missing files and corrupt JSON (skips without failing boot).
- **`src/migrations/mod.rs`**: Bumped the migration target to **v16** and registered the new migration.

### Tests
- Added **three deterministic Rust unit tests** in `src/session/instance.rs` verifying:
  - archived sessions are not converted into `Error` during polling,
  - genuine pre-set `Error` states are preserved,
  - the tmux-gone error footprint on archived sessions is corrected.

## Benefits
- Archived sessions no longer appear as broken in the dashboard, eliminating confusing “tmux session is gone” messaging.
- Any already-persisted archived “tmux-gone” error rows are automatically cleaned up via migration (and/or corrected on subsequent polling).
- Real errors remain real: the PR preserves the intended archive/unarchive semantics so only the specific tmux-gone artifact is healed.

## Technical Details (if you need them)

- The status poller now **short-circuits** for archived sessions inside `Instance::update_status_with_metadata_inner`, preventing tmux probing from changing archived rows’ state.
- The repo adds a compatibility/data-fixing approach via **migration (v016)** to clear archived rows that were previously persisted in the `error` state for the tmux-gone case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->