### PR TITLE
feat(web): mobile sidebar toggle button in the terminal view

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -6,7 +6,7 @@ The dashboard is the home screen of the web app: a workspace sidebar on the left
 
 ## Layout
 
-- **Workspace sidebar** (left) lists every session grouped by repo, with a live status glyph per row. On phones it collapses behind a top-bar toggle. With no sessions, it shows a hint and a **New session** button.
+- **Workspace sidebar** (left) lists every session grouped by repo, with a live status glyph per row. On phones it collapses behind a top-bar toggle. Optionally, turn on **Show sidebar button on mobile** in Settings > Terminal to add a button in the terminal pane, next to the keyboard toggle, that opens the sidebar without reaching the top bar (off by default). With no sessions, it shows a hint and a **New session** button.
 - **Main pane** shows the selected session: the agent terminal (or structured view), with the diff and paired terminal reachable from the top bar.
 - **Top bar** carries the command-palette trigger, the right-panel picker, and the overflow (three-dot) **More options** menu.
 - **Home screen** (no session selected) shows the AoE logo and a count of running, waiting, and error sessions.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1065,6 +1065,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           activeSessionId={activeSessionId}
           sessions={sessions}
           webSettings={webSettings}
+          sidebarOpen={sidebarOpen}
+          onToggleSidebar={() => setSidebarOpen((o) => !o)}
           selectedFilePath={selectedFilePath}
           selectedRepoName={selectedRepoName}
           revision={revision}
@@ -1116,6 +1118,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                     sessions={sessions.filter((session) => session.view !== "structured")}
                     persistent={webSettings.persistentTerminals}
                     maxPersistentTerminals={webSettings.maxPersistentTerminals}
+                    sidebarOpen={sidebarOpen}
+                    onToggleSidebar={() => setSidebarOpen((o) => !o)}
                   />
                 )}
               </div>

--- a/web/src/components/LiveTerminalView.tsx
+++ b/web/src/components/LiveTerminalView.tsx
@@ -5,6 +5,8 @@ import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
 import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
 import { MobileLiveTerminal } from "./MobileLiveTerminal";
 import { KeyboardFab } from "./KeyboardFab";
+import { SidebarFab } from "./SidebarFab";
+import { useWebSettings } from "../hooks/useWebSettings";
 import { TerminalConnectionBanners } from "./TerminalConnectionBanners";
 import { ensureSession, ensureTerminal } from "../lib/api";
 import type { SessionResponse } from "../lib/types";
