### PR TITLE
fix(tui): keep diff file list selection visible

### DIFF
--- a/src/tui/diff/input.rs
+++ b/src/tui/diff/input.rs
@@ -61,8 +61,9 @@ impl DiffView {
         let pos = ratatui::layout::Position::from((col, row));
         if self.file_list_inner.contains(pos) {
             let row_in_list = (row - self.file_list_inner.y) as usize;
-            if row_in_list < self.files.len() && self.selected_file != row_in_list {
-                self.selected_file = row_in_list;
+            let file_index = self.file_list_scroll_offset + row_in_list;
+            if file_index < self.files.len() && self.selected_file != file_index {
+                self.selected_file = file_index;
                 self.scroll_offset = 0;
             }
         }
@@ -312,6 +313,45 @@ mod tests {
             view.success_message.as_deref(),
             Some("Copied src/app/foo.rs")
         );
+    }
+
+    #[test]
+    fn file_list_scroll_tracks_the_selected_file() {
+        let mut view = make_diff_view_no_warning();
+        view.files = (0..20)
+            .map(|i| diff_file(&format!("src/file_{i}.rs")))
+            .collect();
+
+        view.selected_file = 0;
+        view.ensure_selected_file_visible_in_list(5);
+        assert_eq!(view.file_list_scroll_offset, 0);
+
+        view.selected_file = 5;
+        view.ensure_selected_file_visible_in_list(5);
+        assert_eq!(view.file_list_scroll_offset, 1);
+
+        view.selected_file = 19;
+        view.ensure_selected_file_visible_in_list(5);
+        assert_eq!(view.file_list_scroll_offset, 15);
+
+        view.selected_file = 14;
+        view.ensure_selected_file_visible_in_list(5);
+        assert_eq!(view.file_list_scroll_offset, 14);
+    }
+
+    #[test]
+    fn file_list_click_uses_the_visible_scroll_offset() {
+        let mut view = make_diff_view_no_warning();
+        view.files = (0..20)
+            .map(|i| diff_file(&format!("src/file_{i}.rs")))
+            .collect();
+        view.file_list_scroll_offset = 10;
+        view.file_list_inner = ratatui::layout::Rect::new(0, 5, 20, 5);
+
+        view.handle_click(1, 7);
+
+        assert_eq!(view.selected_file, 12);
+        assert_eq!(view.scroll_offset, 0);
     }
 
     #[test]

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -98,6 +98,11 @@ pub struct DiffView {
     /// the same way `j`/`k` would.
     pub(crate) file_list_inner: ratatui::layout::Rect,
 
+    /// First file index currently rendered in the file-list panel.
+    /// Keeps keyboard selection and mouse clicks aligned when the file list is
+    /// taller than the visible panel.
+    pub(crate) file_list_scroll_offset: usize,
+
     /// Process-wide file-watch primitive, threaded through to per-session
     /// `Storage` writes so the local in-process Local fast path fires when
     /// the diff view persists a `base_branch_override`.
@@ -179,6 +184,7 @@ impl DiffView {
             warning_dialog,
             pending_override: None,
             file_list_inner: ratatui::layout::Rect::default(),
+            file_list_scroll_offset: 0,
             file_watch,
         };
 
@@ -192,6 +198,13 @@ impl DiffView {
         self.diff_cache.clear();
         if self.selected_file >= self.files.len() {
             self.selected_file = self.files.len().saturating_sub(1);
+        }
+        if self.files.is_empty() {
+            self.file_list_scroll_offset = 0;
+        } else {
+            self.file_list_scroll_offset = self
+                .file_list_scroll_offset
+                .min(self.files.len().saturating_sub(1));
         }
         self.scroll_offset = 0;
         Ok(())
@@ -318,6 +331,26 @@ impl DiffView {
         }
     }
 
+    /// Keep the selected file within the visible file-list rows.
+    pub(crate) fn ensure_selected_file_visible_in_list(&mut self, visible_rows: usize) {
+        if self.files.is_empty() || visible_rows == 0 {
+            self.file_list_scroll_offset = 0;
+            return;
+        }
+
+        let selected = self.selected_file.min(self.files.len().saturating_sub(1));
+        let max_offset = self.files.len().saturating_sub(visible_rows);
+        self.file_list_scroll_offset = self.file_list_scroll_offset.min(max_offset);
+
+        if selected < self.file_list_scroll_offset {
+            self.file_list_scroll_offset = selected;
+        } else if selected >= self.file_list_scroll_offset + visible_rows {
+            self.file_list_scroll_offset = selected + 1 - visible_rows;
+        }
+
+        self.file_list_scroll_offset = self.file_list_scroll_offset.min(max_offset);
+    }
+
     /// Scroll diff content down
     pub fn scroll_down(&mut self, amount: u16) {
         let max_scroll = self.total_lines.saturating_sub(self.visible_lines);
@@ -431,6 +464,7 @@ impl DiffView {
             warning_dialog: None,
             pending_override: None,
             file_list_inner: ratatui::layout::Rect::default(),
+            file_list_scroll_offset: 0,
             file_watch: FileWatchService::noop(),
         }
     }

--- a/src/tui/diff/render.rs
+++ b/src/tui/diff/render.rs
@@ -150,6 +150,10 @@ impl DiffView {
             return;
         }
 
+        self.ensure_selected_file_visible_in_list(inner.height as usize);
+        let start = self.file_list_scroll_offset;
+        let visible_rows = inner.height as usize;
+
         // Available width for the file path text (subtract borders, padding, prefix, status)
         let max_path_width = inner.width.saturating_sub(4) as usize; // "  M " = 4 chars
 
@@ -157,6 +161,8 @@ impl DiffView {
             .files
             .iter()
             .enumerate()
+            .skip(start)
+            .take(visible_rows)
             .map(|(i, file)| {
                 let is_selected = i == self.selected_file;
 
@@ -761,6 +767,58 @@ mod tests {
             out.push('\n');
         }
         out
+    }
+
+    fn diff_file(path: &str) -> crate::git::diff::DiffFile {
+        crate::git::diff::DiffFile {
+            path: std::path::PathBuf::from(path),
+            old_path: None,
+            status: FileStatus::Modified,
+            additions: 1,
+            deletions: 0,
+        }
+    }
+
+    #[test]
+    fn file_list_render_keeps_selected_file_visible_after_scroll() {
+        use crate::git::diff::{DiffHunk, DiffLine, FileDiff};
+
+        let mut view = DiffView::test_default();
+        view.files = (0..20)
+            .map(|i| diff_file(&format!("src/file_{i:02}.rs")))
+            .collect();
+        view.selected_file = 14;
+
+        let selected = view.files[14].clone();
+        view.diff_cache.insert(
+            selected.path.clone(),
+            FileDiff {
+                file: selected,
+                hunks: vec![DiffHunk {
+                    old_start: 1,
+                    old_lines: 1,
+                    new_start: 1,
+                    new_lines: 1,
+                    lines: vec![DiffLine {
+                        tag: ChangeTag::Equal,
+                        old_line_num: Some(1),
+                        new_line_num: Some(1),
+                        content: "selected file diff content\n".to_string(),
+                    }],
+                }],
+                is_binary: false,
+            },
+        );
+
+        let out = render_diff_to_string(&mut view, 100, 16);
+        assert!(
+            out.contains("> M src/file_14.rs"),
+            "selected file marker must remain visible in the file list, got:\n{out}"
+        );
+        assert!(
+            out.contains("selected file diff content"),
+            "selected file diff content should render in the diff pane, got:\n{out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description
Fixes #2242.

The TUI diff view's left Files panel now keeps the selected file visible when the changed-file list is taller than the panel. The view tracks a file-list viewport offset, renders only the visible file slice, and maps mouse clicks through that offset so selection remains correct after scrolling.

Render evidence from the focused regression scenario:

![TUI diff file list keeps the selected file visible](https://gist.githubusercontent.com/MTGVim/25bc4a9b0a9634ed88fb308cfa7db36c/raw/aoe-diff-file-list-render.png)

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass for the touched TUI diff surface. Full `cargo test` was also run and reported unrelated environment-dependent failures listed below.
- [x] Documentation was updated where necessary (not required for this internal TUI behavior fix)
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this is covered by focused TUI state and render-buffer regression tests. The render test exercises the actual `DiffView::render` path with `ratatui::TestBackend` and proves the selected file marker remains visible after the file-list viewport scrolls.

## Testing
- `cargo fmt --check`
- `CC=/usr/bin/gcc cargo test file_list_render_keeps_selected_file_visible_after_scroll --lib`
- `CC=/usr/bin/gcc cargo test tui::diff::input::tests --lib`
- `CC=/usr/bin/gcc cargo check`
- `CC=/usr/bin/gcc cargo clippy -- -D warnings`
- `CC=/usr/bin/gcc cargo test` *(fails in unrelated environment-dependent tests: .claude ignored by global gitignore in submodule/worktree tests, tmux capture tests, and one Claude approval prompt status test; 3148 passed, 6 failed, 2 ignored)*

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
Hermes Agent / OpenAI Codex CLI-style agent workflow

**Any Additional AI Details you'd like to share:**
AI assistance was used to investigate the bug, implement the fix, add regression coverage, run validation commands, and draft this PR body. I reviewed and submitted the change.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Fixed a critical usability bug in the TUI diff view where the file list panel did not scroll when the number of changed files exceeded the panel's visible height. Previously, navigating down the file list would cause the selection marker to disappear below the visible area, making it impossible to see which file was selected.

## What Changed

**Three files were modified:**

1. **`src/tui/diff/mod.rs`**
   - Added a new `file_list_scroll_offset` field to track which file in the list appears at the top of the visible panel
   - Added `ensure_selected_file_visible_in_list()` method to automatically adjust scrolling when the selected file would go out of view

2. **`src/tui/diff/render.rs`**
   - Updated the file list rendering to calculate and display only the slice of files that fit in the visible panel area
   - Integrated viewport awareness so the selected file is kept visible when rendering

3. **`src/tui/diff/input.rs`**
   - Updated mouse click handling to account for the scroll offset when determining which file was clicked
   - This ensures clicks select the correct file even after the list has scrolled

## Benefits

- **Users can now navigate through all files**: Sessions with hundreds or thousands of changed files are now fully accessible
- **Selection always remains visible**: The selection marker no longer disappears when navigating through the file list
- **Mouse interactions work correctly**: Clicking on files in the scrolled list selects the intended file
- **Seamless user experience**: Automatic scrolling keeps the selected file in view without requiring manual adjustment

## Testing

Regression tests were added covering:
- Viewport offset updates as the selected file changes
- Mouse click selection with non-zero scroll offsets
- Selected file visibility after list scrolling

All tests pass, confirming the fix works correctly and existing functionality remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->