### PR TITLE
fix(web): allow archive and snooze on pinned sessions

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -74,7 +74,7 @@ The right-click (long-press on touch) context menu on any session row exposes th
 - **Archive**: tears down every tmux session the workspace owns (agent, web terminal, container terminal, and tool sub-sessions; pass `kill_pane: false` in the API body, or `--no-kill` on the CLI, to skip the tmux teardown) and shuts down the structured-view worker for ACP sessions, then sinks the row into the collapsible "Snoozed & archived" footer. Sending a message wakes it back into the live list. Daemon restarts skip archived sessions. See #1868.
 - **Snooze**: sinks the row for a chosen duration (presets: 1h, 2h, 3h, 4h, 5h, 6h, 1d, 1w). Wakes when the timer expires; sending a message wakes it early.
 
-Snooze and archive are mutually exclusive with pin (pinning a sunk row surfaces it; archiving or snoozing a pinned row removes the pin). The "Snoozed & archived" section sits at the bottom and aggregates every sunk workspace; collapsed by default, its state persists in localStorage. The three menu entries are hidden in read-only mode.
+A session is never pinned and sunk at once, but the transitions are one-step in either direction: pinning a sunk row surfaces it, and a pinned row's menu still offers Archive and Snooze, either of which removes the pin (matching the TUI, no unpin-first needed). Bulk Archive and Snooze include pinned rows in the selection for the same reason. The "Snoozed & archived" section sits at the bottom and aggregates every sunk workspace; collapsed by default, its state persists in localStorage. The three menu entries are hidden in read-only mode.
 
 ### Multi-select and bulk triage
 

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1153,11 +1153,13 @@ export const SessionRow = memo(function SessionRow({
                 <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">Triage</div>
                 {(() => {
                   // Menu actions are gated by the row's current triage
-                  // state so contradictory transitions never appear in
-                  // the UI: an archived row only offers Unarchive, a
-                  // pinned row only offers Unpin, etc. The shape helper
-                  // lives in `lib/sidebarSort.ts` so it can be unit
-                  // tested. See #1581.
+                  // state so contradictory toggles never appear in the
+                  // UI: an archived row only offers Unarchive, a snoozed
+                  // row only offers Unsnooze. A pinned row also offers
+                  // Archive/Snooze, since those are valid transitions
+                  // (the backend clears the pin) and match the TUI. The
+                  // shape helper lives in `lib/sidebarSort.ts` so it can
+                  // be unit tested. See #1581.
                   const shape = triageMenuShape(
                     triageStateOf({
                       isPinned: effectivePinned,

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -223,7 +223,7 @@ describe("SessionRow smart-rename chip", () => {
 });
 
 describe("SessionRow context menu", () => {
-  it("shows only the Unpin toggle when pinned", () => {
+  it("offers Unpin plus Archive and Snooze when pinned", () => {
     const ws = workspace("w-pinned", [session({ pinned_at: "2026-01-01T00:00:00Z" })]);
     render(
       <Wrap>
@@ -233,9 +233,11 @@ describe("SessionRow context menu", () => {
     const row = screen.getByTestId("sidebar-session-row");
     fireEvent.contextMenu(row);
     const menu = screen.getByTestId("sidebar-context-menu");
+    // Archiving or snoozing a pinned session clears the pin on the
+    // backend, matching the TUI, so the menu must not force unpin-first.
     expect(menu.textContent).toContain("Unpin");
-    expect(menu.textContent).not.toContain("Archive");
-    expect(menu.textContent).not.toContain("Snooze");
+    expect(menu.textContent).toContain("Archive");
+    expect(menu.textContent).toContain("Snooze");
   });
 
   it("shows only the Unarchive toggle when archived", () => {

--- a/web/src/lib/__tests__/sidebarBulk.test.ts
+++ b/web/src/lib/__tests__/sidebarBulk.test.ts
@@ -29,8 +29,10 @@ describe("bucketSelectionForBulk", () => {
     ];
     const b = bucketSelectionForBulk(workspaces, noOverride);
     expect(b.pinnable.map((w) => w.id)).toEqual(["live"]);
-    expect(b.archivable.map((w) => w.id)).toEqual(["live"]);
-    expect(b.snoozable.map((w) => w.id)).toEqual(["live"]);
+    // Pinned rows are archivable/snoozable too: the backend clears the
+    // pin on either transition, so bulk Archive/Snooze includes them.
+    expect(b.archivable.map((w) => w.id)).toEqual(["live", "pinned"]);
+    expect(b.snoozable.map((w) => w.id)).toEqual(["live", "pinned"]);
     expect(b.unpinnable.map((w) => w.id)).toEqual(["pinned"]);
     expect(b.unarchivable.map((w) => w.id)).toEqual(["archived"]);
     expect(b.unsnoozable.map((w) => w.id)).toEqual(["snoozed"]);

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -446,16 +446,16 @@ describe("triageMenuShape", () => {
     expect(shape.showUnsnooze).toBe(false);
   });
 
-  it("a pinned row only offers Unpin", () => {
-    // Regression: a pinned row used to show Archive and Snooze
-    // alongside Unpin, letting the user trigger contradictory
-    // transitions from the menu. See #1581.
+  it("a pinned row offers Unpin plus Archive / Snooze", () => {
+    // Archiving or snoozing a pinned session is a valid transition
+    // (the backend clears pinned_at) and the TUI already allows it,
+    // so the menu must not force unpin-first.
     const shape = triageMenuShape("pinned");
     expect(shape.showUnpin).toBe(true);
+    expect(shape.showArchive).toBe(true);
+    expect(shape.showSnooze).toBe(true);
     expect(shape.showPin).toBe(false);
-    expect(shape.showArchive).toBe(false);
     expect(shape.showUnarchive).toBe(false);
-    expect(shape.showSnooze).toBe(false);
     expect(shape.showUnsnooze).toBe(false);
   });
 

--- a/web/src/lib/sidebarBulk.ts
+++ b/web/src/lib/sidebarBulk.ts
@@ -53,7 +53,12 @@ export function bucketSelectionForBulk(
         buckets.snoozable.push(ws);
         break;
       case "pinned":
+        // Pinned rows can be unpinned, and also archived or snoozed
+        // directly: the backend clears the pin on either transition,
+        // matching the single-row menu (triageMenuShape) and the TUI.
         buckets.unpinnable.push(ws);
+        buckets.archivable.push(ws);
+        buckets.snoozable.push(ws);
         break;
       case "archived":
         buckets.unarchivable.push(ws);

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -154,12 +154,16 @@ export function triageStateOf(input: { isPinned: boolean; isArchived: boolean; i
 export function triageMenuShape(state: TriageState): TriageMenuShape {
   switch (state) {
     case "pinned":
+      // A pinned row offers Unpin plus Archive/Snooze: archiving or
+      // snoozing a pinned session is a valid transition (the backend
+      // clears pinned_at), and the TUI already allows it directly, so
+      // forcing unpin-first on the web was a parity gap.
       return {
         showPin: false,
         showUnpin: true,
-        showArchive: false,
+        showArchive: true,
         showUnarchive: false,
-        showSnooze: false,
+        showSnooze: true,
         showUnsnooze: false,
       };
     case "archived":

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2407,7 +2407,11 @@
         "src/lib/__tests__/sidebarOptimistic.test.ts",
         "src/lib/__tests__/sidebarBulk.test.ts"
       ],
-      "components": ["web/src/components/WorkspaceSidebar.tsx", "web/src/components/BulkActionBar.tsx"]
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/BulkActionBar.tsx",
+        "web/src/lib/sidebarBulk.ts"
+      ]
     },
     {
       "id": "sidebar.multi-select-gestures",

--- a/web/tests/live/triage-pin.spec.ts
+++ b/web/tests/live/triage-pin.spec.ts
@@ -54,15 +54,15 @@ base.describe("sidebar pin via context menu (#1581)", () => {
         timeout: 5_000,
       });
 
-      // Regression: a pinned row's menu only offers Unpin, not the
-      // contradictory Archive or Snooze toggles. The Pin button still
-      // exists because its testid is shared with Unpin; the others
-      // must be hidden entirely. See #1581. The reload below resets
-      // the page so we don't need to dismiss the menu by hand.
+      // A pinned row's menu offers Unpin plus Archive and Snooze:
+      // archiving or snoozing a pinned session clears the pin on the
+      // backend (matching the TUI), so the menu must not force
+      // unpin-first. See #1581. The reload below resets the page so we
+      // don't need to dismiss the menu by hand.
       await row.click({ button: "right" });
       await expect(page.locator("[data-testid='sidebar-context-menu-pin']")).toContainText("Unpin");
-      await expect(page.locator("[data-testid='sidebar-context-menu-archive']")).toHaveCount(0);
-      await expect(page.locator("[data-testid='sidebar-context-menu-snooze']")).toHaveCount(0);
+      await expect(page.locator("[data-testid='sidebar-context-menu-archive']")).toHaveCount(1);
+      await expect(page.locator("[data-testid='sidebar-context-menu-snooze']")).toHaveCount(1);
 
       // Server reflects the pin in the next list response.
       await expect


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the web dashboard, a pinned session's context menu only offered **Unpin**. To archive or snooze a pinned session you had to unpin it first, then re-open the menu and archive/snooze, a needless two-step.

This was a parity gap, not intended behavior. The TUI has no such guard (`src/tui/home/operations.rs` archives/snoozes the cursor session regardless of pin state), and the backend already treats these as one-step transitions: `Instance::archive()` and `Instance::snooze()` clear `pinned_at`. The web menu state machine (added in #1581 for parity with TUI/CLI triage) was the outlier that hid the actions.

The fix is frontend-only:

- `triageMenuShape("pinned")` now exposes **Archive** and **Snooze** alongside **Unpin** (`web/src/lib/sidebarSort.ts`). Clicking either transitions the session and clears the pin on the backend.
- `bucketSelectionForBulk` now puts pinned rows into the `archivable` / `snoozable` buckets too, so bulk multi-select Archive/Snooze includes pinned rows for the same reason (`web/src/lib/sidebarBulk.ts`).

No backend, schema, or migration changes; the transition semantics already existed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated tests and updated `web/tests/coverage-matrix.json`
- Note: the changed behavior is pure menu/bulk state-machine logic, so the regression lives in Vitest (`src/lib/__tests__/sidebarSort.test.ts`, `sidebarBulk.test.ts`), the canonical surface for this per `AGENTS.md`. The pinned-row assertions flip from "only Unpin" to "Unpin + Archive + Snooze" and fail on the pre-fix code. Added `web/src/lib/sidebarBulk.ts` to the `sidebar.multi-select-logic` matrix entry.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## How to test

- [ ] In the web dashboard, right-click (or long-press) a session and Pin it.
- [ ] Right-click the pinned session again: the menu now shows Archive and Snooze in addition to Unpin.
- [ ] Click Archive on the pinned session: it sinks into "Snoozed & archived" and is no longer pinned.
- [ ] Pin another session, then Snooze it from the menu: it sinks for the chosen duration and is no longer pinned.
- [ ] Multi-select a mix that includes a pinned session and run bulk Archive (or Snooze): the pinned row is included and gets archived/snoozed.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design call (restore TUI parity, transition clears the pin) and reviewed each change.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784268227&installation_id=139138837&pr_number=2235&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2235&signature=c533b12ecef809351cc54faccf3a3ffab79b3514a05eaec450817ab7c6d52d23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR enables users to archive or snooze pinned sessions directly from the context menu and bulk actions, eliminating the previous two-step process of unpinning first. The changes are frontend-only and align the web dashboard behavior with the TUI and backend capabilities.

## What Changed

**Menu behavior**: Pinned sessions now display **Archive**, **Snooze**, and **Unpin** options together in the context menu, allowing any action in a single step.

**Bulk actions**: Pinned sessions are now included in bulk Archive and Snooze selections, enabling multi-select operations to include pinned items.

**Documentation**: Updated the dashboard guide to clarify that pinning and sinking (archiving/snoozed) states transition in one step and that Archive/Snooze actions remove the pin as part of the backend transition.

**Test coverage**: Updated unit and integration tests to verify that pinned sessions now expose Archive and Snooze options. Added `web/src/lib/sidebarBulk.ts` to the test coverage matrix.

## Technical Details

- **`web/src/lib/sidebarSort.ts`**: The `triageMenuShape("pinned")` function now sets `showArchive: true` and `showSnooze: true` (previously `false` for both).
- **`web/src/lib/sidebarBulk.ts`**: The `bucketSelectionForBulk` function adds pinned workspaces to the `archivable` and `snoozable` buckets alongside the existing `unpinnable` bucket.
- **`web/src/components/WorkspaceSidebar.tsx`**: Comment clarification about valid triage actions and reference to `triageMenuShape` helper in `sidebarSort.ts`.
- **Tests**: Updated assertions in `sidebarSort.test.ts`, `sidebarBulk.test.ts`, `SessionRowTriage.test.tsx`, and `triage-pin.spec.ts` to reflect new menu behavior.

## Benefits

- **Reduced friction**: Users no longer need to unpin before archiving or snozing, streamlining workflows.
- **Consistency**: Web dashboard behavior now matches TUI and backend capabilities.
- **No breaking changes**: Backend already supported clearing `pinned_at` during archive/snooze transitions; this is a frontend-only update that leverages existing backend behavior.

## Note

The PR has merge conflicts that require resolution before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->