### PR TITLE
fix(serve): heal structured session status out of a stale Stopped

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3585,13 +3585,24 @@ pub(crate) async fn seed_acp_statuses(state: Arc<AppState>) {
         let Some(event) = state.acp_event_store.latest_status_event(&id) else {
             continue;
         };
-        let intent = derive_acp_status(&event);
-        if intent.is_none() {
+        let Some(intent) = derive_acp_status(&event) else {
             continue;
-        }
+        };
         let mut instances = state.instances.write().await;
         if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
-            apply_status_intent(inst, intent, &state.status_tx);
+            // At startup the on-disk event log is the whole truth: nothing
+            // is racing the apply, unlike the live stream. If the latest
+            // lifecycle event shows a turn was in flight when the previous
+            // daemon died, a stale persisted Stopped must not trap the dot
+            // grey, so clear it before the Running/Waiting intent applies.
+            // A latest Idle/Error (clean or deliberate stop) is left as
+            // Stopped by apply_status_intent's guard. See #2248.
+            if inst.status == Status::Stopped
+                && matches!(intent, StatusIntent::Set(Status::Running | Status::Waiting))
+            {
+                inst.status = Status::Idle;
+            }
+            apply_status_intent(inst, Some(intent), &state.status_tx);
         }
     }
 }
