### PR TITLE
feat(acp): show answered AskUserQuestion in the structured-view transcript

### DIFF
--- a/docs/structured-view/controls.md
+++ b/docs/structured-view/controls.md
@@ -41,9 +41,10 @@ Some agents ask a structured question mid-turn rather than guessing. With `claud
 - **Single-choice** questions render as radio buttons, **multi-choice** as checkboxes, and a free-text "Other" field shows when the agent offers one. When an option carries an explanation, it renders as a second line under the option label.
 - MCP forms can also include **text** fields (typed by their format, so email / URL / date inputs get the matching control), **number** and **integer** fields, and **yes/no** checkboxes. Any field default the agent supplies is pre-filled.
 - **Submit** sends your answers back and the turn continues. **Skip** answers nothing (the agent proceeds without your input). **Cancel** aborts the tool call.
+- After you answer, the card closes and your picked answer is recorded in the transcript as your turn, so the history shows what you chose instead of jumping straight to the next agent output. Skipping leaves a short "skipped" note; cancelling adds nothing.
 - Required fields and every constraint the schema declares (selection min/max, text length, regex pattern, numeric range) are enforced before Submit; the daemon re-validates, so a stale or malformed answer never reaches the agent.
 
-The rich question form is web-only. In the native TUI the card shows the question with a pointer to answer it in the web dashboard, plus keys to skip or cancel from the transcript pane so a TUI-only session never stalls on a question.
+The rich question form is web-only. In the native TUI the card shows the question with a pointer to answer it in the web dashboard, plus keys to skip or cancel from the transcript pane so a TUI-only session never stalls on a question. Once answered (from any surface) the TUI transcript records the chosen answer too.
 
 > AskUserQuestion options can carry a `preview` (a code snippet or mockup shown on focus in the Claude Code CLI/desktop). The `claude-agent-acp` adapter does not forward `preview` over ACP, so it cannot be shown here; this is an adapter limitation, not a dashboard one.
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -46,7 +46,8 @@ use super::agent_profiles;
 use super::agent_registry::AgentSpec;
 use super::approvals::{is_destructive, ApprovalDecision, Nonce};
 use super::elicitations::{
-    build_response, parse_elicitation, Elicitation, ElicitationOutcome, ElicitationResolution,
+    build_response, parse_elicitation, summarize_answers, Elicitation, ElicitationAnswer,
+    ElicitationOutcome, ElicitationResolution,
 };
 use super::event_store::AttachmentBlob;
 use super::fs_handler::{self, FsPolicy, SandboxPathMap};
@@ -1122,7 +1123,7 @@ enum PendingResolver {
     /// just forwards them. Boxed to keep the enum small.
     Elicitation {
         elicitation: Box<Elicitation>,
-        resolver: oneshot::Sender<(CreateElicitationResponse, ElicitationOutcome)>,
+        resolver: oneshot::Sender<ElicitationResolutionMessage>,
     },
 }
 
@@ -1131,6 +1132,16 @@ enum PendingResolver {
 enum ApprovalResolutionMessage {
     Decision { decision: ApprovalDecision },
     Cancelled,
+}
+
+/// Message sent over the elicitation resolver oneshot. Carries the
+/// validated wire response for the agent, the outcome for status
+/// derivation, and the display-ready answers for the transcript
+/// (`Event::ElicitationResolved.answers`). See #2209.
+struct ElicitationResolutionMessage {
+    response: CreateElicitationResponse,
+    outcome: ElicitationOutcome,
+    answers: Vec<ElicitationAnswer>,
 }
 
 type PendingResponders = Arc<Mutex<HashMap<Nonce, PendingResponder>>>;
@@ -1833,6 +1844,13 @@ impl AcpClient {
         // Validate against the parked form while it is still borrowed; on
         // failure the nonce stays in the map untouched.
         let outcome = resolution.outcome();
+        // Render the submitted answers for the transcript before
+        // `build_response` consumes `resolution`. The parked form supplies
+        // question titles; selects carry the clean label. See #2209.
+        let answers = match &resolution {
+            ElicitationResolution::Accept { answers } => summarize_answers(elicitation, answers),
+            ElicitationResolution::Decline | ElicitationResolution::Cancel => Vec::new(),
+        };
         let response = build_response(elicitation, resolution)
             .map_err(|e| AcpError::InvalidAnswer(e.to_string()))?;
         // Valid: now consume the responder and forward the built response.
@@ -1841,7 +1859,11 @@ impl AcpClient {
             unreachable!("checked above");
         };
         resolver
-            .send((response, outcome))
+            .send(ElicitationResolutionMessage {
+                response,
+                outcome,
+                answers,
+            })
             .map_err(|_| AcpError::AgentExited)
     }
 
@@ -5974,8 +5996,7 @@ async fn handle_elicitation_request(
         }
     };
 
-    let (resolve_tx, resolve_rx) =
-        oneshot::channel::<(CreateElicitationResponse, ElicitationOutcome)>();
+    let (resolve_tx, resolve_rx) = oneshot::channel::<ElicitationResolutionMessage>();
     pending.lock().await.insert(
         nonce.clone(),
         PendingResponder {
@@ -6001,17 +6022,23 @@ async fn handle_elicitation_request(
     // before sending, so whatever arrives here is already a built, valid
     // response. A dropped resolver (daemon teardown, agent cancel) cancels
     // the tool call.
-    let (response, outcome) = resolve_rx.await.unwrap_or_else(|_| {
-        (
-            CreateElicitationResponse::new(ElicitationAction::Cancel),
-            ElicitationOutcome::Cancelled,
-        )
-    });
+    let ElicitationResolutionMessage {
+        response,
+        outcome,
+        answers,
+    } = resolve_rx
+        .await
+        .unwrap_or_else(|_| ElicitationResolutionMessage {
+            response: CreateElicitationResponse::new(ElicitationAction::Cancel),
+            outcome: ElicitationOutcome::Cancelled,
+            answers: Vec::new(),
+        });
 
     let _ = event_tx
         .send(Event::ElicitationResolved {
             nonce: nonce.clone(),
             outcome,
+            answers,
         })
         .await;
 

--- a/src/acp/elicitations.rs
+++ b/src/acp/elicitations.rs
@@ -136,17 +136,18 @@ pub struct ElicitationAnswer {
     pub answer: String,
 }
 
-/// Render the user's submitted answers into display-ready pairs, in the
-/// form's question order. Only answered questions are included (an
-/// optional question left blank is omitted). Single/multi selects carry
-/// the option value, which for AskUserQuestion is already the clean
-/// label (see `ElicitationOption::value`), so no option lookup is needed.
 /// Separator the claude-agent-acp adapter wedges between an AskUserQuestion
 /// option's label and its description when flattening into the enum title
 /// (`"<label> <sep> <description>"`). Written as an escape so the em dash
 /// never appears literally in source. Mirrors the web card's separator.
 const OPTION_DESC_SEP: &str = " \u{2014} ";
 
+/// Render the user's submitted answers into display-ready pairs, in the
+/// form's question order. Only answered questions are included (an optional
+/// question left blank is omitted). Select values are mapped to their option
+/// label; for AskUserQuestion the value is already the label (and `label` may
+/// carry a trailing description, which is dropped), while a generic MCP form
+/// maps its machine token to the human label.
 pub fn summarize_answers(
     elicitation: &Elicitation,
     answers: &BTreeMap<String, AnswerValue>,

--- a/src/acp/elicitations.rs
+++ b/src/acp/elicitations.rs
@@ -141,6 +141,12 @@ pub struct ElicitationAnswer {
 /// optional question left blank is omitted). Single/multi selects carry
 /// the option value, which for AskUserQuestion is already the clean
 /// label (see `ElicitationOption::value`), so no option lookup is needed.
+/// Separator the claude-agent-acp adapter wedges between an AskUserQuestion
+/// option's label and its description when flattening into the enum title
+/// (`"<label> <sep> <description>"`). Written as an escape so the em dash
+/// never appears literally in source. Mirrors the web card's separator.
+const OPTION_DESC_SEP: &str = " \u{2014} ";
+
 pub fn summarize_answers(
     elicitation: &Elicitation,
     answers: &BTreeMap<String, AnswerValue>,
@@ -149,6 +155,19 @@ pub fn summarize_answers(
     for question in &elicitation.questions {
         let Some(value) = answers.get(&question.field_key) else {
             continue;
+        };
+        // Map a selected option value to its human label. For a generic MCP
+        // form the value is a machine token and the label the display text; for
+        // AskUserQuestion the value is already the label (and `label` may carry
+        // a `"value <sep> description"` form, so we keep the bare value there).
+        // Mirrors `optionParts` in the web AskUserQuestionCard. See #2209.
+        let label_for = |raw: &str| -> String {
+            match question.options.iter().find(|o| o.value == raw) {
+                Some(o) if !o.label.starts_with(&format!("{raw}{OPTION_DESC_SEP}")) => {
+                    o.label.clone()
+                }
+                _ => raw.to_string(),
+            }
         };
         let answer = match value {
             AnswerValue::Bool(b) => {
@@ -160,8 +179,12 @@ pub fn summarize_answers(
             }
             AnswerValue::Integer(i) => i.to_string(),
             AnswerValue::Number(n) => n.to_string(),
-            AnswerValue::Text(s) => s.clone(),
-            AnswerValue::List(values) => values.join(", "),
+            AnswerValue::Text(s) => label_for(s),
+            AnswerValue::List(values) => values
+                .iter()
+                .map(|v| label_for(v))
+                .collect::<Vec<_>>()
+                .join(", "),
         };
         let question = question
             .title
@@ -992,12 +1015,48 @@ mod tests {
         );
         answers.insert("question_0".to_string(), AnswerValue::Text("Yes".into()));
         let summary = summarize_answers(&e, &answers);
-        // Question order from the form, not BTreeMap key order.
+        // Question order from the form, not BTreeMap key order. Selected
+        // values render as their option labels ("a"/"b" -> "A"/"B").
         assert_eq!(summary.len(), 2);
         assert_eq!(summary[0].question, "question_0");
         assert_eq!(summary[0].answer, "Yes");
         assert_eq!(summary[1].question, "tags");
-        assert_eq!(summary[1].answer, "a, b");
+        assert_eq!(summary[1].answer, "A, B");
+    }
+
+    #[test]
+    fn summarize_maps_select_values_to_option_labels() {
+        // Generic MCP form: value is a machine token, label is human text.
+        let mcp = Elicitation {
+            nonce: Nonce::new(),
+            message: "q".into(),
+            title: None,
+            description: None,
+            tool_call_id: None,
+            questions: vec![ElicitationQuestion {
+                options: vec![
+                    ElicitationOption {
+                        value: "tok_blue".into(),
+                        label: "Blue".into(),
+                    },
+                    // AskUserQuestion-style "label <sep> description": the bare
+                    // value is kept, the description dropped from the summary.
+                    ElicitationOption {
+                        value: "Green".into(),
+                        label: "Green \u{2014} the color green".into(),
+                    },
+                ],
+                ..empty_question("color", ElicitationFieldKind::SingleSelect, true)
+            }],
+            requested_at: Utc::now(),
+            resolved: None,
+        };
+        let mut a = BTreeMap::new();
+        a.insert("color".to_string(), AnswerValue::Text("tok_blue".into()));
+        assert_eq!(summarize_answers(&mcp, &a)[0].answer, "Blue");
+        let mut b = BTreeMap::new();
+        b.insert("color".to_string(), AnswerValue::Text("Green".into()));
+        assert_eq!(summarize_answers(&mcp, &b)[0].answer, "Green");
     }
 
     #[test]

--- a/src/acp/elicitations.rs
+++ b/src/acp/elicitations.rs
@@ -124,6 +124,54 @@ pub struct ResolvedElicitation {
     pub resolved_at: DateTime<Utc>,
 }
 
+/// One answered question, rendered for the transcript. `question` is the
+/// human-readable prompt (the question title, or the field key as a
+/// fallback); `answer` is the display value the user submitted. Computed
+/// server-side at resolve time and carried on `Event::ElicitationResolved`
+/// so the structured view can show what the user picked after the card
+/// closes. See #2209.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ElicitationAnswer {
+    pub question: String,
+    pub answer: String,
+}
+
+/// Render the user's submitted answers into display-ready pairs, in the
+/// form's question order. Only answered questions are included (an
+/// optional question left blank is omitted). Single/multi selects carry
+/// the option value, which for AskUserQuestion is already the clean
+/// label (see `ElicitationOption::value`), so no option lookup is needed.
+pub fn summarize_answers(
+    elicitation: &Elicitation,
+    answers: &BTreeMap<String, AnswerValue>,
+) -> Vec<ElicitationAnswer> {
+    let mut out = Vec::new();
+    for question in &elicitation.questions {
+        let Some(value) = answers.get(&question.field_key) else {
+            continue;
+        };
+        let answer = match value {
+            AnswerValue::Bool(b) => {
+                if *b {
+                    "Yes".to_string()
+                } else {
+                    "No".to_string()
+                }
+            }
+            AnswerValue::Integer(i) => i.to_string(),
+            AnswerValue::Number(n) => n.to_string(),
+            AnswerValue::Text(s) => s.clone(),
+            AnswerValue::List(values) => values.join(", "),
+        };
+        let question = question
+            .title
+            .clone()
+            .unwrap_or_else(|| question.field_key.clone());
+        out.push(ElicitationAnswer { question, answer });
+    }
+    out
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ElicitationOutcome {
     /// User submitted answers (ACP `accept`).
@@ -931,6 +979,74 @@ mod tests {
         assert_eq!(
             content.get("tags"),
             Some(&ElicitationContentValue::StringArray(vec!["a".into()]))
+        );
+    }
+
+    #[test]
+    fn summarize_renders_answers_in_question_order() {
+        let e = sample_elicitation();
+        let mut answers = BTreeMap::new();
+        answers.insert(
+            "tags".to_string(),
+            AnswerValue::List(vec!["a".into(), "b".into()]),
+        );
+        answers.insert("question_0".to_string(), AnswerValue::Text("Yes".into()));
+        let summary = summarize_answers(&e, &answers);
+        // Question order from the form, not BTreeMap key order.
+        assert_eq!(summary.len(), 2);
+        assert_eq!(summary[0].question, "question_0");
+        assert_eq!(summary[0].answer, "Yes");
+        assert_eq!(summary[1].question, "tags");
+        assert_eq!(summary[1].answer, "a, b");
+    }
+
+    #[test]
+    fn summarize_omits_unanswered_and_renders_scalar_kinds() {
+        let e = Elicitation {
+            nonce: Nonce::new(),
+            message: "q".into(),
+            title: None,
+            description: None,
+            tool_call_id: None,
+            questions: vec![
+                ElicitationQuestion {
+                    title: Some("Your name".into()),
+                    ..empty_question("name", ElicitationFieldKind::FreeText, false)
+                },
+                ElicitationQuestion {
+                    title: Some("Enable it".into()),
+                    ..empty_question("flag", ElicitationFieldKind::Boolean, false)
+                },
+                ElicitationQuestion {
+                    title: Some("Count".into()),
+                    ..empty_question("count", ElicitationFieldKind::Integer, false)
+                },
+                empty_question("skipped", ElicitationFieldKind::FreeText, false),
+            ],
+            requested_at: Utc::now(),
+            resolved: None,
+        };
+        let mut answers = BTreeMap::new();
+        answers.insert("name".to_string(), AnswerValue::Text("Ada".into()));
+        answers.insert("flag".to_string(), AnswerValue::Bool(false));
+        answers.insert("count".to_string(), AnswerValue::Integer(3));
+        let summary = summarize_answers(&e, &answers);
+        assert_eq!(
+            summary,
+            vec![
+                ElicitationAnswer {
+                    question: "Your name".into(),
+                    answer: "Ada".into()
+                },
+                ElicitationAnswer {
+                    question: "Enable it".into(),
+                    answer: "No".into()
+                },
+                ElicitationAnswer {
+                    question: "Count".into(),
+                    answer: "3".into()
+                },
+            ]
         );
     }
 

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -2577,6 +2577,7 @@ mod tests {
                 &Event::ElicitationResolved {
                     nonce: nonce_a,
                     outcome: ElicitationOutcome::Accepted,
+                    answers: Vec::new(),
                 },
             )
             .unwrap();
@@ -2617,6 +2618,7 @@ mod tests {
                 &Event::ElicitationResolved {
                     nonce: nonce_a,
                     outcome: ElicitationOutcome::Accepted,
+                    answers: Vec::new(),
                 },
             )
             .unwrap();

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::approvals::{Approval, ApprovalDecision, Nonce};
-use super::elicitations::{Elicitation, ElicitationOutcome};
+use super::elicitations::{Elicitation, ElicitationAnswer, ElicitationOutcome};
 
 /// Identifier for a structured view session. Distinct from `SessionId` in
 /// `src/session/` because structured view sessions are a separate `SessionBackend`.
@@ -618,10 +618,15 @@ pub enum Event {
     },
     /// An elicitation was answered, skipped, cancelled, or torn down. The
     /// reducer drops the matching pending card. `outcome` records how it
-    /// ended for replay/debugging.
+    /// ended for replay/debugging. `answers` carries the user's submitted
+    /// answers (display-ready, in form order) so the transcript can show
+    /// what was picked after the card closes; empty for skip/cancel/teardown
+    /// and for events stored before #2209.
     ElicitationResolved {
         nonce: Nonce,
         outcome: ElicitationOutcome,
+        #[serde(default)]
+        answers: Vec<ElicitationAnswer>,
     },
     DiffEmitted {
         diff: DiffPreview,

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -2484,6 +2484,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                 &Event::ElicitationResolved {
                     nonce,
                     outcome: ElicitationOutcome::Cancelled,
+                    answers: Vec::new(),
                 },
             );
         }
@@ -4834,7 +4835,7 @@ mod tests {
         );
         for (frame, expected) in frames.iter().zip(["e-a", "e-b"]) {
             match &frame.2 {
-                Event::ElicitationResolved { nonce, outcome } => {
+                Event::ElicitationResolved { nonce, outcome, .. } => {
                     assert_eq!(nonce.0, expected);
                     assert!(matches!(outcome, ElicitationOutcome::Cancelled));
                 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4452,6 +4452,7 @@ mod tests {
             derive_acp_status(&Event::ElicitationResolved {
                 nonce: Nonce("e-1".into()),
                 outcome: crate::acp::elicitations::ElicitationOutcome::Accepted,
+                answers: Vec::new(),
             }),
             Some(StatusIntent::Set(Status::Running))
         );

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -20,6 +20,7 @@
 //!   layer can offer the "paste a context primer" affordance.
 
 use crate::acp::approvals::ApprovalDecision;
+use crate::acp::elicitations::{ElicitationAnswer, ElicitationOutcome};
 use crate::acp::protocol::AcpBroadcastFrame;
 use crate::acp::state::{AvailableCommand, Event, PlanStepStatus, ToolOutputBlock};
 
@@ -104,7 +105,14 @@ pub enum ActivityRow {
     ToolCall(ToolCallRow),
     Approval(ApprovalRow),
     Plan(Vec<PlanLine>),
-    Note { kind: NoteKind, text: String },
+    /// The user's answers to an AskUserQuestion / elicitation form, kept
+    /// in the transcript so the picked answer survives the card closing.
+    /// See #2209.
+    ElicitationAnswer(Vec<ElicitationAnswer>),
+    Note {
+        kind: NoteKind,
+        text: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -405,9 +413,25 @@ impl AcpTranscript {
                     nonce: elicitation.nonce.0.clone(),
                 });
             }
-            Event::ElicitationResolved { nonce, .. } => {
+            Event::ElicitationResolved {
+                nonce,
+                outcome,
+                answers,
+            } => {
                 self.flush_pending_chunk();
                 self.pending_elicitations.retain(|p| p.nonce != nonce.0);
+                // Record what the user picked so the transcript keeps a
+                // trace after the card closes. Skip (Decline) leaves a
+                // short note; Cancel / teardown adds nothing. See #2209.
+                if !answers.is_empty() {
+                    self.rows
+                        .push(ActivityRow::ElicitationAnswer(answers.clone()));
+                } else if matches!(outcome, ElicitationOutcome::Declined) {
+                    self.rows.push(ActivityRow::Note {
+                        kind: NoteKind::Info,
+                        text: "You skipped the question.".to_string(),
+                    });
+                }
             }
             Event::PlanUpdated { plan } => {
                 self.flush_pending_chunk();
@@ -786,9 +810,53 @@ mod tests {
             Event::ElicitationResolved {
                 nonce: Nonce("e-1".into()),
                 outcome: ElicitationOutcome::Declined,
+                answers: Vec::new(),
             },
         ));
         assert!(t.pending_elicitations.is_empty());
+        // A skip leaves a short note so the transcript records the choice.
+        assert!(matches!(
+            t.rows.last(),
+            Some(ActivityRow::Note { text, .. }) if text.contains("skipped")
+        ));
+    }
+
+    #[test]
+    fn elicitation_accepted_records_answer_row() {
+        use crate::acp::elicitations::{Elicitation, ElicitationAnswer, ElicitationOutcome};
+        let mut t = AcpTranscript::new("s-1");
+        let elicitation = Elicitation {
+            nonce: Nonce("e-1".into()),
+            message: "Pick one".into(),
+            title: None,
+            description: None,
+            tool_call_id: None,
+            questions: Vec::new(),
+            requested_at: Utc::now(),
+            resolved: None,
+        };
+        t.apply(&frame(1, Event::ElicitationRequested { elicitation }));
+        t.apply(&frame(
+            2,
+            Event::ElicitationResolved {
+                nonce: Nonce("e-1".into()),
+                outcome: ElicitationOutcome::Accepted,
+                answers: vec![ElicitationAnswer {
+                    question: "Proceed?".into(),
+                    answer: "Yes".into(),
+                }],
+            },
+        ));
+        assert!(t.pending_elicitations.is_empty());
+        // #2209: the picked answer must survive the card closing.
+        match t.rows.last() {
+            Some(ActivityRow::ElicitationAnswer(answers)) => {
+                assert_eq!(answers.len(), 1);
+                assert_eq!(answers[0].question, "Proceed?");
+                assert_eq!(answers[0].answer, "Yes");
+            }
+            other => panic!("expected ElicitationAnswer row, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -419,7 +419,16 @@ impl AcpTranscript {
                 answers,
             } => {
                 self.flush_pending_chunk();
+                // Gate on the card actually being pending: a resolved
+                // elicitation can be re-broadcast (cancel-on-teardown racing a
+                // POST; the store is lenient on the nonce), and replaying it
+                // must not append a second row. The web reducer dedupes by row
+                // id; here the pending card is the dedupe key. See #2209.
+                let was_pending = self.pending_elicitations.iter().any(|p| p.nonce == nonce.0);
                 self.pending_elicitations.retain(|p| p.nonce != nonce.0);
+                if !was_pending {
+                    return;
+                }
                 // Record what the user picked so the transcript keeps a
                 // trace after the card closes. Skip (Decline) leaves a
                 // short note; Cancel / teardown adds nothing. See #2209.

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -1343,6 +1343,30 @@ mod tests {
     }
 
     #[test]
+    fn transcript_renders_elicitation_answers_as_user_rows() {
+        use crate::acp::elicitations::ElicitationAnswer;
+        let mut t = AcpTranscript::new("s-1");
+        t.rows.push(ActivityRow::ElicitationAnswer(vec![
+            ElicitationAnswer {
+                question: "Proceed?".into(),
+                answer: "Yes".into(),
+            },
+            ElicitationAnswer {
+                question: "Mode".into(),
+                answer: "Fast".into(),
+            },
+        ]));
+        let out = joined(&transcript_lines(
+            &t,
+            None,
+            Focus::Transcript,
+            &Theme::default(),
+        ));
+        assert!(out.contains("you  ▸ Proceed?: Yes"), "{out:?}");
+        assert!(out.contains("you  ▸ Mode: Fast"), "{out:?}");
+    }
+
+    #[test]
     fn edit_kind_renders_added_and_removed_diff_lines() {
         let row = tool_row(
             "edit",

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -722,6 +722,15 @@ fn transcript_lines<'a>(
                 }
                 out.push(Line::default());
             }
+            ActivityRow::ElicitationAnswer(answers) => {
+                for answer in answers {
+                    out.push(Line::from(Span::styled(
+                        format!("you  ▸ {}: {}", answer.question, answer.answer),
+                        Style::default().add_modifier(Modifier::BOLD),
+                    )));
+                }
+                out.push(Line::default());
+            }
             ActivityRow::Note { kind, text } => {
                 let modifier = match kind {
                     NoteKind::Info => Modifier::DIM,

--- a/web/src/components/acp/AcpRuntime.test.ts
+++ b/web/src/components/acp/AcpRuntime.test.ts
@@ -510,6 +510,37 @@ describe("activityToThreadMessages; diff-comments user card (#1123)", () => {
   });
 });
 
+describe("activityToThreadMessages; elicitation answer (#2209)", () => {
+  it("emits a user message with the answers on metadata.custom", () => {
+    const row: ActivityRow = {
+      id: "elicitation-el-1",
+      kind: "elicitation_answered",
+      text: "Proceed?: Yes",
+      elicitationAnswers: [{ question: "Proceed?", answer: "Yes" }],
+      at: "2026-05-12T00:00:00Z",
+    };
+    const messages = activityToThreadMessages([row], false);
+    const user = messages.find((m) => m.role === "user")!;
+    const parts = user.content as Array<{ type: string; text?: string }>;
+    expect(parts[0]!.type).toBe("text");
+    expect(parts[0]!.text).toBe("Proceed?: Yes");
+    const custom = (user.metadata as { custom?: { elicitationAnswers?: unknown[] } } | undefined)?.custom;
+    expect(custom?.elicitationAnswers).toHaveLength(1);
+  });
+
+  it("omits metadata when the structured answers are absent", () => {
+    const row: ActivityRow = {
+      id: "elicitation-el-2",
+      kind: "elicitation_answered",
+      text: "Q: A",
+      at: "2026-05-12T00:00:00Z",
+    };
+    const messages = activityToThreadMessages([row], false);
+    const user = messages.find((m) => m.role === "user")!;
+    expect(user.metadata).toBeUndefined();
+  });
+});
+
 function toolStopped(id: string, text = ""): ActivityRow {
   return {
     id: `stopped-${id}-9`,

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -311,6 +311,23 @@ export function activityToThreadMessages(
       continue;
     }
 
+    if (row.kind === "elicitation_answered") {
+      // The user's answer to an AskUserQuestion / elicitation form. Render
+      // as a user-authored message so the picked answer reads like the
+      // user's turn (mirrors how Claude Code shows it), but keep it a
+      // distinct row kind so it never folds into prompt grouping. The
+      // structured pairs ride on metadata for richer rendering. See #2209.
+      flushAssistant();
+      messages.push({
+        id: row.id,
+        role: "user",
+        content: [{ type: "text", text: row.text }],
+        metadata: row.elicitationAnswers ? { custom: { elicitationAnswers: row.elicitationAnswers } } : undefined,
+        createdAt: parseDate(row.at),
+      });
+      continue;
+    }
+
     if (row.kind === "user_diff_comments") {
       // A typed diff-comments prompt. The assembled markdown is the
       // user-visible / agent body (and the fallback if the card can't

--- a/web/src/components/acp/ElicitationAnswerCard.test.tsx
+++ b/web/src/components/acp/ElicitationAnswerCard.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+//
+// Render tests for ElicitationAnswerCard, the rich AskUserQuestion / elicitation
+// answer card in the structured-view user-message slot (#2209). Covers the
+// answer count label, each question/answer pair, and the payload type guard
+// that gates the card vs the plain-text fallback in UserText.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { ElicitationAnswerCard } from "./ElicitationAnswerCard";
+import { isElicitationAnswersPayload } from "../../lib/acpTypes";
+
+afterEach(() => cleanup());
+
+describe("ElicitationAnswerCard", () => {
+  it("renders each question/answer pair and a count label", () => {
+    render(
+      <ElicitationAnswerCard
+        answers={[
+          { question: "Color?", answer: "Blue" },
+          { question: "Languages?", answer: "Rust, TypeScript" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("2 answers")).toBeTruthy();
+    expect(screen.getByText("Color?")).toBeTruthy();
+    expect(screen.getByText("Blue")).toBeTruthy();
+    expect(screen.getByText("Languages?")).toBeTruthy();
+    expect(screen.getByText("Rust, TypeScript")).toBeTruthy();
+  });
+
+  it("uses the singular label for a single answer", () => {
+    render(<ElicitationAnswerCard answers={[{ question: "Proceed?", answer: "Yes" }]} />);
+    expect(screen.getByText("1 answer")).toBeTruthy();
+  });
+});
+
+describe("isElicitationAnswersPayload", () => {
+  it("accepts a non-empty array of question/answer pairs", () => {
+    expect(isElicitationAnswersPayload([{ question: "q", answer: "a" }])).toBe(true);
+  });
+
+  it("rejects an empty array, non-arrays, and malformed entries", () => {
+    expect(isElicitationAnswersPayload([])).toBe(false);
+    expect(isElicitationAnswersPayload(undefined)).toBe(false);
+    expect(isElicitationAnswersPayload("nope")).toBe(false);
+    expect(isElicitationAnswersPayload([{ question: "q" }])).toBe(false);
+    expect(isElicitationAnswersPayload([{ question: 1, answer: 2 }])).toBe(false);
+  });
+});

--- a/web/src/components/acp/ElicitationAnswerCard.tsx
+++ b/web/src/components/acp/ElicitationAnswerCard.tsx
@@ -1,0 +1,34 @@
+import type { ElicitationAnswer } from "../../lib/acpTypes";
+
+interface Props {
+  answers: ElicitationAnswer[];
+}
+
+/** Rich rendering of the user's reply to an AskUserQuestion / elicitation
+ *  form in the structured view user-message slot. Built from the typed
+ *  answers carried on the assistant-ui message metadata; falls back to raw
+ *  text rendering upstream when absent. Mirrors `DiffCommentsUserCard` so a
+ *  structured pick reads as a tidy card, not a flat "Q: A" line. See #2209. */
+export function ElicitationAnswerCard({ answers }: Props) {
+  return (
+    <div className="w-full max-w-3xl rounded-2xl rounded-br-sm border border-surface-700 bg-surface-800/70 px-4 py-3 text-sm">
+      <div className="mb-2 flex items-center gap-2 text-[11px] uppercase tracking-wider text-text-dim">
+        <span className="rounded bg-brand-600/15 px-1.5 py-0.5 font-mono text-brand-300">answer</span>
+        <span>
+          {answers.length} answer{answers.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {answers.map((a, i) => (
+          <li
+            key={`${i}-${a.question}`}
+            className="rounded-lg border border-surface-700/60 bg-surface-900/60 px-3 py-2"
+          >
+            <div className="mb-0.5 text-[11px] uppercase tracking-wider text-text-dim">{a.question}</div>
+            <div className="whitespace-pre-wrap text-text-primary">{a.answer}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/acp/ElicitationAnswerCard.tsx
+++ b/web/src/components/acp/ElicitationAnswerCard.tsx
@@ -11,7 +11,10 @@ interface Props {
  *  structured pick reads as a tidy card, not a flat "Q: A" line. See #2209. */
 export function ElicitationAnswerCard({ answers }: Props) {
   return (
-    <div className="w-full max-w-3xl rounded-2xl rounded-br-sm border border-surface-700 bg-surface-800/70 px-4 py-3 text-sm">
+    <div
+      data-testid="elicitation-answer-card"
+      className="w-full max-w-3xl rounded-2xl rounded-br-sm border border-surface-700 bg-surface-800/70 px-4 py-3 text-sm"
+    >
       <div className="mb-2 flex items-center gap-2 text-[11px] uppercase tracking-wider text-text-dim">
         <span className="rounded bg-brand-600/15 px-1.5 py-0.5 font-mono text-brand-300">answer</span>
         <span>

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -35,6 +35,8 @@ import { pickWorkerStoppedVariant } from "./workerStoppedBanner";
 import { SubagentCard, ToolCard, ToolGroupCard, TodoGroupCard } from "./ToolCards";
 import { DiffCommentsUserCard } from "../diff/comments/DiffCommentsUserCard";
 import { isDiffCommentsCardPayload, parseDiffCommentsSentinel } from "../diff/comments/buildPrompt";
+import { ElicitationAnswerCard } from "./ElicitationAnswerCard";
+import { isElicitationAnswersPayload } from "../../lib/acpTypes";
 import {
   SPINNER_FRAMES,
   SPINNER_INTERVAL_MS,
@@ -543,8 +545,16 @@ function UserMessage() {
  *  prompts. Falls back to the classic chat bubble otherwise. */
 function UserText({ text }: { text: string }) {
   const typedPayload = useMessage((m) => (m.metadata?.custom as { diffComments?: unknown } | undefined)?.diffComments);
+  // An answered AskUserQuestion / elicitation: render the picked answer as
+  // a tidy card from the typed payload on the message metadata. See #2209.
+  const answers = useMessage(
+    (m) => (m.metadata?.custom as { elicitationAnswers?: unknown } | undefined)?.elicitationAnswers,
+  );
   if (isDiffCommentsCardPayload(typedPayload)) {
     return <DiffCommentsUserCard payload={typedPayload} />;
+  }
+  if (isElicitationAnswersPayload(answers)) {
+    return <ElicitationAnswerCard answers={answers} />;
   }
   // Legacy fallback: older prompts carry the structured data in a
   // base64 sentinel at the top of the text body. Decode + render the

--- a/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
+++ b/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
@@ -94,9 +94,11 @@ describe("reducer elicitation_resolved_locally", () => {
               title: "Proceed?",
               required: true,
               kind: "single_select",
+              // value != label so the test catches raw internal values
+              // leaking into the transcript instead of the display label.
               options: [
-                { value: "Yes", label: "Yes" },
-                { value: "No", label: "No" },
+                { value: "yes_internal", label: "Yes" },
+                { value: "no_internal", label: "No" },
               ],
             },
           ]
@@ -128,7 +130,7 @@ describe("reducer elicitation_resolved_locally", () => {
     const action: Action = {
       kind: "elicitation_resolved_locally",
       nonce: "e-1",
-      resolution: { action: "accept", answers: { question_0: "Yes" } },
+      resolution: { action: "accept", answers: { question_0: "yes_internal" } },
     };
     const next = reducer(state, action);
     const row = next.activity.find((r) => r.kind === "elicitation_answered");

--- a/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
+++ b/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
@@ -136,6 +136,18 @@ describe("reducer elicitation_resolved_locally", () => {
     expect(row?.elicitationAnswers).toEqual([{ question: "Proceed?", answer: "Yes" }]);
   });
 
+  it("adds no answer row when the pending card is already gone", () => {
+    // The broadcast may have cleared the card first; with no pending card to
+    // read questions from, the optimistic path records nothing and leaves the
+    // server-event row (if any) to stand.
+    const next = reducer(emptyAcpState(), {
+      kind: "elicitation_resolved_locally",
+      nonce: "missing",
+      resolution: { action: "accept", answers: { question_0: "Yes" } },
+    });
+    expect(next.activity.some((r) => r.kind === "elicitation_answered")).toBe(false);
+  });
+
   it("adds no answer row when the question was declined", () => {
     const state = {
       ...emptyAcpState(),

--- a/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
+++ b/web/src/hooks/__tests__/useAcpResolveApproval.test.ts
@@ -82,12 +82,25 @@ describe("classifyElicitationResolveResponse", () => {
 });
 
 describe("reducer elicitation_resolved_locally", () => {
-  function elicitation(nonce: string): Elicitation {
+  function elicitation(nonce: string, withQuestion = false): Elicitation {
     return {
       nonce,
       message: "Pick",
       tool_call_id: null,
-      questions: [],
+      questions: withQuestion
+        ? [
+            {
+              field_key: "question_0",
+              title: "Proceed?",
+              required: true,
+              kind: "single_select",
+              options: [
+                { value: "Yes", label: "Yes" },
+                { value: "No", label: "No" },
+              ],
+            },
+          ]
+        : [],
       requested_at: new Date().toISOString(),
       resolved: null,
     };
@@ -98,9 +111,42 @@ describe("reducer elicitation_resolved_locally", () => {
       ...emptyAcpState(),
       pendingElicitations: [elicitation("e-1"), elicitation("e-2")],
     };
-    const action: Action = { kind: "elicitation_resolved_locally", nonce: "e-1" };
+    const action: Action = {
+      kind: "elicitation_resolved_locally",
+      nonce: "e-1",
+      resolution: { action: "decline" },
+    };
     const next = reducer(state, action);
     expect(next.pendingElicitations.map((e) => e.nonce)).toEqual(["e-2"]);
+  });
+
+  it("records the answer row from the pending card and the submitted resolution (#2209)", () => {
+    const state = {
+      ...emptyAcpState(),
+      pendingElicitations: [elicitation("e-1", true)],
+    };
+    const action: Action = {
+      kind: "elicitation_resolved_locally",
+      nonce: "e-1",
+      resolution: { action: "accept", answers: { question_0: "Yes" } },
+    };
+    const next = reducer(state, action);
+    const row = next.activity.find((r) => r.kind === "elicitation_answered");
+    expect(row?.id).toBe("elicitation-e-1");
+    expect(row?.elicitationAnswers).toEqual([{ question: "Proceed?", answer: "Yes" }]);
+  });
+
+  it("adds no answer row when the question was declined", () => {
+    const state = {
+      ...emptyAcpState(),
+      pendingElicitations: [elicitation("e-1", true)],
+    };
+    const next = reducer(state, {
+      kind: "elicitation_resolved_locally",
+      nonce: "e-1",
+      resolution: { action: "decline" },
+    });
+    expect(next.activity.some((r) => r.kind === "elicitation_answered")).toBe(false);
   });
 });
 

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -9,11 +9,13 @@
 
 import { useCallback, useEffect, useReducer, useRef, useState, useSyncExternalStore } from "react";
 import {
+  appendElicitationAnswerRow,
   applyEvent,
   emptyAcpState,
   isTurnActive,
   normaliseTurnCounters,
   setActivityLimit,
+  summarizeAnswers,
   type ApprovalDecision,
   type AcpAttachment,
   type AcpFrame,
@@ -52,7 +54,7 @@ export type Action =
   | { kind: "error"; message: string }
   | { kind: "clear_error" }
   | { kind: "approval_resolved_locally"; nonce: string }
-  | { kind: "elicitation_resolved_locally"; nonce: string }
+  | { kind: "elicitation_resolved_locally"; nonce: string; resolution: ElicitationResolution }
   | { kind: "lagged_resolved" }
   | { kind: "reset" }
   | { kind: "hydrate"; state: AcpState }
@@ -449,12 +451,18 @@ export function reducer(state: AcpState, action: Action): AcpState {
     // Optimistically drop the elicitation card once the server accepts the
     // resolution (204) or reports the nonce gone (404), instead of waiting
     // on the ElicitationResolved broadcast, which the seq dedupe can drop.
+    const card = state.pendingElicitations.find((e) => e.nonce === action.nonce);
     const pendingElicitations = state.pendingElicitations.filter((e) => e.nonce !== action.nonce);
     const removed = pendingElicitations.length !== state.pendingElicitations.length;
+    // Record the picked answer immediately (deduped by id), so it shows
+    // even when the broadcast is dropped by seq dedupe. See #2209.
+    const answers =
+      card && action.resolution.action === "accept" ? summarizeAnswers(card, action.resolution.answers) : [];
     return {
       ...state,
       lastError: removed ? null : state.lastError,
       pendingElicitations,
+      activity: appendElicitationAnswerRow(state.activity, action.nonce, answers),
     };
   }
   if (action.kind === "hydrate") {
@@ -1197,7 +1205,7 @@ export function useAcpSession(
       const detail = res.ok ? "" : await safeText(res);
       const outcome = classifyElicitationResolveResponse(res.ok, res.status, detail, nonce);
       if (outcome.kind === "resolved") {
-        dispatch({ kind: "elicitation_resolved_locally", nonce });
+        dispatch({ kind: "elicitation_resolved_locally", nonce, resolution });
         return;
       }
       // A validation rejection (422) leaves the elicitation pending

--- a/web/src/lib/acpTypes.reducer.test.ts
+++ b/web/src/lib/acpTypes.reducer.test.ts
@@ -118,6 +118,75 @@ describe("applyEvent / approval lifecycle", () => {
   });
 });
 
+describe("applyEvent / elicitation answer (#2209)", () => {
+  const elicitation = {
+    nonce: "el-1",
+    message: "Pick",
+    questions: [],
+    requested_at: "2026-01-01T00:00:00Z",
+  };
+
+  it("records an elicitation_answered row on ElicitationResolved and clears the card", () => {
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { ElicitationRequested: { elicitation } },
+    });
+    expect(state.pendingElicitations).toHaveLength(1);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ElicitationResolved: {
+          nonce: "el-1",
+          outcome: "Accepted",
+          answers: [{ question: "Proceed?", answer: "Yes" }],
+        },
+      },
+    });
+    expect(state.pendingElicitations).toHaveLength(0);
+    const row = state.activity.find((r) => r.kind === "elicitation_answered");
+    expect(row?.id).toBe("elicitation-el-1");
+    expect(row?.elicitationAnswers).toEqual([{ question: "Proceed?", answer: "Yes" }]);
+  });
+
+  it("dedupes by id so a re-broadcast does not add a second row", () => {
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ElicitationResolved: {
+          nonce: "el-1",
+          outcome: "Accepted",
+          answers: [{ question: "Q", answer: "A" }],
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ElicitationResolved: {
+          nonce: "el-1",
+          outcome: "Accepted",
+          answers: [{ question: "Q", answer: "A" }],
+        },
+      },
+    });
+    expect(state.activity.filter((r) => r.kind === "elicitation_answered")).toHaveLength(1);
+  });
+
+  it("adds no row when the elicitation was skipped or cancelled (empty answers)", () => {
+    const state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { ElicitationResolved: { nonce: "el-1", outcome: "Declined", answers: [] } },
+    });
+    expect(state.activity.some((r) => r.kind === "elicitation_answered")).toBe(false);
+  });
+});
+
 describe("applyEvent / DiffEmitted", () => {
   it("appends diffs and caps the buffer at 16 most-recent", () => {
     let state = emptyAcpState();

--- a/web/src/lib/acpTypes.reducer.test.ts
+++ b/web/src/lib/acpTypes.reducer.test.ts
@@ -1,6 +1,16 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { applyEvent, emptyAcpState, setActivityLimit, type AcpFrame, type AcpState, type ToolCall } from "./acpTypes";
+import {
+  appendElicitationAnswerRow,
+  applyEvent,
+  emptyAcpState,
+  setActivityLimit,
+  summarizeAnswers,
+  type AcpFrame,
+  type AcpState,
+  type Elicitation,
+  type ToolCall,
+} from "./acpTypes";
 
 // Targets the AcpEvent variants and helper branches the canonical
 // acpTypes.test.ts leaves cold: PlanUpdated, ThinkingEnded, the
@@ -118,6 +128,62 @@ describe("applyEvent / approval lifecycle", () => {
   });
 });
 
+describe("summarizeAnswers (#2209)", () => {
+  function question(field_key: string, kind: Elicitation["questions"][number]["kind"], title?: string) {
+    return { field_key, title: title ?? null, required: false, kind, options: [] };
+  }
+  function form(questions: Elicitation["questions"]): Elicitation {
+    return { nonce: "n", message: "m", questions, requested_at: "2026-01-01T00:00:00Z" };
+  }
+
+  it("renders every answer kind in question order, omitting unanswered fields", () => {
+    const elicitation = form([
+      question("sel", "single_select", "Color"),
+      question("multi", "multi_select", "Tags"),
+      question("txt", "free_text", "Name"),
+      question("flag_on", "boolean", "On"),
+      question("flag_off", "boolean", "Off"),
+      question("num", "number", "Score"),
+      question("blank", "free_text"), // unanswered -> omitted
+    ]);
+    const out = summarizeAnswers(elicitation, {
+      sel: "Blue",
+      multi: ["a", "b"],
+      txt: "Ada",
+      flag_on: true,
+      flag_off: false,
+      num: 4,
+    });
+    expect(out).toEqual([
+      { question: "Color", answer: "Blue" },
+      { question: "Tags", answer: "a, b" },
+      { question: "Name", answer: "Ada" },
+      { question: "On", answer: "Yes" },
+      { question: "Off", answer: "No" },
+      { question: "Score", answer: "4" },
+    ]);
+  });
+
+  it("falls back to the field key when a question has no title", () => {
+    const out = summarizeAnswers(form([question("question_0", "free_text")]), { question_0: "hi" });
+    expect(out).toEqual([{ question: "question_0", answer: "hi" }]);
+  });
+});
+
+describe("appendElicitationAnswerRow (#2209)", () => {
+  it("appends a keyed row and is idempotent by id", () => {
+    const a = appendElicitationAnswerRow([], "n-1", [{ question: "q", answer: "a" }]);
+    expect(a).toHaveLength(1);
+    expect(a[0]!.id).toBe("elicitation-n-1");
+    const b = appendElicitationAnswerRow(a, "n-1", [{ question: "q", answer: "a" }]);
+    expect(b).toBe(a); // same ref, no duplicate
+  });
+
+  it("is a no-op for empty answers", () => {
+    expect(appendElicitationAnswerRow([], "n-1", [])).toEqual([]);
+  });
+});
+
 describe("applyEvent / elicitation answer (#2209)", () => {
   const elicitation = {
     nonce: "el-1",
@@ -182,6 +248,15 @@ describe("applyEvent / elicitation answer (#2209)", () => {
       session_id: "s-1",
       seq: 1,
       event: { ElicitationResolved: { nonce: "el-1", outcome: "Declined", answers: [] } },
+    });
+    expect(state.activity.some((r) => r.kind === "elicitation_answered")).toBe(false);
+  });
+
+  it("tolerates an event with no answers field (pre-#2209 stored events)", () => {
+    const state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { ElicitationResolved: { nonce: "el-1", outcome: "Accepted" } },
     });
     expect(state.activity.some((r) => r.kind === "elicitation_answered")).toBe(false);
   });

--- a/web/src/lib/acpTypes.reducer.test.ts
+++ b/web/src/lib/acpTypes.reducer.test.ts
@@ -168,6 +168,21 @@ describe("summarizeAnswers (#2209)", () => {
     const out = summarizeAnswers(form([question("question_0", "free_text")]), { question_0: "hi" });
     expect(out).toEqual([{ question: "question_0", answer: "hi" }]);
   });
+
+  it("maps select values to option labels (MCP token, and AskUserQuestion desc)", () => {
+    const q = {
+      field_key: "color",
+      title: "Color",
+      required: true,
+      kind: "single_select" as const,
+      options: [
+        { value: "tok_blue", label: "Blue" }, // MCP: token -> human label
+        { value: "Green", label: "Green \u2014 the color green" }, // AskUserQuestion: keep bare value
+      ],
+    };
+    expect(summarizeAnswers(form([q]), { color: "tok_blue" })[0]!.answer).toBe("Blue");
+    expect(summarizeAnswers(form([q]), { color: "Green" })[0]!.answer).toBe("Green");
+  });
 });
 
 describe("appendElicitationAnswerRow (#2209)", () => {

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -254,6 +254,40 @@ export type ElicitationResolution =
   | { action: "decline" }
   | { action: "cancel" };
 
+/** One answered question rendered for the transcript. Mirror of
+ *  `ElicitationAnswer` in src/acp/elicitations.rs. Carried on
+ *  `ElicitationResolved` (server-rendered) and rebuilt locally by the
+ *  optimistic path. See #2209. */
+export interface ElicitationAnswer {
+  question: string;
+  answer: string;
+}
+
+/** Render a submitted answer value for display. Selects carry the option
+ *  value, which for AskUserQuestion is already the clean label. */
+function renderAnswerValue(value: AnswerValue): string {
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (Array.isArray(value)) return value.join(", ");
+  return String(value);
+}
+
+/** Build display-ready answer pairs from a form and the submitted answers,
+ *  in question order, omitting unanswered questions. Mirrors
+ *  `summarize_answers` in src/acp/elicitations.rs so the optimistic local
+ *  path renders the same row the server broadcasts. */
+export function summarizeAnswers(elicitation: Elicitation, answers: Record<string, AnswerValue>): ElicitationAnswer[] {
+  const out: ElicitationAnswer[] = [];
+  for (const question of elicitation.questions) {
+    const value = answers[question.field_key];
+    if (value === undefined) continue;
+    out.push({
+      question: question.title || question.field_key,
+      answer: renderAnswerValue(value),
+    });
+  }
+  return out;
+}
+
 /** Mirror of `StartupErrorDetail` in src/acp/state.rs. Serde's
  *  default for `#[serde(tag = "kind", ...)]` is internal tagging keyed
  *  on `kind`. Carries the structured remediation data the
