### PR TITLE
fix(serve): tied-worktree rename no longer crash-loops the structured-view worker

### DIFF
--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -72,6 +72,26 @@ fn record_and_check_respawn_budget(
     false
 }
 
+/// Build the banner published when a structured-view worker exhausts its
+/// respawn budget and the session is parked. When the session's project_path
+/// no longer exists on disk, every respawn is doomed for the same reason: the
+/// working directory was moved or deleted, not the adapter. Embed the exact
+/// `AcpError::ProjectPathMissing` Display text (`project path no longer exists:
+/// <path>`) so the web banner regex routes to the moved-cwd remediation instead
+/// of the misleading install-the-adapter copy. See #2260 and #1089.
+fn park_message(project_path: &str) -> String {
+    let base = format!(
+        "Structured view worker failed to stay up after {} restart attempts in {}s; auto-respawn paused.",
+        RECONCILER_MAX_RESPAWNS_IN_WINDOW,
+        RECONCILER_RESPAWN_WINDOW.as_secs(),
+    );
+    if !std::path::Path::new(project_path).exists() {
+        format!("{base} project path no longer exists: {project_path}")
+    } else {
+        format!("{base} Retry from the dashboard once the underlying issue is fixed.")
+    }
+}
+
 /// Per-target resume outcome. Drives whether the reconciler should
 /// retry on the next tick or leave `attempted` set so the same target
 /// isn't poked every 2s.
@@ -324,16 +344,9 @@ pub async fn reconcile_acp_workers(
                 "structured-view worker respawn budget exhausted; parking session"
             );
             if parked.insert(id.clone()) {
-                state.acp_supervisor.publish_startup_error(
-                    &id,
-                    format!(
-                        "Structured view worker failed to stay up after {} restart attempts in {}s; \
-                         auto-respawn paused. Retry from the dashboard once the underlying \
-                         issue is fixed.",
-                        RECONCILER_MAX_RESPAWNS_IN_WINDOW,
-                        RECONCILER_RESPAWN_WINDOW.as_secs(),
-                    ),
-                );
+                state
+                    .acp_supervisor
+                    .publish_startup_error(&id, park_message(&project_path));
             }
             attempted.insert(id);
             continue;
