### PR TITLE
test(web): deflake acp-history-window Load earlier reveal loops

### DIFF
--- a/web/tests/acp-history-window.spec.ts
+++ b/web/tests/acp-history-window.spec.ts
@@ -7,6 +7,8 @@
 // rows, past the 150-row default window) and asserts the oldest turn is
 // not painted until the user loads earlier history.
 
+import type { Page } from "@playwright/test";
+
 import { test, expect } from "./helpers/mockedTest";
 import { mockAcpSession, openStructuredSession, agentMessageChunk, stopped } from "./helpers/acpMock";
 
@@ -24,6 +26,27 @@ function longTranscript(): unknown[] {
     events.push(stopped());
   }
   return events;
+}
+
+// Click "Load earlier" until the oldest turn (`prompt number 0`) surfaces.
+// The button is conditionally mounted and disables itself while a server
+// `before` fetch is in flight (StructuredView `canLoadEarlierHistory` /
+// `loadingEarlierHistory`), so it unmounts and remounts mid-interaction. A
+// fixed-interval click loop races that re-render and the click lands on a
+// detaching node ("element was detached from the DOM"), which flaked #2236's
+// network-paging test. Re-resolve the button on every poll and bound each
+// click, so a click waits out an in-flight load instead of racing it.
+async function revealOldestTurn(page: Page): Promise<void> {
+  const oldest = page.getByText("prompt number 0");
+  await expect(async () => {
+    if ((await oldest.count()) === 0) {
+      await page
+        .getByTestId("acp-load-earlier")
+        .click({ timeout: 2_000 })
+        .catch(() => {});
+    }
+    expect(await oldest.count()).toBeGreaterThan(0);
+  }).toPass({ timeout: 30_000 });
 }
 
 test("long transcript renders recent first and reveals older on Load earlier", async ({ page }) => {
@@ -44,10 +67,7 @@ test("long transcript renders recent first and reveals older on Load earlier", a
   await expect(loadEarlier).toBeVisible();
 
   // Growing the window enough times reveals the oldest turn.
-  for (let i = 0; i < 3; i += 1) {
-    if ((await page.getByText("prompt number 0").count()) > 0) break;
-    await loadEarlier.click();
-  }
+  await revealOldestTurn(page);
   await expect(page.getByText("prompt number 0")).toBeVisible({ timeout: 10_000 });
 });
 
@@ -92,14 +112,9 @@ test("loads older events from the server when the loaded window is exhausted", a
   // Turn 0 is not in the recent page at all; it must be fetched.
   await expect(page.getByText("prompt number 0")).toHaveCount(0);
 
-  const loadEarlier = page.getByTestId("acp-load-earlier");
-  // Reveal loaded rows, then trip the server fetch, until the very first
-  // turn surfaces.
-  for (let i = 0; i < 12; i += 1) {
-    if ((await page.getByText("prompt number 0").count()) > 0) break;
-    await loadEarlier.click();
-    await page.waitForTimeout(150);
-  }
+  // Reveal loaded rows, then trip the server `before` fetch, until the very
+  // first turn surfaces.
+  await revealOldestTurn(page);
   await expect(page.getByText("prompt number 0")).toBeVisible({ timeout: 10_000 });
 });
 


### PR DESCRIPTION
## Description

Deflakes `web/tests/acp-history-window.spec.ts`. Two button-driven reveal tests (`long transcript ... reveals older on Load earlier` and `loads older events from the server when the loaded window is exhausted`) clicked `acp-load-earlier` on a fixed interval regardless of load state.

The button is conditionally mounted and disables itself while a server `before` fetch is in flight (`StructuredView` `canLoadEarlierHistory` / `loadingEarlierHistory`), so it unmounts and remounts mid-interaction. A fixed-interval click loop races that re-render, the click lands on a detaching node, and the test times out with `locator.click: Test timeout ... element was detached from the DOM`. This is the flake that blocked the recent #2278 / #2279 / #2280 merges.

The fix replaces both loops with a `revealOldestTurn` helper that re-resolves the button on every `toPass` poll and bounds each click, so a click waits out an in-flight load instead of racing it. No product code changes.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A, no UI surface touched)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

This is a test-reliability change to an existing spec; behavior under test is unchanged. The `acp.history-window` coverage-matrix entry already references this spec and the validator passes.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## How tested

Local, arm64, on the merged `main`:

- `npm run format:check`, `npm run lint`, `npx tsc -b`: all clean.
- Full spec single pass: 5/5 passed.
- Before/after stress (`--repeat-each=20` on the two flaky tests):
  - Pre-fix (current `main` spec): **10/40 failed** with the `locator.click` timeout.
  - Post-fix: **40/40 passed**.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (Claude Code).

**Any Additional AI Details you'd like to share:**

Authored by Claude Code via back-and-forth with @njbrake while triaging the CI flake that was blocking three of jerome-benoit's PRs. The diagnosis (button unmount/remount during the server fetch), the fix shape, and the before/after stress validation were carried out by the agent and reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784418092&installation_id=139138837&pr_number=2285&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2285&signature=f4ddccfb8f3f68a30bb7f93ad37b49755ff7faab2a6b8f30790d48f2267b1bc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves the reliability of two flaky tests in the ACP history window test suite by introducing a more robust button interaction pattern. The tests were previously unreliable because they clicked a button on fixed intervals regardless of whether the button was currently mounted or disabled, causing clicks to occasionally land on detached DOM nodes and timeout.

## Changes Made

**Added:**
- A new `revealOldestTurn` helper function that reliably reveals the oldest transcript turn
- Import for `Page` type

**Replaced:**
- Two separate manual click loops in different tests with the unified `revealOldestTurn` helper
- Both the "long transcript renders recent first" test and the "loads older events from the server" test now use the new helper

**Removed:**
- 12 lines of flaky click-polling logic

## Benefits

- **Improved Test Reliability:** Pre-fix stress testing showed 10/40 test runs failed; post-fix shows 40/40 consistently pass
- **Eliminates Race Conditions:** The helper re-resolves the button on each poll attempt, ensuring clicks wait for in-flight server loads instead of racing them
- **Better Code Reusability:** Consolidates duplicate reveal logic into a single, tested helper function
- **Unblocks Merging:** Fixes the flakiness that was blocking three PRs (`#2278`, `#2279`, `#2280`) from merging

No product code changes—this is purely a test infrastructure improvement that maintains all existing test assertions while fixing the underlying timing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->