@@ -358,7 +392,13 @@ export type AcpEvent =
   | { ApprovalRequested: { approval: Approval } }
   | { ApprovalResolved: { nonce: string; decision: ApprovalDecision } }
   | { ElicitationRequested: { elicitation: Elicitation } }
-  | { ElicitationResolved: { nonce: string; outcome: ElicitationOutcome } }
+  | {
+      ElicitationResolved: {
+        nonce: string;
+        outcome: ElicitationOutcome;
+        answers?: ElicitationAnswer[];
+      };
+    }
   | "SessionCleared"
   | "ConversationCompacted"
   | { DiffEmitted: { diff: DiffPreview } }
@@ -745,6 +785,7 @@ export interface ActivityRow {
     | "thinking"
     | "user_prompt"
     | "user_diff_comments"
+    | "elicitation_answered"
     | "empty_output"
     | "context_reset"
     | "session_cleared"
@@ -774,6 +815,10 @@ export interface ActivityRow {
    *  ships them only at completion. Absent for text-only completions
    *  (those render from `text`). See #1818. */
   output?: ToolOutputBlock[];
+  /** Display-ready answers on an `elicitation_answered` row (the user's
+   *  reply to an AskUserQuestion / elicitation form). `text` holds a flat
+   *  fallback; the card renders the structured pairs. See #2209. */
+  elicitationAnswers?: ElicitationAnswer[];
   at: string; // ISO-8601
 }
 
@@ -1171,8 +1216,13 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     return next;
   }
   if ("ElicitationResolved" in event) {
-    const { nonce } = event.ElicitationResolved;
+    const { nonce, answers } = event.ElicitationResolved;
     next.pendingElicitations = next.pendingElicitations.filter((e) => e.nonce !== nonce);
+    // Record the picked answer so it survives the card closing. Deduped by
+    // id, so this is a no-op if the optimistic local clear already added it
+    // (and the safety net when that clear never ran: cold replay, a second
+    // device). See #2209.
+    next.activity = appendElicitationAnswerRow(next.activity, nonce, answers ?? []);
     return next;
   }
   if ("DiffEmitted" in event) {
@@ -1781,6 +1831,29 @@ function pushActivity(rows: ActivityRow[], row: ActivityRow): ActivityRow[] {
     return next.slice(next.length - activityLimit);
   }
   return next;
+}
+
+/** Append an `elicitation_answered` row recording the user's answers,
+ *  keyed by `elicitation-<nonce>` and deduped by id. Shared by the
+ *  optimistic local clear (renders from the pending card) and the
+ *  server-event handler (renders from the broadcast), so whichever lands
+ *  first wins and the other is a no-op even when the broadcast survives
+ *  seq dedupe. No row for empty answers (skip / cancel / teardown). See
+ *  #2209. */
+export function appendElicitationAnswerRow(
+  rows: ActivityRow[],
+  nonce: string,
+  answers: ElicitationAnswer[],
+): ActivityRow[] {
+  const id = `elicitation-${nonce}`;
+  if (answers.length === 0 || rows.some((r) => r.id === id)) return rows;
+  return pushActivity(rows, {
+    id,
+    kind: "elicitation_answered",
+    text: answers.map((a) => `${a.question}: ${a.answer}`).join("\n"),
+    elicitationAnswers: answers,
+    at: new Date().toISOString(),
+  });
 }
 
 /** Close any `tool_start` rows that never received a matching terminal

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -263,6 +263,22 @@ export interface ElicitationAnswer {
   answer: string;
 }
 
+/** Narrow a message-metadata payload to a non-empty answer list, so
+ *  UserText can pick the card over the plain-text fallback. */
+export function isElicitationAnswersPayload(value: unknown): value is ElicitationAnswer[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(
+      (x) =>
+        typeof x === "object" &&
+        x !== null &&
+        typeof (x as ElicitationAnswer).question === "string" &&
+        typeof (x as ElicitationAnswer).answer === "string",
+    )
+  );
+}
+
 /** Render a submitted answer value for display. Selects carry the option
  *  value, which for AskUserQuestion is already the clean label. */
 function renderAnswerValue(value: AnswerValue): string {

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -279,11 +279,28 @@ export function isElicitationAnswersPayload(value: unknown): value is Elicitatio
   );
 }
 
