### PR TITLE
fix(acp): reliable structured-view stop, turn-end, and session recovery

### DIFF
--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -245,8 +245,14 @@ blocking command) do not honor a graceful cancel. When that happens a
 **Force stop** button appears next to the spinner, even while a tool is
 in flight. Force stop ends the turn immediately: it restarts the agent
 worker and kills the whole command tree, so a runaway loop actually
-stops instead of waiting out the grace window. Clicking **Stop** again
-while it already reads "Stopping..." does the same thing.
+stops instead of waiting out the grace window.
+
+Clicking **Stop** a second time always escalates to a force stop, even
+when the spinner is stuck "active" but the daemon no longer has a turn in
+flight (for example after the worker was restarted mid-turn). The second
+press no longer waits for the server to confirm the first cancel, so the
+button is always a working escape and you should not need
+`aoe acp restart` to clear a wedged spinner.
 
 Force stop is a hard interrupt. The agent resumes from its saved
 transcript on the next prompt, but any partial output from the tool that

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -233,6 +233,19 @@ container (rather than bind-mounting from the host).
 - A repeatedly-failing worker is parked with a red "session parked" banner.
   Retry from the dashboard or run `aoe acp restart <session>`.
 
+### "Restarting worker" banner after a turn looked done
+
+Some agents (notably `claude-agent-acp`) occasionally finish a turn, stream
+the final message and the end-of-turn usage, but never send the protocol's
+turn-complete acknowledgement. The daemon used to treat that as a wedge and
+restart the worker, showing **Agent finished but didn't notify the daemon.
+Restarting worker; your transcript will be preserved.** When the agent had
+already emitted its end-of-turn usage and was not running a background or
+scheduled task, the daemon now ends the turn cleanly instead, so a completed
+turn no longer triggers a restart. A genuine stall (no end-of-turn usage, or a
+monitor / scheduled-wake turn that overran) still restarts the worker and
+shows the banner; the transcript is preserved either way.
+
 ### "Force end turn" button under the spinner
 
 If the agent finished a turn but the working spinner is still rattling, a small

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -232,6 +232,11 @@ container (rather than bind-mounting from the host).
   reconnect status if the WebSocket is degraded.
 - A repeatedly-failing worker is parked with a red "session parked" banner.
   Retry from the dashboard or run `aoe acp restart <session>`.
+- A session that was auto-stopped for inactivity and then respawned (for
+  example after a version upgrade) used to be able to keep a stale "dormant"
+  marker, which made the daemon refuse to bring the worker back after it next
+  exited; a follow-up message would then sit unsent. A worker coming online now
+  clears that marker, so this no longer strands a queued message.
 
 ### "Restarting worker" banner after a turn looked done
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -5309,8 +5309,20 @@ async fn run_connection_task<W, R>(
                     }
                     Some(ClientCmd::Cancel) => {
                         info!(target: "acp.protocol", "sending session/cancel (no prompt in flight)");
-                        connection
-                            .send_notification(CancelNotification::new(acp_session_id.clone()))?;
+                        // Best-effort, NOT `?`: a failed notification means
+                        // the agent connection is likely already gone, which
+                        // is exactly when the UI most needs the synthetic
+                        // Stopped below to unstick. Propagating the error here
+                        // would skip that emit and defeat the desync recovery.
+                        if let Err(e) = connection
+                            .send_notification(CancelNotification::new(acp_session_id.clone()))
+                        {
+                            warn!(
+                                target: "acp.protocol",
+                                error = %e,
+                                "session/cancel (no prompt in flight) notification failed; still emitting Stopped"
+                            );
+                        }
                         // A cancel with no prompt in flight means the UI
                         // and the daemon have desynced: the client thinks
                         // a turn is running but this loop owns no

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -5238,6 +5238,22 @@ async fn run_connection_task<W, R>(
                         info!(target: "acp.protocol", "sending session/cancel (no prompt in flight)");
                         connection
                             .send_notification(CancelNotification::new(acp_session_id.clone()))?;
+                        // A cancel with no prompt in flight means the UI
+                        // and the daemon have desynced: the client thinks
+                        // a turn is running but this loop owns no
+                        // prompt_fut, so no terminal Stopped will ever be
+                        // emitted (the adopted/orphaned-turn residual of
+                        // #1216). Publish one now so the spinner clears on
+                        // the first Stop press instead of forcing the user
+                        // onto `aoe acp restart`. Harmless when the UI is
+                        // already idle: the reducer caps lastStoppedSeq at
+                        // pendingUserPromptSeq, so a spurious Stopped while
+                        // idle is a no-op. See #2237.
+                        let _ = event_tx_for_block
+                            .send(Event::Stopped {
+                                reason: "cancelled".into(),
+                            })
+                            .await;
                     }
                     Some(ClientCmd::ForceStop) => {
                         // No prompt in flight: nothing to kill here. The

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -6255,11 +6255,19 @@ mod tests {
             wall,
             cfg,
         );
-        // WakeupPending clears cost_seen and sets off-protocol work, so
-        // the clean-completion guard (cost_seen && off_protocol none) is
-        // false: a scheduled-wake turn never takes the prompt_complete
-        // shortcut.
-        assert!(!w.cost_seen());
+        // Now apply the end-of-turn cost marker. TerminalUsage sets
+        // cost_seen, but (unlike a backgrounded command, #1858) a scheduled
+        // wakeup is NOT dropped, so off-protocol work stays set. This is the
+        // "with cost" case the test name promises: the clean-completion guard
+        // (cost_seen && off_protocol none) is still false, so a scheduled-wake
+        // turn keeps the orphan path even once its cost usage lands.
+        w.apply_signal(
+            LifecycleSignal::TerminalUsage,
+            t0 + std::time::Duration::from_secs(2),
+            wall,
+            cfg,
+        );
+        assert!(w.cost_seen());
         assert!(w.off_protocol_work_seen().is_some());
     }
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -839,6 +839,51 @@ impl SilentOrphanWatchdog {
     fn off_protocol_work_seen(&self) -> Option<OffProtocolWorkKind> {
         self.off_protocol_work_seen
     }
+
+    /// True once a cost-populated `UsageUpdate` (the end-of-turn
+    /// accounting marker) has arrived and nothing has reset progress
+    /// since. At watchdog-fire time this means the turn demonstrably
+    /// wrapped up but the adapter never sent the JSON-RPC PromptResponse,
+    /// so the right recovery is a clean `prompt_complete`, not a
+    /// cancel-and-restart orphan. See #2237.
+    fn cost_seen(&self) -> bool {
+        self.cost_seen
+    }
+}
+
+/// Resolve the terminal `Stopped` reason for a prompt turn from the
+/// mutually-prioritised end-of-turn flags. Extracted as a pure function
+/// so the precedence is unit-testable without the connection loop.
+///
+/// Precedence (highest first) and why each wins where it does is
+/// documented inline at the single call site. The finished-but-unacked
+/// recovery (#2237) deliberately sets NONE of these flags and breaks the
+/// loop, so it falls through to `prompt_complete`: the turn finished, the
+/// adapter just never sent the PromptResponse, so it must NOT collapse
+/// into `prompt_orphaned` (which would trigger a worker restart).
+fn terminal_stop_reason(
+    rate_limited: bool,
+    force_stopped: bool,
+    prompt_orphaned: bool,
+    agent_unresponsive: bool,
+    shutdown: bool,
+    prompt_cancelled: bool,
+) -> &'static str {
+    if rate_limited {
+        "rate_limited"
+    } else if force_stopped {
+        "user_forced"
+    } else if prompt_orphaned {
+        "prompt_orphaned"
+    } else if agent_unresponsive {
+        "agent_unresponsive"
+    } else if shutdown {
+        "shutdown"
+    } else if prompt_cancelled {
+        "cancelled"
+    } else {
+        "prompt_complete"
+    }
 }
 
 /// Tagged lifecycle signal carried over the watchdog mpsc. The
