### PR TITLE
feat(acp): one-click adapter update clears every blocked session

### DIFF
--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -84,17 +84,22 @@ Two recovery controls sit on the compatibility screen:
 - **Update & restart** runs the agent's `npm install -g` on the host (as the
   user running the daemon) and then respawns. It appears only for
   npm-installable agents (`claude-agent-acp`, `codex-acp`, `gemini`) and only
-  when `acp.allow_agent_install` is enabled.
+  when `acp.allow_agent_install` is enabled. Because the install is global, the
+  same click also queues **every other session blocked on that same adapter** for
+  an automatic respawn, so one update clears every red X at once (the screen
+  reports how many other sessions it recovered). When the setting is off the
+  button is shown disabled with a hint to enable it.
 
 `acp.allow_agent_install` is **off by default**: running a global package install
 from the daemon is a host-level capability that executes the package's npm
 lifecycle scripts as the daemon user. It is always blocked in `--read-only` mode,
-and the setting is `local_only` (you can only turn it on from a dashboard
-connection to localhost, not a remote one). For agents that install some other
-way (`opencode`, `vibe-acp`, `pi-acp`), the screen shows the manual command
-instead of an Update button. Inside a sandbox session, a host install would not
-reach the containerized agent, so the action is refused; install the agent in the
-container image instead.
+and the setting is `local_only`, so the web dashboard cannot turn it on (the leaf
+is stripped from every web settings write, remote or local). Enable it from the
+`aoe` TUI settings (Advanced) or in the config file; the button activates on the
+next reload. For agents that install some other way (`opencode`, `vibe-acp`,
+`pi-acp`), the screen shows the manual command instead of an Update button.
+Inside a sandbox session, a host install would not reach the containerized agent,
+so the action is refused; install the agent in the container image instead.
 
 ### "Failed to start structured view agent" while the adapter is installed
 

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -369,6 +369,20 @@ pub struct Supervisor<S: BroadcastSink> {
     /// respawns these on the current binary once the turn finishes. See
     /// #1754.
     build_respawn_pending: Arc<std::sync::Mutex<HashSet<String>>>,
+    /// Sessions currently parked on a per-adapter compatibility rejection,
+    /// mapped to the binary that failed the check. Populated at every
+    /// `IncompatibleAgent` publish site, cleared on a successful (re)spawn.
+    /// Lets the web "Update & restart" install endpoint find every other
+    /// session blocked on the same adapter and respawn them all at once, so
+    /// one global `npm install -g` clears every red X without a per-session
+    /// manual restart. See #2109.
+    incompatible_binaries: Arc<std::sync::Mutex<HashMap<String, String>>>,
+    /// Sessions an out-of-band caller (the web install endpoint) wants the
+    /// reconciler to fresh-spawn on its next tick, regardless of the
+    /// `attempted` guard that otherwise pins a permanently-failing spawn.
+    /// Used to clear every red X after a global adapter install without a
+    /// per-session manual restart. See #2109.
+    force_respawn: Arc<std::sync::Mutex<HashSet<String>>>,
     /// Cap on concurrently-running workers, snapshotted from
     /// `[acp] max_concurrent_workers` at startup. Enforced in
     /// `spawn`; new workers past the cap return `CapacityFull`.
@@ -578,6 +592,8 @@ impl<S: BroadcastSink> Supervisor<S> {
             agent_warmup_locks: Arc::new(std::sync::Mutex::new(HashMap::new())),
             worker_notify: Arc::new(tokio::sync::Notify::new()),
             build_respawn_pending: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            incompatible_binaries: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            force_respawn: Arc::new(std::sync::Mutex::new(HashSet::new())),
             max_concurrent_workers,
         }
     }
