### PR TITLE
fix(migrations): route all persistent writes through atomic_write

### DIFF
--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -185,7 +185,7 @@ fn get_current_version() -> u32 {
 fn set_version(version: u32) -> Result<()> {
     let dir = crate::session::get_app_dir()?;
     let version_file = dir.join(VERSION_FILE);
-    fs::write(&version_file, version.to_string())?;
+    crate::session::atomic_write(&version_file, version.to_string().as_bytes())?;
     debug!("Updated schema version to {}", version);
     Ok(())
 }

--- a/src/migrations/v003_yolo_mode_config.rs
+++ b/src/migrations/v003_yolo_mode_config.rs
@@ -90,7 +90,7 @@ fn migrate_config_file(path: &PathBuf) -> Result<()> {
     }
 
     let new_content = toml::to_string_pretty(&doc)?;
-    fs::write(path, new_content)?;
+    crate::session::atomic_write(path, new_content.as_bytes())?;
 
     Ok(())
 }

--- a/src/migrations/v004_unified_environment.rs
+++ b/src/migrations/v004_unified_environment.rs
@@ -71,7 +71,7 @@ fn migrate_config_file(path: &PathBuf) -> Result<()> {
             sandbox.remove("environment_values");
         }
         let new_content = toml::to_string_pretty(&doc)?;
-        fs::write(path, new_content)?;
+        crate::session::atomic_write(path, new_content.as_bytes())?;
         return Ok(());
     }
 
@@ -104,7 +104,7 @@ fn migrate_config_file(path: &PathBuf) -> Result<()> {
     sandbox.remove("environment_values");
 
     let new_content = toml::to_string_pretty(&doc)?;
-    fs::write(path, new_content)?;
+    crate::session::atomic_write(path, new_content.as_bytes())?;
 
     Ok(())
 }

