### PR TITLE
fix(tui): address #2294 review follow-ups (footer hover staleness, persistence logging, docs)

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -944,6 +944,11 @@ impl App {
                             // action dispatch, structured-view drain). The
                             // footer is a disjoint area from the list/preview/
                             // diff, so nothing else in this arm needs to run.
+                            // This runs ahead of the dialog/context-menu click
+                            // handlers, but that is not a hazard: when an
+                            // overlay is open `footer_button_at` returns `None`
+                            // (its `has_non_live_send_overlay()` guard), so a
+                            // click can never fire a shortcut behind a modal.
                             if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
                                 if let Some(key) =
                                     self.home.footer_button_at(mouse.column, mouse.row)

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -4023,14 +4023,16 @@ impl HomeView {
             overlay_changed |= dialog.handle_hover(col, row);
         }
 
-        // Footer-toolbar hover: the index drives the inverted-chip highlight
-        // on the next render. Recomputed against the current button rects so
-        // it clears the moment the pointer leaves a button.
+        // Footer-toolbar hover: the hovered button's shortcut drives the
+        // inverted-chip highlight on the next render. Recomputed against the
+        // current button rects so it clears the moment the pointer leaves a
+        // button.
         let prev_footer_hover = self.footer_hover;
         self.footer_hover = self
             .footer_buttons
             .iter()
-            .position(|(rect, _)| rect.contains(Position::from((col, row))));
+            .find(|(rect, _)| rect.contains(Position::from((col, row))))
+            .map(|(_, key)| *key);
         let footer_changed = prev_footer_hover != self.footer_hover;
 
         let new_pos = if self.list_inner_area.contains(Position::from((col, row))) {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -718,9 +718,13 @@ pub struct HomeView {
     /// dispatched through the exact same path as pressing the shortcut).
     /// Rebuilt every frame; empty in live mode and the takeover views.
     pub(super) footer_buttons: Vec<(Rect, crossterm::event::KeyEvent)>,
-    /// Index into `footer_buttons` the pointer is currently over, used to
-    /// draw a hover highlight. Recomputed on every `Moved` event.
-    pub(super) footer_hover: Option<usize>,
+    /// The `KeyEvent` of the footer button the pointer is currently over, used
+    /// to draw a hover highlight. Recomputed on every `Moved` event. Keyed by
+    /// the button's shortcut rather than its index into `footer_buttons` so the
+    /// highlight follows the right button when a sort/group/view-mode change
+    /// reorders the toolbar between the move and the next render, and can never
+    /// index a button that no longer exists.
+    pub(super) footer_hover: Option<crossterm::event::KeyEvent>,
     /// Last reported mouse position when it was over `list_inner_area`,
     /// `None` when the cursor is outside the list. Stored as a position
     /// rather than a resolved item index so wheel scrolls implicitly
@@ -3840,32 +3844,45 @@ impl HomeView {
         self.save_sidebar_collapsed();
     }
 
-    fn save_sidebar_collapsed(&self) {
-        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
-            config.app_state.home_sidebar_collapsed = Some(self.sidebar_collapsed);
-            if let Err(e) = save_config(&config) {
-                tracing::warn!(target: "tui.home", "Failed to save config: {e}");
+    /// Load the persisted config, apply `mutate` to its `app_state`, and write
+    /// it back. Both the load and save failure paths are logged, so a
+    /// UI-preference write never fails silently in one persister while being
+    /// reported in another. Centralizes the load/mutate/save boilerplate the
+    /// home view's preference persisters would otherwise each repeat.
+    fn persist_app_state(
+        what: &str,
+        mutate: impl FnOnce(&mut crate::session::config::AppStateConfig),
+    ) {
+        match load_config() {
+            Ok(config) => {
+                let mut config = config.unwrap_or_default();
+                mutate(&mut config.app_state);
+                if let Err(e) = save_config(&config) {
+                    tracing::warn!(target: "tui.home", "Failed to save config ({what}): {e}");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(target: "tui.home", "Failed to load config for {what} save: {e}");
             }
         }
     }
 
+    fn save_sidebar_collapsed(&self) {
+        let collapsed = self.sidebar_collapsed;
+        Self::persist_app_state("sidebar collapsed", |s| {
+            s.home_sidebar_collapsed = Some(collapsed)
+        });
+    }
+
     fn save_list_width(&self) {
-        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
-            config.app_state.home_list_width = Some(self.list_width);
-            if let Err(e) = save_config(&config) {
-                tracing::warn!(target: "tui.home", "Failed to save config: {e}");
-            }
-        }
+        let width = self.list_width;
+        Self::persist_app_state("list width", |s| s.home_list_width = Some(width));
     }
 
     pub fn toggle_preview_info(&mut self) {
         self.show_preview_info = !self.show_preview_info;
-        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
-            config.app_state.show_preview_info = Some(self.show_preview_info);
-            if let Err(e) = save_config(&config) {
-                tracing::warn!(target: "tui.home", "Failed to save config: {e}");
-            }
-        }
+        let show = self.show_preview_info;
+        Self::persist_app_state("preview info", |s| s.show_preview_info = Some(show));
     }
 
     /// Forget the last non-live preview resize so the next render re-asserts the
@@ -3887,22 +3904,17 @@ impl HomeView {
             return;
         }
         self.archived_section_collapsed = false;
-        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
-            config.app_state.archived_section_collapsed = Some(false);
-            if let Err(e) = save_config(&config) {
-                tracing::warn!(target: "tui.home", "Failed to save config: {e}");
-            }
-        }
+        Self::persist_app_state("archived section", |s| {
+            s.archived_section_collapsed = Some(false)
+        });
     }
 
     pub fn toggle_archived_section(&mut self) {
         self.archived_section_collapsed = !self.archived_section_collapsed;
-        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
-            config.app_state.archived_section_collapsed = Some(self.archived_section_collapsed);
-            if let Err(e) = save_config(&config) {
-                tracing::warn!(target: "tui.home", "Failed to save config: {e}");
-            }
-        }
+        let collapsed = self.archived_section_collapsed;
+        Self::persist_app_state("archived section", |s| {
+            s.archived_section_collapsed = Some(collapsed)
+        });
         self.flat_items = self.build_flat_items();
         // Defensive cursor clamp + selection refresh. Today the only
         // call site routes through `toggle_group_collapsed` after the

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -821,7 +821,10 @@ impl HomeView {
         // narrow case needs no else).
         const COLLAPSE_LABEL: &str = " \u{00AB} ";
         const COLLAPSE_LABEL_WIDTH: u16 = 3;
-        if area.width > COLLAPSE_LABEL_WIDTH + 6 {
+        // Columns kept clear for the title that shares this top border row, so
+        // the collapse affordance only draws when it won't collide with it.
+        const COLLAPSE_LABEL_TITLE_RESERVE: u16 = 6;
+        if area.width > COLLAPSE_LABEL_WIDTH + COLLAPSE_LABEL_TITLE_RESERVE {
             let btn_rect = Rect {
                 x: area.right() - COLLAPSE_LABEL_WIDTH,
                 y: area.y,
@@ -3002,7 +3005,6 @@ impl HomeView {
         // Column of the next span; starts past the leading space margin. Used
         // to record each clickable button's hit rect as it's laid out.
         let mut col = area.x.saturating_add(1);
-        let mut clickable_idx = 0usize;
         for (i, (_, key, group)) in groups.into_iter().enumerate() {
             if !keep[i] {
                 continue;
@@ -3023,14 +3025,13 @@ impl HomeView {
                         },
                         key,
                     ));
-                    if self.footer_hover == Some(clickable_idx) {
+                    if self.footer_hover == Some(key) {
                         for s in group {
                             spans.push(Span::styled(s.content, hover_style));
                         }
                     } else {
                         spans.extend(group);
                     }
-                    clickable_idx += 1;
                 }
                 None => spans.extend(group),
             }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8999,12 +8999,12 @@ mod footer_toolbar {
     fn hover_tracks_button_under_pointer() {
         let mut env = create_test_env_with_sessions(3);
         render_at(&mut env, 120, 12);
-        let (rect, _) = env.view.footer_buttons[1];
+        let (rect, key) = env.view.footer_buttons[1];
 
         assert!(env.view.footer_hover.is_none());
         let changed = env.view.handle_hover(rect.x + 1, rect.y);
         assert!(changed, "moving onto a button is a hover change");
-        assert_eq!(env.view.footer_hover, Some(1));
+        assert_eq!(env.view.footer_hover, Some(key));
 
         // Same button, no change reported.
         assert!(!env.view.handle_hover(rect.x, rect.y));


### PR DESCRIPTION
## Description

Follow-up to #2294. That PR merged with four non-blocking review notes from @jerome-benoit left unaddressed (the last commit predated his review, so nothing was pushed after it). This PR clears all four.

- **Footer hover staleness (`input.rs`, `render.rs`, `mod.rs`).** `footer_hover` was an index into the per-frame `footer_buttons` vector. A sort/group/view-mode change between a mouse move and the next render could reorder the toolbar, so the cached index could highlight the wrong button (or, before the next move recomputed it, go out of bounds). It is now keyed by the button's `KeyEvent` shortcut, so the highlight follows the right button across any reorder and can never index a button that no longer exists. Chosen over scattering hover invalidation across the roughly eight sort/group/view-mode mutation sites because it is centralized and also closes the out-of-bounds case.
- **Persistence error logging (`mod.rs`).** The home view's `app_state` persisters (sidebar collapse, list width, preview info, archived section) silently dropped `load_config()` failures. They now route through a shared `persist_app_state` helper that logs both the load and save failure paths, so a load error is no longer swallowed in one persister while being reported in another.
- **Magic constant (`render.rs`).** `COLLAPSE_LABEL_WIDTH + 6` is now a named `COLLAPSE_LABEL_TITLE_RESERVE` const with a comment explaining the columns reserved for the title sharing that border row.
- **Ordering doc (`app.rs`).** The footer-click arm runs ahead of the dialog and context-menu click handlers; a comment now records why that is safe (`footer_button_at` returns `None` under an overlay via its `has_non_live_send_overlay()` guard).

A separate concern from the same review (the pre-existing stacked-mode double horizontal seam, raised on the `render.rs:576` thread) is tracked in #2301 rather than expanded here.

## PR Type

- [x] Bug Fix
- [x] Refactor
- [x] Documentation

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a new e2e test, because: the hover contract is covered by the existing `footer_toolbar::hover_tracks_button_under_pointer` unit test, updated here to assert the hovered button by `KeyEvent` identity. Switching the field to a `KeyEvent` makes the out-of-bounds failure mode unrepresentable at the type level, so a byte-level reorder e2e adds little. `theme_apply_needed_compares_name_and_palette_mode`, the `footer_toolbar` module, and the sidebar/takeover tests from #2294 continue to pass.

## How tested

- `cargo fmt`, `cargo clippy --lib --tests` (no new warnings), `cargo test --lib tui::home` (595 passing) and `cargo test --lib tui::app` (40 passing), including the `footer_toolbar` and `theme_apply_needed` regression tests.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Used to address the review follow-ups and write the tests, in back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)
