### PR TITLE
chore(acp): bump claude-agent-acp floor to 0.46.0 and pair per-question Other boxes

### DIFF
--- a/acp-worker/test-shim/shim.mjs
+++ b/acp-worker/test-shim/shim.mjs
@@ -99,7 +99,7 @@ class ShimAgent {
         name: "@agentclientprotocol/claude-agent-acp",
         // Keep at (or above) the agent_compat floor in
         // src/acp/agent_compat.rs, or the gate rejects the shim's handshake.
-        version: "0.44.0",
+        version: "0.46.0",
       },
     };
   }

--- a/acp-worker/test-shim/shim.mjs
+++ b/acp-worker/test-shim/shim.mjs
@@ -99,7 +99,7 @@ class ShimAgent {
         name: "@agentclientprotocol/claude-agent-acp",
         // Keep at (or above) the agent_compat floor in
         // src/acp/agent_compat.rs, or the gate rejects the shim's handshake.
-        version: "0.46.0",
+        version: "0.47.0",
       },
     };
   }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN npm install -g @qwen-code/qwen-code
 # `gemini --acp`, `vibe-acp`) are already provided by their respective
 # CLIs above.
 RUN npm install -g \
-    @agentclientprotocol/claude-agent-acp@^0.46.0 \
+    @agentclientprotocol/claude-agent-acp@^0.47.0 \
     @zed-industries/codex-acp \
     pi-acp
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN npm install -g @qwen-code/qwen-code
 # `gemini --acp`, `vibe-acp`) are already provided by their respective
 # CLIs above.
 RUN npm install -g \
-    @agentclientprotocol/claude-agent-acp@^0.44.0 \
+    @agentclientprotocol/claude-agent-acp@^0.46.0 \
     @zed-industries/codex-acp \
     pi-acp
 

--- a/docs/structured-view/controls.md
+++ b/docs/structured-view/controls.md
@@ -38,14 +38,14 @@ The card clears as soon as your decision is accepted. If it already resolved on 
 
 Some agents ask a structured question mid-turn rather than guessing. With `claude-agent-acp` this is the built-in `AskUserQuestion` tool; the daemon advertises the ACP form-elicitation capability so the agent surfaces it as a question card in the web dashboard. The same capability also lets an MCP server attached to the agent collect arbitrary structured input, which renders through the same card:
 
-- **Single-choice** questions render as radio buttons, **multi-choice** as checkboxes, and a free-text "Other" field shows when the agent offers one. When an option carries an explanation, it renders as a second line under the option label.
+- **Single-choice** questions render as radio buttons, **multi-choice** as checkboxes, and each question carries its own free-text "Other" box so you can type an answer instead of picking an option, scoped to that question. When an option carries an explanation, it renders as a second line under the option label.
 - MCP forms can also include **text** fields (typed by their format, so email / URL / date inputs get the matching control), **number** and **integer** fields, and **yes/no** checkboxes. Any field default the agent supplies is pre-filled.
 - **Submit** sends your answers back and the turn continues. **Skip** answers nothing (the agent proceeds without your input). **Cancel** aborts the tool call.
 - Required fields and every constraint the schema declares (selection min/max, text length, regex pattern, numeric range) are enforced before Submit; the daemon re-validates, so a stale or malformed answer never reaches the agent.
 
 The rich question form is web-only. In the native TUI the card shows the question with a pointer to answer it in the web dashboard, plus keys to skip or cancel from the transcript pane so a TUI-only session never stalls on a question.
 