@@ -602,6 +618,58 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// is gone). Idempotent.
     pub fn clear_build_respawn_pending(&self, session_id: &str) {
         lock_recover(&self.build_respawn_pending).remove(session_id);
+    }
+
+    /// Record that a session is parked on a compatibility rejection for
+    /// `binary`. Overwrites any prior entry. Cleared by
+    /// `clear_incompatible_binary` on a successful (re)spawn. See #2109.
+    fn mark_incompatible_binary(&self, session_id: &str, binary: &str) {
+        lock_recover(&self.incompatible_binaries)
+            .insert(session_id.to_string(), binary.to_string());
+    }
+
+    /// Drop a session's compatibility-rejection record once it spawns
+    /// cleanly (or is gone). Idempotent. See #2109.
+    fn clear_incompatible_binary(&self, session_id: &str) {
+        lock_recover(&self.incompatible_binaries).remove(session_id);
+    }
+
+    /// Ask the reconciler to fresh-spawn these sessions on its next tick,
+    /// bypassing the `attempted` guard. Idempotent. See #2109.
+    pub fn request_respawn(&self, session_id: &str) {
+        lock_recover(&self.force_respawn).insert(session_id.to_string());
+    }
+
+    /// Drain the pending force-respawn requests. Called once per reconciler
+    /// tick; the ids are removed from `attempted` so the resume pass treats
+    /// them as fresh. See #2109.
+    pub fn take_respawn_requests(&self) -> Vec<String> {
+        let mut set = lock_recover(&self.force_respawn);
+        let ids = set.iter().cloned().collect();
+        set.clear();
+        ids
+    }
+
+    /// Session ids currently parked on a compatibility rejection for
+    /// `binary` that have no live worker. The `is_running` filter is the
+    /// safety net against a stale entry: a session that already recovered
+    /// (or was stopped by the user) is running or absent-but-not-parked, so
+    /// it is never resurrected by a bulk install-and-respawn. See #2109.
+    pub async fn incompatible_sessions_for_binary(&self, binary: &str) -> Vec<String> {
+        let candidates: Vec<String> = {
+            let map = lock_recover(&self.incompatible_binaries);
+            map.iter()
+                .filter(|(_, b)| b.as_str() == binary)
+                .map(|(id, _)| id.clone())
+                .collect()
+        };
+        let mut out = Vec::new();
+        for id in candidates {
+            if !self.is_running(&id).await {
+                out.push(id);
+            }
+        }
+        out
     }
 
     /// Snapshot the lifecycle state of every structured view session known to
