### PR TITLE
test(acp): registry-terminate sibling regression test for cancelled_resumes (#2283)

### DIFF
--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -4473,6 +4473,28 @@ mod tests {
         );
     }
 
+    /// Park until `shutter` is alive and holding `workers` (the
+    /// steady state both lock-pair regression tests probe), or
+    /// finish, or hit a 5s deadline. Polling avoids a fixed sleep
+    /// that flakes on contended CI runners; the caller's asserts
+    /// distinguish the three exit shapes.
+    ///
+    /// `clippy::await_holding_lock` is suppressed at each call site
+    /// because the test holds `cancelled_guard` (a std `MutexGuard`)
+    /// at fn scope across the inner sleep; the guard's lint scope
+    /// follows the guard, not the `await`.
+    async fn wait_for_shutter_park<T>(
+        shutter: &tokio::task::JoinHandle<T>,
+        sup: &Supervisor<VecSink>,
+    ) {
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !shutter.is_finished() && sup.workers.try_lock().is_ok() {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+        })
+        .await;
+    }
+
     /// Regression for #1848: `shutdown_with_reason` must hold the
     /// `workers` lock across its `cancelled_resumes.insert(...)`,
     /// otherwise a concurrent `spawn` or `attach` that reacquires
@@ -4481,20 +4503,14 @@ mod tests {
     /// disable. Locks down the lock-pair invariant under typical
     /// scheduling: the test holds `cancelled_resumes` before
     /// spawning a shutter, so `shutdown_with_reason` parks at its
-    /// own breadcrumb insert; a 50ms sleep gives the shutter time
-    /// to reach that park on a multi-core runtime;
+    /// own breadcrumb insert; `wait_for_shutter_park` polls until
+    /// the shutter is parked inside `workers`;
     /// `workers.try_lock()` from the test then samples the invariant
     /// directly. `Err(_)` means the seed runs while `workers` is
     /// held (the bug shape #1848 closed); `Ok(_)` means a future
     /// reorder put the seed after the drop and the assert fails
     /// with the embedded message.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    // The `await_holding_lock` lint analyses the std `MutexGuard`'s
-    // drop scope relative to every await in the function, so it
-    // cannot be narrowed to a single statement: the guard
-    // `cancelled_guard` lives at fn scope until `drop(cancelled_guard)`,
-    // and the lint scope follows the guard, not the await. Holding
-    // `cancelled_guard` across the sleep is the test mechanism.
     #[allow(clippy::await_holding_lock)]
     async fn shutdown_holds_workers_lock_across_cancelled_resumes_seed() {
         let sup = Arc::new(Supervisor::new(VecSink::new()));
@@ -4510,11 +4526,7 @@ mod tests {
             tokio::spawn(async move { sup.shutdown("s-race").await })
         };
 
-        // Wait for shutter to reach steady state (parked on the std
-        // mutex the test is holding). On a multi-core runtime this
-        // happens within microseconds; the wait is generous so the
-        // test stays deterministic on slow CI hardware.
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        wait_for_shutter_park(&shutter, &sup).await;
 
         // Sanity probe: distinguishes a real #1848 regression from a
         // test-environment timing failure. If shutter completed, the
@@ -4542,6 +4554,103 @@ mod tests {
         assert!(
             sup.cancelled_resumes.lock().unwrap().contains("s-race"),
             "shutdown must seed cancelled_resumes for the in-flight resume"
+        );
+    }
+
+    /// Regression for #1848 (registry-terminate sibling of
+    /// `shutdown_holds_workers_lock_across_cancelled_resumes_seed`):
+    /// the registry-terminate writer branch in `shutdown_with_reason`
+    /// must also seed `cancelled_resumes` while still holding `workers`,
+    /// otherwise a concurrent `spawn` or `attach` reacquiring `workers`
+    /// between the drop and the insert observes an empty breadcrumb set
+    /// and installs an orphan worker against the SIGTERMed runner. Same
+    /// lock-hold mechanism as the pending-only sibling. HOME is
+    /// isolated so `worker_registry::save` writes under the tempdir;
+    /// the saved record carries a sentinel PID well above `PID_MAX` on
+    /// macOS and Linux so `killpg`/`kill` in
+    /// `terminate_runner_for_session` return `ESRCH`, which
+    /// `signal_runner_group` discards.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial_test::serial]
+    #[allow(clippy::await_holding_lock)]
+    async fn shutdown_holds_workers_lock_across_cancelled_resumes_seed_registry_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // SAFETY: `std::env::set_var` is unsound (Rust 1.80+) under
+        // concurrent env reads. `#[serial]` excludes other
+        // HOME-mutating tests in this crate (notably
+        // `restart_budget_burns_after_threshold`); non-`#[serial]`
+        // parallel readers of HOME via `get_app_dir()` are not
+        // excluded.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+
+        let sup = Arc::new(Supervisor::new(VecSink::new()));
+
+        // Save a registry record so `shutdown_with_reason` enters the
+        // registry-terminate branch (`worker_registry::load` returns Some).
+        // Sentinel PID is above macOS PID_MAX (99998) and Linux default
+        // pid_max (4_194_304), so signal_runner_group's killpg+kill both
+        // ESRCH and the test never signals an unrelated process.
+        let socket_path = tmp.path().join("registry-race.sock");
+        let record = crate::acp::worker_registry::WorkerRecord::new(
+            "s-registry-race".into(),
+            999_999_999,
+            socket_path,
+            "claude-agent-acp".into(),
+            "claude-code".into(),
+            std::env::temp_dir(),
+            None,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
+        crate::acp::worker_registry::save(&record).unwrap();
+
+        // The registry-terminate branch only seeds the breadcrumb when
+        // `pending_has_it` is true, mirroring the writer at line 2264.
+        sup.pending_resumes
+            .lock()
+            .unwrap()
+            .insert("s-registry-race".into(), ResumeKind::Spawn);
+
+        let cancelled_guard = sup.cancelled_resumes.lock().unwrap();
+
+        let shutter = {
+            let sup = Arc::clone(&sup);
+            tokio::spawn(async move { sup.shutdown("s-registry-race").await })
+        };
+
+        wait_for_shutter_park(&shutter, &sup).await;
+
+        assert!(
+            !shutter.is_finished(),
+            "shutter completed unexpectedly; cancelled_resumes parking \
+             did not engage on the registry-terminate path (test \
+             environment timing issue, not a #1848 regression)"
+        );
+
+        assert!(
+            sup.workers.try_lock().is_err(),
+            "regression #1848 (registry-terminate path): shutdown \
+             released `workers` before writing the `cancelled_resumes` \
+             breadcrumb"
+        );
+
+        drop(cancelled_guard);
+        shutter
+            .await
+            .expect("shutter task panicked")
+            .expect("shutdown should succeed");
+        assert!(
+            sup.cancelled_resumes
+                .lock()
+                .unwrap()
+                .contains("s-registry-race"),
+            "shutdown must seed cancelled_resumes for the in-flight \
+             resume on the registry-terminate path"
         );
     }
 


### PR DESCRIPTION
## Description

Adds the registry-terminate sibling regression test for #1848, mirroring `shutdown_holds_workers_lock_across_cancelled_resumes_seed`. The new test exercises the same lock-pair invariant (tokio `workers` outside, std `cancelled_resumes` inside, doc-protected at `src/acp/supervisor.rs:342-353`) on the second writer site of `shutdown_with_reason`: the registry-terminate branch at `src/acp/supervisor.rs:2251-2270`, where the breadcrumb is seeded at line 2265 before `drop(workers)` at line 2267.

The pending-only branch at `:2271-2289` got its regression test in #2279. The registry-terminate branch was protected by docs only. This PR closes that coverage gap. Per the contract on #2283, closing #2283 also closes #1848.

Both siblings now share a `wait_for_shutter_park` helper (`tokio::time::timeout` over a 5s deadline) that polls until the shutter is parked inside `workers`, replacing the previous fixed 50ms sleep on the existing pending-only test and removing CI flake risk under contention. Lock-pair invariant assertions are unchanged.

How the test steers control to the registry-terminate branch:

- `worker_registry::save(&record)` puts a `WorkerRecord` on disk for `"s-registry-race"`, so `worker_registry::load(...)` returns `Some` at line 2251 and the registry branch is taken.
- `pending_resumes.insert("s-registry-race", ResumeKind::Spawn)` makes `pending_has_it` true at line 2196, so the gate at line 2264 (`if pending_has_it`) opens and the breadcrumb insert at line 2265 actually executes.
- Holding `cancelled_resumes` from the test before spawning the shutter parks the writer on the std mutex insert at line 2265 while it owns the tokio `workers` mutex; `sup.workers.try_lock().is_err()` then proves the writer is inside its `workers` critical section.

Safety of the test environment:

- `HOME` and `XDG_CONFIG_HOME` are redirected to a `tempfile::TempDir` so `worker_registry::save` only touches the tempdir. Mirrors the precedent at `restart_budget_burns_after_threshold` (`src/acp/supervisor.rs:3318`).
- The saved record carries sentinel PID `999_999_999`, above macOS `PID_MAX` (99998) and Linux default `pid_max` (4_194_304). `terminate_runner_for_session` therefore calls `signal_runner_group` (`src/acp/worker_registry.rs:457-463`), whose `killpg` + `kill` ladder discards `Errno` via `let _ = ...` and returns `ESRCH`. No unrelated process can be signalled.

Closes #2283
Closes #1848

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How tested

Local Apple Silicon, Rust 1.x stable:

- `cargo fmt`
- `cargo clippy --all-targets --features serve -- -D warnings`
- `cargo test --lib -p agent-of-empires --features serve shutdown_holds_workers_lock_across_cancelled_resumes_seed_registry_path -- --nocapture` (the new test, ~60ms)
- `cargo test --lib -p agent-of-empires --features serve "acp::supervisor::tests::shutdown_holds_workers_lock_across_cancelled_resumes_seed"` (both siblings green)
- `cargo test --lib -p agent-of-empires --features serve "acp::supervisor::"` (51 passed, 0 failed, 0 ignored)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** `anthropic/claude-opus-4-7`

**Any Additional AI Details you'd like to share:**
AI assistance was used to draft the test body, this PR description, and the commit message. The branch reachability claim (which arm of `shutdown_with_reason` the test exercises), the sentinel-PID safety argument (PID_MAX bounds, ESRCH handling on `killpg`/`kill`), and the lock-pair probe (`workers.try_lock().is_err()` while `cancelled_resumes` is held) were each cross-checked by an Oracle reviewer pass against the cited source lines before the test was committed. Direction, scope, and final review are human; the human author owns the change.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784493490&installation_id=139138837&pr_number=2296&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2296&signature=78e3a0340cad0f31b5044382a00da1de8389fcaa5fd344cb0bbd3b017272efa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

### Added
- A new regression test (`shutdown_holds_workers_lock_across_cancelled_resumes_seed_registry_path`) to verify the supervisor's lock-pair invariant when the shutdown process takes the registry-terminate code path
- A polling helper function (`wait_for_shutter_park`) to reliably detect when a background task has acquired and is holding a critical lock

### Modified
- Updated the existing regression test (`shutdown_holds_workers_lock_across_cancelled_resumes_seed`) to use the new polling helper instead of fixed timing delays

### Removed
- Fixed 50ms sleep that was used to detect intermediate test states (replaced by intelligent polling)

## Why This Matters

**The Problem Being Fixed:** The supervisor code had a subtle race condition in how it manages two locks during shutdown. The existing test caught this for one code path, but a second code path (the registry-terminate branch) was untested and potentially vulnerable to the same race condition.

**The Solution:** 
- The new test exercises the previously untested registry-terminate branch, ensuring the lock ordering invariant is maintained there too
- The `wait_for_shutter_park` helper replaces unreliable fixed-delay timing with active polling over a 5-second timeout, eliminating flaky test failures that could occur under system contention
- Both tests now verify the same critical property: that the tokio `workers` mutex is held *outside* (before) the standard library `cancelled_resumes` mutex

**Benefits:**
1. **Comprehensive coverage** — The registry-terminate branch is now covered by regression testing, preventing future regressions in that code path
2. **More reliable CI** — Replaces timing-dependent sleep with intelligent polling, reducing CI flakiness
3. **Proper isolation** — Uses temporary directories to isolate test environment variables and a sentinel PID (999_999_999) to prevent test processes from interfering with real system processes

**Lines of Code:** +122 added, -13 removed (net +109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->