### PR TITLE
fix(web): self-heal zombie structured-view WebSocket behind a proxy

### DIFF
--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -302,14 +302,6 @@ shows `Reconnecting (N/7) in Xs...` while the auto-retry is armed, and a manual
 **Reconnect** button after the attempts exhaust. Returning the tab to the
 foreground triggers an immediate reconnect.
 
-Behind a reverse proxy (Tailscale Serve, Cloudflare, nginx) an idle connection
-can be reset without the browser ever seeing a close, leaving the socket in a
-half-open state the browser still reports as connected. To catch this, the
-daemon emits a small heartbeat frame every 30s and the view runs a staleness
-watchdog: if no frame (event or heartbeat) arrives for 75s, it treats the
-socket as dead and re-dials, even while the tab is foregrounded and idle. So a
-session left open behind a proxy resyncs on its own instead of silently
-stalling until you send a message.
 
 ### Approval card vanished without resolving
 

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -302,6 +302,15 @@ shows `Reconnecting (N/7) in Xs...` while the auto-retry is armed, and a manual
 **Reconnect** button after the attempts exhaust. Returning the tab to the
 foreground triggers an immediate reconnect.
 
+Behind a reverse proxy (Tailscale Serve, Cloudflare, nginx) an idle connection
+can be reset without the browser ever seeing a close, leaving the socket in a
+half-open state the browser still reports as connected. To catch this, the
+daemon emits a small heartbeat frame every 30s and the view runs a staleness
+watchdog: if no frame (event or heartbeat) arrives for 75s, it treats the
+socket as dead and re-dials, even while the tab is foregrounded and idle. So a
+session left open behind a proxy resyncs on its own instead of silently
+stalling until you send a message.
+
 ### Approval card vanished without resolving
 
 Approvals expire after `approval_timeout_secs` (default 300). The agent receives

--- a/src/server/acp_ws.rs
+++ b/src/server/acp_ws.rs
@@ -51,6 +51,14 @@ const PING_INTERVAL: Duration = Duration::from_secs(30);
 /// recovery, not a session loss.
 const PONG_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 
+/// The app-level keepalive frame emitted on every ping tick. A plain
+/// Text frame the browser delivers to `onmessage`, unlike the WS Ping
+/// the browser handles invisibly. The client keys its staleness
+/// watchdog on this exact shape, so keep it stable. See #2287.
+fn heartbeat_frame() -> String {
+    r#"{"kind":"heartbeat"}"#.to_string()
+}
+
 /// Query parameters for the structured view WS upgrade. Clients pass
 /// `?since=<lastSeq>` so the on-connect drain only resends events
 /// newer than what they already have. Without this, a long-running
@@ -168,6 +176,22 @@ async fn handle(mut socket: WebSocket, session_id: String, state: Arc<AppState>,
                         idle_secs = last_pong_at.elapsed().as_secs(),
                         "agent ws idle reaper fired (no Pong from peer)"
                     );
+                    break;
+                }
+                // App-level heartbeat the browser can actually see. The WS
+                // Ping below keeps the server-side pong reaper honest, but
+                // browser JavaScript cannot observe Ping/Pong frames, so a
+                // quiet-but-live session gives the client no liveness signal
+                // and it cannot tell a healthy idle socket from a half-open
+                // (zombie) one a proxy reset without the browser noticing.
+                // This Text frame is that signal; the client's staleness
+                // watchdog reconnects when it stops arriving. See #2287.
+                if socket
+                    .send(Message::Text(heartbeat_frame().into()))
+                    .await
+                    .is_err()
+                {
+                    debug!(target: "acp.ws", session = %session_id, "ws heartbeat send failed, peer gone");
                     break;
                 }
                 if socket
@@ -489,5 +513,14 @@ mod tests {
             "PING_INTERVAL ({:?}) must be shorter than Cloudflare's 100s tunnel idle cap",
             PING_INTERVAL,
         );
