### PR TITLE
fix(acp): stop agent messages rendering twice from leaked consolidated chunk

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -4208,6 +4208,12 @@ async fn run_connection_task<W, R>(
     // section stays synchronous and the guard never crosses an await.
     let agent_msg_dedup = Arc::new(std::sync::Mutex::new(AgentMessageDedup::default()));
     let agent_msg_dedup_for_notif = agent_msg_dedup.clone();
+    // The prompt loop resets the deduper at turn boundaries (a new prompt, and
+    // the turn's terminal Stopped). Turn completion is not a SessionUpdate, so
+    // without this an open text block could survive into the next turn and a
+    // new turn that legitimately reuses the prior turn's trailing text under a
+    // fresh message_id would be misclassified as a restatement. See #2281.
+    let agent_msg_dedup_for_block = agent_msg_dedup.clone();
 
     let result = Client
         .builder()
@@ -4898,6 +4904,13 @@ async fn run_connection_task<W, R>(
                 let cmd = cmd_rx.recv().await;
                 match cmd {
                     Some(ClientCmd::Prompt(blocks)) => {
+                        // Scope the agent-message deduper to one turn: a new
+                        // prompt starts a fresh assistant block, so forget any
+                        // block left open by the prior turn. See #2281.
+                        agent_msg_dedup_for_block
+                            .lock()
+                            .expect("agent message dedup mutex poisoned")
+                            .reset();
                         // First user prompt after session/load: stop
                         // dropping notifications. The agent's history-
                         // replay window is over; everything from now on
@@ -5482,6 +5495,14 @@ async fn run_connection_task<W, R>(
                                 reason: reason.into(),
                             })
                             .await;
+                        // Turn ended: close any open assistant text block so a
+                        // restatement can never be matched across the turn
+                        // boundary. The next prompt also resets, this is the
+                        // belt to that suspenders. See #2281.
+                        agent_msg_dedup_for_block
+                            .lock()
+                            .expect("agent message dedup mutex poisoned")
+                            .reset();
                         if shutdown {
                             break;
                         }

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -23,14 +23,15 @@ use agent_client_protocol::schema::{
     CreateTerminalResponse, ElicitationAction, ElicitationCapabilities,
     ElicitationFormCapabilities, EmbeddedResource, EmbeddedResourceResource,
     FileSystemCapabilities, ImageContent, InitializeRequest, KillTerminalRequest,
-    KillTerminalResponse, LoadSessionRequest, McpServer, NewSessionRequest, PermissionOptionKind,
-    PromptRequest, ProtocolVersion, ReadTextFileRequest, ReadTextFileResponse,
-    ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
-    SessionConfigId, SessionConfigValueId, SessionId, SessionNotification, SessionUpdate,
-    SetSessionConfigOptionRequest, SetSessionModeRequest, StopReason, TerminalId,
-    TerminalOutputRequest, TerminalOutputResponse, TextContent, WaitForTerminalExitRequest,
-    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
+    KillTerminalResponse, LoadSessionRequest, McpServer, MessageId, NewSessionRequest,
+    PermissionOptionKind, PromptRequest, ProtocolVersion, ReadTextFileRequest,
+    ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    SelectedPermissionOutcome, SessionConfigId, SessionConfigValueId, SessionId,
+    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
+    StopReason, TerminalId, TerminalOutputRequest, TerminalOutputResponse, TextContent,
+    WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
+    WriteTextFileResponse,
 };
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectionTo, JsonRpcRequest, JsonRpcResponse, Responder,
@@ -3032,6 +3033,94 @@ fn is_compact_completion(text: &str) -> bool {
     text.contains("Compacting completed.")
 }
 
+/// Tracks the in-flight assistant text block so claude-agent-acp's leaked
+/// consolidated `agent_message_chunk` restatement can be dropped before it
+/// reaches the watchdog, the event store, or any client. The adapter streams a
+/// text block as incremental chunks, then re-sends the whole block as one
+/// chunk; its own dedup (`streamedTextIds`) is meant to suppress that copy but
+/// misses on a message-id mismatch (deterministic right after an Opus to Sonnet
+/// switch, intermittent otherwise), so both reach us and every reducer appends
+/// both, doubling the message. See #2281.
+///
+/// The schema guarantees that a change in `message_id` marks a new message, and
+/// the streamed deltas plus the empty block-start marker all share the streamed
+/// id while the leaked restatement carries a different one. So a non-empty chunk
+/// whose id differs from the open block and whose text restates the block's
+/// accumulated text is the leak; a same-id chunk is always a genuine delta and
+/// is never dropped (a legitimately repeated delta keeps the same id). Absent
+/// ids on either side degrade to never-drop, which leaves that rarer leak shape
+/// in place rather than risk corrupting real output.
+#[derive(Default)]
+struct AgentMessageDedup {
+    block: Option<AgentTextBlock>,
+}
+
+struct AgentTextBlock {
+    id: Option<MessageId>,
+    text: String,
+}
+
+impl AgentMessageDedup {
+    /// Forget any in-flight block. Called while post-load history replay is
+    /// suppressed so replayed chunks cannot poison live block tracking once
+    /// suppression lifts.
+    fn reset(&mut self) {
+        self.block = None;
+    }
+
+    /// Returns true when `update` is the leaked consolidated restatement and the
+    /// whole notification should be skipped (not mapped, not emitted).
+    fn observe(&mut self, update: &SessionUpdate) -> bool {
+        let SessionUpdate::AgentMessageChunk(chunk) = update else {
+            // Any non-message-chunk update ends the current text block. The
+            // event stream never interleaves ambient updates inside a streamed
+            // block, so this is a safe block terminator.
+            self.block = None;
+            return false;
+        };
+        let ContentBlock::Text(t) = &chunk.content else {
+            // Non-text content (image, audio) ends the text block.
+            self.block = None;
+            return false;
+        };
+        if t.text.is_empty() {
+            // The adapter emits an empty chunk at each block start; treat it as
+            // the boundary so adjacent blocks never merge in the accumulator.
+            // Empty text renders nothing, so keep forwarding it.
+            self.block = Some(AgentTextBlock {
+                id: chunk.message_id.clone(),
+                text: String::new(),
+            });
+            return false;
+        }
+        match &mut self.block {
+            Some(block) if block.id == chunk.message_id => {
+                // Same message: a genuine streamed delta (or both ids absent).
+                // Never dropped.
+                block.text.push_str(&t.text);
+                false
+            }
+            Some(block)
+                if block.id.is_some() && chunk.message_id.is_some() && block.text == t.text =>
+            {
+                // Different message id restating the whole block verbatim: the
+                // leaked consolidated copy. Drop it and close the block.
+                self.block = None;
+                true
+            }
+            _ => {
+                // A genuinely new block (id changed, text differs) or no open
+                // block: start tracking fresh.
+                self.block = Some(AgentTextBlock {
+                    id: chunk.message_id.clone(),
+                    text: t.text.clone(),
+                });
+                false
+            }
+        }
+    }
+}
+
 /// Map an ACP `SessionUpdate` to the structured view's typed `Event`. Variants we
 /// don't yet handle pass through as `RawAgentUpdate` so UI clients can at
 /// least see them; we'll narrow these as the schema stabilises.
@@ -4113,6 +4202,13 @@ async fn run_connection_task<W, R>(
     let last_event_at_for_notif = last_event_at.clone();
     let first_event_after_attach_for_notif = first_event_after_attach.clone();
 
+    // Per-session tracker that drops claude-agent-acp's leaked consolidated
+    // agent_message_chunk restatement before it doubles the rendered message.
+    // See AgentMessageDedup and #2281. std Mutex (not tokio) so the critical
+    // section stays synchronous and the guard never crosses an await.
+    let agent_msg_dedup = Arc::new(std::sync::Mutex::new(AgentMessageDedup::default()));
+    let agent_msg_dedup_for_notif = agent_msg_dedup.clone();
+
     let result = Client
         .builder()
         .name("aoe-acp")
@@ -4126,10 +4222,31 @@ async fn run_connection_task<W, R>(
                     first_event_after_attach_for_notif.clone();
                 let lifecycle_signal_tx = lifecycle_signal_tx_for_notif.clone();
                 let current_prompt_epoch = current_prompt_epoch_for_notif.clone();
+                let agent_msg_dedup = agent_msg_dedup_for_notif.clone();
                 async move {
                     last_event_at
                         .store(chrono::Utc::now().timestamp_millis(), Ordering::Relaxed);
                     let suppressing = suppress.load(Ordering::Relaxed);
+                    // Drop claude-agent-acp's leaked consolidated
+                    // agent_message_chunk restatement before it reaches the
+                    // watchdog, the event store, or any client (#2281). During
+                    // post-load history replay the deduper is reset rather than
+                    // fed, so replayed chunks can't poison live block tracking.
+                    {
+                        let mut dedup = agent_msg_dedup
+                            .lock()
+                            .expect("agent message dedup mutex poisoned");
+                        if suppressing {
+                            dedup.reset();
+                        } else if dedup.observe(&notification.update) {
+                            debug!(
+                                target: "acp.protocol",
+                                session = %session_label,
+                                "dropping leaked consolidated agent_message_chunk restatement (#2281)"
+                            );
+                            return Ok(());
+                        }
+                    }
                     // Snapshot the prompt epoch ONCE per notification so
                     // every signal derived from this update shares the
                     // same epoch. If the prompt loop bumps the atomic
@@ -7194,6 +7311,92 @@ mod tests {
             _ => None,
         });
         assert!(started.unwrap().parent_tool_call_id.is_none());
+    }
+
+    fn text_chunk(text: &str, id: Option<&str>) -> SessionUpdate {
+        use agent_client_protocol::schema::{ContentBlock, ContentChunk, TextContent};
+        let mut chunk = ContentChunk::new(ContentBlock::Text(TextContent::new(text)));
+        if let Some(id) = id {
+            chunk = chunk.message_id(id);
+        }
+        SessionUpdate::AgentMessageChunk(chunk)
+    }
+
+    fn tool_update() -> SessionUpdate {
+        use agent_client_protocol::schema::ToolCall as AcpToolCall;
+        SessionUpdate::ToolCall(AcpToolCall::new("t-dedup", "Read"))
+    }
+
+    #[test]
+    fn dedup_drops_consolidated_restatement_after_deltas() {
+        // The reported leak: empty marker + two streamed deltas sharing the
+        // streamed id, then the whole block re-sent under a different id.
+        let mut d = AgentMessageDedup::default();
+        assert!(!d.observe(&text_chunk("", Some("m1"))));
+        assert!(!d.observe(&text_chunk(
+            "Concrete repro. Let me inspect the events around lgtm and",
+            Some("m1")
+        )));
+        assert!(!d.observe(&text_chunk(
+            " the \"Plan approved\" message in that session.",
+            Some("m1")
+        )));
+        // Consolidated copy carries the mismatched id and restates the block.
+        assert!(d.observe(&text_chunk(
+            "Concrete repro. Let me inspect the events around lgtm and the \"Plan approved\" message in that session.",
+            Some("m2")
+        )));
+    }
+
+    #[test]
+    fn dedup_drops_single_delta_restatement() {
+        let mut d = AgentMessageDedup::default();
+        assert!(!d.observe(&text_chunk("hello world", Some("m1"))));
+        assert!(d.observe(&text_chunk("hello world", Some("m2"))));
+    }
+
+    #[test]
+    fn dedup_keeps_legitimate_repeated_same_id_delta() {
+        // Two identical deltas that share a message id are genuine streamed
+        // output ("haha"), not a restatement. Never dropped.
+        let mut d = AgentMessageDedup::default();
+        assert!(!d.observe(&text_chunk("", Some("m1"))));
+        assert!(!d.observe(&text_chunk("ha", Some("m1"))));
+        assert!(!d.observe(&text_chunk("ha", Some("m1"))));
+    }
+
+    #[test]
+    fn dedup_resets_on_boundary_and_handles_adjacent_blocks() {
+        let mut d = AgentMessageDedup::default();
+        // Block 1: delta then restatement, dropped.
+        assert!(!d.observe(&text_chunk("ab", Some("m1"))));
+        assert!(d.observe(&text_chunk("ab", Some("m2"))));
+        // A tool call ends the block.
+        assert!(!d.observe(&tool_update()));
+        // Block 2 reuses text "ab": the first chunk after the boundary must
+        // not be mistaken for a restatement of the closed block.
+        assert!(!d.observe(&text_chunk("ab", Some("m3"))));
+        assert!(d.observe(&text_chunk("ab", Some("m4"))));
+    }
+
+    #[test]
+    fn dedup_never_drops_when_ids_absent() {
+        // Without message ids the delta-vs-restatement distinction is
+        // ambiguous; degrade to never-drop so real output is never corrupted.
+        let mut d = AgentMessageDedup::default();
+        assert!(!d.observe(&text_chunk("", None)));
+        assert!(!d.observe(&text_chunk("done", None)));
+        assert!(!d.observe(&text_chunk("done", None)));
+    }
+
+    #[test]
+    fn dedup_reset_forgets_in_flight_block() {
+        // Mirrors the suppression path: reset() between a block's deltas and
+        // its restatement means the restatement is treated as a fresh block.
+        let mut d = AgentMessageDedup::default();
+        assert!(!d.observe(&text_chunk("ab", Some("m1"))));
+        d.reset();
+        assert!(!d.observe(&text_chunk("ab", Some("m2"))));
     }
 
     #[test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the structured view an agent message intermittently rendered twice, the full text repeated back-to-back. It reproduced deterministically right after switching model (for example Opus to Sonnet) and intermittently otherwise.

Root cause: `@agentclientprotocol/claude-agent-acp` streams an assistant text block as incremental `agent_message_chunk` deltas, then re-sends the whole block as one consolidated chunk. Its `streamedTextIds` dedup is meant to suppress that consolidated copy, but it misses on a message-id mismatch (a model switch starts a fresh stream id, which is exactly that condition), so both the deltas and the consolidated restatement reach us. aoe recorded every chunk into the event store and every reducer (web and TUI) appends each chunk into one assistant bubble, so the block showed up twice.

This fix tracks the in-flight assistant text block in the `on_receive_notification` handler in `src/acp/acp_client.rs`, keyed by `message_id`. The schema guarantees a change in `message_id` marks a new message; the streamed deltas and the empty block-start marker share the streamed id while the leaked restatement carries a different one. A non-empty chunk whose id differs from the open block and whose text restates the block's accumulated text is dropped before it reaches the watchdog, the event store, or any client. Same-id chunks are genuine deltas and are never dropped (a legitimately repeated delta keeps its id), and absent ids on either side degrade to never-drop so real output is never corrupted. Dropping the whole update keeps the duplicate out of every surface at once and lets the reducers stay dumb appenders. The deduper is reset during post-load history replay so replayed chunks cannot poison live tracking.

Already-stored doubled transcripts are left as-is (the event store is append-only; no migration). The underlying upstream adapter leak will be reported separately to claude-agent-acp.

Closes #2281

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session, send a prompt to Opus, switch the model to Sonnet, send another prompt; the first Sonnet reply renders exactly once.
- [ ] In any session, send a prompt that yields a multi-sentence reply; confirm the reply is not duplicated back-to-back.
- [ ] Reload the web view of a session whose recent turn previously doubled; the message now renders once for newly produced turns (old stored transcripts keep the historical artifact).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the fix is server-side in the ACP ingress (`src/acp/acp_client.rs`); no `web/src` files change. It is covered by Rust unit tests on `AgentMessageDedup` (streamed-then-restated drops, single-delta restatement drops, legit repeated same-id delta kept, boundary reset, absent-id never-drop, replay reset).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. The design was vetted through a two-model debate (gemini + gpt-5.5) that settled the placement (server-side over a web-only reducer patch) and the message-id discriminator over naive text equality. I made the design calls and ran the validation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784551967&installation_id=139138837&pr_number=2308&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2308&signature=daa5c7e010c1a290e1c07c2f4bb0c473a331af78516148430b9f943f8461aa48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

- **Added server-side deduplication** in `src/acp/acp_client.rs` to prevent assistant messages from being rendered **twice** in the structured view when the upstream ACP adapter “leaks” a consolidated restatement after streaming smaller text deltas.
- **Introduced an in-memory tracker** that watches the currently streaming assistant text block and **suppresses the leaked duplicate** (while keeping the real streamed deltas).
- **Hardened reset behavior** so the deduplication window is scoped correctly to a single turn:
  - reset when a new `ClientCmd::Prompt` starts
  - reset again right before emitting the terminal `Event::Stopped` for that turn
- **Added unit tests** covering leaked restatements, same-id delta behavior, boundary resets, and “never-drop” safety when IDs are missing.
- Rewrapped **import formatting only** (no logic change).

## Benefits

- **Fixes the duplicate-message bug** that could deterministically appear when switching models and intermittently in other scenarios.
- **Prevents duplicates from entering the event store or reaching any client surfaces**, instead of only hiding them later.
- **Reduces risk of data loss** by only dropping the specific leaked consolidated restatement pattern, while preserving chunks when identifiers are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->