### PR TITLE
fix(acp): end agent-initiated turns that run with no driving prompt

### DIFF
--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -242,12 +242,6 @@ container (rather than bind-mounting from the host).
   marker, which made the daemon refuse to bring the worker back after it next
   exited; a follow-up message would then sit unsent. A worker coming online now
   clears that marker, so this no longer strands a queued message.
-- An agent that armed a monitor or a scheduled wake, finished the turn, then was
-  woken later by that background task used to keep the session marked "running"
-  forever: the resumed turn ran with no driving prompt, so nothing ended it. The
-  daemon now ends such a turn cleanly once it goes idle (a few seconds after
-  the agent's last output, longer while a fresh wake is still pending), so the
-  session returns to idle on its own without `aoe acp restart`.
 
 ### "Restarting worker" banner after a turn looked done
 

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -245,7 +245,7 @@ container (rather than bind-mounting from the host).
 - An agent that armed a monitor or a scheduled wake, finished the turn, then was
   woken later by that background task used to keep the session marked "running"
   forever: the resumed turn ran with no driving prompt, so nothing ended it. The
-  daemon now ends such a turn cleanly once it goes idle (about 20 seconds after
+  daemon now ends such a turn cleanly once it goes idle (a few seconds after
   the agent's last output, longer while a fresh wake is still pending), so the
   session returns to idle on its own without `aoe acp restart`.
 

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -242,6 +242,12 @@ container (rather than bind-mounting from the host).
   marker, which made the daemon refuse to bring the worker back after it next
   exited; a follow-up message would then sit unsent. A worker coming online now
   clears that marker, so this no longer strands a queued message.
+- An agent that armed a monitor or a scheduled wake, finished the turn, then was
+  woken later by that background task used to keep the session marked "running"
+  forever: the resumed turn ran with no driving prompt, so nothing ended it. The
+  daemon now ends such a turn cleanly once it goes idle (about 20 seconds after
+  the agent's last output, longer while a fresh wake is still pending), so the
+  session returns to idle on its own without `aoe acp restart`.
 
 ### "Restarting worker" banner after a turn looked done
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -464,6 +464,24 @@ const SILENT_ORPHAN_FAST_GRACE_DEFAULT: std::time::Duration = std::time::Duratio
 /// notification handler to reach back into a pinned `tokio::time::sleep`.
 const SILENT_ORPHAN_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Idle grace for the between-prompt watchdog once the cost-bearing
+/// end-of-turn `UsageUpdate` has arrived. Much shorter than the per-prompt
+/// `SILENT_ORPHAN_FAST_GRACE_DEFAULT`: that one also waits out a
+/// possibly-late `PromptResponse` over the wire, but a between-prompt
+/// agent-initiated turn has no RPC to wait for, so once it emits its
+/// end-of-turn marker and goes quiet a few seconds is enough. Kept low so
+/// the "monitoring" badge and running status clear promptly after a monitor
+/// turn finishes. A turn that actually continues emits fresh progress,
+/// which resets the idle timer and clears `cost_seen`, so this cannot cut a
+/// live turn short. See #2325.
+const BETWEEN_PROMPT_IDLE_GRACE: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Tick cadence for the between-prompt idle check. Faster than
+/// `SILENT_ORPHAN_CHECK_INTERVAL` so the badge and status clear within a few
+/// seconds of the turn ending. Only polled while the command loop is parked
+/// between prompts, so the extra wakeups are cheap. See #2325.
+const BETWEEN_PROMPT_IDLE_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Classification of an inbound ACP `SessionUpdate` for the silent-
 /// orphan watchdog state machine. Sent from the notification handler
 /// to the prompt loop via a dedicated mpsc; the prompt loop owns the
@@ -5004,7 +5022,7 @@ async fn run_connection_task<W, R>(
             // command loop (never a detached task) keeps it serialized with
             // every other command, so it can't race a new prompt's events.
             let mut between_prompt_idle_tick =
-                tokio::time::interval(SILENT_ORPHAN_CHECK_INTERVAL);
+                tokio::time::interval(BETWEEN_PROMPT_IDLE_CHECK_INTERVAL);
             between_prompt_idle_tick
                 .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
@@ -5018,7 +5036,7 @@ async fn run_connection_task<W, R>(
                             last_lifecycle_at.load(Ordering::Relaxed),
                             between_prompt_wake_until.load(Ordering::Relaxed),
                             between_prompt_cost_seen.load(Ordering::Relaxed),
-                            SILENT_ORPHAN_FAST_GRACE_DEFAULT,
+                            BETWEEN_PROMPT_IDLE_GRACE,
                             OFF_PROTOCOL_WORK_GRACE_FLOOR,
                         ) {
                             between_prompt_active.store(false, Ordering::Relaxed);
@@ -6657,8 +6675,9 @@ mod tests {
     }
 
     // Between-prompt idle watchdog fire decision (#2325). Wall-clock millis.
-    const FAST: std::time::Duration = std::time::Duration::from_secs(20);
-    const FLOOR: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+    // Bind to the production constants so the test tracks the real grace.
+    const FAST: std::time::Duration = BETWEEN_PROMPT_IDLE_GRACE;
+    const FLOOR: std::time::Duration = OFF_PROTOCOL_WORK_GRACE_FLOOR;
 
     #[test]
     fn between_prompt_inactive_never_fires() {
@@ -6671,20 +6690,21 @@ mod tests {
     #[test]
     fn between_prompt_fires_after_fast_grace_when_cost_seen() {
         let last = 1_000_000;
-        // 19s idle: still within the 20s fast grace.
+        let grace_ms = FAST.as_millis() as i64;
+        // Just under the fast grace: still waiting.
         assert!(!between_prompt_should_fire(
             true,
-            last + 19_000,
+            last + grace_ms - 500,
             last,
             0,
             true,
             FAST,
             FLOOR
         ));
-        // 21s idle: past the fast grace, the completed turn ends.
+        // Past the fast grace: the completed turn ends.
         assert!(between_prompt_should_fire(
             true,
-            last + 21_000,
+            last + grace_ms + 500,
             last,
             0,
             true,

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -922,6 +922,55 @@ fn terminal_stop_reason(
 /// otherwise the vendor-agnostic off-protocol floor governs. A pending
 /// scheduled wake (`wake_until` in the future) suppresses firing so a
 /// legitimately-sleeping monitor is never killed early.
+/// State update the between-prompt watchdog should apply for one inbound
+/// notification's classified signals. `None` when neither a lifecycle nor a
+/// wakeup signal is present (ambient updates do not touch the watchdog).
+///
+/// Extracted as a pure function so the cost / progress / wake bookkeeping is
+/// unit-testable without the notification closure. Every tracked signal
+/// refreshes `last_lifecycle_at` to `now_ms`, including `TerminalUsage`: the
+/// cost-bearing `UsageUpdate` is the end-of-turn marker, and the fast grace
+/// must measure from it (when the turn wrapped up) rather than from a
+/// possibly-stale earlier progress event. See #2325.
+#[derive(Debug, PartialEq)]
+struct BetweenPromptUpdate {
+    cost_seen: bool,
+    last_lifecycle_at: i64,
+    wake_until: i64,
+}
+
+fn between_prompt_signal_update(
+    lifecycle: Option<&LifecycleSignal>,
+    wakeup: Option<&LifecycleSignal>,
+    now_ms: i64,
+    prev_wake_until: i64,
+) -> Option<BetweenPromptUpdate> {
+    let mut update = match lifecycle {
+        Some(LifecycleSignal::TerminalUsage) => Some(BetweenPromptUpdate {
+            cost_seen: true,
+            last_lifecycle_at: now_ms,
+            wake_until: prev_wake_until,
+        }),
+        Some(_) => Some(BetweenPromptUpdate {
+            cost_seen: false,
+            last_lifecycle_at: now_ms,
+            wake_until: prev_wake_until,
+        }),
+        None => None,
+    };
+    // A scheduled wake (a re-armed monitor) suppresses firing until its
+    // deadline. Multiple wakes extend, never shorten, suppression.
+    if let Some(LifecycleSignal::WakeupPending { at }) = wakeup {
+        let deadline = at.timestamp_millis() + OFF_PROTOCOL_WORK_GRACE_FLOOR.as_millis() as i64;
+        update = Some(BetweenPromptUpdate {
+            cost_seen: false,
+            last_lifecycle_at: now_ms,
+            wake_until: deadline.max(prev_wake_until),
+        });
+    }
+    update
+}
+
 fn between_prompt_should_fire(
     active: bool,
     now_ms: i64,
@@ -4365,34 +4414,22 @@ async fn run_connection_task<W, R>(
                     // idle tick applies the same grace. During a real prompt
                     // the per-prompt watchdog owns this, so skip.
                     if !prompt_in_flight.load(Ordering::Relaxed) {
-                        match &lifecycle_signal {
-                            Some(LifecycleSignal::TerminalUsage) => {
-                                between_prompt_active.store(true, Ordering::Relaxed);
-                                between_prompt_cost_seen.store(true, Ordering::Relaxed);
-                            }
-                            Some(_) => {
-                                between_prompt_active.store(true, Ordering::Relaxed);
-                                between_prompt_cost_seen.store(false, Ordering::Relaxed);
-                                last_lifecycle_at.store(
-                                    chrono::Utc::now().timestamp_millis(),
-                                    Ordering::Relaxed,
-                                );
-                            }
-                            None => {}
-                        }
-                        if let Some(LifecycleSignal::WakeupPending { at }) = &wakeup_signal {
+                        let now = chrono::Utc::now().timestamp_millis();
+                        if let Some(u) = between_prompt_signal_update(
+                            lifecycle_signal.as_ref(),
+                            wakeup_signal.as_ref(),
+                            now,
+                            between_prompt_wake_until.load(Ordering::Relaxed),
+                        ) {
                             between_prompt_active.store(true, Ordering::Relaxed);
-                            between_prompt_cost_seen.store(false, Ordering::Relaxed);
-                            last_lifecycle_at.store(
-                                chrono::Utc::now().timestamp_millis(),
-                                Ordering::Relaxed,
-                            );
-                            let deadline = at.timestamp_millis()
-                                + OFF_PROTOCOL_WORK_GRACE_FLOOR.as_millis() as i64;
-                            // Multiple wakes extend, never shorten, suppression.
-                            let prev = between_prompt_wake_until.load(Ordering::Relaxed);
-                            between_prompt_wake_until
-                                .store(deadline.max(prev), Ordering::Relaxed);
+                            between_prompt_cost_seen.store(u.cost_seen, Ordering::Relaxed);
+                            // Refresh from `now` on every tracked signal,
+                            // including TerminalUsage, so the fast grace
+                            // measures from when the turn wrapped up rather
+                            // than from a possibly-stale earlier progress
+                            // event. See #2325 review.
+                            last_lifecycle_at.store(u.last_lifecycle_at, Ordering::Relaxed);
+                            between_prompt_wake_until.store(u.wake_until, Ordering::Relaxed);
                         }
                     }
                     let mapped_events =
@@ -6756,6 +6793,111 @@ mod tests {
             true,
             FAST,
             FLOOR
+        ));
+    }
+
+    #[test]
+    fn between_prompt_signal_update_terminal_usage_refreshes_timestamp() {
+        // TerminalUsage marks cost_seen AND refreshes last_lifecycle_at to
+        // `now`, so the fast grace measures from the cost marker, not a
+        // stale earlier progress event. See #2325 review.
+        let u =
+            between_prompt_signal_update(Some(&LifecycleSignal::TerminalUsage), None, 500_000, 0)
+                .expect("TerminalUsage is a tracked signal");
+        assert_eq!(
+            u,
+            BetweenPromptUpdate {
+                cost_seen: true,
+                last_lifecycle_at: 500_000,
+                wake_until: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn between_prompt_signal_update_progress_clears_cost_and_refreshes() {
+        let u = between_prompt_signal_update(Some(&LifecycleSignal::Progress), None, 500_000, 0)
+            .expect("Progress is a tracked signal");
+        assert_eq!(
+            u,
+            BetweenPromptUpdate {
+                cost_seen: false,
+                last_lifecycle_at: 500_000,
+                wake_until: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn between_prompt_signal_update_ambient_is_none() {
+        // No lifecycle and no wakeup signal: ambient update, no state change.
+        assert!(between_prompt_signal_update(None, None, 500_000, 42).is_none());
+    }
+
+    #[test]
+    fn between_prompt_signal_update_wakeup_extends_suppression() {
+        let at = chrono::DateTime::from_timestamp_millis(600_000).unwrap();
+        let expected_deadline = 600_000 + OFF_PROTOCOL_WORK_GRACE_FLOOR.as_millis() as i64;
+        // A later wake deadline wins; an earlier prev does not shorten it.
+        let u = between_prompt_signal_update(
+            None,
+            Some(&LifecycleSignal::WakeupPending { at }),
+            500_000,
+            1_000,
+        )
+        .expect("WakeupPending is a tracked signal");
+        assert_eq!(
+            u,
+            BetweenPromptUpdate {
+                cost_seen: false,
+                last_lifecycle_at: 500_000,
+                wake_until: expected_deadline,
+            }
+        );
+        // A larger prev_wake_until is preserved (suppression only extends).
+        let u2 = between_prompt_signal_update(
+            None,
+            Some(&LifecycleSignal::WakeupPending { at }),
+            500_000,
+            expected_deadline + 10_000,
+        )
+        .unwrap();
+        assert_eq!(u2.wake_until, expected_deadline + 10_000);
+    }
+
+    #[test]
+    fn between_prompt_stale_progress_plus_cost_marker_does_not_fire_early() {
+        // Regression for the state-update path (#2325 review): a progress
+        // event 10s ago, then a cost-bearing UsageUpdate now. The cost marker
+        // refreshes last_lifecycle_at, so 2s later (under the 3s grace) the
+        // watchdog must NOT fire even though cost_seen is true and the prior
+        // progress is older than the grace.
+        let cost_now = 1_000_000;
+        let stale_progress = cost_now - 10_000;
+        let u =
+            between_prompt_signal_update(Some(&LifecycleSignal::TerminalUsage), None, cost_now, 0)
+                .unwrap();
+        // The refresh, not the stale progress, governs the grace window.
+        assert_eq!(u.last_lifecycle_at, cost_now);
+        assert_ne!(u.last_lifecycle_at, stale_progress);
+        assert!(!between_prompt_should_fire(
+            true,
+            cost_now + 2_000,
+            u.last_lifecycle_at,
+            u.wake_until,
+            u.cost_seen,
+            FAST,
+            FLOOR,
+        ));
+        // After the full grace it does fire.
+        assert!(between_prompt_should_fire(
+            true,
+            cost_now + FAST.as_millis() as i64 + 1,
+            u.last_lifecycle_at,
+            u.wake_until,
+            u.cost_seen,
+            FAST,
+            FLOOR,
         ));
     }
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -888,6 +888,41 @@ fn terminal_stop_reason(
     }
 }
 
+/// Decide whether the between-prompt idle watchdog should synthesize a
+/// terminal `Stopped` for an agent-initiated turn that ran with no
+/// aoe-issued `session/prompt`. A claude-code Monitor (or any backgrounded
+/// task) can fire AFTER the prompt that armed it already completed,
+/// resuming the agent into a fresh turn the per-prompt watchdog never
+/// saw; without this the turn never ends and the UI stays "running"
+/// forever. See #2325.
+///
+/// Pure so the precedence is unit-testable without the connection loop.
+/// Times are wall-clock millis (`chrono::Utc::now().timestamp_millis()`),
+/// matching the resume-idle watchdog. Mirrors the per-prompt watchdog's
+/// grace policy: the cost-bearing `UsageUpdate` is claude-agent-acp's
+/// end-of-turn marker, so once it has arrived the fast grace applies;
+/// otherwise the vendor-agnostic off-protocol floor governs. A pending
+/// scheduled wake (`wake_until` in the future) suppresses firing so a
+/// legitimately-sleeping monitor is never killed early.
+fn between_prompt_should_fire(
+    active: bool,
+    now_ms: i64,
+    last_lifecycle_ms: i64,
+    wake_until_ms: i64,
+    cost_seen: bool,
+    fast_grace: std::time::Duration,
+    floor: std::time::Duration,
+) -> bool {
+    if !active {
+        return false;
+    }
+    if now_ms < wake_until_ms {
+        return false;
+    }
+    let grace = if cost_seen { fast_grace } else { floor };
+    now_ms - last_lifecycle_ms >= grace.as_millis() as i64
+}
+
 /// Tagged lifecycle signal carried over the watchdog mpsc. The
 /// `epoch` field is captured at signal-construction time from the
 /// shared `current_prompt_epoch` atomic; the prompt loop discards
@@ -4199,8 +4234,24 @@ async fn run_connection_task<W, R>(
     let first_event_after_attach = Arc::new(AtomicBool::new(false));
     let prompt_sent_since_attach = Arc::new(AtomicBool::new(false));
     let watchdog_fired = Arc::new(AtomicBool::new(false));
+    // Between-prompt idle watchdog state (#2325). Tracks an agent-initiated
+    // turn (Monitor / scheduled-wake resume) that runs with no aoe-issued
+    // `session/prompt`, so the outer command loop's idle tick can synthesize
+    // its terminal Stopped. `last_lifecycle_at` is updated only on transcript
+    // progress (NOT ambient AvailableCommandsUpdate), so periodic
+    // command-list refreshes can't keep resetting the idle timer.
+    let last_lifecycle_at = Arc::new(AtomicI64::new(now_ms));
+    let between_prompt_active = Arc::new(AtomicBool::new(false));
+    let between_prompt_cost_seen = Arc::new(AtomicBool::new(false));
+    let between_prompt_wake_until = Arc::new(AtomicI64::new(0));
+    let prompt_in_flight = Arc::new(AtomicBool::new(false));
     let last_event_at_for_notif = last_event_at.clone();
     let first_event_after_attach_for_notif = first_event_after_attach.clone();
+    let last_lifecycle_at_for_notif = last_lifecycle_at.clone();
+    let between_prompt_active_for_notif = between_prompt_active.clone();
+    let between_prompt_cost_seen_for_notif = between_prompt_cost_seen.clone();
+    let between_prompt_wake_until_for_notif = between_prompt_wake_until.clone();
+    let prompt_in_flight_for_notif = prompt_in_flight.clone();
 
     // Per-session tracker that drops claude-agent-acp's leaked consolidated
     // agent_message_chunk restatement before it doubles the rendered message.
@@ -4229,6 +4280,13 @@ async fn run_connection_task<W, R>(
                 let lifecycle_signal_tx = lifecycle_signal_tx_for_notif.clone();
                 let current_prompt_epoch = current_prompt_epoch_for_notif.clone();
                 let agent_msg_dedup = agent_msg_dedup_for_notif.clone();
+                let last_lifecycle_at = last_lifecycle_at_for_notif.clone();
+                let between_prompt_active = between_prompt_active_for_notif.clone();
+                let between_prompt_cost_seen =
+                    between_prompt_cost_seen_for_notif.clone();
+                let between_prompt_wake_until =
+                    between_prompt_wake_until_for_notif.clone();
+                let prompt_in_flight = prompt_in_flight_for_notif.clone();
                 async move {
                     last_event_at
                         .store(chrono::Utc::now().timestamp_millis(), Ordering::Relaxed);
@@ -4280,6 +4338,44 @@ async fn run_connection_task<W, R>(
                     // not proof of in-flight turn progress.
                     if lifecycle_signal.is_some() || wakeup_signal.is_some() {
                         first_event_after_attach.store(true, Ordering::Relaxed);
+                    }
+                    // Between-prompt idle tracking (#2325). Only while no
+                    // aoe-issued prompt is in flight: a lifecycle signal here
+                    // means the agent resumed itself (Monitor / scheduled
+                    // wake), a turn the per-prompt watchdog never sees. Mirror
+                    // its cost/progress/wake semantics so the outer loop's
+                    // idle tick applies the same grace. During a real prompt
+                    // the per-prompt watchdog owns this, so skip.
+                    if !prompt_in_flight.load(Ordering::Relaxed) {
+                        match &lifecycle_signal {
+                            Some(LifecycleSignal::TerminalUsage) => {
+                                between_prompt_active.store(true, Ordering::Relaxed);
+                                between_prompt_cost_seen.store(true, Ordering::Relaxed);
+                            }
+                            Some(_) => {
+                                between_prompt_active.store(true, Ordering::Relaxed);
+                                between_prompt_cost_seen.store(false, Ordering::Relaxed);
+                                last_lifecycle_at.store(
+                                    chrono::Utc::now().timestamp_millis(),
+                                    Ordering::Relaxed,
+                                );
+                            }
+                            None => {}
+                        }
+                        if let Some(LifecycleSignal::WakeupPending { at }) = &wakeup_signal {
+                            between_prompt_active.store(true, Ordering::Relaxed);
+                            between_prompt_cost_seen.store(false, Ordering::Relaxed);
+                            last_lifecycle_at.store(
+                                chrono::Utc::now().timestamp_millis(),
+                                Ordering::Relaxed,
+                            );
+                            let deadline = at.timestamp_millis()
+                                + OFF_PROTOCOL_WORK_GRACE_FLOOR.as_millis() as i64;
+                            // Multiple wakes extend, never shorten, suppression.
+                            let prev = between_prompt_wake_until.load(Ordering::Relaxed);
+                            between_prompt_wake_until
+                                .store(deadline.max(prev), Ordering::Relaxed);
+                        }
                     }
                     let mapped_events =
                         map_update_to_events(notification.update, profile);
@@ -4900,8 +4996,46 @@ async fn run_connection_task<W, R>(
                 });
             }
 
+            // The idle tick fires the between-prompt watchdog (#2325). It is
+            // only polled while this loop is parked at `cmd_rx.recv()`, i.e.
+            // between prompts; during a prompt the inner drain owns the
+            // connection and this arm never runs, so the per-prompt watchdog
+            // stays the sole idle authority there. Emitting Stopped from the
+            // command loop (never a detached task) keeps it serialized with
+            // every other command, so it can't race a new prompt's events.
+            let mut between_prompt_idle_tick =
+                tokio::time::interval(SILENT_ORPHAN_CHECK_INTERVAL);
+            between_prompt_idle_tick
+                .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
-                let cmd = cmd_rx.recv().await;
+                let cmd = tokio::select! {
+                    cmd = cmd_rx.recv() => cmd,
+                    _ = between_prompt_idle_tick.tick() => {
+                        let now = chrono::Utc::now().timestamp_millis();
+                        if between_prompt_should_fire(
+                            between_prompt_active.load(Ordering::Relaxed),
+                            now,
+                            last_lifecycle_at.load(Ordering::Relaxed),
+                            between_prompt_wake_until.load(Ordering::Relaxed),
+                            between_prompt_cost_seen.load(Ordering::Relaxed),
+                            SILENT_ORPHAN_FAST_GRACE_DEFAULT,
+                            OFF_PROTOCOL_WORK_GRACE_FLOOR,
+                        ) {
+                            between_prompt_active.store(false, Ordering::Relaxed);
+                            info!(
+                                target: "acp.protocol",
+                                session = %session_label,
+                                "between-prompt idle watchdog: synthesizing Stopped for completed agent-initiated turn"
+                            );
+                            let _ = event_tx_for_block
+                                .send(Event::Stopped {
+                                    reason: "agent_idle".into(),
+                                })
+                                .await;
+                        }
+                        continue;
+                    }
+                };
                 match cmd {
                     Some(ClientCmd::Prompt(blocks)) => {
                         // Scope the agent-message deduper to one turn: a new
@@ -4927,6 +5061,13 @@ async fn run_connection_task<W, R>(
                         // transition, so we no longer need to synthesize
                         // one for the orphaned prior turn.
                         prompt_sent_since_attach.store(true, Ordering::Relaxed);
+                        // A real prompt supersedes any agent-initiated turn the
+                        // between-prompt idle watchdog was tracking; this
+                        // prompt's own Stopped will own the next transition.
+                        // The per-prompt watchdog owns idle detection until the
+                        // Stopped emit below clears `prompt_in_flight`. See #2325.
+                        prompt_in_flight.store(true, Ordering::Relaxed);
+                        between_prompt_active.store(false, Ordering::Relaxed);
                         info!(target: "acp.protocol", "sending prompt ({} content blocks)", blocks.len());
                         // Drive the prompt request concurrently with the
                         // command channel so out-of-band notifications
@@ -5503,6 +5644,10 @@ async fn run_connection_task<W, R>(
                             .lock()
                             .expect("agent message dedup mutex poisoned")
                             .reset();
+                        // The prompt drain is done; hand idle ownership back to
+                        // the between-prompt watchdog for any agent-initiated
+                        // turn that fires after this point. See #2325.
+                        prompt_in_flight.store(false, Ordering::Relaxed);
                         if shutdown {
                             break;
                         }
@@ -6509,6 +6654,89 @@ mod tests {
             terminal_stop_reason(false, false, false, false, false, true),
             "cancelled"
         );
+    }
+
+    // Between-prompt idle watchdog fire decision (#2325). Wall-clock millis.
+    const FAST: std::time::Duration = std::time::Duration::from_secs(20);
+    const FLOOR: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+    #[test]
+    fn between_prompt_inactive_never_fires() {
+        // No agent-initiated turn tracked, even long past any grace.
+        assert!(!between_prompt_should_fire(
+            false, 10_000_000, 0, 0, true, FAST, FLOOR
+        ));
+    }
+
+    #[test]
+    fn between_prompt_fires_after_fast_grace_when_cost_seen() {
+        let last = 1_000_000;
+        // 19s idle: still within the 20s fast grace.
+        assert!(!between_prompt_should_fire(
+            true,
+            last + 19_000,
+            last,
+            0,
+            true,
+            FAST,
+            FLOOR
+        ));
+        // 21s idle: past the fast grace, the completed turn ends.
+        assert!(between_prompt_should_fire(
+            true,
+            last + 21_000,
+            last,
+            0,
+            true,
+            FAST,
+            FLOOR
+        ));
+    }
+
+    #[test]
+    fn between_prompt_uses_floor_without_cost() {
+        let last = 1_000_000;
+        // 21s idle but no cost marker: the generous floor governs, no fire.
+        assert!(!between_prompt_should_fire(
+            true,
+            last + 21_000,
+            last,
+            0,
+            false,
+            FAST,
+            FLOOR
+        ));
+        // Past the 30-minute floor: fire even without a cost marker.
+        assert!(between_prompt_should_fire(
+            true,
+            last + 30 * 60 * 1000 + 1,
+            last,
+            0,
+            false,
+            FAST,
+            FLOOR
+        ));
+    }
+
+    #[test]
+    fn between_prompt_suppressed_while_wake_pending() {
+        let last = 1_000_000;
+        let now = last + 60_000; // idle well past fast grace
+        let wake_until = now + 5_000; // a re-armed monitor still sleeping
+                                      // Suppressed: the agent is deliberately asleep on a scheduled wake.
+        assert!(!between_prompt_should_fire(
+            true, now, last, wake_until, true, FAST, FLOOR
+        ));
+        // Once the wake deadline passes, the idle grace governs again.
+        assert!(between_prompt_should_fire(
+            true,
+            wake_until + 21_000,
+            last,
+            wake_until,
+            true,
+            FAST,
+            FLOOR
+        ));
     }
 
     #[tokio::test]

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -811,17 +811,18 @@ impl EventStore {
     /// the latest `MonitorArmed` description when active, `None` otherwise.
     ///
     /// A `Monitor` is fire-and-forget with no fixed end time, so unlike
-    /// `latest_pending_wakeup` there is no timestamp to gate on. A monitor
-    /// firing re-invokes the agent with activity but never a
-    /// `UserPromptSent`, so the badge must persist across re-fires and clear
-    /// only when the user takes over: treat the monitor as active iff the
-    /// latest `MonitorArmed` has no `UserPromptSent` at a higher seq.
-    ///
-    /// Known ceiling: a monitor that exits / times out, or is torn down by a
-    /// `TaskStop`, with no following user prompt leaves the badge up until
-    /// the user's next prompt. aoe gets no clean disarm signal, and a stale
-    /// "monitoring" badge that clears on any user action is strictly better
-    /// than an idle dot that looks dead.
+    /// `latest_pending_wakeup` there is no timestamp to gate on, and the
+    /// `Monitor` tool call itself completes at arm time (it returns "monitor
+    /// started"), so its completion is not the disarm signal either. The
+    /// badge stays up from the arm until either the user takes over
+    /// (`UserPromptSent` at a higher seq) or the monitor fires and that turn
+    /// ends. The fire is observed as a tool call started after the arm (the
+    /// agent acting on the wake); the badge then retires on the next
+    /// `Stopped`. This covers both shapes: the agent ending the arming turn
+    /// and resuming later between prompts (closed by `agent_idle`), and the
+    /// monitor blocking the arming turn in-band (closed by `prompt_complete`).
+    /// A `Stopped` with no post-arm tool work is the arming turn ending while
+    /// the monitor is still pending, so it leaves the badge up. See #2325.
     pub fn latest_active_monitor(&self, session_id: &str) -> Option<Option<String>> {
         let conn = match self.conn.lock() {
             Ok(g) => g,
@@ -841,9 +842,9 @@ impl EventStore {
             .ok()
             .flatten();
         let (armed_seq, json) = row?;
-        // A user prompt after the arm means the user took over; the badge
-        // clears. No log on the common "no monitor" branch above (this query
-        // fans out per structured session on every ~2-3s sessions poll).
+        // The user taking over clears the badge immediately. No log on the
+        // common "no monitor" branch above (this query fans out per
+        // structured session on every ~2-3s sessions poll).
         let user_took_over: Option<i64> = conn
             .query_row(
                 "SELECT 1 FROM acp_events
@@ -859,6 +860,41 @@ impl EventStore {
             .flatten();
         if user_took_over.is_some() {
             return None;
+        }
+        // Otherwise the badge clears once the monitor fired (a tool call
+        // started after the arm) AND that turn has since ended (a Stopped
+        // past that tool start). Without the post-work gate, the arming
+        // turn's own Stopped while the monitor is still pending would clear
+        // it prematurely.
+        let first_work_seq: Option<i64> = conn
+            .query_row(
+                "SELECT MIN(seq) FROM acp_events
+                 WHERE session_id = ?1
+                   AND seq > ?2
+                   AND event_json LIKE '{\"ToolCallStarted\":%'",
+                params![session_id, armed_seq],
+                |row| row.get(0),
+            )
+            .optional()
+            .ok()
+            .flatten();
+        if let Some(work_seq) = first_work_seq {
+            let turn_ended: Option<i64> = conn
+                .query_row(
+                    "SELECT 1 FROM acp_events
+                     WHERE session_id = ?1
+                       AND seq > ?2
+                       AND event_json LIKE '{\"Stopped\":%'
+                     LIMIT 1",
+                    params![session_id, work_seq],
+                    |row| row.get(0),
+                )
+                .optional()
+                .ok()
+                .flatten();
+            if turn_ended.is_some() {
+                return None;
+            }
         }
         match serde_json::from_str::<Event>(&json) {
             Ok(Event::MonitorArmed { description }) => Some(description),
@@ -2534,6 +2570,85 @@ mod tests {
             )
             .unwrap();
         assert!(store.latest_active_monitor("s-1").is_none());
+    }
+
+    #[test]
+    fn latest_active_monitor_persists_on_arming_turn_stop() {
+        // The arming turn ending while the monitor is still pending (no
+        // post-arm tool work yet) must NOT clear the badge (#2325).
+        let (_tmp, store) = open_store(1000);
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::MonitorArmed {
+                    description: Some("watch".into()),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::Stopped {
+                    reason: "prompt_complete".into(),
+                },
+            )
+            .unwrap();
+        assert!(store.latest_active_monitor("s-1").is_some());
+    }
+
+    #[test]
+    fn latest_active_monitor_clears_after_fired_work_and_stop() {
+        // The monitor fired (a tool call started after the arm) and that turn
+        // then ended: the badge clears regardless of the Stopped reason, so
+        // both the in-band (`prompt_complete`) and between-prompt
+        // (`agent_idle`) monitor shapes are covered (#2325).
+        for reason in ["prompt_complete", "agent_idle"] {
+            let (_tmp, store) = open_store(1000);
+            store
+                .record(
+                    "s-1",
+                    1,
+                    &Event::MonitorArmed {
+                        description: Some("watch".into()),
+                    },
+                )
+                .unwrap();
+            store
+                .record(
+                    "s-1",
+                    2,
+                    &Event::ToolCallStarted {
+                        tool_call: crate::acp::state::ToolCall {
+                            id: "tc-1".into(),
+                            name: "Read".into(),
+                            kind: "read".into(),
+                            args_preview: String::new(),
+                            started_at: Utc::now(),
+                            parent_tool_call_id: None,
+                            memory_recall: None,
+                            diffs: Vec::new(),
+                        },
+                    },
+                )
+                .unwrap();
+            // Tool started but turn not yet ended: badge still up.
+            assert!(store.latest_active_monitor("s-1").is_some());
+            store
+                .record(
+                    "s-1",
+                    3,
+                    &Event::Stopped {
+                        reason: reason.into(),
+                    },
+                )
+                .unwrap();
+            assert!(
+                store.latest_active_monitor("s-1").is_none(),
+                "badge should clear after fired work + Stopped({reason})"
+            );
+        }
     }
 
     #[test]

--- a/web/src/lib/acpTypes.test.ts
+++ b/web/src/lib/acpTypes.test.ts
@@ -1109,6 +1109,60 @@ describe("applyEvent / MonitorArmed lifecycle", () => {
     expect(state.monitorArmed).toBe(false);
     expect(state.monitorDescription).toBeNull();
   });
+
+  it("persists on the arming turn's Stopped while the monitor is still pending", () => {
+    // Arm, then end the turn with no post-arm tool work: the monitor has not
+    // fired yet, the badge must stay up. See #2325.
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { MonitorArmed: { description: "watch" } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    expect(state.monitorArmed).toBe(true);
+  });
+
+  it.each(["prompt_complete", "agent_idle"])(
+    "clears once the monitor fired (tool started after arm) and the turn ends with %s",
+    (reason) => {
+      // The fire makes the agent act (a tool call after the arm); the badge
+      // then retires on the next Stopped, covering both the in-band
+      // (prompt_complete) and between-prompt (agent_idle) shapes. See #2325.
+      let state = applyEvent(emptyAcpState(), {
+        session_id: "s-1",
+        seq: 1,
+        event: { MonitorArmed: { description: "watch" } },
+      });
+      state = applyEvent(state, {
+        session_id: "s-1",
+        seq: 2,
+        event: {
+          ToolCallStarted: {
+            tool_call: {
+              id: "tc-1",
+              name: "Read File",
+              kind: "read",
+              args_preview: "{}",
+              started_at: new Date().toISOString(),
+            },
+          },
+        },
+      });
+      // Fired-work seen but turn not ended yet: badge still up.
+      expect(state.monitorArmed).toBe(true);
+      state = applyEvent(state, {
+        session_id: "s-1",
+        seq: 3,
+        event: { Stopped: { reason } },
+      });
+      expect(state.monitorArmed).toBe(false);
+      expect(state.monitorDescription).toBeNull();
+    },
+  );
 });
 
 describe("applyEvent / CancelRequested lifecycle (#1727)", () => {

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -723,9 +723,17 @@ export interface AcpState {
    *  Unlike a scheduled wakeup it has no fire time, so the UI shows a
    *  static "monitoring" badge, not a countdown. A monitor firing
    *  re-invokes the agent with activity but never a `UserPromptSent`, so
-   *  this persists across re-fires and clears only on the next
-   *  `UserPromptSent` (the user takes over). */
+   *  this persists across the wait and clears when the user takes over
+   *  (`UserPromptSent`) or the monitor fires and that turn ends: a tool
+   *  call started after the arm (`monitorWorkSeen`) followed by a
+   *  `Stopped`. See #2325. */
   monitorArmed: boolean;
+  /** True once a tool call has started after the latest `MonitorArmed`,
+   *  i.e. the monitor fired and the agent acted on it. Gates the badge
+   *  clear on the next `Stopped` so the arming turn ending while the
+   *  monitor is still pending does not clear it. Reset by `MonitorArmed`
+   *  and `UserPromptSent`. See #2325. */
+  monitorWorkSeen: boolean;
   /** The `description` the agent gave the `Monitor` tool, shown as the
    *  badge tooltip. Null when none was provided or no monitor is armed. */
   monitorDescription: string | null;
@@ -935,6 +943,7 @@ export function emptyAcpState(): AcpState {
     nextWakeupAt: null,
     nextWakeupReason: null,
     monitorArmed: false,
+    monitorWorkSeen: false,
     monitorDescription: null,
     cancelling: false,
     cancelEscalatesAt: null,
@@ -998,6 +1007,7 @@ function applyNewTurnResets(next: AcpState): void {
   // self-fires a prompt, so any UserPromptSent reaching here is the user
   // taking over: clear the "monitoring" badge unconditionally.
   next.monitorArmed = false;
+  next.monitorWorkSeen = false;
   next.monitorDescription = null;
   // Any pending context-primer offer is consumed once the user submits
   // a new prompt; the recovery affordance is one-shot.
@@ -1105,6 +1115,13 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
       return next;
     }
     next.inFlightTool = tc;
+    // A tool call after the monitor armed means the monitor fired and the
+    // agent is acting on it; gate the badge clear on the next Stopped. The
+    // Monitor tool's own start precedes its MonitorArmed, so it never marks
+    // itself. See #2325.
+    if (next.monitorArmed) {
+      next.monitorWorkSeen = true;
+    }
     // The reasoning block produced output (a tool call), so the agent is
     // no longer thinking. The adapter often skips ThinkingEnded when it
     // transitions into tool calls, so clear it here. See #1213.
@@ -1436,6 +1453,20 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     next.cancelEscalatesAt = null;
     next.lastStoppedSeq = Math.min(next.lastStoppedSeq + 1, next.pendingUserPromptSeq);
     next.turnActive = isTurnActive(next);
+    // Clear the "monitoring" badge once the monitor has fired and that turn
+    // ends. The monitor firing makes the agent act (a tool call after the
+    // arm, tracked by `monitorWorkSeen`); the badge then retires on the next
+    // Stopped. This covers both shapes: the agent ending the arming turn and
+    // resuming later between prompts (closed by `agent_idle`), and the
+    // monitor blocking the arming turn in-band (closed by `prompt_complete`).
+    // A Stopped with no post-arm work is the arming turn ending while the
+    // monitor is still pending, so it deliberately leaves the badge up. See
+    // #2325.
+    if (next.monitorArmed && next.monitorWorkSeen) {
+      next.monitorArmed = false;
+      next.monitorWorkSeen = false;
+      next.monitorDescription = null;
+    }
     // The "user_stopped" / "restart_pending" reasons are published by
     // the supervisor's reap_user_stopped pass when it detects an
     // out-of-band CLI teardown. Surface a distinct UI state for each:
@@ -1738,6 +1769,8 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
   }
   if ("MonitorArmed" in event) {
     next.monitorArmed = true;
+    // Reset the fired-work gate: work only counts once it follows THIS arm.
+    next.monitorWorkSeen = false;
     next.monitorDescription = event.MonitorArmed.description ?? null;
     return next;
   }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A structured-view / web session stayed marked running (green) forever when the agent's final turn was started by a claude-code Monitor (or any backgrounded task) firing after the prompt that armed it had already completed. That resumed turn runs with no aoe-issued `session/prompt`, so the per-prompt silent-orphan watchdog never sees it and no terminal `Stopped` is ever emitted; `turn_active` stays true and the only escape was `aoe acp restart`.

The daemon now tracks agent-initiated activity that happens between prompts via shared atomics maintained by the notification handler (`last_lifecycle_at`, `between_prompt_active`, `between_prompt_cost_seen`, `between_prompt_wake_until`, `prompt_in_flight`), mirroring the per-prompt watchdog's cost / progress / wake semantics. An idle tick is folded into the outer command loop's `recv` `select!`, so it is polled only while the loop is parked between prompts; during a real prompt the inner drain owns the connection and the per-prompt watchdog stays the sole idle authority. When the agent-initiated turn goes idle past grace (a short 3 second grace once the cost-bearing `UsageUpdate` end-of-turn marker has arrived, otherwise the 30-minute off-protocol floor, and suppressed entirely while a scheduled wake is still pending) the loop emits a clean `Stopped { reason: "agent_idle" }`. A 1 second check cadence (vs the per-prompt 5 seconds) keeps the badge and status clearing within a few seconds of the turn finishing.

Emitting the synthetic `Stopped` from the command loop, never a detached timer, keeps it serialized with every other command so it cannot race a new prompt's events and reorder the UI. `"agent_idle"` is a clean stop: the supervisor only restarts on `agent_unresponsive` / `prompt_orphaned` / `user_forced` / `rate_limited`, so a completed between-prompt turn does not burn restart budget. The fire decision is the pure, unit-tested `between_prompt_should_fire` helper.

This is a daemon-side fix, so every surface (web dashboard and the native structured view) inherits it.

The fix also clears the "monitoring" badge and banner. Those are driven by `MonitorArmed` and previously cleared only on a following `UserPromptSent`, with a documented ceiling: a monitor that fired and finished with no user prompt left the badge up indefinitely (the `Monitor` tool call itself completes at arm time, so its completion is not the disarm signal). The badge now clears once the monitor fires and that turn ends: the fire makes the agent act (a tool call started after the arm), and the badge retires on the next `Stopped`. This covers both observed shapes, the agent ending the arming turn and resuming later between prompts (closed by `agent_idle`) and the monitor blocking the arming turn in-band (closed by `prompt_complete`). A `Stopped` with no post-arm tool work is the arming turn ending while the monitor is still pending, so it deliberately leaves the badge up. Applied in the web reducer (`monitorWorkSeen` gate) and the server-side `latest_active_monitor` query.

Closes #2325

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a structured-view session with claude (yolo). Have the agent kick off a long-running background script, arm a Monitor to be notified when it finishes, then end its turn. Confirm the turn completes normally (spinner clears, session idle) while the background work is still running.
- [ ] Let the background script finish so the Monitor fires. The agent resumes on its own, streams a final report, then goes quiet. Confirm that within a few seconds of the agent's last output the session returns to idle by itself, with no green "running" spinner and without `aoe acp restart`.
- [ ] Negative case: while the agent is deliberately asleep waiting on a pending monitor / scheduled wake, confirm the session is NOT prematurely forced to idle during the wait window.
- [ ] Confirm the "monitoring" sidebar badge and the top banner also clear once the resumed monitor turn goes idle (not just the running spinner), with no `aoe acp restart`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The user-visible behavior (spinner clearing) is driven by the daemon-side synthetic `Stopped`, whose decision logic is covered by Rust unit tests (`between_prompt_should_fire`). The one `web/src` change is the reducer clearing the monitoring badge on `agent_idle`, covered by a Vitest case in `web/src/lib/acpTypes.test.ts` (badge persists on `prompt_complete`, clears on `agent_idle`); reducer state transitions are pure logic, the Vitest layer per `AGENTS.md`. Driving a real claude-code Monitor wake end-to-end through Playwright is not deterministic, so the core paths are unit-tested instead. `web/tests/validate-coverage-matrix.mjs` passes.

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the between-prompt idle decision is covered by deterministic Rust unit tests on `between_prompt_should_fire` (fast-grace fire, off-protocol floor, pending-wake suppression, inactive no-fire). A full live e2e would need a real agent to arm a Monitor and have it fire after the arming turn ends, which is not deterministic in the harness.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction, including a `/debate` consult that pushed the design from a free-running timer to a command-loop-owned idle tick to avoid out-of-order `Stopped` emission. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784716290&installation_id=139138837&pr_number=2326&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2326&signature=4d87438e50b245f0a783f1ff11113a40863792c961de5e65b465fa781b2e19f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes sessions that could stay stuck in a “running” (green) state indefinitely after a Monitor (or scheduled wake) fires but the agent then finishes an agent-driven turn with no terminal stop event emitted. It also fixes the web “monitoring” badge so it no longer persists after the monitor’s work is done.

## What Changed

### 1) Daemon: between-prompt idle watchdog
- Added a new “between prompts” idle check that watches for agent activity that ends after emitting the end-of-turn cost marker, but before the next user prompt.
- When the agent goes idle long enough in that between-prompt window, the daemon now emits a clean terminal event: `Stopped { reason: "agent_idle" }`.
- This event is generated from the main command loop (not a detached timer) to keep event ordering consistent.

### 2) Daemon: correct monitor lifecycle → correct UI badge clearing signal
- Updated backend logic so the UI only clears the “monitoring” badge after:
  - the monitor actually starts its work (not just when it arms), and
  - the turn ends afterward.
- This prevents the badge from disappearing too early or remaining stuck when a monitor fires without a subsequent user prompt.

### 3) Frontend (web): monitoring badge state tracking
- Added `monitorWorkSeen` to the web ACP reducer state.
- The reducer now clears `monitorArmed` / badge only when both:
  - the monitor work has started, and
  - a terminating `Stopped` frame arrives.
- Added reducer tests covering both `prompt_complete` and `agent_idle` stop reasons around monitor firing.

### 4) Tests
- Added unit tests for the new between-prompt idle watchdog “helper” logic (including grace timing, suppression while wake is pending, and regression coverage to avoid premature firing).
- Extended tests for the updated monitor badge retirement behavior.

## Benefits
- Prevents sessions from getting stuck in “running” indefinitely and removes the need for manual restarts.
- Ensures the monitoring badge accurately reflects when a monitor has actually fired and the turn has completed.
- Works across all daemon-consumed surfaces since the main behavioral fix is daemon-side.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->