+    }
+
+    /// The client staleness watchdog matches this exact byte string to
+    /// distinguish a keepalive tick from a real event frame. If the shape
+    /// drifts, the client treats heartbeats as malformed and a quiet but
+    /// live session looks stale. See #2287.
+    #[test]
+    fn heartbeat_frame_shape_is_stable() {
+        assert_eq!(heartbeat_frame(), r#"{"kind":"heartbeat"}"#);
     }
 }

--- a/web/src/hooks/useAcpSession.reconnect.test.ts
+++ b/web/src/hooks/useAcpSession.reconnect.test.ts
@@ -9,7 +9,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ACP_MAX_RETRIES_EXPORT, acpRetryDelayMs, useAcpSession } from "./useAcpSession";
+import { ACP_MAX_RETRIES_EXPORT, ACP_WS_STALE_MS, acpRetryDelayMs, useAcpSession } from "./useAcpSession";
 
 describe("acpRetryDelayMs", () => {
   it("returns 1s for the first attempt", () => {
@@ -258,5 +258,77 @@ describe("useAcpSession reconnect (#1130)", () => {
     });
     expect(result.current.retryCount).toBe(0);
     expect(result.current.reconnecting).toBe(false);
+  });
+});
+
+describe("useAcpSession liveness watchdog (#2287)", () => {
+  // Deliver a server heartbeat frame on the captured socket.
+  function heartbeat(sock: FakeSocket): void {
+    sock.onmessage?.({ data: JSON.stringify({ kind: "heartbeat" }) } as MessageEvent);
+  }
+
+  it("force-redials a stale OPEN socket the browser still reports as alive (zombie)", async () => {
+    renderHook(() => useAcpSession("sess-zombie"));
+    await flushAsync();
+    expect(sockets).toHaveLength(1);
+    const first = sockets[0]!;
+    act(() => {
+      first.readyState = FakeWebSocket.OPEN;
+      first.onopen?.({} as Event);
+    });
+
+    // No frames or heartbeats arrive: the proxy reset the socket without
+    // the browser seeing onclose, so readyState stays OPEN forever. The
+    // watchdog must notice the silence and re-dial without any user
+    // action and WITHOUT depending on the dead socket firing onclose.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ACP_WS_STALE_MS + 15000);
+    });
+    await flushAsync();
+
+    expect(first.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(sockets.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not reconnect while heartbeats keep the socket fresh", async () => {
+    renderHook(() => useAcpSession("sess-alive"));
+    await flushAsync();
+    expect(sockets).toHaveLength(1);
+    const first = sockets[0]!;
+    act(() => {
+      first.readyState = FakeWebSocket.OPEN;
+      first.onopen?.({} as Event);
+    });
+
+    // Heartbeat every 30s for two minutes; the watchdog must never trip.
+    for (let i = 0; i < 4; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30000);
+      });
+      act(() => heartbeat(first));
+    }
+    await flushAsync();
+
+    expect(sockets).toHaveLength(1);
+    expect(first.readyState).toBe(FakeWebSocket.OPEN);
+  });
+
+  it("watchdog never dials a socket that is not OPEN (no resurrection)", async () => {
+    // The watchdog redial is gated on readyState === OPEN precisely so it
+    // can't fire on a socket that is connecting, closed, or
+    // retry-exhausted (wsRef nulled) and step on the backoff / manual
+    // affordance that owns those states. Hold the dial in CONNECTING (the
+    // canonical non-OPEN state with no pending backoff timer) and prove
+    // the watchdog stays idle across several intervals.
+    renderHook(() => useAcpSession("sess-connecting"));
+    await flushAsync();
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.CONNECTING);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ACP_WS_STALE_MS + 30000);
+    });
+    await flushAsync();
+    expect(sockets).toHaveLength(1);
   });
 });

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -663,6 +663,19 @@ export function acpRetryDelayMs(attempt: number): number {
 }
 export const ACP_MAX_RETRIES_EXPORT = ACP_MAX_RETRIES;
 
