### PR TITLE
fix(web): tolerate finger jitter on sidebar long-press so the session menu opens on Android

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -52,6 +52,7 @@ import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import { REPO_COLOR_OPTIONS, type RepoAppearanceUpdate, type RepoColor } from "../lib/repoAppearance";
 import { STATUS_DOT_CLASS, getStatusTextClass, isSessionActive } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
+import { exceedsTouchSlop } from "../lib/longPress";
 import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import { renameSession, setSessionNotifications, setWorktreeName, updateSessionGroup } from "../lib/api";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
@@ -705,6 +706,7 @@ export const SessionRow = memo(function SessionRow({
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressFired = useRef(false);
   const touchOpenedAt = useRef(0);
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -766,12 +768,24 @@ export const SessionRow = memo(function SessionRow({
     if (!touch) return;
     const tx = touch.clientX;
     const ty = touch.clientY;
+    touchStart.current = { x: tx, y: ty };
     longPressTimer.current = setTimeout(() => {
       longPressFired.current = true;
       touchOpenedAt.current = Date.now();
       closeOtherContextMenus();
       setContextMenu({ x: tx, y: ty });
     }, 500);
+  };
+
+  // Cancel the pending long-press only once the finger moves past the slop, so
+  // a normal jittery hold still opens the menu while a deliberate drag
+  // (scroll/reorder) cancels it. See exceedsTouchSlop (#2232).
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch || !touchStart.current) return;
+    if (exceedsTouchSlop(touchStart.current, { x: touch.clientX, y: touch.clientY })) {
+      clearLongPress();
+    }
   };
 
   const handleTouchEnd = (e: React.TouchEvent) => {
@@ -897,7 +911,7 @@ export const SessionRow = memo(function SessionRow({
         onContextMenu={handleContextMenu}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
-        onTouchMove={clearLongPress}
+        onTouchMove={handleTouchMove}
         onTouchCancel={clearLongPress}
         data-selected={isSelected || undefined}
         className={`block w-full text-left py-2 cursor-pointer select-none [-webkit-touch-callout:none] transition-colors duration-75 ${

--- a/web/src/lib/__tests__/longPress.test.ts
+++ b/web/src/lib/__tests__/longPress.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { exceedsTouchSlop, LONG_PRESS_SLOP_PX } from "../longPress";
+
+describe("exceedsTouchSlop (#2232)", () => {
+  const start = { x: 100, y: 100 };
+
+  it("treats a stationary touch as within slop", () => {
+    expect(exceedsTouchSlop(start, { x: 100, y: 100 })).toBe(false);
+  });
+
+  it("tolerates normal finger jitter under the slop so the long-press survives", () => {
+    // A real hold wobbles a few px; the old cancel-on-any-move killed the menu.
+    expect(exceedsTouchSlop(start, { x: 103, y: 98 })).toBe(false);
+    expect(exceedsTouchSlop(start, { x: 95, y: 104 })).toBe(false);
+  });
+
+  it("does not cancel exactly at the slop boundary", () => {
+    expect(exceedsTouchSlop(start, { x: 100 + LONG_PRESS_SLOP_PX, y: 100 })).toBe(false);
+  });
+
+  it("cancels once a deliberate drag passes the slop", () => {
+    expect(exceedsTouchSlop(start, { x: 100 + LONG_PRESS_SLOP_PX + 1, y: 100 })).toBe(true);
+    expect(exceedsTouchSlop(start, { x: 140, y: 100 })).toBe(true);
+    expect(exceedsTouchSlop(start, { x: 100, y: 60 })).toBe(true);
+  });
+
+  it("uses 8px to match the dnd-kit TouchSensor reorder tolerance", () => {
+    expect(LONG_PRESS_SLOP_PX).toBe(8);
+  });
+});

--- a/web/src/lib/longPress.ts
+++ b/web/src/lib/longPress.ts
@@ -1,0 +1,19 @@
+// Long-press gesture tolerance for sidebar session rows.
+//
+// A finger never holds perfectly still during a long-press. Cancelling the
+// pending long-press on any movement (the old behavior) meant the rename/delete
+// menu only opened when you pressed unnaturally precisely; otherwise Android's
+// slop-tolerant native link menu won the gesture instead (#2232). We only treat
+// the press as cancelled once movement exceeds this slop, the same 8px the
+// dnd-kit TouchSensor uses for its reorder activation tolerance, so a normal
+// jittery hold still arms the menu while a deliberate drag (scroll/reorder)
+// still cancels it.
+export const LONG_PRESS_SLOP_PX = 8;
+
+export function exceedsTouchSlop(
+  start: { x: number; y: number },
+  point: { x: number; y: number },
+  slop = LONG_PRESS_SLOP_PX,
+): boolean {
+  return Math.hypot(point.x - start.x, point.y - start.y) > slop;
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -796,6 +796,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.longpress-slop",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/lib/__tests__/longPress.test.ts"],
+      "components": ["web/src/lib/longPress.ts", "web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.favorite-indicator",
       "kind": "deferred",
       "issue": "https://github.com/agent-of-empires/agent-of-empires/issues/986",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On the mobile PWA (Android), long-pressing a sidebar session row was supposed to open the app's rename/delete context menu, but unless you pressed very precisely and held perfectly still you got the browser's native link menu (open in new tab, copy link) instead.

Root cause: the session row is an `<a href>`, and `onTouchMove={clearLongPress}` cancelled the 500ms long-press timer on any pixel of movement. A normal finger long-press always jitters a few pixels, so the timer was cancelled before it fired and the custom menu never opened, while Android's slop-tolerant native long-press won the gesture. The only native suppressant on the row was the iOS-only `[-webkit-touch-callout:none]` from #1613, which does nothing on Android. This is the Android sibling of #1451.

The fix introduces an `exceedsTouchSlop` helper and only cancels the pending long-press once movement passes an 8px slop, the same tolerance the dnd-kit `TouchSensor` already uses for reorder activation. A jittery stationary hold now keeps the timer armed and opens the menu; a deliberate drag (scroll or reorder) still cancels it.

The regression test is a Vitest on `exceedsTouchSlop` rather than a Playwright spec: chromium synthesizes a `contextmenu` event on a small-movement touch long-press (which opens the menu through a different code path) but not on a drag, so a Playwright menu-visibility assertion passes identically on the buggy and fixed builds and cannot discriminate the slop logic. The Vitest fails on the old cancel-on-any-move behavior (slop 0) and passes on the fix. Confirming the native-menu suppression on a real device stays a manual check, same as #1613.

Closes #2232

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] On an Android phone, open the PWA, long-press a session row with a normal (slightly jittery) hold; confirm the app's rename/delete menu opens and the browser's native link menu does not.
- [ ] Press a row and drag more than ~8px (scroll intent); confirm no context menu opens and the list scrolls.
- [ ] Desktop: right-click a session row; confirm the context menu still opens as before.
- [ ] `cd web && npx vitest run src/lib/__tests__/longPress.test.ts` passes.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: a Playwright menu-visibility assertion cannot discriminate this fix (chromium's touch-to-contextmenu synthesis opens the menu on small movement regardless of the slop logic), so the regression test is a deterministic Vitest on `exceedsTouchSlop` and `web/tests/coverage-matrix.json` is updated with the `sidebar.longpress-slop` entry pointing at it.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (slop value, Vitest over a confounded Playwright spec) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784267954&installation_id=139138837&pr_number=2234&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2234&signature=f9e8a2a41990eac053347e6c899b3eb48c176d34a1c0fb15579a4fb34de968ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes an Android PWA bug where long-pressing a sidebar session row opens the browser's native link menu instead of the app's custom rename/delete context menu. The issue occurs because the app's custom long-press timer is cancelled on any touch movement, while Android's native gesture detector tolerates small finger jitter, causing it to win the gesture race.

## What Changed

**Added:**
- New `longPress.ts` utility module with a movement detection helper and 8-pixel threshold constant
- Vitest test suite validating the movement detection logic
- Touch movement tracking in the sidebar session row component
- Coverage matrix entry for the new functionality

**Modified:**
- `WorkspaceSidebar.tsx` updated to track initial touch coordinates and only cancel the long-press timer when finger movement exceeds the 8-pixel threshold

## Benefits
- Users can now reliably open the app's custom context menu on Android with normal long-press gestures that include natural finger jitter
- The native Android link menu is suppressed during long-press interactions
- Intentional drags (scrolls or reorders) still properly cancel the long-press timer
- Desktop right-click and iOS behaviors remain unaffected
- The 8-pixel threshold matches industry-standard gesture slop tolerances (dnd-kit's TouchSensor)

## Technical Details
The fix introduces an `exceedsTouchSlop` helper function that:
- Calculates Euclidean distance between initial touch position and current position
- Cancels the custom long-press timer only when movement exceeds 8 pixels
- Allows normal stationary holds with minor jitter (< 8px) to fire the custom context menu
- Still cancels the timer for deliberate drags beyond the threshold

The 8-pixel slop value is configurable and matches the tolerance used by the dnd-kit library for reorder gesture activation, providing consistent gesture semantics across the application.

Testing uses Vitest unit tests rather than Playwright because Chromium's touch simulation synthesizes a `contextmenu` event regardless of slop logic, making Playwright unable to reliably discriminate between buggy and fixed builds. The unit tests deterministically validate the slop behavior with structured test cases. Manual verification on a real Android device is required to confirm native menu suppression.

**Addresses:** Issue `#2232` and `#1451`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->