@@ -22,6 +24,12 @@ interface Props {
    *  default; the paired host/container shells reuse the same chrome
    *  with their own WS route, ensure call, and focus target. */
   surface?: "agent" | "paired-host" | "paired-container";
+  /** Current session-sidebar open state, for the optional mobile sidebar
+   *  FAB's aria-label. Only threaded for the agent terminal stack. */
+  sidebarOpen?: boolean;
+  /** Toggles the session sidebar. When provided (and the setting is on),
+   *  a mobile FAB renders next to the keyboard FAB (#2245). */
+  onToggleSidebar?: () => void;
 }
 
 const SURFACES = {
@@ -45,8 +53,9 @@ const SURFACES = {
  * not shrink. The pane re-pins itself to the bottom when its container
  * resizes, which is all a bottom-anchored chat-style surface needs.
  */
-export function LiveTerminalView({ session, active = true, surface = "agent" }: Props) {
+export function LiveTerminalView({ session, active = true, surface = "agent", sidebarOpen, onToggleSidebar }: Props) {
   const { wsPath, focusTarget, dataTerm } = SURFACES[surface];
+  const { settings } = useWebSettings();
   // Touch-only chrome (the soft-keyboard toolbar and its toggle FAB) is
   // pointless with a physical keyboard, so it stays off fine-pointer devices
   // now that this view also renders on desktop.
@@ -280,6 +289,9 @@ export function LiveTerminalView({ session, active = true, surface = "agent" }: 
           bottomAlign={surface === "agent"}
         />
         {coarse && live.state.connected && <KeyboardFab keyboardOpen={inputFocused} onToggle={toggleKeyboard} />}
+        {coarse && live.state.connected && settings.showSidebarFab && onToggleSidebar && (
+          <SidebarFab sidebarOpen={!!sidebarOpen} onToggle={onToggleSidebar} />
+        )}
       </div>
 
       {coarse && live.state.connected && (

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -131,7 +131,12 @@ export function MobileMainPane({
 
         {pairedMounted && (
           <div className={layerClass(view === "paired")} inert={view !== "paired"}>
-            <PairedShellPane session={activeSession} sessionId={activeSessionId} />
+            <PairedShellPane
+              session={activeSession}
+              sessionId={activeSessionId}
+              sidebarOpen={sidebarOpen}
+              onToggleSidebar={onToggleSidebar}
+            />
           </div>
         )}
 

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -21,6 +21,8 @@ interface Props {
   activeSessionId: string | null;
   sessions: SessionResponse[];
   webSettings: { persistentTerminals: boolean; maxPersistentTerminals: number };
+  sidebarOpen: boolean;
+  onToggleSidebar: () => void;
   selectedFilePath: string | null;
   selectedRepoName: string | undefined;
   revision: number;
@@ -61,6 +63,8 @@ export function MobileMainPane({
   activeSessionId,
   sessions,
   webSettings,
+  sidebarOpen,
+  onToggleSidebar,
   selectedFilePath,
   selectedRepoName,
   revision,
@@ -119,6 +123,8 @@ export function MobileMainPane({
               sessions={sessions.filter((session) => session.view !== "structured")}
               persistent={webSettings.persistentTerminals}
               maxPersistentTerminals={webSettings.maxPersistentTerminals}
+              sidebarOpen={sidebarOpen}
+              onToggleSidebar={onToggleSidebar}
             />
           )}
         </div>

--- a/web/src/components/PairedTerminal.tsx
+++ b/web/src/components/PairedTerminal.tsx
@@ -8,7 +8,17 @@ type ShellMode = "host" | "container";
  *  desktop right-panel split and as the promoted single full-viewport mobile
  *  pane. Renders the capture-snapshot live view on every device (same
  *  architecture as the agent pane); the xterm.js PTY relay was removed. */
-export function PairedShellPane({ session, sessionId }: { session: SessionResponse | null; sessionId: string | null }) {
+export function PairedShellPane({
+  session,
+  sessionId,
+  sidebarOpen,
+  onToggleSidebar,
+}: {
+  session: SessionResponse | null;
+  sessionId: string | null;
+  sidebarOpen?: boolean;
+  onToggleSidebar?: () => void;
+}) {
   const [shellMode, setShellMode] = useState<ShellMode>("host");
   const isSandboxed = session?.is_sandboxed ?? false;
 
@@ -41,6 +51,8 @@ export function PairedShellPane({ session, sessionId }: { session: SessionRespon
           key={`${sessionId}-${shellMode}`}
           session={session}
           surface={shellMode === "container" ? "paired-container" : "paired-host"}
+          sidebarOpen={sidebarOpen}
+          onToggleSidebar={onToggleSidebar}
         />
       ) : (
         <div className="flex-1 flex items-center justify-center bg-surface-950 text-text-dim">

--- a/web/src/components/SidebarFab.tsx
+++ b/web/src/components/SidebarFab.tsx
@@ -1,0 +1,37 @@
+interface Props {
+  sidebarOpen: boolean;
+  onToggle: () => void;
+}
+
+// Optional mobile shortcut to the session sidebar, clustered with the
+// keyboard FAB in the terminal pane so you don't have to reach the top-bar
+// toggle mid-session (#2245). Off by default; enabled in Terminal settings.
+export function SidebarFab({ sidebarOpen, onToggle }: Props) {
+  return (
+    <button
+      type="button"
+      aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
+      onClick={onToggle}
+      // Keep focus where it is: a button steals focus on pointer-down, which
+      // would blur the terminal input and close the keyboard. The sidebar
+      // should be openable while the keyboard is up. onClick still fires.
+      onMouseDown={(e) => e.preventDefault()}
+      className="absolute left-3 bottom-3 z-10 w-10 h-10 rounded-full bg-surface-800/90 border border-surface-700/30 text-text-secondary flex items-center justify-center shadow-lg backdrop-blur-sm active:scale-95"
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        <line x1="9" y1="4" x2="9" y2="20" />
+      </svg>
+    </button>
+  );
+}

--- a/web/src/components/TerminalSessionStack.tsx
+++ b/web/src/components/TerminalSessionStack.tsx
@@ -8,6 +8,8 @@ interface Props {
   sessions: SessionResponse[];
   persistent: boolean;
   maxPersistentTerminals?: number;
+  sidebarOpen?: boolean;
+  onToggleSidebar?: () => void;
 }
 
 export function TerminalSessionStack({
@@ -15,6 +17,8 @@ export function TerminalSessionStack({
   sessions,
   persistent,
   maxPersistentTerminals = DEFAULT_PERSISTENT_TERMINALS,
+  sidebarOpen,
+  onToggleSidebar,
 }: Props) {
   const [recentIds, setRecentIds] = useState<string[]>([]);
   const limit = normalizePersistentTerminalLimit(maxPersistentTerminals);
@@ -66,7 +70,12 @@ export function TerminalSessionStack({
                 : "absolute inset-0 flex flex-col min-h-0 invisible pointer-events-none"
             }
           >
-            <TerminalView session={session} active={active} />
+            <TerminalView
+              session={session}
+              active={active}
+              sidebarOpen={sidebarOpen}
+              onToggleSidebar={onToggleSidebar}
+            />
           </div>
         );
       })}

--- a/web/src/components/TerminalSettings.tsx
+++ b/web/src/components/TerminalSettings.tsx
@@ -94,6 +94,24 @@ export function TerminalSettings() {
         </div>
 
         <div>
+          <label className="flex items-center justify-between gap-3 cursor-pointer">
+            <div>
+              <div className="text-[13px] text-text-secondary">Show sidebar button on mobile</div>
+              <p className="text-[11px] text-text-muted mt-1">
+                Add a button in the terminal pane, next to the keyboard toggle, that opens the session sidebar so you
+                don't have to reach the top bar.
+              </p>
+            </div>
+            <input
+              type="checkbox"
+              checked={settings.showSidebarFab}
+              onChange={(e) => update({ showSidebarFab: e.target.checked })}
+              className="accent-brand-600 w-4 h-4 shrink-0"
+            />
+          </label>
+        </div>
+
+        <div>
           <div className="space-y-3">
             <label className="flex items-center justify-between gap-3 cursor-pointer">
               <div>

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -4,12 +4,16 @@ import type { SessionResponse } from "../lib/types";
 interface Props {
   session: SessionResponse;
   active?: boolean;
+  sidebarOpen?: boolean;
+  onToggleSidebar?: () => void;
 }
 
 /** Agent terminal: the capture-snapshot live view (the TUI's live-mode
  *  architecture, native scroll, send-keys input, no PTY attach), on every
  *  device. The xterm.js PTY relay was removed in favor of this single
  *  renderer so desktop, mobile, and the TUI all show the pane the same way. */
-export function TerminalView({ session, active = true }: Props) {
-  return <LiveTerminalView session={session} active={active} />;
+export function TerminalView({ session, active = true, sidebarOpen, onToggleSidebar }: Props) {
+  return (
+    <LiveTerminalView session={session} active={active} sidebarOpen={sidebarOpen} onToggleSidebar={onToggleSidebar} />
+  );
 }

--- a/web/src/components/__tests__/PairedTerminal.test.tsx
+++ b/web/src/components/__tests__/PairedTerminal.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+//
+// The paired terminal is the "terminal" of a structured/ACP session. The
+// mobile sidebar FAB lives in LiveTerminalView and only renders when an
+// onToggleSidebar callback is threaded in, so PairedShellPane must forward
+// the sidebar props or the FAB silently never shows there (#2245).
+
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+const liveProps: Array<Record<string, unknown>> = [];
+vi.mock("../LiveTerminalView", () => ({
+  LiveTerminalView: (props: Record<string, unknown>) => {
+    liveProps.push(props);
+    return null;
+  },
+}));
+
+import { PairedShellPane } from "../PairedTerminal";
+import type { SessionResponse } from "../../lib/types";
+
+const session = { id: "s1", is_sandboxed: false } as unknown as SessionResponse;
+
+describe("PairedShellPane", () => {
+  it("forwards sidebar open state and toggle to LiveTerminalView", () => {
+    liveProps.length = 0;
+    const onToggleSidebar = vi.fn();
+    render(<PairedShellPane session={session} sessionId="s1" sidebarOpen onToggleSidebar={onToggleSidebar} />);
+
+    expect(liveProps).toHaveLength(1);
+    expect(liveProps[0].sidebarOpen).toBe(true);
+    expect(liveProps[0].onToggleSidebar).toBe(onToggleSidebar);
+  });
+});

--- a/web/src/components/__tests__/SidebarFab.test.tsx
+++ b/web/src/components/__tests__/SidebarFab.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+//
+// Behavior contract for the mobile sidebar FAB (#2245): the aria-label
+// reflects sidebar state, the click toggles, and pointer-down is prevented
+// so tapping it does not blur the terminal input / dismiss the keyboard.
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { SidebarFab } from "../SidebarFab";
+
+describe("SidebarFab", () => {
+  it("labels the action 'Open sidebar' when closed", () => {
+    const { getByRole } = render(<SidebarFab sidebarOpen={false} onToggle={() => {}} />);
+    expect(getByRole("button").getAttribute("aria-label")).toBe("Open sidebar");
+  });
+
+  it("labels the action 'Close sidebar' when open", () => {
+    const { getByRole } = render(<SidebarFab sidebarOpen onToggle={() => {}} />);
+    expect(getByRole("button").getAttribute("aria-label")).toBe("Close sidebar");
+  });
+
+  it("fires onToggle on click", () => {
+    const onToggle = vi.fn();
+    const { getByRole } = render(<SidebarFab sidebarOpen={false} onToggle={onToggle} />);
+    fireEvent.click(getByRole("button"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents default on pointer-down to keep terminal focus", () => {
+    const { getByRole } = render(<SidebarFab sidebarOpen={false} onToggle={() => {}} />);
+    const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+    getByRole("button").dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/web/src/components/__tests__/TerminalSettings.test.tsx
+++ b/web/src/components/__tests__/TerminalSettings.test.tsx
@@ -63,9 +63,17 @@ describe("TerminalSettings localStorage contract", () => {
     expect(readStored().autoOpenKeyboard).toBe(false);
   });
 
-  it("persistent terminals checkbox writes the beta flag", () => {
+  it("showSidebarFab checkbox writes the boolean flag", () => {
     const { container } = render(<TerminalSettings />);
     const checkbox = container.querySelectorAll("input[type=checkbox]")[1] as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    fireEvent.click(checkbox);
+    expect(readStored().showSidebarFab).toBe(true);
+  });
+
+  it("persistent terminals checkbox writes the beta flag", () => {
+    const { container } = render(<TerminalSettings />);
+    const checkbox = container.querySelectorAll("input[type=checkbox]")[2] as HTMLInputElement;
     fireEvent.click(checkbox);
     expect(readStored().persistentTerminals).toBe(true);
   });
@@ -125,7 +133,7 @@ describe("TerminalSettings localStorage contract", () => {
     const desktopSelect = container.querySelectorAll("select")[1] as HTMLSelectElement;
     const checkboxes = container.querySelectorAll("input[type=checkbox]");
     const checkbox = checkboxes[0] as HTMLInputElement;
-    const persistentCheckbox = checkboxes[1] as HTMLInputElement;
+    const persistentCheckbox = checkboxes[2] as HTMLInputElement;
     const persistentLimit = container.querySelector("input[type=number]") as HTMLInputElement;
     expect(mobileSelect.value).toBe("22");
     expect(desktopSelect.value).toBe("16");
@@ -144,7 +152,7 @@ describe("TerminalSettings localStorage contract", () => {
     );
     const { container } = render(<TerminalSettings />);
     const checkboxes = container.querySelectorAll("input[type=checkbox]");
-    const persistentCheckbox = checkboxes[1] as HTMLInputElement;
+    const persistentCheckbox = checkboxes[2] as HTMLInputElement;
     const persistentLimit = container.querySelector("input[type=number]") as HTMLInputElement | null;
 
     expect(persistentCheckbox.checked).toBe(false);

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -9,6 +9,7 @@ export interface WebSettings {
   mobileFontSize: number;
   desktopFontSize: number;
   autoOpenKeyboard: boolean;
+  showSidebarFab: boolean;
   persistentTerminals: boolean;
   maxPersistentTerminals: number;
   diffViewMode: "flat" | "tree";
@@ -21,6 +22,7 @@ function getDefaults(): WebSettings {
     mobileFontSize: 8,
     desktopFontSize: 14,
     autoOpenKeyboard: true,
+    showSidebarFab: false,
     persistentTerminals: false,
     maxPersistentTerminals: DEFAULT_PERSISTENT_TERMINALS,
     diffViewMode: window.innerWidth < 768 ? "flat" : "tree",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -357,6 +357,17 @@
       "components": ["web/src/components/TerminalSettings.tsx", "web/src/components/TerminalSessionStack.tsx"]
     },
     {
+      "id": "terminal.mobile-sidebar-fab",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["tests/mobile-sidebar-fab.spec.ts", "src/components/__tests__/SidebarFab.test.tsx"],
+      "components": [
+        "web/src/components/SidebarFab.tsx",
+        "web/src/components/LiveTerminalView.tsx",
+        "web/src/components/MobileMainPane.tsx"
+      ]
+    },
+    {
       "id": "app-shell.topbar-dev-badge",
       "kind": "vitest",
       "risk": "low",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -360,11 +360,16 @@
       "id": "terminal.mobile-sidebar-fab",
       "kind": "mocked-playwright",
       "risk": "medium",
-      "specs": ["tests/mobile-sidebar-fab.spec.ts", "src/components/__tests__/SidebarFab.test.tsx"],
+      "specs": [
+        "tests/mobile-sidebar-fab.spec.ts",
+        "src/components/__tests__/SidebarFab.test.tsx",
+        "src/components/__tests__/PairedTerminal.test.tsx"
+      ],
       "components": [
         "web/src/components/SidebarFab.tsx",
         "web/src/components/LiveTerminalView.tsx",
-        "web/src/components/MobileMainPane.tsx"
+        "web/src/components/MobileMainPane.tsx",
+        "web/src/components/PairedTerminal.tsx"
       ]
     },
     {

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -183,7 +183,7 @@ export function readFontSize(page: Page, which: "mobile" | "desktop") {
 
 export async function seedSettings(
   page: Page,
-  settings: { mobileFontSize?: number; desktopFontSize?: number; autoOpenKeyboard?: boolean },
+  settings: { mobileFontSize?: number; desktopFontSize?: number; autoOpenKeyboard?: boolean; showSidebarFab?: boolean },
 ) {
   await page.evaluate((settings) => {
     localStorage.setItem(

--- a/web/tests/mobile-sidebar-fab.spec.ts
+++ b/web/tests/mobile-sidebar-fab.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+import { mockTerminalApis, seedSettings } from "./helpers/terminal-mocks";
+
+// Use iPhone 13 profile: pointer:coarse, hasTouch, correct viewport, WebKit UA.
+// The sidebar FAB shares the keyboard FAB's `coarse && connected` gate, so it
+// only renders on a coarse pointer (#2245).
+test.use({ ...devices["iPhone 13"] });
+
+async function setup(page: Page, opts: { showSidebarFab: boolean }) {
+  await mockTerminalApis(page);
+  await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
+  await page.goto("/");
+  // autoOpenKeyboard off so selecting a session doesn't pop the keyboard and
+  // shift focus; this suite only exercises the sidebar FAB.
+  await seedSettings(page, { autoOpenKeyboard: false, showSidebarFab: opts.showSidebarFab });
+  await page.reload();
+  await page.waitForTimeout(500);
+  // Open the sidebar, pick a session; on mobile the select handler closes the
+  // sidebar again, leaving the terminal pane (and its FABs) in view.
+  await openMobileSidebar(page);
+  await clickSidebarSession(page, "pinch-test");
+  await page.locator("[data-live-terminal]").waitFor({ state: "visible", timeout: 10_000 });
+}
+
+async function sidebarRowX(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const row = document.querySelector('[data-testid="sidebar-session-row"]');
+    return row ? (row as HTMLElement).getBoundingClientRect().x : Number.NaN;
+  });
+}
+
+test.describe("Mobile sidebar FAB", () => {
+  test("renders when enabled and opens the sidebar on tap", async ({ page }) => {
+    await setup(page, { showSidebarFab: true });
+
+    const fab = page.getByRole("button", { name: "Open sidebar" });
+    await expect(fab).toBeVisible();
+
+    // Sidebar is closed: its rows sit off-screen to the left (negative x).
+    expect(await sidebarRowX(page)).toBeLessThan(0);
+
+    await fab.click();
+
+    // Tapping the FAB toggles the sidebar in: rows settle inside the viewport
+    // and the FAB's aria-label flips to the close action.
+    await page.waitForFunction(
+      () => {
+        const row = document.querySelector('[data-testid="sidebar-session-row"]');
+        return !!row && (row as HTMLElement).getBoundingClientRect().x >= 0;
+      },
+      null,
+      { timeout: 5_000 },
+    );
+    await expect(page.getByRole("button", { name: "Close sidebar" })).toBeVisible();
+  });
+
+  test("does not render when the setting is off (default)", async ({ page }) => {
+    await setup(page, { showSidebarFab: false });
+
+    // The keyboard FAB still proves the coarse-pointer FAB layer is mounted,
+    // so the sidebar FAB's absence is the setting gate, not a missing surface.
+    await expect(page.getByRole("button", { name: "Open keyboard" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open sidebar" })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On mobile the only way to open the session sidebar mid-session is the small icon in the top-left of the top bar, which means reaching all the way to the top of the screen while you are deep in a terminal. This adds an optional circular button in the terminal pane, clustered with the keyboard FAB, that toggles the sidebar in easy thumb reach.

The button is mobile-only (it shares the keyboard FAB's coarse-pointer + live-session gate) and is off by default. A new per-browser preference, **Show sidebar button on mobile**, in Settings > Terminal turns it on. It lives in `useWebSettings` (localStorage) next to the existing mobile toggles, so no backend, TUI, or config-schema surface is involved.

`onMouseDown` is prevented on the button so tapping it does not blur the terminal input or dismiss the soft keyboard; the sidebar can be opened while the keyboard is up. The aria-label flips between "Open sidebar" and "Close sidebar" with state. The existing top-bar toggle is unchanged; this is an additional shortcut. The sidebar open/toggle state threads from `App` down to `LiveTerminalView` across every mobile terminal path: the agent terminal (`MobileMainPane` > `TerminalSessionStack`) and the paired shell of a structured/ACP session (`MobileMainPane` > `PairedShellPane`), which is where the terminal lives for claude/agent sessions.

The right-side `right-3 bottom-14` position from the issue is deferred: it pairs with the sidebar-position setting, which does not exist in the tree yet, so the button defaults to bottom-left.

Closes #2245

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] On a phone (or a coarse-pointer / mobile-emulated browser), open a session; with the setting off (default), confirm no extra button appears in the terminal pane.
- [ ] Open Settings > Terminal, turn on **Show sidebar button on mobile**.
- [ ] Back in a session, confirm a circular button appears at the bottom-left of the terminal pane, next to the keyboard toggle.
- [ ] In a structured/ACP (claude) session, open the paired terminal and confirm the button appears there too.
- [ ] Tap it and confirm the sidebar opens; with the keyboard up, confirm tapping it does not close the keyboard or blur the input.
- [ ] On desktop (fine pointer), confirm the button never appears regardless of the setting.
- [ ] Confirm the existing top-bar sidebar toggle still works.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (mobile-only, off-by-default setting, deferring the right-side variant), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784281669&installation_id=139138837&pr_number=2251&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2251&signature=e7527ca066c16ed8f4d437574872575cc0c4537f60b64405f2e27fccbcdc47aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR adds an optional mobile sidebar toggle button to the terminal view, addressing a mobile usability issue where the only way to open the sidebar required reaching the top of the screen. The feature introduces:

**New Component:**
- `SidebarFab` – a circular button positioned at the bottom-left of the terminal pane, styled like the existing keyboard FAB, that toggles the session sidebar open and closed

**New Setting:**
- "Show sidebar button on mobile" toggle in Settings > Terminal (disabled by default, stored in browser localStorage)

**State Threading:**
- Sidebar open/toggle state is passed from `App` down through the component hierarchy (`MobileMainPane` → `TerminalSessionStack`/`PairedShellPane` → `TerminalView` → `LiveTerminalView`)

**Documentation:**
- Updated the web dashboard guide to mention the new sidebar button setting

## What Was Added

- New `SidebarFab.tsx` component
- New setting `showSidebarFab` in `useWebSettings` hook
- Checkbox for the setting in `TerminalSettings` component
- Comprehensive test coverage:
  - Unit tests for `SidebarFab` component behavior
  - Unit test for `PairedShellPane` prop forwarding
  - Updated `TerminalSettings` tests to verify the new setting persists
  - Updated test helper `seedSettings` to support the new setting
  - Playwright e2e test validating the mobile sidebar FAB behavior on actual device profiles

## Technical Implementation Details

- The button uses `onMouseDown` with `preventDefault()` to prevent blurring the terminal input or dismissing the soft keyboard when tapped, allowing the sidebar to open while keeping the keyboard visible
- The button's `aria-label` dynamically updates between "Open sidebar" and "Close sidebar" based on sidebar state
- The feature only appears on mobile devices with coarse pointer support and during active terminal sessions (same conditions as the keyboard FAB)
- The button defaults to bottom-left positioning; right-side repositioning is deferred pending implementation of the sidebar-position setting
- Props are threaded through both mobile terminal render paths: agent terminal and paired shell pane of structured/ACP sessions

## Benefits

- Improves mobile usability by placing sidebar access at a convenient location (bottom of screen) during active terminal sessions
- Keeps the existing top-bar toggle intact, providing multiple access paths
- Fully optional feature that doesn't affect existing workflows
- No backend or configuration schema changes required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->