### PR TITLE
fix(serve): make structured-view smart-rename observable and robust

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -29,6 +29,7 @@ Top-level roots:
 | `hooks` | Agent hook install/uninstall, status-file lifecycle, hook command + watcher failures. |
 | `sound` | Notification sound download/install and per-event playback. |
 | `telemetry` | Opt-in usage telemetry (all `debug`); consent route emits under `http.api.telemetry`. |
+| `smart_rename` | First-message auto-rename of structured-view sessions: eligibility skips (`debug`) and the rename outcome (`info`). |
 | `log.runtime` | Filter swaps (REST + runner file-watch). A swap matching the active directive is a silent no-op, so a watcher write cannot re-trigger itself. |
 
 ## Levels

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -147,6 +147,7 @@ pub const DEFAULT_TARGET_ROOTS: &[&str] = &[
     "hooks",
     "sound",
     "telemetry",
+    "smart_rename",
 ];
 
 /// Sub-targets users can tune individually from the settings UI.
@@ -1096,6 +1097,19 @@ mod tests {
                 "missing {root} in {s}"
             );
         }
+    }
+
+    #[test]
+    fn smart_rename_target_is_captured_by_default_filter() {
+        // The expanded filter has no global default directive, so a target that
+        // is not a known root is dropped at every level. smart_rename emits under
+        // `target: "smart_rename"`; without a root entry its skip/success lines
+        // are invisible and the feature cannot be diagnosed.
+        let s = LogConfig::filter_for_level(LogLevel::Debug);
+        assert!(
+            s.contains("smart_rename=debug"),
+            "smart_rename root missing from filter: {s}"
+        );
     }
 
     #[test]

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -247,7 +247,7 @@ mod serve {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
-    const ONESHOT_TIMEOUT: Duration = Duration::from_secs(12);
+    const ONESHOT_TIMEOUT: Duration = Duration::from_secs(45);
 
     /// Marks a session as having an in-flight one-shot rename so a burst of
     /// rapid first prompts cannot spawn concurrent title generators. Removed on
@@ -326,9 +326,22 @@ mod serve {
             return;
         };
 
-        // One attempt per session lifetime. A failed or unusable first try
-        // leaves the name default; without this guard every later prompt would
-        // respawn a one-shot agent (12s + tokens) until one happened to succeed.
+        let prompt = build_prompt(&first_message);
+        let Some(argv) = build_oneshot_argv(agent, &prompt) else {
+            return;
+        };
+
+        // A spawn error, timeout, or non-zero exit returns None. Do NOT mark the
+        // session attempted in that case: a transient slow first prompt (cold
+        // agent start) must not permanently disable naming. A later prompt
+        // retries. The inflight guard above already prevents concurrent spawns.
+        let Some(raw) = run_oneshot(&argv, &project_path).await else {
+            return;
+        };
+
+        // The agent produced output (usable or not). Mark attempted now, once per
+        // session lifetime: an answer the sanitizer rejects is not worth respawning
+        // a one-shot agent (tokens) for on every later prompt.
         {
             let mut attempted = state
                 .smart_rename_attempted
@@ -338,15 +351,6 @@ mod serve {
                 return;
             }
         }
-
-        let prompt = build_prompt(&first_message);
-        let Some(argv) = build_oneshot_argv(agent, &prompt) else {
-            return;
-        };
-
-        let Some(raw) = run_oneshot(&argv, &project_path).await else {
-            return;
-        };
         let Some(new_title) = sanitize_title(&raw, &first_message) else {
             tracing::debug!(target: "smart_rename", session = %session_id, "skip: agent output not a usable title");
             return;
@@ -441,6 +445,24 @@ mod serve {
                 tracing::info!(target: "smart_rename", session = %id, old = %inst.title, new = %new_title, "renamed session from first message");
                 inst.title = new_title.to_string();
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[tokio::test]
+        async fn run_oneshot_returns_none_on_spawn_failure() {
+            // A failed spawn must surface as None so try_smart_rename leaves the
+            // session un-attempted and a later prompt can retry. A binary that
+            // does not exist is the deterministic, machine-independent failure.
+            let argv = vec![
+                "aoe-smart-rename-nonexistent-binary-xyz".to_string(),
+                "-p".to_string(),
+                "title this".to_string(),
+            ];
+            assert!(run_oneshot(&argv, "").await.is_none());
         }
     }
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Makes the new structured-view smart-rename feature observable and robust. (The tied-worktree-rename crash this branch originally also targeted is already fixed on main by #2260, which quiesces the worker before the move and resumes the conversation at the new path; that work has been dropped from here to avoid conflicting with it.)

Two commits:

1. **Logging.** The smart-rename path logs every eligibility skip (`debug`) and each rename outcome (`info`) under `target: "smart_rename"`, but that target was not in `DEFAULT_TARGET_ROOTS`. The default filter expands a level into one directive per root with no global default, so the target was dropped at every level: zero output, feature undiagnosable. Added the root and a row to the logging taxonomy doc.

2. **One-shot robustness.** The session was marked attempted (one try per daemon lifetime) before the one-shot ran, so a spawn error or timeout left it permanently un-named until a restart. Mark attempted only after the one-shot returns output, so a transient slow start retries on the next prompt while a usable-but-rejected answer still does not respawn the agent every prompt. Also raised the one-shot timeout from 12s to 45s, since a cold agent start (`claude -p` and friends) routinely exceeds 12s and times out into the bug above.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe log-level smart_rename=debug`, send a first prompt to a fresh civ-named structured-view session, and confirm a `smart_rename` line appears (a skip reason, or `renamed session from first message`). Before this PR there was no output at all, at any level.
- [ ] Send a first prompt that makes the agent's cold start exceed 12s and confirm the session still auto-renames (no premature 12s timeout) and is not left permanently un-named.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (logging filter + one-shot lifecycle on the backend).

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: covered by Rust unit tests instead. `smart_rename_target_is_captured_by_default_filter` asserts the logging root is present; `run_oneshot_returns_none_on_spawn_failure` pins the failure path the retry guard keys off. The attempted-after-result reorder is a localized control-flow change in the serve module.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a crash that occurs when renaming sessions with tied worktree directories in a structured-view worker context. The crash was caused by the worker attempting to resume a session using a stored ID that referenced an old, moved directory path.

## What Changed

**Logging improvements:**
- Added a new `smart_rename` logging target to enable diagnostic output for the auto-rename feature
- Updated logging documentation to include the new target

**One-shot robustness:**
- Increased the one-shot timeout from 12 seconds to 45 seconds to accommodate cold agent starts
- Changed when sessions are marked as "attempted": now happens after successful output instead of before execution, allowing transient failures to retry on subsequent prompts

**Core crash fix:**
- Modified the rename logic to clear the stored session ID when a worktree path actually moves, forcing a fresh session at the new location
- The live worker is shut down to prevent its cached working directory from interfering
- Branch-only renames (where the path stays the same) preserve the resumable session

## Key Trade-off

Renaming a tied session resets the agent's conversation since the prior session was rooted at the old directory and cannot be resumed. This design choice prioritizes functionality (users can rename sessions) over conversation continuity, and is documented in the worktree guides.

## Benefits

- **Prevents crashes**: Eliminates the `Internal error: Path "<old>" does not exist` crash
- **Improves reliability**: Transient timeouts no longer permanently disable session naming
- **Better diagnostics**: New logging enables troubleshooting of rename operations
- **Handles cold starts**: Longer timeout accommodates slower agent initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->