### PR TITLE
fix(release): drop obsolete clawhub publish.js sed workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,10 +284,6 @@ jobs:
         if: env.CLAWHUB_TOKEN != ''
         run: |
           bun install -g clawhub
-          # Workaround: clawhub CLI v0.7.0 doesn't send acceptLicenseTerms
-          GLOBAL_DIR="$(bun pm ls -g 2>/dev/null | head -1 | sed 's/ .*//')"
-          PUBLISH_JS="${GLOBAL_DIR}/node_modules/clawhub/dist/cli/commands/publish.js"
-          sed -i 's/slug,/slug, acceptLicenseTerms: true,/' "$PUBLISH_JS"
 
       - name: Publish skill
         if: env.CLAWHUB_TOKEN != ''


### PR DESCRIPTION
## Description

The `v1.11.1` release run's `Publish to ClawHub` job failed with:

```
.bun/install/global/node_modules/clawhub/dist/cli/commands/publish.js:55
  const resolved = await resolveSkillVersion(registry, slug, acceptLicenseTerms: true, hashed.fingerprint, optionalToken);
                                                             ^^^^^^^^^^^^^^^^^^
SyntaxError: missing ) after argument list
```

The "Install clawhub CLI" step carried a `sed` workaround written for clawhub **v0.7.0**, which patched `publish.js` to inject `acceptLicenseTerms`. That workaround is now both obsolete and actively breaking the job:

- Current clawhub (0.22.0, what `bun install -g clawhub` pulls) already sends `acceptLicenseTerms: true` natively in its publish payload.
- Its `resolveSkillVersion(registry, slug, fingerprint, token)` is now a positional call. The `sed s/slug,/slug, acceptLicenseTerms: true,/` injects an object-property fragment as a bare positional argument into that call, producing the syntax error above.

This drops the `sed` workaround, leaving just `bun install -g clawhub`.

Note: this only fixes future releases. Re-running the `v1.11.1` ClawHub publish job would still use the workflow at the `v1.11.1` tag (which has the broken `sed`), so the v1.11.1 skill mirror stays behind until the next release or a manual `clawhub publish`. The GitHub Release for v1.11.1 itself completed successfully.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**

Claude diagnosed the failing release job and drafted this CI fix via back-and-forth with @njbrake; the reasoning and decision are his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784317303&installation_id=139138837&pr_number=2269&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2269&signature=5e323669272460fb01645e8f65b7f5a6f80c5d82cd00def68fc0a810ba9e63d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The `publish-clawhub` job in the release workflow has been simplified by removing an obsolete workaround. Previously, a `sed` command modified the installed `clawhub` CLI's `publish.js` file to inject the `acceptLicenseTerms: true` parameter. This step has been completely removed, leaving only the straightforward `bun install -g clawhub` command to install the CLI.

**Lines changed:** 4 lines removed

## Benefits

This fix resolves a `SyntaxError: missing ) after argument list` that was blocking ClawHub publication in the v1.11.1 release. By removing the obsolete workaround:

- **Fixes the immediate issue**: The current clawhub version (0.22.0) already natively includes the `acceptLicenseTerms: true` functionality, making the workaround unnecessary.
- **Removes incompatible code**: The function signature for `resolveSkillVersion()` has changed from named parameters to positional arguments, causing the old `sed` injection to create invalid syntax.
- **Simplifies maintenance**: Eliminates technical debt by removing outdated code designed for an older clawhub version (0.7.0).

## Technical Details

The `sed` command was attempting to inject an object-property fragment (`acceptLicenseTerms: true,`) as a bare positional argument into the `resolveSkillVersion()` function call. This worked with the original function signature that accepted named parameters, but the current function expects positional arguments, causing the injected code to produce a syntax error. By removing the workaround and relying on the current clawhub's native implementation, the workflow now functions correctly.

**Impact scope:** Infrastructure/CI - Release workflow only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->