### PR TITLE
fix(tui): clear context-menu highlight when the cursor leaves every item

### DIFF
--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -37,7 +37,12 @@ pub enum ContextMenuAction {
 
 pub struct ContextMenuDialog {
     items: Vec<(ContextMenuAction, &'static str)>,
-    selected: usize,
+    /// Which item is highlighted, or `None` when the pointer is not over
+    /// any item. Opens at `Some(0)` so the keyboard default and the
+    /// "Enter submits the first item" behavior hold, but mouse hover can
+    /// clear it to `None` so no row stays lit once the cursor leaves every
+    /// item (a near-miss onto the border or off the menu entirely).
+    highlight: Option<usize>,
     /// Anchor where the popup's top-left corner wants to sit. The renderer
     /// clamps this into the visible area so a click near the bottom-right
     /// edge of the screen doesn't push the menu off-frame.
@@ -144,14 +149,21 @@ impl ContextMenuDialog {
     fn new(anchor: (u16, u16), items: Vec<(ContextMenuAction, &'static str)>) -> Self {
         Self {
             items,
-            selected: 0,
+            highlight: Some(0),
             anchor,
             last_area: Rect::default(),
         }
     }
 
     pub fn selected_action(&self) -> ContextMenuAction {
-        self.items[self.selected].0
+        self.items[self.highlight.unwrap_or(0)].0
+    }
+
+    /// Test-only accessor: the currently highlighted item index, or
+    /// `None` when the pointer left every item and nothing is lit.
+    #[cfg(test)]
+    pub fn highlight_for_test(&self) -> Option<usize> {
+        self.highlight
     }
 
     /// Test-only accessor: returns the (action, label) pairs in order
@@ -198,42 +210,53 @@ impl ContextMenuDialog {
                 Some(DialogResult::Continue)
             }
             Some(idx) => {
-                self.selected = idx;
+                self.highlight = Some(idx);
                 Some(DialogResult::Submit(self.items[idx].0))
             }
         }
     }
 
-    /// Move the selection (and thus the highlighted row) to whichever
-    /// item the mouse is hovering, so the visual cue tracks the cursor
-    /// the same way a desktop menu does. Returns true when the
-    /// highlight actually changed, so the caller can skip a redraw on
+    /// Move the highlight to whichever item the mouse is hovering, so the
+    /// visual cue tracks the cursor the same way a desktop menu does. When
+    /// the cursor is not over any item (a border row/column, or off the
+    /// menu entirely) the highlight clears to `None` so the last-hovered
+    /// item doesn't stay lit once the pointer leaves it. Returns true when
+    /// the highlight actually changed, so the caller can skip a redraw on
     /// every pixel-level mouse twitch.
     pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
-        let Some(idx) = row_to_item_idx(self.last_area, self.items.len(), col, row) else {
-            return false;
-        };
-        if self.selected == idx {
+        let next = row_to_item_idx(self.last_area, self.items.len(), col, row);
+        if self.highlight == next {
             return false;
         }
-        self.selected = idx;
+        self.highlight = next;
         true
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<ContextMenuAction> {
         match key.code {
             KeyCode::Esc => DialogResult::Cancel,
-            KeyCode::Enter => DialogResult::Submit(self.items[self.selected].0),
+            // Enter submits the highlighted item. If mouse hover cleared the
+            // highlight (cursor left every item) there's nothing to submit,
+            // so keep the menu open rather than firing a stale action.
+            KeyCode::Enter => match self.highlight {
+                Some(idx) => DialogResult::Submit(self.items[idx].0),
+                None => DialogResult::Continue,
+            },
+            // Arrow keys always re-establish a concrete highlight, so the
+            // keyboard works even after hover cleared it to `None`.
             KeyCode::Up | KeyCode::Char('k') => {
-                if self.selected == 0 {
-                    self.selected = self.items.len() - 1;
-                } else {
-                    self.selected -= 1;
-                }
+                let last = self.items.len() - 1;
+                self.highlight = Some(match self.highlight {
+                    None | Some(0) => last,
+                    Some(idx) => idx - 1,
+                });
                 DialogResult::Continue
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                self.selected = (self.selected + 1) % self.items.len();
+                self.highlight = Some(match self.highlight {
+                    None => 0,
+                    Some(idx) => (idx + 1) % self.items.len(),
+                });
                 DialogResult::Continue
             }
             // Quick-pick hotkeys mirror the underlying actions' home-view
@@ -325,7 +348,7 @@ impl ContextMenuDialog {
             .iter()
             .enumerate()
             .map(|(idx, (_, label))| {
-                let style = if idx == self.selected {
+                let style = if Some(idx) == self.highlight {
                     Style::default()
                         .fg(theme.background)
                         .bg(theme.accent)
@@ -753,16 +776,65 @@ mod tests {
     }
 
     #[test]
-    fn hover_off_menu_leaves_selection_alone() {
+    fn hover_off_menu_clears_the_highlight() {
         let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
         stub_render(&mut menu, 10, 10, 14, 7);
         menu.handle_hover(12, 15); // Delete (fifth/last row)
-        assert_eq!(menu.selected_action(), ContextMenuAction::Delete);
-        assert!(!menu.handle_hover(40, 40));
+        assert_eq!(menu.highlight_for_test(), Some(4));
+        // Moving the cursor off every item must drop the highlight so no
+        // row stays lit once the pointer is no longer over any of them.
+        assert!(menu.handle_hover(40, 40));
         assert_eq!(
-            menu.selected_action(),
-            ContextMenuAction::Delete,
-            "hover outside menu must not snap the highlight back"
+            menu.highlight_for_test(),
+            None,
+            "hover off every item must clear the highlight, not keep the last one"
         );
+        // A second move that is still off every item is a no-op redraw-wise.
+        assert!(!menu.handle_hover(41, 41));
+    }
+
+    #[test]
+    fn hover_onto_border_clears_the_highlight() {
+        // Regression for the reported bug: hovering an item then sliding
+        // onto the menu's own border (still inside `last_area`, but not an
+        // item row) must unhighlight rather than leave the item lit.
+        let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
+        stub_render(&mut menu, 10, 10, 14, 7);
+        menu.handle_hover(12, 12); // Rename (second row)
+        assert_eq!(menu.highlight_for_test(), Some(1));
+        // Top border row (y itself) is inside the menu but not an item.
+        assert!(menu.handle_hover(12, 10));
+        assert_eq!(menu.highlight_for_test(), None);
+    }
+
+    #[test]
+    fn enter_after_hover_cleared_keeps_menu_open() {
+        // With nothing highlighted, Enter has no item to submit, so the
+        // menu stays open instead of firing a stale action.
+        let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
+        stub_render(&mut menu, 10, 10, 14, 7);
+        menu.handle_hover(40, 40); // off every item -> None
+        assert!(matches!(
+            menu.handle_key(key(KeyCode::Enter)),
+            DialogResult::Continue
+        ));
+    }
+
+    #[test]
+    fn arrow_down_after_hover_cleared_starts_at_first_item() {
+        let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
+        stub_render(&mut menu, 10, 10, 14, 7);
+        menu.handle_hover(40, 40); // off every item -> None
+        menu.handle_key(key(KeyCode::Down));
+        assert_eq!(menu.selected_action(), ContextMenuAction::NewFromSelection);
+    }
+
+    #[test]
+    fn arrow_up_after_hover_cleared_starts_at_last_item() {
+        let mut menu = ContextMenuDialog::for_session((10, 10), false, Some(false));
+        stub_render(&mut menu, 10, 10, 14, 7);
+        menu.handle_hover(40, 40); // off every item -> None
+        menu.handle_key(key(KeyCode::Up));
+        assert_eq!(menu.selected_action(), ContextMenuAction::Delete);
     }
 }

--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -155,6 +155,9 @@ impl ContextMenuDialog {
         }
     }
 
+    /// The action `Enter` would submit. Falls back to the first item when
+    /// nothing is highlighted (e.g. mouse hover cleared it), mirroring the
+    /// `Some(0)` open state, so the accessor is always total.
     pub fn selected_action(&self) -> ContextMenuAction {
         self.items[self.highlight.unwrap_or(0)].0
     }
@@ -223,6 +226,13 @@ impl ContextMenuDialog {
     /// item doesn't stay lit once the pointer leaves it. Returns true when
     /// the highlight actually changed, so the caller can skip a redraw on
     /// every pixel-level mouse twitch.
+    ///
+    /// This intentionally diverges from the focus-style dialogs
+    /// (`ConfirmDialog` and friends), which keep their selection when the
+    /// mouse drifts off so a click still lands on a sensible default. A
+    /// multi-row popup menu follows desktop semantics instead: drift off
+    /// and nothing is armed, so an accidental near-miss can't leave a
+    /// misleading row lit for `Enter`.
     pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
         let next = row_to_item_idx(self.last_area, self.items.len(), col, row);
         if self.highlight == next {


### PR DESCRIPTION
## Description

In the TUI sidebar's right-click context menu, the hover highlight could get stuck on the last item the pointer crossed. If you right-clicked a session, moved the mouse over the menu items, then moved the cursor off all of them (onto the menu border or off the menu entirely), the last-hovered item stayed highlighted instead of unhighlighting.

Root cause: the highlight was stored as `selected: usize`, which can't represent "nothing highlighted". `handle_hover` is called on every mouse move while the menu is open, but it only moved the highlight when the cursor was over an item; when `row_to_item_idx` returned `None` (border or off-menu) it bailed out without clearing.

Fix: model the highlight as `Option<usize>`.

- Opens at `Some(0)`, preserving the keyboard default and "Enter submits the first item" behavior.
- `handle_hover` sets the highlight to the item under the cursor, or clears it to `None` when over no item, so the highlight tracks the mouse exactly and nothing stays lit once you leave every item.
- Arrow keys (Up/Down/j/k) always re-establish a concrete index, so the keyboard still works after hover clears the highlight.
- Enter with nothing highlighted is a no-op that keeps the menu open rather than firing a stale action.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

This is purely the context-menu dialog's hover/highlight state machine, covered by unit tests in `src/tui/dialogs/context_menu.rs`. Added regression tests: hover-off-menu clears the highlight, hover-onto-border clears it, Enter-after-clear keeps the menu open, and arrow keys recover from a cleared state. Full TUI suite (1395 tests) passes; `cargo fmt` and `cargo clippy` clean.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784379665&installation_id=139138837&pr_number=2275&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2275&signature=cdb9ad28c96d4c9625769b7b2e81edaeba56dc53b5b27a3e1caec81b5f9f5455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR fixes a right-click context menu bug in the TUI sidebar where the hover highlight could get “stuck” on the last menu item. If the cursor moved off the menu items (e.g., onto the menu border or outside the menu), the highlight was not cleared as expected.

### What Changed
- **Highlight state model updated**: The menu’s internal selection was changed from a single always-valid index (`selected: usize`) to an **optional** highlight (`highlight: Option<usize>`), so the UI can represent “no item is highlighted.”
- **Hover behavior fixed**: Hovering over a menu item highlights it; hovering over non-item areas clears the highlight.
- **Keyboard behavior improved**:
  - Arrow-key navigation continues to work and also **re-establishes a real highlighted item** after hover clears it.
  - Pressing **Enter with nothing highlighted** no longer triggers a stale action; it simply keeps the menu open.

### What Was Added
- **Regression tests** covering:
  - highlight clearing when hovering off menu items (including border/empty areas)
  - Enter behavior after the highlight is cleared
  - arrow-key recovery when the highlight is currently `None`
- A small **test-only accessor** to inspect the highlight state during tests.

### Benefits
- **More intuitive, polished UI**: the highlighted row now accurately reflects what the cursor is over.
- **Prevents stale actions**: Enter can’t submit an item based on an outdated hover state.
- **Reliable behavior across inputs**: consistent handling between mouse hover and keyboard navigation, backed by targeted regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->