### PR TITLE
fix(serve): flip sidebar dot to Running on agent activity

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3768,6 +3768,15 @@ pub(crate) fn derive_acp_status(event: &crate::acp::Event) -> Option<StatusInten
         Event::UserPromptSent { .. }
         | Event::ApprovalResolved { .. }
         | Event::ElicitationResolved { .. } => Some(StatusIntent::Set(Status::Running)),
+        // Agent transcript output means a turn is live even when no
+        // UserPromptSent preceded it. A fired ScheduleWakeup or a background
+        // TaskOutput notification resumes the turn agent-side, streaming only
+        // these events; aoe never publishes a prompt for them, so without this
+        // the sidebar dot stayed grey through real work. apply_status_intent's
+        // guards keep a deliberate Stopped grey and no-op once already Running.
+        Event::ThinkingStarted
+        | Event::AgentMessageChunk { .. }
+        | Event::ToolCallStarted { .. } => Some(StatusIntent::Set(Status::Running)),
         // A pending approval or elicitation both block the turn on the
         // user, so the sidebar dot goes yellow either way.
         Event::ApprovalRequested { .. } | Event::ElicitationRequested { .. } => {
@@ -4628,14 +4637,37 @@ mod tests {
 
     #[cfg(feature = "serve")]
     #[test]
-    fn derive_acp_status_ignores_streaming_and_string_events() {
+    fn derive_acp_status_running_on_agent_activity() {
+        use crate::acp::state::ToolCall;
         use crate::acp::Event;
-        // Mid-turn events that shouldn't move the session out of Running.
+        // A turn that resumes agent-side (fired ScheduleWakeup, background
+        // TaskOutput notification) streams only these events, never a
+        // UserPromptSent. They must drive Running so the sidebar dot recovers.
         assert_eq!(
             derive_acp_status(&Event::AgentMessageChunk { text: "x".into() }),
-            None
+            Some(StatusIntent::Set(Status::Running))
         );
-        assert_eq!(derive_acp_status(&Event::ThinkingStarted), None);
+        assert_eq!(
+            derive_acp_status(&Event::ThinkingStarted),
+            Some(StatusIntent::Set(Status::Running))
+        );
+        assert_eq!(
+            derive_acp_status(&Event::ToolCallStarted {
+                tool_call: ToolCall {
+                    id: "t".into(),
+                    name: "shell".into(),
+                    kind: "execute".into(),
+                    args_preview: "{}".into(),
+                    started_at: chrono::Utc::now(),
+                    parent_tool_call_id: None,
+                    memory_recall: None,
+                    diffs: Vec::new(),
+                },
+            }),
+            Some(StatusIntent::Set(Status::Running))
+        );
+        // ThinkingEnded is a sub-phase terminator, not a work signal; leaving
+        // it None avoids needless intents (ThinkingStarted already set Running).
         assert_eq!(derive_acp_status(&Event::ThinkingEnded), None);
     }
 
@@ -4668,6 +4700,20 @@ mod tests {
         // The UserPromptSent that follows the respawn then drives Running.
         apply(&mut inst, StatusIntent::Set(Status::Running));
         assert_eq!(inst.status, Status::Running);
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn agent_activity_wakes_an_idle_session_after_a_fired_wakeup() {
+        // A session that paused on ScheduleWakeup sits Idle. When the wake
+        // fires the turn resumes agent-side with activity events (no
+        // UserPromptSent), so the activity-derived Set(Running) must flip the
+        // dot green instead of leaving it grey.
+        let mut inst = stopped_structured_instance();
+        inst.status = Status::Idle;
+        apply(&mut inst, StatusIntent::Set(Status::Running));
+        assert_eq!(inst.status, Status::Running);
+        assert_eq!(inst.idle_entered_at, None);
     }
 
     #[cfg(feature = "serve")]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A structured-view session that pauses (for example, calling `ScheduleWakeup` to wait for a build) goes Idle and the sidebar dot turns grey, which is correct. When the wake fires, or when a background `TaskOutput` notification arrives, the agent resumes its turn agent-side: it streams transcript activity (`ThinkingStarted` / `AgentMessageChunk` / `ToolCallStarted`) but no `UserPromptSent`. aoe only publishes `UserPromptSent` when it forwards a user/aoe prompt through `/acp/prompt`, so a self-resumed turn never produces one.

`derive_acp_status` mapped only `UserPromptSent` / `ApprovalResolved` / `ElicitationResolved` to `Running`, so after a wake-fire or task-output resume the session stayed on the `Idle` it entered at the pause. The dot stayed grey while the agent was actively working.

This maps `ThinkingStarted` / `AgentMessageChunk` / `ToolCallStarted` to `Set(Running)`. The existing `apply_status_intent` guards are intact: a deliberate `Stopped` (manual stop, rate-limit park) is never woken by trailing activity, and `status == target` no-ops once already Running, so there is no mid-turn broadcast spam. The startup seeding path is unaffected because `latest_status_event` does not return activity events.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] In the web dashboard, start a structured-view (Claude) session and give it a task that calls `ScheduleWakeup` (or run a `/loop`), so it pauses and the sidebar dot goes grey (Idle).
- [ ] Wait for the wake to fire. Confirm the dot turns green (Running spinner) as soon as the agent resumes streaming, instead of staying grey.
- [ ] Repeat with a background task: have the agent launch a background `Bash`/Task and later read its output via `TaskOutput`. Confirm the dot returns to green when the agent resumes on the task notification.
- [ ] Deliberately stop a session (manual stop). Confirm trailing activity does NOT revive the dot, it stays grey.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Skipped a test, because: the fix is backend status-derivation in `src/server/mod.rs`; it is covered by Rust unit tests (`derive_acp_status_running_on_agent_activity`, `agent_activity_wakes_an_idle_session_after_a_fired_wakeup`) and no `web/` file changed.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: status derivation is a pure function with direct unit tests proving both directions (activity wakes Idle to Running; a deliberate Stopped stays grey); a full e2e is not warranted for a one-arm match change.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls and reviewed each change.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784307947&installation_id=139138837&pr_number=2264&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2264&signature=e1c79e2a4fe09919ac8d09de2dd8680c8a519add7735300c94017bc40eb26e71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary of Changes

**What was changed:**
- Updated `derive_acp_status()` function in `src/server/mod.rs` to recognize agent-side activity events as indicators of an active turn

**What was added:**
Three new event-to-status mappings that drive the session status to `Running`:
- `ThinkingStarted` 
- `AgentMessageChunk`
- `ToolCallStarted`

**What was removed/replaced:**
The old test asserting that streaming/activity events were ignored was replaced with a new test validating they now correctly map to `Running` status.

**New tests added:**
- `derive_acp_status_running_on_agent_activity`: Validates that the three agent activity events map to `Running` status
- `agent_activity_wakes_an_idle_session_after_a_fired_wakeup`: Verifies that applying `StatusIntent::Set(Status::Running)` to an Idle session properly transitions it to Running and clears the `idle_entered_at` timestamp

## Non-Technical Explanation

**The Problem:**
When a structured-view session pauses to wait for a scheduled wakeup or background task, the sidebar status indicator dot turns grey (Idle). When the session resumes and the agent starts working again, the dot should turn green (Running), but it was staying grey even though real work was happening.

**Root Cause:**
The status logic only recognized "user prompt sent" events as signals of active work. When a session resumed from a scheduled wakeup or background notification, it would stream only agent activity events (thinking, message chunks, tool calls), never a "user prompt sent" event, so the system didn't realize work was occurring.

**The Fix:**
Added recognition of three agent-activity event types (`ThinkingStarted`, `AgentMessageChunk`, `ToolCallStarted`) as signals that a turn is actively running. Existing safety guards ensure:
- Manually stopped sessions stay grey despite trailing activity
- Already-running sessions don't spam unnecessary status broadcasts
- Startup behavior is unaffected

## Benefits

- Users now see accurate real-time status for sessions resuming from scheduled wakeups and background tasks
- Sessions that pause and resume will correctly reflect active work in the UI
- The fix is minimal and surgical, with comprehensive test coverage ensuring it doesn't affect other status transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->