### PR TITLE
docs(structured-view): note blank diff from page-restyling browser extensions

### DIFF
--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -233,6 +233,20 @@ container (rather than bind-mounting from the host).
 - A repeatedly-failing worker is parked with a red "session parked" banner.
   Retry from the dashboard or run `aoe acp restart <session>`.
 
+### Diff viewer is blank (page-restyling browser extensions)
+
+If the Changes panel shows a file's header (path, `+`/`-` counts, the
+Unified/Split toggle) but the diff body below is empty, with no error and a
+clean console, a page-restyling browser extension is almost certainly
+overriding the diff styling. The diff renders into a shadow DOM, and "dark
+mode for every site" extensions (Midnight Lizard, DocsAfterDark, and similar)
+reach into it and make the rows invisible. This is most common on Firefox.
+
+To confirm it is an extension, open the dashboard in Firefox Troubleshoot Mode
+(Menu, Help, Troubleshoot Mode); if the diff renders there, an extension is
+the cause. Fix it by disabling the restyling extension for the dashboard, or
+allowlist the dashboard origin in the extension's settings.
+
 ### "Force end turn" button under the spinner
 
 If the agent finished a turn but the working spinner is still rattling, a small


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a structured-view troubleshooting entry for a confusing failure: on Firefox, opening the Changes panel and clicking a file can render a blank diff body (the file header with path and `+`/`-` counts still shows), with no error and a clean console.

Root cause is not aoe code. A page-restyling browser extension (confirmed with Midnight Lizard; the same class includes DocsAfterDark and other "dark mode for every site" extensions) injects CSS through the diff renderer's shadow DOM and makes the rendered rows invisible. The diff content is actually present (the scroll container reports a non-zero height), it is just styled away. Isolation matrix: renders fine in Chromium, in an extension-free Firefox, in Firefox Troubleshoot Mode, and with the extension disabled; blank only with the extension on.

This is docs-only. The new entry tells users to confirm via Firefox Troubleshoot Mode and to disable or allowlist the restyling extension. No code change.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] Build the docs site or read `docs/structured-view/troubleshooting.md`; confirm the new "Diff viewer is blank (page-restyling browser extensions)" entry reads clearly.
- [ ] In Firefox with a page-restyling extension (e.g. Midnight Lizard) enabled, open the dashboard, open the Changes panel, click a file; confirm the diff body is blank (the symptom the entry describes).
- [ ] Disable the extension (or use Firefox Troubleshoot Mode) and reload; confirm the diff renders, matching the fix the entry recommends.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-investigate` and `/aoe-implement` skills)

**Any Additional AI Details you'd like to share:**
Investigation, browser repro, and prose drafted by Claude under my direction. I drove the Firefox reproduction, made the call that it is an extension conflict rather than an aoe bug, and chose to land it as a docs note.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784276221&installation_id=139138837&pr_number=2241&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2241&signature=7fddd46c9963bbb0d138807ffb16ec89b794fa9fdf0dd71a54ca8506596e0a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->