### PR TITLE
feat(web): tap anywhere to open the keyboard on mobile (terminal and structured view)

### DIFF
--- a/docs/guides/web/terminal.md
+++ b/docs/guides/web/terminal.md
@@ -53,7 +53,7 @@ On touch devices the agent pane uses a different architecture, mirroring the TUI
 
 - **Scrolling is the browser's own scroll**: momentum, rubber-banding, and finger-true tracking, over the pane's real tmux scrollback. No copy-mode round trips, and the agent keeps running while you read history.
 - **Text selection is native**: long-press to select and copy, like any web page.
-- **Typing** goes back over the same WebSocket and is delivered with `tmux send-keys`; the floating keyboard button toggles the soft keyboard, and the terminal toolbar provides arrows, Tab, Esc, a `Ctrl` modifier toggle, interrupt, and paste.
+- **Typing** goes back over the same WebSocket and is delivered with `tmux send-keys`; tapping anywhere on the terminal brings up the soft keyboard, the floating keyboard button toggles it open and closed, and the terminal toolbar provides arrows, Tab, Esc, a `Ctrl` modifier toggle, interrupt, and paste.
 - **Pinch** adjusts the font size; the pane resizes the tmux window to the resulting grid.
 
 A "Back to live" pill appears while you are scrolled up; tapping it (or scrolling to the bottom) returns to the live tail. The pane stays mounted while you switch views so the connection and scroll position survive. Desktop keeps the full xterm.js PTY relay described above.

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -146,6 +146,11 @@ Bluetooth keyboard) keep the desktop Enter-to-send convention.
 On-screen keyboard dictation (the mic icon, e.g. iOS Safari) commits
 into the composer correctly.
 
+On touch devices, tapping anywhere in the transcript focuses the composer
+and brings up the soft keyboard, so you do not have to reach for the
+composer field to start typing. Tapping a control inside a message (a
+tool-call card, a link, a button) still does its own thing instead.
+
 ## Composer attachments (images, audio, files)
 
 The web composer can send attachments alongside the prompt text when the

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -493,6 +493,21 @@ export function MobileLiveTerminal({
     returnToLive(rowsRef.current);
   }, [returnToLive, liveScrollTarget]);
 
