### PR TITLE
fix(tui): exit live-send before tmux attach on double-click (#2290)

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2933,6 +2933,7 @@ impl HomeView {
                 ) {
                     self.start_live_send()
                 } else {
+                    self.exit_live_send_before_attach();
                     Some(Action::AttachSession(id))
                 }
             }
@@ -2957,9 +2958,14 @@ impl HomeView {
                 } else {
                     TerminalMode::Host
                 };
+                self.exit_live_send_before_attach();
                 Some(Action::AttachTerminal(id, terminal_mode))
             }
-            ViewMode::Tool(ref tool_name) => Some(Action::AttachToolSession(id, tool_name.clone())),
+            ViewMode::Tool(ref tool_name) => {
+                let tool_name = tool_name.clone();
+                self.exit_live_send_before_attach();
+                Some(Action::AttachToolSession(id, tool_name))
+            }
         }
     }
 
@@ -4317,6 +4323,23 @@ impl HomeView {
                 }
                 self.stamp_last_accessed(&state.session_id);
             }
+        }
+    }
+
+    /// Exit live-send before an activation hands the terminal to a tmux
+    /// attach. The double-click (and Enter) activation path resolves
+    /// through `default_attach_mode`, so when `click_action = LiveSend`
+    /// the *first* click of a double-click already entered live-send for
+    /// the row; the second click then resolves to a tmux attach
+    /// (`default_attach_mode = Tmux`). Without this teardown the
+    /// just-spawned worker keeps dispatching against a pane we're
+    /// leaving, the attach inherits the preview-pinned window size
+    /// instead of growing to the client, and detaching drops the user
+    /// back into live mode rather than the home list (#2290). No-op when
+    /// not live-sending.
+    fn exit_live_send_before_attach(&mut self) {
+        if let Some(state) = self.live_send.clone() {
+            self.exit_live_send_and_restore_sizing(&state);
         }
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -9000,6 +9000,60 @@ mod click_to_select {
 
     #[test]
     #[serial]
+    fn double_click_tears_down_live_send_before_tmux_attach() {
+        // Regression for #2290: with `click_action = LiveSend` the first
+        // click of a double-click enters live-send for the row, then the
+        // second click resolves to a tmux attach via
+        // `default_attach_mode = Tmux`. The attach must exit live mode
+        // first, otherwise the worker is stranded against a pane we're
+        // leaving and detaching drops the user back into live mode.
+        use crate::session::config::{save_config, ClickAction, Config};
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let mut config = Config::default();
+        config.session.click_action = ClickAction::LiveSend;
+        save_config(&config).unwrap();
+
+        // Simulate the first click of the double having already entered
+        // live-send (the real install runs in App::execute_action, which a
+        // HomeView unit test can't drive): pin live_send to the row we are
+        // about to double-click.
+        let expected_id = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+        env.view.live_send = Some(crate::tui::home::live_send::LiveSendState {
+            session_id: expected_id.clone(),
+            title: "row-2".to_string(),
+            tmux_name: "aoe_test_2290".to_string(),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
+            exit_chords: Vec::new(),
+            leader: None,
+        });
+
+        let t0 = std::time::Instant::now();
+        // Seed last_click so the next click within the threshold is treated
+        // as the second click of a double-click on the same row.
+        env.view.last_click = Some((t0, 5, 3));
+        let t1 = t0 + std::time::Duration::from_millis(100);
+        let action = env.view.handle_click_at(t1, 5, 3);
+
+        assert_eq!(
+            action,
+            Some(crate::tui::app::Action::AttachSession(expected_id)),
+            "double-click must still resolve to a tmux attach under default_attach_mode (Tmux)"
+        );
+        assert!(
+            env.view.live_send.is_none(),
+            "the tmux attach path must exit live mode first, not strand the worker"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn click_on_already_selected_row_does_not_move_cursor() {
         let mut env = create_test_env_with_sessions(3);
         setup_inner(&mut env);


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Closes #2290.

When `click_action = "live_send"` is combined with `default_attach_mode = "tmux"`, double-clicking a session row had the first click enter live-send (spawning a worker) and the second click resolve to a tmux attach through `default_attach_mode`. That left the just-spawned worker dispatching against a pane we were leaving, the attach inherited the preview-pinned window size instead of growing to the client, and detaching dropped the user back into live mode rather than the home list.

`activate_selected_session` (the Enter and double-click path) now exits live-send, tearing down the worker and restoring `window-size latest`, before returning any `Attach*` action. It is a no-op when not live-sending, so the Enter path and the non-racing cases are unaffected.

This does not remove the brief visual flash of live mode on the first click, which is inherent to eager single-click handling; the documented config workaround (`default_attach_mode = "live_send"`) avoids the path entirely.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no docs affected; behavior fix)
- [ ] For UI changes: included screenshot or recording (no static visual to capture; the fix suppresses an unwanted attach, verified by a regression test)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: added a focused unit regression test (`double_click_tears_down_live_send_before_tmux_attach`) at the activation decision point instead. Driving the sub-400ms double-click plus live-send worker spawn and post-detach state through the full tmux e2e harness would be timing-flaky; the unit test locks the contract that the attach path exits live mode first.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8, 1M context)

**Any Additional AI Details you'd like to share:**
Claude investigated the TUI click handling, identified the `click_action` (single click) vs `default_attach_mode` (Enter / double-click) split behind the bug, implemented the teardown, and wrote the regression test. @njbrake reviewed the diagnosis and the approach.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784482205&installation_id=139138837&pr_number=2293&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2293&signature=b92779014a11171cf99e31858f6ee947ad92e9be697d4c4a7ea7d0359cc08091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

**Problem**: When users double-clicked a session row with conflicting settings (`click_action = "live_send"` and `default_attach_mode = "tmux"`), the first click would spawn a live-send worker, and the second click would trigger a tmux attach. This left the spawned worker dangling and caused incorrect behavior (wrong window sizing, incorrect post-detach navigation).

**Solution**: Modified the session activation logic in `src/tui/home/input.rs` to detect when a double-click resolves to a tmux attach action and clean up any active live-send worker before proceeding. A new helper function `exit_live_send_before_attach()` centralizes this cleanup behavior.

**What was added**:
- Helper function to tear down live-send state before tmux attach operations
- Logic to call this helper in the Structured, Terminal, and Tool view paths before returning attach actions
- A regression test (`double_click_tears_down_live_send_before_tmux_attach`) that verifies double-click properly exits live-send and attaches to the session

**What was removed**: Nothing significant; the fix is a targeted addition.

## Benefits

- Eliminates dangling worker processes from double-click races
- Restores correct window sizing (expands to client size instead of inheriting preview size)
- Fixes post-detach navigation (users return to home list instead of live mode)
- Non-intrusive fix that becomes a no-op for non-conflicting configurations or single clicks
- Includes regression test to prevent reoccurrence
- All existing tests continue to pass

## Technical Details

The fix works by inserting a cleanup step (`exit_live_send_and_restore_sizing()`) before any `AttachSession`, `AttachTerminal`, or `AttachToolSession` action is returned from `activate_selected_session()`. The helper function checks if live-send is currently active and only performs cleanup if necessary, making it safe to call unconditionally. This approach preserves the single-click performance (no deferral of spawn) while fixing the double-click race condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->