### PR TITLE
fix(web): keep sub-agent Task grouped when the history window cuts mid-block

### DIFF
--- a/web/src/lib/acpHistoryWindow.test.ts
+++ b/web/src/lib/acpHistoryWindow.test.ts
@@ -18,6 +18,40 @@ function transcript(turns: number, perTurn: number): ActivityRow[] {
   return rows;
 }
 
+/** A `tool_start` row carrying the ToolCall fields the sub-agent
+ *  grouping reads: `tool.id` (the call id) and, on a sub-agent child,
+ *  `tool.parent_tool_call_id` pointing at the parent Task's id. */
+function toolRow(id: string, parentId?: string): ActivityRow {
+  return {
+    id,
+    kind: "tool_start",
+    text: id,
+    tool: {
+      id,
+      name: id,
+      kind: "other",
+      args_preview: "{}",
+      started_at: "",
+      parent_tool_call_id: parentId,
+    },
+  };
+}
+
+/** One prompt, `lead` filler tool rows, then a Task parent `task` with
+ *  `children` child tool calls, with no later user boundary so the cap
+ *  cut falls inside the sub-agent block. */
+function subagentTranscript(lead: number, children: number, parentChain: string[] = ["task1"]): ActivityRow[] {
+  const rows: ActivityRow[] = [row("user_prompt", 0)];
+  for (let i = 0; i < lead; i += 1) rows.push(row("tool_complete", i));
+  // Parent chain top-first: task1 (top-level), then nested sub-agents.
+  for (let p = 0; p < parentChain.length; p += 1) {
+    rows.push(toolRow(parentChain[p]!, p === 0 ? undefined : parentChain[p - 1]!));
+  }
+  const leafParent = parentChain[parentChain.length - 1]!;
+  for (let c = 0; c < children; c += 1) rows.push(toolRow(`child-${c}`, leafParent));
+  return rows;
+}
+
 describe("historyWindowStart", () => {
   it("returns 0 when everything fits", () => {
     const rows = transcript(2, 3); // 8 rows
@@ -63,6 +97,41 @@ describe("historyWindowStart", () => {
     const rows = transcript(10, 10);
     expect(historyWindowStart(rows, 0)).toBe(0);
     expect(historyWindowStart(rows, -5)).toBe(0);
+  });
+
+  it("pulls the cut back to the Task parent when it lands among sub-agent children (#2313)", () => {
+    // prompt(0) + 100 filler(1..100) + parent task1(101) + 50 children(102..151).
+    const rows = subagentTranscript(100, 50);
+    const parentIdx = rows.findIndex((r) => r.kind === "tool_start" && r.tool?.id === "task1");
+    expect(parentIdx).toBe(101);
+    // visibleRows 40 -> cap = 112, a child row, no user boundary after it.
+    // Without the snap the window would open mid-block at 112, orphaning
+    // the children from their Task. The snap pulls start back to 101.
+    const start = historyWindowStart(rows, 40);
+    expect(start).toBe(parentIdx);
+    expect(rows[start]!.tool?.parent_tool_call_id).toBeUndefined();
+  });
+
+  it("leaves the cut alone when it lands exactly on the Task parent", () => {
+    const rows = subagentTranscript(100, 50); // 152 rows, parent at 101.
+    // visibleRows 51 -> cap = 101, the parent itself: nothing to pull back.
+    expect(historyWindowStart(rows, 51)).toBe(101);
+  });
+
+  it("walks the whole parent chain back for nested sub-agents", () => {
+    // task1(101) -> task2(102, child of task1) -> 49 grandchildren(103..151).
+    const rows = subagentTranscript(100, 49, ["task1", "task2"]);
+    // visibleRows 40 -> cap = 112, a grandchild; snap climbs task2 then task1.
+    expect(historyWindowStart(rows, 40)).toBe(101);
+  });
+
+  it("does not pull back a clean user-boundary start", () => {
+    // The forward-snap landed on a user_prompt (no tool), so the sub-agent
+    // snap is a no-op and the boundary stands.
+    const rows = transcript(10, 10);
+    const start = historyWindowStart(rows, 30);
+    expect(rows[start]!.kind).toBe("user_prompt");
+    expect(start).toBe(88);
   });
 });
 

--- a/web/src/lib/acpHistoryWindow.ts
+++ b/web/src/lib/acpHistoryWindow.ts
@@ -17,6 +17,37 @@ function isUserTurnBoundary(row: ActivityRow): boolean {
   return row.kind === "user_prompt" || row.kind === "user_diff_comments";
 }
 
+/** Pull `start` back so the window never opens strictly between a
+ *  sub-agent `Task` row and its child tool calls. The child rows carry
+ *  `tool.parent_tool_call_id` (the parent Task's `tool.id`); when `start`
+ *  lands on such a child whose parent sits earlier, the parent has been
+ *  folded into "earlier" and the children render as headless orphan
+ *  cards instead of one SubagentCard (#2313). Walk the parent chain back
+ *  to the top-level Task. A `user_prompt` boundary start carries no
+ *  `tool`, so the loop is a no-op there and the forward-snap stands.
+ *
+ *  ponytail: linear scan per hop, bounded by the sub-agent block, only
+ *  runs at the window cut. A sub-agent with more child rows than the
+ *  whole window pulls `start` back past the cap, rendering the full
+ *  block; a headless run of orphan cards is the worse outcome. */
+function snapBackToSubagentParent(rows: readonly ActivityRow[], start: number): number {
+  let s = start;
+  while (s > 0) {
+    const parentId = rows[s]?.tool?.parent_tool_call_id;
+    if (!parentId) break;
+    let parentIdx = -1;
+    for (let i = s - 1; i >= 0; i -= 1) {
+      if (rows[i]!.kind === "tool_start" && rows[i]!.tool?.id === parentId) {
+        parentIdx = i;
+        break;
+      }
+    }
+    if (parentIdx < 0) break;
+    s = parentIdx;
+  }
+  return s;
+}
+
 /**
  * Index into `rows` from which the transcript should render, given how
  * many recent rows the caller wants visible (`visibleRows`).
@@ -26,7 +57,9 @@ function isUserTurnBoundary(row: ActivityRow): boolean {
  * tool rows under one prompt) can never blow the window past the cap.
  * Within that cap the start snaps FORWARD to the nearest user turn
  * boundary so the top is a clean user message rather than a half turn.
- * When no boundary sits at or after the cap cut, the cut is used as-is.
+ * When no boundary sits at or after the cap cut, the cut is used as-is,
+ * then pulled back so it never severs a sub-agent from its children
+ * (#2313).
  *
  * Returns 0 when every row fits (nothing earlier to load).
  */
@@ -34,10 +67,14 @@ export function historyWindowStart(rows: readonly ActivityRow[], visibleRows: nu
   if (visibleRows <= 0) return 0;
   const cap = Math.max(0, rows.length - visibleRows);
   if (cap === 0) return 0;
+  let start = cap;
   for (let i = cap; i < rows.length; i += 1) {
-    if (isUserTurnBoundary(rows[i]!)) return i;
+    if (isUserTurnBoundary(rows[i]!)) {
+      start = i;
+      break;
+    }
   }
-  return cap;
+  return snapBackToSubagentParent(rows, start);
 }
 
 /** Index of the latest `/clear` divider, or -1 when cleared turns are


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the structured view, a Claude sub-agent (the `Task` tool plus the child tool calls it runs) normally renders as one collapsible `SubagentCard`. In a long session it broke apart into a row of individual per-tool cards once enough later activity pushed the sub-agent turn up far enough that the history window folded part of it behind "Load earlier".

Root cause: `historyWindowStart` (`web/src/lib/acpHistoryWindow.ts`) snaps the window's cap cut FORWARD only to `user_prompt` / `user_diff_comments` boundaries. A single huge agent turn that runs a sub-agent has no such boundary at or after the cap, so the raw cap cut is used as-is, and it can land between the parent `Task` `tool_start` row and its child tool rows. After the slice the parent sits in the hidden "earlier" region while the children head the visible window; `collapseSubagents` then finds children whose parent is not in the same message and leaves them as orphans, so each renders as its own card.

Fix: after computing the start (forward-snap or raw cap), pull it BACK along the `parent_tool_call_id` chain to the top-level `Task` whenever it lands on a sub-agent child whose parent sits earlier. The whole sub-agent block stays together. A `user_prompt` boundary start carries no `tool`, so the existing forward-snap behavior is untouched. The backward walk is bounded by the sub-agent block and only runs at the window cut.

User-observable impact: sub-agents stay grouped as one card in long sessions instead of degrading into a wall of loose tool cards.

Closes #2313

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session whose transcript is long enough (more than ~150 activity rows) that an older agent turn folds behind "Load earlier".
- [ ] In that long turn, have a sub-agent (`Task`) that ran several child tool calls, positioned so the window cut falls inside the sub-agent's children.
- [ ] Confirm the sub-agent renders as one collapsible `SubagentCard`, not a row of individual child tool cards.
- [ ] Click "Load earlier" to reveal the parent `Task`; confirm the block stays grouped (no flip back to loose cards).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the regression is in the pure helper `historyWindowStart`, covered by red/green Vitest cases in `web/src/lib/acpHistoryWindow.test.ts` (the new tests fail on the pre-fix tree, returning a mid-children index, and pass after). The coverage-matrix validator only gates `components/**/*.tsx`; this change is `src/lib`. A Playwright repro would need a synthesized 150+ row transcript to exercise a pure window-math boundary.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (backward-snap over cross-message grouping), reviewed each commit, and verified the reproduce-then-fix went red on the pre-fix tree.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784659142&installation_id=139138837&pr_number=2314&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2314&signature=772d79101e840a8b96edda4d5b1ae768fc8db5454e08b76f4d473759f7232dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The code adds a fix to prevent sub-agent task groups from breaking apart when the browseable history window cuts into them during long sessions. Two files were modified:

**web/src/lib/acpHistoryWindow.ts** (~40 lines added):
- Added a new helper function `snapBackToSubagentParent` that intelligently adjusts the window's starting position when it would otherwise split a parent task from its child tool calls
- Modified `historyWindowStart` to apply this backward-snap logic after the existing forward-snap to user boundaries

**web/src/lib/acpHistoryWindow.test.ts** (~69 lines added):
- Added helper functions to generate test data representing sub-agent tool-call hierarchies
- Added comprehensive test cases validating that the window start is correctly positioned to keep parent tasks and child tools together

## Benefits

- **Improved user experience in long sessions**: Sub-agents remain displayed as a single collapsible card instead of degrading into scattered individual tool cards
- **Backward compatibility**: The fix works alongside the existing user-boundary snapping logic without changing it
- **Performant**: The backward walk is bounded by sub-agent block size, which is small relative to the typical 150-row visible window

## Technical Details

The root cause was that `historyWindowStart` snapped the window's start position forward to the nearest user-prompt boundary, but when a large agent turn (containing a sub-agent) exceeded the visible row limit, it could land partway through a sub-agent block—leaving the parent `Task` row hidden and only showing the child tool rows. The fix adds a backward traversal of the `parent_tool_call_id` chain to ensure when the computed start lands on a sub-agent child, the start is pulled back to include the parent task, keeping the entire group together in the visible window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->