@@ -1337,6 +1405,9 @@ impl<S: BroadcastSink> Supervisor<S> {
         let mut client = match AcpClient::spawn(config.clone(), acp_session_id.clone()).await {
             Ok(c) => c,
             Err(err) => {
+                if matches!(err, AcpError::IncompatibleAgent(_)) {
+                    self.mark_incompatible_binary(&session_id, &config.spec.command);
+                }
                 self.publish_compat_rejection(&session_id, &err);
                 return Err(SupervisorError::Acp(err));
             }
@@ -1353,6 +1424,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         drop(warmup_guard);
 
         info!(target: "acp.supervisor", session = %session_id, "structured view worker spawned");
+        self.clear_incompatible_binary(&session_id);
 
         // Move the inbound receiver out so the drain task can poll events
         // without holding the client mutex (which would deadlock
@@ -1447,6 +1519,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         let sink = Arc::clone(&self.sink);
         let workers = Arc::clone(&self.workers);
         let next_seqs = Arc::clone(&self.next_seqs);
+        let incompatible_binaries = Arc::clone(&self.incompatible_binaries);
         crate::task_util::spawn_supervised(
             "supervisor.drain",
             crate::task_util::PanicPolicy::Log,
@@ -1798,6 +1871,10 @@ impl<S: BroadcastSink> Supervisor<S> {
                                 // stale runner before dropping the worker
                                 // entry.
                                 if let AcpError::IncompatibleAgent(payload) = &e {
+                                    lock_recover(&incompatible_binaries).insert(
+                                        session_id.clone(),
+                                        respawn_config.spec.command.clone(),
+                                    );
                                     let seq = next_seq(&next_seqs, &session_id);
                                     sink.publish(
                                         &session_id,
@@ -1877,6 +1954,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                         session = %session_id,
                         "structured view worker respawned"
                     );
+                    lock_recover(&incompatible_binaries).remove(&session_id);
                     inbound = new_inbound;
                 }
             },
@@ -3990,6 +4068,57 @@ mod tests {
         let frames = sink.frames.lock().unwrap().clone();
         assert_eq!(frames.len(), 1);
         assert!(matches!(&frames[0].2, Event::UserPromptSent { .. }));
+    }
+
+    /// Incompatible-session tracking (#2109): a session marked for one
+    /// binary is returned only for that binary's query and only while it
+    /// has no live worker; clearing drops it. None of the test sessions
+    /// have a worker, so the `is_running` filter passes them all through.
+    #[tokio::test]
+    async fn incompatible_sessions_tracked_and_filtered_by_binary() {
+        let sup = Supervisor::new(VecSink::new());
+        sup.mark_incompatible_binary("s-claude-1", "claude-agent-acp");
+        sup.mark_incompatible_binary("s-claude-2", "claude-agent-acp");
+        sup.mark_incompatible_binary("s-codex", "codex-acp");
+
+        let mut claude = sup
+            .incompatible_sessions_for_binary("claude-agent-acp")
+            .await;
+        claude.sort();
+        assert_eq!(claude, vec!["s-claude-1", "s-claude-2"]);
+        assert_eq!(
+            sup.incompatible_sessions_for_binary("codex-acp").await,
+            vec!["s-codex"]
+        );
+        // Unknown binary matches nothing.
+        assert!(sup
+            .incompatible_sessions_for_binary("gemini")
+            .await
+            .is_empty());
+
+        // A clean (re)spawn clears the entry.
+        sup.clear_incompatible_binary("s-claude-1");
+        assert_eq!(
+            sup.incompatible_sessions_for_binary("claude-agent-acp")
+                .await,
+            vec!["s-claude-2"]
+        );
+    }
+
+    /// Force-respawn requests round-trip through the supervisor and drain
+    /// to empty so a second tick does not re-respawn the same session. See
+    /// #2109.
+    #[test]
+    fn force_respawn_requests_drain_once() {
+        let sup = Supervisor::new(VecSink::new());
+        sup.request_respawn("s-1");
+        sup.request_respawn("s-2");
+        sup.request_respawn("s-1"); // idempotent
+        let mut ids = sup.take_respawn_requests();
+        ids.sort();
+        assert_eq!(ids, vec!["s-1", "s-2"]);
+        // Drained: nothing left for the next tick.
+        assert!(sup.take_respawn_requests().is_empty());
     }
 
     /// `next_seq` increments per-session and is independent of the

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -160,6 +160,19 @@ pub async fn reconcile_acp_workers(
         respawn_history.remove(id);
     }
 
+    // Out-of-band respawn requests (web "Update & restart" after a global
+    // adapter install, #2109). These sessions failed their spawn on a
+    // compatibility rejection and have no live worker, so the
+    // `reap_user_stopped` path above never sees them; they sit pinned in
+    // `attempted`. Clear the guard (and the respawn budget, like an
+    // explicit restart) so the resume pass below fresh-spawns them on the
+    // freshly-installed adapter and the next handshake clears the red X.
+    for id in state.acp_supervisor.take_respawn_requests() {
+        attempted.remove(&id);
+        parked.remove(&id);
+        respawn_history.remove(&id);
+    }
+
     // Idle auto-stop (#1689). Cadence-gated to IDLE_REAP_INTERVAL so the
     // batched activity query does not run on every 2s tick. Runs BEFORE
     // the resume snapshot below: a worker marked dormant here is excluded

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -401,6 +401,12 @@ pub struct InstallAgentResponse {
     pub exit_code: Option<i32>,
     pub stdout: String,
     pub stderr: String,
+    /// How many *other* sessions parked on the same adapter's compatibility
+    /// rejection were queued for an automatic respawn on the freshly
+    /// installed version. The install is global, so one click clears every
+    /// red X. The current session is excluded (the client respawns it
+    /// directly). See #2109.
+    pub recovered_sessions: usize,
 }
 
 /// `POST /api/sessions/{id}/acp/install-agent`: run `npm install -g <pkg>`
@@ -545,6 +551,26 @@ pub async fn install_agent(
         }
     };
 
+    // On success the global npm prefix now carries the required version, so
+    // every other session parked on the same binary's compatibility check
+    // can recover too. Queue them for the reconciler to fresh-spawn; the
+    // current session is excluded because the client respawns it directly
+    // (and a double-spawn would race). See #2109.
+    let mut recovered_sessions = 0;
+    if output.status.success() {
+        for other in state
+            .acp_supervisor
+            .incompatible_sessions_for_binary(&binary)
+            .await
+        {
+            if other == id {
+                continue;
+            }
+            state.acp_supervisor.request_respawn(&other);
+            recovered_sessions += 1;
+        }
+    }
+
     Json(InstallAgentResponse {
         session_id: id,
         package: package.to_string(),
@@ -552,6 +578,7 @@ pub async fn install_agent(
         exit_code: output.status.code(),
         stdout: truncate_install_log(&output.stdout),
         stderr: truncate_install_log(&output.stderr),
+        recovered_sessions,
     })
     .into_response()
 }

--- a/web/src/components/acp/StartupErrorScreen.tsx
+++ b/web/src/components/acp/StartupErrorScreen.tsx
@@ -19,7 +19,12 @@ interface Props {
  *  "Restart agent" respawns the worker (re-running the handshake after a
  *  manual reinstall), and, when the agent is npm-installable and the
  *  `acp.allow_agent_install` setting is on, "Update & restart" runs the
- *  install on the host then respawns. See #2109. */
+ *  install on the host then respawns. The install is global, so it also
+ *  queues every other session blocked on the same adapter for an automatic
+ *  respawn (reported as `recovered_sessions`), clearing every red X from
+ *  one click. When the setting is off the button is shown disabled with a
+ *  hint to enable it in the TUI (it is `local_only`, so the web cannot flip
+ *  it). See #2109. */
 export function StartupErrorScreen({ detail, sessionId }: Props) {
   const heading = headingFor(detail);
   const summary = summaryFor(detail);
@@ -31,6 +36,7 @@ export function StartupErrorScreen({ detail, sessionId }: Props) {
   const [installState, setInstallState] = useState<"idle" | "installing" | "failed">("idle");
   const [installError, setInstallError] = useState<string | null>(null);
   const [installOutput, setInstallOutput] = useState<string | null>(null);
+  const [recoveredCount, setRecoveredCount] = useState(0);
 
   useEffect(() => {
     let alive = true;
@@ -59,6 +65,7 @@ export function StartupErrorScreen({ detail, sessionId }: Props) {
         setInstallError(`Install exited with code ${res.exit_code ?? "unknown"}.`);
         return;
       }
+      setRecoveredCount(res.recovered_sessions);
       setInstallState("idle");
       // Re-run the handshake against the freshly installed version.
       await respawn();
@@ -119,11 +126,34 @@ export function StartupErrorScreen({ detail, sessionId }: Props) {
               {installState === "installing" ? "Updating…" : "Update & restart"}
             </button>
           )}
+          {autoInstallable && !allowInstall && (
+            <button
+              type="button"
+              data-testid="startup-error-update-restart-disabled"
+              disabled
+              title="Enable acp.allow_agent_install in the aoe TUI settings (Advanced) to install from the dashboard"
+              className="cursor-not-allowed rounded-md border border-surface-700 bg-surface-800 px-3 py-1.5 text-xs font-medium text-text-dim opacity-60"
+            >
+              Update & restart
+            </button>
+          )}
         </div>
+
+        {autoInstallable && !allowInstall && (
+          <div className="mt-2 text-xs text-text-dim" data-testid="startup-error-enable-hint">
+            One-click install is off. Enable{" "}
+            <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">acp.allow_agent_install</code> in the{" "}
+            <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">aoe</code> TUI settings (Advanced) to
+            run the update from here. It is blocked from the web on purpose: it runs{" "}
+            <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">npm install</code> on the host.
+          </div>
+        )}
 
         {respawnState === "ok" && (
           <div className="mt-2 text-xs text-emerald-200/90">
             Restart requested. The agent re-runs the compatibility check on the next handshake.
+            {recoveredCount > 0 &&
+              ` Also restarting ${recoveredCount} other session${recoveredCount === 1 ? "" : "s"} blocked on the same adapter.`}
           </div>
         )}
         {respawnState === "failed" && respawnError && (

--- a/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
+++ b/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
@@ -122,19 +122,25 @@ describe("StartupErrorScreen", () => {
     );
   });
 
-  it("hides Update & restart when the install setting is off", async () => {
+  it("shows a disabled Update & restart plus an enable hint when the install setting is off", async () => {
     fetchSettings.mockResolvedValue({ acp: { allow_agent_install: false } });
-    const { queryByTestId } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" />);
-    // Give the settings effect a tick to resolve.
+    const { queryByTestId, findByTestId } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" />);
+    // The active button stays hidden; the disabled placeholder + hint appear.
     await waitFor(() => expect(fetchSettings).toHaveBeenCalled());
     expect(queryByTestId("startup-error-update-restart")).toBeNull();
+    const disabled = await findByTestId("startup-error-update-restart-disabled");
+    expect((disabled as HTMLButtonElement).disabled).toBe(true);
+    const hint = await findByTestId("startup-error-enable-hint");
+    expect(hint.textContent).toContain("acp.allow_agent_install");
   });
 
-  it("hides Update & restart for non-npm agents even when the setting is on", async () => {
+  it("hides Update & restart entirely for non-npm agents even when the setting is on", async () => {
     fetchSettings.mockResolvedValue({ acp: { allow_agent_install: true } });
     const { queryByTestId } = render(<StartupErrorScreen detail={incompatible(false)} sessionId="s1" />);
     await waitFor(() => expect(fetchSettings).toHaveBeenCalled());
     expect(queryByTestId("startup-error-update-restart")).toBeNull();
+    expect(queryByTestId("startup-error-update-restart-disabled")).toBeNull();
+    expect(queryByTestId("startup-error-enable-hint")).toBeNull();
   });
 
   it("Update & restart installs then respawns on success", async () => {
@@ -146,6 +152,7 @@ describe("StartupErrorScreen", () => {
       exit_code: 0,
       stdout: "added 1 package",
       stderr: "",
+      recovered_sessions: 0,
     });
     const { findByTestId } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" />);
     const btn = await findByTestId("startup-error-update-restart");
@@ -154,6 +161,22 @@ describe("StartupErrorScreen", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenCalledWith("/api/sessions/s1/acp/spawn", expect.objectContaining({ method: "POST" })),
     );
+  });
+
+  it("reports how many other sessions were queued for recovery after a global install", async () => {
+    fetchSettings.mockResolvedValue({ acp: { allow_agent_install: true } });
+    installAcpAgent.mockResolvedValue({
+      session_id: "s1",
+      package: "@agentclientprotocol/claude-agent-acp@latest",
+      success: true,
+      exit_code: 0,
+      stdout: "added 1 package",
+      stderr: "",
+      recovered_sessions: 3,
+    });
+    const { findByTestId, container } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" />);
+    fireEvent.click(await findByTestId("startup-error-update-restart"));
+    await waitFor(() => expect(container.textContent).toContain("3 other sessions"));
   });
 
   it("Update & restart surfaces the error and does not respawn on failure", async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -687,6 +687,9 @@ export interface InstallAgentResponse {
   exit_code: number | null;
   stdout: string;
   stderr: string;
+  /** Other sessions blocked on the same adapter that were queued for an
+   *  automatic respawn (the install is global). See #2109. */
+  recovered_sessions: number;
 }
 
 /** Run `npm install -g` for the session's agent on the host. Opt-in and


### PR DESCRIPTION
## Description

When an ACP adapter version bumps under `aoe`, every session using it lands on the **Adapter compatibility check failed** screen with a red X. The #2109 "Update & restart" button installed the adapter globally but respawned **only the current session**, so the other red Xs stuck around until each was manually restarted, and the button was hidden entirely when `acp.allow_agent_install` was off (no discoverable path).

This makes one click fix everything:

- **Track blocked sessions by binary.** `Supervisor` records sessions parked on a compatibility rejection keyed by the failed binary, populated at both `IncompatibleAgent` publish sites and cleared on a clean (re)spawn.
- **Auto-recover all sessions.** On a successful host install, the install endpoint queues every *other* session blocked on the same binary for an automatic respawn via a new force-respawn channel the reconciler drains each tick (clearing the `attempted` guard so the resume pass fresh-spawns them). The handshake re-runs on the freshly installed adapter and each red X clears. The response reports `recovered_sessions`, shown in the UI ("Also restarting N other sessions").
- **Discoverable button.** When `acp.allow_agent_install` is off the screen shows a **disabled** Update & restart button plus a hint to enable it in the TUI.

### Note on the enable path
`acp.allow_agent_install` is `local_only`: `strip_local_only` drops it from *every* web settings PATCH (remote or local), so the web can never set it. The button is enabled from the TUI settings (Advanced) or config file. The prior troubleshooting-doc claim that a localhost dashboard connection could flip it on was inaccurate and is corrected here.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec (`StartupErrorScreen.test.tsx`: disabled-button + enable-hint branch, recovered-count message). Existing `acp.startup-error-screen` coverage-matrix entry already maps this component + spec.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. Backend logic covered by new supervisor unit tests (`incompatible_sessions_tracked_and_filtered_by_binary`, `force_respawn_requests_drain_once`).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation and prose via back-and-forth; idea and decisions are mine.

- [ ] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784307829&installation_id=139138837&pr_number=2263&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2263&signature=2dd921215202d24bf91f154d5bc2ac22c1c0c9e28d5dbd22bfaa6a06c6286622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR improves the handling of adapter version updates in ACP (Agent Compatibility Platform) when multiple sessions are running. Previously, when an adapter was updated, only the current session would be updated and restarted, leaving other sessions stuck on an error screen. This PR implements automatic recovery for all affected sessions and clarifies the user experience around install permissions.

## What Changed

**Documentation Updates**
- Updated troubleshooting guide to explain the improved recovery flow, including how multiple sessions are automatically restarted
- Clarified that `acp.allow_agent_install` is disabled by default and can only be toggled in the TUI (not via the web dashboard)

**Session Tracking & Recovery**
- The Supervisor now maintains a registry of which sessions are blocked on specific adapter failures
- When an adapter is successfully installed, other sessions that were waiting on that adapter are automatically queued for respawn
- The reconciler processes these respawn requests and clears any error states, allowing sessions to restart cleanly on the new adapter

**User Interface Improvements**
- The "Update & restart" button now displays in a disabled state with a helpful hint when `acp.allow_agent_install` is disabled (rather than being hidden)
- Success messages now indicate how many other sessions were automatically recovered (e.g., "Also restarting 3 other sessions")
- Added tests to verify the disabled button state and recovery reporting behavior

**API Response Enhancement**
- The install endpoint response now includes a `recovered_sessions` count, reporting how many other blocked sessions are being automatically restarted

## Benefits

- **Reduced manual work:** Users no longer need to manually restart each session after an adapter update
- **Better visibility:** The disabled button state makes it clear why the install option isn't available, rather than appearing hidden
- **Clearer user guidance:** Documentation and UI hints help users understand the `acp.allow_agent_install` setting and how to enable it
- **Improved reliability:** All sessions recover automatically after an adapter version bump, preventing prolonged error states

## Technical Components Added

- New session tracking APIs in `Supervisor`: `request_respawn()`, `take_respawn_requests()`, `incompatible_sessions_for_binary()`
- Reconciler enhancement to process and drain respawn requests
- Response field `recovered_sessions` added to track successful automatic recoveries
- UI state and message updates to reflect multi-session recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->