+/** Liveness watchdog (#2287). The server emits a `{"kind":"heartbeat"}`
+ *  Text frame every 30s. A proxy can RST the idle connection so the
+ *  daemon's Close never reaches the browser, leaving the socket in
+ *  `readyState === OPEN` (a zombie) while no frames arrive. Browser JS
+ *  cannot see WS Ping/Pong, so the heartbeat is the only liveness
+ *  signal: if none arrives within `ACP_WS_STALE_MS`, the socket is
+ *  treated as dead and re-dialed. 75s tolerates two missed heartbeats
+ *  plus a watchdog interval and stays under the daemon's 90s pong
+ *  reaper, so the client heals first. A false positive is cheap: the
+ *  redial resumes from `?since=<lastSeq>` and dedupes. */
+const ACP_WS_WATCHDOG_INTERVAL_MS = 15000;
+export const ACP_WS_STALE_MS = 75000;
+
 export function useAcpSession(
   sessionId: string | null,
   /** Live structured view worker lifecycle from `SessionResponse.acp_worker_state`.
@@ -845,6 +858,12 @@ export function useAcpSession(
     }
   }, []);
 
+  // Timestamp (ms) of the most recent message received on the current
+  // socket (any frame, including the server heartbeat). The liveness
+  // watchdog and the visibility/online triggers compare it against
+  // ACP_WS_STALE_MS to spot a zombie socket. See #2287.
+  const lastServerMsgRef = useRef<number>(0);
+
   // Stable callback ref for visibility/online/pageshow triggers so the
   // reactive effects below can reconnect without depending on sessionId
   // (satisfies react-you-might-not-need-an-effect/no-event-handler).
@@ -852,13 +871,36 @@ export function useAcpSession(
   tryAutoReconnectRef.current = () => {
     const ws = wsRef.current;
     const ready = ws?.readyState;
-    if (ready === WebSocket.OPEN || ready === WebSocket.CONNECTING) return;
+    if (ready === WebSocket.CONNECTING) return;
+    // A socket that reports OPEN but has gone quiet past the stale
+    // window is a half-open zombie (proxy RST the browser never saw).
+    // Fall through and re-dial; connect() closes it and bumps the dial
+    // generation, so we don't rely on the dead socket ever firing
+    // onclose. A genuinely fresh OPEN socket bails here. See #2287.
+    if (ready === WebSocket.OPEN && Date.now() - lastServerMsgRef.current < ACP_WS_STALE_MS) {
+      return;
+    }
     retryCountRef.current = 0;
     setRetryCount(0);
     setRetryCountdown(0);
     clearRetryTimers();
     connectRef.current?.();
   };
+
+  // Liveness watchdog: a foreground-visible idle tab fires neither
+  // visibilitychange nor online, so a zombie socket would otherwise sit
+  // forever. Poll while the socket reports OPEN and let
+  // tryAutoReconnect re-dial only when it's also stale. Gated on OPEN so
+  // it never resurrects an intentionally-closed or retry-exhausted
+  // socket; backoff owns those. See #2287.
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        tryAutoReconnectRef.current();
+      }
+    }, ACP_WS_WATCHDOG_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
 
   // Subscribe to visibility+pageshow and online via useSyncExternalStore
   // so no effect directly subscribes to an external store, satisfying
@@ -1151,11 +1193,15 @@ export function useAcpSession(
       if (cancelled) return;
       // Cancel any pending scheduled retry; a fresh dial supersedes it.
       clearRetryTimers();
-      // Close any prior socket synchronously so its handlers fire (and
-      // get filtered out by the generation check below) before the new
-      // dial starts. Without this, the orphan's `onclose` can land
-      // after the new WS opens and re-arm scheduleReconnect on top of
-      // a healthy connection.
+      // Bump the dial generation BEFORE closing any prior socket, so a
+      // synchronously-firing `onclose` sees itself as orphaned
+      // (`isCurrentDial()` false) and bails instead of re-arming
+      // scheduleReconnect on top of this fresh dial. This matters when
+      // connect() is invoked on a still-OPEN zombie socket (the
+      // staleness watchdog path, #2287); the previous order only worked
+      // because every other caller reached connect() with an
+      // already-closed or null socket.
+      dialGenRef.current += 1;
       if (wsRef.current) {
         try {
           wsRef.current.close();
@@ -1164,7 +1210,6 @@ export function useAcpSession(
         }
         wsRef.current = null;
       }
-      dialGenRef.current += 1;
       const myGen = dialGenRef.current;
       const isCurrentDial = () => !cancelled && dialGenRef.current === myGen;
       statusRef.current = "connecting";
@@ -1235,6 +1280,9 @@ export function useAcpSession(
           statusRef.current = "open";
           setStatusRef.current("open");
           setHasEverOpenedRef.current(true);
+          // Seed the liveness clock so a slow first heartbeat doesn't
+          // trip the staleness watchdog right after connect. See #2287.
+          lastServerMsgRef.current = Date.now();
           // A live socket is the right moment to reset the retry
           // envelope: a future close from here is a genuinely new
           // failure, not a continuation of the prior backoff chain.
@@ -1257,8 +1305,17 @@ export function useAcpSession(
         };
         ws.onmessage = (ev) => {
           if (!isCurrentDial()) return;
+          // Any message on the current socket proves the browser-visible
+          // path is alive, so refresh the liveness clock before parsing.
+          // The server heartbeat keeps this fresh on quiet sessions; a
+          // busy stream keeps it fresh too. See #2287.
+          lastServerMsgRef.current = Date.now();
           try {
-            const data = JSON.parse(ev.data) as AcpFrame | { kind: "lagged"; skipped?: number };
+            const data = JSON.parse(ev.data) as AcpFrame | { kind: "lagged"; skipped?: number } | { kind: "heartbeat" };
+            if (typeof data === "object" && data !== null && (data as { kind?: unknown }).kind === "heartbeat") {
+              // Keepalive tick; liveness clock already bumped above.
+              return;
+            }
             if (
               typeof data === "object" &&
               data !== null &&

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1467,6 +1467,13 @@
       ]
     },
     {
+      "id": "acp.ws-reconnect-liveness",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/hooks/useAcpSession.reconnect.test.ts"],
+      "components": ["web/src/hooks/useAcpSession.ts"]
+    },
+    {
       "id": "acp.args",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On a remote, behind-proxy deployment (Tailscale Serve, Cloudflare), the structured-view live WebSocket silently stalls: you return to a session tab and see no new messages, with no disconnected indicator. Sending a message reconnects and flushes everything at once. No data is lost (events are persisted and replayed), the live view is just stale until you act.

Root cause is a half-open (zombie) socket, not the gaps the report first suspected. The #1130 client reconnect (visibilitychange / online / backoff) and the daemon WS Ping keepalive both already shipped in 1.11.1. They do not help here because: the proxy RSTs the idle leg, the daemon's Close send fails silently on the dead socket, and the browser never receives `onclose`, so the WS sits in `readyState === OPEN` forever. Browser JavaScript cannot observe WS Ping/Pong frames, so a quiet session has no liveness signal, and the visibility/online reconnect bailed whenever `readyState === OPEN`. Nothing re-dialed until a user send finally surfaced the dead socket.

This PR makes the view self-heal:

- **Daemon:** emit a small `{"kind":"heartbeat"}` Text frame on the existing 30s ping tick, alongside the WS Ping. The Ping stays for the server-side pong reaper; the Text frame is the JS-observable liveness signal.
- **Web:** track the timestamp of the last message received on the current socket (bumped on every frame, including the heartbeat). A 15s watchdog and the visibility/online triggers re-dial when an `OPEN` socket goes quiet past 75s (two missed heartbeats plus slack, under the daemon's 90s reap). The watchdog is gated on `readyState === OPEN`, so it heals zombies but never resurrects an intentionally-closed or retry-exhausted socket. Re-dial routes through `connect()`, which closes the zombie and bumps the dial generation, so recovery never depends on the dead socket firing `onclose`. `connect()` now bumps that generation before closing the prior socket so a synchronously-firing `onclose` is correctly orphaned.

A false-positive reconnect is cheap: the re-dial resumes from `?since=<lastSeq>` and dedupes.

Closes #2287

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe serve --behind-proxy` behind a reverse proxy with a WS idle timeout (Tailscale Serve, Cloudflare).
- [ ] Open a session in the structured view and leave the tab foregrounded but idle while the agent keeps emitting output. Within ~75s of the socket dying, the view re-dials on its own and missed messages flush, without sending anything.
- [ ] Background the tab, let the socket die, then refocus: live updates resume immediately (no message send needed).
- [ ] Leave a quiet, healthy session open for several minutes: it stays connected and does not spuriously flicker into "Reconnecting".
- [ ] Confirm the daemon `debug.log` still shows the keepalive working and the view recovers after a `Connection reset without closing handshake`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test and updated `web/tests/coverage-matrix.json`

Covered with Vitest rather than Playwright: a half-open zombie socket (browser still reports `OPEN` after a silent proxy RST) cannot be produced through a real browser in Playwright, but the `FakeWebSocket` harness in `web/src/hooks/useAcpSession.reconnect.test.ts` drives it exactly. New cases: (a) a stale `OPEN` socket with no heartbeat re-dials on its own (verified red on the pre-fix tree), (b) heartbeats keep a quiet socket alive with no spurious reconnect, (c) the watchdog never dials a non-`OPEN` socket. New matrix entry `acp.ws-reconnect-liveness`. Rust unit test `heartbeat_frame_shape_is_stable` pins the wire shape the client keys on.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult on the threshold and reconnect-vs-close design. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784704689&installation_id=139138837&pr_number=2324&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2324&signature=11e4c584d97c5f41e4713d372eabc600fecdb4893acc1464f72594b31c89e113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes structured-view WebSocket “silent stalls” behind reverse proxies (e.g., Tailscale Serve, Cloudflare) by adding an application-level heartbeat and a client-side liveness watchdog so dead connections are detected and automatically re-dialed—without requiring user interaction.

## What Changed (high level)

**Added**
- **Server heartbeat frames:** The daemon now sends a small, client-visible `{"kind":"heartbeat"}` text message on its existing keepalive cadence.
- **Client liveness watchdog:** The browser tracks the timestamp of the last message it received (including heartbeats). If an `OPEN` socket goes quiet too long, the client treats it as dead and forces a reconnect.
- **Safer reconnect behavior:** The reconnect logic was adjusted so “old socket close events” can’t accidentally interfere with the newest connection attempt.
- **Visibility/online recovery support:** The client will also re-dial when the tab comes back into view or the browser regains online status (to recover from stale `OPEN` sockets).
- **Documentation:** Troubleshooting guidance was expanded to explain how half-open WebSockets can get stuck behind proxies and how the new recovery works.
- **Tests + coverage:** New/updated unit tests validate the exact heartbeat shape and the watchdog reconnect behavior across important edge cases, plus an added coverage-matrix entry.

**Modified**
- **Reconnect safety in the hook:** The hook’s internal reconnect “dial generation” ordering and retry reset behavior were updated to make reconnection deterministic and resilient to proxy/socket quirks.

## Benefits

- **No more frozen structured views:** The UI recovers automatically after proxy idle timeouts.
- **No manual “poke” required:** Users no longer need to send a message to trigger recovery.
- **No data loss:** Reconnect resumes from the last known sequence and deduplicates correctly, so stale replay can’t cause duplicates or missing updates.
- **Works across proxies:** Designed to handle environments where proxies abruptly reset idle WebSockets without properly triggering a browser-visible close.

## Potential areas for further enhancement
- Add observability hooks (e.g., metrics/logging for watchdog-triggered reconnects) so operators can measure how often “zombie” stalls occur and confirm effectiveness in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->