-/** Render a submitted answer value for display. Selects carry the option
- *  value, which for AskUserQuestion is already the clean label. */
-function renderAnswerValue(value: AnswerValue): string {
+/** Separator the adapter wedges between an AskUserQuestion option's label and
+ *  its description (`"<label> <sep> <description>"`). Written as an escape so
+ *  the em dash never appears literally in source. Mirrors `OPTION_DESC_SEP` in
+ *  AskUserQuestionCard and `OPTION_DESC_SEP` in src/acp/elicitations.rs. */
+const OPTION_DESC_SEP = " \u2014 ";
+
+/** Map a selected option value to its human label. A generic MCP form sends a
+ *  machine token as the value and the display text as the label; AskUserQuestion
+ *  sends the label as the value (with `label` possibly carrying a trailing
+ *  `"value <sep> description"`), so the bare value is kept there. */
+function selectLabel(question: ElicitationQuestion, raw: string): string {
+  const opt = question.options.find((o) => o.value === raw);
+  if (!opt) return raw;
+  return opt.label.startsWith(`${raw}${OPTION_DESC_SEP}`) ? raw : opt.label;
+}
+
+/** Render a submitted answer value for display, mapping select values to their
+ *  option labels. */
+function renderAnswerValue(question: ElicitationQuestion, value: AnswerValue): string {
   if (typeof value === "boolean") return value ? "Yes" : "No";
-  if (Array.isArray(value)) return value.join(", ");
+  if (Array.isArray(value)) return value.map((v) => selectLabel(question, v)).join(", ");
+  if (typeof value === "string") return selectLabel(question, value);
   return String(value);
 }
 
@@ -298,7 +315,7 @@ export function summarizeAnswers(elicitation: Elicitation, answers: Record<strin
     if (value === undefined) continue;
     out.push({
       question: question.title || question.field_key,
-      answer: renderAnswerValue(value),
+      answer: renderAnswerValue(question, value),
     });
   }
   return out;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1155,11 +1155,17 @@
       "id": "acp.elicitation-answer",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/lib/acpTypes.reducer.test.ts", "src/hooks/__tests__/useAcpResolveApproval.test.ts"],
+      "specs": [
+        "src/lib/acpTypes.reducer.test.ts",
+        "src/hooks/__tests__/useAcpResolveApproval.test.ts",
+        "src/components/acp/ElicitationAnswerCard.test.tsx"
+      ],
       "components": [
         "web/src/lib/acpTypes.ts",
         "web/src/hooks/useAcpSession.ts",
-        "web/src/components/acp/AcpRuntime.tsx"
+        "web/src/components/acp/AcpRuntime.tsx",
+        "web/src/components/acp/ElicitationAnswerCard.tsx",
+        "web/src/components/acp/StructuredView.tsx"
       ]
     },
     {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1152,6 +1152,17 @@
       ]
     },
     {
+      "id": "acp.elicitation-answer",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/lib/acpTypes.reducer.test.ts", "src/hooks/__tests__/useAcpResolveApproval.test.ts"],
+      "components": [
+        "web/src/lib/acpTypes.ts",
+        "web/src/hooks/useAcpSession.ts",
+        "web/src/components/acp/AcpRuntime.tsx"
+      ]
+    },
+    {
       "id": "acp.force-end-turn-gate",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/live/acp-stories/ask-user-question.spec.ts
+++ b/web/tests/live/acp-stories/ask-user-question.spec.ts
@@ -131,6 +131,14 @@ base("AskUserQuestion card submit resolves and the turn continues", async ({ pag
 
     await expect(postAnswerChunk).toBeVisible({ timeout: 10_000 });
     await expect(questionDialog).toBeHidden({ timeout: 10_000 });
+
+    // #2209: the picked answer is recorded in the transcript as the user's
+    // turn, so the history shows what was chosen rather than jumping to the
+    // next agent output.
+    const answerCard = page.getByTestId("elicitation-answer-card");
+    await expect(answerCard).toBeVisible({ timeout: 10_000 });
+    await expect(answerCard).toContainText("Which color?");
+    await expect(answerCard).toContainText("Blue");
   } finally {
     await serve.stop();
     rmSync(scriptDir, { recursive: true, force: true });

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -55,14 +55,20 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
     const resp = await postSeen;
     expect(resp.status()).toBe(200);
     await expect(page.getByText(FIRST_STEP)).toBeHidden();
+    // The POST returns 200 before the server has flushed the flag to
+    // config.toml, so GET /api/settings can briefly still report false.
+    // Poll with the same 10s budget the rest of this spec uses; the default
+    // 5s poll window is too tight under CI load and flakes here.
     await expect
-      .poll(() =>
-        page.evaluate(async () => {
-          const res = await fetch("/api/settings", { cache: "no-store" });
-          if (!res.ok) return false;
-          const cfg = await res.json();
-          return cfg?.app_state?.has_seen_web_tour === true;
-        }),
+      .poll(
+        () =>
+          page.evaluate(async () => {
+            const res = await fetch("/api/settings", { cache: "no-store" });
+            if (!res.ok) return false;
+            const cfg = await res.json();
+            return cfg?.app_state?.has_seen_web_tour === true;
+          }),
+        { timeout: 10_000 },
       )
       .toBe(true);
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

After answering an AskUserQuestion / ACP elicitation in the structured view, the chosen answer was never shown back: the card just disappeared and the next agent output looked concatenated, with no record of what you picked. Claude Code keeps the picked answer in the transcript; this brings the structured view (web and native TUI) to parity.

Root cause: `Event::ElicitationResolved` carried only the nonce and a coarse outcome (Accepted / Declined / Cancelled). The user's answers existed at resolve time but were dropped, and both reducers simply retained-out the pending card without recording anything.

The fix renders the submitted answers into display-ready pairs server-side at resolve time (where the parked form supplies the question titles and selects already carry the clean label), carries them on `ElicitationResolved`, and has each surface append a transcript row:

- Backend: a new `ElicitationAnswer { question, answer }` plus `summarize_answers`; the answers ride a named resolver message and land on the event (`#[serde(default)]`, so older stored events stay valid).
- Native TUI: a new `ActivityRow::ElicitationAnswer` rendered as a user-authored line; a skip leaves a short note, a cancel adds nothing.
- Web: a distinct `elicitation_answered` activity row (kept separate from `user_prompt` so it never folds into prompt grouping), rendered through a dedicated `ElicitationAnswerCard` in the user-message slot (a labelled chip plus question/answer pairs, mirroring the diff-review comments card). The optimistic local clear builds the row from the pending card and the submitted resolution and the server-event handler dedupes by id, so the answer shows immediately even when the `ElicitationResolved` broadcast is dropped by seq dedupe.

Closes #2209

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the web structured view, have an agent ask an AskUserQuestion (single-choice). Pick an option and Submit. Confirm the card closes and your pick stays in the transcript as your turn, above the next agent output.
- [ ] Do the same for a multi-choice question; confirm the selected options are shown (comma-joined).
- [ ] Answer a free-text / "Other" field; confirm the typed text is recorded verbatim.
- [ ] Click Skip on a question; confirm no fabricated answer appears (web: card just closes; TUI: a short "skipped" note).
- [ ] In the native TUI, answer the question from the web dashboard; confirm the TUI transcript now shows the chosen answer too.
- [ ] Reload the page after answering (cold replay); confirm the answer row is still present and not duplicated.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec and updated `web/tests/coverage-matrix.json` (`acp.elicitation-answer`): reducer appends the answer row + dedupes by id (`src/lib/acpTypes.reducer.test.ts`), the optimistic local path builds the row from the pending card + resolution (`src/hooks/__tests__/useAcpResolveApproval.test.ts`), and the card render + payload guard (`src/components/acp/ElicitationAnswerCard.test.tsx`).

**TUI / CLI (e2e test)**
- [x] Added Rust unit coverage instead of e2e: `summarize_answers` across field kinds (`src/acp/elicitations.rs`) and the TUI reducer recording an `ElicitationAnswer` row on resolve / a skip note on decline (`src/tui/structured_view/reducer.rs`).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` pass on the design (row-kind choice, structured payload, optimistic dedupe). I made the design calls, reviewed each commit, and ran the validation.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784231141&installation_id=139138837&pr_number=2228&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2228&signature=ebe6a950f650aeb3a17797775210478ef9146f71e2abaefdc955fa9420a757b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR makes answers to ACP `AskUserQuestion` (elicitation) cards reliably show up in the structured-view transcript on both web and native TUI. Previously, after a user answered, the card could disappear without leaving any transcript record of what was selected.

## What Changed
### Backend
- Added a consistent “question → answer” representation for submitted elicitation responses.
- Updated the `ElicitationResolved` event to carry the submitted answers (while still supporting older saved events that don’t include them).
- Ensured select-style answers display the user-friendly option labels (not internal/machine tokens).

### Native TUI
- Added a new transcript row type to record elicitation answers line-by-line after the card closes.
- Skip/decline behavior now leaves a short “skipped” style note, while canceling records nothing.

### Web
- Added an `ElicitationAnswerCard` in the user-message area to visually show the question/answer pairs right after submitting.
- Added a dedicated `elicitation_answered` transcript activity row so the structured transcript reflects what the user chose.
- Implemented optimistic rendering plus deduping so the transcript doesn’t end up with duplicate entries during retries/re-broadcasts (including cancellation-related flows).

### Types / Replay / Deduping
- Updated shared types and reducers to support optional answer payloads on resolved events.
- Added idempotency so cold replay and repeated events produce the same single transcript entry.

### Tests & Docs
- Expanded coverage for single-choice, multi-choice, free-text, skip/cancel flows, cross-platform synchronization, and cold replay/deduplication.
- Updated structured-view documentation to clarify the post-answer behavior and the difference between skip/decline vs cancel.
- Updated/added tests specifically around the answer formatting and label mapping.

## Benefits
- Users now get a dependable, persistent record of what they answered.
- Web and native TUI show consistent “what you selected” information in the structured transcript.
- Improved robustness against replay and event broadcast quirks (no missing answers, no duplicates).

## Potential Areas for Further Enhancement
- Improve transcript readability for very long answers (wrapping/truncation/formatting strategy).
- Double-check consistent wording for skip vs decline across every surface and transcript variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->