### PR TITLE
fix(serve): silence past-due wakeup trace spam and skip lookups for archived sessions

### DIFF
--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -770,10 +770,12 @@ impl EventStore {
             .flatten();
         // No log for the "no row" branch. The web UI polls /api/sessions
         // every ~2-3s and fans this query out per structured view session; every
-        // idle session would land here on every poll. The "still pending"
-        // and "treated as fired" branches below stay at trace because
-        // those carry the wake `at` timestamp, which is the only
-        // diagnostic value of this function.
+        // idle session would land here on every poll. The past-due branch
+        // below is silent for the same reason: once a wakeup's `at` is in
+        // the past it stays past forever, so logging there would spam one
+        // line per poll for the session's whole life. Only the bounded
+        // "still pending" branch logs; it carries the wake `at` and clears
+        // the moment the wakeup fires.
         let json = json?;
         let event: Event = match serde_json::from_str(&json) {
             Ok(e) => e,
@@ -798,13 +800,6 @@ impl EventStore {
                 );
                 Some((at, reason))
             } else {
-                trace!(
-                    target: "acp.event_store",
-                    session = %session_id,
-                    wake_at = %at,
-                    elapsed_secs = (now - at).num_seconds(),
-                    "latest_pending_wakeup: wake `at` in past; treating as fired"
-                );
                 None
             }
         } else {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -462,7 +462,12 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
             } else {
                 None
             };
-            let (next_wakeup_at, next_wakeup_reason) = if inst.is_structured() {
+            // Archived sessions are sunk and not live; their wakeup/monitor
+            // badge is meaningless, so skip the per-poll SQLite lookups for
+            // them. Unarchiving restores the queries. latest_plan stays
+            // ungated: a collapsed archived row may still show a plan summary.
+            let structured_live = inst.is_structured() && !inst.is_archived();
+            let (next_wakeup_at, next_wakeup_reason) = if structured_live {
                 match state.acp_event_store.latest_pending_wakeup(&inst.id) {
                     Some((at, reason)) => (Some(at.to_rfc3339()), reason),
                     None => (None, None),
@@ -470,7 +475,7 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
             } else {
                 (None, None)
             };
-            let active_monitor = if inst.is_structured() {
+            let active_monitor = if structured_live {
                 state.acp_event_store.latest_active_monitor(&inst.id)
             } else {
                 None


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`latest_pending_wakeup` logged a trace line on every call where a session's scheduled wakeup `at` was in the past. The web dashboard polls `/api/sessions` every ~2-3 seconds and fans this query out per structured session, and a fired wakeup stays past forever, so the same `latest_pending_wakeup: wake \`at\` in past; treating as fired` line repeated indefinitely with a climbing `elapsed_secs`. With trace logging on, this drowned `debug.log` for any session that ever used `ScheduleWakeup`. The branch returns `None`, identical to the no-row branch which is already silent for this exact reason, so the log is dropped.

Second, `list_sessions` ran `latest_pending_wakeup` and `latest_active_monitor` for every structured instance including archived ones. Archived sessions are sunk and not live, so their wakeup/monitor badge is meaningless. Both lookups are now gated on `!inst.is_archived()`, removing per-poll SQLite work for sunk rows. `latest_plan` stays ungated so a collapsed archived row can still show its plan summary.

No user-facing behavior changes: `next_wakeup_at` was already `None` for past-due wakeups (the function returned `None`), and archived sessions had no live badge to lose. This is a logging and per-poll-work fix only.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe serve` with trace logging enabled (`AGENT_OF_EMPIRES_DEBUG=1` or `[logging] level = "trace"`), have a structured session with a past-due wakeup, and confirm `debug.log` no longer gets a `latest_pending_wakeup: wake \`at\` in past` line every few seconds.
- [ ] Confirm a session with an armed (future) wakeup still logs the bounded `latest_pending_wakeup: still pending` trace and the web UI still shows its wakeup badge.
- [ ] Archive a structured session, confirm its row shows no wakeup/monitor badge; unarchive it and confirm the badge returns.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the only behavior change is dropping a trace log and skipping a backend lookup for archived sessions; no dashboard flow changes. The existing `latest_pending_wakeup_returns_none_when_at_in_past` unit test already covers the unchanged `None` return for the past-due branch.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (drop the log vs dedupe it, gate archived lookups) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784716595&installation_id=139138837&pr_number=2327&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2327&signature=4ccf8d836e5dc9dd9afcae326e5195e0591d2ee1364ec967d5c33a833ecfa91f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR eliminates unnecessary logging spam and database queries in the `/api/sessions` endpoint polling path, which is regularly called by the web dashboard every 2–3 seconds.

## Changes Made

### 1. Removed Trace Logging for Past-Due Wakeups
In `src/acp/event_store.rs`, the `latest_pending_wakeup` function no longer emits a trace log when a session's scheduled wakeup timestamp is in the past. Previously, this log line would repeat indefinitely on every poll for any session with a fired wakeup, creating debug log spam with no useful information.

**Result:** Cleaner logs when trace logging is enabled.

### 2. Skipped Database Queries for Archived Sessions
In `src/server/api/sessions.rs`, the `list_sessions` handler now skips wakeup and monitor lookups for archived sessions. A new `structured_live` condition gates these queries to only run for active sessions (structured view + not archived), since archived sessions are inactive and their wakeup/monitor badges are meaningless.

The plan summary lookup remains ungated to preserve the ability to display plan information in collapsed archived rows.

**Result:** Fewer SQLite queries per poll cycle, improving performance of the session list endpoint.

## Benefits
- **Performance improvement:** Eliminated redundant database queries for inactive (archived) sessions
- **Log cleanliness:** Removed spam trace logs that accumulated indefinitely for past-due wakeups
- **No behavior changes:** Both optimizations were silent operations—archived sessions already displayed no live badges, and the function already returned `None` for past-due wakeups

## Technical Details

### Event Store Change
The `latest_pending_wakeup` function now silently returns `None` for wakeups in the past instead of logging `"latest_pending_wakeup: wake \`at\` in past; treating as fired"`. The updated documentation clarifies that only the bounded "still pending" branch logs; the "no row" and "past-due" branches are silent to avoid polling spam.

### Session Handler Change
Added a `structured_live` boolean (`inst.is_structured() && !inst.is_archived()`) to conditionally gate:
- `latest_pending_wakeup()` → populates `next_wakeup_at` and `next_wakeup_reason`
- `latest_active_monitor()` → populates the `active_monitor` field

The `latest_plan()` lookup remains unconditional to support plan display in the collapsed archived session view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->