@@ -1114,17 +1127,25 @@ async fn build_spawn_request(
     target: &ResumeTarget,
 ) -> Result<crate::acp::supervisor::SpawnRequest, ()> {
     let supervisor = Arc::clone(&state.acp_supervisor);
+
+    let inst_lock = state.instance_lock(&target.id).await;
+    // Re-read project_path under the per-session lock instead of trusting
+    // target.project_path, which the reconciler snapshotted up to a tick ago.
+    // A tied-worktree rename (rename_session / set_worktree_name) holds this
+    // same lock across `git worktree move` plus the metadata write, so once we
+    // hold it the move has landed and the path is final. Spawning at the stale
+    // pre-move path is the crash-loop in #2260. Bail if the session vanished
+    // mid-flight (e.g. deleted during the handshake); ensure_container below
+    // re-acquires the same lock, so this read-and-release must not hold it.
+    let cwd = PathBuf::from(&target.project_path); // TEMP pre-fix
     let agent = supervisor
         .pick_agent_for_tool(
             &target.tool,
             target.agent_override.as_deref(),
             &target.source_profile,
-            std::path::Path::new(&target.project_path),
+            &cwd,
         )
         .await;
-    let cwd = PathBuf::from(&target.project_path);
-
-    let inst_lock = state.instance_lock(&target.id).await;
     let sandbox_info = match crate::acp::sandbox::ensure_container_for_session(
         &state.instances,
         &inst_lock,
@@ -1394,6 +1415,82 @@ mod tests {
     use chrono::{Duration, TimeZone, Utc};
 
     const HOUR_MS: i64 = 3_600_000;
+
+    // --- park banner classification (#2260) ---
+
+    /// When the parked session's project_path is gone, the banner must carry
+    /// the exact `ProjectPathMissing` Display text so the web routes to the
+    /// moved-cwd remediation instead of the install-the-adapter copy.
+    #[test]
+    fn park_message_names_missing_project_path() {
+        use super::park_message;
+        let missing = "/tmp/aoe-does-not-exist-2260/worktrees/Burmese";
+        let msg = park_message(missing);
+        assert!(
+            msg.contains(&format!("project path no longer exists: {missing}")),
+            "park message must embed the ProjectPathMissing text, got: {msg}"
+        );
+        // Defends the web regex contract: it must not steer to the adapter copy.
+        assert!(!msg.contains("Retry from the dashboard"));
+    }
+
+    /// When the project_path still exists, a park is not a moved-cwd problem,
+    /// so the generic retry copy is used (no false moved-cwd banner).
+    #[test]
+    fn park_message_generic_when_path_present() {
+        use super::park_message;
+        let present = std::env::temp_dir();
+        let msg = park_message(&present.to_string_lossy());
+        assert!(
+            !msg.contains("project path no longer exists"),
+            "an existing path must not produce the moved-cwd banner, got: {msg}"
+        );
+        assert!(msg.contains("Retry from the dashboard"));
+    }
+
+    // --- reconciler uses the live cwd, not the stale snapshot (#2260) ---
+
+    /// A tied-worktree rename moves the dir and updates the instance's
+    /// project_path, but the reconciler may already hold a ResumeTarget
+    /// snapshotted at the OLD path. build_spawn_request must re-read the
+    /// current project_path under the instance_lock so the respawn lands at
+    /// the new path; using the stale target path is the crash-loop in #2260.
+    #[tokio::test]
+    async fn build_spawn_request_uses_live_project_path_not_stale_target() {
+        use super::{build_spawn_request, ResumeTarget};
+        use crate::server::test_support::build_test_app_state;
+        use crate::session::{Instance, View};
+        use std::path::PathBuf;
+
+        let new_path = "/tmp/aoe-2260-after-rename";
+        let mut inst = Instance::new("renamed", new_path);
+        inst.id = "sess-2260".to_string();
+        inst.view = View::Structured; // structured, non-sandboxed
+        let state = build_test_app_state(vec![inst]);
+
+        // The reconciler snapshotted the pre-move path a tick ago.
+        let target = ResumeTarget {
+            id: "sess-2260".to_string(),
+            tool: "claude".to_string(),
+            agent_override: Some("claude".to_string()),
+            model: None,
+            project_path: "/tmp/aoe-2260-before-rename".to_string(),
+            stored_acp_session_id: None,
+            source_profile: "default".to_string(),
+            in_flight_turn: false,
+            yolo_mode: false,
+            command: String::new(),
+        };
+
+        let req = build_spawn_request(&state, &target)
+            .await
+            .expect("spawn request builds for a non-sandboxed structured session");
+        assert_eq!(
+            req.cwd,
+            PathBuf::from(new_path),
+            "respawn must target the current project_path, not the stale snapshot"
+        );
+    }
 
     // --- reconciler respawn budget (#1945) ---
 

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1137,7 +1137,14 @@ async fn build_spawn_request(
     // pre-move path is the crash-loop in #2260. Bail if the session vanished
     // mid-flight (e.g. deleted during the handshake); ensure_container below
     // re-acquires the same lock, so this read-and-release must not hold it.
-    let cwd = PathBuf::from(&target.project_path); // TEMP pre-fix
+    let cwd = {
+        let _guard = inst_lock.lock().await;
+        let instances = state.instances.read().await;
+        let Some(inst) = instances.iter().find(|i| i.id == target.id) else {
+            return Err(());
+        };
+        PathBuf::from(&inst.project_path)
+    };
     let agent = supervisor
         .pick_agent_for_tool(
             &target.tool,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -807,6 +807,50 @@ fn apply_session_title_rename(inst: &mut Instance, title: String) {
     inst.title = title;
 }
 
+/// Quiesce a structured-view worker before its worktree directory is moved.
+/// A live ACP worker is pinned to the current cwd; `git worktree move` pulls
+/// that directory out, the worker crashes, and the supervisor respawns it at
+/// the stale baked-in cwd, crash-looping until the reconciler parks the
+/// session with a misleading install-the-adapter banner (#2260). The
+/// blocks_worktree_edit gate does not catch this because a structured session
+/// the user "stopped" sits at Idle yet still owns a live worker.
+///
+/// `shutdown` is the reversible teardown: it keeps the agent transcript and the
+/// instance's acp_session_id, so once the move lands the reconciler fresh-spawns
+/// at the new path and resumes context via session/load. Callers hold the
+/// session's instance_lock across shutdown plus move plus persist, and the
+/// reconciler re-reads project_path under that same lock, so the post-move
+/// respawn never targets the old path. No-op for a session with no live worker;
+/// refuses the move (409) if a live worker cannot be stopped, so the directory
+/// is never moved out from under one.
+async fn quiesce_structured_worker_for_worktree_move(
+    state: &Arc<AppState>,
+    id: &str,
+    is_structured: bool,
+) -> Result<(), axum::response::Response> {
+    if !is_structured {
+        return Ok(());
+    }
+    match state.acp_supervisor.shutdown(id).await {
+        Ok(()) | Err(crate::acp::supervisor::SupervisorError::UnknownSession(_)) => Ok(()),
+        Err(e) => {
+            tracing::warn!(
+                target: "http.api.sessions",
+                session = %id,
+                "could not stop structured-view worker before worktree move: {e}"
+            );
+            Err((
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": "worker_shutdown_failed",
+                    "message": "Could not stop the structured view worker before renaming; retry in a moment"
+                })),
+            )
+                .into_response())
+        }
+    }
+}
+
 pub async fn rename_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -846,7 +890,7 @@ pub async fn rename_session(
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
-    let (worktree_info, current_path, status, profile, is_sandboxed) = {
+    let (worktree_info, current_path, status, profile, is_sandboxed, is_structured) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return (
@@ -861,6 +905,7 @@ pub async fn rename_session(
             inst.status,
             inst.source_profile.clone(),
             inst.is_sandboxed(),
+            inst.is_structured(),
         )
     };
 
@@ -901,6 +946,17 @@ pub async fn rename_session(
                 })),
             )
                 .into_response();
+        }
+
+        // Stop any live structured-view worker before the move so it can't
+        // crash on the pulled-out cwd and respawn-loop at the stale path
+        // (#2260). Done under the instance_lock held since the top of this
+        // function. Preserves the agent transcript so the reconciler resumes
+        // context at the new path.
+        if let Err(resp) =
+            quiesce_structured_worker_for_worktree_move(&state, &id, is_structured).await
+        {
+            return resp;
         }
 
         let wt = worktree_info.expect("tied implies worktree_info is Some");
