### PR TITLE
fix(web): auto-dismiss stuck "Waking…" banner after the wake fires

### DIFF
--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -1538,22 +1538,47 @@ function WorkerResumingBanner() {
   );
 }
 
+/** How long the post-fire "Waking…" state lingers before self-dismissing.
+ *  A genuine fire flips `turnActive` (which hides this banner) within a
+ *  second or two, so this only ever clears a stale banner. */
+const WAKING_GRACE_MS = 10_000;
+
 /** Top-of-structured view chip shown while the agent's `ScheduleWakeup` is
  *  pending. Visible only when no turn is in flight (turns produce their
  *  own busy chrome) and no other recovery banner is up. 1Hz local tick
  *  for the countdown; once the wake fires the next UserPromptSent
  *  clears `state.nextWakeupAt` on the reducer side and this unmounts.
- *  See #1091. */
-function ScheduledWakeupBanner({ wakeAt, reason }: { wakeAt: string; reason: string | null }) {
+ *  See #1091.
+ *
+ *  A fallback `ScheduleWakeup` superseded by its primary signal (a turn
+ *  that fired before `wakeAt`) leaves `nextWakeupAt` set with nothing
+ *  left to clear it: a prompt arriving before `wakeAt` is kept on
+ *  purpose, and once `wakeAt` passes no further prompt lands. That left
+ *  "Waking…" stuck indefinitely. Self-dismiss `WAKING_GRACE_MS` after
+ *  firing so the stale banner clears on its own. */
+export function ScheduledWakeupBanner({ wakeAt, reason }: { wakeAt: string; reason: string | null }) {
   const targetMs = Date.parse(wakeAt);
   const [now, setNow] = useState(() => Date.now());
+  const [dismissed, setDismissed] = useState(false);
   const elapsed = !Number.isFinite(targetMs) || targetMs <= now;
+  // A fresh wake reuses this instance (same render slot); un-dismiss
+  // during render so the new countdown shows.
+  const [prevWakeAt, setPrevWakeAt] = useState(wakeAt);
+  if (wakeAt !== prevWakeAt) {
+    setPrevWakeAt(wakeAt);
+    setDismissed(false);
+  }
   useEffect(() => {
     if (elapsed) return;
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
   }, [elapsed]);
-  if (!Number.isFinite(targetMs)) return null;
+  useEffect(() => {
+    if (!elapsed) return;
+    const id = setTimeout(() => setDismissed(true), WAKING_GRACE_MS);
+    return () => clearTimeout(id);
+  }, [elapsed]);
+  if (!Number.isFinite(targetMs) || dismissed) return null;
   const remaining = Math.max(0, Math.floor((targetMs - now) / 1000));
   const wakeDate = new Date(targetMs);
   const clock = `${String(wakeDate.getHours()).padStart(2, "0")}:${String(wakeDate.getMinutes()).padStart(2, "0")}`;

--- a/web/src/components/acp/__tests__/ScheduledWakeupBanner.test.tsx
+++ b/web/src/components/acp/__tests__/ScheduledWakeupBanner.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+//
+// The structured-view "Waking…" banner must self-dismiss shortly after
+// the wake fires. A fallback ScheduleWakeup superseded by its primary
+// signal leaves `nextWakeupAt` set with nothing to clear it, so without
+// the grace timeout the banner stuck on "Waking…" forever.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+
+import { ScheduledWakeupBanner } from "../StructuredView";
+
+describe("ScheduledWakeupBanner self-dismiss", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows Waking… once fired, then unmounts after the grace window", () => {
+    const past = new Date(Date.now() - 1_000).toISOString();
+    const { container } = render(<ScheduledWakeupBanner wakeAt={past} reason="fallback" />);
+    expect(container.textContent).toContain("Waking…");
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(container.textContent).toBe("");
+  });
+
+  it("keeps showing the countdown while the wake is still in the future", () => {
+    const future = new Date(Date.now() + 120_000).toISOString();
+    const { container } = render(<ScheduledWakeupBanner wakeAt={future} reason="fallback" />);
+    expect(container.textContent).toContain("Asleep until");
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(container.textContent).toContain("Asleep until");
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2481,7 +2481,10 @@
       "id": "triage.acp-banners",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/acp/__tests__/TriageBanners.test.tsx"],
+      "specs": [
+        "src/components/acp/__tests__/TriageBanners.test.tsx",
+        "src/components/acp/__tests__/ScheduledWakeupBanner.test.tsx"
+      ],
       "components": ["web/src/components/acp/StructuredView.tsx"]
     },
     {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The structured-view "Waking…" banner could get stuck on screen indefinitely after a scheduled wake had already fired, which was distracting.

`ScheduledWakeupBanner` renders from `state.nextWakeupAt`, which the reducer only clears on a `UserPromptSent` that arrives at or after `wakeAt`. A fallback `ScheduleWakeup` that is superseded by its primary signal fires a turn *before* `wakeAt`. A prompt arriving before `wakeAt` is intentionally kept as a mid-wait follow-up (#1091), so the wakeup survives; then once `wakeAt` passes, nothing else lands to clear it and the banner sits on "Waking…" forever. The sidebar countdown self-heals on the next sessions-endpoint poll, but the structured view has no equivalent refresh, so only the structured-view banner stuck.

The fix self-dismisses the banner 10s after the wake fires. A genuine fire flips `turnActive` (which hides the banner) within a second or two and clears `nextWakeupAt` via the post-`wakeAt` prompt, so the grace window only ever clears the stale, superseded case. The reducer is left untouched: the lingering `nextWakeupAt` is harmless because this banner is its only consumer in the structured view.

Reported against session `339dcfabc14840ae`, whose fallback wakeup ("Fallback while the e2e binary relinks and the link test runs; primary signal is task b0lwf7kyg completion") fired but left the banner up. No GitHub issue was filed; this PR fixes the bug directly.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a structured-view session whose agent schedules a fallback `ScheduleWakeup` while a primary signal (e.g. a background task) is what actually drives it forward.
- [ ] Let the primary signal fire a turn before the scheduled `wakeAt` time.
- [ ] Wait for `wakeAt` to pass; confirm the "Waking…" banner appears briefly then disappears on its own within ~10s instead of sticking.
- [ ] Separately, schedule a wake well in the future and confirm the "Asleep until …" countdown still shows and ticks normally (not prematurely dismissed).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test (Vitest) and updated `web/tests/coverage-matrix.json`

New `web/src/components/acp/__tests__/ScheduledWakeupBanner.test.tsx` (mapped under the `triage.acp-banners` entry) covers both directions: a past `wakeAt` shows "Waking…" then unmounts after the grace window; a future `wakeAt` keeps showing the countdown. This is component-local timer behavior, so a Vitest with fake timers is the right level rather than a Playwright spec.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design call (client-side grace dismiss, reducer left alone) and reviewed the diff.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784307382&installation_id=139138837&pr_number=2261&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2261&signature=4dd323eb9865a4af9a64a5cd8ee36fe87dab90d1666dfe18edb663f41bcb37a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a bug where the "Waking…" banner could remain stuck on the screen indefinitely after a scheduled wake has already completed. The issue occurs when a fallback wake fires before the scheduled time, causing the banner state to persist even after the actual wake is no longer relevant.

### What Changed

**ScheduledWakeupBanner Component** (`web/src/components/acp/StructuredView.tsx`)
- Added automatic banner dismissal: The banner now hides itself 10 seconds after the scheduled wake time has passed
- Made the component externally accessible by exporting it (previously it was internal-only)
- Added state tracking to manage when the banner has been dismissed

**New Test Coverage** (`web/src/components/acp/__tests__/ScheduledWakeupBanner.test.tsx`)
- Added comprehensive test suite that verifies the new self-dismissal behavior works correctly
- Tests cover two scenarios: past wake times (banner should auto-dismiss) and future wake times (banner continues showing countdown)

**Test Configuration** (`web/tests/coverage-matrix.json`)
- Updated to include the new test file in the coverage tracking system

### Benefits

- **Prevents UI Glitches**: Users will no longer see a stale "Waking…" banner lingering indefinitely on screen
- **Graceful Fallback**: The 10-second grace window ensures the banner only self-dismisses in edge cases where the normal state update doesn't occur, without affecting normal operations
- **Better Test Coverage**: New tests ensure the fix works as intended and prevent regression

### Technical Details

The fix implements a client-side grace window (`WAKING_GRACE_MS = 10000ms`) that monitors when the scheduled wake time passes. The component tracks a `dismissed` flag that gets cleared when the wake time changes, and the banner returns `null` when dismissed or when the wake time is invalid. Since genuine wake completions update the UI state within 1-2 seconds, the 10-second grace window only affects the edge case where the previous fallback wake has already fired and been superseded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->