### PR TITLE
feat(web): copy session id from the About modal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1405,7 +1405,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
         {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
 
-        {showAbout && <AboutModal onClose={() => setShowAbout(false)} />}
+        {showAbout && <AboutModal onClose={() => setShowAbout(false)} sessionId={activeSessionId} />}
         {telemetryConsentNeeded && <TelemetryConsentModal onChoose={handleTelemetryConsent} />}
 
         {deletingSession && (

--- a/web/src/components/AboutModal.tsx
+++ b/web/src/components/AboutModal.tsx
@@ -122,7 +122,9 @@ export function AboutModal({ onClose, sessionId }: Props) {
               <span className="font-mono text-[11px] uppercase tracking-wider text-text-muted shrink-0">
                 Session id
               </span>
-              <span className="text-sm text-brand-500 group-hover:text-brand-400 font-mono truncate">{sessionId}</span>
+              <span className="text-sm text-text-secondary group-hover:text-text-primary font-mono truncate">
+                {sessionId}
+              </span>
             </button>
           )}
 

--- a/web/src/components/AboutModal.tsx
+++ b/web/src/components/AboutModal.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import { fetchAbout } from "../lib/api";
+import { writeClipboard } from "../lib/clipboard";
+import { reportError, reportInfo } from "../lib/toastBus";
 
 interface Props {
   onClose: () => void;
+  /** Id of the currently-open session, or null on the dashboard / no session.
+   *  When set, the modal shows a "Copy session id" row; the id is otherwise
+   *  unreachable in a PWA install where the URL bar is hidden. */
+  sessionId: string | null;
 }
 
 interface LinkRow {
@@ -53,7 +59,7 @@ function buildFeedbackUrl(version: string | null): string {
   return `https://github.com/agent-of-empires/agent-of-empires/issues/new?${params.toString()}`;
 }
 
-export function AboutModal({ onClose }: Props) {
+export function AboutModal({ onClose, sessionId }: Props) {
   const closeRef = useRef<HTMLButtonElement>(null);
   const [version, setVersion] = useState<string | null>(null);
 
@@ -100,6 +106,25 @@ export function AboutModal({ onClose }: Props) {
           <p className="text-sm text-text-secondary">
             Terminal session manager for parallel AI coding agents. Open source, cross-platform, sandboxed.
           </p>
+
+          {sessionId && (
+            <button
+              type="button"
+              onClick={async () => {
+                const ok = await writeClipboard(sessionId);
+                if (ok) reportInfo("Copied session id");
+                else reportError("Copy failed");
+              }}
+              className="w-full flex items-center justify-between gap-3 px-3 py-2 rounded-md bg-surface-900 border border-surface-700/50 hover:border-surface-700 hover:bg-surface-850 transition-colors group cursor-pointer text-left"
+              title="Copy session id to clipboard"
+              aria-label="Copy session id"
+            >
+              <span className="font-mono text-[11px] uppercase tracking-wider text-text-muted shrink-0">
+                Session id
+              </span>
+              <span className="text-sm text-brand-500 group-hover:text-brand-400 font-mono truncate">{sessionId}</span>
+            </button>
+          )}
 
           <div className="space-y-2">
             {LINKS.map((link) => (

--- a/web/src/components/__tests__/AboutModal.test.tsx
+++ b/web/src/components/__tests__/AboutModal.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { AboutModal } from "../AboutModal";
+import { toastBus } from "../../lib/toastBus";
+
+vi.mock("../../lib/api", () => ({
+  fetchAbout: vi.fn().mockResolvedValue(null),
+}));
+
+function setSecureContext(secure: boolean) {
+  Object.defineProperty(window, "isSecureContext", { value: secure, configurable: true });
+}
+
+function stubClipboard() {
+  setSecureContext(true);
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+  return writeText;
+}
+
+function stubToasts() {
+  const info = vi.fn();
+  const error = vi.fn();
+  toastBus.handler = { push: vi.fn(), info, error };
+  return { info, error };
+}
+
+// writeClipboard awaits a promise before toasting; flush microtasks so the
+// toast assertion sees the settled result.
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  toastBus.handler = null;
+});
+
+describe("AboutModal session id", () => {
+  it("copies the session id and reports success", async () => {
+    const writeText = stubClipboard();
+    const { info } = stubToasts();
+    render(<AboutModal onClose={() => {}} sessionId="my-project-20250622" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /copy session id/i }));
+    await flushMicrotasks();
+
+    expect(writeText).toHaveBeenCalledWith("my-project-20250622");
+    expect(info).toHaveBeenCalledWith("Copied session id");
+  });
+
+  it("falls back to execCommand when navigator.clipboard is unavailable", async () => {
+    setSecureContext(false);
+    Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
+    const exec = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", { value: exec, configurable: true });
+    const { info } = stubToasts();
+    render(<AboutModal onClose={() => {}} sessionId="sess-fallback" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /copy session id/i }));
+    await flushMicrotasks();
+
+    expect(exec).toHaveBeenCalledWith("copy");
+    expect(info).toHaveBeenCalledWith("Copied session id");
+  });
+
+  it("renders no session-id row when there is no open session", () => {
+    render(<AboutModal onClose={() => {}} sessionId={null} />);
+    expect(screen.queryByRole("button", { name: /copy session id/i })).toBeNull();
+  });
+});

--- a/web/src/components/__tests__/AboutModal.test.tsx
+++ b/web/src/components/__tests__/AboutModal.test.tsx
@@ -68,6 +68,21 @@ describe("AboutModal session id", () => {
     expect(info).toHaveBeenCalledWith("Copied session id");
   });
 
+  it("reports an error when the copy fails", async () => {
+    setSecureContext(false);
+    Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
+    const exec = vi.fn().mockReturnValue(false);
+    Object.defineProperty(document, "execCommand", { value: exec, configurable: true });
+    const { info, error } = stubToasts();
+    render(<AboutModal onClose={() => {}} sessionId="sess-fail" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /copy session id/i }));
+    await flushMicrotasks();
+
+    expect(error).toHaveBeenCalledWith("Copy failed");
+    expect(info).not.toHaveBeenCalled();
+  });
+
   it("renders no session-id row when there is no open session", () => {
     render(<AboutModal onClose={() => {}} sessionId={null} />);
     expect(screen.queryByRole("button", { name: /copy session id/i })).toBeNull();

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1959,6 +1959,13 @@
       "components": ["web/src/components/settings/SchemaSection.tsx"]
     },
     {
+      "id": "story.modal-about-copy-session-id",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/__tests__/AboutModal.test.tsx"],
+      "components": ["web/src/components/AboutModal.tsx"]
+    },
+    {
       "id": "story.modal-about-escape",
       "kind": "mocked-playwright",
       "risk": "low",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The structured/ACP session id only lives in the URL (`/session/:sessionId`). In a PWA install the URL bar is hidden, so the id is effectively unreachable, which matters whenever you want to grab it for a bug report.

This adds a "Copy session id" row to the About modal. When a session is open, the modal shows the current session's id and copies it to the clipboard on click, using the existing `writeClipboard` helper (which falls back to `execCommand("copy")` on plain HTTP over LAN / Tailscale where `navigator.clipboard` is undefined) and toasts the result. When no session is open (dashboard view) the row is hidden.

Scoped intentionally to the About modal; the login/device session id, a per-session TopBar button, and the Help overlay are out of scope.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured session in the web dashboard, open the overflow menu, click About; confirm a "Session id" row shows the current id.
- [ ] Click the row; confirm a "Copied session id" toast and that the id is on your clipboard.
- [ ] Go to the dashboard (no session open), open About; confirm no session-id row is shown.
- [ ] Reach `aoe serve` over plain HTTP on a LAN / Tailscale IP and repeat the copy; confirm it still copies (execCommand fallback).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added Vitest coverage at `web/src/components/__tests__/AboutModal.test.tsx` (copy success + toast, execCommand fallback, hidden when no session) and a `story.modal-about-copy-session-id` entry in `web/tests/coverage-matrix.json`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (which session id, About modal placement) and ran the test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784717992&installation_id=139138837&pr_number=2328&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2328&signature=6746216a48928d477f13f5c0d31deb4bd21b6ff02c1c3fbde354783d6b98cf20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

- Added a **“Copy session id”** row to the **About modal** in the web dashboard.
- The row appears **only when a session is open** (hidden on the dashboard view).
- Clicking it **copies the session ID to the clipboard** and shows a **toast confirmation**.

## What Was Added / Improved

- **Clipboard support with fallback**: uses the existing clipboard helper, including an `execCommand("copy")` fallback for environments where `navigator.clipboard` isn’t available.
- **User feedback**:
  - Success toast: **“Copied session id”**
  - Failure toast: **“Copy failed”**
- **Automated coverage**:
  - Vitest unit tests for copy success, failure, toast notifications, the fallback behavior, and conditional visibility.
  - Playwright coverage-matrix entry for the modal story.

## What Was Modified

- `App.tsx`: now passes the active `sessionId` into `AboutModal`.
- `AboutModal.tsx`: accepts a `sessionId` prop and conditionally renders the copy row.
- UI tweak from follow-up: replaced the **brand amber** token with **semantic text tokens** for the session ID display styling.

## Benefits

- **Faster support/bug reporting**: users can copy the session ID without manually extracting it from a URL (especially helpful in PWA contexts where the URL path may be hidden).
- **More reliable clipboard behavior** across different browser/security/network environments.
- **Confidence through tests**, including the previously missing copy-failure branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->