### PR TITLE
fix(tui): register a click on an OS-unfocused terminal

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -198,6 +198,15 @@ pub struct App {
     /// differs. Single-process scope; on restart the new binary's
     /// `CARGO_PKG_VERSION` makes the underlying check return "no update".
     last_installed_version_in_session: Option<String>,
+    /// Whether a left-button press is currently outstanding: a `Down(Left)`
+    /// was seen without a matching `Up(Left)` yet. Used to recognize an
+    /// "orphan" left release. When you click an OS-unfocused terminal, the
+    /// window manager consumes the focusing mouse-down to raise the window
+    /// but the terminal still reports the mouse-up; motion is reported
+    /// regardless of focus (so hover already highlighted the target). With
+    /// no preceding Down the click would be lost, so we treat such an orphan
+    /// Up as a click at its own coordinates, which match the hovered element.
+    left_button_down: bool,
 }
 
 /// Check if the app version changed and return the previous version if changelog should be shown.
@@ -371,6 +380,7 @@ impl App {
             pending_structured_view_open: None,
             pending_install_version: None,
             last_installed_version_in_session: None,
+            left_button_down: false,
         })
     }
 
@@ -813,6 +823,10 @@ impl App {
                                                     // during dictation can click again after the burst
                                                     // ends.
                                                     MouseEventKind::Down(MouseButton::Left) => {
+                                                        // Keep press tracking in sync with the
+                                                        // non-burst arm so the paired release isn't
+                                                        // misread as a focus-click orphan.
+                                                        self.left_button_down = true;
                                                         if self.home.handle_context_menu_click(mouse.column, mouse.row) {
                                                             // Click consumed by the context menu
                                                             // (item dispatched, kept open, or
@@ -922,10 +936,28 @@ impl App {
                             // PreviewSelect; `handle_drag_end` collapses it
                             // back to no selection on release if the cursor
                             // never moved.
-                            let click_action = if matches!(
+                            //
+                            // `treat_as_click` fires for a real `Down(Left)`
+                            // and for an "orphan" `Up(Left)` (a release with
+                            // no outstanding press, see `left_button_down`):
+                            // the latter is the click on an OS-unfocused
+                            // terminal whose mouse-down the window manager ate
+                            // to raise the window. The orphan release skips
+                            // drag-start (there's nothing to drag on a release)
+                            // and lands the click on whatever the hover already
+                            // highlighted at the release coordinates.
+                            let is_left_down =
+                                matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left));
+                            let orphan_left_up = matches!(
                                 mouse.kind,
-                                MouseEventKind::Down(MouseButton::Left)
-                            ) {
+                                MouseEventKind::Up(MouseButton::Left)
+                            ) && !self.left_button_down;
+                            if is_left_down {
+                                self.left_button_down = true;
+                            } else if matches!(mouse.kind, MouseEventKind::Up(MouseButton::Left)) {
+                                self.left_button_down = false;
+                            }
+                            let click_action = if is_left_down || orphan_left_up {
                                 if self
                                     .home
                                     .handle_context_menu_click(mouse.column, mouse.row)
@@ -952,9 +984,8 @@ impl App {
                                     self.sync_mouse_capture(terminal)?;
                                     self.draw(terminal)?;
                                     None
-                                } else if self
-                                    .home
-                                    .handle_drag_start(mouse.column, mouse.row)
+                                } else if is_left_down
+                                    && self.home.handle_drag_start(mouse.column, mouse.row)
                                 {
                                     // handle_drag_start already overwrote the
                                     // selection if it started a PreviewSelect;

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -506,6 +506,33 @@ last_seen_version = "{}"
         std::thread::sleep(Duration::from_millis(100));
     }
 
+    /// Send only the SGR release (`m`) for a left button, with no preceding
+    /// press. This reproduces the "focus-click orphan": clicking an
+    /// OS-unfocused terminal, where the window manager swallows the
+    /// focusing mouse-down to raise the window but the terminal still
+    /// reports the mouse-up. The TUI treats such an orphan release as a
+    /// click at its coordinates.
+    pub fn send_mouse_release(&self, button: u8, col: u16, row: u16) {
+        assert!(self.spawned, "must call spawn_tui() or spawn() first");
+        let seq = format!("\x1b[<{button};{col};{row}m");
+        let output = Command::new("tmux")
+            .arg("-S")
+            .arg(&self.socket_path)
+            .arg("send-keys")
+            .arg("-t")
+            .arg(&self.session_name)
+            .arg("-l")
+            .arg(&seq)
+            .output()
+            .expect("failed to send mouse release");
+        assert!(
+            output.status.success(),
+            "send_mouse_release failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
     /// Send literal text (prevents "Enter" in text from being interpreted as
     /// the Enter key).
     pub fn type_text(&self, text: &str) {

--- a/tests/e2e/new_session.rs
+++ b/tests/e2e/new_session.rs
@@ -182,6 +182,43 @@ fn test_right_click_on_session_row_opens_rename_delete_menu() {
     h.wait_for_absent("Rename", Duration::from_secs(5));
 }
 
+#[test]
+#[serial]
+fn test_orphan_left_release_clicks_hovered_row() {
+    // Clicking a session row in an OS-unfocused terminal: the window
+    // manager swallows the focusing mouse-down to raise the window, so
+    // the TUI only ever sees the mouse-up. With the default LiveSend
+    // click action, that orphan release must still land the click and
+    // enter live-send on the row, exactly as a real (paired down+up)
+    // click would. Motion is reported regardless of focus, so the row was
+    // already hover-highlighted; the release coordinates match it.
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("orphan_release_click");
+    let project = h.project_path();
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "OrphanRow"]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    h.spawn_tui();
+    h.wait_for(" aoe ");
+    h.send_keys("Enter"); // dismiss welcome
+    h.wait_for("OrphanRow");
+
+    // Release-only (SGR `m`) over the first session row, no preceding
+    // press. Same coordinates the right-click row test uses: top border
+    // is row 1, the first item is row 2, column 5 is the label area.
+    h.send_mouse_release(0, 5, 2);
+
+    // The LIVE footer banner is the load-bearing tell that the orphan
+    // release entered live-send on the clicked row.
+    h.wait_for_timeout("LIVE", Duration::from_secs(10));
+    h.assert_screen_contains(" aoe ");
+}
+
 /// Submit the new session dialog, handling the "Path does not exist. Create?"
 /// prompt if it appears.
 ///


### PR DESCRIPTION
## Description

Clicking a TUI terminal that is not the OS-focused window only activated the terminal; the click never registered on the row under the cursor. Hover, by contrast, worked fine.

Root cause: when you click an unfocused terminal window, the window manager consumes the focusing mouse-down to raise the window, so the app only ever sees the mouse-up. Motion is reported regardless of focus (which is why hover highlighted the right row), but selection/activation acted on `Down(Left)` only, so the focusing click landed as a lone `Up(Left)` that did nothing but end a (nonexistent) drag.

Fix: track whether a left press is outstanding and treat a left `Up` with no preceding `Down` as an "orphan" release, the swallowed focus-click. It now runs the same click handling as a real `Down(Left)` at the release coordinates (which match the hovered element), skipping drag-start. Normal clicks are unaffected because their `Up` is always preceded by a `Down`.

Note: this works when the terminal delivers the mouse-up on the focusing click (the common macOS pattern: iTerm2, Terminal.app, Ghostty). A terminal that swallows both the down and the up sends the app nothing, so it cannot synthesize the click.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Added a `send_mouse_release` harness helper (SGR release with no preceding press) and `test_orphan_left_release_clicks_hovered_row`, which seeds a session, sends an orphan release on its row, and asserts it enters live-send like a real click. Verified the new test plus the existing left/right-click and live-mode e2e tests pass.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause investigation and implementation done with Claude Code; reasoning and decisions reviewed by me.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784295770&installation_id=139138837&pr_number=2257&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2257&signature=b3fa99cc8de7f02293db79636c035cbd54a8af2407deb457cf65fa5916ce2a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a usability issue where clicking on an unfocused TUI terminal would activate the window but fail to register the click action on the element under the cursor. The problem occurs because when you click an unfocused window, the OS window manager intercepts the mouse-down event to raise the window, leaving the application to receive only the mouse-up event.

## What Changed

**Core Fix (src/tui/app.rs):**
- Added left-button press tracking to the `App` struct with a new `left_button_down` boolean field
- Updated mouse event handling to track when the left mouse button is pressed and released
- Modified click routing logic to recognize "orphan" mouse-release events (up events with no corresponding down event)
- When an orphan release is detected, it's treated as a click, triggering the same action as a normal click

**Test Coverage:**
- Added a new `send_mouse_release` helper method in the test harness (tests/e2e/harness.rs) to simulate orphan mouse-release events
- Added a regression test (tests/e2e/new_session.rs) that verifies orphan releases correctly trigger click handling on session rows

## Benefits

- **Improved User Experience**: Users can now click on an unfocused terminal and have both the focus activation AND the intended click action register correctly
- **Broader Compatibility**: Works with terminals that deliver the mouse-up event on the focus-click (common on macOS terminals like iTerm2, Terminal.app, and Ghostty)
- **Backward Compatible**: Normal click behavior remains unaffected since regular clicks always have a matching down-then-up sequence

## Technical Details

The solution works by:
1. Tracking outstanding left mouse presses in a boolean flag
2. Detecting when a left Up event occurs without a preceding Down event (the orphan release)
3. Treating the orphan release coordinates as a click target since the cursor position at release matches the hovered element
4. Restricting drag-start behavior to real Down events only, so orphan releases won't trigger unintended drag operations

**Limitation**: This fix cannot help if a terminal completely swallows both the down and up events—it requires the terminal to deliver the up event even if it consumed the down event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->