### PR TITLE
fix(web): raise new-session wizard above the tooltip layer on mobile

### DIFF
--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -335,7 +335,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center">
       <div className="absolute inset-0 bg-black/60" onClick={onClose} />
       <div
         data-testid="session-wizard"

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -464,7 +464,8 @@
         "tests/wizard-agent-step.spec.ts",
         "tests/wizard-single-screen.spec.ts",
         "tests/wizard-extra-repos.spec.ts",
-        "tests/wizard-custom-agent.spec.ts"
+        "tests/wizard-custom-agent.spec.ts",
+        "tests/wizard-tooltip-z-index.spec.ts"
       ],
       "components": [
         "web/src/components/DirectoryBrowser.tsx",

--- a/web/tests/helpers/acp.ts
+++ b/web/tests/helpers/acp.ts
@@ -392,7 +392,7 @@ export async function attachServeDiagnostics(testInfo: TestInfo, serve: { home: 
  * sidebar / topbar elements behind the overlay.
  */
 export function wizardScope(page: Page): Locator {
-  return page.locator('div.fixed.inset-0.z-50:has(h1:has-text("New session"))');
+  return page.locator('[data-testid="session-wizard"]');
 }
 
 /**

--- a/web/tests/live/palette-scratch-launch.spec.ts
+++ b/web/tests/live/palette-scratch-launch.spec.ts
@@ -22,7 +22,7 @@ test("palette 'New scratch session' opens the wizard and launches a scratch sess
   await page.getByPlaceholder(PALETTE_PLACEHOLDER).fill("scratch");
   await page.getByRole("option", { name: /New scratch session/i }).click();
 
-  const wizard = page.locator('div.fixed.inset-0.z-50:has(h1:has-text("New session"))');
+  const wizard = page.locator('[data-testid="session-wizard"]');
   await expect(wizard).toBeVisible({ timeout: 10_000 });
 
   // The palette command opens the single-screen wizard with scratch enabled;

--- a/web/tests/live/wizard-acp-create-session.spec.ts
+++ b/web/tests/live/wizard-acp-create-session.spec.ts
@@ -18,7 +18,7 @@ test("wizard with Use structured view on creates a structured_view session", asy
     await page.goto(serve.baseUrl);
     await page.getByRole("button", { name: "New session", exact: true }).first().click();
 
-    const wizard = page.locator('div.fixed.inset-0.z-50:has(h1:has-text("New session"))');
+    const wizard = page.locator('[data-testid="session-wizard"]');
     await expect(wizard).toBeVisible({ timeout: 15_000 });
 
     // Single screen: a scratch dir keeps the test self-contained.

--- a/web/tests/live/wizard-recent-projects-persist.spec.ts
+++ b/web/tests/live/wizard-recent-projects-persist.spec.ts
@@ -39,7 +39,7 @@ test("project stays in the wizard Recent tab after its last session is deleted (
     await page.goto(serve.baseUrl);
     await page.getByRole("button", { name: "New session", exact: true }).first().click();
 
-    const wizard = page.locator('div.fixed.inset-0.z-50:has(h1:has-text("New session"))');
+    const wizard = page.locator('[data-testid="session-wizard"]');
     await expect(wizard).toBeVisible({ timeout: 15_000 });
     await expect(wizard.getByText("frontend", { exact: true })).toBeVisible({ timeout: 10_000 });
     await expect(wizard.getByText("0 sessions")).toBeVisible();

--- a/web/tests/live/wizard-scratch-delete-cleans-tempdir.spec.ts
+++ b/web/tests/live/wizard-scratch-delete-cleans-tempdir.spec.ts
@@ -17,7 +17,7 @@ base("deleting a scratch session removes its scratch dir", async ({ page }, test
     await page.goto(serve.baseUrl);
     await page.getByRole("button", { name: "New session", exact: true }).first().click();
 
-    const wizard = page.locator('div.fixed.inset-0.z-50:has(h1:has-text("New session"))');
+    const wizard = page.locator('[data-testid="session-wizard"]');
     await expect(wizard).toBeVisible({ timeout: 15_000 });
 
     await wizard.getByRole("switch", { name: "Skip project folder" }).click();

--- a/web/tests/live/wizard-scratch-launch.spec.ts
+++ b/web/tests/live/wizard-scratch-launch.spec.ts
@@ -17,7 +17,7 @@ base("scratch happy path: launch creates a scratch-dir session", async ({ page }
     await page.goto(serve.baseUrl);
     await page.getByRole("button", { name: "New session", exact: true }).first().click();
 
-    const wizard = page.locator('div.fixed.inset-0.z-50:has(h1:has-text("New session"))');
+    const wizard = page.locator('[data-testid="session-wizard"]');
     await expect(wizard).toBeVisible({ timeout: 15_000 });
 
     // Single screen: enable scratch. The scratch callout confirms the mode

--- a/web/tests/wizard-tooltip-z-index.spec.ts
+++ b/web/tests/wizard-tooltip-z-index.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+import { openWizard } from "./helpers/wizard";
+
+// Regression for the new-session tooltip rendering above the wizard modal on
+// mobile (#2215 follow-up). The shared Tooltip portals a `fixed z-50` span to
+// document.body; the wizard overlay used to also be `z-50`, so the tooltip,
+// appended later in the DOM, won the equal-z tie and floated over the modal.
+// The wizard overlay must outrank the tooltip layer (z-50).
+
+async function mockApis(page: Page) {
+  await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  for (const path of ["settings", "themes", "profiles", "groups", "devices", "about", "system/update-status"]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({
+        json: path === "settings" || path === "about" || path === "system/update-status" ? {} : [],
+      }),
+    );
+  }
+  await page.route("**/api/docker/status", (r) => r.fulfill({ json: { available: false, runtime: null } }));
+  await page.route("**/api/agents", (r) =>
+    r.fulfill({ json: [{ name: "claude", binary: "claude", host_only: false, installed: true, install_hint: "" }] }),
+  );
+  await page.route("**/api/sessions", (r) => r.fulfill({ json: { sessions: [], workspace_ordering: [] } }));
+}
+
+test("wizard overlay outranks the z-50 tooltip layer on mobile", async ({ page }) => {
+  await mockApis(page);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  await openWizard(page);
+
+  const overlayZ = await page
+    .getByTestId("session-wizard")
+    .evaluate((el) => Number(getComputedStyle(el.parentElement as HTMLElement).zIndex));
+
+  // Tooltip popups are fixed at z-50; the modal must sit above them.
+  expect(overlayZ).toBeGreaterThan(50);
+});


### PR DESCRIPTION
> **AI disclosure:** This PR was authored by an AI agent (Claude Opus 4.8) on behalf of the repository owner.

## Description

The shared `Tooltip` portals a `fixed z-50` span to `document.body`. The new-session wizard overlay was also `z-50`, so the tooltip, appended later in the DOM, won the equal-z tie and rendered **over** the modal on mobile (where tapping the new-session button both opens the wizard and triggers the button's tooltip). Bump the wizard overlay to `z-[60]`, matching its sibling modals (command palette, sidebar dialogs), so it always sits above the tooltip layer.

One-token CSS fix; also removes a stacking inconsistency (the wizard was the only modal at `z-50`).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A: z-index layering fix, no documented behavior changes)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under \`web/tests/\` and updated \`web/tests/coverage-matrix.json\`

Added \`web/tests/wizard-tooltip-z-index.spec.ts\` (mocked, mobile viewport) asserting the wizard overlay outranks the \`z-50\` tooltip layer. Verified it fails on the pre-fix \`z-50\` and passes on \`z-[60]\`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## How tested

- [ ] \`cd web && npm run format:check\` (oxfmt) clean
- [ ] \`cd web && npm run lint\` (ESLint) clean
- [ ] \`cd web && npx tsc -b\` clean
- [ ] \`npx playwright test --config=playwright.config.ts tests/wizard-tooltip-z-index.spec.ts\` passes
- [ ] On a mobile viewport, open the new-session wizard and confirm no tooltip floats over the modal

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (1M context) via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784305776&installation_id=139138837&pr_number=2259&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2259&signature=abb7a4f8cae38b11d5d5fa281a4649aea9d414910912ef639ba2473ddeabe347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR fixes a mobile UI layering issue where a tooltip could appear above (and obscure) the new-session wizard modal. It does so by adjusting the wizard’s stacking order and adding automated coverage to ensure the problem doesn’t come back.

**What Changed:**
- The session wizard overlay’s z-index was increased (so it reliably renders above the tooltip).
- A new Playwright regression test was added for mobile viewports to validate the correct layering.
- Existing wizard-related Playwright tests were updated to locate the wizard using a stable `data-testid` attribute instead of relying on z-index/CSS structure.

**What Was Added:**
- `web/tests/wizard-tooltip-z-index.spec.ts`: verifies the wizard appears above the tooltip on mobile and would fail under the previous z-index behavior.
- An entry in `web/tests/coverage-matrix.json` to include the new test.

**What Was Removed:**
- Nothing removed—this is a corrective, additive change.

**Benefits:**
- Prevents the tooltip from covering the wizard on mobile, restoring correct interaction.
- Aligns the wizard’s layering behavior with other modal components.
- Improves test robustness by switching to a stable `data-testid` locator for the wizard.
- Adds regression protection specifically targeted at the original stacking/z-index bug.
- Potential follow-up: the review suggested further hardening the new test by adding a dedicated `data-testid` on the overlay container itself (to reduce reliance on DOM traversal/structure).

---

## Technical Details

- **Root cause:** The tooltip is portaled to `document.body` with `fixed z-50`, and the wizard overlay was also `z-50`. On mobile, when both are present, DOM insertion order could cause the tooltip to render above the wizard despite matching z-index values.
- **Fix:** Increase the wizard overlay from `z-50` to `z-[60]` in `SessionWizard.tsx`, ensuring it layers above the tooltip.
- **Testing:** The new Playwright spec validates the computed layering behavior on mobile by opening the wizard and checking the tooltip’s z-index relationship to the wizard.
- **Test maintenance:** Updated the wizard test helper/locators and several live specs to use `data-testid="session-wizard"` rather than CSS/z-index-based selectors, reducing brittleness if styling changes again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->