### PR TITLE
fix(telemetry): recover plan-mode signal, retire orphaned view_toggles

### DIFF
--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1521,12 +1521,7 @@ pub async fn acp_enable(
     }
 
     // A real terminal -> acp transition is now committed (the idempotent
-    // already-acp and unresolvable-agent cases returned above). Tally the
-    // substrate toggle for the opt-in telemetry snapshot.
-    state
-        .telemetry_structured
-        .view_toggles
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    // already-acp and unresolvable-agent cases returned above).
 
     // Tear down the tmux side. Best-effort: a stale tmux name should
     // not block the swap. Run on a blocking pool worker because each
@@ -1696,12 +1691,7 @@ pub async fn acp_disable(
     }
 
     // A real acp -> terminal transition is now committed (the idempotent
-    // already-terminal case returned above). Tally the substrate toggle for the
-    // opt-in telemetry snapshot.
-    state
-        .telemetry_structured
-        .view_toggles
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    // already-terminal case returned above).
 
     // Tear down the acp worker. Disabling acp mode discards the
     // conversation (we delete on-disk history and clear the stored ACP
@@ -1803,6 +1793,16 @@ pub struct SetModeRequest {
     pub mode_id: String,
 }
 
+/// Whether a mode value selects plan mode. `"plan"` is the canonical plan value
+/// on both mode channels: the legacy `session/set_mode` `mode_id` and the
+/// config-option `value` (claude-agent-acp v0.37.0+, OpenCode). Routing both
+/// `acp_set_mode` and `acp_set_config_option` through this one check keeps the
+/// plan-mode telemetry tally from drifting between the two paths. See the web
+/// `modeChannel.ts`, where the plan choice id is `"plan"` regardless of channel.
+fn is_plan_mode_value(value: &str) -> bool {
+    value == "plan"
+}
+
 /// Set the active session mode (Default / Plan / AcceptEdits /
 /// BypassPermissions). Sends an ACP `session/set_mode` request.
 pub async fn acp_set_mode(
@@ -1819,10 +1819,9 @@ pub async fn acp_set_mode(
     };
     match state.acp_supervisor.set_mode(&id, &req.mode_id).await {
         Ok(()) => {
-            // The agent accepted the mode switch. "plan" is the canonical ACP
-            // mode id; tally plan-mode adoption for the opt-in telemetry
-            // snapshot. Other modes are out of scope for now.
-            if req.mode_id == "plan" {
+            // The agent accepted the mode switch; tally plan-mode adoption for
+            // the opt-in telemetry snapshot. Other modes are out of scope for now.
+            if is_plan_mode_value(&req.mode_id) {
                 state
                     .telemetry_structured
                     .plan_mode_seen
@@ -1869,7 +1868,22 @@ pub async fn acp_set_config_option(
         .set_config_option(&id, &req.config_id, &req.value)
         .await
     {
-        Ok(()) => StatusCode::ACCEPTED.into_response(),
+        Ok(()) => {
+            // Tally plan-mode adoption. claude-agent-acp v0.37.0+ (and OpenCode)
+            // advertise the mode picker as a config option of category "mode" and
+            // switch through this path rather than the legacy `session/set_mode`
+            // handled by `acp_set_mode`, so the plan tally has to live here too or
+            // the modern fleet reports zero. No other config category (model,
+            // thought level) carries a "plan" value, so keying on the value alone
+            // is safe and stays in sync with the legacy path via the shared check.
+            if is_plan_mode_value(&req.value) {
+                state
+                    .telemetry_structured
+                    .plan_mode_seen
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            StatusCode::ACCEPTED.into_response()
+        }
         Err(SupervisorError::UnknownSession(_)) => (
             StatusCode::NOT_FOUND,
             "session has no running structured view",
@@ -2116,6 +2130,21 @@ mod tests {
             "application/pdf"
         ));
         assert!(!mime_allowed(PromptAttachmentKind::Resource, "text/html"));
+    }
+
+    #[test]
+    fn plan_mode_value_matches_only_plan() {
+        // Both `acp_set_mode` (legacy `mode_id`) and `acp_set_config_option`
+        // (config-option `value`) tally plan-mode adoption through this check, so
+        // it must accept the canonical "plan" value and reject every other mode or
+        // selector value (Default / AcceptEdits / model ids / thought levels).
+        assert!(is_plan_mode_value("plan"));
+        assert!(!is_plan_mode_value("default"));
+        assert!(!is_plan_mode_value("accept_edits"));
+        assert!(!is_plan_mode_value("bypassPermissions"));
+        assert!(!is_plan_mode_value("yolo"));
+        assert!(!is_plan_mode_value("Plan"));
+        assert!(!is_plan_mode_value(""));
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2665,7 +2665,6 @@ pub struct StructuredTelemetryCounters {
     pub approvals_allow_always: std::sync::atomic::AtomicU32,
     pub approvals_deny: std::sync::atomic::AtomicU32,
     pub agent_switches: std::sync::atomic::AtomicU32,
-    pub view_toggles: std::sync::atomic::AtomicU32,
     pub plan_mode_seen: std::sync::atomic::AtomicU32,
     pub prompts_queued: std::sync::atomic::AtomicU32,
 }
@@ -2691,7 +2690,6 @@ struct ReportedAcpCounts {
     approvals_allow_always: u32,
     approvals_deny: u32,
     agent_switches: u32,
-    view_toggles: u32,
     plan_mode: u32,
     prompts_queued: u32,
 }
@@ -2722,7 +2720,6 @@ async fn build_serve_snapshot(
         approvals_allow_always: c.approvals_allow_always.load(Ordering::Relaxed),
         approvals_deny: c.approvals_deny.load(Ordering::Relaxed),
         agent_switches: c.agent_switches.load(Ordering::Relaxed),
-        view_toggles: c.view_toggles.load(Ordering::Relaxed),
         plan_mode: c.plan_mode_seen.load(Ordering::Relaxed),
         prompts_queued: c.prompts_queued.load(Ordering::Relaxed),
     };
@@ -2731,7 +2728,6 @@ async fn build_serve_snapshot(
         approvals_allow_always: reported_acp.approvals_allow_always,
         approvals_deny: reported_acp.approvals_deny,
         agent_switches: reported_acp.agent_switches,
-        view_toggles: reported_acp.view_toggles,
         plan_mode_seen: reported_acp.plan_mode > 0,
         prompts_queued: reported_acp.prompts_queued,
     };
@@ -2790,7 +2786,6 @@ fn clear_reported_serve_signals(state: &AppState, outcome: crate::telemetry::Sen
     decrement_reported_count(&c.approvals_allow_always, rc.approvals_allow_always);
     decrement_reported_count(&c.approvals_deny, rc.approvals_deny);
     decrement_reported_count(&c.agent_switches, rc.agent_switches);
-    decrement_reported_count(&c.view_toggles, rc.view_toggles);
     decrement_reported_count(&c.plan_mode_seen, rc.plan_mode);
     decrement_reported_count(&c.prompts_queued, rc.prompts_queued);
 }

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -31,7 +31,11 @@ use serde::Serialize;
 /// v11 (#1888): added the structured-interaction aggregates (`approvals_resolved`,
 /// `approvals_by_decision`, `agent_switches`, `view_toggles`,
 /// `plan_mode_seen`, `prompts_queued`).
-pub const SCHEMA_VERSION: u32 = 11;
+/// v12: retired `view_toggles`. The terminal<->structured swap it counted has no
+/// trigger in the shipped UI (structured view is the default since #1925), so it
+/// only ever reported zero. The `acp_enable` / `acp_disable` endpoints stay; they
+/// just no longer feed a dead metric.
+pub const SCHEMA_VERSION: u32 = 12;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -258,10 +262,6 @@ pub struct UsageSnapshot {
     pub approvals_by_decision: BTreeMap<String, u32>,
     /// Mid-session agent switches since the last snapshot.
     pub agent_switches: u32,
-    /// Structured-view/terminal view toggles since the last snapshot. Only real
-    /// transitions count; an enable on an already-structured session (or a disable
-    /// on an already-terminal session) is a no-op and is not counted.
-    pub view_toggles: u32,
     /// A session entered plan mode at least once since the last snapshot.
     pub plan_mode_seen: bool,
     /// Prompts the web structured view queued (parked because the agent was busy)
@@ -280,7 +280,6 @@ pub struct StructuredInteractionCounts {
     pub approvals_allow_always: u32,
     pub approvals_deny: u32,
     pub agent_switches: u32,
-    pub view_toggles: u32,
     pub plan_mode_seen: bool,
     pub prompts_queued: u32,
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -486,7 +486,6 @@ fn assemble_usage_snapshot(
         approvals_resolved: acp_counts.approvals_resolved(),
         approvals_by_decision: acp_counts.approvals_by_decision(),
         agent_switches: acp_counts.agent_switches,
-        view_toggles: acp_counts.view_toggles,
         plan_mode_seen: acp_counts.plan_mode_seen,
         prompts_queued: acp_counts.prompts_queued,
     }
@@ -791,7 +790,6 @@ mod tests {
             approvals_resolved: 0,
             approvals_by_decision: BTreeMap::new(),
             agent_switches: 0,
-            view_toggles: 0,
             plan_mode_seen: false,
             prompts_queued: 0,
         }

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -730,7 +730,7 @@ fn snapshot_carries_acp_interaction_counts() {
     assert_eq!(snap.agent_switches, 1);
     assert!(snap.plan_mode_seen);
     assert_eq!(snap.prompts_queued, 1);
-    // Schema version bumped for the v8 field set.
+    // Confirm the snapshot uses the current schema version.
     assert_eq!(snap.schema, telemetry::SCHEMA_VERSION);
 }
 

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -709,7 +709,6 @@ fn snapshot_carries_acp_interaction_counts() {
         approvals_allow_always: 0,
         approvals_deny: 1,
         agent_switches: 1,
-        view_toggles: 2,
         plan_mode_seen: true,
         prompts_queued: 1,
     };
@@ -729,7 +728,6 @@ fn snapshot_carries_acp_interaction_counts() {
     assert_eq!(snap.approvals_by_decision.get("deny"), Some(&1));
     assert!(!snap.approvals_by_decision.contains_key("allow_always"));
     assert_eq!(snap.agent_switches, 1);
-    assert_eq!(snap.view_toggles, 2);
     assert!(snap.plan_mode_seen);
     assert_eq!(snap.prompts_queued, 1);
     // Schema version bumped for the v8 field set.
@@ -751,7 +749,6 @@ fn acp_interaction_payload_is_counts_and_allowlisted_keys_only() {
         approvals_allow_always: 4,
         approvals_deny: 5,
         agent_switches: 6,
-        view_toggles: 7,
         plan_mode_seen: true,
         prompts_queued: 8,
     };
@@ -778,12 +775,7 @@ fn acp_interaction_payload_is_counts_and_allowlisted_keys_only() {
     let obj = json.as_object().expect("snapshot is a JSON object");
 
     // The structured-interaction fields are all integers or a bool, never strings.
-    for field in [
-        "approvals_resolved",
-        "agent_switches",
-        "view_toggles",
-        "prompts_queued",
-    ] {
+    for field in ["approvals_resolved", "agent_switches", "prompts_queued"] {
         assert!(
             obj.get(field).and_then(serde_json::Value::as_u64).is_some(),
             "`{field}` must serialize as a count"


### PR DESCRIPTION
This PR was authored by an AI agent (Claude Opus 4.8) on behalf of the repository owner.

## Description

Two structured-view interaction counters reported **zero across the entire fleet**, so their PostHog dashboard panes were dead. Audited every emitted `usage_snapshot` field against live data (2013 events / 7d) to find which counters never increment.

**`plan_mode_seen` (real signal lost).** The tally lived only in `acp_set_mode`, the legacy `session/set_mode` channel. But `claude-agent-acp` v0.37.0+ and OpenCode advertise the mode picker as a config option and switch through `session/set_config_option` (see web `modeChannel.ts`), which never tallied. So the modern fleet reported zero plan-mode use (0 of 2013 events). Now `acp_set_config_option` tallies too, and both handlers route through a shared `is_plan_mode_value` check so the two paths cannot drift. `"plan"` is the canonical mode value on both channels.

**`view_toggles` (dead metric retired).** Its only increment sites were `acp_enable` / `acp_disable`, the terminal↔structured swap. That swap has no trigger in the shipped UI since structured view became the default (#1925), so it only ever counted zero. Retired the field and bumped the telemetry schema to v12. The `acp_enable` / `acp_disable` endpoints stay (live Playwright + the programmatic structured-view-enable path use them); they just no longer feed a dead metric.

**Not a bug (verified, left alone):** `agent_switches` (live `/acp/switch-agent` route, genuine low usage), `prompts_queued`, `approvals_resolved`, `peak_concurrent_sessions`, `session_creates`, form-factor maps, `usage_seen` are all populating correctly.

### Dashboard panes (fixed out-of-band on PostHog, not in this diff)
- `w1Y4grp6`: dropped the dead `view_toggles` series, kept switches / plan-mode / queued.
- `3yt8UOb8` (feature adoption): was returning all-NULL because `toFloat()` on a JSON boolean yields NULL; switched to `JSONExtractBool`. Also dropped the retired `features.cockpit` column.
- `RoS1TpiJ` / `eaf5TsxZ` (model bucket): queried a nonexistent `unknown` bucket (NULL column); the real key is `other`.
- `668j4XND` (approvals): `deny` showed NULL because `approvals_by_decision` omits zero-count keys; coalesced to 0.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (`cargo test --features serve`: telemetry suite 30/30, acp helper unit test)
- [x] Documentation was updated where necessary (N/A: `docs/telemetry.md` never documented `view_toggles` and already lists plan-mode use, which now works; schema changelog lives in `events.rs`)
- [ ] For UI changes: included screenshot or recording (N/A: no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (backend telemetry counters; the PostHog panes are not repo state)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Regression coverage: added a `is_plan_mode_value` unit test in `src/server/api/acp.rs` locking the shared plan-mode check (accepts `"plan"`, rejects other mode/selector values) so the two handlers cannot drift; existing `tests/telemetry.rs` integration tests exercise the snapshot field set and pass with `view_toggles` removed.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (1M context) via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784552896&installation_id=139138837&pr_number=2309&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2309&signature=9d919dcab3dab16b70c78fa4ffd58297a7d44d3963dfb85e32c9b9398710f32c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes telemetry tracking so PostHog dashboards keep working and removes a metric that can no longer collect meaningful data.

### What was fixed

1. **`plan_mode_seen` counter recovery**
   - The counter previously updated only when plan mode was changed through the legacy `acp_set_mode` path.
   - Newer clients switch plan mode via `acp_set_config_option`, which didn’t increment the counter—so modern fleet data showed plan-mode usage as **zero**.
   - The fix updates `acp_set_config_option` to increment the same counter and centralizes the “is this the canonical `plan` value?” logic in a shared helper, ensuring both paths behave consistently.

2. **`view_toggles` counter retirement**
   - This counter was tied to a terminal-vs-structured view toggle, but that swap no longer occurs in shipped UI (structured view is the default).
   - As a result, the counter stayed at **zero** and provided no value.
   - The metric is removed from the telemetry schema by bumping the wire schema version to **v12**, and the code no longer tracks/serializes it (while keeping related endpoints for programmatic/test usage).

### What changed in the code

- Added a shared `is_plan_mode_value` helper and used it in both:
  - `acp_set_mode`
  - `acp_set_config_option` (now increments `plan_mode_seen` when appropriate)
- Removed `view_toggles` from:
  - structured telemetry counters and snapshot payloads
  - serve-snapshot assembly and post-send clearing logic
  - telemetry wire structures and tests
- Updated telemetry schema version to **v12** and adjusted test fixtures/expectations accordingly.
- Added a unit test to ensure the plan-mode helper only accepts the canonical value (`"plan"`).

### Benefits

- Restores accurate **plan mode usage** reporting in PostHog (previously missing for the modern fleet).
- Eliminates a **dead/always-zero** metric that could break or mislead dashboard panes.
- Reduces future risk of inconsistencies by using one shared validation rule for plan-mode detection.
- Telemetry tests were updated to match the new schema and continue to pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->