@@ -4909,6 +4954,42 @@ async fn run_connection_task<W, R>(
                                 {
                                     let now = tokio::time::Instant::now();
                                     let should_fire = watchdog.should_fire(now, watchdog_cfg);
+                                    if should_fire
+                                        && watchdog.cost_seen()
+                                        && watchdog.off_protocol_work_seen().is_none()
+                                    {
+                                        // The turn emitted its cost-populated
+                                        // end-of-turn UsageUpdate and then went
+                                        // silent with no in-flight tools and no
+                                        // off-protocol work: claude-agent-acp
+                                        // finished but never returned the
+                                        // PromptResponse. Cancelling and
+                                        // restarting the worker here (the orphan
+                                        // path below) restarts a turn that
+                                        // actually succeeded and shows the
+                                        // "Agent finished but didn't notify the
+                                        // daemon" banner. Treat the cost marker
+                                        // as authoritative and end the turn
+                                        // cleanly as prompt_complete; the
+                                        // connection task stays alive for the
+                                        // next prompt. The genuinely-wedged
+                                        // case (no cost marker) still falls
+                                        // through to the orphan path. See #2237;
+                                        // the off-protocol guard preserves the
+                                        // monitor / async-agent grace behavior
+                                        // of #1360 / #1401 / #1858.
+                                        info!(
+                                            target: "acp.protocol",
+                                            session = %session_label,
+                                            grace_secs = watchdog.effective_grace(watchdog_cfg).as_secs(),
+                                            "silent-orphan watchdog: turn wrapped up (cost-populated usage) without PromptResponse; ending cleanly as prompt_complete"
+                                        );
+                                        // Break with NO orphan/shutdown flag set so the
+                                        // terminal reason falls through to prompt_complete:
+                                        // a clean end, no worker restart, connection task
+                                        // survives for the next prompt. See #2237.
+                                        break;
+                                    }
                                     if should_fire {
                                         warn!(
                                             target: "acp.protocol",
@@ -5194,37 +5275,29 @@ async fn run_connection_task<W, R>(
                         //     "agent_unresponsive" would lose the
                         //     failure signature in postmortems. See
                         //     #1240.
-                        let reason = if rate_limited {
-                            "rate_limited"
-                        } else if force_stopped {
-                            // Explicit user "Force stop" wins over the
-                            // orphan/unresponsive watchdog reasons: it's the
-                            // proximate cause of THIS turn ending (we broke
-                            // the loop the moment the user clicked), so it
-                            // must not be masked by a prompt_orphaned flag
-                            // that was set earlier. The drain task treats it
-                            // like `agent_unresponsive` (kill process group +
-                            // respawn) but the reason string keeps the
-                            // user-initiated signal distinct in postmortems.
-                            // See #1727.
-                            "user_forced"
-                        } else if prompt_orphaned {
-                            "prompt_orphaned"
-                        } else if agent_unresponsive {
-                            "agent_unresponsive"
-                        } else if shutdown {
-                            "shutdown"
-                        } else if prompt_cancelled {
-                            // The adapter resolved cancel cleanly with
-                            // StopReason::Cancelled (upstream #694). The
-                            // 10s cancel-escalation watchdog never
-                            // promoted this to `agent_unresponsive`, so
-                            // surface the cleanly-cancelled signal
-                            // distinctly from `prompt_complete`.
-                            "cancelled"
-                        } else {
-                            "prompt_complete"
-                        };
+                        // Reason precedence lives in `terminal_stop_reason`
+                        // (unit-tested). Notable orderings:
+                        //   - `force_stopped` (user "Force stop") wins over
+                        //     orphan/unresponsive: it's the proximate cause of
+                        //     THIS turn ending and must not be masked by a
+                        //     prompt_orphaned flag set earlier. The drain task
+                        //     still kills + respawns, but the reason keeps the
+                        //     user-initiated signal distinct in postmortems
+                        //     (#1727).
+                        //   - `prompt_cancelled` surfaces the adapter's clean
+                        //     StopReason::Cancelled (upstream #694) distinctly
+                        //     from prompt_complete.
+                        //   - the finished-but-unacked recovery breaks with
+                        //     no flag set, falling through to prompt_complete
+                        //     so the turn does NOT restart the worker (#2237).
+                        let reason = terminal_stop_reason(
+                            rate_limited,
+                            force_stopped,
+                            prompt_orphaned,
+                            agent_unresponsive,
+                            shutdown,
+                            prompt_cancelled,
+                        );
                         let _ = event_tx_for_block
                             .send(Event::Stopped {
                                 reason: reason.into(),
@@ -6119,6 +6192,98 @@ mod tests {
         // Fast grace is 20s; 25s after the last progress with cost_seen
         // and no in-flight work must fire.
         assert!(w.should_fire(t0 + std::time::Duration::from_secs(25), cfg));
+    }
+
+    // #2237: when the watchdog fires on a turn that already emitted its
+    // cost-populated end-of-turn UsageUpdate (and no off-protocol work),
+    // the prompt loop ends the turn cleanly instead of cancel+restart.
+    // The decision keys on cost_seen() + off_protocol_work_seen(); guard
+    // both so the clean-completion branch is reachable only in that exact
+    // shape.
+    #[tokio::test]
+    async fn watchdog_cost_seen_marks_completed_unacked_path() {
+        let cfg = watchdog_test_cfg();
+        let t0 = tokio::time::Instant::now();
+        let wall = chrono::Utc::now();
+        let mut w = SilentOrphanWatchdog::new();
+        w.apply_signal(LifecycleSignal::Progress, t0, wall, cfg);
+        w.apply_signal(
+            LifecycleSignal::TerminalUsage,
+            t0 + std::time::Duration::from_secs(1),
+            wall,
+            cfg,
+        );
+        let fire_at = t0 + std::time::Duration::from_secs(25);
+        assert!(w.should_fire(fire_at, cfg));
+        // The clean-completion branch is gated on both signals.
+        assert!(w.cost_seen(), "cost marker must be observable at fire");
+        assert!(
+            w.off_protocol_work_seen().is_none(),
+            "no off-protocol work, so clean completion (not the monitor floor) applies"
+        );
+    }
+
+    #[tokio::test]
+    async fn watchdog_off_protocol_keeps_orphan_path_even_with_cost() {
+        // A backgrounded command before the cost marker is dropped by
+        // TerminalUsage (#1858), so cost_seen + no off-protocol holds and
+        // the clean path applies. But an async-agent / scheduled wakeup is
+        // NOT dropped, so those keep off_protocol set and must stay on the
+        // orphan path. Lock that distinction down.
+        let cfg = watchdog_test_cfg();
+        let t0 = tokio::time::Instant::now();
+        let wall = chrono::Utc::now();
+        let mut w = SilentOrphanWatchdog::new();
+        w.apply_signal(LifecycleSignal::Progress, t0, wall, cfg);
+        w.apply_signal(
+            LifecycleSignal::WakeupPending {
+                at: wall + chrono::Duration::seconds(1),
+            },
+            t0 + std::time::Duration::from_secs(1),
+            wall,
+            cfg,
+        );
+        // WakeupPending clears cost_seen and sets off-protocol work, so
+        // the clean-completion guard (cost_seen && off_protocol none) is
+        // false: a scheduled-wake turn never takes the prompt_complete
+        // shortcut.
+        assert!(!w.cost_seen());
+        assert!(w.off_protocol_work_seen().is_some());
+    }
+
+    // #2237: the finished-but-unacked recovery breaks with no flag set, so
+    // it must fall through to prompt_complete (the non-restart reason), NOT
+    // prompt_orphaned. Guard the all-false fall-through here; the watchdog
+    // test above guards the branch condition (cost_seen + no off-protocol).
+    #[test]
+    fn terminal_stop_reason_all_false_is_prompt_complete() {
+        assert_eq!(
+            terminal_stop_reason(false, false, false, false, false, false),
+            "prompt_complete"
+        );
+    }
+
+    #[test]
+    fn terminal_stop_reason_precedence_is_preserved() {
+        // rate_limited wins over everything.
+        assert_eq!(
+            terminal_stop_reason(true, true, true, true, true, true),
+            "rate_limited"
+        );
+        // force_stopped beats a prompt_orphaned flag set earlier.
+        assert_eq!(
+            terminal_stop_reason(false, true, true, false, false, false),
+            "user_forced"
+        );
+        // prompt_orphaned (genuine wedge) wins over a later shutdown/cancel.
+        assert_eq!(
+            terminal_stop_reason(false, false, true, false, true, false),
+            "prompt_orphaned"
+        );
+        assert_eq!(
+            terminal_stop_reason(false, false, false, false, false, true),
+            "cancelled"
+        );
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3661,8 +3661,28 @@ fn apply_acp_session_change(
 ) -> Option<String> {
     match change? {
         AcpSessionChange::Assigned(new_id) => {
+            // A worker just initialized (session/new or session/load), so the
+            // session is by definition no longer idle-dormant. Clear any
+            // marker now: a stale one left by a non-user respawn (e.g. the
+            // build-stale respawn #1754, which brings the worker back without
+            // a user wake) otherwise makes the reconciler's
+            // `!is_idle_dormant()` resume filter refuse to bring the session
+            // back after this worker later dies, deadlocking a queued prompt
+            // that the client parked waiting for a worker that never returns.
+            // See #2237.
+            let cleared_stale_dormant = inst.idle_dormant_since.take().is_some();
             if inst.acp_session_id.as_deref() == Some(new_id.as_str()) {
-                // Same id — already on disk, no need to rewrite.
+                // Same id (a reattach / session/load reuses it). Only persist
+                // if we actually cleared a stale dormant marker; otherwise the
+                // id is already on disk and there is nothing to rewrite.
+                if cleared_stale_dormant {
+                    tracing::info!(
+                        target: "acp.event_listener",
+                        session = %session_id,
+                        "cleared stale idle-dormant marker on worker (re)assign"
+                    );
+                    return Some(inst.source_profile.clone());
+                }
                 return None;
             }
             tracing::info!(
@@ -3934,6 +3954,53 @@ mod tests {
 
         let merged = merge_runtime_fields(prior, fresh);
         assert_eq!(merged.last_error.as_deref(), Some("recovery cascade: foo"));
+    }
+
+    // #2237: a worker coming live (AcpSessionAssigned) must clear a stale
+    // idle-dormant marker, even when the acp_session_id is unchanged (a
+    // session/load reattach reuses it). Without this, a stale marker left by a
+    // non-user respawn keeps the reconciler's resume filter skipping the
+    // session forever once the worker dies, deadlocking a queued prompt.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn acp_session_assigned_clears_stale_dormant_marker_on_same_id() {
+        let mut inst = Instance::new("seed", "/tmp/seed");
+        inst.acp_session_id = Some("sid-1".to_string());
+        inst.idle_dormant_since = Some(chrono::Utc::now());
+
+        // Same id as already stored: the only reason to persist is the
+        // stale-dormant clear, so the function must return Some(profile).
+        let persist = apply_acp_session_change(
+            &mut inst,
+            "seed",
+            Some(&AcpSessionChange::Assigned("sid-1".to_string())),
+        );
+        assert!(
+            inst.idle_dormant_since.is_none(),
+            "dormant marker must be cleared when a worker (re)assigns"
+        );
+        assert!(
+            persist.is_some(),
+            "clearing a stale marker must trigger a persist even on an unchanged id"
+        );
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn acp_session_assigned_same_id_no_marker_is_noop() {
+        let mut inst = Instance::new("seed", "/tmp/seed");
+        inst.acp_session_id = Some("sid-1".to_string());
+        inst.idle_dormant_since = None;
+        // Same id, nothing stale to clear: must stay a no-op (no rewrite).
+        let persist = apply_acp_session_change(
+            &mut inst,
+            "seed",
+            Some(&AcpSessionChange::Assigned("sid-1".to_string())),
+        );
+        assert!(
+            persist.is_none(),
+            "unchanged id with no stale marker is a no-op"
+        );
     }
 
     #[test]

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -43,6 +43,18 @@ import { hasTodoItemsArgsText, parseJsonObject } from "../../lib/acpArgs";
 import { useHistoryWindow } from "../../hooks/useHistoryWindow";
 import { useAgentProfile } from "../../lib/agentProfileContext";
 
+/**
+ * Decides whether a Stop-button press should send a graceful cancel or
+ * escalate to a force-end. Pure so it can be unit-tested without the
+ * assistant-ui runtime. Escalation happens when the server has confirmed
+ * a cancel is in flight (`cancelling`) OR the user has already pressed
+ * Stop once this turn (`alreadyRequested`), so the escape hatch never
+ * depends on an acknowledgement from the wedged daemon. See #2237.
+ */
+export function nextCancelAction(cancelling: boolean, alreadyRequested: boolean): "cancel" | "force" {
+  return cancelling || alreadyRequested ? "force" : "cancel";
+}
+
 interface Props {
   sessionId: string;
   /** Live acp worker lifecycle pulled from `SessionResponse.acp_worker_state`.
@@ -130,6 +142,24 @@ export function AcpRuntime({
   useEffect(() => {
     pendingAttachmentsRef.current = pendingAttachments;
   }, [pendingAttachments]);
+  // Tracks whether the user has already clicked Stop for the current
+  // turn. The server confirms a cancel by flipping `acp.state.cancelling`
+  // via a CancelRequested event, but that event is only emitted while a
+  // prompt is in flight on the daemon. When the UI is stuck "active" but
+  // the daemon has no in-flight prompt (an adopted/orphaned turn whose
+  // terminal Stopped was lost, see #1216), CancelRequested never arrives,
+  // so `cancelling` never flips and the Stop button could never escalate.
+  // This local ref is the client-owned escape hatch: it does not require
+  // an acknowledgement from the system it is escaping. See #2237.
+  const cancelRequestedRef = useRef(false);
+  // Reset the local cancel intent the moment the turn is no longer
+  // active (a terminal Stopped landed, or a fresh prompt started), so the
+  // next turn starts from a graceful-cancel-first state.
+  useEffect(() => {
+    if (!acp.state.turnActive) {
+      cancelRequestedRef.current = false;
+    }
+  }, [acp.state.turnActive]);
   // Render only the most recent slice of the transcript so a long
   // session does not block first paint on mobile; older rows stay in
   // reducer state and are revealed via "Load earlier". See #2144.
@@ -177,14 +207,20 @@ export function AcpRuntime({
       setPendingAttachments([]);
     },
     onCancel: async () => {
-      // First Stop sends a graceful cancel. If a cancel is already in
-      // flight (the agent is ignoring session/cancel on a stuck loop),
-      // a second Stop escalates to a force-stop instead of resending a
-      // no-op notification, so the user's instinct to click again
-      // actually ends the turn. See #1727.
-      if (acp.state.cancelling) {
+      // First Stop sends a graceful cancel. A second Stop escalates to a
+      // force-stop instead of resending a no-op notification, so the
+      // user's instinct to click again actually ends the turn. See #1727.
+      //
+      // The escalation triggers on EITHER the server-confirmed
+      // `cancelling` flag OR our local `cancelRequestedRef`. Relying on
+      // the server flag alone bricks the button whenever no in-flight
+      // prompt exists on the daemon (an adopted/orphaned turn whose
+      // CancelRequested is never emitted), which is the exact state that
+      // forced users onto `aoe acp restart`. See #2237.
+      if (nextCancelAction(acp.state.cancelling, cancelRequestedRef.current) === "force") {
         await acp.forceEndTurn();
       } else {
+        cancelRequestedRef.current = true;
         await acp.cancelPrompt();
       }
     },

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -42,18 +42,11 @@ import type {
 import { hasTodoItemsArgsText, parseJsonObject } from "../../lib/acpArgs";
 import { useHistoryWindow } from "../../hooks/useHistoryWindow";
 import { useAgentProfile } from "../../lib/agentProfileContext";
+import { useCancelEscalation } from "./useCancelEscalation";
 
-/**
- * Decides whether a Stop-button press should send a graceful cancel or
- * escalate to a force-end. Pure so it can be unit-tested without the
- * assistant-ui runtime. Escalation happens when the server has confirmed
- * a cancel is in flight (`cancelling`) OR the user has already pressed
- * Stop once this turn (`alreadyRequested`), so the escape hatch never
- * depends on an acknowledgement from the wedged daemon. See #2237.
- */
-export function nextCancelAction(cancelling: boolean, alreadyRequested: boolean): "cancel" | "force" {
-  return cancelling || alreadyRequested ? "force" : "cancel";
-}
+// Re-exported for existing tests that import it from this module; the
+// implementation now lives alongside the escalation hook. See #2237.
+export { nextCancelAction } from "./useCancelEscalation";
 
 interface Props {
   sessionId: string;
@@ -142,24 +135,17 @@ export function AcpRuntime({
   useEffect(() => {
     pendingAttachmentsRef.current = pendingAttachments;
   }, [pendingAttachments]);
-  // Tracks whether the user has already clicked Stop for the current
-  // turn. The server confirms a cancel by flipping `acp.state.cancelling`
-  // via a CancelRequested event, but that event is only emitted while a
-  // prompt is in flight on the daemon. When the UI is stuck "active" but
-  // the daemon has no in-flight prompt (an adopted/orphaned turn whose
-  // terminal Stopped was lost, see #1216), CancelRequested never arrives,
-  // so `cancelling` never flips and the Stop button could never escalate.
-  // This local ref is the client-owned escape hatch: it does not require
-  // an acknowledgement from the system it is escaping. See #2237.
-  const cancelRequestedRef = useRef(false);
-  // Reset the local cancel intent the moment the turn is no longer
-  // active (a terminal Stopped landed, or a fresh prompt started), so the
-  // next turn starts from a graceful-cancel-first state.
-  useEffect(() => {
-    if (!acp.state.turnActive) {
-      cancelRequestedRef.current = false;
-    }
-  }, [acp.state.turnActive]);
+  // Stop-button escalation: a second press always force-ends, even when the
+  // server never confirms the first cancel (no in-flight prompt on the
+  // daemon). Owns its own reset-on-turn-end and reset-on-session-switch
+  // lifecycle. See #2237.
+  const onCancel = useCancelEscalation(
+    sessionId,
+    acp.state.pendingUserPromptSeq,
+    acp.state.cancelling,
+    acp.cancelPrompt,
+    acp.forceEndTurn,
+  );
   // Render only the most recent slice of the transcript so a long
   // session does not block first paint on mobile; older rows stay in
   // reducer state and are revealed via "Load earlier". See #2144.
@@ -206,24 +192,7 @@ export function AcpRuntime({
       await acp.sendPrompt(text, attachments);
       setPendingAttachments([]);
     },
-    onCancel: async () => {
-      // First Stop sends a graceful cancel. A second Stop escalates to a
-      // force-stop instead of resending a no-op notification, so the
-      // user's instinct to click again actually ends the turn. See #1727.
-      //
-      // The escalation triggers on EITHER the server-confirmed
-      // `cancelling` flag OR our local `cancelRequestedRef`. Relying on
-      // the server flag alone bricks the button whenever no in-flight
-      // prompt exists on the daemon (an adopted/orphaned turn whose
-      // CancelRequested is never emitted), which is the exact state that
-      // forced users onto `aoe acp restart`. See #2237.
-      if (nextCancelAction(acp.state.cancelling, cancelRequestedRef.current) === "force") {
-        await acp.forceEndTurn();
-      } else {
-        cancelRequestedRef.current = true;
-        await acp.cancelPrompt();
-      }
-    },
+    onCancel,
   });
 
   return (

--- a/web/src/components/acp/__tests__/AcpRuntime.cancelEscalation.test.ts
+++ b/web/src/components/acp/__tests__/AcpRuntime.cancelEscalation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { nextCancelAction } from "../AcpRuntime";
+
+// Regression guard for #2237: the Stop button must be able to escalate to
+// a force-end without the server-confirmed `cancelling` flag, because that
+// flag never flips when the daemon has no in-flight prompt (an adopted or
+// orphaned turn). The local "already requested" intent is what keeps the
+// escape hatch reachable.
+describe("nextCancelAction (#2237)", () => {
+  it("first press with a clean state sends a graceful cancel", () => {
+    expect(nextCancelAction(false, false)).toBe("cancel");
+  });
+
+  it("escalates to force once the user has already pressed Stop this turn", () => {
+    // This is the case the old `if (acp.state.cancelling)` gate missed:
+    // no server confirmation, but the user clicked Stop a second time.
+    expect(nextCancelAction(false, true)).toBe("force");
+  });
+
+  it("escalates to force when the server confirmed the cancel", () => {
+    expect(nextCancelAction(true, false)).toBe("force");
+  });
+
+  it("escalates to force when both signals are set", () => {
+    expect(nextCancelAction(true, true)).toBe("force");
+  });
+});

--- a/web/src/components/acp/__tests__/useCancelEscalation.test.tsx
+++ b/web/src/components/acp/__tests__/useCancelEscalation.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useCancelEscalation } from "../useCancelEscalation";
+
+// Regression guard for #2237: the Stop button must escalate to force-end on a
+// second press without depending on the server-confirmed `cancelling` flag,
+// and the local intent must reset on turn end (turnSeq bump) and on session
+// switch so it never leaks across turns or sessions.
+describe("useCancelEscalation (#2237)", () => {
+  function setup(initial: { sessionId?: string; turnSeq?: number; cancelling?: boolean } = {}) {
+    const cancelPrompt = vi.fn().mockResolvedValue(undefined);
+    const forceEndTurn = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderHook(
+      ({ sessionId, turnSeq, cancelling }) =>
+        useCancelEscalation(sessionId, turnSeq, cancelling, cancelPrompt, forceEndTurn),
+      {
+        initialProps: {
+          sessionId: initial.sessionId ?? "s-1",
+          turnSeq: initial.turnSeq ?? 1,
+          cancelling: initial.cancelling ?? false,
+        },
+      },
+    );
+    return { result, rerender, cancelPrompt, forceEndTurn };
+  }
+
+  it("first press sends a graceful cancel, second press force-ends", async () => {
+    const { result, cancelPrompt, forceEndTurn } = setup();
+    await act(async () => {
+      await result.current();
+    });
+    expect(cancelPrompt).toHaveBeenCalledTimes(1);
+    expect(forceEndTurn).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current();
+    });
+    expect(forceEndTurn).toHaveBeenCalledTimes(1);
+    expect(cancelPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it("escalates to force on the first press when the server already confirmed a cancel", async () => {
+    const { result, cancelPrompt, forceEndTurn } = setup({ cancelling: true });
+    await act(async () => {
+      await result.current();
+    });
+    expect(forceEndTurn).toHaveBeenCalledTimes(1);
+    expect(cancelPrompt).not.toHaveBeenCalled();
+  });
+
+  it("resets the local intent when a new turn starts (turnSeq bumps)", async () => {
+    const { result, rerender, cancelPrompt, forceEndTurn } = setup({ turnSeq: 1 });
+    await act(async () => {
+      await result.current();
+    });
+    // Next turn: pendingUserPromptSeq advances.
+    rerender({ sessionId: "s-1", turnSeq: 2, cancelling: false });
+    await act(async () => {
+      await result.current();
+    });
+    // Back to graceful cancel: the stale "already requested" intent does not
+    // carry into the new turn.
+    expect(cancelPrompt).toHaveBeenCalledTimes(2);
+    expect(forceEndTurn).not.toHaveBeenCalled();
+  });
+
+  it("resets the local intent on a session switch without unmount", async () => {
+    const { result, rerender, cancelPrompt, forceEndTurn } = setup({ sessionId: "s-1", turnSeq: 5 });
+    await act(async () => {
+      await result.current();
+    });
+    // Switch to a different session that happens to share the same turnSeq.
+    rerender({ sessionId: "s-2", turnSeq: 5, cancelling: false });
+    await act(async () => {
+      await result.current();
+    });
+    // First press in the new session must be a graceful cancel, not a force.
+    expect(cancelPrompt).toHaveBeenCalledTimes(2);
+    expect(forceEndTurn).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/acp/useCancelEscalation.ts
+++ b/web/src/components/acp/useCancelEscalation.ts
@@ -1,0 +1,56 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * Decides whether a Stop-button press should send a graceful cancel or
+ * escalate to a force-end. Pure so it can be unit-tested without React.
+ * Escalation happens when the server has confirmed a cancel is in flight
+ * (`cancelling`) OR the user has already pressed Stop once this turn
+ * (`alreadyRequested`), so the escape hatch never depends on an
+ * acknowledgement from the wedged daemon. See #2237.
+ */
+export function nextCancelAction(cancelling: boolean, alreadyRequested: boolean): "cancel" | "force" {
+  return cancelling || alreadyRequested ? "force" : "cancel";
+}
+
+/**
+ * Owns the Stop-button escalation state for the structured-view composer and
+ * returns the `onCancel` handler.
+ *
+ * The server confirms a cancel by flipping `cancelling` via a
+ * `CancelRequested` event, but that event is only emitted while a prompt is
+ * in flight on the daemon. When the UI is stuck "active" with no in-flight
+ * prompt (an adopted/orphaned turn whose terminal `Stopped` was lost, see
+ * #1216), `CancelRequested` never arrives, so `cancelling` never flips and the
+ * Stop button could never escalate. We track a client-owned "already pressed
+ * Stop this turn" intent so a second press always force-ends, independent of
+ * any acknowledgement from the system it is escaping. See #2237.
+ *
+ * The intent is captured as a `(sessionId, turnSeq)` token rather than reset
+ * via an effect: a new turn bumps `turnSeq` and a session switch changes
+ * `sessionId`, so either one is automatically a mismatch and the first Stop of
+ * the next turn or session is graceful again. `turnSeq` is the monotonic
+ * per-turn prompt counter (`pendingUserPromptSeq`).
+ */
+export function useCancelEscalation(
+  sessionId: string,
+  turnSeq: number,
+  cancelling: boolean,
+  cancelPrompt: () => Promise<void>,
+  forceEndTurn: () => Promise<void>,
+): () => Promise<void> {
+  const requestedAtRef = useRef<string | null>(null);
+
+  return useCallback(async () => {
+    const token = `${sessionId}:${turnSeq}`;
+    const alreadyRequested = requestedAtRef.current === token;
+    // First Stop sends a graceful cancel; a second escalates to force-end
+    // instead of resending a no-op notification, so the user's instinct to
+    // click again actually ends the turn. See #1727 / #2237.
+    if (nextCancelAction(cancelling, alreadyRequested) === "force") {
+      await forceEndTurn();
+    } else {
+      requestedAtRef.current = token;
+      await cancelPrompt();
+    }
+  }, [sessionId, turnSeq, cancelling, cancelPrompt, forceEndTurn]);
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1191,6 +1191,13 @@
       "components": []
     },
     {
+      "id": "acp.stop-button-escalation",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/acp/__tests__/AcpRuntime.cancelEscalation.test.ts"],
+      "components": ["web/src/components/acp/AcpRuntime.tsx"]
+    },
+    {
       "id": "acp.spinner-tool-precedence",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1194,8 +1194,11 @@
       "id": "acp.stop-button-escalation",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/components/acp/__tests__/AcpRuntime.cancelEscalation.test.ts"],
-      "components": ["web/src/components/acp/AcpRuntime.tsx"]
+      "specs": [
+        "src/components/acp/__tests__/AcpRuntime.cancelEscalation.test.ts",
+        "src/components/acp/__tests__/useCancelEscalation.test.tsx"
+      ],
+      "components": ["web/src/components/acp/AcpRuntime.tsx", "web/src/components/acp/useCancelEscalation.ts"]
     },
     {
       "id": "acp.spinner-tool-precedence",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Structured-view sessions could get stuck in several ways that all forced the user to fall back to `aoe acp restart`: a spinner that never clears with a Stop button that did nothing, a turn that actually finished getting force-restarted, and a queued follow-up that never sent. This PR fixes four distinct points in the ACP session lifecycle, all surfaced from real stuck sessions.

**1. Stop button always escalates (web).** The composer Stop button only escalated to force-end when the server-confirmed `cancelling` flag was set, but that flag flips only on a `CancelRequested` event the daemon emits while a prompt is in flight. With no in-flight prompt (an adopted/orphaned turn whose terminal `Stopped` was lost, the residual of #1216), `cancelling` never flips, so every click stayed on the graceful-cancel branch and force-end was unreachable. The button now tracks a client-owned "cancel already requested" ref, so a second press always force-ends regardless of the server flag.

**2. Cancel with no prompt in flight self-heals (backend).** That same desync left the daemon's no-prompt-in-flight `ClientCmd::Cancel` arm sending a bare `session/cancel` and nothing else. It now publishes a terminal `Stopped { reason: "cancelled" }` so the first Stop press resyncs the UI. The reducer caps `lastStoppedSeq` at `pendingUserPromptSeq`, so a spurious `Stopped` while already idle is a no-op.

**3. Finished-but-unacked turns end cleanly instead of restarting (backend).** `claude-agent-acp` sometimes finishes a turn (streams the final message and the cost-populated end-of-turn `UsageUpdate`) but never sends the JSON-RPC `PromptResponse`, leaving `prompt_fut` pending. The silent-orphan watchdog then cancelled and force-restarted the worker, showing "Agent finished but didn't notify the daemon" on a turn that actually succeeded. When the watchdog fires on a turn that already emitted its cost-populated usage with no off-protocol work or in-flight tools, the daemon now treats the cost marker as authoritative and ends the turn cleanly as `prompt_complete` (no restart). The genuinely-wedged case (no cost marker) keeps the orphan-restart path, and the off-protocol guard preserves the monitor / async-agent grace behavior of #1360 / #1401 / #1858.

**4. Stale idle-dormant marker no longer strands a queued prompt (backend).** An idle-auto-stopped session gets an `idle_dormant_since` marker (#1689) so the reconciler stops respawning it. Non-user respawn paths (notably the build-stale respawn #1754) could bring a worker back without clearing it; when that worker later exited, the reconciler's `!is_idle_dormant()` resume filter refused to bring the session back, and the web client parked the user's follow-up prompt waiting for a worker that never returned: a deadlock. The daemon now clears `idle_dormant_since` whenever `AcpSessionAssigned` lands (a live worker is by definition not dormant), persisting the clear even on an unchanged-id reattach. `AcpSessionAssigned` fires only on successful worker init, never during the idle reaper's mark-then-shutdown, so there is no race with #1689.

Closes #2237

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session, send a prompt, and while the agent is working click Stop twice; confirm the second click ends the turn (spinner clears) without waiting out a countdown.
- [ ] Get the UI into a stuck spinner with no prompt in flight on the daemon (restart the worker out of band mid-turn). Click Stop once; confirm the spinner clears (single-click self-heal) instead of needing `aoe acp restart`.
- [ ] Let a `claude-agent-acp` turn finish; confirm it does not produce an "Agent finished but didn't notify the daemon. Restarting worker" banner on a completed turn (it ends cleanly).
- [ ] Let a session auto-stop for idle, send a follow-up, and confirm it wakes and runs. Then force a respawn (e.g. version upgrade) and, after the worker later exits, confirm a queued follow-up still brings the session back without `aoe acp restart`.
- [ ] On a normal completed turn, confirm a single Stop during work still does a graceful cancel first (no regression for the common case).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

<!-- The web escalation is guarded by a Vitest unit test on the extracted pure helper (nextCancelAction), mapped via the new coverage-matrix entry acp.stop-button-escalation. The three backend fixes are guarded by Rust unit tests: terminal_stop_reason precedence + the SilentOrphanWatchdog cost_seen/off-protocol gate (acp_client.rs), and apply_acp_session_change clearing a stale dormant marker on (re)assign (server/mod.rs). The cmd-loop arms (B) have no trait seam to unit-test in isolation; they rely on the reducer guarantee that a Stopped clears turnActive (acpTypes.test.ts) plus the manual steps above. -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle in a way the e2e harness covers
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation (grounded in the live event store + worker logs of several stuck sessions), plan, `/debate` design consultation, and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784274309&installation_id=139138837&pr_number=2239&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2239&signature=bc40f2bb66819fd99eee1ee082a09a60294389be806e3f8517de13b11c2d5cc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes four interconnected reliability issues that leave Agent of Empires sessions stuck and requiring manual restart via CLI.

### What Changed

**Documentation Updates:**
- Updated "Stopping a turn" guide to clarify that the Stop button now always escalates to force-end on a second click, even when the daemon has no prompt in flight
- Added troubleshooting entries explaining recovery for sessions stuck with stale "dormant" markers and for agents that finish output but don't send completion acknowledgement

**Backend Session Management:**
- Modified turn-completion handling to distinguish between finished-but-unacknowledged turns (which now end cleanly) vs. genuinely-wedged turns (which follow the orphan-restart path)
- Added logic to emit a synthetic `Stopped` event when cancel is requested with no prompt in flight, resyncing UI and daemon state
- Added clearing of stale `idle_dormant_since` markers whenever a worker comes online, preventing deadlocks in session recovery

**Web-Side Cancel Escalation:**
- Introduced a client-local "cancel requested" tracker so the Stop button can escalate to force-end on a second click without waiting for server confirmation
- Added helper function `nextCancelAction()` to encapsulate escalation logic

**Test Coverage:**
- Added new regression test file validating Stop button escalation behavior across multiple scenarios
- Extended backend unit tests for cost-marker-based completion and terminal stop-reason precedence
- Updated coverage matrix with new high-risk test entry

### What Was Added

- New helper function `nextCancelAction(cancelling, alreadyRequested)` in web component
- New `terminal_stop_reason()` helper in backend for stop-reason precedence logic
- `cost_seen()` accessor on watchdog for detecting cost-populated completion
- Client-local `cancelRequestedRef` state tracking in AcpRuntime
- New regression test file: `AcpRuntime.cancelEscalation.test.ts`
- New test coverage entries in coverage-matrix.json

### What Was Removed

- Inline stop-reason conditionals (centralized into `terminal_stop_reason()`)

### Benefits

**User Experience:**
- Stop button becomes a functional escape route—clicking it twice always restarts the worker without requiring CLI restart
- Spinner clears automatically when daemon receives cancel with no in-flight prompt, reducing user confusion
- Sessions no longer deadlock when idle-auto-stopped and later respawned

**System Reliability:**
- Eliminates desynchronization between UI and daemon state during session recovery
- Prevents unnecessary worker restarts when agents finish normally but don't send completion acknowledgement
- Stops treating stale dormant markers as permanent blockers to session recovery

**Code Quality:**
- Centralizes stop-reason precedence logic for maintainability
- Adds clear separation between finished-but-unacked vs. genuinely-wedged turn scenarios
- Comprehensive test coverage for previously-unhandled edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->