### PR TITLE
fix: honor yolo/auto-approve for codex sessions (full-access mode)

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -7917,6 +7917,40 @@ mod tests {
     }
 
     #[test]
+    fn profile_yolo_mode_ids_pass_the_advertised_guard() {
+        use super::super::agent_profiles;
+        // The supervisor's post-spawn `set_mode(profile.yolo_mode_id)` is
+        // gated by this same `is_mode_advertised` guard. Pin each adapter's
+        // YOLO id against the modes that adapter actually advertises, so a
+        // mismatch (the #1142 codex bug: `bypassPermissions` vs `full-access`)
+        // can't silently get dropped again.
+        let claude_modes = Some(vec![
+            "auto".to_string(),
+            "default".to_string(),
+            "acceptEdits".to_string(),
+            "plan".to_string(),
+            "bypassPermissions".to_string(),
+        ]);
+        let codex_modes = Some(vec![
+            "read-only".to_string(),
+            "auto".to_string(),
+            "full-access".to_string(),
+        ]);
+
+        let claude_yolo = agent_profiles::resolve("claude").yolo_mode_id.unwrap();
+        assert!(is_mode_advertised(claude_yolo, &claude_modes, false));
+
+        let codex_yolo = agent_profiles::resolve("codex").yolo_mode_id.unwrap();
+        assert!(is_mode_advertised(codex_yolo, &codex_modes, false));
+        // The old hard-coded id would NOT survive the guard for codex.
+        assert!(!is_mode_advertised(
+            "bypassPermissions",
+            &codex_modes,
+            false
+        ));
+    }
+
+    #[test]
     fn is_mode_advertised_without_mode_list_defers_to_config_option() {
         // No SessionMode list: the agent steers mode through a config option,
         // so set_mode must NOT be sent (returns false). Without a config-option

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -37,6 +37,17 @@ pub struct AgentProfile {
     /// a tool call titled `"ScheduleWakeup"`. Specific to Claude's
     /// `/loop` dynamic-pacing flow.
     pub supports_wakeup_tools: bool,
+    /// ACP session-mode id that means "bypass all permission prompts"
+    /// (the wizard's "Auto-approve" / profile `yolo_mode_default`). Each
+    /// adapter names this differently: claude-agent-acp advertises
+    /// `bypassPermissions`, codex-acp advertises `full-access`, gemini-cli
+    /// advertises `yolo`. The supervisor sends this id via
+    /// `session/set_mode` immediately after spawn (see
+    /// `supervisor::spawn_inner`). `None` for adapters with no known
+    /// bypass mode: YOLO then stays a best-effort no-op and the session
+    /// keeps the adapter's default mode rather than guessing an id the
+    /// adapter would reject. See #1142.
+    pub yolo_mode_id: Option<&'static str>,
 }
 
 impl AgentProfile {
@@ -97,6 +108,7 @@ pub const CLAUDE: AgentProfile = AgentProfile {
     clear_aliases: &["/clear"],
     supports_exit_plan_mode: true,
     supports_wakeup_tools: true,
+    yolo_mode_id: Some("bypassPermissions"),
 };
 
 /// Legacy alias key carried by older session records (`agent_name="claude-code"`).
@@ -115,6 +127,9 @@ pub const CODEX: AgentProfile = AgentProfile {
     clear_aliases: &["/new"],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    // codex-acp advertises its bypass preset as the `full-access` session
+    // mode (read-only / auto / full-access), not Claude's `bypassPermissions`.
+    yolo_mode_id: Some("full-access"),
 };
 
 /// SST OpenCode via native `opencode acp`. OpenCode's `task` tool can
@@ -127,6 +142,9 @@ pub const OPENCODE: AgentProfile = AgentProfile {
     clear_aliases: &["/new"],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    // OpenCode's bypass-mode id over ACP is unverified; leave YOLO a no-op
+    // until observed rather than guessing an id the adapter would reject.
+    yolo_mode_id: None,
 };
 
 /// Google Gemini CLI via native `gemini --acp`. Gemini's `/restore` is
@@ -138,6 +156,9 @@ pub const GEMINI: AgentProfile = AgentProfile {
     clear_aliases: &[],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    // gemini-cli surfaces its YOLO approval mode over `gemini --acp` with
+    // the `yolo` id (see the CurrentModeUpdate mapping in acp_client.rs).
+    yolo_mode_id: Some("yolo"),
 };
 
 /// Mistral Vibe via bundled `vibe-acp`. Defaults until verified.
@@ -147,6 +168,7 @@ pub const VIBE: AgentProfile = AgentProfile {
     clear_aliases: &[],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    yolo_mode_id: None,
 };
 
 /// Pi coding agent via `pi-acp`. Defaults until verified.
@@ -156,6 +178,7 @@ pub const PI: AgentProfile = AgentProfile {
     clear_aliases: &[],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    yolo_mode_id: None,
 };
 
 /// aoe's bundled multi-provider agent. Treated as Claude-equivalent
@@ -177,6 +200,7 @@ pub const DEFAULT: AgentProfile = AgentProfile {
     clear_aliases: &[],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    yolo_mode_id: None,
 };
 
 /// Resolve a static profile by registry key. Returns `DEFAULT` for
@@ -215,6 +239,30 @@ mod tests {
     fn resolve_falls_back_to_default() {
         assert_eq!(resolve("").key, "default");
         assert_eq!(resolve("unknown-agent").key, "default");
+    }
+
+    #[test]
+    fn yolo_mode_id_is_adapter_specific() {
+        // Each adapter names its bypass-all-permissions mode differently;
+        // the supervisor sends exactly this id via session/set_mode.
+        assert_eq!(resolve("claude").yolo_mode_id, Some("bypassPermissions"));
+        // Inherited from CLAUDE via `..CLAUDE`.
+        assert_eq!(
+            resolve("claude-code").yolo_mode_id,
+            Some("bypassPermissions")
+        );
+        assert_eq!(resolve("aoe-agent").yolo_mode_id, Some("bypassPermissions"));
+        // Regression for #1142: codex's bypass preset is `full-access`, not
+        // Claude's `bypassPermissions`. A hard-coded `bypassPermissions` was
+        // dropped by the not-advertised guard, leaving codex prompting for
+        // approvals despite yolo_mode_default.
+        assert_eq!(resolve("codex").yolo_mode_id, Some("full-access"));
+        assert_eq!(resolve("gemini").yolo_mode_id, Some("yolo"));
+        // Adapters with no verified bypass mode keep YOLO a no-op.
+        assert_eq!(resolve("opencode").yolo_mode_id, None);
+        assert_eq!(resolve("vibe").yolo_mode_id, None);
+        assert_eq!(resolve("pi").yolo_mode_id, None);
+        assert_eq!(resolve("unknown-agent").yolo_mode_id, None);
     }
 
     #[test]

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -1415,21 +1415,29 @@ impl<S: BroadcastSink> Supervisor<S> {
         self.worker_notify.notify_waiters();
 
         // Honor the wizard's "Auto-approve" / profile `yolo_mode_default`
-        // by switching the ACP session to bypassPermissions mode. The
+        // by switching the ACP session to the adapter's bypass mode. The
         // tmux path achieves the same with `--dangerously-skip-permissions`
         // (see `apply_yolo_mode()` in `src/session/instance.rs`); structured view
         // can't pass CLI flags through the ACP adapter, so we set the
-        // mode via `session/set_mode` instead. Best-effort: the call is
+        // mode via `session/set_mode` instead. The mode id is adapter-specific
+        // (claude: `bypassPermissions`, codex: `full-access`, gemini: `yolo`),
+        // so resolve it from the agent profile rather than hard-coding Claude's
+        // id — codex advertises `full-access`, not `bypassPermissions`, so a
+        // hard-coded `bypassPermissions` was silently dropped by the
+        // not-advertised guard and left codex sessions in their default
+        // (approval-prompting) preset. Best-effort: the call is
         // fire-and-forget through cmd_tx, the connection loop warns on
-        // failure, and adapters that don't advertise bypass mode stay in
-        // default. See #1142.
+        // failure, and adapters with no known bypass mode (`yolo_mode_id:
+        // None`) stay in default. See #1142.
         if let Some(client) = client_for_yolo {
-            if let Err(e) = client.set_mode("bypassPermissions").await {
-                warn!(
-                    target: "acp.supervisor",
-                    session = %session_id,
-                    "set_mode(bypassPermissions) after spawn failed: {e}"
-                );
+            if let Some(mode_id) = super::agent_profiles::resolve(&agent).yolo_mode_id {
+                if let Err(e) = client.set_mode(mode_id).await {
+                    warn!(
+                        target: "acp.supervisor",
+                        session = %session_id,
+                        "set_mode({mode_id}) after spawn failed: {e}"
+                    );
+                }
             }
         }
         Ok(())

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -1422,7 +1422,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         // mode via `session/set_mode` instead. The mode id is adapter-specific
         // (claude: `bypassPermissions`, codex: `full-access`, gemini: `yolo`),
         // so resolve it from the agent profile rather than hard-coding Claude's
-        // id — codex advertises `full-access`, not `bypassPermissions`, so a
+        // id; codex advertises `full-access`, not `bypassPermissions`, so a
         // hard-coded `bypassPermissions` was silently dropped by the
         // not-advertised guard and left codex sessions in their default
         // (approval-prompting) preset. Best-effort: the call is


### PR DESCRIPTION
## Description
<!-- Describe your changes and the problem they solve -->

The structured-view supervisor honored the YOLO / "Auto-approve" session setting (profile `yolo_mode_default`, or the new-session wizard toggle) by sending `session/set_mode("bypassPermissions")` immediately after spawn. That mode id is Claude's. **`codex-acp` advertises its bypass preset as the `full-access` session mode** (its modes are `read-only` / `auto` / `full-access`), so the not-advertised guard (`is_mode_advertised`) in the `ClientCmd::SetMode` handler silently dropped the unknown `bypassPermissions` id. Codex sessions therefore stayed in their default `auto` preset and kept prompting for approvals despite YOLO being enabled — the user had to switch the mode to **Full Access** by hand on every new session.

**Root cause:** `supervisor::spawn_inner` hard-coded `client.set_mode("bypassPermissions")`. The bypass mode id is adapter-specific, so a single hard-coded id can only ever work for one adapter.

**Fix:** add an `AgentProfile::yolo_mode_id` field and resolve the bypass mode from the profile rather than hard-coding Claude's id:
- `claude` (+ `claude-code`, `aoe-agent`) → `bypassPermissions`
- `codex` → `full-access`
- `gemini` → `yolo`
- `opencode` / `vibe` / `pi` / unknown → `None` (YOLO stays a best-effort no-op rather than guessing an id the adapter would reject)

`codex` advertises `full-access` in its session modes, so the existing `is_mode_advertised` gate now passes it through `session/set_mode`, exactly as Claude already gets `bypassPermissions` at spawn.

Related to #1142 (the original "wizard ignores `yolo_mode_default`" fix, which wired up the Claude-only `set_mode` path).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary <!-- rustdoc on the new field + supervisor rationale; no end-user docs affected -->
- [x] For UI changes: included screenshot or recording <!-- N/A: no UI change, server-side mode selection only -->

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow <!-- the change is which mode id the server sends at spawn; the dashboard renders whatever mode the adapter reports back. The decisive logic is pinned by Rust unit tests. -->
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the fix lives in the structured-view (serve) ACP spawn path, not TUI rendering or a CLI subcommand. It is covered by Rust unit tests — `acp::agent_profiles::tests::yolo_mode_id_is_adapter_specific` pins each adapter's id, and `acp::acp_client::tests::profile_yolo_mode_ids_pass_the_advertised_guard` asserts codex's `full-access` survives the same `is_mode_advertised` guard the supervisor relies on (while the old `bypassPermissions` would not). An end-to-end test would need a live `codex-acp` agent advertising `full-access`, which the acp e2e harness doesn't currently stub.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude Code (Claude Opus 4.8)


**Any Additional AI Details you'd like to share:**
Root-cause investigation (tracing the live ACP event store to confirm codex sessions start in `auto` and only reach `full-access` on manual selection) and the patch were produced with Claude Code under my direction and review.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784450269&installation_id=139138837&pr_number=2289&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2289&signature=2db6ba1527b3789c2305e0763c4ab8eb50b1b261dba7faec38a2a7e4eeefb20d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed
This PR fixes why the YOLO (“Auto-approve”) session setting was ignored for Codex sessions. The supervisor previously used a single, hard-coded “bypass” mode ID that only matched Claude—Codex expects a different mode ID, so the request was discarded and users had to switch to “Full Access” manually each time.

## What Was Added / Updated
- The agent profile now includes an adapter-specific YOLO bypass identifier (`yolo_mode_id`).
- Each supported adapter is mapped to its correct YOLO mode:
  - Claude (and variants) → `bypassPermissions`
  - Codex → `full-access`
  - Gemini → `yolo`
  - Others/unknown adapters → `None` (the supervisor won’t guess an ID)
- Unit tests were added to verify that each adapter’s YOLO mode ID passes the “only apply if advertised” guard, including a regression check for the old hard-coded Claude-only ID.

## Benefits
- Codex sessions now automatically honor YOLO/Auto-approve when enabled (no manual “Full Access” switching).
- The behavior is more reliable and future-proof by using adapter-specific configuration instead of assuming one shared mode ID across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->