### PR TITLE
test(acp): regression test and lock-order docs for cancelled_resumes (#1848)

### DIFF
--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -329,15 +329,28 @@ pub struct Supervisor<S: BroadcastSink> {
     /// removes the entry on success, error, or panic.
     pending_resumes: Arc<std::sync::Mutex<HashMap<String, ResumeKind>>>,
     /// Session ids whose in-flight resume (spawn or attach) should
-    /// bail out instead of inserting the freshly-built WorkerHandle.
+    /// bail out instead of inserting the freshly-built `WorkerHandle`.
     /// Set by `shutdown` when it observes a session that's in
     /// `pending_resumes`, either with no live runner record (the
     /// `pending_has_it` path) or against an existing runner about to
-    /// be SIGTERMed (the registry-terminate path). Without this, a
+    /// be SIGTERMed (the registry-terminate path). Without this, an
     /// `acp_disable` arriving during the 2-3s ACP handshake
     /// would no-op while the in-flight resume still completed a few
     /// seconds later, producing an orphaned worker the user can no
     /// longer manage.
+    ///
+    /// Lock-order invariant (see #1848): this mutex is taken
+    /// while `workers` is held. Writers in `shutdown_with_reason`
+    /// insert before `drop(workers)`; readers in `spawn` and
+    /// `attach` consume the breadcrumb (via `HashSet::remove`) after
+    /// `workers.lock().await` and before their own `drop(workers)`.
+    /// The lock pair (tokio `workers` outside, std `cancelled_resumes`
+    /// inside) sequences the writer's seed inside its `workers`
+    /// critical section: any resumer whose `workers.lock().await`
+    /// completes after the writer's `drop(workers)` is then guaranteed
+    /// to observe the seed when it next locks `cancelled_resumes`,
+    /// so its pre-insert check consumes the breadcrumb instead of
+    /// finding an empty set.
     cancelled_resumes: Arc<std::sync::Mutex<HashSet<String>>>,
     /// Per-agent install gate. claude-agent-acp lazy-installs its
     /// native binary on first ever run; two concurrent `session/new`
@@ -2239,6 +2252,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             // the breadcrumb under the workers lock so the racing
             // resume that re-acquires workers cannot observe an empty
             // cancelled_resumes between our drop and its read.
+            // Sibling test: `shutdown_holds_workers_lock_across_cancelled_resumes_seed`.
             if pending_has_it {
                 lock_recover(&self.cancelled_resumes).insert(session_id.to_string());
             }
@@ -2255,6 +2269,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             // between our drop and its read. The reservation cleanup
             // (ResumeReservation::Drop) clears `pending_resumes` on
             // exit, so we don't have to.
+            // Sibling test: `shutdown_holds_workers_lock_across_cancelled_resumes_seed`.
             lock_recover(&self.cancelled_resumes).insert(session_id.to_string());
             drop(workers);
             debug!(
@@ -4447,6 +4462,78 @@ mod tests {
                 .unwrap()
                 .contains("s-attach-cancel"),
             "shutdown must mark the pending attach for cancellation regardless of ResumeKind"
+        );
+    }
+
+    /// Regression for #1848: `shutdown_with_reason` must hold the
+    /// `workers` lock across its `cancelled_resumes.insert(...)`,
+    /// otherwise a concurrent `spawn` or `attach` that reacquires
+    /// `workers` between the drop and the insert observes an empty
+    /// breadcrumb set and installs an orphan worker the user cannot
+    /// disable. Locks down the lock-pair invariant under typical
+    /// scheduling: the test holds `cancelled_resumes` before
+    /// spawning a shutter, so `shutdown_with_reason` parks at its
+    /// own breadcrumb insert; a 50ms sleep gives the shutter time
+    /// to reach that park on a multi-core runtime;
+    /// `workers.try_lock()` from the test then samples the invariant
+    /// directly. `Err(_)` means the seed runs while `workers` is
+    /// held (the bug shape #1848 closed); `Ok(_)` means a future
+    /// reorder put the seed after the drop and the assert fails
+    /// with the embedded message.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    // The `await_holding_lock` lint analyses the std `MutexGuard`'s
+    // drop scope relative to every await in the function, so it
+    // cannot be narrowed to a single statement: the guard
+    // `cancelled_guard` lives at fn scope until `drop(cancelled_guard)`,
+    // and the lint scope follows the guard, not the await. Holding
+    // `cancelled_guard` across the sleep is the test mechanism.
+    #[allow(clippy::await_holding_lock)]
+    async fn shutdown_holds_workers_lock_across_cancelled_resumes_seed() {
+        let sup = Arc::new(Supervisor::new(VecSink::new()));
+        sup.pending_resumes
+            .lock()
+            .unwrap()
+            .insert("s-race".into(), ResumeKind::Spawn);
+
+        let cancelled_guard = sup.cancelled_resumes.lock().unwrap();
+
+        let shutter = {
+            let sup = Arc::clone(&sup);
+            tokio::spawn(async move { sup.shutdown("s-race").await })
+        };
+
+        // Wait for shutter to reach steady state (parked on the std
+        // mutex the test is holding). On a multi-core runtime this
+        // happens within microseconds; the wait is generous so the
+        // test stays deterministic on slow CI hardware.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Sanity probe: distinguishes a real #1848 regression from a
+        // test-environment timing failure. If shutter completed, the
+        // breadcrumb seed cannot have parked on the held std mutex,
+        // and the assertion below would mis-attribute that failure
+        // mode to the regression. Fail with a clearer message.
+        assert!(
+            !shutter.is_finished(),
+            "shutter completed unexpectedly; cancelled_resumes parking \
+             did not engage (test environment timing issue, not a \
+             #1848 regression)"
+        );
+
+        assert!(
+            sup.workers.try_lock().is_err(),
+            "regression #1848: shutdown released `workers` before \
+             writing the `cancelled_resumes` breadcrumb"
+        );
+
+        drop(cancelled_guard);
+        shutter
+            .await
+            .expect("shutter task panicked")
+            .expect("shutdown should succeed");
+        assert!(
+            sup.cancelled_resumes.lock().unwrap().contains("s-race"),
+            "shutdown must seed cancelled_resumes for the in-flight resume"
         );
     }
 


### PR DESCRIPTION
## Description

Completes the regression-test and lock-order-doc deliverables for #1848. The underlying race in `shutdown_with_reason` was closed by PR #1308 (commit `e510b746`, merged 2026-05-20, 13 days before #1848 was filed on 2026-06-02): #1308 reordered the seed under the `workers` guard at both writer branches, building on the `std::sync::Mutex` migration from PR #1284 the same day. The two remaining acceptance items from #1848 are completed here:

- **Lock-order invariant** documented at the [`cancelled_resumes` field declaration](src/acp/supervisor.rs:354), in a new paragraph at [`:342`-`:353`](src/acp/supervisor.rs:342). The doc names the writer (`shutdown_with_reason`) and reader (`spawn` / `attach`) sites that must respect the ordering, so a future maintainer who splits the critical sections sees the invariant before the change becomes a regression.
- **Stress-bounded regression test** [`shutdown_holds_workers_lock_across_cancelled_resumes_seed`](src/acp/supervisor.rs:4491) that locks down the `workers`-then-`cancelled_resumes` lock-pair invariant under typical scheduling. The test holds the std mutex on `cancelled_resumes` before spawning a shutter, so `shutdown_with_reason` blocks at its own breadcrumb insert; a 50ms `tokio::time::sleep` lets the shutter park on that mutex on a multi-core runtime, and `sup.workers.try_lock()` from the test then samples the invariant: `Err(_)` (test passes) means the seed runs while `workers` is still held; `Ok(_)` (test fails with the embedded message) means a future reorder put the seed after `drop(workers)`. The 50ms wait is sized so that on every supported runtime the shutter has reached steady state on the held std mutex before the assert; the budget is observed scheduling worst-case plus headroom, not a retry-until-pass loop.

Local verification: ran `cargo test --lib --features serve acp::supervisor::tests::shutdown_holds_workers_lock_across_cancelled_resumes_seed` against HEAD (passes in 0.06s) and against a hand-edited revert that moves both `lock_recover(&self.cancelled_resumes).insert(...)` calls ([src/acp/supervisor.rs:2257](src/acp/supervisor.rs:2257) registry-terminate, [`:2273`](src/acp/supervisor.rs:2273) pending-only) to after their respective `drop(workers)`. The reverted build fails the test with `regression #1848: shutdown released `workers` before writing the `cancelled_resumes` breadcrumb` (the `assert!` at [src/acp/supervisor.rs:4525](src/acp/supervisor.rs:4525)) in 0.06s.

Refs #1848. Acceptance criterion mapping against the issue body:

- **Criterion 1** (insert under `workers` guard): shipped in PR #1308 / commit `e510b746` (2026-05-20), 13 days before the issue was filed.
- **Criterion 2** (regression test): partially addressed. Pending-only writer branch ([src/acp/supervisor.rs:2263](src/acp/supervisor.rs:2263)) is covered by the new test at [src/acp/supervisor.rs:4491](src/acp/supervisor.rs:4491); the structurally identical registry-terminate branch ([`:2243`](src/acp/supervisor.rs:2243)) is not yet covered by an automated test.
- **Criterion 3** (lock-order doc at the field): fully addressed by the lock-order paragraph at [src/acp/supervisor.rs:342](src/acp/supervisor.rs:342)-`:353`.

Recommend leaving #1848 open with a checklist comment until the registry-terminate sibling test lands. Tracking that as follow-up rather than blocking this PR: the registry-terminate branch is doc-protected on read at the field, and a real test there needs `$HOME` tempdir isolation, manual `worker_registry::save` of a sentinel record, and a fake-PID handle for `terminate_runner_for_session`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

(Test + lock-order doc; production logic unchanged. The race fix shipped in PR #1308 / commit `e510b746` on 2026-05-20.)

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A, no UI surface touched)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The added test is a unit-level concurrency regression in `mod tests` of `src/acp/supervisor.rs`, alongside the existing single-threaded shutdown-vs-pending-resume tests at [`:4411`](src/acp/supervisor.rs:4411) (spawn variant) and [`:4449`](src/acp/supervisor.rs:4449) (attach variant).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via OpenCode (Sisyphus orchestration).

**Any Additional AI Details you'd like to share:**

I (jerome-benoit) authored issue #1848 and the prior fix in PR #1308 (merged 2026-05-20, 13 days before the issue was filed on 2026-06-02). #1848 was filed against the post-merge state to track the two acceptance items the original fix did not carry: a regression test and a lock-order doc-comment. This PR closes those two items.

AI assistance covered: mechanical mapping of the issue's `src/cockpit/supervisor.rs` line refs to the current `src/acp/supervisor.rs` paths (PR #1925 merged the rename on 2026-06-04, after the issue was filed); a first-draft stress-loop regression test; AGENTS.md style review of the commit message and docstrings.

Decisions I took ownership of:

- Pivoting the test from a stress loop racing two tasks at microsecond timing to the lock-hold pattern at [src/acp/supervisor.rs:4491](src/acp/supervisor.rs:4491) (test holds `cancelled_resumes` from outside, samples `sup.workers.try_lock()` to read the lock-pair invariant directly). The AI draft chose the stress loop; I picked the lock-hold variant because it asserts the invariant without depending on a flake-budget retry count.
- Deferring a sibling test for the registry-terminate writer branch ([src/acp/supervisor.rs:2243](src/acp/supervisor.rs:2243)-[`:2261`](src/acp/supervisor.rs:2261)) instead of expanding scope. The branch is doc-protected at [`:342`-`:353`](src/acp/supervisor.rs:342) and tracked as follow-up above; adding a real test there needs `$HOME` tempdir isolation, manual `worker_registry::save` of a sentinel, and a fake-PID handle for `terminate_runner_for_session`.
- The `Refs #1848` framing (instead of `Closes`) and the recommendation that the issue stay open with a checklist comment until the registry-terminate sibling test lands.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR adds documentation and a regression test to prevent a race condition in the supervisor's shutdown logic. No production code was modified.

**Changes to `src/acp/supervisor.rs`:**
- **Added lock-order documentation** (lines 342–353): Clear documentation at the `cancelled_resumes` field explaining the required lock ordering—the `workers` tokio mutex must be held when seeding the `cancelled_resumes` standard mutex. The documentation names the sites responsible for maintaining this ordering.
- **Added regression test** (lines 4491+): A new test called `shutdown_holds_workers_lock_across_cancelled_resumes_seed` that verifies the lock ordering is maintained during shutdown. The test spawns a shutdown task, intentionally blocks it using the `cancelled_resumes` mutex, and confirms that the `workers` lock is still held before the breadcrumb is inserted.
- **Added reference comments** (in `shutdown_with_reason` branches): Two single-line comments cross-referencing the regression test to help maintainers understand the locking invariant.

## Benefits

- **Prevents race condition**: Documents and tests the fix for issue `#1848`, a race condition that could occur if the `workers` lock is released before seeding `cancelled_resumes`.
- **Catches future regressions**: The regression test will fail immediately if someone accidentally moves the breadcrumb seed operation outside the `workers` guard, preventing the race condition from being reintroduced.
- **Improves code clarity**: Explicit documentation of the lock ordering invariant makes the intent clear to future maintainers.
- **Low risk**: Only adds documentation and tests; no production logic changes mean zero risk to existing functionality.

## Technical Details

The regression test uses a lock-hold pattern to deterministically verify the lock ordering:
1. Acquires the `cancelled_resumes` std mutex externally
2. Spawns a shutter task that attempts to call `shutdown_with_reason`
3. Sleeps 50ms to allow the shutter to reach the breadcrumb insert operation and block
4. Calls `workers.try_lock()` to verify the tokio mutex is still held (confirming the seed hasn't happened yet)
5. Releases the `cancelled_resumes` lock and verifies the breadcrumb was successfully seeded

The test is verified to pass on current code and fail when the seed operation is moved outside the `workers` guard, confirming it correctly catches the regression.

**Coverage note**: The test covers the pending-only writer branch; the registry-terminate branch is deferred as a follow-up due to complexity requirements around temporary directory isolation and fake-PID handling.

**Test results**: All 405 existing tests pass; no regressions introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->