### PR TITLE
feat(tui): collapsible sidebar + clickable footer toolbar (and fix config-save screen flicker)

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -667,6 +667,12 @@ pub struct AppStateConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub home_list_width: Option<u16>,
 
+    /// Whether the home-view session list is collapsed to a narrow,
+    /// click-to-expand strip. Persisted so the choice survives restarts,
+    /// mirroring `home_list_width`. `None`/absent means expanded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home_sidebar_collapsed: Option<bool>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub diff_file_list_width: Option<u16>,
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -132,6 +132,16 @@ pub struct App {
     home: HomeView,
     should_quit: bool,
     theme: Theme,
+    /// Identity of the currently applied `theme` (global theme name +
+    /// palette-downsample mode). `set_theme` compares against this so a
+    /// re-apply with the same identity is a no-op. The config-file watcher
+    /// re-dispatches the theme on EVERY `config.toml` save (it can't tell
+    /// what changed), and a needless `set_theme` there sets `needs_redraw`,
+    /// forcing a full-screen `clear_terminal` that flickers. Guarding here
+    /// keeps any config save (collapse persistence, list resize, `i`,
+    /// settings) from clearing the screen when the theme is unchanged.
+    theme_name: String,
+    theme_palette_mode: bool,
     needs_redraw: bool,
     update_info: Option<UpdateInfo>,
     update_rx: Option<tokio::sync::oneshot::Receiver<anyhow::Result<UpdateInfo>>>,
@@ -213,6 +223,15 @@ pub fn check_version_change() -> Result<Option<String>> {
     } else {
         Ok(None)
     }
+}
+
+/// Whether applying `next` `(theme name, palette-downsample mode)` would change
+/// the active theme `current`. Pulled out of `App::set_theme` so the
+/// idempotency guard (which keeps a config-file-watcher theme re-dispatch from
+/// forcing a flickering full-screen clear on every `config.toml` save) is
+/// unit-testable without constructing a full `App`.
+fn theme_apply_needed(current: (&str, bool), next: (&str, bool)) -> bool {
+    current != next
 }
 
 impl App {
@@ -349,6 +368,8 @@ impl App {
             home,
             should_quit: false,
             theme,
+            theme_name,
+            theme_palette_mode: palette_mode,
             needs_redraw: true,
             update_info: None,
             update_rx: None,
@@ -531,7 +552,20 @@ impl App {
         // global config: theme (and its color_mode) is a global preference,
         // not profile-merged.
         let palette_mode = crate::session::config::resolve_theme_palette_mode();
+        // No-op when the theme is already applied. The config watcher
+        // re-dispatches the theme on every `config.toml` save, so without
+        // this a list-resize / `i` / collapse-persistence / settings save
+        // would force a full-screen `clear_terminal` and flicker even though
+        // nothing visual changed.
+        if !theme_apply_needed(
+            (&self.theme_name, self.theme_palette_mode),
+            (name, palette_mode),
+        ) {
+            return;
+        }
         self.theme = crate::tui::styles::load_theme_with_mode(name, palette_mode);
+        self.theme_name = name.to_string();
+        self.theme_palette_mode = palette_mode;
         self.needs_redraw = true;
     }
 
@@ -823,6 +857,10 @@ impl App {
                                                             // non-burst path so dialog buttons are
                                                             // clickable even when a mouse event lands
                                                             // right after a paste/dictation burst.
+                                                        } else if self.home.handle_sidebar_collapse_click(mouse.column, mouse.row) {
+                                                            // Sidebar collapse/expand toggle; must
+                                                            // precede hit_list (button is on the
+                                                            // list's top border).
                                                         } else if hit_list {
                                                             let action = self.home.handle_click(mouse.column, mouse.row);
                                                             if action.is_none() {
@@ -899,6 +937,29 @@ impl App {
                             continue;
                         }
                         Some(Ok(Event::Mouse(mouse))) => {
+                            // Footer toolbar: a left-click on a button
+                            // synthesizes its shortcut and routes it through
+                            // the full key handler, so clicking behaves
+                            // exactly like pressing the key (global handling,
+                            // action dispatch, structured-view drain). The
+                            // footer is a disjoint area from the list/preview/
+                            // diff, so nothing else in this arm needs to run.
+                            if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+                                if let Some(key) =
+                                    self.home.footer_button_at(mouse.column, mouse.row)
+                                {
+                                    let _ = self.home.clear_preview_selection();
+                                    self.handle_key(key, terminal).await?;
+                                    self.sync_mouse_capture(terminal)?;
+                                    if !self.needs_redraw {
+                                        self.draw(terminal)?;
+                                    }
+                                    if self.should_quit {
+                                        break;
+                                    }
+                                    continue;
+                                }
+                            }
                             let hit_list = self.home.hit_list(mouse.column, mouse.row);
                             let hit_preview = self.home.hit_preview(mouse.column, mouse.row);
                             let hit_diff = self.home.is_diff_open()
@@ -950,6 +1011,17 @@ impl App {
                                         self.set_theme(&name);
                                     }
                                     self.sync_mouse_capture(terminal)?;
+                                    self.draw(terminal)?;
+                                    None
+                                } else if self
+                                    .home
+                                    .handle_sidebar_collapse_click(mouse.column, mouse.row)
+                                {
+                                    // Collapse button (expanded list border) or
+                                    // the collapsed strip toggled the sidebar.
+                                    // Runs before hit_list because the button
+                                    // lives on the list's top border.
+                                    let _ = self.home.clear_preview_selection();
                                     self.draw(terminal)?;
                                     None
                                 } else if self
@@ -2985,6 +3057,27 @@ mod tests {
     use super::*;
     use crate::telemetry::SendOutcome;
     use std::sync::atomic::Ordering;
+
+    /// The theme idempotency guard must treat both the name AND the palette
+    /// mode as part of the theme identity, and report "no change" only when
+    /// both match. This is what keeps a config-file-watcher theme re-dispatch
+    /// (fired on every `config.toml` save: sidebar-collapse persistence, list
+    /// resize, `i`, settings) from forcing a flickering full-screen clear.
+    #[test]
+    fn theme_apply_needed_compares_name_and_palette_mode() {
+        assert!(
+            !theme_apply_needed(("empire", false), ("empire", false)),
+            "identical name + mode is a no-op (no redraw, no clear)"
+        );
+        assert!(
+            theme_apply_needed(("empire", false), ("zinc", false)),
+            "a different name must re-apply"
+        );
+        assert!(
+            theme_apply_needed(("empire", false), ("empire", true)),
+            "a different palette mode must re-apply even with the same name"
+        );
+    }
 
     // The TUI create counter is a process-global static, so these tests mutate
     // shared state. `#[serial]` (with the `telemetry_creates` group key) keeps

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -373,8 +373,14 @@ impl HomeView {
     /// The `KeyEvent` a footer-toolbar button at `(col, row)` synthesizes,
     /// or `None` when the click misses every button. The caller routes the
     /// returned key through the normal key handler so a click behaves
-    /// exactly like pressing the shortcut.
+    /// exactly like pressing the shortcut. Returns `None` while a non-live
+    /// overlay (dialog, context menu, help, search) is open: the footer is
+    /// drawn underneath it, but the overlay owns clicks, so a footer button
+    /// must not fire a shortcut behind it.
     pub fn footer_button_at(&self, col: u16, row: u16) -> Option<KeyEvent> {
+        if self.has_non_live_send_overlay() {
+            return None;
+        }
         let pos = Position::from((col, row));
         self.footer_buttons
             .iter()
@@ -389,7 +395,13 @@ impl HomeView {
     /// path. The collapse button sits on the list's top border, which is
     /// inside `list_area`, so this MUST run before `hit_list` or the click
     /// falls through to `handle_empty_list_click` and opens a new session.
+    /// No-op while a non-live overlay is open so a click can't toggle the
+    /// sidebar behind a modal (the rects are cleared for the full-screen
+    /// takeover views, so a dialog overlay is the case left to guard).
     pub fn handle_sidebar_collapse_click(&mut self, col: u16, row: u16) -> bool {
+        if self.has_non_live_send_overlay() {
+            return false;
+        }
         let pos = Position::from((col, row));
         if self.collapse_button_area.contains(pos) || self.expand_strip_area.contains(pos) {
             self.toggle_sidebar_collapsed();

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -370,6 +370,35 @@ impl HomeView {
         self.list_area.contains(Position::from((col, row)))
     }
 
+    /// The `KeyEvent` a footer-toolbar button at `(col, row)` synthesizes,
+    /// or `None` when the click misses every button. The caller routes the
+    /// returned key through the normal key handler so a click behaves
+    /// exactly like pressing the shortcut.
+    pub fn footer_button_at(&self, col: u16, row: u16) -> Option<KeyEvent> {
+        let pos = Position::from((col, row));
+        self.footer_buttons
+            .iter()
+            .find(|(rect, _)| rect.contains(pos))
+            .map(|(_, key)| *key)
+    }
+
+    /// Handle a left-click on the sidebar collapse/expand affordances:
+    /// the collapse button on the expanded list's top-right border, or
+    /// anywhere in the collapsed strip. Returns true when the click landed
+    /// on one (and toggled), so the caller can stop before the row-click
+    /// path. The collapse button sits on the list's top border, which is
+    /// inside `list_area`, so this MUST run before `hit_list` or the click
+    /// falls through to `handle_empty_list_click` and opens a new session.
+    pub fn handle_sidebar_collapse_click(&mut self, col: u16, row: u16) -> bool {
+        let pos = Position::from((col, row));
+        if self.collapse_button_area.contains(pos) || self.expand_strip_area.contains(pos) {
+            self.toggle_sidebar_collapsed();
+            true
+        } else {
+            false
+        }
+    }
+
     /// True when `(col, row)` lands on the side-by-side list/preview
     /// divider. The divider is the preview's left border column (one
     /// past `list_area.right()` is exclusive, so this *is* a valid hit
@@ -3955,6 +3984,16 @@ impl HomeView {
             overlay_changed |= dialog.handle_hover(col, row);
         }
 
+        // Footer-toolbar hover: the index drives the inverted-chip highlight
+        // on the next render. Recomputed against the current button rects so
+        // it clears the moment the pointer leaves a button.
+        let prev_footer_hover = self.footer_hover;
+        self.footer_hover = self
+            .footer_buttons
+            .iter()
+            .position(|(rect, _)| rect.contains(Position::from((col, row))));
+        let footer_changed = prev_footer_hover != self.footer_hover;
+
         let new_pos = if self.list_inner_area.contains(Position::from((col, row))) {
             Some((col, row))
         } else {
@@ -3963,7 +4002,7 @@ impl HomeView {
         let prev_idx = self.hovered_index();
         self.mouse_pos = new_pos;
         let new_idx = self.hovered_index();
-        overlay_changed || prev_idx != new_idx
+        overlay_changed || footer_changed || prev_idx != new_idx
     }
 
     /// Route a mouse-wheel-down at (col, row); see handle_scroll_up.
@@ -4315,11 +4354,12 @@ impl HomeView {
         // previewed after exit, just at the idle cadence. The render
         // reconcile retunes it (and retargets if the view later changes).
         self.live_send_last_resize = None;
-        // The leader menu and sidebar collapse are live-mode-only: drop
-        // any half-entered leader chord and re-reveal the session list so
-        // the normal home view is never left in a collapsed or armed state.
+        // The leader menu is live-mode-only: drop any half-entered chord so
+        // the home view is never left armed. The sidebar collapse is now a
+        // general, persisted home-view state (the collapsed strip stays
+        // clickable here), so exiting live mode deliberately leaves it as
+        // the user set it rather than force-revealing the list.
         self.live_send_pending_leader = false;
-        self.sidebar_collapsed = false;
         // Live mode just owned the pane's size; the non-live preview must
         // re-assert its geometry on the next render now that the header is
         // visible again (and so the agent reflows back to the previewed size).

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -558,10 +558,12 @@ pub struct HomeView {
     /// shows the which-key menu. Always false outside live mode; cleared on
     /// live-send exit. See `handle_live_send_key`.
     pub(super) live_send_pending_leader: bool,
-    /// When true, the session list (sidebar) is hidden so the preview pane
-    /// gets the full terminal width. Toggled from live mode via the leader
-    /// (`leader b`) for a distraction-free structured view; reset on live-send
-    /// exit so the list always reappears in the normal home view.
+    /// When true, the session list (sidebar) collapses to a narrow,
+    /// click-to-expand strip so the preview pane gets nearly the full
+    /// terminal width. Toggled by the collapse button on the list border,
+    /// by clicking the collapsed strip, or from live mode via the leader
+    /// (`leader b`). Persisted to `app_state.home_sidebar_collapsed` so the
+    /// choice survives restarts.
     pub(super) sidebar_collapsed: bool,
     /// `(session_id, cols, rows)` of the last NON-live preview resize we sent
     /// to the selected agent's pane, so the 250ms preview poll doesn't
@@ -693,6 +695,23 @@ pub struct HomeView {
     /// keep working; clicks use the inner rect so we don't try to select
     /// the border row.
     pub(super) list_inner_area: Rect,
+    /// Clickable rect of the collapse button drawn on the list block's
+    /// top-right border (expanded side-by-side/stacked view). Zeroed on
+    /// frames where the button isn't drawn (e.g. while collapsed) so a
+    /// stale rect can't swallow clicks.
+    pub(super) collapse_button_area: Rect,
+    /// Clickable rect of the narrow strip shown in place of the list when
+    /// collapsed. Clicking anywhere in it re-expands the sidebar. Zeroed
+    /// while the full list is drawn.
+    pub(super) expand_strip_area: Rect,
+    /// Clickable footer-toolbar buttons captured during `render_status_bar`,
+    /// each paired with the `KeyEvent` a click synthesizes (so a click is
+    /// dispatched through the exact same path as pressing the shortcut).
+    /// Rebuilt every frame; empty in live mode and the takeover views.
+    pub(super) footer_buttons: Vec<(Rect, crossterm::event::KeyEvent)>,
+    /// Index into `footer_buttons` the pointer is currently over, used to
+    /// draw a hover highlight. Recomputed on every `Moved` event.
+    pub(super) footer_hover: Option<usize>,
     /// Last reported mouse position when it was over `list_inner_area`,
     /// `None` when the cursor is outside the list. Stored as a position
     /// rather than a resolved item index so wheel scrolls implicitly
@@ -1335,7 +1354,14 @@ impl HomeView {
             preview_wake: std::sync::Arc::new(tokio::sync::Notify::new()),
             live_send_last_resize: None,
             live_send_pending_leader: false,
-            sidebar_collapsed: false,
+            sidebar_collapsed: user_config
+                .as_ref()
+                .and_then(|c| c.app_state.home_sidebar_collapsed)
+                .unwrap_or(false),
+            collapse_button_area: Rect::default(),
+            expand_strip_area: Rect::default(),
+            footer_buttons: Vec::new(),
+            footer_hover: None,
             preview_pane_synced: None,
             pending_paste: None,
             pending_attach_after_warning: None,
@@ -3752,14 +3778,22 @@ impl HomeView {
         self.save_list_width();
     }
 
-    /// Hide or reveal the session list so the preview pane can use the
-    /// full terminal width. Only meaningful while live mode is active
-    /// (the render path ignores the flag otherwise and `exit_live_send_*`
-    /// resets it), so this is deliberately ephemeral rather than persisted
-    /// to config. The next render reflows the preview, and the live-send
-    /// resize loop pushes the new geometry to the agent's pane.
+    /// Collapse the session list to a narrow click-to-expand strip, or
+    /// re-expand it. The next render reflows the preview into the freed
+    /// width; in live mode the resize loop pushes the new geometry to the
+    /// agent's pane. Persisted so the choice survives restarts.
     pub fn toggle_sidebar_collapsed(&mut self) {
         self.sidebar_collapsed = !self.sidebar_collapsed;
+        self.save_sidebar_collapsed();
+    }
+
+    fn save_sidebar_collapsed(&self) {
+        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
+            config.app_state.home_sidebar_collapsed = Some(self.sidebar_collapsed);
+            if let Err(e) = save_config(&config) {
+                tracing::warn!(target: "tui.home", "Failed to save config: {e}");
+            }
+        }
     }
 
     fn save_list_width(&self) {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -737,8 +737,11 @@ impl HomeView {
             ViewMode::Structured => theme.border,
             ViewMode::Terminal | ViewMode::Tool(_) => theme.terminal_border,
         };
+        // Drop the right border so the preview's left border is the single
+        // shared seam, matching the expanded list and DESIGN.md's
+        // "eliminate the double-border between list and preview" rule.
         let block = Block::default()
-            .borders(Borders::ALL)
+            .borders(Borders::TOP | Borders::LEFT | Borders::BOTTOM)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(border_color));
         let inner = block.inner(area);
@@ -2936,9 +2939,11 @@ impl HomeView {
         // Greedy pack by priority. Width of a group = sum of span char counts;
         // separator between kept groups adds 3 cols each (" · "). Reserve 1
         // col for the leading space margin.
+        // Display-cell width (not `chars().count()`) so the greedy pack and
+        // the click rects line up with the cells ratatui actually paints.
         let widths: Vec<usize> = groups
             .iter()
-            .map(|(_, _, g)| g.iter().map(|s| s.content.chars().count()).sum::<usize>())
+            .map(|(_, _, g)| g.iter().map(|s| s.width()).sum::<usize>())
             .collect();
         let avail = (area.width as usize).saturating_sub(1);
 

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1,6 +1,7 @@
 //! Rendering for HomeView
 
 use chrono::{DateTime, Utc};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 use std::time::{Duration, Instant};
@@ -468,6 +469,13 @@ impl HomeView {
         update_status: Option<&str>,
         image_update: Option<&ImageUpdate>,
     ) {
+        // Start each frame with no footer buttons; `render_status_bar`
+        // repopulates them for the normal home view. The takeover views
+        // (settings/diff/serve) return before that runs, and the live-send
+        // banner replaces the footer, so in those cases the list stays
+        // empty and stale rects can't swallow clicks.
+        self.footer_buttons.clear();
+
         // Settings view takes over the whole screen
         if let Some(ref mut settings) = self.settings_view {
             self.divider_col = None;
@@ -539,20 +547,28 @@ impl HomeView {
         // stacking gives the preview the full width.
         let available_width = main_chunks[0].width;
         self.main_area_width = available_width;
-        // Collapsed sidebar (live mode only): hand the whole main area to
-        // the preview so the agent pane fills the terminal. The live-send
-        // resize loop then reflows the agent to the wider geometry. Reset
-        // on live-send exit, so the list always returns in the home view.
-        if self.live_send.is_some() && self.sidebar_collapsed {
+        // Collapsed sidebar: the list shrinks to a narrow click-to-expand
+        // strip on the left and the preview takes the rest of the width
+        // (in live mode the resize loop then reflows the agent pane). This
+        // path is width-independent: a collapsed list is narrow enough that
+        // re-imposing the stacked breakpoint would only waste space.
+        if self.sidebar_collapsed {
             self.divider_col = None;
-            // render_list is skipped, so its hit-test rects would otherwise
-            // keep last frame's values and a click in the now-preview area
-            // could resolve to an invisible list row (and switch the live
-            // target). Zero them so mouse hit-testing can't target the
-            // hidden sidebar.
+            let strip_width = responsive::COLLAPSED_STRIP_WIDTH.min(available_width);
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Length(strip_width), Constraint::Min(0)])
+                .split(main_chunks[0]);
+            // The full list isn't drawn, so its hit-test rects would
+            // otherwise keep last frame's values and a click in the now-
+            // preview area could resolve to an invisible list row (and
+            // switch the live target). Zero them so mouse hit-testing can't
+            // target the hidden sidebar; the strip carries its own rect.
             self.list_area = Rect::default();
             self.list_inner_area = Rect::default();
-            self.render_preview(frame, main_chunks[0], theme);
+            self.collapse_button_area = Rect::default();
+            self.render_collapsed_strip(frame, chunks[0], theme);
+            self.render_preview(frame, chunks[1], theme);
         } else if available_width < responsive::STACKED_BREAKPOINT {
             let main_height = main_chunks[0].height;
             let list_height = responsive::stacked_list_height(main_height);
@@ -705,6 +721,44 @@ impl HomeView {
         Block::default().borders(Borders::ALL).inner(panes[1])
     }
 
+    /// Render the collapsed sidebar: a narrow bordered strip standing in
+    /// for the full list. The whole strip is the click target (stored in
+    /// `expand_strip_area`) and re-expands the sidebar. A `»` glyph hints
+    /// the expand direction; the session count sits below it so the strip
+    /// still conveys "there are N sessions here".
+    fn render_collapsed_strip(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        self.expand_strip_area = area;
+        let border_color = match self.view_mode {
+            ViewMode::Structured => theme.border,
+            ViewMode::Terminal | ViewMode::Tool(_) => theme.terminal_border,
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(border_color));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+        let mut lines = vec![
+            Line::from(Span::styled(
+                "\u{00BB}",
+                Style::default().fg(theme.hint).bold(),
+            )),
+            Line::from(""),
+        ];
+        // Session count stacked one digit per row, since the strip is a
+        // single cell wide.
+        for ch in self.instances().len().to_string().chars() {
+            lines.push(Line::from(Span::styled(
+                ch.to_string(),
+                Style::default().fg(theme.dimmed),
+            )));
+        }
+        frame.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
+    }
+
     fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         self.list_area = area;
         let profile = self.active_profile_display();
@@ -750,6 +804,34 @@ impl HomeView {
         let inner = block.inner(area);
         self.list_inner_area = inner;
         frame.render_widget(block, area);
+
+        // Collapse affordance on the top-right border. Clicking it shrinks
+        // the list to the click-to-expand strip. Drawn as an overlay on the
+        // border (after the block) so its clickable rect is known exactly,
+        // and skipped on a list too narrow to spare the columns without
+        // colliding with the title. The strip carries the inverse rect, so
+        // zero it here while the full list is on screen.
+        self.expand_strip_area = Rect::default();
+        const COLLAPSE_LABEL: &str = " \u{00AB} ";
+        const COLLAPSE_LABEL_WIDTH: u16 = 3;
+        if area.width > COLLAPSE_LABEL_WIDTH + 6 {
+            let btn_rect = Rect {
+                x: area.right() - COLLAPSE_LABEL_WIDTH,
+                y: area.y,
+                width: COLLAPSE_LABEL_WIDTH,
+                height: 1,
+            };
+            self.collapse_button_area = btn_rect;
+            frame.render_widget(
+                Paragraph::new(Span::styled(
+                    COLLAPSE_LABEL,
+                    Style::default().fg(theme.hint).bold(),
+                )),
+                btn_rect,
+            );
+        } else {
+            self.collapse_button_area = Rect::default();
+        }
 
         if self.instances().is_empty() && !self.has_any_groups() {
             let empty_text = vec![
@@ -2523,7 +2605,7 @@ impl HomeView {
         frame.render_widget(para, area);
     }
 
-    fn render_status_bar(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_status_bar(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         // Live-send banner takes over the status bar so the user has an
         // always-visible reminder that keystrokes are being relayed to
         // the pane (and how to get out). Distinct color + bold so it
@@ -2673,7 +2755,17 @@ impl HomeView {
         let mk_key =
             |key: &str| -> Vec<Span<'static>> { vec![Span::styled(key.to_string(), key_style)] };
 
-        let mut groups: Vec<(u8, Vec<Span<'static>>)> = Vec::new();
+        // Key a footer button synthesizes on click. The registry matches on
+        // the bare keycode (Shift implied by an uppercase char, Ctrl by the
+        // flag), so a plain char and a Ctrl char cover every footer chord.
+        let kc = |c: char| Some(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+        let kctrl = |c: char| Some(KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL));
+        let kenter = Some(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        // (priority, click-key, spans). `click-key` is `None` for the
+        // non-actionable status indicators (Serve / watching), which render
+        // but aren't clickable.
+        let mut groups: Vec<(u8, Option<KeyEvent>, Vec<Span<'static>>)> = Vec::new();
 
         // Serve indicator: shown only when the `aoe serve` daemon is live.
         // The TUI does not own the daemon, so we probe the PID file each
@@ -2689,6 +2781,7 @@ impl HomeView {
                 };
                 groups.push((
                     0,
+                    None,
                     vec![Span::styled(
                         label,
                         Style::default().fg(theme.running).bold(),
@@ -2705,6 +2798,7 @@ impl HomeView {
         if self.active_tui_count > 1 {
             groups.push((
                 0,
+                None,
                 vec![Span::styled(
                     format!(" \u{25C9} {} watching ", self.active_tui_count),
                     Style::default().fg(theme.accent).bold(),
@@ -2723,7 +2817,7 @@ impl HomeView {
                 let desc = format!("send {} buffered", buf.chars().count());
                 let mut spans = mk(key, &desc);
                 spans[1] = Span::styled(desc, Style::default().fg(theme.running).bold());
-                groups.push((0, spans));
+                groups.push((0, kc(if strict { 'M' } else { 'm' }), spans));
             }
         }
 
@@ -2743,29 +2837,45 @@ impl HomeView {
             // visual gap before the description — at most fonts the arrow
             // glyph fills its cell tightly and a single mk-internal space
             // looks too close to the desc.
-            groups.push((0, mk("↵ ", enter_action_text)));
+            groups.push((0, kenter, mk("↵ ", enter_action_text)));
         }
 
-        groups.push((2, mk(if strict { "T" } else { "t" }, "View")));
+        groups.push((
+            2,
+            kc(if strict { 'T' } else { 't' }),
+            mk(if strict { "T" } else { "t" }, "View"),
+        ));
         if matches!(self.view_mode, ViewMode::Tool(_)) {
-            groups.push((1, mk(";", "Back")));
+            groups.push((1, kc(';'), mk(";", "Back")));
         } else if !self.tool_configs.is_empty() {
-            groups.push((2, mk(";", "Tools")));
+            groups.push((2, kc(';'), mk(";", "Tools")));
         }
-        groups.push((3, mk(if strict { "^G" } else { "g" }, "Group")));
+        groups.push((
+            3,
+            if strict { kctrl('g') } else { kc('g') },
+            mk(if strict { "^G" } else { "g" }, "Group"),
+        ));
 
         // c: container/host toggle hint for sandboxed sessions in Terminal view
         if self.view_mode == ViewMode::Terminal {
             if let Some(id) = &self.selected_session {
                 if let Some(inst) = self.get_instance(id) {
                     if inst.is_sandboxed() {
-                        groups.push((4, mk(if strict { "C" } else { "c" }, "Mode")));
+                        groups.push((
+                            4,
+                            kc(if strict { 'C' } else { 'c' }),
+                            mk(if strict { "C" } else { "c" }, "Mode"),
+                        ));
                     }
                 }
             }
         }
 
-        groups.push((2, mk(if strict { "N" } else { "n" }, "New")));
+        groups.push((
+            2,
+            kc(if strict { 'N' } else { 'n' }),
+            mk(if strict { "N" } else { "n" }, "New"),
+        ));
 
         // Priority 1: user's core daily workflow (message / del).
         // These survive the greedy pack under narrow-pane widths (iPad
@@ -2773,10 +2883,18 @@ impl HomeView {
         // reaches for most often. Del stays at p3, less frequent,
         // OK to drop first.
         if self.selected_session.is_some() {
-            groups.push((1, mk(if strict { "M" } else { "m" }, "Msg")));
+            groups.push((
+                1,
+                kc(if strict { 'M' } else { 'm' }),
+                mk(if strict { "M" } else { "m" }, "Msg"),
+            ));
         }
         if !self.flat_items.is_empty() {
-            groups.push((3, mk(if strict { "D" } else { "d" }, "Del")));
+            groups.push((
+                3,
+                kc(if strict { 'D' } else { 'd' }),
+                mk(if strict { "D" } else { "d" }, "Del"),
+            ));
         }
         // Attention-workflow shortcuts (Archive / Fav / Snooze) only render
         // when the user is in Attention sort. They are only useful for
@@ -2784,25 +2902,41 @@ impl HomeView {
         // they just take footer space without changing what the user sees.
         if self.sort_order == SortOrder::Attention {
             if !self.flat_items.is_empty() {
-                groups.push((1, mk(if strict { "Z" } else { "z" }, "Archive")));
+                groups.push((
+                    1,
+                    kc(if strict { 'Z' } else { 'z' }),
+                    mk(if strict { "Z" } else { "z" }, "Archive"),
+                ));
             }
             if self.selected_session.is_some() {
-                groups.push((1, mk(if strict { "F" } else { "f" }, "Fav")));
-                groups.push((1, mk(if strict { "H" } else { "h" }, "Snooze")));
+                groups.push((
+                    1,
+                    kc(if strict { 'F' } else { 'f' }),
+                    mk(if strict { "F" } else { "f" }, "Fav"),
+                ));
+                groups.push((
+                    1,
+                    kc(if strict { 'H' } else { 'h' }),
+                    mk(if strict { "H" } else { "h" }, "Snooze"),
+                ));
             }
         }
 
-        groups.push((4, mk_key("/")));
-        groups.push((4, mk(if strict { "^D" } else { "D" }, "Diff")));
-        groups.push((1, mk("^K", "Cmds")));
-        groups.push((0, mk_key("?")));
+        groups.push((4, kc('/'), mk_key("/")));
+        groups.push((
+            4,
+            if strict { kctrl('d') } else { kc('D') },
+            mk(if strict { "^D" } else { "D" }, "Diff"),
+        ));
+        groups.push((1, kctrl('k'), mk("^K", "Cmds")));
+        groups.push((0, kc('?'), mk_key("?")));
 
         // Greedy pack by priority. Width of a group = sum of span char counts;
         // separator between kept groups adds 3 cols each (" · "). Reserve 1
         // col for the leading space margin.
         let widths: Vec<usize> = groups
             .iter()
-            .map(|(_, g)| g.iter().map(|s| s.content.chars().count()).sum::<usize>())
+            .map(|(_, _, g)| g.iter().map(|s| s.content.chars().count()).sum::<usize>())
             .collect();
         let avail = (area.width as usize).saturating_sub(1);
 
@@ -2821,16 +2955,51 @@ impl HomeView {
             }
         }
 
+        // Inverted-chip highlight for the button under the pointer, matching
+        // the LIVE chip's fg/bg swap so hover reads as "this is clickable".
+        let hover_style = Style::default()
+            .fg(theme.background)
+            .bg(theme.accent)
+            .bold();
+
         let mut spans: Vec<Span> = vec![Span::raw(" ")];
         let mut first = true;
-        for (i, (_, group)) in groups.into_iter().enumerate() {
+        // Column of the next span; starts past the leading space margin. Used
+        // to record each clickable button's hit rect as it's laid out.
+        let mut col = area.x.saturating_add(1);
+        let mut clickable_idx = 0usize;
+        for (i, (_, key, group)) in groups.into_iter().enumerate() {
             if !keep[i] {
                 continue;
             }
             if !first {
                 spans.push(Span::styled(" · ", sep_style));
+                col = col.saturating_add(3);
             }
-            spans.extend(group);
+            let width = widths[i] as u16;
+            match key {
+                Some(key) => {
+                    self.footer_buttons.push((
+                        Rect {
+                            x: col,
+                            y: area.y,
+                            width,
+                            height: area.height,
+                        },
+                        key,
+                    ));
+                    if self.footer_hover == Some(clickable_idx) {
+                        for s in group {
+                            spans.push(Span::styled(s.content, hover_style));
+                        }
+                    } else {
+                        spans.extend(group);
+                    }
+                    clickable_idx += 1;
+                }
+                None => spans.extend(group),
+            }
+            col = col.saturating_add(width);
             first = false;
         }
 

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -469,12 +469,17 @@ impl HomeView {
         update_status: Option<&str>,
         image_update: Option<&ImageUpdate>,
     ) {
-        // Start each frame with no footer buttons; `render_status_bar`
-        // repopulates them for the normal home view. The takeover views
-        // (settings/diff/serve) return before that runs, and the live-send
-        // banner replaces the footer, so in those cases the list stays
-        // empty and stale rects can't swallow clicks.
+        // Start each frame with no footer buttons and no sidebar
+        // collapse/expand hit rects; the home-view render paths
+        // (`render_status_bar`, `render_list` / `render_collapsed_strip`)
+        // repopulate them. The takeover views (settings/diff/serve) return
+        // before those run, so clearing here keeps a stale rect from a prior
+        // home frame from swallowing a click on the diff/serve surface (the
+        // collapse handler runs ahead of `hit_diff`). The live-send banner
+        // likewise replaces the footer, leaving the list empty.
         self.footer_buttons.clear();
+        self.collapse_button_area = Rect::default();
+        self.expand_strip_area = Rect::default();
 
         // Settings view takes over the whole screen
         if let Some(ref mut settings) = self.settings_view {
@@ -563,10 +568,10 @@ impl HomeView {
             // otherwise keep last frame's values and a click in the now-
             // preview area could resolve to an invisible list row (and
             // switch the live target). Zero them so mouse hit-testing can't
-            // target the hidden sidebar; the strip carries its own rect.
+            // target the hidden sidebar; `render` already cleared the
+            // collapse button rect, and the strip sets its own.
             self.list_area = Rect::default();
             self.list_inner_area = Rect::default();
-            self.collapse_button_area = Rect::default();
             self.render_collapsed_strip(frame, chunks[0], theme);
             self.render_preview(frame, chunks[1], theme);
         } else if available_width < responsive::STACKED_BREAKPOINT {
@@ -809,9 +814,8 @@ impl HomeView {
         // the list to the click-to-expand strip. Drawn as an overlay on the
         // border (after the block) so its clickable rect is known exactly,
         // and skipped on a list too narrow to spare the columns without
-        // colliding with the title. The strip carries the inverse rect, so
-        // zero it here while the full list is on screen.
-        self.expand_strip_area = Rect::default();
+        // colliding with the title (`render` already zeroed the rect, so the
+        // narrow case needs no else).
         const COLLAPSE_LABEL: &str = " \u{00AB} ";
         const COLLAPSE_LABEL_WIDTH: u16 = 3;
         if area.width > COLLAPSE_LABEL_WIDTH + 6 {
@@ -829,8 +833,6 @@ impl HomeView {
                 )),
                 btn_rect,
             );
-        } else {
-            self.collapse_button_area = Rect::default();
         }
 
         if self.instances().is_empty() && !self.has_any_groups() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8565,6 +8565,49 @@ mod scroll_pane_isolation {
             "strip click re-expands the sidebar"
         );
     }
+
+    /// A takeover view (settings/diff/serve) returns early in `render`
+    /// before the home-view paths run, so the collapse/expand and footer
+    /// hit rects must be cleared up front. Otherwise a stale rect from the
+    /// prior home frame could swallow a click on the takeover surface (the
+    /// collapse handler runs ahead of `hit_diff`).
+    #[test]
+    #[serial]
+    fn takeover_view_clears_sidebar_hit_rects() {
+        use ratatui::backend::TestBackend;
+        use ratatui::layout::Rect;
+        use ratatui::Terminal;
+
+        let mut env = create_test_env_with_sessions(3);
+        let theme = crate::tui::styles::load_theme("empire");
+        let render = |env: &mut TestEnv| {
+            let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+            terminal
+                .draw(|f| {
+                    let area = f.area();
+                    env.view.render(f, area, &theme, None, None, None);
+                })
+                .unwrap();
+        };
+
+        // Home view populates the collapse button + footer rects.
+        render(&mut env);
+        assert!(env.view.collapse_button_area.width > 0);
+        assert!(!env.view.footer_buttons.is_empty());
+
+        // Opening settings is a full-screen takeover; the next render must
+        // clear the stale rects so a click can't toggle the hidden sidebar.
+        env.view.settings_view =
+            Some(crate::tui::settings::SettingsView::new("test", None).unwrap());
+        render(&mut env);
+        assert_eq!(env.view.collapse_button_area, Rect::default());
+        assert_eq!(env.view.expand_strip_area, Rect::default());
+        assert!(env.view.footer_buttons.is_empty());
+        assert!(
+            !env.view.handle_sidebar_collapse_click(0, 0),
+            "no sidebar rect can be hit while a takeover view owns the screen"
+        );
+    }
 }
 
 mod footer_toolbar {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8358,7 +8358,9 @@ mod scroll_pane_isolation {
         assert!(env.view.live_send.is_some());
     }
 
-    /// Leader + q exits live mode and resets the live-only UI state.
+    /// Leader + q exits live mode and disarms the leader menu. The sidebar
+    /// collapse is now a persisted general state, so exiting live mode
+    /// deliberately leaves it as the user set it (no force-reveal).
     #[test]
     #[serial]
     fn live_leader_q_exits() {
@@ -8368,8 +8370,8 @@ mod scroll_pane_isolation {
         env.view.handle_key(key(KeyCode::Char('q')), None);
         assert!(env.view.live_send.is_none(), "leader+q exits live mode");
         assert!(
-            !env.view.sidebar_collapsed,
-            "exiting must re-reveal the sidebar"
+            env.view.sidebar_collapsed,
+            "collapse is persisted, not reset on live exit"
         );
         assert!(!env.view.live_send_pending_leader);
     }
@@ -8446,7 +8448,10 @@ mod scroll_pane_isolation {
             "committing a palette command must drop out of live mode"
         );
         assert!(env.view.command_palette.is_none());
-        assert!(!env.view.sidebar_collapsed, "live-only state is reset");
+        assert!(
+            !env.view.sidebar_collapsed,
+            "sidebar was never collapsed, so it stays expanded"
+        );
     }
 
     /// Collapsing the sidebar in live mode hands the preview the full
@@ -8494,6 +8499,237 @@ mod scroll_pane_isolation {
         // The which-key banner renders without panicking while armed.
         env.view.live_send_pending_leader = true;
         let _ = render(&mut env);
+    }
+
+    /// The collapse button (expanded) and the strip (collapsed) are
+    /// click-toggle affordances: clicking the button collapses, clicking
+    /// the strip re-expands, and each reports its hit rect while the other
+    /// is cleared.
+    #[test]
+    #[serial]
+    fn sidebar_collapse_button_and_strip_toggle() {
+        use ratatui::backend::TestBackend;
+        use ratatui::layout::Rect;
+        use ratatui::Terminal;
+
+        let mut env = create_test_env_with_sessions(3);
+        let theme = crate::tui::styles::load_theme("empire");
+
+        let render = |env: &mut TestEnv| {
+            let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+            terminal
+                .draw(|f| {
+                    let area = f.area();
+                    env.view.render(f, area, &theme, None, None, None);
+                })
+                .unwrap();
+        };
+
+        // Expanded: the collapse button has a real rect; clicking it collapses.
+        render(&mut env);
+        assert!(!env.view.sidebar_collapsed);
+        let btn = env.view.collapse_button_area;
+        assert!(
+            btn.width > 0 && btn.height > 0,
+            "collapse button must have a hit rect while expanded"
+        );
+        assert!(
+            env.view.handle_sidebar_collapse_click(btn.x, btn.y),
+            "clicking the collapse button is consumed"
+        );
+        assert!(
+            env.view.sidebar_collapsed,
+            "collapse button click collapses the sidebar"
+        );
+
+        // Collapsed: the strip has a real rect, the button rect is cleared,
+        // and clicking the strip re-expands.
+        render(&mut env);
+        let strip = env.view.expand_strip_area;
+        assert!(
+            strip.width > 0 && strip.height > 0,
+            "collapsed strip must have a hit rect"
+        );
+        assert_eq!(
+            env.view.collapse_button_area,
+            Rect::default(),
+            "collapse button rect cleared while collapsed"
+        );
+        assert!(
+            env.view
+                .handle_sidebar_collapse_click(strip.x + 1, strip.y + 1),
+            "clicking the strip is consumed"
+        );
+        assert!(
+            !env.view.sidebar_collapsed,
+            "strip click re-expands the sidebar"
+        );
+    }
+}
+
+mod footer_toolbar {
+    //! The footer hint bar is a clickable toolbar: each shortcut renders a
+    //! hit rect paired with the key it synthesizes, a click dispatches that
+    //! key through the normal handler, and hover highlights the button.
+    use super::*;
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn render_at(env: &mut TestEnv, w: u16, h: u16) {
+        let theme = crate::tui::styles::load_theme("empire");
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                env.view.render(f, area, &theme, None, None, None);
+            })
+            .unwrap();
+    }
+
+    fn button_key(env: &TestEnv, code: KeyCode) -> Option<KeyEvent> {
+        env.view
+            .footer_buttons
+            .iter()
+            .find(|(_, k)| k.code == code)
+            .map(|(_, k)| *k)
+    }
+
+    /// Each rendered shortcut produces a hit rect carrying the equivalent
+    /// key, and `footer_button_at` resolves a click inside one to that key.
+    #[test]
+    #[serial]
+    fn buttons_map_clicks_to_shortcuts() {
+        let mut env = create_test_env_with_sessions(3);
+        render_at(&mut env, 120, 12);
+
+        assert!(
+            !env.view.footer_buttons.is_empty(),
+            "footer should expose clickable buttons"
+        );
+        // New / View / Group / Cmds are always present in the home view.
+        assert_eq!(
+            button_key(&env, KeyCode::Char('n')).map(|k| k.modifiers),
+            Some(KeyModifiers::NONE),
+            "New maps to a plain 'n'"
+        );
+        let cmds = button_key(&env, KeyCode::Char('k')).expect("Cmds button present");
+        assert_eq!(cmds.modifiers, KeyModifiers::CONTROL, "Cmds maps to Ctrl+K");
+
+        // A click inside the New button's rect resolves to its key; a click
+        // outside every button resolves to nothing.
+        let (new_rect, _) = env
+            .view
+            .footer_buttons
+            .iter()
+            .find(|(_, k)| k.code == KeyCode::Char('n'))
+            .cloned()
+            .expect("New button rect");
+        assert_eq!(
+            env.view
+                .footer_button_at(new_rect.x, new_rect.y)
+                .map(|k| k.code),
+            Some(KeyCode::Char('n'))
+        );
+        assert!(
+            env.view
+                .footer_button_at(new_rect.x, new_rect.y + 5)
+                .is_none(),
+            "a click off the footer row hits no button"
+        );
+    }
+
+    /// Dispatching a footer button's key runs the same action as the
+    /// keypress: the New button opens the new-session dialog.
+    #[test]
+    #[serial]
+    fn clicking_new_opens_dialog() {
+        let mut env = create_test_env_with_sessions(3);
+        render_at(&mut env, 120, 12);
+        let key = button_key(&env, KeyCode::Char('n')).expect("New button");
+        assert!(env.view.new_dialog.is_none());
+        env.view.handle_key(key, None);
+        assert!(
+            env.view.new_dialog.is_some(),
+            "clicking New opens the new-session dialog"
+        );
+    }
+
+    /// Strict-hotkey mode shifts the chords: Diff becomes Ctrl+D and Delete
+    /// becomes an uppercase 'D', and the buttons synthesize those exactly.
+    #[test]
+    #[serial]
+    fn strict_mode_buttons_carry_shifted_chords() {
+        let mut env = create_test_env_with_sessions(3);
+        env.view.strict_hotkeys = true;
+        render_at(&mut env, 120, 12);
+
+        let diff = button_key(&env, KeyCode::Char('d')).expect("Diff button (strict ^D)");
+        assert_eq!(
+            diff.modifiers,
+            KeyModifiers::CONTROL,
+            "strict Diff is Ctrl+D"
+        );
+        assert!(
+            button_key(&env, KeyCode::Char('D')).is_some(),
+            "strict Delete is an uppercase D"
+        );
+    }
+
+    /// Hover sets `footer_hover` to the button under the pointer, reports the
+    /// change, and clears when the pointer leaves the footer.
+    #[test]
+    #[serial]
+    fn hover_tracks_button_under_pointer() {
+        let mut env = create_test_env_with_sessions(3);
+        render_at(&mut env, 120, 12);
+        let (rect, _) = env.view.footer_buttons[1];
+
+        assert!(env.view.footer_hover.is_none());
+        let changed = env.view.handle_hover(rect.x + 1, rect.y);
+        assert!(changed, "moving onto a button is a hover change");
+        assert_eq!(env.view.footer_hover, Some(1));
+
+        // Same button, no change reported.
+        assert!(!env.view.handle_hover(rect.x, rect.y));
+
+        // Off the footer row clears the hover.
+        let changed = env.view.handle_hover(rect.x, rect.y.saturating_sub(5));
+        assert!(changed);
+        assert!(env.view.footer_hover.is_none());
+    }
+
+    /// The footer is replaced by the live-send banner, so it exposes no
+    /// clickable buttons while live mode owns the status bar.
+    #[test]
+    #[serial]
+    fn no_buttons_during_live_send() {
+        let mut env = create_test_env_with_sessions(3);
+        render_at(&mut env, 120, 12);
+        assert!(!env.view.footer_buttons.is_empty());
+
+        env.view.cursor = 1;
+        env.view.update_selected();
+        let id = match env.view.flat_items.get(1) {
+            Some(Item::Session { id, .. }) => id.clone(),
+            _ => panic!("expected a session at flat_items[1]"),
+        };
+        env.view.live_send = Some(crate::tui::home::live_send::LiveSendState {
+            session_id: id,
+            title: "s".to_string(),
+            tmux_name: "fake".to_string(),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
+            exit_chords: crate::tui::home::live_send::parse_chord_list(
+                crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
+            ),
+            leader: None,
+        });
+        render_at(&mut env, 120, 12);
+        assert!(
+            env.view.footer_buttons.is_empty(),
+            "live-send banner replaces the footer toolbar"
+        );
+        assert_eq!(env.view.footer_button_at(0, 11), None);
     }
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8698,6 +8698,34 @@ mod footer_toolbar {
         );
     }
 
+    /// While a non-live overlay (here the help screen) is open, the footer
+    /// is drawn underneath but the overlay owns clicks: `footer_button_at`
+    /// and `handle_sidebar_collapse_click` must report no hit so a click
+    /// can't fire a shortcut or toggle the sidebar behind the modal.
+    #[test]
+    #[serial]
+    fn overlay_blocks_footer_and_sidebar_clicks() {
+        let mut env = create_test_env_with_sessions(3);
+        render_at(&mut env, 120, 12);
+        let (rect, _) = env.view.footer_buttons[0];
+        // No overlay: the button resolves.
+        assert!(env.view.footer_button_at(rect.x, rect.y).is_some());
+
+        env.view.show_help = true;
+        assert!(
+            env.view.has_non_live_send_overlay(),
+            "help screen is a non-live overlay"
+        );
+        assert!(
+            env.view.footer_button_at(rect.x, rect.y).is_none(),
+            "footer click is blocked while an overlay owns the screen"
+        );
+        assert!(
+            !env.view.handle_sidebar_collapse_click(0, 0),
+            "sidebar toggle is blocked while an overlay owns the screen"
+        );
+    }
+
     /// Strict-hotkey mode shifts the chords: Diff becomes Ctrl+D and Delete
     /// becomes an uppercase 'D', and the buttons synthesize those exactly.
     #[test]

--- a/src/tui/responsive.rs
+++ b/src/tui/responsive.rs
@@ -32,6 +32,11 @@ pub const STACKED_BREAKPOINT: u16 = 80;
 /// without hash-soup wrapping. Used as the side-by-side preview floor.
 pub const PREVIEW_MIN_WIDTH: u16 = 40;
 
+/// Width of the collapsed-sidebar strip: a bordered column wide enough
+/// for the `»` expand glyph plus its two border columns. Everything else
+/// goes to the preview, so the strip is intentionally minimal.
+pub const COLLAPSED_STRIP_WIDTH: u16 = 3;
+
 /// In stacked mode the list takes 1/N of vertical space.
 pub const STACKED_LIST_HEIGHT_FRACTION: u16 = 3;
 


### PR DESCRIPTION
## Description

Two related changes for the clickable TUI.

**Feature: collapsible sidebar + clickable footer toolbar**

- A collapse button (`«`) sits on the session list's top-right border. Clicking it collapses the list to a narrow click-to-expand strip (`»` plus the session count); the preview takes the freed width. The state persists via `app_state.home_sidebar_collapsed`, and the existing live-send `leader b` toggle now drives the same persisted state.
- The footer hint bar is now a real toolbar: each shortcut renders a hit rect paired with the key it represents, and a click synthesizes that key through the full key handler, so a click behaves exactly like pressing the shortcut (strict-hotkey mappings included). The hovered button highlights as an inverted accent chip; hover tracking was wired through `handle_hover` centrally so future clickable surfaces can reuse it.

**Fix: config saves no longer force a full-screen clear (flicker)**

While testing the collapse button I found it flickered. Capturing the TUI's raw output showed a bare `\033[2J` full-screen clear plus a full repaint on every toggle. Root cause: `App::set_theme` set `needs_redraw` unconditionally, and the config-file watcher re-dispatches the theme on every `config.toml` save. So any config-writing action forced a `clear_terminal()` flash. This was pre-existing: list resize (`<`/`>`), the info toggle (`i`), and settings saves all flickered the same way; the new collapse persistence just inherited it.

`set_theme` is now idempotent: it tracks the applied `(theme name, palette mode)` and no-ops (no `needs_redraw`) when nothing changed. After the fix, collapse/expand and the other config-saving actions emit zero `\033[2J` clears.

## PR Type

- [x] New Feature
- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated tests (unit/integration under `src/tui/home/tests.rs` and `src/tui/app.rs`)
  - `footer_toolbar`: buttons map clicks to shortcuts, strict-mode chords, hover tracking, no buttons during live-send.
  - `sidebar_collapse_button_and_strip_toggle`: collapse-button and strip click toggles + hit rects.
  - `theme_apply_needed_compares_name_and_palette_mode`: the idempotency guard that prevents the flicker.

  Note: the flicker fix was also verified directly by capturing the TUI's raw terminal output (`tmux pipe-pane`) and asserting zero `\033[2J` clears on collapse/expand/`<`/`>`/`i`; that byte-level check isn't practical to land as an automated test, so the regression is guarded by the `theme_apply_needed` unit test instead.

## How tested

- `cargo fmt`, `cargo clippy --all-targets`, `cargo test --lib tui::` (1398 passing) + `tui::app` (40 passing).
- Manual: ran the real `aoe` binary against a live session in tmux, injected collapse/expand mouse clicks, and confirmed via raw-output capture that the full-screen clear is gone.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Used for implementation, root-cause investigation of the flicker (byte-level terminal-output capture), and tests, in back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784488536&installation_id=139138837&pr_number=2294&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2294&signature=60826697e28a1a749274fe559d6ee915f07001f840e0305399eded40d01d876d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves the TUI with a persistent, collapsible session sidebar, a mouse-clickable footer shortcut toolbar, and a fix for distracting full-screen flicker when settings/theme/config change.

## What changed

**Collapsible sidebar (persistent):**  
A collapse button (`«`) on the session list now collapses the sidebar into a narrow strip (`»` + session count), freeing space for the preview pane. The collapsed/expanded state is saved and restored across restarts. The existing `leader b` control now drives the same persisted sidebar state.  
Visual polish: it removes a double-border seam so the preview’s left border is the single shared separator.

**Clickable footer toolbar:**  
Footer shortcut hints are now real clickable buttons. Clicking a button triggers the same behavior as pressing the shortcut (including strict hotkey/chord behavior), and hovered buttons highlight consistently.  
Usability improvements: click + hover geometry is recalculated per render to avoid stale hit targets, footer click rectangles match what the UI actually draws (using rendered cell width), and footer/sidebar clicks are isolated so they don’t take effect while modal-style overlays are open.

**Flicker fix (theme/config saves):**  
Theme application is now idempotent: config/theme re-dispatches no longer trigger full-screen clears when the effective theme hasn’t changed. This removes flicker during sidebar collapse/expand, list resizing, info toggle, and settings saves.

## Benefits

- More usable horizontal space via sidebar collapse without losing interaction state.
- Better mouse usability: footer shortcuts behave like real key presses, including strict hotkey mappings.
- Smoother visuals: eliminates distracting full-screen flicker during common UI/config actions.
- More reliable clicking: hit regions are kept accurate and cleared when takeover/modal views are active.

## Technical notes (for review)

- Added persisted UI preference: `AppStateConfig.home_sidebar_collapsed: Option<bool>`.
- `App::set_theme` made idempotent by tracking applied `(theme_name, palette_mode)` and skipping redraw work when unchanged.
- Home view hit-testing/rendering updates:
  - Rebuild frame-local click geometry on render to prevent stale rectangles (especially for takeover views).
  - Footer toolbar hover and click routing added; click targets synthesized into normal key handling.
  - Footer hit-rectangle width uses `Span::width()` so clicks align with rendered button cells.
- Sidebar/footer click isolation added so shortcuts don’t get synthesized behind open modal overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->