-> AskUserQuestion options can carry a `preview` (a code snippet or mockup shown on focus in the Claude Code CLI/desktop). The `claude-agent-acp` adapter does not forward `preview` over ACP, so it cannot be shown here; this is an adapter limitation, not a dashboard one.
+> AskUserQuestion options can carry a `preview` (a code snippet or mockup shown on focus in the Claude Code CLI/desktop). As of `claude-agent-acp` 0.46 the adapter does forward `preview` (and the option's structured `description`) under an ACP `_meta` extension, but the ACP enum-option type the dashboard parses has no slot for it yet, so previews still cannot be shown here; the option `description` continues to render via the flattened option label.
 
 ### Notifications and sound
 

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -36,7 +36,7 @@ use super::state::StartupErrorDetail;
 /// sandbox image stuck below the host floor. User docs deliberately do not
 /// restate the number; the startup-error path reports the exact floor
 /// dynamically at rejection time.
-pub const CLAUDE_AGENT_ACP_MIN_VERSION: &str = "0.44.0";
+pub const CLAUDE_AGENT_ACP_MIN_VERSION: &str = "0.46.0";
 
 /// Parsed form of [`CLAUDE_AGENT_ACP_MIN_VERSION`]. Runs once per adapter
 /// initialize, not in a hot path, so parsing on demand is fine.

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -36,7 +36,7 @@ use super::state::StartupErrorDetail;
 /// sandbox image stuck below the host floor. User docs deliberately do not
 /// restate the number; the startup-error path reports the exact floor
 /// dynamically at rejection time.
-pub const CLAUDE_AGENT_ACP_MIN_VERSION: &str = "0.46.0";
+pub const CLAUDE_AGENT_ACP_MIN_VERSION: &str = "0.47.0";
 
 /// Parsed form of [`CLAUDE_AGENT_ACP_MIN_VERSION`]. Runs once per adapter
 /// initialize, not in a hot path, so parsing on demand is fine.

--- a/src/acp/elicitations.rs
+++ b/src/acp/elicitations.rs
@@ -62,7 +62,7 @@ pub struct Elicitation {
 /// One field of the elicitation form.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ElicitationQuestion {
-    /// Schema property key (`question_0`, `customAnswer`, ...). Echoed
+    /// Schema property key (`question_0`, `question_0_custom`, ...). Echoed
     /// back verbatim as the answer key in the response content.
     pub field_key: String,
     pub title: Option<String>,
@@ -218,18 +218,29 @@ impl ElicitationResolution {
 }
 
 /// Order a form's properties for display. The adapter keys questions
-/// `question_0..N` and serializes them through a `BTreeMap`, which sorts
-/// lexically (`question_10` before `question_2`), so recover the numeric
-/// order; non-`question_N` keys (e.g. `customAnswer`) sort after, by key.
+/// `question_0..N`, each optionally followed by its own free-text "Other"
+/// box `question_<n>_custom`, and serializes them through a `BTreeMap`,
+/// which sorts lexically (`question_10` before `question_2`, and every
+/// `question_<n>_custom` after every `question_<n>`). Recover the numeric
+/// order and keep each `_custom` box adjacent to its question, so the
+/// per-question "Other" field renders next to the question it belongs to
+/// rather than bunched at the end. Non-`question_N` keys (arbitrary MCP
+/// form fields) sort after, by key.
 fn ordered_fields(
     properties: &BTreeMap<String, ElicitationPropertySchema>,
 ) -> Vec<(&String, &ElicitationPropertySchema)> {
-    fn question_index(key: &str) -> Option<u64> {
-        key.strip_prefix("question_").and_then(|n| n.parse().ok())
+    // `(index, is_custom)`: the base question (0) sorts before its paired
+    // `_custom` box (1), and both before the next question's index.
+    fn question_order(key: &str) -> Option<(u64, u8)> {
+        let rest = key.strip_prefix("question_")?;
+        match rest.strip_suffix("_custom") {
+            Some(index) => Some((index.parse().ok()?, 1)),
+            None => Some((rest.parse().ok()?, 0)),
+        }
     }
     let mut fields: Vec<_> = properties.iter().collect();
     fields.sort_by(
-        |(a, _), (b, _)| match (question_index(a), question_index(b)) {
+        |(a, _), (b, _)| match (question_order(a), question_order(b)) {
             (Some(ai), Some(bi)) => ai.cmp(&bi),
             (Some(_), None) => std::cmp::Ordering::Less,
             (None, Some(_)) => std::cmp::Ordering::Greater,
@@ -780,6 +791,39 @@ mod tests {
         assert_eq!(e.questions[1].field_key, "question_10");
         assert_eq!(e.questions[1].kind, ElicitationFieldKind::MultiSelect);
         assert_eq!(e.questions[2].field_key, "customAnswer");
+    }
+
+    #[test]
+    fn per_question_custom_box_stays_next_to_its_question() {
+        // claude-agent-acp >=0.46 emits a per-question "Other" box keyed
+        // `question_<n>_custom` right after each `question_<n>`. The BTreeMap
+        // would otherwise sort every `_custom` after every question; the
+        // ordering must instead keep each box adjacent to its question.
+        let schema = ElicitationSchema::new()
+            .string("question_0", false)
+            .property(
+                "question_0_custom",
+                StringPropertySchema::new().title("Other"),
+                false,
+            )
+            .string("question_1", false)
+            .property(
+                "question_1_custom",
+                StringPropertySchema::new().title("Other"),
+                false,
+            );
+        let req = form_request(schema, "many");
+        let e = parse_elicitation(Nonce::new(), &req, Utc::now()).unwrap();
+        let keys: Vec<&str> = e.questions.iter().map(|q| q.field_key.as_str()).collect();
+        assert_eq!(
+            keys,
+            [
+                "question_0",
+                "question_0_custom",
+                "question_1",
+                "question_1_custom"
+            ]
+        );
     }
 
     #[test]

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -346,11 +346,12 @@ const INITIALIZE_RESULT = {
   agentInfo: {
     name: "@agentclientprotocol/claude-agent-acp",
     // Keep at (or above) the agent_compat floor in src/acp/agent_compat.rs
-    // (>=0.44.0, the release that routes AskUserQuestion through form
-    // elicitation); the gate rejects the fake's handshake otherwise, which
-    // fails every live Playwright acp spec and the acp live-daemon e2e
-    // suite (#2077 bumped the floor without this fixture and broke both).
-    version: "0.44.0",
+    // (>=0.46.0, the release with per-question "Other" boxes and the
+    // PromptResponse-hang fix); the gate rejects the fake's handshake
+    // otherwise, which fails every live Playwright acp spec and the acp
+    // live-daemon e2e suite (#2077 bumped the floor without this fixture
+    // and broke both).
+    version: "0.46.0",
   },
   // No authMethods key at all. An empty array is interpreted by some
   // ACP client implementations as "auth methods listed but none

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -346,12 +346,12 @@ const INITIALIZE_RESULT = {
   agentInfo: {
     name: "@agentclientprotocol/claude-agent-acp",
     // Keep at (or above) the agent_compat floor in src/acp/agent_compat.rs
-    // (>=0.46.0, the release with per-question "Other" boxes and the
-    // PromptResponse-hang fix); the gate rejects the fake's handshake
-    // otherwise, which fails every live Playwright acp spec and the acp
-    // live-daemon e2e suite (#2077 bumped the floor without this fixture
-    // and broke both).
-    version: "0.46.0",
+    // (>=0.47.0, which adds the duplicate-message fix on top of 0.46's
+    // per-question "Other" boxes and PromptResponse-hang fix); the gate
+    // rejects the fake's handshake otherwise, which fails every live
+    // Playwright acp spec and the acp live-daemon e2e suite (#2077 bumped
+    // the floor without this fixture and broke both).
+    version: "0.47.0",
   },
   // No authMethods key at all. An empty array is interpreted by some
   // ACP client implementations as "auth methods listed but none


### PR DESCRIPTION
## Description

Post-release follow-up for the three upstream `claude-agent-acp` issues we filed, all fixed in `0.46.0`:

- [#770](https://github.com/agentclientprotocol/claude-agent-acp/issues/770): per-question "Other" custom-answer collapsed into one form-level field. 0.46 now emits a per-question `question_<n>_custom` box.
- [#764](https://github.com/agentclientprotocol/claude-agent-acp/issues/764): option `preview` dropped and `description` flattened. 0.46 forwards both under an ACP `_meta` extension.
- [#688](https://github.com/agentclientprotocol/claude-agent-acp/issues/688): `session/prompt` `PromptResponse` never sent on long agent turns, hanging the request. Fixed in the adapter.

Changes here:

- Bump `CLAUDE_AGENT_ACP_MIN_VERSION` `0.44.0` -> `0.46.0` and the matching `docker/Dockerfile` npm pin (the `dockerfile_pin_matches_floor` test enforces parity).
- Bump the fake ACP agent's reported version to `0.46.0` so the compat gate keeps accepting it in live Playwright and the acp live-daemon e2e.
- `ordered_fields` now keeps each `question_<n>_custom` box adjacent to its `question_<n>`. The 0.46 per-question shape would otherwise be scattered: the keys go through a `BTreeMap`, which sorts every `question_<n>_custom` after every `question_<n>`, so all the "Other" boxes bunched at the end of the form instead of sitting next to their question. New regression test covers the ordering.
- Docs: per-question "Other" wording, plus a corrected `preview` note.

### Why #688 needs no client change

The fix is entirely adapter-side (the adapter now always sends `PromptResponse`); the floor bump delivers it. The host-side orphan watchdog stays in place as defense in depth.

### Why #764 option `preview`/`description` is not rendered yet

0.46 forwards them under `_meta._claude/askUserQuestionOption`, but the latest `agent-client-protocol` Rust crate (0.14) `EnumOption` is `#[non_exhaustive] { value, title }` with no `_meta` slot, so the dashboard cannot deserialize them yet. The option `description` still surfaces via the flattened option title. Rendering `preview` structurally is blocked until the ACP crate exposes `_meta` on `EnumOption`; the docs note and the controls note both call this out.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The form-field ordering normalization lives in the Rust daemon (`src/acp/elicitations.rs`) and is covered by a unit test (`per_question_custom_box_stays_next_to_its_question`). The web simply renders the server-normalized question list in order, so there is no new browser-side logic to exercise. The fake-agent version bump keeps the existing live/e2e acp specs green rather than adding a flow.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude handled the investigation (mapping each upstream fix to the 0.46.0 dist shapes and the client-side impact), the floor bump, the `ordered_fields` fix plus its test, and the doc edits. Decisions and review are mine.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784274234&installation_id=139138837&pr_number=2238&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2238&signature=e1bf6cfebfd09869ad7ed428dcad04d41f50bb4f00308d3e03274baa9b4c6ebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR upgrades the `claude-agent-acp` adapter from 0.44.0 to 0.47.0 and updates the web client, docs, and test shims to stay compatible with upstream behavioral fixes.

## What Changed
**1) Adapter version + compatibility gates**
- Bumped the installed adapter dependency in the Docker image to `^0.47.0`.
- Raised the client-side minimum supported adapter version constant to `0.47.0`.
- Updated the fake ACP agent/test-shim handshake to report version `0.47.0` (to keep Playwright/e2e tests aligned), including the test-shim handshake version.

**2) Form layout fix for "Other" per question**
- Adjusted question field ordering so that each per-question free-text "Other" box stays next to its corresponding question (instead of drifting to the end).
- Added a regression test to lock in the intended ordering.

**3) Documentation update for option preview/description**
- Updated docs to reflect that the adapter now forwards `preview` and `description` via ACP `_meta`.
- Noted that the dashboard still can't render these structurally yet due to a limitation in the Rust protocol library; `description` continues to be surfaced via the flattened option label.

**4) Adapter-side hang fix**
- No additional client-side logic changes beyond the version upgrade, since the upstream fix addresses potential hangs on long agent turns on the adapter side.

## Benefits
- Prevents confusing UI behavior by keeping related "Other" inputs visually paired with their questions.
- Maintains test/e2e compatibility by updating version negotiation expectations.
- Improves clarity for how option metadata is handled, and sets expectations about what can/can't be rendered yet.
- Includes upstream fixes for stability improvements during extended agent interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->