### PR TITLE
fix(tui): hold a fresh manual unread for the current visit

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3037,6 +3037,12 @@ impl HomeView {
             }
             if self.selected_session != prev_session {
                 self.preview_scroll_offset = 0;
+                // Moving off a hand-flagged row ends its manual-unread hold, so
+                // returning to it later dwell-clears like any other unread. Done
+                // here at the cursor->selection sync (every navigation path runs
+                // through it) so the release doesn't hinge on a dwell tick
+                // happening to fire during a quick hop to another row.
+                self.manual_unread_hold = None;
             }
         }
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -717,9 +717,17 @@ pub struct HomeView {
     /// id and the instant the selection landed on it (while the list is the
     /// foreground, no dialog/live-send). When the same row stays selected for
     /// `UNREAD_DWELL`, the marker is cleared, distinguishing "scrolled past"
-    /// from "actually read." Reset on selection change, on leaving the list,
-    /// and on a manual unread toggle so re-flagging isn't instantly undone.
+    /// from "actually read." Reset on selection change and on leaving the list.
     pub(super) unread_dwell: Option<(String, std::time::Instant)>,
+
+    /// Session id the user just flagged unread by hand (`u`) and has not yet
+    /// navigated away from. While this row stays selected, dwell-to-read won't
+    /// undo the mark, so flagging a session and keeping the cursor on it
+    /// sticks. It is released the moment the cursor leaves the row (see
+    /// `tick_unread_dwell`), so returning to it later lets the dwell clear it
+    /// like any other unread row. In-memory only: a manual flag is a
+    /// this-visit hint, not a durable badge.
+    pub(super) manual_unread_hold: Option<String>,
 
     // Terminal mode for sandboxed sessions (per-session, ephemeral)
     pub(super) terminal_modes: HashMap<String, TerminalMode>,
@@ -1394,6 +1402,7 @@ impl HomeView {
             mouse_pos: None,
             last_click: None,
             unread_dwell: None,
+            manual_unread_hold: None,
             terminal_modes: HashMap::new(),
             default_terminal_mode,
             sound_config,
@@ -5046,6 +5055,11 @@ impl HomeView {
     /// actually unread, so an already-read session doesn't churn the storage
     /// flock.
     pub(crate) fn clear_unread_on_view(&mut self, id: &str) {
+        // Engaging with the row ends its manual-flag visit, so drop any hold;
+        // otherwise a stale hold could later suppress an auto mark on this row.
+        if self.manual_unread_hold.as_deref() == Some(id) {
+            self.manual_unread_hold = None;
+        }
         let is_unread = self.get_instance(id).is_some_and(|i| i.is_unread());
         if is_unread {
             let _ = self.apply_user_action(id, |i| i.mark_read());
@@ -5061,9 +5075,10 @@ impl HomeView {
     /// The clock is suspended (and reset) whenever the feature is off, a
     /// dialog or live-send is up (the list isn't being read then), or nothing
     /// is selected, and it restarts whenever the selection moves to a
-    /// different row. `toggle_unread_at_cursor` also restarts it, so manually
-    /// re-flagging the current row isn't undone by the dwell on the very next
-    /// tick.
+    /// different row. A row the user just flagged unread by hand is held until
+    /// the cursor leaves it (`manual_unread_hold`), so flagging it and sitting
+    /// there doesn't instantly undo the mark; once you leave and come back, it
+    /// clears on dwell like any other unread row.
     pub fn tick_unread_dwell(&mut self, now: std::time::Instant) -> bool {
         if !crate::session::unread_enabled() || self.has_dialog() {
             self.unread_dwell = None;
@@ -5073,6 +5088,16 @@ impl HomeView {
             self.unread_dwell = None;
             return false;
         };
+        // The manual hold only protects the row while it stays selected; the
+        // moment the cursor moves elsewhere, release it so a later return reads
+        // normally.
+        if self
+            .manual_unread_hold
+            .as_deref()
+            .is_some_and(|held| held != id)
+        {
+            self.manual_unread_hold = None;
+        }
         let started = match &self.unread_dwell {
             Some((prev, started)) if *prev == id => *started,
             // First tick on this row (or selection moved): start the clock.
@@ -5084,9 +5109,12 @@ impl HomeView {
         if now.duration_since(started) < UNREAD_DWELL {
             return false;
         }
-        // Dwell satisfied. Clear if the row is unread; leave the clock parked
-        // on this row either way so we don't re-evaluate every tick (a manual
-        // re-flag resets it via `toggle_unread_at_cursor`).
+        // A row the user just flagged by hand is held for this visit, so the
+        // dwell doesn't undo the mark while they sit on it. The clock stays
+        // parked on this row either way so we don't re-evaluate every tick.
+        if self.manual_unread_hold.as_deref() == Some(id.as_str()) {
+            return false;
+        }
         if self.get_instance(&id).is_some_and(|i| i.is_unread()) {
             self.clear_unread_on_view(&id);
             return true;

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1305,11 +1305,14 @@ impl HomeView {
             return Ok(());
         }
         self.apply_user_action(&id, |inst| inst.toggle_unread())?;
-        // Restart the dwell clock for this row: without this, re-flagging the
-        // currently-selected session unread would be undone on the next tick
-        // (it has already been dwelled on past the threshold). The window
-        // restarts so the flag sticks until the user dwells again or moves on.
-        self.unread_dwell = Some((id.clone(), std::time::Instant::now()));
+        // Hold this row for the current visit so the dwell doesn't undo a fresh
+        // `u` while the cursor stays on it; the hold is released once the cursor
+        // leaves (see `tick_unread_dwell`). Toggling back to read drops it.
+        if self.get_instance(&id).is_some_and(|i| i.is_unread()) {
+            self.manual_unread_hold = Some(id.clone());
+        } else if self.manual_unread_hold.as_deref() == Some(id.as_str()) {
+            self.manual_unread_hold = None;
+        }
         self.flat_items = self.build_flat_items();
         // In Attention sort, toggling unread changes the row's rank, so the
         // rebuild can move it; reseat the cursor by id so the next action

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -659,6 +659,127 @@ fn unread_dwell_clears_after_threshold() {
     assert!(!env.view.get_instance(&id).unwrap().is_unread());
 }
 
+/// A fresh manual flag (`u`) is held for the current visit: marking a session
+/// unread and keeping the cursor on it must not let dwell-to-read undo the
+/// mark. Regression for the bug where staying on the row past `UNREAD_DWELL`
+/// silently re-cleared it.
+#[test]
+#[serial]
+fn manual_unread_survives_same_visit_dwell() {
+    use std::time::{Duration, Instant};
+    crate::session::set_unread_enabled(true);
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances()[0].id.clone();
+    env.view.mutate_instance(&id, |inst| {
+        inst.status = crate::session::Status::Idle;
+    });
+    env.view.flat_items = env.view.build_flat_items();
+    env.view.select_session_by_id(&id);
+    env.view
+        .toggle_unread_at_cursor()
+        .expect("manual toggle should succeed");
+    assert!(env.view.get_instance(&id).unwrap().is_unread());
+
+    let t0 = Instant::now();
+    // Arm the clock, then sit well past the threshold without moving: the hold
+    // keeps the mark.
+    assert!(!env.view.tick_unread_dwell(t0));
+    assert!(!env
+        .view
+        .tick_unread_dwell(t0 + super::UNREAD_DWELL + Duration::from_secs(5)));
+    assert!(
+        env.view.get_instance(&id).unwrap().is_unread(),
+        "a freshly hand-flagged row must survive dwell while it stays selected"
+    );
+}
+
+/// The manual hold is per-visit: after leaving a hand-flagged row and coming
+/// back, dwelling on it clears the mark like any other unread row. This is the
+/// behavior verified by hand (select A, mark unread, move to B, move back, sit
+/// past the threshold -> it clears).
+#[test]
+#[serial]
+fn manual_unread_clears_after_leave_and_return() {
+    use std::time::{Duration, Instant};
+    crate::session::set_unread_enabled(true);
+    let mut env = create_test_env_with_sessions(2);
+    let a = env.view.instances()[0].id.clone();
+    let b = env.view.instances()[1].id.clone();
+    for id in [&a, &b] {
+        env.view.mutate_instance(id, |inst| {
+            inst.status = crate::session::Status::Idle;
+        });
+    }
+    env.view.flat_items = env.view.build_flat_items();
+
+    // Select A and flag it unread by hand.
+    env.view.select_session_by_id(&a);
+    env.view.toggle_unread_at_cursor().expect("manual mark A");
+    assert!(env.view.get_instance(&a).unwrap().is_unread());
+
+    // Move to B with NO dwell tick in between (a quick hop, like real
+    // navigation). The hold must release purely from the selection change;
+    // otherwise returning to A would stay suppressed forever (the reported
+    // bug, which an in-between tick would have masked).
+    env.view.select_session_by_id(&b);
+    assert!(
+        env.view.manual_unread_hold.is_none(),
+        "moving off the row must release the hold without needing a dwell tick"
+    );
+
+    // Come back to A: arm the clock, then sit past the threshold. Now it clears.
+    let t0 = Instant::now();
+    env.view.select_session_by_id(&a);
+    assert!(!env.view.tick_unread_dwell(t0));
+    let cleared = env
+        .view
+        .tick_unread_dwell(t0 + super::UNREAD_DWELL + Duration::from_secs(1));
+    assert!(cleared, "revisiting and dwelling should clear the mark");
+    assert!(
+        !env.view.get_instance(&a).unwrap().is_unread(),
+        "a hand-flagged row clears on revisit + dwell (per-visit hold)"
+    );
+}
+
+/// Engaging with a hand-flagged row (open/attach, which clears it) also drops
+/// the per-visit hold, so a *later* auto mark on that same still-selected row
+/// is not wrongly suppressed and clears on dwell.
+#[test]
+#[serial]
+fn manual_hold_released_on_engagement_lets_auto_clear() {
+    use std::time::{Duration, Instant};
+    crate::session::set_unread_enabled(true);
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances()[0].id.clone();
+    env.view.mutate_instance(&id, |inst| {
+        inst.status = crate::session::Status::Idle;
+    });
+    env.view.flat_items = env.view.build_flat_items();
+    env.view.select_session_by_id(&id);
+
+    // Hand-flag, then engage (the open/attach path), which clears it and ends
+    // the hold even though the cursor never left the row.
+    env.view.toggle_unread_at_cursor().expect("manual mark");
+    env.view.clear_unread_on_view(&id);
+    assert!(
+        env.view.manual_unread_hold.is_none(),
+        "engaging with the row must release the manual hold"
+    );
+    assert!(!env.view.get_instance(&id).unwrap().is_unread());
+
+    // A later auto mark on the same (still-selected) row must clear on dwell.
+    env.view.mutate_instance(&id, |inst| inst.mark_unread());
+    let t0 = Instant::now();
+    assert!(!env.view.tick_unread_dwell(t0));
+    let cleared = env
+        .view
+        .tick_unread_dwell(t0 + super::UNREAD_DWELL + Duration::from_secs(1));
+    assert!(
+        cleared && !env.view.get_instance(&id).unwrap().is_unread(),
+        "a later auto mark must not be suppressed by a stale hold"
+    );
+}
+
 /// Moving the selection to a different row before the dwell completes spares
 /// the first row: arrowing through a list doesn't read everything you pass.
 #[test]


### PR DESCRIPTION
## Description

The unread feature (#2088) clears a session's unread marker after about 2 seconds of keeping its row selected (dwell-to-read). That instantly undid a manual `u` mark: flag a session unread, don't move off the row quickly, and it reverted to read, the bug reported.

A hand-set mark is now held for the current visit via an in-memory `manual_unread_hold`. While the flagged row stays selected, dwell-to-read leaves it alone, so the mark sticks. The hold is released the moment the cursor leaves the row, so returning to it later and dwelling clears it like any other unread (the mark-as-unread feel of a mail client). Engaging with the row (open/attach) also releases the hold and clears the mark, so a later auto mark on that row isn't suppressed by a stale hold.

The manual mark is a this-visit hint, not durable state: nothing is persisted, and auto marks (set when a turn finishes) clear on dwell as before. Net change is three TUI files.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (doc comments on `manual_unread_hold`, `tick_unread_dwell`, and `clear_unread_on_view`)
- [x] For UI changes: included screenshot or recording (N/A: no visual change, this is a behavior fix)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (no `web/` or server change at all; the fix is entirely in the TUI home view)

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the dwell logic is timing-based and is tested deterministically with injected clocks at the module level. Added three tests in `src/tui/home/tests.rs`: `manual_unread_survives_same_visit_dwell` (mark + sit stays unread, the reported bug), `manual_unread_clears_after_leave_and_return` (leave + return + dwell clears it), and `manual_hold_released_on_engagement_lets_auto_clear` (open/attach drops the hold so a later auto mark still clears). A tmux e2e would re-exercise the same paths with real-time sleeps and more flakiness.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**

Claude investigated the bug and iterated on the behavior model with njbrake, who chose the per-visit hold (a manual mark sticks while you sit on it, then clears on a later visit) over a durable flag. The reasoning and decisions are his; Claude wrote the code and drafted this description.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR fixes a TUI timing bug where a session a user manually marked as unread could be automatically cleared back to “read” after ~2 seconds—if the user kept the cursor on that same row.

## Key Modifications

- **Added a per-visit protection for manual unread marks** via an in-memory `manual_unread_hold` in the home view.
- **While the cursor remains on the manually-unread row**, the dwell-to-read timer now skips clearing it.
- **The protection is released when it should be**, so normal unread behavior returns:
  - when the cursor moves off the row
  - when the user engages with the session (open/attach/view-related actions)
  - and when the row is revisited later and the dwell timer triggers
- **Updated unread toggle behavior** so manually setting/unsetting unread updates the hold correctly.

## Tests Added

Three new deterministic regression tests were added to verify:
- manual unread survives dwell expiration while the row stays selected
- manual unread clears after leaving and later returning to the row
- engagement releases the hold and allows normal auto-clear behavior

## Benefits

- **Respects user intent**: manual “mark unread” no longer gets undone by the dwell timer.
- **More intuitive behavior**: protection applies only to the currently selected row during the current visit.
- **Prevents regressions**: targeted unit tests lock in the expected dwell/engagement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->