@@ -1126,7 +1182,7 @@ pub async fn set_worktree_name(
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
-    let (worktree_info, current_path, status, profile, is_sandboxed) = {
+    let (worktree_info, current_path, status, profile, is_sandboxed, is_structured) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return (
@@ -1141,6 +1197,7 @@ pub async fn set_worktree_name(
             inst.status,
             inst.source_profile.clone(),
             inst.is_sandboxed(),
+            inst.is_structured(),
         )
     };
 
@@ -1189,6 +1246,14 @@ pub async fn set_worktree_name(
             })),
         )
             .into_response();
+    }
+
+    // Stop any live structured-view worker before the move so it can't crash on
+    // the pulled-out cwd and respawn-loop at the stale path (#2260). Held under
+    // the instance_lock acquired at the top of this function.
+    if let Err(resp) = quiesce_structured_worker_for_worktree_move(&state, &id, is_structured).await
+    {
+        return resp;
     }
 
     let wt = worktree_info.clone();

--- a/web/src/components/acp/__tests__/StartupErrorBanner.test.tsx
+++ b/web/src/components/acp/__tests__/StartupErrorBanner.test.tsx
@@ -52,6 +52,29 @@ describe("StartupErrorBanner native-binary branch", () => {
   });
 });
 
+describe("StartupErrorBanner respawn-budget park with a moved project_path (#2260)", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ exists: false, tail: "" }) }),
+    );
+  });
+
+  // The reconciler park banner embeds the ProjectPathMissing Display text when
+  // the cwd is gone (see acp_reconciler::park_message). The banner must route to
+  // the moved-cwd remediation, not tell the user to reinstall a healthy adapter.
+  const PARK_MOVED_CWD =
+    "Structured view worker failed to stay up after 5 restart attempts in 60s; auto-respawn paused. " +
+    "project path no longer exists: /Users/me/aoe/worktrees/Burmese";
+
+  it("renders the moved-cwd remediation and echoes the path, not the doctor --fix copy", () => {
+    const { container } = render(<StartupErrorBanner sessionId="s-1" message={PARK_MOVED_CWD} />);
+    expect(container.textContent).toContain("working directory no longer exists");
+    expect(container.textContent).toContain("/Users/me/aoe/worktrees/Burmese");
+    expect(container.textContent).not.toContain("aoe acp doctor --fix");
+  });
+});
+
 describe("StartupErrorBanner fallback branch (unchanged)", () => {
   it("still renders the doctor --fix copy on a generic failure", () => {
     vi.stubGlobal(


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Renaming a tied-worktree structured-view (ACP) session from the dashboard moved the worktree directory out from under the still-live worker. The `blocks_worktree_edit` gate allows `Status::Idle`, but an idle structured-view session still owns a running worker pinned to the old cwd. `git worktree move` pulled the directory out, the worker crashed, and the supervisor respawned it at its baked-in old cwd, looping `ProjectPathMissing` until the reconciler's respawn budget parked the session behind a red banner that wrongly told the user to reinstall the ACP adapter. After a while it respawned at the new path but without its prior conversation context.

This fixes both layers:

- Coordination: `rename_session` and `set_worktree_name` now stop any live structured-view worker via `supervisor.shutdown` before the move. `shutdown` is the reversible teardown, so it keeps the agent transcript and the instance's `acp_session_id`; the reconciler then fresh-spawns at the new path and resumes context via `session/load`. Both handlers already hold the session `instance_lock` across shutdown, move, and persist, and `build_spawn_request` now re-reads `project_path` from the live instance under that same lock instead of trusting the stale snapshot the reconciler captured up to a tick earlier. That serialization is what guarantees the respawn lands at the new directory, never the moved-away one.
- Banner: when a parked session's `project_path` no longer exists on disk, the park message now embeds the exact `project path no longer exists: <path>` text so the dashboard routes to the moved-cwd remediation (with the path) instead of the install-the-adapter copy. This restores the #1089 intent at the respawn-budget park boundary, where the classification used to be lost.

The git branch keeping its old auto-generated name after a rename is unchanged: branch rename stays opt-in per #1927.

Closes #2260

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start `aoe serve`, create a structured-view session on an aoe-managed worktree with "Tie Worktree Directory to Session Name" on, prompt the agent so a worker is live, let it go Idle.
- [ ] Rename the session from the sidebar; confirm the worktree directory and title move to the new name and no red "failed to stay up" banner appears.
- [ ] Send a follow-up prompt; confirm the agent still has its earlier conversation context (resumed, not a fresh transcript).
- [ ] Separately, move or delete a structured session's worktree directory out from under a live worker and let it park; confirm the banner says the working directory moved and shows the path, and does NOT say to run `aoe acp doctor --fix` or `npm install`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

The user-visible regression (the park banner steering to the wrong remediation) is asserted by an added Vitest case in `web/src/components/acp/__tests__/StartupErrorBanner.test.tsx`, which is the right layer for banner-copy routing per AGENTS.md; that spec is already mapped to `StructuredView.tsx` in `coverage-matrix.json`, so the matrix needs no new entry. The backend coordination is covered by Rust unit tests in `src/server/acp_reconciler.rs` (`build_spawn_request` re-reads the live `project_path`; `park_message` names a missing cwd and stays generic otherwise).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with the worker-lifecycle approach pressure-tested across two external models. I made the design calls, reviewed each commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784319094&installation_id=139138837&pr_number=2271&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2271&signature=669fbf7d48a6f227854f926b11dbb52bc44ee521169a44328df7c0636a9551b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a crash-loop bug in the structured-view worker when renaming a tied-worktree session. The issue occurred because renaming a session moved the worktree directory while the worker was still running, causing the worker to crash and respawn at the stale path.

### What Changed

**Better error messaging for moved sessions:** Added a `park_message()` function that detects when a session's working directory no longer exists on disk and displays an accurate error message instead of suggesting an adapter reinstall.

**Worker cleanup before directory moves:** Added `quiesce_structured_worker_for_worktree_move()` helper that stops any running workers before the session directory is moved during rename operations. This prevents workers from crashing when their working directory disappears.

**Use of live path information:** Modified worker respawn logic to read the current project path from active session state (under proper locking) instead of using stale path information captured before the rename.

**Test coverage:** Added tests validating the error message routing for moved directories and verifying that respawned workers use the updated directory path.

### Technical Details

- `park_message()` in `acp_reconciler.rs` generates startup/banner copy by checking if `project_path` exists and embedding `AcpError::ProjectPathMissing` text when the path is missing
- `quiesce_structured_worker_for_worktree_move()` in `sessions.rs` calls supervisor shutdown to stop workers before directory moves
- `rename_session` and `set_worktree_name` handlers now invoke the quiesce helper while holding the session lock, ensuring consistent state across shutdown, move, and metadata persist
- `build_spawn_request()` re-reads `project_path` from the live instance state under the per-session lock instead of using a snapshot, ensuring respawn occurs at the correct directory
- Added unit tests for banner classification and a Tokio test verifying live path usage in respawn

### Benefits

- Eliminates crash-loop when renaming idle structured-view sessions
- Preserves conversation context on worker respawn by reusing stored `acp_session_id`
- Provides accurate, actionable error messages when sessions fail due to moved directories
- Ensures worker registry paths stay synchronized with persisted session state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->