### PR TITLE
fix(hooks): preserve foreign keys and skip rewrite when state is clean

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -765,6 +765,9 @@ fn remove_aoe_entries(matchers: &mut Vec<Value>) {
 /// Merges AoE hook entries into the existing hooks configuration, preserving
 /// any user-defined hooks. Existing AoE hooks are replaced (idempotent).
 ///
+/// Idempotent on disk: when the on-disk file already encodes the same
+/// AoE-managed hook subtree, it is not rewritten (same inode, same bytes).
+///
 /// If the file doesn't exist, it will be created with just the hooks.
 pub fn install_hooks(
     settings_path: &Path,
@@ -781,6 +784,8 @@ pub fn install_hooks(
         } else {
             serde_json::json!({})
         };
+
+        let before = settings.clone();
 
         let aoe_hooks = build_aoe_hooks(events, target);
 
@@ -812,6 +817,13 @@ pub fn install_hooks(
             }
         }
 
+        if settings == before {
+            tracing::debug!(target: "hooks.install",
+                "AoE hooks in {} already up to date; skipping write",
+                settings_path.display());
+            return Ok(());
+        }
+
         if let Some(parent) = settings_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -839,6 +851,9 @@ const CODEX_HOOK_EVENT_NAMES: &[&str] = &[
 /// Codex also stores hook trust state in this file. Keep every AoE mutation
 /// behind the lock and atomic replace below so repeated launches cannot leave
 /// duplicated hook blocks or torn TOML.
+///
+/// Idempotent on disk: when the on-disk file already encodes the same
+/// AoE-managed hook subtree, it is not rewritten (same inode, same bytes).
 pub fn install_codex_hooks(
     config_path: &Path,
     events: &[crate::agents::HookEvent],
@@ -874,6 +889,8 @@ pub(crate) fn install_codex_hooks_with_preserved_state(
             return Ok(());
         }
 
+        let before = config.to_string();
+
         if let Some(state) = preserved_state {
             let hooks = ensure_codex_hooks_table(&mut config)?;
             if !hooks.contains_key("state") {
@@ -882,12 +899,19 @@ pub(crate) fn install_codex_hooks_with_preserved_state(
         }
         remove_codex_aoe_hooks(&mut config)?;
         merge_codex_hooks(&mut config, events, target)?;
-        write_codex_config(config_path, &config)?;
-        Ok(())
-    })?;
 
-    tracing::info!(target: "hooks.install", "Installed AoE hooks in {}", config_path.display());
-    Ok(())
+        if config.to_string() == before {
+            tracing::debug!(target: "hooks.install",
+                "AoE hooks in {} already up to date; skipping write",
+                config_path.display());
+            return Ok(());
+        }
+
+        write_codex_config(config_path, &config)?;
+        tracing::info!(target: "hooks.install",
+            "Installed AoE hooks in {}", config_path.display());
+        Ok(())
+    })
 }
 
 fn with_codex_config_lock<T>(config_path: &Path, f: impl FnOnce() -> Result<T>) -> Result<T> {
@@ -1269,6 +1293,9 @@ const SETTL_HOOKS: &[(&str, &str)] = &[
 /// previous AoE-managed hooks (identified by the marker), and adds hooks
 /// for the three status transitions: TurnStarted->running,
 /// WaitingForHuman->waiting, GameWon->idle.
+///
+/// Idempotent on disk: when the on-disk file already encodes the same
+/// AoE-managed hook subtree, it is not rewritten (same inode, same bytes).
 pub fn install_settl_hooks(config_path: &Path, target: HookInstallTarget) -> Result<()> {
     with_config_lock(config_path, "toml.lock", || {
         let mut config: toml::Value = if config_path.exists() {
@@ -1280,6 +1307,8 @@ pub fn install_settl_hooks(config_path: &Path, target: HookInstallTarget) -> Res
         } else {
             toml::Value::Table(toml::map::Map::new())
         };
+
+        let before = config.clone();
 
         let table = config
             .as_table_mut()
@@ -1307,6 +1336,13 @@ pub fn install_settl_hooks(config_path: &Path, target: HookInstallTarget) -> Res
                 toml::Value::String(hook_command(status, target)),
             );
             hooks_arr.push(toml::Value::Table(entry));
+        }
+
+        if config == before {
+            tracing::debug!(target: "hooks.install",
+                "AoE hooks in {} already up to date; skipping write",
+                config_path.display());
+            return Ok(());
         }
 
         if let Some(parent) = config_path.parent() {
@@ -1386,6 +1422,9 @@ const HERMES_HOOKS: &[(&str, &str)] = &[
 /// itself tolerates a missing/stale allowlist by re-prompting for
 /// consent, which is recoverable. Hardening to atomic-write across both
 /// files is tracked as a follow-up.
+///
+/// Idempotent on disk: when the YAML config and the allowlist already
+/// encode the same AoE state, neither is rewritten (same inode, same bytes).
 pub fn install_hermes_hooks(config_path: &Path, target: HookInstallTarget) -> Result<()> {
     with_config_lock(config_path, "yaml.lock", || {
         let mut config: serde_yaml::Value = if config_path.exists() {
@@ -1399,6 +1438,8 @@ pub fn install_hermes_hooks(config_path: &Path, target: HookInstallTarget) -> Re
         } else {
             serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
         };
+
+        let yaml_before = config.clone();
 
         let root = config
             .as_mapping_mut()
@@ -1439,24 +1480,46 @@ pub fn install_hermes_hooks(config_path: &Path, target: HookInstallTarget) -> Re
             arr.push(serde_yaml::Value::Mapping(entry));
         }
 
-        let formatted = serde_yaml::to_string(&config)?;
+        let yaml_changed = config != yaml_before;
+
         let config_dir = config_path
             .parent()
             .ok_or_else(|| anyhow::anyhow!("config path has no parent"))?;
         let (allowlist_path, allowlist_formatted) = render_hermes_allowlist(config_dir, target)?;
+        // Byte-compare (vs the structural YAML compare above) is sound:
+        // render_hermes_allowlist preserves approved_at on (event, command)
+        // collision and serde_json::to_string_pretty is deterministic, so
+        // a clean reinstall is byte-identical from the second install onward.
+        let allowlist_changed = if allowlist_path.exists() {
+            std::fs::read(&allowlist_path)? != allowlist_formatted.as_bytes()
+        } else {
+            true
+        };
 
-        if let Some(parent) = config_path.parent() {
-            std::fs::create_dir_all(parent)?;
+        if !yaml_changed && !allowlist_changed {
+            tracing::debug!(target: "hooks.install",
+                "AoE hooks in {} already up to date; skipping write",
+                config_path.display());
+            return Ok(());
         }
-        crate::session::atomic_write_following_symlinks(config_path, formatted.as_bytes())?;
 
-        if let Some(parent) = allowlist_path.parent() {
-            std::fs::create_dir_all(parent)?;
+        if yaml_changed {
+            if let Some(parent) = config_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let formatted = serde_yaml::to_string(&config)?;
+            crate::session::atomic_write_following_symlinks(config_path, formatted.as_bytes())?;
         }
-        crate::session::atomic_write_following_symlinks(
-            &allowlist_path,
-            allowlist_formatted.as_bytes(),
-        )?;
+
+        if allowlist_changed {
+            if let Some(parent) = allowlist_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            crate::session::atomic_write_following_symlinks(
+                &allowlist_path,
+                allowlist_formatted.as_bytes(),
+            )?;
+        }
 
         tracing::info!(target: "hooks.install", "Installed AoE hooks in {}", config_path.display());
         Ok(())
@@ -1631,6 +1694,9 @@ pub const KIRO_HOOKS_AGENT_FILE: &str = concat!(".kiro/agents/", kiro_hooks_agen
 /// from any context (host install, sandbox provisioning, tests). To make
 /// the agent the active default on the host, call
 /// [`set_kiro_default_agent_if_builtin`] after this returns.
+///
+/// Idempotent on disk: when the on-disk file already encodes the same
+/// AoE-managed hook subtree, it is not rewritten (same inode, same bytes).
 pub fn install_kiro_hooks(agent_config_path: &Path, target: HookInstallTarget) -> Result<()> {
     with_config_lock(agent_config_path, "json.lock", || {
         let mut config: serde_json::Map<String, Value> = if agent_config_path.exists() {
@@ -1639,6 +1705,8 @@ pub fn install_kiro_hooks(agent_config_path: &Path, target: HookInstallTarget) -
         } else {
             serde_json::Map::new()
         };
+
+        let before = config.clone();
 
         config
             .entry("name".to_string())
@@ -1669,6 +1737,13 @@ pub fn install_kiro_hooks(agent_config_path: &Path, target: HookInstallTarget) -
         }
 
         config.insert("hooks".to_string(), Value::Object(hooks_obj));
+
+        if config == before {
+            tracing::debug!(target: "hooks.install",
+                "AoE hooks in {} already up to date; skipping write",
+                agent_config_path.display());
+            return Ok(());
+        }
 
         if let Some(parent) = agent_config_path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -4154,5 +4229,272 @@ hooks_auto_accept: false
             HOOK_STATUS_BASE_IN_CONTAINER.contains(AOE_HOOK_MARKER),
             "container base path must embed AOE_HOOK_MARKER verbatim"
         );
+    }
+
+    #[test]
+    fn test_install_hooks_preserves_statusline_foreign_key() {
+        let tmp = TempDir::new().unwrap();
+        let settings_path = tmp.path().join("settings.json");
+
+        let existing = serde_json::json!({
+            "statusLine": {"type": "command", "command": "my-status"},
+            "model": "opus",
+            "hooks": {}
+        });
+        std::fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&existing).unwrap(),
+        )
+        .unwrap();
+
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
+
+        let content: Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert_eq!(content["statusLine"]["type"], "command");
+        assert_eq!(content["statusLine"]["command"], "my-status");
+        assert_eq!(content["model"], "opus");
+        assert!(
+            content["hooks"].is_object(),
+            "AoE hooks subtree must be present"
+        );
+        assert!(
+            content["hooks"]["SessionStart"].is_array(),
+            "AoE SessionStart hook must be installed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_install_hooks_no_rewrite_when_unchanged() {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = TempDir::new().unwrap();
+        let settings_path = tmp.path().join("settings.json");
+
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
+        let ino_before = std::fs::metadata(&settings_path).unwrap().ino();
+        let bytes_before = std::fs::read(&settings_path).unwrap();
+
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
+        assert_eq!(
+            std::fs::metadata(&settings_path).unwrap().ino(),
+            ino_before,
+            "second install must not replace the inode"
+        );
+        assert_eq!(
+            std::fs::read(&settings_path).unwrap(),
+            bytes_before,
+            "second install must leave bytes byte-identical"
+        );
+    }
+
+    #[test]
+    fn test_install_settl_hooks_preserves_foreign_root_key() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "model = \"settl-pro\"\n").unwrap();
+
+        install_settl_hooks(&config_path, HookInstallTarget::Host).unwrap();
+
+        let config: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(config["model"].as_str(), Some("settl-pro"));
+        assert!(config["hooks"].is_array(), "AoE hooks must be installed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_install_settl_hooks_no_rewrite_when_unchanged() {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        install_settl_hooks(&config_path, HookInstallTarget::Host).unwrap();
+        let ino_before = std::fs::metadata(&config_path).unwrap().ino();
+        let bytes_before = std::fs::read(&config_path).unwrap();
+
+        install_settl_hooks(&config_path, HookInstallTarget::Host).unwrap();
+        assert_eq!(
+            std::fs::metadata(&config_path).unwrap().ino(),
+            ino_before,
+            "second install must not replace the inode"
+        );
+        assert_eq!(
+            std::fs::read(&config_path).unwrap(),
+            bytes_before,
+            "second install must leave bytes byte-identical"
+        );
+    }
+
+    #[test]
+    fn test_install_hermes_hooks_preserves_foreign_yaml_and_allowlist_keys() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.yaml");
+        std::fs::write(
+            &config_path,
+            "model: hermes-pro\nhooks_auto_accept: false\n",
+        )
+        .unwrap();
+        let allowlist_path = tmp.path().join("shell-hooks-allowlist.json");
+        std::fs::write(&allowlist_path, "{\"version\":7,\"approvals\":[]}").unwrap();
+
+        install_hermes_hooks(&config_path, HookInstallTarget::Host).unwrap();
+
+        let yaml: serde_yaml::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            yaml.get("model").and_then(|v| v.as_str()),
+            Some("hermes-pro")
+        );
+        assert_eq!(
+            yaml.get("hooks_auto_accept").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert!(yaml.get("hooks").is_some());
+
+        let allowlist: Value =
+            serde_json::from_str(&std::fs::read_to_string(&allowlist_path).unwrap()).unwrap();
+        assert_eq!(allowlist["version"], 7);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_install_hermes_hooks_no_rewrite_when_unchanged() {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.yaml");
+        let allowlist_path = tmp.path().join("shell-hooks-allowlist.json");
+
+        install_hermes_hooks(&config_path, HookInstallTarget::Host).unwrap();
+        let yaml_ino_before = std::fs::metadata(&config_path).unwrap().ino();
+        let yaml_bytes_before = std::fs::read(&config_path).unwrap();
+        let allowlist_ino_before = std::fs::metadata(&allowlist_path).unwrap().ino();
+        let allowlist_bytes_before = std::fs::read(&allowlist_path).unwrap();
+
+        install_hermes_hooks(&config_path, HookInstallTarget::Host).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&config_path).unwrap().ino(),
+            yaml_ino_before,
+            "config.yaml inode must be stable on a second clean install"
+        );
+        assert_eq!(std::fs::read(&config_path).unwrap(), yaml_bytes_before);
+        assert_eq!(
+            std::fs::metadata(&allowlist_path).unwrap().ino(),
+            allowlist_ino_before,
+            "shell-hooks-allowlist.json inode must be stable on a second clean install"
+        );
+        assert_eq!(
+            std::fs::read(&allowlist_path).unwrap(),
+            allowlist_bytes_before
+        );
+    }
+
+    #[test]
+    fn test_install_kiro_hooks_preserves_foreign_root_keys() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("aoe-hooks.json");
+        std::fs::write(&path, "{\"description\":\"keep me\",\"version\":3}").unwrap();
+
+        install_kiro_hooks(&path, HookInstallTarget::Host).unwrap();
+
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v["description"], "keep me");
+        assert_eq!(v["version"], 3);
+        assert!(v["hooks"].is_object());
+        assert!(
+            v["hooks"]["preToolUse"].is_array(),
+            "AoE preToolUse hook must be installed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_install_kiro_hooks_no_rewrite_when_unchanged() {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("aoe-hooks.json");
+
+        install_kiro_hooks(&path, HookInstallTarget::Host).unwrap();
+        let ino_before = std::fs::metadata(&path).unwrap().ino();
+        let bytes_before = std::fs::read(&path).unwrap();
+
+        install_kiro_hooks(&path, HookInstallTarget::Host).unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().ino(),
+            ino_before,
+            "second install must not replace the inode"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), bytes_before);
+    }
+
+    #[test]
+    fn test_install_codex_hooks_preserves_foreign_root_key_and_comment() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        let original = "# user comment\n\
+                        model = \"gpt-5.3-codex\"\n\
+                        approval_policy = \"on-failure\"\n";
+        std::fs::write(&config_path, original).unwrap();
+
+        install_codex_hooks(&config_path, codex_events(), HookInstallTarget::Host).unwrap();
+
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            after.contains("# user comment"),
+            "user comment must survive toml_edit round-trip; got:\n{after}"
+        );
+        assert!(after.contains("model = \"gpt-5.3-codex\""));
+        assert!(after.contains("approval_policy = \"on-failure\""));
+        let parsed: toml::Value = toml::from_str(&after).unwrap();
+        assert!(parsed["hooks"]["SessionStart"].is_array());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_install_codex_hooks_no_rewrite_when_unchanged() {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        install_codex_hooks(&config_path, codex_events(), HookInstallTarget::Host).unwrap();
+        let ino_before = std::fs::metadata(&config_path).unwrap().ino();
+        let bytes_before = std::fs::read(&config_path).unwrap();
+
+        install_codex_hooks(&config_path, codex_events(), HookInstallTarget::Host).unwrap();
+        assert_eq!(
+            std::fs::metadata(&config_path).unwrap().ino(),
+            ino_before,
+            "second install must not replace the inode"
+        );
+        assert_eq!(std::fs::read(&config_path).unwrap(), bytes_before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_install_codex_with_preserved_state_no_rewrite_when_unchanged() {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        install_codex_hooks(&config_path, codex_events(), HookInstallTarget::Host).unwrap();
+        let preserved = snapshot_codex_hooks_state(&config_path).unwrap();
+        let ino_before = std::fs::metadata(&config_path).unwrap().ino();
+        let bytes_before = std::fs::read(&config_path).unwrap();
+
+        install_codex_hooks_with_preserved_state(
+            &config_path,
+            codex_events(),
+            preserved,
+            HookInstallTarget::Host,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&config_path).unwrap().ino(),
+            ino_before,
+            "preserved-state install must not replace the inode when state and events are clean"
+        );
+        assert_eq!(std::fs::read(&config_path).unwrap(), bytes_before);
     }
 }


### PR DESCRIPTION
## Description

Every install path in `src/hooks/mod.rs` (Claude JSON, Codex TOML, settl TOML, Hermes YAML + `shell-hooks-allowlist.json`, Kiro JSON) re-serialized and rewrote its config file on every launch, even when AoE-owned state was already byte-identical to what was on disk. Under dotfile-sync setups (chezmoi, syncthing) and on Claude-Code-on-NixOS the constant rewrite churn produced sync conflicts and gave outside writers a window to lose top-level user keys (the user-reported case is Claude `statusLine` getting dropped between AoE's read and AoE's write).

The fix snapshots the parsed in-memory tree inside the existing `with_config_lock` critical section, applies the AoE mutation, structurally compares the result against the snapshot, and skips the `atomic_write_following_symlinks` call when nothing changed. For Codex (`toml_edit::DocumentMut`) the comparison is on `doc.to_string()`, which is byte-stable on round-trip because toml_edit preserves trivia. For Hermes the YAML config and the JSON allowlist are evaluated independently, so a clean half is not rewritten when the other half changed. Foreign-root-key preservation falls out of the snapshot path: every install path already used an untyped tree (`serde_json::Value`, `toml_edit::DocumentMut`, `toml::Value`, `serde_yaml::Value`, `serde_json::Map`), and the AoE mutation only ever touches the AoE-owned subtree, so a clean install never re-emits user content.

On the first install after upgrade, files whose formatting is non-canonical (CRLF line endings on Codex `config.toml`, hand-formatted indentation in the Hermes allowlist, AoE entries placed before user entries within a Hermes per-event array) are rewritten once into the canonical shape. Subsequent installs are byte-stable: `render_hermes_allowlist` preserves `approved_at` on `(event, command)` collision, `serde_json::to_string_pretty` is deterministic with the default `BTreeMap` backing, and `toml_edit` round-trips bytes-for-bytes when nothing in the document was mutated.

Closes #2154.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A: behavior fix, no public API or user-facing doc change)
- [x] For UI changes: included screenshot or recording (N/A: no UI surface)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The change is pure `src/hooks/mod.rs` logic plus format-roundtrip unit tests. Eleven new in-module tests cover the change:

- Foreign-root-key preservation per install path: Claude (`statusLine` per the #2154 repro), settl (`model` root key), Hermes (YAML `model` + `hooks_auto_accept`, allowlist `version`), Kiro (`description`, `version`), Codex (root key `model` + `approval_policy` + a leading `# user comment` line, locking the `toml_edit` comment-survival contract).
- Skip-no-diff per install path under `#[cfg(unix)]`: each test calls install twice with identical inputs, captures `(inode, bytes)` after the first call, and asserts both are unchanged after the second. Inode equality is the load-bearing signal because `atomic_write_following_symlinks` goes through `tempfile::persist`, which renames a fresh inode in on every actual write.
- One additional `#[cfg(unix)]` test on the v015 migration call shape (`install_codex_hooks_with_preserved_state` with `Some(preserved_state)` and clean events) to lock the cross product of state-preservation and skip-no-diff.

Run: `cargo test --lib hooks::` (160 tests pass, including the 11 new ones) and `cargo test --lib migrations::v015` (17 tests pass). `cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt -- --check` all clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via OpenCode.

**Any Additional AI Details you'd like to share:**

AI assisted with: bug-surface enumeration across the five install paths, per-format fix-shape evaluation (byte-compare vs structural compare on `serde_json::Value`, `toml::Value`, `serde_yaml::Value`, `toml_edit::DocumentMut`), patch drafting inside the existing `with_config_lock` critical section, and regression test design (foreign-key preservation per format plus `#[cfg(unix)]` inode + byte stability). The author approved the design before any code was written, ran the full test suite locally, and reviewed the diff line by line.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The pull request fixes hook installation logic across multiple configuration formats (JSON, TOML, and YAML) to prevent unnecessary file rewrites. Previously, every agent launch would re-serialize and overwrite these configuration files even when the managed hook content hadn't changed, which corrupted user settings and created sync conflicts in dotfile-managed environments.

The fix introduces idempotency checks before each file write:
- **Claude settings (JSON):** Snapshots the configuration before applying hook changes, then compares to detect if anything actually changed
- **Codex configuration (TOML):** Captures the serialized string before mutations and skips writing if the final output matches
- **Settl configuration (TOML):** Adds equality comparison to avoid writes when no changes occurred
- **Hermes configuration (YAML + JSON allowlist):** Independently evaluates both components and writes only if one actually changed
- **Kiro configuration (JSON):** Snapshots before mutations and skips writing on no-op installations

The PR also includes comprehensive test coverage for foreign-key preservation and idempotency verification, including inode-equality checks on Unix systems to confirm files aren't unnecessarily rewritten.

## Benefits

1. **Prevents data loss:** Foreign keys and user-authored configuration entries are no longer silently dropped during concurrent agent launches
2. **Eliminates sync conflicts:** Dotfile-synced setups (Syncthing, chezmoi, etc.) no longer generate conflict files from redundant rewrites
3. **Improves performance:** Unnecessary disk I/O is eliminated when installations are already in the desired state
4. **Ensures idempotency:** Multiple consecutive installs with unchanged configuration result in no file modifications

## Technical Details

The implementation uses snapshot-and-compare pattern within existing lock-protected critical sections:
- Pre-mutation snapshots capture the parsed in-memory tree state
- Post-mutation comparison determines if structural changes occurred (JSON/TOML value equality or byte-stable string comparison for TOML)
- For Hermes, YAML and JSON allowlist are evaluated independently, allowing one to remain unchanged without forcing unnecessary rewrites of both
- Atomic write semantics via `atomic_write_following_symlinks` are only invoked when actual changes are detected, preventing race conditions and corruption during concurrent access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->