+  // Tap anywhere on the terminal brings up the soft keyboard, so the user does
+  // not have to find the keyboard FAB. The focus() must be synchronous inside
+  // the click handler for iOS to honor the user-gesture requirement for showing
+  // the keyboard, so nothing async runs before it. The active-element check
+  // skips a redundant re-focus when the keyboard is already up, and a click that
+  // ends a text selection is left alone so select-to-copy still works (this view
+  // renders on desktop too). The FAB and "Back to live" button are siblings of
+  // the scroller, not descendants, so tapping them never reaches this handler.
+  const focusInputOnTap = useCallback(() => {
+    if (document.activeElement === inputRef.current) return;
+    const sel = window.getSelection();
+    if (sel && !sel.isCollapsed) return;
+    inputRef.current?.focus();
+  }, [inputRef]);
+
   // Map a viewport point to the app's 1-based pane cell for the forwarded
   // wheel event (apps mostly ignore the exact cell, but send a sane one).
   const pointerCell = useCallback(
@@ -826,6 +841,7 @@ export function MobileLiveTerminal({
         ref={scrollerRef}
         onScroll={onScroll}
         onWheel={onWheel}
+        onClick={focusInputOnTap}
         onTouchStart={onTouchStart}
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}

--- a/web/src/components/__tests__/MobileLiveTerminal.tapFocus.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.tapFocus.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+//
+// Tapping anywhere on the terminal content focuses the hidden input, which is
+// what brings up the soft keyboard on mobile (see #2243). The focus is
+// synchronous inside the click handler for iOS, the active-element guard skips
+// a redundant re-focus, and a live text selection is left alone so
+// select-to-copy keeps working on desktop.
+
+import { createRef } from "react";
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { MobileLiveTerminal } from "../MobileLiveTerminal";
+import type { LiveFrame } from "../../hooks/useLiveTerminal";
+
+vi.mock("../../hooks/useWebSettings", () => ({
+  useWebSettings: () => ({ settings: { mobileFontSize: 14 }, update: vi.fn() }),
+}));
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+const frame: LiveFrame = {
+  content: "$ \n",
+  rows: 3,
+  history: 1000,
+  cursor: null,
+  altScreen: false,
+  mouse: false,
+  mouseSgr: false,
+};
+
+function renderTerm() {
+  const inputRef = createRef<HTMLTextAreaElement>();
+  const utils = render(
+    <MobileLiveTerminal
+      frame={frame}
+      connected
+      active
+      reading={false}
+      sendResize={vi.fn()}
+      setWindow={vi.fn()}
+      setCadence={vi.fn()}
+      enterReading={vi.fn()}
+      returnToLive={vi.fn()}
+      sendData={vi.fn()}
+      forwardWheel={vi.fn()}
+      ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
+      clearCtrl={vi.fn()}
+      inputRef={inputRef}
+      onInputFocusChange={vi.fn()}
+      bottomAlign
+    />,
+  );
+  const scroller = utils.container.querySelector("[data-live-terminal]")!.firstElementChild as HTMLElement;
+  return { scroller, inputRef, utils };
+}
+
+describe("MobileLiveTerminal tap-to-focus", () => {
+  it("focuses the hidden input when the terminal is tapped", () => {
+    const { scroller, inputRef } = renderTerm();
+    expect(document.activeElement).not.toBe(inputRef.current);
+    fireEvent.click(scroller);
+    expect(document.activeElement).toBe(inputRef.current);
+  });
+
+  it("does not steal focus from an active text selection", () => {
+    const { scroller, inputRef } = renderTerm();
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(scroller);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    expect(selection?.isCollapsed).toBe(false);
+    fireEvent.click(scroller);
+    expect(document.activeElement).not.toBe(inputRef.current);
+  });
+});

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -51,6 +51,8 @@ import { AttentionChime } from "./AttentionChime";
 import { useRespawnSession } from "../../hooks/useRespawnSession";
 import { useIsCoarsePointer } from "../../hooks/useIsCoarsePointer";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
+import { dispatchFocusTerminal } from "../../lib/terminalFocus";
+import { shouldFocusComposerOnThreadTap } from "./threadTapFocus";
 import type {
   Approval,
   ActivityRow,
@@ -277,6 +279,21 @@ function AcpChrome({
   const belowViewportRef = useRef<HTMLDivElement | null>(null);
   const wasAtBottomRef = useRef<boolean>(true);
 
+  // Tap anywhere in the transcript focuses the composer and brings up the soft
+  // keyboard on touch, mirroring the live terminal's tap-to-focus (#2243). The
+  // bus dispatch runs the Composer's focus listener synchronously, so iOS still
+  // sees the focus inside the user-gesture call stack. Coarse-only: desktop
+  // already auto-focuses the composer, and a fine-pointer transcript click is
+  // usually a selection. Interactive targets and live selections are skipped by
+  // the guard.
+  const isCoarse = useIsCoarsePointer();
+  const onThreadTap = (e: React.MouseEvent) => {
+    const sel = window.getSelection();
+    if (shouldFocusComposerOnThreadTap({ isCoarse, target: e.target, hasSelection: !!sel && !sel.isCollapsed })) {
+      dispatchFocusTerminal("composer");
+    }
+  };
+
   useLayoutEffect(() => {
     const vp = viewportRef.current;
     const below = belowViewportRef.current;
@@ -384,6 +401,7 @@ function AcpChrome({
           ref={viewportRef}
           data-testid="acp-viewport"
           className="flex-1 overflow-x-hidden overflow-y-auto"
+          onClick={onThreadTap}
         >
           <div className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl px-4 py-6">
             <ThreadPrimitive.Empty>

--- a/web/src/components/acp/threadTapFocus.test.ts
+++ b/web/src/components/acp/threadTapFocus.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { shouldFocusComposerOnThreadTap } from "./threadTapFocus";
+
+function el(html: string): Element {
+  const host = document.createElement("div");
+  host.innerHTML = html;
+  return host.firstElementChild!;
+}
+
+describe("shouldFocusComposerOnThreadTap", () => {
+  const plain = el("<p>hello</p>");
+
+  it("focuses on a coarse-pointer tap on plain transcript text", () => {
+    expect(shouldFocusComposerOnThreadTap({ isCoarse: true, target: plain, hasSelection: false })).toBe(true);
+  });
+
+  it("never fires on a fine pointer (desktop already auto-focuses the composer)", () => {
+    expect(shouldFocusComposerOnThreadTap({ isCoarse: false, target: plain, hasSelection: false })).toBe(false);
+  });
+
+  it("skips a tap that ends a text selection", () => {
+    expect(shouldFocusComposerOnThreadTap({ isCoarse: true, target: plain, hasSelection: true })).toBe(false);
+  });
+
+  it("skips taps on interactive controls so they do their own thing", () => {
+    const card = el('<div><button type="button"><span>expand</span></button></div>');
+    const inner = card.querySelector("span")!;
+    expect(shouldFocusComposerOnThreadTap({ isCoarse: true, target: inner, hasSelection: false })).toBe(false);
+    const link = el('<a href="#">file.ts</a>');
+    expect(shouldFocusComposerOnThreadTap({ isCoarse: true, target: link, hasSelection: false })).toBe(false);
+  });
+
+  it("tolerates a null / non-element target", () => {
+    expect(shouldFocusComposerOnThreadTap({ isCoarse: true, target: null, hasSelection: false })).toBe(true);
+  });
+});

--- a/web/src/components/acp/threadTapFocus.ts
+++ b/web/src/components/acp/threadTapFocus.ts
@@ -10,7 +10,7 @@
 // Kept pure so the guard is unit-testable without mounting the assistant-ui
 // runtime; the caller does the (synchronous, iOS-gesture-safe) focus dispatch.
 
-const INTERACTIVE_SELECTOR = 'button, a, input, textarea, select, [role="button"], [contenteditable="true"]';
+const INTERACTIVE_SELECTOR = 'button, a, input, textarea, select, [role="button"], [contenteditable]';
 
 export function shouldFocusComposerOnThreadTap(opts: {
   isCoarse: boolean;

--- a/web/src/components/acp/threadTapFocus.ts
+++ b/web/src/components/acp/threadTapFocus.ts
@@ -1,0 +1,25 @@
+// Decide whether a tap on the structured-view transcript should focus the
+// composer (and so bring up the soft keyboard on mobile, see #2243).
+//
+// Only fires on coarse pointers: desktop already auto-focuses the composer on
+// mount, and a fine-pointer click into the transcript is usually a
+// select-to-copy. A tap that lands on an interactive control (tool card, link,
+// button, the "load earlier" affordance) must do its own thing rather than pop
+// the keyboard, and a tap that ends a text selection is left alone.
+//
+// Kept pure so the guard is unit-testable without mounting the assistant-ui
+// runtime; the caller does the (synchronous, iOS-gesture-safe) focus dispatch.
+
+const INTERACTIVE_SELECTOR = 'button, a, input, textarea, select, [role="button"], [contenteditable="true"]';
+
+export function shouldFocusComposerOnThreadTap(opts: {
+  isCoarse: boolean;
+  target: EventTarget | null;
+  hasSelection: boolean;
+}): boolean {
+  if (!opts.isCoarse) return false;
+  if (opts.hasSelection) return false;
+  const el = opts.target instanceof Element ? opts.target : null;
+  if (el?.closest(INTERACTIVE_SELECTOR)) return false;
+  return true;
+}

--- a/web/tests/acp-thread-tap-focus.spec.ts
+++ b/web/tests/acp-thread-tap-focus.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+
+// Tapping anywhere in the structured-view transcript focuses the composer and
+// brings up the soft keyboard on touch (#2243). On a coarse pointer the
+// composer is NOT auto-focused on mount (#1178), so a tap on the transcript is
+// the only thing that should move focus into it here.
+
+test.use({ ...devices["iPhone 13"] });
+
+const SESSION_ID = "sess-acp-tap";
+const TITLE = "acp-tap";
+
+async function setup(page: Page) {
+  await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+    "system/update-status",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({
+        json:
+          path === "docker/status" || path === "about" || path === "settings" || path === "system/update-status"
+            ? {}
+            : [],
+      }),
+    );
+  }
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: [
+          {
+            id: SESSION_ID,
+            title: TITLE,
+            project_path: "/tmp/acp-tap",
+            group_path: "/tmp",
+            tool: "claude",
+            status: "Running",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+            workspace_repos: [],
+            view: "structured",
+            acp_worker_state: "running",
+            claude_fullscreen: false,
+          },
+        ],
+        workspace_ordering: [],
+      },
+    });
+  });
+  await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
+  await page.route("**/api/sessions/*/acp/**", (r) => r.fulfill({ json: {} }));
+  await page.routeWebSocket(/\/sessions\/[^/]+\/ws(\?|$)/, () => {});
+  await page.routeWebSocket(/\/sessions\/[^/]+\/acp\/ws/, () => {});
+}
+
+async function openStructuredSession(page: Page) {
+  await page.goto("/");
+  await expect(page.locator("header")).toBeVisible();
+  await openMobileSidebar(page);
+  await clickSidebarSession(page, TITLE);
+  await expect(page.getByTestId("structured-view-root")).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("Structured-view tap-to-focus (#2243)", () => {
+  test("tapping the transcript focuses the composer", async ({ page }) => {
+    await setup(page);
+    await openStructuredSession(page);
+
+    const composer = page.getByPlaceholder(/Send a message/);
+    await expect(composer).toBeVisible();
+    // Start from an unfocused composer so the tap is what moves focus into it.
+    await composer.blur();
+    await expect(composer).not.toBeFocused();
+
+    // Tap an empty area near the top of the transcript (away from the centered
+    // starter-prompt buttons) so the tap lands on non-interactive content.
+    await page.getByTestId("acp-viewport").click({ position: { x: 8, y: 8 } });
+
+    await expect(composer).toBeFocused();
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1276,9 +1276,9 @@
     },
     {
       "id": "acp.thread-tap-focus",
-      "kind": "vitest",
+      "kind": "mocked-playwright",
       "risk": "medium",
-      "specs": ["src/components/acp/threadTapFocus.test.ts"],
+      "specs": ["tests/acp-thread-tap-focus.spec.ts", "src/components/acp/threadTapFocus.test.ts"],
       "components": ["web/src/components/acp/StructuredView.tsx", "web/src/components/acp/threadTapFocus.ts"]
     },
     {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -113,6 +113,13 @@
       "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/components/LiveTerminalView.tsx"]
     },
     {
+      "id": "terminal.mobile-tap-to-focus",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/__tests__/MobileLiveTerminal.tapFocus.test.tsx"],
+      "components": ["web/src/components/MobileLiveTerminal.tsx"]
+    },
+    {
       "id": "terminal.mobile-live-wheel-forward-e2e",
       "kind": "mocked-playwright",
       "risk": "high",
@@ -1266,6 +1273,13 @@
         "src/components/acp/__tests__/StructuredViewRoot.test.tsx"
       ],
       "components": ["web/src/components/acp/StructuredView.tsx"]
+    },
+    {
+      "id": "acp.thread-tap-focus",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/acp/threadTapFocus.test.ts"],
+      "components": ["web/src/components/acp/StructuredView.tsx", "web/src/components/acp/threadTapFocus.ts"]
     },
     {
       "id": "acp.composer-queue-recall",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On mobile the only way to bring up the soft keyboard was a precise tap on the small keyboard FAB. Tapping the terminal content itself did nothing, which breaks the natural "tap where you want to type" expectation. The structured view had the same gap: the composer textarea took a native tap-to-focus, but tapping the message history above it did nothing.

This makes a tap anywhere bring up the keyboard on both surfaces:

- **Live terminal:** the terminal scroller now focuses the hidden input on tap. The `focus()` is synchronous inside the click handler to satisfy iOS's user-gesture requirement for showing the keyboard; an active-element guard skips a redundant re-focus, and a tap that ends a text selection is left alone so desktop select-to-copy keeps working. The keyboard FAB and the "Back to live" pill are siblings of the scroller, not descendants, so tapping them never re-pops the keyboard.
- **Structured view:** tapping anywhere in the ACP transcript focuses the composer via the existing `terminalFocus` bus, so the Composer's focus listener runs synchronously inside the click gesture and iOS shows the keyboard. It is gated to coarse pointers (desktop already auto-focuses the composer), and a small pure guard skips interactive targets (tool cards, links, buttons) and taps that end a text selection.

The FAB still works as an open/close toggle; it is just no longer the only way to open the keyboard.

Closes #2243

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] On a phone, open a session's live terminal and tap anywhere on the terminal content; the soft keyboard comes up.
- [ ] With the keyboard already open, tap the terminal again; nothing flickers, and tapping the keyboard FAB still closes it.
- [ ] Scroll up into scrollback and tap the "Back to live" pill; it returns to live without popping the keyboard.
- [ ] In a structured-view session on a phone, tap in the message history above the composer; the composer focuses and the keyboard comes up.
- [ ] Tap a tool-call card or a link inside a message; it expands / opens as before and does not steal focus to the composer.
- [ ] On desktop, select text in the terminal or transcript and confirm the selection is not cleared by a stray focus.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated specs and updated `web/tests/coverage-matrix.json` (vitest: `MobileLiveTerminal.tapFocus.test.tsx` drives the terminal tap-to-focus in jsdom; `threadTapFocus.test.ts` covers the structured-view tap guard as a pure helper). The decision logic and the terminal focus are deterministic in jsdom, so these are unit/DOM specs rather than Playwright; the matrix maps both under `terminal.mobile-tap-to-focus` and `acp.thread-tap-focus`.
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Skipped a test

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (focus on the scroller, reuse the terminalFocus bus for the composer, coarse-pointer gating) and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784280971&installation_id=139138837&pr_number=2249&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2249&signature=41b69070df4098cadfa5a217347852eabb764b0553e5d61267d058f849b74697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR improves mobile keyboard accessibility by letting users open the soft keyboard by tapping anywhere in the terminal content (live) or message transcript (structured view), instead of relying on the small keyboard floating button.

### What Changed

**Documentation**
- Updated the mobile “Typing” guidance for the terminal to reflect tap-to-open behavior.
- Added a note in the structured-view composer documentation that tapping the transcript focuses the composer and brings up the keyboard (while tapping controls inside messages still works normally).

**Live Terminal**
- The terminal scroller now focuses the hidden input immediately when the user taps it (to satisfy mobile/iOS behavior).
- Added safeguards so repeated taps don’t steal focus when the user is actively selecting text.
- Ensured the floating keyboard FAB and “Back to live” button do **not** trigger keyboard opening when tapped (they act independently as siblings of the scroller).

**Structured View (ACP Transcript)**
- The transcript viewport now supports tap-to-focus on coarse-pointer devices (mobile), dispatching focus to the composer.
- Added a guard to avoid interfering with:
  - fine-pointer behavior (desktop auto-focus)
  - active text selection
  - taps on interactive elements like buttons, links, inputs, and tool cards.

**Testing & Coverage**
- Added a mobile-focused test for live terminal tap-to-focus (`MobileLiveTerminal.tapFocus.test.tsx`), including the “don’t steal focus during selection” edge case.
- Added tests for the structured-view tap guard (`threadTapFocus.test.ts`) and a mocked Playwright spec (`acp-thread-tap-focus.spec.ts`) to cover the interaction end-to-end.
- Updated the coverage matrix to include both new surfaces.

### Benefits
- **Much better mobile UX:** users can tap where they want to type, matching common mobile expectations.
- **No regression for desktop:** text selection behavior and select-to-copy are preserved.
- **No interference with message controls:** buttons/links/tool cards still behave normally.
- **Cleaner mental model:** the FAB remains a dedicated open/close toggle rather than the only way to show the keyboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->