--- a/src/migrations/v005_cockpit_defaults.rs
+++ b/src/migrations/v005_cockpit_defaults.rs
@@ -54,7 +54,7 @@ pub(crate) fn run_in(app_dir: &Path) -> Result<()> {
     doc.insert("cockpit".into(), toml::Value::Table(cockpit));
 
     let serialized = toml::to_string_pretty(&doc)?;
-    fs::write(&global_config, serialized)?;
+    crate::session::atomic_write(&global_config, serialized.as_bytes())?;
 
     info!(
         "v005: seeded [cockpit] section in {}",

--- a/src/migrations/v006_unlimited_cockpit_history.rs
+++ b/src/migrations/v006_unlimited_cockpit_history.rs
@@ -56,7 +56,7 @@ pub(crate) fn run_in(app_dir: &Path) -> Result<()> {
     cockpit.insert("replay_events".into(), (0_i64).into());
 
     let serialized = toml::to_string_pretty(&doc)?;
-    fs::write(&global_config, serialized)?;
+    crate::session::atomic_write(&global_config, serialized.as_bytes())?;
 
     info!(
         "v006: flipped cockpit.replay_events from 500 to 0 (unlimited) in {}",

--- a/src/migrations/v008_lock_in_default_profile.rs
+++ b/src/migrations/v008_lock_in_default_profile.rs
@@ -74,7 +74,7 @@ pub(crate) fn run_in(app_dir: &Path) -> Result<()> {
     );
 
     let serialized = toml::to_string_pretty(&doc)?;
-    fs::write(&global_config, serialized)?;
+    crate::session::atomic_write(&global_config, serialized.as_bytes())?;
 
     info!(
         "v008: locked in default_profile = \"default\" in {}",

--- a/src/migrations/v009_update_check_mode.rs
+++ b/src/migrations/v009_update_check_mode.rs
@@ -93,7 +93,7 @@ fn migrate_config_file(path: &PathBuf) -> Result<()> {
     }
 
     let new_content = toml::to_string_pretty(&doc)?;
-    fs::write(path, new_content)?;
+    crate::session::atomic_write(path, new_content.as_bytes())?;
 
     Ok(())
 }

--- a/src/migrations/v010_drop_legacy_live_send_exit_chord.rs
+++ b/src/migrations/v010_drop_legacy_live_send_exit_chord.rs
@@ -116,7 +116,7 @@ fn migrate_config_file(path: &PathBuf) -> Result<()> {
     session.remove("live_send_exit_chord");
 
     let new_content = toml::to_string_pretty(&doc)?;
-    fs::write(path, new_content)?;
+    crate::session::atomic_write(path, new_content.as_bytes())?;
 
     Ok(())
 }

--- a/src/migrations/v011_relocate_sandbox_image.rs
+++ b/src/migrations/v011_relocate_sandbox_image.rs
@@ -76,7 +76,7 @@ fn migrate_config_file(path: &PathBuf) -> Result<()> {
     sandbox.insert("default_image".to_string(), toml::Value::String(new_value));
 
     let new_content = toml::to_string_pretty(&doc)?;
-    fs::write(path, new_content)?;
+    crate::session::atomic_write(path, new_content.as_bytes())?;
 
     Ok(())
 }

--- a/src/migrations/v012_acp_rename.rs
+++ b/src/migrations/v012_acp_rename.rs
@@ -223,7 +223,7 @@ fn migrate_config_file(path: &Path) -> Result<()> {
     // stale `[cockpit]` rather than clobbering.
     doc.entry("acp".to_string()).or_insert(cockpit);
 
-    fs::write(path, toml::to_string_pretty(&doc)?)?;
+    crate::session::atomic_write(path, toml::to_string_pretty(&doc)?.as_bytes())?;
     info!("v012: renamed [cockpit] -> [acp] in {}", path.display());
     Ok(())
 }
@@ -268,7 +268,7 @@ fn migrate_sessions_file(path: &Path) -> Result<()> {
     }
 
     if changed {
-        fs::write(path, serde_json::to_string_pretty(&value)?)?;
+        crate::session::atomic_write(path, serde_json::to_string_pretty(&value)?.as_bytes())?;
         info!(
             "v012: migrated cockpit_* session keys in {}",
             path.display()

--- a/src/migrations/v013_strip_profile_theme.rs
+++ b/src/migrations/v013_strip_profile_theme.rs
@@ -74,7 +74,7 @@ fn strip_profile_theme(path: &Path) -> Result<()> {
         path.display()
     );
     let new_content = toml::to_string_pretty(&doc)?;
-    fs::write(path, new_content)?;
+    crate::session::atomic_write(path, new_content.as_bytes())?;
     Ok(())
 }
 

--- a/src/migrations/v014_rename_default_theme.rs
+++ b/src/migrations/v014_rename_default_theme.rs
@@ -36,7 +36,7 @@ fn rename_theme(path: &Path) -> Result<()> {
     theme.insert("name".into(), toml::Value::String("zinc".into()));
 
     info!("Renaming theme 'default' -> 'zinc' in {}", path.display());
-    fs::write(path, toml::to_string_pretty(&doc)?)?;
+    crate::session::atomic_write(path, toml::to_string_pretty(&doc)?.as_bytes())?;
     Ok(())
 }
 

--- a/src/migrations/v016_clear_archived_tmux_gone_error.rs
+++ b/src/migrations/v016_clear_archived_tmux_gone_error.rs
@@ -77,7 +77,7 @@ fn clear_archived_error(path: &Path) -> Result<()> {
     }
 
     if healed > 0 {
-        fs::write(path, serde_json::to_string_pretty(&value)?)?;
+        crate::session::atomic_write(path, serde_json::to_string_pretty(&value)?.as_bytes())?;
         info!(
             "v016: cleared spurious archived Error on {healed} session(s) in {} (#2206)",
             path.display()


### PR DESCRIPTION
## Description

Migrations write four classes of files: the `.schema_version` marker that gates re-runs across boots, global `config.toml` under app_dir, per-profile `config.toml`, and `sessions.json`. All used bare `fs::write` (truncate-then-write). Power loss during any of these strands the file at the truncation point: a 0-byte `.schema_version` forces every migration to re-run from v001 on the next boot; a half-written `sessions.json` fails subsequent loads.

Swap every production `fs::write` in `src/migrations/` to `crate::session::atomic_write`, which was already used for session/config storage and (via PR #2265) every hook install path. Tempfile + fsync + rename + dir fsync gives all-or-nothing semantics: either the old or the new bytes are observable, never a partial.

13 production sites swapped:

- [`src/migrations/mod.rs:179`](src/migrations/mod.rs#L179) (`set_version`, the schema_version writer)
- v003 yolo_mode_config (1 site)
- v004 unified_environment (2 sites)
- v005 cockpit_defaults (1 site)
- v006 unlimited_cockpit_history (1 site)
- v008 lock_in_default_profile (1 site)
- v009 update_check_mode (1 site)
- v010 drop_legacy_live_send_exit_chord (1 site)
- v011 relocate_sandbox_image (1 site)
- v012 acp_rename (2 sites: TOML + JSON)
- v013 strip_profile_theme (1 site)
- v014 rename_default_theme (1 site)
- v016 clear_archived_tmux_gone_error (1 site)

v002 and v007 were already free of `fs::write` in production paths (seed-from-volumes is read-only; serve_log_to_legacy renames). v015 was hardened in PR #2265.

Test-only `fs::write` calls in `#[cfg(test)]` setup are intentionally left as-is.

Migrations write to AoE-internal paths only (`~/.agent-of-empires/`, profile dirs), so plain `atomic_write` is the right primitive. No symlink-following needed: dotfile users symlink agent configs like `~/.claude/settings.json` into a dotfiles repo, not AoE's own app data.

Closes #2190 (set_version).
Closes #1396 (v003-v014 sweep, supersedes #1395 which was closed without the fix landing; this PR also covers v010 through v016 which were added after the original tracking issue).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (`cargo test --lib migrations::` 84/84)
- [x] Documentation was updated where necessary (no doc-comment changes needed; `atomic_write`'s contract is unchanged)
- [x] For UI changes: included screenshot or recording: N/A (no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The change is a transparent swap of the underlying write primitive. `atomic_write` already has dedicated regression coverage in `src/session/storage.rs` (happy-path temp-cleanup at `:881`, Err-on-failure rollback at `:1448` and `tests/integration/storage_concurrency.rs:243`). Existing migration tests parse the post-write file and verify content; a regression that broke writes silently would fail those assertions. A power-loss simulation would need a fault-injection harness that does not exist in the project; not warranted for this drop-in.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (via OpenCode)

**Any Additional AI Details you'd like to share:**

Identified the scope by triaging the two open backlog issues (#2190 + #1396) and surveying every production `fs::write` in `src/migrations/` (13 sites across 12 files). The change itself is a mechanical 13-site swap; AI assisted with locating callsites, drafting the commit message, and verifying that no production path was missed. All swaps were verified by hand against the diff (`git diff --stat` 13 files / 15+/15-) and the build / clippy / migrations test suite ran locally before push.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784320826&installation_id=139138837&pr_number=2272&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2272&signature=39594ff26d35c395908f9a5b09cfa556598d22dc5b917f0d8b169c532747e63c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR makes migration writes more crash-safe by routing all production persistence through an atomic write helper. It replaces direct “truncate-then-write” file writes so that an unexpected shutdown can’t leave config/session files partially written or empty.

## What Changed
**Files modified:** `src/migrations/mod.rs` plus the following migrations:
- `v003_yolo_mode_config`
- `v004_unified_environment`
- `v005_cockpit_defaults`
- `v006_unlimited_cockpit_history`
- `v008_lock_in_default_profile`
- `v009_update_check_mode`
- `v010_drop_legacy_live_send_exit_chord`
- `v011_relocate_sandbox_image`
- `v012_acp_rename`
- `v013_strip_profile_theme`
- `v014_rename_default_theme`
- `v016_clear_archived_tmux_gone_error`

**Nature of changes:** In each affected location, the PR replaces the direct write call with `crate::session::atomic_write(...)`. Migration behavior, data transformations, and conditions are kept the same—only the durability mechanism changes.

**Scope details:**
- `set_version` (the `.schema_version` marker) is hardened to prevent an empty/invalid marker from triggering re-runs.
- Writes covered include `config.toml` (global + per-profile) and `sessions.json`, depending on the migration.
- Test-only write calls (`#[cfg(test)]`) were intentionally left unchanged.
- Some earlier migrations were already safe (e.g., read-only / already using rename), and `v015` was handled previously.

## Benefits & Impact
- **More reliable upgrades:** Prevents partially written or truncated config/session files after power loss or crashes.
- **Stops noisy re-runs:** Avoids the `.schema_version` marker becoming empty, which would otherwise cause all migrations to re-run from an earlier version.
- **Safer-by-default migrations:** Centralizes durability guarantees for future migration work.
- **No behavior change:** Existing migration tests continue to pass (all 84).

## Potential Follow-ups
- Add a guardrail (e.g., code check/search) to ensure future migration code paths use the atomic helper for production writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->