@@ -3607,22 +3618,32 @@ pub(crate) fn apply_status_intent(
     status_tx: &broadcast::Sender<StatusChange>,
 ) {
     let Some(intent) = intent else { return };
-    // Don't fight terminal lifecycle states. Acp events keep
-    // arriving for a few ticks after a Stop/Delete, and we don't
-    // want the spinner to flicker back to Running.
-    if matches!(
-        inst.status,
-        Status::Stopped | Status::Deleting | Status::Creating
-    ) {
+    // Genuine in-flight terminal states: never fight them.
+    if matches!(inst.status, Status::Deleting | Status::Creating) {
         return;
     }
     let target = match intent {
-        StatusIntent::Set(s) => s,
-        // HealError: only move from Error → Idle. Skip when the
-        // session is in a normal state so a respawn during an active
-        // Running turn doesn't stop the spinner.
+        StatusIntent::Set(s) => {
+            // A Stopped session must not be woken by a trailing worker
+            // event: acp events keep arriving for a few ticks after a
+            // Stop, and a deliberate Stop must keep showing Stopped. Only
+            // a fresh worker-epoch signal (HealError below) lifts Stopped;
+            // the live UserPromptSent that follows the respawn then drives
+            // Running. Without this, the chain Stopped -> (trailing prompt)
+            // Running -> (trailing stop) Idle would strand a deliberate
+            // Stop on Idle.
+            if inst.status == Status::Stopped {
+                return;
+            }
+            s
+        }
+        // HealError comes only from AcpSessionAssigned / RateLimitAuto
+        // Resumed, both emitted when a fresh worker attaches and never as
+        // trailing post-stop events. So heal a sticky Error AND wake a
+        // session out of a stale Stopped (idle-reap or manual stop, then
+        // re-prompt): the live worker is provably back. See #2248.
         StatusIntent::HealError => {
-            if inst.status != Status::Error {
+            if !matches!(inst.status, Status::Error | Status::Stopped) {
                 return;
             }
             Status::Idle
@@ -4548,6 +4569,125 @@ mod tests {
         );
         assert_eq!(derive_acp_status(&Event::ThinkingStarted), None);
         assert_eq!(derive_acp_status(&Event::ThinkingEnded), None);
+    }
+
+    // --- #2248: a structured session must heal out of a stale Stopped ---
+
+    #[cfg(feature = "serve")]
+    fn stopped_structured_instance() -> Instance {
+        let mut inst = Instance::new("s", "/tmp/s");
+        inst.view = crate::session::View::Structured;
+        inst.status = Status::Stopped;
+        inst
+    }
+
+    #[cfg(feature = "serve")]
+    fn apply(inst: &mut Instance, intent: StatusIntent) {
+        let tx = broadcast::channel(8).0;
+        apply_status_intent(inst, Some(intent), &tx);
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn heal_error_wakes_a_stopped_session() {
+        // AcpSessionAssigned / RateLimitAutoResumed -> HealError: a fresh
+        // worker attached, so a stale Stopped from idle-reap or a prior
+        // manual stop must heal. This is the #2248 trap: pre-fix the guard
+        // froze Stopped and the dot stayed grey through a live turn.
+        let mut inst = stopped_structured_instance();
+        apply(&mut inst, StatusIntent::HealError);
+        assert_eq!(inst.status, Status::Idle);
+        // The UserPromptSent that follows the respawn then drives Running.
+        apply(&mut inst, StatusIntent::Set(Status::Running));
+        assert_eq!(inst.status, Status::Running);
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn heal_error_still_heals_a_sticky_error() {
+        let mut inst = stopped_structured_instance();
+        inst.status = Status::Error;
+        apply(&mut inst, StatusIntent::HealError);
+        assert_eq!(inst.status, Status::Idle);
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn trailing_set_intents_do_not_wake_a_stopped_session() {
+        // A deliberate Stop, or a session mid-stop, keeps emitting acp
+        // events for a few ticks. None of those Set intents may revive it,
+        // or the chain Stopped -> Running -> Idle would strand a deliberate
+        // Stop on Idle.
+        for target in [Status::Running, Status::Waiting, Status::Idle] {
+            let mut inst = stopped_structured_instance();
+            apply(&mut inst, StatusIntent::Set(target));
+            assert_eq!(
+                inst.status,
+                Status::Stopped,
+                "target {target:?} woke Stopped"
+            );
+        }
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn deleting_and_creating_block_every_intent() {
+        for terminal in [Status::Deleting, Status::Creating] {
+            let mut inst = stopped_structured_instance();
+            inst.status = terminal;
+            apply(&mut inst, StatusIntent::Set(Status::Running));
+            assert_eq!(inst.status, terminal);
+            apply(&mut inst, StatusIntent::HealError);
+            assert_eq!(inst.status, terminal);
+        }
+    }
+
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn seed_unblocks_a_stopped_session_with_an_in_flight_turn() {
+        use crate::acp::Event;
+        // Daemon restart: session persisted Stopped, but the last lifecycle
+        // event was a UserPromptSent (a turn was in flight when the prior
+        // daemon died). Seed must reflect the live turn, not the stale dot.
+        let inst = stopped_structured_instance();
+        let id = inst.id.clone();
+        let state = test_support::build_test_app_state(vec![inst]);
+        state
+            .acp_event_store
+            .record(
+                &id,
+                1,
+                &Event::UserPromptSent {
+                    text: "go".into(),
+                    attachments: Vec::new(),
+                },
+            )
+            .expect("record");
+        seed_acp_statuses(state.clone()).await;
+        assert_eq!(state.instances.read().await[0].status, Status::Running);
+    }
+
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn seed_preserves_a_deliberate_stop_across_restart() {
+        use crate::acp::Event;
+        // Latest event is a Stopped (clean / deliberate stop), so the seed
+        // leaves the persisted Stopped intact rather than downgrading it.
+        let inst = stopped_structured_instance();
+        let id = inst.id.clone();
+        let state = test_support::build_test_app_state(vec![inst]);
+        state
+            .acp_event_store
+            .record(
+                &id,
+                1,
+                &Event::Stopped {
+                    reason: "prompt_complete".into(),
+                },
+            )
+            .expect("record");
+        seed_acp_statuses(state.clone()).await;
+        assert_eq!(state.instances.read().await[0].status, Status::Stopped);
     }
 
     #[test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A structured-view (ACP) session whose worker was idle-reaped or manually stopped, then re-prompted, stayed grey in the sidebar forever even while the respawned worker streamed a live turn. Root cause: `apply_status_intent` early-returned whenever `inst.status == Status::Stopped`, so no live ACP event could revive the dot. `seed_acp_statuses` hit the same guard at startup, so a session persisted `Stopped` with an in-flight turn also stayed grey across a daemon restart.

This moves the `Stopped` block into the `Set` arm, so trailing post-stop events still cannot wake a deliberate Stop (the chain `Stopped -> (trailing prompt) Running -> (trailing stop) Idle` that would otherwise strand a deliberate stop on `Idle`). `HealError` (derived only from `AcpSessionAssigned` / `RateLimitAutoResumed`, both emitted on a fresh worker attach and never as trailing events) now heals `Error` AND `Stopped` to `Idle`; the `UserPromptSent` that follows the respawn then drives `Running`.

In `seed_acp_statuses`, where the on-disk event log is the whole truth with no trailing-event race, a stale `Stopped` is cleared when the latest lifecycle event proves an in-flight turn (`Running`/`Waiting`). A latest `Idle`/`Error` (clean or deliberate stop) leaves `Stopped` intact, so a deliberate stop survives a restart.

This is the Tier 1 fix: it neutralizes the trap on both the live and restart paths with a small, contained change in `src/server/mod.rs`. The deeper cleanup (de-overloading `Status::Stopped` into distinct deliberate-stop vs dormant variants) is deferred to #2250.

Closes #2248

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard with a structured-view session. Leave it idle until the idle reaper auto-stops the worker (or click Stop), confirm the sidebar dot goes grey.
- [ ] Send a new prompt to that session. Confirm the dot turns green (Running) while the agent works, instead of staying grey.
- [ ] Stop a structured session deliberately, confirm it shows Stopped and stays Stopped (does not flip to Idle from trailing events).
- [ ] With a structured session mid-turn, restart `aoe serve`; confirm the dot reflects the in-flight turn rather than a stale grey, while a deliberately-stopped session stays Stopped after restart.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the change is pure backend status-derivation logic shared by the web and TUI sidebars, not a dashboard component or flow. It is covered directly by Rust unit tests on `apply_status_intent` and `seed_acp_statuses` (reproduce-then-fix: both new bug tests were confirmed red on the pre-fix tree).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle; only the daemon's status-intent folding, covered by Rust unit tests.
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, a `/debate` design pass between two models, the plan, and the implementation were drafted by Claude under my direction. I made the design calls (epoch-signal heal over target-sniffing, Tier 1 scope, deferring Tier 2 to #2250), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784282306&installation_id=139138837&pr_number=2253&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2253&signature=245d01aa61137d17124baa3651070a0e6c21f47156ba00a97c364b0599d58715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->