### PR TITLE
feat(web): surface the tips system on the dashboard as a tip-of-the-day

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -182,8 +182,8 @@ When you leave the PWA and come back, it reopens to the session you last had ope
 
 ## Tips
 
-The dashboard surfaces the same "did you know" tips as the TUI. When a tip you have not seen is available, a clickable lightbulb badge (💡 with a count) appears in the top bar. Click it to open the tips panel: unseen tips lead, and ones you have already read collapse into an expandable section. Opening a tip marks it read, so the badge clears once you have seen everything. Read state is stored on the server, so it follows you across browsers and devices.
+The dashboard surfaces the same "did you know" tips as the TUI, as a tip-of-the-day modal. When you have an unseen tip, it pops once on startup (after the first-run onboarding settles); step through tips with Previous and Next. Reopen it any time from the top-bar menu (More options > Tips). Each tip is marked read as you view it, and read state is stored on the server, so it follows you across browsers and devices and a tip never re-pops once seen.
 
-"Don't show again" in the panel turns tips off everywhere (it sets the same `Show tips` preference as the TUI). Turn them back on under Settings > Interaction > Show tips. Tips are surface-aware: keyboard-shortcut tips stay in the TUI and never show on the dashboard.
+The "Show tips on startup" checkbox in the modal controls whether it auto-pops; it sets the same `Show tips` preference as the TUI, also editable under Settings > Interaction > Show tips. Tips are surface-aware: keyboard-shortcut tips stay in the TUI and never show on the dashboard.
 
 For build, architecture, and frontend-development details, see [Web Dashboard Development](../development/web-dashboard.md).

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -6,7 +6,7 @@ Monitor and interact with agent sessions from any browser (phone, tablet, or ano
 
 ## In this section
 
-This page covers running the server, access modes, the security model, and PWA install. The rest of the surface has its own pages:
+This page covers running the server, access modes, the security model, PWA install, and tips. The rest of the surface has its own pages:
 
 - **[Dashboard & workspaces](web/dashboard.md)**: layout, status glyphs, session-creation wizard, sidebar sort/grouping, triage (pin / archive / snooze), command palette, first-run tutorial.
 - **[Terminal view](web/terminal.md)**: agent and paired terminals, reconnect behavior, WebSocket close codes, read-only mode.
@@ -179,5 +179,11 @@ The PWA needs the server running; use `--daemon` to keep it up (`aoe serve --sto
 When you leave the PWA and come back, it reopens to the session you last had open rather than the dashboard. The last session is remembered per device (not synced across devices); if you were on the dashboard when you left, or that session no longer exists, you land on the dashboard.
 
 `Ctrl-C` on a foreground server, or `aoe serve --stop` against a daemon, both exit within ~5 seconds even with open tabs. Live clients receive a `1001` ("going away") close frame and reconnect once a fresh server is running.
+
+## Tips
+
+The dashboard surfaces the same "did you know" tips as the TUI. When a tip you have not seen is available, a clickable lightbulb badge (💡 with a count) appears in the top bar. Click it to open the tips panel: unseen tips lead, and ones you have already read collapse into an expandable section. Opening a tip marks it read, so the badge clears once you have seen everything. Read state is stored on the server, so it follows you across browsers and devices.
+
+"Don't show again" in the panel turns tips off everywhere (it sets the same `Show tips` preference as the TUI). Turn them back on under Settings > Interaction > Show tips. Tips are surface-aware: keyboard-shortcut tips stay in the TUI and never show on the dashboard.
 
 For build, architecture, and frontend-development details, see [Web Dashboard Development](../development/web-dashboard.md).

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -6,7 +6,7 @@ Monitor and interact with agent sessions from any browser (phone, tablet, or ano
 
 ## In this section
 
-This page covers running the server, access modes, the security model, PWA install, and tips. The rest of the surface has its own pages:
+This page covers running the server, access modes, the security model, and PWA install. The rest of the surface has its own pages:
 
 - **[Dashboard & workspaces](web/dashboard.md)**: layout, status glyphs, session-creation wizard, sidebar sort/grouping, triage (pin / archive / snooze), command palette, first-run tutorial.
 - **[Terminal view](web/terminal.md)**: agent and paired terminals, reconnect behavior, WebSocket close codes, read-only mode.
@@ -179,11 +179,5 @@ The PWA needs the server running; use `--daemon` to keep it up (`aoe serve --sto
 When you leave the PWA and come back, it reopens to the session you last had open rather than the dashboard. The last session is remembered per device (not synced across devices); if you were on the dashboard when you left, or that session no longer exists, you land on the dashboard.
 
 `Ctrl-C` on a foreground server, or `aoe serve --stop` against a daemon, both exit within ~5 seconds even with open tabs. Live clients receive a `1001` ("going away") close frame and reconnect once a fresh server is running.
-
-## Tips
-
-The dashboard surfaces the same "did you know" tips as the TUI, as a tip-of-the-day modal. When you have an unseen tip, it pops once on startup (after the first-run onboarding settles); step through tips with Previous and Next. Reopen it any time from the top-bar menu (More options > Tips). Each tip is marked read as you view it, and read state is stored on the server, so it follows you across browsers and devices and a tip never re-pops once seen.
-
-The "Show tips on startup" checkbox in the modal controls whether it auto-pops; it sets the same `Show tips` preference as the TUI, also editable under Settings > Interaction > Show tips. Tips are surface-aware: keyboard-shortcut tips stay in the TUI and never show on the dashboard.
 
 For build, architecture, and frontend-development details, see [Web Dashboard Development](../development/web-dashboard.md).

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -49,10 +49,10 @@ pub(crate) use sessions::persist_session_update;
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, dismiss_update,
     docker_status, filesystem_home, get_about, get_current_theme, get_profile_settings,
-    get_resolved_theme, get_settings, get_settings_schema, get_update_status, get_web_ui_state,
-    list_agents, list_groups, list_profiles, list_sounds, list_themes,
-    mark_volume_ignores_globs_acknowledged, mark_web_tour_seen, patch_web_ui_state, rename_profile,
-    serve_sound_file, update_profile_settings, update_settings, update_theme,
+    get_resolved_theme, get_settings, get_settings_schema, get_tips, get_update_status,
+    get_web_ui_state, list_agents, list_groups, list_profiles, list_sounds, list_themes,
+    mark_tip_seen, mark_volume_ignores_globs_acknowledged, mark_web_tour_seen, patch_web_ui_state,
+    rename_profile, serve_sound_file, update_profile_settings, update_settings, update_theme,
 };
 pub use telemetry::{
     get_telemetry_status, post_telemetry_seen, post_telemetry_structured_interaction,
@@ -192,6 +192,7 @@ mod tests {
                     "dismiss_update",
                     "patch_web_ui_state",
                     "mark_web_tour_seen",
+                    "mark_tip_seen",
                     "mark_volume_ignores_globs_acknowledged",
                     "create_profile",
                     "delete_profile",
@@ -345,6 +346,7 @@ mod tests {
                     "update_settings",
                     "dismiss_update",
                     "patch_web_ui_state",
+                    "mark_tip_seen",
                     "create_profile",
                     "delete_profile",
                     "rename_profile",

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -47,12 +47,12 @@ pub use sessions::{
 // Shared by the status poll loop's auto-unread persistence; not a route handler.
 pub(crate) use sessions::persist_session_update;
 pub use system::{
-    browse_filesystem, create_profile, default_profile, delete_profile, disable_tips,
-    dismiss_update, docker_status, filesystem_home, get_about, get_current_theme,
-    get_profile_settings, get_resolved_theme, get_settings, get_settings_schema, get_tips,
-    get_update_status, get_web_ui_state, list_agents, list_groups, list_profiles, list_sounds,
-    list_themes, mark_tip_seen, mark_volume_ignores_globs_acknowledged, mark_web_tour_seen,
-    patch_web_ui_state, rename_profile, serve_sound_file, update_profile_settings, update_settings,
+    browse_filesystem, create_profile, default_profile, delete_profile, dismiss_update,
+    docker_status, filesystem_home, get_about, get_current_theme, get_profile_settings,
+    get_resolved_theme, get_settings, get_settings_schema, get_tips, get_update_status,
+    get_web_ui_state, list_agents, list_groups, list_profiles, list_sounds, list_themes,
+    mark_tip_seen, mark_volume_ignores_globs_acknowledged, mark_web_tour_seen, patch_web_ui_state,
+    rename_profile, serve_sound_file, set_show_tips, update_profile_settings, update_settings,
     update_theme,
 };
 pub use telemetry::{
@@ -194,7 +194,7 @@ mod tests {
                     "patch_web_ui_state",
                     "mark_web_tour_seen",
                     "mark_tip_seen",
-                    "disable_tips",
+                    "set_show_tips",
                     "mark_volume_ignores_globs_acknowledged",
                     "create_profile",
                     "delete_profile",
@@ -349,6 +349,7 @@ mod tests {
                     "dismiss_update",
                     "patch_web_ui_state",
                     "mark_tip_seen",
+                    "set_show_tips",
                     "create_profile",
                     "delete_profile",
                     "rename_profile",

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -47,12 +47,13 @@ pub use sessions::{
 // Shared by the status poll loop's auto-unread persistence; not a route handler.
 pub(crate) use sessions::persist_session_update;
 pub use system::{
-    browse_filesystem, create_profile, default_profile, delete_profile, dismiss_update,
-    docker_status, filesystem_home, get_about, get_current_theme, get_profile_settings,
-    get_resolved_theme, get_settings, get_settings_schema, get_tips, get_update_status,
-    get_web_ui_state, list_agents, list_groups, list_profiles, list_sounds, list_themes,
-    mark_tip_seen, mark_volume_ignores_globs_acknowledged, mark_web_tour_seen, patch_web_ui_state,
-    rename_profile, serve_sound_file, update_profile_settings, update_settings, update_theme,
+    browse_filesystem, create_profile, default_profile, delete_profile, disable_tips,
+    dismiss_update, docker_status, filesystem_home, get_about, get_current_theme,
+    get_profile_settings, get_resolved_theme, get_settings, get_settings_schema, get_tips,
+    get_update_status, get_web_ui_state, list_agents, list_groups, list_profiles, list_sounds,
+    list_themes, mark_tip_seen, mark_volume_ignores_globs_acknowledged, mark_web_tour_seen,
+    patch_web_ui_state, rename_profile, serve_sound_file, update_profile_settings, update_settings,
+    update_theme,
 };
 pub use telemetry::{
     get_telemetry_status, post_telemetry_seen, post_telemetry_structured_interaction,
@@ -193,6 +194,7 @@ mod tests {
                     "patch_web_ui_state",
                     "mark_web_tour_seen",
                     "mark_tip_seen",
+                    "disable_tips",
                     "mark_volume_ignores_globs_acknowledged",
                     "create_profile",
                     "delete_profile",

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -585,6 +585,57 @@ pub async fn mark_tip_seen(
     }
 }
 
+/// Turns tips off by setting `session.show_tips = false`, the dashboard's
+/// "don't show again". A dedicated single-purpose write rather than `PATCH
+/// /api/settings`, which the auth middleware elevation-gates: disabling tips is
+/// a cosmetic preference and must not trip the passphrase wall on a remote
+/// server. Mirrors [`mark_web_tour_seen`]: exempt from elevation, still blocked
+/// by `read_only`, and uses `Config::load()` so a corrupt config is not
+/// silently replaced. Re-enabling stays in the settings Interaction tab.
+pub async fn disable_tips(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+
+    let result = tokio::task::spawn_blocking(|| {
+        let mut config = crate::session::Config::load()?;
+        config.session.show_tips = false;
+        crate::session::save_config(&config)?;
+        Ok::<_, anyhow::Error>(())
+    })
+    .await;
+
+    match result {
+        Ok(Ok(())) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"show_tips": false})),
+        )
+            .into_response(),
+        Ok(Err(e)) => {
+            tracing::warn!(target: "http.api.system", "Disabling tips failed: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "save_failed", "message": "Failed to persist tips state"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(target: "http.api.system", "Disabling tips panicked: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 #[derive(serde::Deserialize)]
 pub struct DismissUpdateBody {
     pub version: String,

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -455,6 +455,136 @@ pub async fn mark_web_tour_seen(State(state): State<Arc<AppState>>) -> impl Into
     }
 }
 
+#[derive(Serialize)]
+pub struct TipDto {
+    pub id: String,
+    pub title: String,
+    pub body: String,
+    pub seen: bool,
+}
+
+#[derive(Serialize)]
+pub struct TipsResponse {
+    /// Mirror of `session.show_tips`. The dashboard hides the badge and panel
+    /// when this is false; the toggle itself is written through the settings
+    /// schema, so this is a read-only projection here.
+    pub enabled: bool,
+    /// Web-eligible tips in catalog order, each flagged with whether it has been
+    /// seen. The frontend derives the badge count from the unseen ones and can
+    /// still show seen tips in a collapsed section.
+    pub tips: Vec<TipDto>,
+}
+
+/// Returns the web-surface tips and whether tips are enabled, composed from the
+/// shared `crate::tips` catalog plus `app_state.tips_seen` and
+/// `session.show_tips`. A read projection, so it stays a plain GET behind the
+/// token wall like [`get_web_ui_state`]; the TUI-only tips never appear here.
+pub async fn get_tips(State(_state): State<Arc<AppState>>) -> impl IntoResponse {
+    let result = tokio::task::spawn_blocking(|| {
+        let config = crate::session::Config::load()?;
+        let signals = crate::tips::TipSignals {
+            new_session_with_selection_count: config.app_state.new_session_with_selection_count,
+            used_new_from_selection: config.app_state.used_new_from_selection,
+        };
+        let seen = &config.app_state.tips_seen;
+        let tips = crate::tips::eligible(crate::tips::TipSurface::Web, &signals)
+            .into_iter()
+            .map(|tip| TipDto {
+                id: tip.id.to_string(),
+                title: tip.title.to_string(),
+                body: tip.body.to_string(),
+                seen: seen.iter().any(|s| s == tip.id),
+            })
+            .collect();
+        Ok::<_, anyhow::Error>(TipsResponse {
+            enabled: config.session.show_tips,
+            tips,
+        })
+    })
+    .await;
+
+    match result {
+        Ok(Ok(resp)) => (StatusCode::OK, Json(resp)).into_response(),
+        // Best-effort: an unreadable config yields an empty, disabled payload so
+        // the dashboard simply shows no badge rather than erroring.
+        _ => (
+            StatusCode::OK,
+            Json(TipsResponse {
+                enabled: false,
+                tips: Vec::new(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct MarkTipSeenBody {
+    pub id: String,
+}
+
+/// Marks one tip seen by appending its id to the shared `app_state.tips_seen`,
+/// so the dashboard's mark-seen-on-view sticks across devices and matches the
+/// TUI. Single-purpose write mirroring [`mark_web_tour_seen`]: exempt from the
+/// elevation wall, still blocked by `read_only`, and uses `Config::load()` so a
+/// corrupt config is not silently replaced. Rejects an id that is not in the
+/// catalog so junk can't accumulate in the persisted seen list.
+pub async fn mark_tip_seen(
+    State(state): State<Arc<AppState>>,
+    body: Result<Json<MarkTipSeenBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    let Json(MarkTipSeenBody { id }) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+    if !crate::tips::id_in_catalog(&id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "unknown_tip", "message": format!("Unknown tip id '{id}'")})),
+        )
+            .into_response();
+    }
+
+    let result = tokio::task::spawn_blocking(move || {
+        let mut config = crate::session::Config::load()?;
+        if !config.app_state.tips_seen.iter().any(|s| s == &id) {
+            config.app_state.tips_seen.push(id);
+        }
+        crate::session::save_config(&config)?;
+        Ok::<_, anyhow::Error>(())
+    })
+    .await;
+
+    match result {
+        Ok(Ok(())) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
+        Ok(Err(e)) => {
+            tracing::warn!(target: "http.api.system", "Marking tip seen failed: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "save_failed", "message": "Failed to persist tip state"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(target: "http.api.system", "Marking tip seen panicked: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 #[derive(serde::Deserialize)]
 pub struct DismissUpdateBody {
     pub version: String,

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -585,14 +585,22 @@ pub async fn mark_tip_seen(
     }
 }
 
-/// Turns tips off by setting `session.show_tips = false`, the dashboard's
-/// "don't show again". A dedicated single-purpose write rather than `PATCH
-/// /api/settings`, which the auth middleware elevation-gates: disabling tips is
-/// a cosmetic preference and must not trip the passphrase wall on a remote
-/// server. Mirrors [`mark_web_tour_seen`]: exempt from elevation, still blocked
-/// by `read_only`, and uses `Config::load()` so a corrupt config is not
-/// silently replaced. Re-enabling stays in the settings Interaction tab.
-pub async fn disable_tips(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+#[derive(Deserialize)]
+pub struct SetShowTipsBody {
+    pub enabled: bool,
+}
+
+/// Sets `session.show_tips`, the "Show tips on startup" checkbox in the tip-of-
+/// the-day modal. A dedicated single-purpose write rather than `PATCH
+/// /api/settings`, which the auth middleware elevation-gates: this is a cosmetic
+/// preference and must not trip the passphrase wall on a remote server. Mirrors
+/// [`mark_web_tour_seen`]: exempt from elevation, still blocked by `read_only`,
+/// and uses `Config::load()` so a corrupt config is not silently replaced. The
+/// same preference is also editable from the settings Interaction tab.
+pub async fn set_show_tips(
+    State(state): State<Arc<AppState>>,
+    body: Result<Json<SetShowTipsBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
     if state.read_only {
         return (
             StatusCode::FORBIDDEN,
@@ -602,10 +610,14 @@ pub async fn disable_tips(State(state): State<Arc<AppState>>) -> impl IntoRespon
         )
             .into_response();
     }
+    let Json(SetShowTipsBody { enabled }) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
 
-    let result = tokio::task::spawn_blocking(|| {
+    let result = tokio::task::spawn_blocking(move || {
         let mut config = crate::session::Config::load()?;
-        config.session.show_tips = false;
+        config.session.show_tips = enabled;
         crate::session::save_config(&config)?;
         Ok::<_, anyhow::Error>(())
     })
@@ -614,11 +626,11 @@ pub async fn disable_tips(State(state): State<Arc<AppState>>) -> impl IntoRespon
     match result {
         Ok(Ok(())) => (
             StatusCode::OK,
-            Json(serde_json::json!({"show_tips": false})),
+            Json(serde_json::json!({"show_tips": enabled})),
         )
             .into_response(),
         Ok(Err(e)) => {
-            tracing::warn!(target: "http.api.system", "Disabling tips failed: {}", e);
+            tracing::warn!(target: "http.api.system", "Setting show_tips failed: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"error": "save_failed", "message": "Failed to persist tips state"})),
@@ -626,7 +638,7 @@ pub async fn disable_tips(State(state): State<Arc<AppState>>) -> impl IntoRespon
                 .into_response()
         }
         Err(e) => {
-            tracing::error!(target: "http.api.system", "Disabling tips panicked: {}", e);
+            tracing::error!(target: "http.api.system", "Setting show_tips panicked: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -466,8 +466,9 @@ pub struct TipDto {
 #[derive(Serialize)]
 pub struct TipsResponse {
     /// Mirror of `session.show_tips`. The dashboard hides the badge and panel
-    /// when this is false; the toggle itself is written through the settings
-    /// schema, so this is a read-only projection here.
+    /// when this is false. This payload is a read projection; the toggle is
+    /// written through the dedicated `POST /api/tips/show` ([`set_show_tips`]),
+    /// and the same preference is also editable from the settings schema.
     pub enabled: bool,
     /// Web-eligible tips in catalog order, each flagged with whether it has been
     /// seen. The frontend derives the badge count from the unseen ones and can

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1443,6 +1443,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/settings/schema", get(api::get_settings_schema))
         .route("/api/tips", get(api::get_tips))
+        .route("/api/tips/disable", post(api::disable_tips))
         .route("/api/app-state/tip-seen", post(api::mark_tip_seen))
         .route(
             "/api/app-state/web-tour-seen",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1443,7 +1443,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/settings/schema", get(api::get_settings_schema))
         .route("/api/tips", get(api::get_tips))
-        .route("/api/tips/disable", post(api::disable_tips))
+        .route("/api/tips/show", post(api::set_show_tips))
         .route("/api/app-state/tip-seen", post(api::mark_tip_seen))
         .route(
             "/api/app-state/web-tour-seen",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1442,6 +1442,8 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(api::get_settings).patch(api::update_settings),
         )
         .route("/api/settings/schema", get(api::get_settings_schema))
+        .route("/api/tips", get(api::get_tips))
+        .route("/api/app-state/tip-seen", post(api::mark_tip_seen))
         .route(
             "/api/app-state/web-tour-seen",
             post(api::mark_web_tour_seen),

--- a/src/tips.rs
+++ b/src/tips.rs
@@ -130,6 +130,98 @@ static CATALOG: &[Tip] = &[
         // About the web dashboard's PWA install, irrelevant to the TUI.
         surfaces: &[TipSurface::Web],
     },
+    // Web feature-discovery tips. These describe web gestures (right-click,
+    // pickers, the wizard), so they are web-only; the TUI teaches the same
+    // features through its help screen and the keyboard tips below.
+    Tip {
+        id: "pin-sessions",
+        title: "Keep important sessions on top",
+        body: "Right-click a session in the sidebar (long-press on touch) and choose Pin to \
+               float it to the top of every sort. Unpin it the same way.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Web],
+    },
+    Tip {
+        id: "archive-sessions",
+        title: "Tuck finished sessions away",
+        body: "Right-click a session and choose Archive to stop it and tuck it into the \
+               \"Snoozed & archived\" footer at the bottom of the sidebar. Sending it a \
+               message brings it right back.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Web],
+    },
+    Tip {
+        id: "snooze-sessions",
+        title: "Snooze a session for later",
+        body: "Right-click a session, choose Snooze, and pick a duration from 1 hour up to \
+               1 week. It stays hidden until the timer runs out or you send it a message.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Web],
+    },
+    Tip {
+        id: "group-sessions",
+        title: "Organize sessions into groups",
+        body: "Use the grouping toggle in the sidebar to switch between By repo, By group, \
+               and By repo and group. Right-click a session and choose Edit group to file it \
+               under any name you like.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Web],
+    },
+    Tip {
+        id: "sort-sidebar",
+        title: "Sort the sidebar your way",
+        body: "The sort picker offers Manual, where you drag the rows into any order \
+               yourself, Recent activity, and Attention, which floats the sessions that need \
+               you to the top.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Web],
+    },
+    Tip {
+        id: "scratch-sessions",
+        title: "Spin up a scratch session",
+        body: "Need a throwaway? Toggle \"Skip project folder\" in the new-session wizard \
+               (or press Ctrl+Shift+N) to start a session with no repo. AoE makes a temp \
+               directory and cleans it up when you delete the session.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Web],
+    },
+    Tip {
+        id: "multi-repo-sessions",
+        title: "Drive several repos at once",
+        body: "Save your repos as projects, then multi-select them in the new-session wizard \
+               to give one agent a worktree in every repo on a shared branch.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Web],
+    },
+    // TUI keyboard-shortcut tips. Keys are written as `{placeholder}` and the
+    // tips overlay substitutes the live chord (correct in strict-hotkey mode);
+    // see `resolve_body` in `src/tui/dialogs/tips.rs`.
+    Tip {
+        id: "tui-core-views",
+        title: "Switch views fast",
+        body: "Toggle the agent and terminal panes with {toggle_view}, open the diff with \
+               {diff}, jump to settings with {settings}, and open this help any time with \
+               {help}.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Tui],
+    },
+    Tip {
+        id: "tui-triage",
+        title: "Triage from the keyboard",
+        body: "Cycle the sort with {sort} and grouping with {group}, and archive a session \
+               with {archive}. In Attention sort, snooze with {snooze} or favorite with \
+               {favorite}.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Tui],
+    },
+    Tip {
+        id: "tui-power",
+        title: "Power moves",
+        body: "Ctrl+K opens the command palette, {serve} exposes the dashboard for remote \
+               access, and {tool_session} opens a tool session like lazygit or yazi.",
+        trigger: TipTrigger::Rotation,
+        surfaces: &[TipSurface::Tui],
+    },
 ];
 
 /// Whether `id` is the id of a tip in the catalog. Used to reject unknown ids
@@ -214,6 +306,13 @@ mod tests {
         assert_eq!(sorted.len(), ids.len(), "tip ids must be unique");
     }
 
+    fn web_unseen_ids(seen: &[String], signals: &TipSignals) -> Vec<&'static str> {
+        eligible_unseen(TipSurface::Web, seen, signals)
+            .iter()
+            .map(|t| t.id)
+            .collect()
+    }
+
     #[test]
     fn earned_tip_suppressed_once_n_used() {
         let tip = by_id("new-from-selection").unwrap();
@@ -223,7 +322,12 @@ mod tests {
             used_new_from_selection: true,
         };
         assert!(!tip.is_eligible(TipSurface::Tui, &used));
-        assert_eq!(unseen_count(TipSurface::Tui, &[], &used), 0);
+        // The earned tip drops out, but rotation TUI tips remain.
+        let unseen: Vec<&str> = eligible_unseen(TipSurface::Tui, &[], &used)
+            .iter()
+            .map(|t| t.id)
+            .collect();
+        assert!(!unseen.contains(&"new-from-selection"));
         assert!(next_earned_pop(TipSurface::Tui, &[], &used).is_none());
     }
 
@@ -245,20 +349,19 @@ mod tests {
 
     #[test]
     fn unseen_count_tracks_eligibility_and_seen() {
-        // The only TUI tip is earned, so below threshold nothing is eligible.
-        assert_eq!(unseen_count(TipSurface::Tui, &[], &signals(0)), 0);
-
-        // At threshold it becomes eligible and unseen.
+        // Earning the N tip adds exactly one to the TUI count, regardless of how
+        // many rotation tips ship alongside it.
+        let base = unseen_count(TipSurface::Tui, &[], &signals(0));
         assert_eq!(
             unseen_count(
                 TipSurface::Tui,
                 &[],
                 &signals(NEW_FROM_SELECTION_TIP_THRESHOLD)
             ),
-            1
+            base + 1
         );
 
-        // Once seen, it drops back out of the count.
+        // Once seen, it drops back to the baseline.
         let seen = vec!["new-from-selection".to_string()];
         assert_eq!(
             unseen_count(
@@ -266,7 +369,7 @@ mod tests {
                 &seen,
                 &signals(NEW_FROM_SELECTION_TIP_THRESHOLD)
             ),
-            0
+            base
         );
     }
 
@@ -316,12 +419,27 @@ mod tests {
     }
 
     #[test]
-    fn web_rotation_tip_is_eligible_by_default() {
-        // The PWA tip is rotation, so a brand-new web user with no signals sees
-        // it (the badge has real content on the web surface).
-        assert_eq!(unseen_count(TipSurface::Web, &[], &signals(0)), 1);
-        // It is not earned, so it never pops on its own.
+    fn web_rotation_tips_are_eligible_by_default() {
+        // Web tips are all rotation, so a brand-new web user sees every one of
+        // them with no signals, and seeing one drops it from the count.
+        let all = web_unseen_ids(&[], &signals(0));
+        assert!(all.contains(&"install-dashboard-pwa"));
+        assert!(all.len() > 1, "more than just the PWA tip ships on the web");
+        let seen = vec!["install-dashboard-pwa".to_string()];
+        assert_eq!(web_unseen_ids(&seen, &signals(0)).len(), all.len() - 1);
+        // No web tip is earned, so nothing pops on its own.
         assert!(next_earned_pop(TipSurface::Web, &[], &signals(0)).is_none());
+    }
+
+    #[test]
+    fn web_tips_carry_no_keybinding_placeholders() {
+        // Web bodies are rendered as-is by the server (no placeholder resolver),
+        // so a `{...}` would leak raw into the dashboard.
+        for tip in catalog() {
+            if tip.surfaces.contains(&TipSurface::Web) {
+                assert!(!tip.body.contains('{'), "{} has a placeholder", tip.id);
+            }
+        }
     }
 
     #[test]

--- a/src/tips.rs
+++ b/src/tips.rs
@@ -35,6 +35,19 @@ pub struct TipSignals {
 /// eventually learns about `N`.
 pub const NEW_FROM_SELECTION_TIP_THRESHOLD: u32 = 3;
 
+/// Which surface a tip is meant for. A tip lists every surface it applies to in
+/// [`Tip::surfaces`], so keyboard-only hints (the `N` shortcut) stay out of the
+/// web dashboard and web-only hints (installing the PWA) stay out of the TUI.
+/// All eligibility queries take a surface so each surface only ever sees its
+/// own tips.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TipSurface {
+    /// The terminal UI.
+    Tui,
+    /// The web dashboard (`aoe serve`).
+    Web,
+}
+
 /// When a tip becomes eligible to surface.
 pub enum TipTrigger {
     /// Always eligible. Surfaced passively via the badge + tips list; never
@@ -57,15 +70,20 @@ pub struct Tip {
     pub body: &'static str,
     /// What makes this tip eligible to surface.
     pub trigger: TipTrigger,
+    /// Surfaces this tip applies to. A tip never shows on a surface it doesn't
+    /// list, so a query for one surface can't leak another surface's tips.
+    pub surfaces: &'static [TipSurface],
 }
 
 impl Tip {
-    /// Whether this tip is eligible to surface given the current signals.
-    fn is_eligible(&self, signals: &TipSignals) -> bool {
-        match self.trigger {
-            TipTrigger::Rotation => true,
-            TipTrigger::Earned(predicate) => predicate(signals),
-        }
+    /// Whether this tip is eligible to surface on `surface` given the current
+    /// signals: it must apply to the surface and its trigger must fire.
+    fn is_eligible(&self, surface: TipSurface, signals: &TipSignals) -> bool {
+        self.surfaces.contains(&surface)
+            && match self.trigger {
+                TipTrigger::Rotation => true,
+                TipTrigger::Earned(predicate) => predicate(signals),
+            }
     }
 
     /// Whether this tip is allowed to pop on its own (earned tips only).
@@ -86,54 +104,84 @@ pub fn catalog() -> &'static [Tip] {
     CATALOG
 }
 
-static CATALOG: &[Tip] = &[Tip {
-    id: "new-from-selection",
-    title: "Reuse the selected session's settings",
-    // `{new_from_selection}` is substituted with the live keybinding label by
-    // the tips overlay, so it stays correct in strict-hotkey mode (where the
-    // chord is Ctrl+N rather than Shift+N).
-    body: "Tired of choosing the directory, profile, and group every time? Press \
-           {new_from_selection} on the home view to start a new session that inherits \
-           all of them from the session you have selected.",
-    trigger: TipTrigger::Earned(earned_new_from_selection),
-}];
+static CATALOG: &[Tip] = &[
+    Tip {
+        id: "new-from-selection",
+        title: "Reuse the selected session's settings",
+        // `{new_from_selection}` is substituted with the live keybinding label
+        // by the tips overlay, so it stays correct in strict-hotkey mode (where
+        // the chord is Ctrl+N rather than Shift+N).
+        body: "Tired of choosing the directory, profile, and group every time? Press \
+               {new_from_selection} on the home view to start a new session that inherits \
+               all of them from the session you have selected.",
+        trigger: TipTrigger::Earned(earned_new_from_selection),
+        // Teaches a keyboard shortcut, so it only makes sense in the TUI.
+        surfaces: &[TipSurface::Tui],
+    },
+    Tip {
+        id: "install-dashboard-pwa",
+        title: "Install the dashboard as an app",
+        // Browser-neutral wording: the engine can't know the user's browser or
+        // whether the dashboard is already installed.
+        body: "You can install the dashboard as an app for quick access. In your browser, \
+               use the install option (Install Agent of Empires in Chrome, or Add to Home \
+               Screen on iOS) to keep it one tap away and keep notifications working.",
+        trigger: TipTrigger::Rotation,
+        // About the web dashboard's PWA install, irrelevant to the TUI.
+        surfaces: &[TipSurface::Web],
+    },
+];
+
+/// Whether `id` is the id of a tip in the catalog. Used to reject unknown ids
+/// before persisting them to the shared seen list.
+pub fn id_in_catalog(id: &str) -> bool {
+    catalog().iter().any(|tip| tip.id == id)
+}
 
 /// Whether `id` is present in the seen list.
 fn is_seen(seen: &[String], id: &str) -> bool {
     seen.iter().any(|s| s == id)
 }
 
-/// Tips eligible to surface given the current signals, ignoring seen-state, in
-/// catalog order. The tips list shows these (seen ones marked); the badge and
-/// pops use the `*_unseen` variants below.
-pub fn eligible(signals: &TipSignals) -> Vec<&'static Tip> {
+/// Tips eligible to surface on `surface` given the current signals, ignoring
+/// seen-state, in catalog order. The tips list shows these (seen ones marked);
+/// the badge and pops use the `*_unseen` variants below.
+pub fn eligible(surface: TipSurface, signals: &TipSignals) -> Vec<&'static Tip> {
     catalog()
         .iter()
-        .filter(|tip| tip.is_eligible(signals))
+        .filter(|tip| tip.is_eligible(surface, signals))
         .collect()
 }
 
-/// Tips eligible to surface for a user who has already seen `seen`, given the
-/// current signals, in catalog order. Callers should additionally honor the
-/// `session.show_tips` setting before showing anything.
-pub fn eligible_unseen(seen: &[String], signals: &TipSignals) -> Vec<&'static Tip> {
-    eligible(signals)
+/// Tips eligible to surface on `surface` for a user who has already seen
+/// `seen`, given the current signals, in catalog order. Callers should
+/// additionally honor the `session.show_tips` setting before showing anything.
+pub fn eligible_unseen(
+    surface: TipSurface,
+    seen: &[String],
+    signals: &TipSignals,
+) -> Vec<&'static Tip> {
+    eligible(surface, signals)
         .into_iter()
         .filter(|tip| !is_seen(seen, tip.id))
         .collect()
 }
 
-/// Count of eligible, unseen tips. Drives the badge.
-pub fn unseen_count(seen: &[String], signals: &TipSignals) -> usize {
-    eligible_unseen(seen, signals).len()
+/// Count of eligible, unseen tips on `surface`. Drives the badge.
+pub fn unseen_count(surface: TipSurface, seen: &[String], signals: &TipSignals) -> usize {
+    eligible_unseen(surface, seen, signals).len()
 }
 
-/// The first earned tip that is eligible and unseen, i.e. one that may pop on
-/// its own right now. Rotation tips never pop, so they are excluded here.
-pub fn next_earned_pop(seen: &[String], signals: &TipSignals) -> Option<&'static Tip> {
+/// The first earned tip eligible and unseen on `surface`, i.e. one that may pop
+/// on its own right now. Rotation tips never pop, so they are excluded here.
+pub fn next_earned_pop(
+    surface: TipSurface,
+    seen: &[String],
+    signals: &TipSignals,
+) -> Option<&'static Tip> {
     catalog()
         .iter()
-        .find(|tip| tip.is_earned() && tip.is_eligible(signals) && !is_seen(seen, tip.id))
+        .find(|tip| tip.is_earned() && tip.is_eligible(surface, signals) && !is_seen(seen, tip.id))
 }
 
 #[cfg(test)]
@@ -174,36 +222,50 @@ mod tests {
             new_session_with_selection_count: NEW_FROM_SELECTION_TIP_THRESHOLD + 5,
             used_new_from_selection: true,
         };
-        assert!(!tip.is_eligible(&used));
-        assert_eq!(unseen_count(&[], &used), 0);
-        assert!(next_earned_pop(&[], &used).is_none());
+        assert!(!tip.is_eligible(TipSurface::Tui, &used));
+        assert_eq!(unseen_count(TipSurface::Tui, &[], &used), 0);
+        assert!(next_earned_pop(TipSurface::Tui, &[], &used).is_none());
     }
 
     #[test]
     fn earned_tip_gates_on_threshold() {
         let tip = by_id("new-from-selection").unwrap();
         assert!(tip.is_earned());
-        assert!(!tip.is_eligible(&signals(0)));
-        assert!(!tip.is_eligible(&signals(NEW_FROM_SELECTION_TIP_THRESHOLD - 1)));
-        assert!(tip.is_eligible(&signals(NEW_FROM_SELECTION_TIP_THRESHOLD)));
-        assert!(tip.is_eligible(&signals(NEW_FROM_SELECTION_TIP_THRESHOLD + 5)));
+        assert!(!tip.is_eligible(TipSurface::Tui, &signals(0)));
+        assert!(!tip.is_eligible(
+            TipSurface::Tui,
+            &signals(NEW_FROM_SELECTION_TIP_THRESHOLD - 1)
+        ));
+        assert!(tip.is_eligible(TipSurface::Tui, &signals(NEW_FROM_SELECTION_TIP_THRESHOLD)));
+        assert!(tip.is_eligible(
+            TipSurface::Tui,
+            &signals(NEW_FROM_SELECTION_TIP_THRESHOLD + 5)
+        ));
     }
 
     #[test]
     fn unseen_count_tracks_eligibility_and_seen() {
-        // The only tip is earned, so below threshold nothing is eligible.
-        assert_eq!(unseen_count(&[], &signals(0)), 0);
+        // The only TUI tip is earned, so below threshold nothing is eligible.
+        assert_eq!(unseen_count(TipSurface::Tui, &[], &signals(0)), 0);
 
         // At threshold it becomes eligible and unseen.
         assert_eq!(
-            unseen_count(&[], &signals(NEW_FROM_SELECTION_TIP_THRESHOLD)),
+            unseen_count(
+                TipSurface::Tui,
+                &[],
+                &signals(NEW_FROM_SELECTION_TIP_THRESHOLD)
+            ),
             1
         );
 
         // Once seen, it drops back out of the count.
         let seen = vec!["new-from-selection".to_string()];
         assert_eq!(
-            unseen_count(&seen, &signals(NEW_FROM_SELECTION_TIP_THRESHOLD)),
+            unseen_count(
+                TipSurface::Tui,
+                &seen,
+                &signals(NEW_FROM_SELECTION_TIP_THRESHOLD)
+            ),
             0
         );
     }
@@ -211,14 +273,62 @@ mod tests {
     #[test]
     fn next_earned_pop_only_when_eligible_and_unseen() {
         // Below threshold: nothing to pop.
-        assert!(next_earned_pop(&[], &signals(0)).is_none());
+        assert!(next_earned_pop(TipSurface::Tui, &[], &signals(0)).is_none());
 
         // At threshold: the new-from-selection tip pops.
-        let pop = next_earned_pop(&[], &signals(NEW_FROM_SELECTION_TIP_THRESHOLD));
+        let pop = next_earned_pop(
+            TipSurface::Tui,
+            &[],
+            &signals(NEW_FROM_SELECTION_TIP_THRESHOLD),
+        );
         assert_eq!(pop.map(|t| t.id), Some("new-from-selection"));
 
         // Once seen, it no longer pops even when eligible.
         let seen = vec!["new-from-selection".to_string()];
-        assert!(next_earned_pop(&seen, &signals(NEW_FROM_SELECTION_TIP_THRESHOLD)).is_none());
+        assert!(next_earned_pop(
+            TipSurface::Tui,
+            &seen,
+            &signals(NEW_FROM_SELECTION_TIP_THRESHOLD)
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn every_tip_lists_at_least_one_surface() {
+        for tip in catalog() {
+            assert!(!tip.surfaces.is_empty(), "{} lists no surface", tip.id);
+        }
+    }
+
+    #[test]
+    fn surfaces_do_not_leak_across() {
+        // The keyboard-shortcut tip is TUI-only; the PWA tip is web-only. Each
+        // surface sees its own and never the other's, even when eligible.
+        let earned = signals(NEW_FROM_SELECTION_TIP_THRESHOLD);
+
+        let web = eligible(TipSurface::Web, &earned);
+        assert!(web.iter().any(|t| t.id == "install-dashboard-pwa"));
+        assert!(!web.iter().any(|t| t.id == "new-from-selection"));
+
+        let tui = eligible(TipSurface::Tui, &earned);
+        assert!(tui.iter().any(|t| t.id == "new-from-selection"));
+        assert!(!tui.iter().any(|t| t.id == "install-dashboard-pwa"));
+    }
+
+    #[test]
+    fn web_rotation_tip_is_eligible_by_default() {
+        // The PWA tip is rotation, so a brand-new web user with no signals sees
+        // it (the badge has real content on the web surface).
+        assert_eq!(unseen_count(TipSurface::Web, &[], &signals(0)), 1);
+        // It is not earned, so it never pops on its own.
+        assert!(next_earned_pop(TipSurface::Web, &[], &signals(0)).is_none());
+    }
+
+    #[test]
+    fn id_in_catalog_matches_known_ids_only() {
+        assert!(id_in_catalog("new-from-selection"));
+        assert!(id_in_catalog("install-dashboard-pwa"));
+        assert!(!id_in_catalog("nope"));
+        assert!(!id_in_catalog(""));
     }
 }

--- a/src/tui/dialogs/tips.rs
+++ b/src/tui/dialogs/tips.rs
@@ -187,10 +187,29 @@ impl TipsDialog {
         if !body.contains('{') {
             return body.to_string();
         }
-        body.replace(
-            "{new_from_selection}",
-            &bindings::label(ActionId::NewFromSelection, self.strict),
-        )
+        // (placeholder, action) pairs; each is replaced with the action's live
+        // chord so the text is correct in strict-hotkey mode too.
+        const PLACEHOLDERS: &[(&str, ActionId)] = &[
+            ("{new_from_selection}", ActionId::NewFromSelection),
+            ("{toggle_view}", ActionId::ToggleView),
+            ("{diff}", ActionId::Diff),
+            ("{settings}", ActionId::Settings),
+            ("{help}", ActionId::Help),
+            ("{sort}", ActionId::SortPicker),
+            ("{group}", ActionId::GroupBy),
+            ("{archive}", ActionId::ToggleArchive),
+            ("{snooze}", ActionId::ToggleSnooze),
+            ("{favorite}", ActionId::ToggleFavorite),
+            ("{serve}", ActionId::Serve),
+            ("{tool_session}", ActionId::ToolPicker),
+        ];
+        let mut out = body.to_string();
+        for (placeholder, action) in PLACEHOLDERS {
+            if out.contains(placeholder) {
+                out = out.replace(placeholder, &bindings::label(*action, self.strict));
+            }
+        }
+        out
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<TipsOutcome> {
@@ -573,6 +592,20 @@ mod tests {
         assert!(strict_resolved.contains(&bindings::label(ActionId::NewFromSelection, true)));
         // The two modes render different chords (Shift+N vs Ctrl+N).
         assert_ne!(resolved, strict_resolved);
+    }
+
+    #[test]
+    fn body_substitutes_all_shortcut_placeholders() {
+        let dialog = TipsDialog::new(all_tips(), vec![], false, false);
+        let body = "{toggle_view} {diff} {settings} {help} {sort} {group} {archive} \
+                    {snooze} {favorite} {serve} {tool_session}";
+        let resolved = dialog.resolve_body(body);
+        assert!(
+            !resolved.contains('{'),
+            "every placeholder filled: {resolved}"
+        );
+        assert!(resolved.contains(&bindings::label(ActionId::Diff, false)));
+        assert!(resolved.contains(&bindings::label(ActionId::ToggleArchive, false)));
     }
 
     fn rendered_dialog(seen: Vec<String>) -> TipsDialog {

--- a/src/tui/dialogs/tips.rs
+++ b/src/tui/dialogs/tips.rs
@@ -437,18 +437,21 @@ mod tests {
             title: "Alpha tip",
             body: "Body of the alpha tip.",
             trigger: crate::tips::TipTrigger::Rotation,
+            surfaces: &[crate::tips::TipSurface::Tui],
         },
         Tip {
             id: "beta",
             title: "Beta tip",
             body: "Body of the beta tip.",
             trigger: crate::tips::TipTrigger::Rotation,
+            surfaces: &[crate::tips::TipSurface::Tui],
         },
         Tip {
             id: "gamma",
             title: "Gamma tip",
             body: "Body of the gamma tip.",
             trigger: crate::tips::TipTrigger::Rotation,
+            surfaces: &[crate::tips::TipSurface::Tui],
         },
     ];
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3633,7 +3633,7 @@ impl HomeView {
             new_session_with_selection_count: config.app_state.new_session_with_selection_count,
             used_new_from_selection: config.app_state.used_new_from_selection,
         };
-        let eligible = crate::tips::eligible(&signals);
+        let eligible = crate::tips::eligible(crate::tips::TipSurface::Tui, &signals);
         self.tips_dialog = Some(TipsDialog::new(
             eligible,
             config.app_state.tips_seen.clone(),
@@ -3717,7 +3717,11 @@ impl HomeView {
             new_session_with_selection_count: config.app_state.new_session_with_selection_count,
             used_new_from_selection: config.app_state.used_new_from_selection,
         };
-        self.pending_tip_pop = crate::tips::next_earned_pop(&config.app_state.tips_seen, &signals);
+        self.pending_tip_pop = crate::tips::next_earned_pop(
+            crate::tips::TipSurface::Tui,
+            &config.app_state.tips_seen,
+            &signals,
+        );
     }
 
     /// Open the queued earned tip as a small one-tip overlay, if any. Called

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1016,6 +1016,7 @@ pub(super) fn tips_unseen_count(config: &crate::session::Config) -> usize {
         return 0;
     }
     crate::tips::unseen_count(
+        crate::tips::TipSurface::Tui,
         &config.app_state.tips_seen,
         &crate::tips::TipSignals {
             new_session_with_selection_count: config.app_state.new_session_with_selection_count,

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1795,7 +1795,8 @@ fn using_n_suppresses_the_earned_tip() {
     env.view.selected_session = Some(id);
     // Earn the tip (badge showing) without queueing a pop.
     earn_tip(&mut env);
-    assert!(env.view.tips_unseen > 0, "tip is earned and badged");
+    let earned = env.view.tips_unseen;
+    assert!(earned > 0, "tip is earned and badged");
 
     // The user discovers N for themselves: open new-from-selection.
     env.view.handle_key(key(KeyCode::Char('N')), None);
@@ -1803,8 +1804,10 @@ fn using_n_suppresses_the_earned_tip() {
         env.view.new_dialog.is_some(),
         "N opens the new-from-selection dialog"
     );
+    // The earned tip drops from the badge (rotation tips, if any, remain).
     assert_eq!(
-        env.view.tips_unseen, 0,
+        env.view.tips_unseen,
+        earned - 1,
         "using N suppresses the tip that teaches it"
     );
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { clearAcpCache } from "./hooks/useAcpSession";
 import { clearDraft, sweepOrphanDrafts } from "./lib/acpDrafts";
 import { AcpPrefsProvider } from "./lib/acpPrefs";
 import { safeGetItem, safeRemoveItem, safeSetItem } from "./lib/safeStorage";
+import { isAutomatedSession } from "./lib/onboarding";
 import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useLastSessionRestore } from "./hooks/useLastSessionRestore";
 import { useRepoGroups } from "./hooks/useRepoGroups";
@@ -358,8 +359,19 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [pairedMounted, setPairedMounted] = useState(false);
   const [showSessionWizard, setShowSessionWizard] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
-  const [showTips, setShowTips] = useState(false);
+  const [tipsOpen, setTipsOpen] = useState(false);
+  const tipsAutoPoppedRef = useRef(false);
   const tips = useTips();
+  // Open the tip-of-the-day modal and mark the tip it opens on seen here (an
+  // event, not an effect); the modal marks the rest as you navigate.
+  const openTips = useCallback(() => {
+    const tip = tips.tips[tips.firstUnseenIndex];
+    if (tip && !tip.seen) tips.markSeen(tip.id);
+    setTipsOpen(true);
+  }, [tips]);
+  // Auto-pop scheduler: defer one frame so the open happens off the effect body
+  // (mirrors the tour's begin()), keeping the state change out of the effect.
+  const beginTipsAutoPop = useCallback(() => requestAnimationFrame(() => openTips()), [openTips]);
   const [showPalette, setShowPalette] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
   const [telemetryConsentNeeded, setTelemetryConsentNeeded] = useState(false);
@@ -1310,6 +1322,29 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     onSeen: handleTourSeen,
   });
 
+  // Auto-pop the tip-of-the-day once per load, after onboarding settles, like
+  // GIMP/DBeaver. Gated like the tour: only on a settled dashboard, only when a
+  // tip is unseen and tips are enabled, never while the welcome/telemetry/tour
+  // flows are up, and never in an automated browser session (so the modal can't
+  // intercept the rest of the Playwright suite). Reopen any time from the menu.
+  useEffect(() => {
+    if (tipsAutoPoppedRef.current) return;
+    if (!tips.loaded || !tips.hasUnseen) return;
+    if (!tourAutoLaunchReady || !welcome.resolved || telemetryConsentNeeded || tour.isTourActive) return;
+    if (isAutomatedSession()) return;
+    tipsAutoPoppedRef.current = true;
+    const id = beginTipsAutoPop();
+    return () => cancelAnimationFrame(id);
+  }, [
+    tips.loaded,
+    tips.hasUnseen,
+    tourAutoLaunchReady,
+    welcome.resolved,
+    telemetryConsentNeeded,
+    tour.isTourActive,
+    beginTipsAutoPop,
+  ]);
+
   return (
     <AcpPrefsProvider value={acpPrefs}>
       <div className="h-dvh flex flex-col bg-surface-900 text-text-primary overflow-hidden safe-area-inset">
@@ -1327,8 +1362,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           loginRequired={loginRequired}
           isOffline={!!error}
           isDevBuild={isDebugBuild(serverAbout)}
-          tipsUnseen={tips.unseenCount}
-          onOpenTips={() => setShowTips(true)}
+          onOpenTips={openTips}
           onGoDashboard={handleGoDashboard}
           sidebarColumnVisible={!showSettings && sidebarOpen}
           rightColumnVisible={isMdUp && !showSettings && !!activeWorkspace && !!activeSession && !diffCollapsed}
@@ -1411,12 +1445,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
         {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
 
-        {showTips && (
+        {tipsOpen && (
           <TipsModal
             tips={tips.tips}
+            startIndex={tips.firstUnseenIndex}
+            enabled={tips.enabled}
             onMarkSeen={tips.markSeen}
-            onDisable={tips.disable}
-            onClose={() => setShowTips(false)}
+            onSetEnabled={tips.setEnabled}
+            onClose={() => setTipsOpen(false)}
           />
         )}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -94,7 +94,7 @@ import { LOGIN_REQUIRED_EVENT, TOKEN_EXPIRED_EVENT, resetTokenExpired } from "./
 import { AboutModal } from "./components/AboutModal";
 import { TelemetryConsentModal } from "./components/TelemetryConsentModal";
 import { TipsModal } from "./components/TipsModal";
-import { useTips } from "./hooks/useTips";
+import { useTips, shouldAutoPopTips } from "./hooks/useTips";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
 import { DisconnectBanner } from "./components/DisconnectBanner";
 import { ElevationPrompt } from "./components/ElevationPrompt";
@@ -359,29 +359,15 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [pairedMounted, setPairedMounted] = useState(false);
   const [showSessionWizard, setShowSessionWizard] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
-  const [tipsOpen, setTipsOpen] = useState(false);
-  const [tipsStartIndex, setTipsStartIndex] = useState(0);
   const tipsAutoPoppedRef = useRef(false);
   // Whether the tour was already seen when this page loaded (set in the settings
   // fetch below). Auto-pop keys off this, not the live tourSeen, so finishing
   // the tour this session does not then pop tips on top of the first-run flow.
   const tourSeenAtLoadRef = useRef<boolean | null>(null);
+  // All tips orchestration (open state, mark-seen, the show toggle, the auto-pop
+  // decision) lives in the hook / lib so it stays out of this component and is
+  // unit-tested directly.
   const tips = useTips();
-  // Open the tip-of-the-day modal on the first unseen tip and mark that tip seen
-  // here (an event, not an effect); the modal marks the rest as you navigate.
-  // Capture the index before marking: marking shifts firstUnseenIndex, so the
-  // modal must open on the captured index, not the recomputed one, or it would
-  // skip the tip we just marked.
-  const openTips = useCallback(() => {
-    const idx = tips.firstUnseenIndex;
-    setTipsStartIndex(idx);
-    setTipsOpen(true);
-    const tip = tips.tips[idx];
-    if (tip && !tip.seen) tips.markSeen(tip.id);
-  }, [tips]);
-  // Auto-pop scheduler: defer one frame so the open happens off the effect body
-  // (mirrors the tour's begin()), keeping the state change out of the effect.
-  const beginTipsAutoPop = useCallback(() => requestAnimationFrame(() => openTips()), [openTips]);
   const [showPalette, setShowPalette] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
   const [telemetryConsentNeeded, setTelemetryConsentNeeded] = useState(false);
@@ -1345,23 +1331,22 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // tour, not a tips modal piled on top. Reopen any time from the menu.
   useEffect(() => {
     if (tipsAutoPoppedRef.current) return;
-    if (!tips.loaded || !tips.hasUnseen) return;
-    if (tourSeenAtLoadRef.current !== true) return;
-    if (!tourAutoLaunchReady || !welcome.resolved || telemetryConsentNeeded || tour.isTourActive) return;
-    if (isAutomatedSession()) return;
+    const gate = shouldAutoPopTips({
+      loaded: tips.loaded,
+      hasUnseen: tips.hasUnseen,
+      tourSeenAtLoad: tourSeenAtLoadRef.current,
+      onboardingReady: tourAutoLaunchReady && welcome.resolved,
+      telemetryPending: telemetryConsentNeeded,
+      tourActive: tour.isTourActive,
+      automated: isAutomatedSession(),
+    });
+    if (!gate) return;
     tipsAutoPoppedRef.current = true;
-    const id = beginTipsAutoPop();
+    // Defer one frame so the open happens off the effect body (mirrors the
+    // tour's begin()), keeping the state change out of the effect.
+    const id = requestAnimationFrame(() => tips.open());
     return () => cancelAnimationFrame(id);
-  }, [
-    tips.loaded,
-    tips.hasUnseen,
-    tourSeenKnown,
-    tourAutoLaunchReady,
-    welcome.resolved,
-    telemetryConsentNeeded,
-    tour.isTourActive,
-    beginTipsAutoPop,
-  ]);
+  }, [tips, tourSeenKnown, tourAutoLaunchReady, welcome.resolved, telemetryConsentNeeded, tour.isTourActive]);
 
   return (
     <AcpPrefsProvider value={acpPrefs}>
@@ -1380,7 +1365,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           loginRequired={loginRequired}
           isOffline={!!error}
           isDevBuild={isDebugBuild(serverAbout)}
-          onOpenTips={openTips}
+          onOpenTips={tips.open}
           onGoDashboard={handleGoDashboard}
           sidebarColumnVisible={!showSettings && sidebarOpen}
           rightColumnVisible={isMdUp && !showSettings && !!activeWorkspace && !!activeSession && !diffCollapsed}
@@ -1463,14 +1448,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
         {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
 
-        {tipsOpen && (
+        {tips.isOpen && (
           <TipsModal
             tips={tips.tips}
-            startIndex={tipsStartIndex}
+            startIndex={tips.startIndex}
             enabled={tips.enabled}
             onMarkSeen={tips.markSeen}
             onSetEnabled={tips.setEnabled}
-            onClose={() => setTipsOpen(false)}
+            onClose={tips.close}
           />
         )}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -360,14 +360,24 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [showSessionWizard, setShowSessionWizard] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [tipsOpen, setTipsOpen] = useState(false);
+  const [tipsStartIndex, setTipsStartIndex] = useState(0);
   const tipsAutoPoppedRef = useRef(false);
+  // Whether the tour was already seen when this page loaded (set in the settings
+  // fetch below). Auto-pop keys off this, not the live tourSeen, so finishing
+  // the tour this session does not then pop tips on top of the first-run flow.
+  const tourSeenAtLoadRef = useRef<boolean | null>(null);
   const tips = useTips();
-  // Open the tip-of-the-day modal and mark the tip it opens on seen here (an
-  // event, not an effect); the modal marks the rest as you navigate.
+  // Open the tip-of-the-day modal on the first unseen tip and mark that tip seen
+  // here (an event, not an effect); the modal marks the rest as you navigate.
+  // Capture the index before marking: marking shifts firstUnseenIndex, so the
+  // modal must open on the captured index, not the recomputed one, or it would
+  // skip the tip we just marked.
   const openTips = useCallback(() => {
-    const tip = tips.tips[tips.firstUnseenIndex];
-    if (tip && !tip.seen) tips.markSeen(tip.id);
+    const idx = tips.firstUnseenIndex;
+    setTipsStartIndex(idx);
     setTipsOpen(true);
+    const tip = tips.tips[idx];
+    if (tip && !tip.seen) tips.markSeen(tip.id);
   }, [tips]);
   // Auto-pop scheduler: defer one frame so the open happens off the effect body
   // (mirrors the tour's begin()), keeping the state change out of the effect.
@@ -1272,8 +1282,12 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       const legacySeen = safeGetItem(LEGACY_TOUR_SEEN_KEY) === "1";
       // Treat the legacy local flag as a suppression hint while the migration
       // POST is in flight, so the tour cannot flash before the backend agrees.
-      setTourSeen(backendSeen || legacySeen);
+      const seenAtLoad = backendSeen || legacySeen;
+      setTourSeen(seenAtLoad);
       setTourSeenKnown(true);
+      // Capture whether onboarding was already done at load so completing the
+      // tour this session does not then pop the tip-of-the-day on top of it.
+      tourSeenAtLoadRef.current = seenAtLoad;
       if (legacySeen && !backendSeen) {
         void markWebTourSeen().then((ok) => {
           if (ok) safeRemoveItem(LEGACY_TOUR_SEEN_KEY);
@@ -1326,10 +1340,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // GIMP/DBeaver. Gated like the tour: only on a settled dashboard, only when a
   // tip is unseen and tips are enabled, never while the welcome/telemetry/tour
   // flows are up, and never in an automated browser session (so the modal can't
-  // intercept the rest of the Playwright suite). Reopen any time from the menu.
+  // intercept the rest of the Playwright suite). Only for users who already
+  // finished onboarding before this load: first-run users get the welcome and
+  // tour, not a tips modal piled on top. Reopen any time from the menu.
   useEffect(() => {
     if (tipsAutoPoppedRef.current) return;
     if (!tips.loaded || !tips.hasUnseen) return;
+    if (tourSeenAtLoadRef.current !== true) return;
     if (!tourAutoLaunchReady || !welcome.resolved || telemetryConsentNeeded || tour.isTourActive) return;
     if (isAutomatedSession()) return;
     tipsAutoPoppedRef.current = true;
@@ -1338,6 +1355,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   }, [
     tips.loaded,
     tips.hasUnseen,
+    tourSeenKnown,
     tourAutoLaunchReady,
     welcome.resolved,
     telemetryConsentNeeded,
@@ -1448,7 +1466,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         {tipsOpen && (
           <TipsModal
             tips={tips.tips}
-            startIndex={tips.firstUnseenIndex}
+            startIndex={tipsStartIndex}
             enabled={tips.enabled}
             onMarkSeen={tips.markSeen}
             onSetEnabled={tips.setEnabled}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -92,6 +92,8 @@ import { TokenEntryPage } from "./components/TokenEntryPage";
 import { LOGIN_REQUIRED_EVENT, TOKEN_EXPIRED_EVENT, resetTokenExpired } from "./lib/fetchInterceptor";
 import { AboutModal } from "./components/AboutModal";
 import { TelemetryConsentModal } from "./components/TelemetryConsentModal";
+import { TipsModal } from "./components/TipsModal";
+import { useTips } from "./hooks/useTips";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
 import { DisconnectBanner } from "./components/DisconnectBanner";
 import { ElevationPrompt } from "./components/ElevationPrompt";
@@ -356,6 +358,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [pairedMounted, setPairedMounted] = useState(false);
   const [showSessionWizard, setShowSessionWizard] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  const [showTips, setShowTips] = useState(false);
+  const tips = useTips();
   const [showPalette, setShowPalette] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
   const [telemetryConsentNeeded, setTelemetryConsentNeeded] = useState(false);
@@ -1323,6 +1327,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           loginRequired={loginRequired}
           isOffline={!!error}
           isDevBuild={isDebugBuild(serverAbout)}
+          tipsUnseen={tips.unseenCount}
+          onOpenTips={() => setShowTips(true)}
           onGoDashboard={handleGoDashboard}
           sidebarColumnVisible={!showSettings && sidebarOpen}
           rightColumnVisible={isMdUp && !showSettings && !!activeWorkspace && !!activeSession && !diffCollapsed}
@@ -1404,6 +1410,15 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         {tour.tourElement}
 
         {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
+
+        {showTips && (
+          <TipsModal
+            tips={tips.tips}
+            onMarkSeen={tips.markSeen}
+            onDisable={tips.disable}
+            onClose={() => setShowTips(false)}
+          />
+        )}
 
         {showAbout && <AboutModal onClose={() => setShowAbout(false)} sessionId={activeSessionId} />}
         {telemetryConsentNeeded && <TelemetryConsentModal onChoose={handleTelemetryConsent} />}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -371,6 +371,11 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [showPalette, setShowPalette] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
   const [telemetryConsentNeeded, setTelemetryConsentNeeded] = useState(false);
+  // Whether the telemetry status fetch has settled. `telemetryConsentNeeded`
+  // starts false, so before this is true "no consent needed" and "not resolved
+  // yet" look the same; the tips auto-pop waits on this so it can't slip in
+  // before a pending consent modal.
+  const [telemetryConsentKnown, setTelemetryConsentKnown] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth >= 768);
   const keyboardProxyRef = useRef<HTMLTextAreaElement>(null);
 
@@ -574,12 +579,16 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       // Read-only servers can't persist an opt-in choice, so skip the ping.
       if (about && !about.read_only) reportTelemetrySeen("web");
     });
-    void fetchTelemetryStatus().then((status) => {
-      if (!active || !status) return;
-      if (!status.responded && !status.do_not_track) {
-        setTelemetryConsentNeeded(true);
-      }
-    });
+    void fetchTelemetryStatus()
+      .then((status) => {
+        if (!active || !status) return;
+        if (!status.responded && !status.do_not_track) {
+          setTelemetryConsentNeeded(true);
+        }
+      })
+      .finally(() => {
+        if (active) setTelemetryConsentKnown(true);
+      });
     return () => {
       active = false;
     };
@@ -1336,7 +1345,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       hasUnseen: tips.hasUnseen,
       tourSeenAtLoad: tourSeenAtLoadRef.current,
       onboardingReady: tourAutoLaunchReady && welcome.resolved,
-      telemetryPending: telemetryConsentNeeded,
+      // Treat "not resolved yet" as pending so tips can't pop ahead of a consent
+      // modal that the in-flight status fetch is about to raise.
+      telemetryPending: !telemetryConsentKnown || telemetryConsentNeeded,
       tourActive: tour.isTourActive,
       automated: isAutomatedSession(),
     });
@@ -1346,7 +1357,15 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     // tour's begin()), keeping the state change out of the effect.
     const id = requestAnimationFrame(() => tips.open());
     return () => cancelAnimationFrame(id);
-  }, [tips, tourSeenKnown, tourAutoLaunchReady, welcome.resolved, telemetryConsentNeeded, tour.isTourActive]);
+  }, [
+    tips,
+    tourSeenKnown,
+    tourAutoLaunchReady,
+    welcome.resolved,
+    telemetryConsentKnown,
+    telemetryConsentNeeded,
+    tour.isTourActive,
+  ]);
 
   return (
     <AcpPrefsProvider value={acpPrefs}>

--- a/web/src/components/TipsModal.tsx
+++ b/web/src/components/TipsModal.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from "react";
+import type { TipDto } from "../lib/api";
+
+interface Props {
+  tips: TipDto[];
+  /** Mark one tip seen (called when an unseen tip is expanded into view). */
+  onMarkSeen: (id: string) => void;
+  /** "Don't show again": turns tips off. */
+  onDisable: () => void;
+  onClose: () => void;
+}
+
+/// Browsable tips panel for the web dashboard, mirroring the TUI overlay:
+/// unseen tips lead, already-seen tips collapse into an expandable section so
+/// what's new is foregrounded. Expanding an unseen tip marks it seen (mark-seen-
+/// on-view), and "Don't show again" turns tips off. Modeled on
+/// TelemetryConsentModal's fixed-overlay styling.
+export function TipsModal({ tips, onMarkSeen, onDisable, onClose }: Props) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [seenOpen, setSeenOpen] = useState(false);
+
+  const unseen = tips.filter((t) => !t.seen);
+  const seen = tips.filter((t) => t.seen);
+
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
+
+  // Esc closes, matching the other dashboard modals.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const toggle = (tip: TipDto) => {
+    const opening = expandedId !== tip.id;
+    setExpandedId(opening ? tip.id : null);
+    // Mark seen when an unseen tip is opened into view.
+    if (opening && !tip.seen) onMarkSeen(tip.id);
+  };
+
+  const row = (tip: TipDto) => (
+    <li key={tip.id} className="border border-surface-700/50 rounded-md overflow-hidden">
+      <button
+        onClick={() => toggle(tip)}
+        aria-expanded={expandedId === tip.id}
+        className="w-full px-3 py-2 flex items-center justify-between text-left text-sm text-text-primary hover:bg-surface-850 transition-colors cursor-pointer"
+      >
+        <span className="flex items-center gap-2">
+          {!tip.seen && <span className="w-1.5 h-1.5 rounded-full bg-brand-500 shrink-0" aria-hidden="true" />}
+          {tip.title}
+        </span>
+        <span className="text-text-dim text-xs">{expandedId === tip.id ? "Hide" : "Read"}</span>
+      </button>
+      {expandedId === tip.id && (
+        <p className="px-3 pb-3 pt-1 text-sm text-text-secondary border-t border-surface-700/50">{tip.body}</p>
+      )}
+    </li>
+  );
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tips-modal-title"
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface-800 border border-surface-700/50 rounded-lg w-[460px] max-w-[90vw] max-h-[80vh] flex flex-col shadow-2xl animate-slide-up"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-5 py-4 border-b border-surface-700 flex items-center gap-2">
+          <span aria-hidden="true">💡</span>
+          <h2 id="tips-modal-title" className="text-sm font-semibold text-text-bright">
+            Tips
+          </h2>
+        </div>
+
+        <div className="p-5 space-y-2 overflow-y-auto">
+          {tips.length === 0 ? (
+            <p className="text-sm text-text-dim">No tips right now. Check back after a new release.</p>
+          ) : (
+            <>
+              {unseen.length > 0 && <ul className="space-y-2">{unseen.map(row)}</ul>}
+              {seen.length > 0 && (
+                <div className={unseen.length > 0 ? "pt-1" : ""}>
+                  <button
+                    onClick={() => setSeenOpen((o) => !o)}
+                    aria-expanded={seenOpen}
+                    className="text-xs text-text-dim hover:text-text-secondary transition-colors cursor-pointer"
+                  >
+                    {seenOpen ? "Hide" : "Show"} seen ({seen.length})
+                  </button>
+                  {seenOpen && <ul className="space-y-2 mt-2">{seen.map(row)}</ul>}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="px-5 py-4 border-t border-surface-700 flex justify-between gap-2">
+          <button
+            onClick={() => {
+              onDisable();
+              onClose();
+            }}
+            className="h-8 px-3 rounded-md border border-surface-700/50 text-sm text-text-secondary hover:bg-surface-850 hover:text-text-primary transition-colors duration-150 cursor-pointer"
+          >
+            Don't show again
+          </button>
+          <button
+            ref={closeRef}
+            onClick={onClose}
+            className="h-8 px-3 rounded-md bg-brand-600 text-sm text-white hover:bg-brand-500 transition-colors duration-150 cursor-pointer"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/TipsModal.tsx
+++ b/web/src/components/TipsModal.tsx
@@ -3,25 +3,27 @@ import type { TipDto } from "../lib/api";
 
 interface Props {
   tips: TipDto[];
-  /** Mark one tip seen (called when an unseen tip is expanded into view). */
+  /** Tip to open on (the first unseen one, so new content leads). */
+  startIndex: number;
+  /** "Show tips on startup" checkbox state (session.show_tips). */
+  enabled: boolean;
+  /** Mark one tip seen (called as each tip is shown). */
   onMarkSeen: (id: string) => void;
-  /** "Don't show again": turns tips off. */
-  onDisable: () => void;
+  /** Toggle "Show tips on startup". */
+  onSetEnabled: (enabled: boolean) => void;
   onClose: () => void;
 }
 
-/// Browsable tips panel for the web dashboard, mirroring the TUI overlay:
-/// unseen tips lead, already-seen tips collapse into an expandable section so
-/// what's new is foregrounded. Expanding an unseen tip marks it seen (mark-seen-
-/// on-view), and "Don't show again" turns tips off. Modeled on
-/// TelemetryConsentModal's fixed-overlay styling.
-export function TipsModal({ tips, onMarkSeen, onDisable, onClose }: Props) {
+/// Tip-of-the-day modal for the web dashboard, in the style of GIMP / DBeaver:
+/// one tip at a time with Previous / Next, a "Show tips on startup" checkbox,
+/// and Close. Auto-pops on startup (from App) and is reopenable from the top-bar
+/// menu. Each tip is marked seen as it is shown, so the seen state stays in sync
+/// with the TUI. Modeled on TelemetryConsentModal's fixed-overlay styling.
+export function TipsModal({ tips, startIndex, enabled, onMarkSeen, onSetEnabled, onClose }: Props) {
+  const count = tips.length;
+  const clampedStart = count === 0 ? 0 : Math.min(Math.max(startIndex, 0), count - 1);
+  const [index, setIndex] = useState(clampedStart);
   const closeRef = useRef<HTMLButtonElement>(null);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [seenOpen, setSeenOpen] = useState(false);
-
-  const unseen = tips.filter((t) => !t.seen);
-  const seen = tips.filter((t) => t.seen);
 
   useEffect(() => {
     closeRef.current?.focus();
@@ -36,31 +38,17 @@ export function TipsModal({ tips, onMarkSeen, onDisable, onClose }: Props) {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  const toggle = (tip: TipDto) => {
-    const opening = expandedId !== tip.id;
-    setExpandedId(opening ? tip.id : null);
-    // Mark seen when an unseen tip is opened into view.
-    if (opening && !tip.seen) onMarkSeen(tip.id);
+  // The initially shown tip is marked seen by the opener (App); navigation
+  // marks the rest, so mark-on-view never runs from an effect.
+  const go = (next: number) => {
+    if (count === 0) return;
+    const wrapped = (next + count) % count;
+    setIndex(wrapped);
+    const t = tips[wrapped];
+    if (t && !t.seen) onMarkSeen(t.id);
   };
 
-  const row = (tip: TipDto) => (
-    <li key={tip.id} className="border border-surface-700/50 rounded-md overflow-hidden">
-      <button
-        onClick={() => toggle(tip)}
-        aria-expanded={expandedId === tip.id}
-        className="w-full px-3 py-2 flex items-center justify-between text-left text-sm text-text-primary hover:bg-surface-850 transition-colors cursor-pointer"
-      >
-        <span className="flex items-center gap-2">
-          {!tip.seen && <span className="w-1.5 h-1.5 rounded-full bg-brand-500 shrink-0" aria-hidden="true" />}
-          {tip.title}
-        </span>
-        <span className="text-text-dim text-xs">{expandedId === tip.id ? "Hide" : "Read"}</span>
-      </button>
-      {expandedId === tip.id && (
-        <p className="px-3 pb-3 pt-1 text-sm text-text-secondary border-t border-surface-700/50">{tip.body}</p>
-      )}
-    </li>
-  );
+  const current = tips[index];
 
   return (
     <div
@@ -71,48 +59,57 @@ export function TipsModal({ tips, onMarkSeen, onDisable, onClose }: Props) {
       onClick={onClose}
     >
       <div
-        className="bg-surface-800 border border-surface-700/50 rounded-lg w-[460px] max-w-[90vw] max-h-[80vh] flex flex-col shadow-2xl animate-slide-up"
+        className="bg-surface-800 border border-surface-700/50 rounded-lg w-[480px] max-w-[90vw] max-h-[80vh] flex flex-col shadow-2xl animate-slide-up"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="px-5 py-4 border-b border-surface-700 flex items-center gap-2">
           <span aria-hidden="true">💡</span>
           <h2 id="tips-modal-title" className="text-sm font-semibold text-text-bright">
-            Tips
+            Tip of the day
           </h2>
         </div>
 
-        <div className="p-5 space-y-2 overflow-y-auto">
-          {tips.length === 0 ? (
-            <p className="text-sm text-text-dim">No tips right now. Check back after a new release.</p>
-          ) : (
+        <div className="p-5 overflow-y-auto min-h-[7rem]">
+          {current ? (
             <>
-              {unseen.length > 0 && <ul className="space-y-2">{unseen.map(row)}</ul>}
-              {seen.length > 0 && (
-                <div className={unseen.length > 0 ? "pt-1" : ""}>
-                  <button
-                    onClick={() => setSeenOpen((o) => !o)}
-                    aria-expanded={seenOpen}
-                    className="text-xs text-text-dim hover:text-text-secondary transition-colors cursor-pointer"
-                  >
-                    {seenOpen ? "Hide" : "Show"} seen ({seen.length})
-                  </button>
-                  {seenOpen && <ul className="space-y-2 mt-2">{seen.map(row)}</ul>}
-                </div>
-              )}
+              <h3 className="text-sm font-semibold text-text-primary mb-2">{current.title}</h3>
+              <p className="text-sm text-text-secondary">{current.body}</p>
             </>
+          ) : (
+            <p className="text-sm text-text-dim">No tips right now. Check back after a new release.</p>
           )}
         </div>
 
-        <div className="px-5 py-4 border-t border-surface-700 flex justify-between gap-2">
-          <button
-            onClick={() => {
-              onDisable();
-              onClose();
-            }}
-            className="h-8 px-3 rounded-md border border-surface-700/50 text-sm text-text-secondary hover:bg-surface-850 hover:text-text-primary transition-colors duration-150 cursor-pointer"
-          >
-            Don't show again
-          </button>
+        <div className="px-5 py-3 border-t border-surface-700 flex items-center justify-between gap-2">
+          <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => onSetEnabled(e.target.checked)}
+              className="accent-brand-500 cursor-pointer"
+            />
+            Show tips on startup
+          </label>
+          {count > 1 && <span className="text-xs text-text-dim">{`Tip ${index + 1} of ${count}`}</span>}
+        </div>
+
+        <div className="px-5 py-3 border-t border-surface-700 flex items-center justify-between gap-2">
+          <div className="flex gap-2">
+            <button
+              onClick={() => go(index - 1)}
+              disabled={count <= 1}
+              className="h-8 px-3 rounded-md border border-surface-700/50 text-sm text-text-secondary hover:bg-surface-850 hover:text-text-primary transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => go(index + 1)}
+              disabled={count <= 1}
+              className="h-8 px-3 rounded-md border border-surface-700/50 text-sm text-text-secondary hover:bg-surface-850 hover:text-text-primary transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
+            >
+              Next
+            </button>
+          </div>
           <button
             ref={closeRef}
             onClick={onClose}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -24,6 +24,10 @@ interface Props {
    *  the port is not visible in the window chrome. Driven by
    *  `ServerAbout.build_flavor === "debug"`. See #1055. */
   isDevBuild: boolean;
+  /** Count of unseen tips. When > 0 a clickable 💡 badge shows in the right
+   *  zone; 0 hides it (tips off or nothing unseen). */
+  tipsUnseen: number;
+  onOpenTips: () => void;
   onGoDashboard: () => void;
   /** When true (desktop, sidebar open, not in a full-width settings/projects
    *  view), the header's left zone widens to match the sidebar column and the
@@ -50,6 +54,8 @@ export function TopBar({
   loginRequired,
   isOffline,
   isDevBuild,
+  tipsUnseen,
+  onOpenTips,
   onGoDashboard,
   sidebarColumnVisible,
   rightColumnVisible,
@@ -138,6 +144,18 @@ export function TopBar({
             <span className="w-1.5 h-1.5 rounded-full bg-status-error animate-pulse" />
             offline
           </span>
+        )}
+
+        {tipsUnseen > 0 && (
+          <button
+            onClick={onOpenTips}
+            className="font-mono text-[11px] px-1.5 py-0.5 rounded-full bg-brand-600/15 text-brand-400 ring-1 ring-brand-500/30 flex items-center gap-1 hover:bg-brand-600/25 transition-colors cursor-pointer"
+            title={`${tipsUnseen} ${tipsUnseen === 1 ? "tip" : "tips"}`}
+            aria-label={`${tipsUnseen} ${tipsUnseen === 1 ? "tip" : "tips"}`}
+          >
+            <span aria-hidden="true">💡</span>
+            {tipsUnseen}
+          </button>
         )}
 
         {activeWorkspace && activeSession && (

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -24,9 +24,8 @@ interface Props {
    *  the port is not visible in the window chrome. Driven by
    *  `ServerAbout.build_flavor === "debug"`. See #1055. */
   isDevBuild: boolean;
-  /** Count of unseen tips. When > 0 a clickable 💡 badge shows in the right
-   *  zone; 0 hides it (tips off or nothing unseen). */
-  tipsUnseen: number;
+  /** Opens the tip-of-the-day modal; wired into the overflow menu so tips are
+   *  re-readable any time, like GIMP/DBeaver's Help menu entry. */
   onOpenTips: () => void;
   onGoDashboard: () => void;
   /** When true (desktop, sidebar open, not in a full-width settings/projects
@@ -54,7 +53,6 @@ export function TopBar({
   loginRequired,
   isOffline,
   isDevBuild,
-  tipsUnseen,
   onOpenTips,
   onGoDashboard,
   sidebarColumnVisible,
@@ -64,11 +62,12 @@ export function TopBar({
     const items: OverflowItem[] = [
       { label: "Help", onClick: onOpenHelp },
       { label: "Show tutorial", onClick: onStartTutorial },
+      { label: "Tips", onClick: onOpenTips },
       { label: "About", onClick: onOpenAbout },
     ];
     if (loginRequired) items.push({ label: "Sign out", onClick: onLogout });
     return items;
-  }, [onOpenHelp, onStartTutorial, onOpenAbout, onLogout, loginRequired]);
+  }, [onOpenHelp, onStartTutorial, onOpenTips, onOpenAbout, onLogout, loginRequired]);
 
   return (
     <header {...tourAnchor(TOUR_ANCHORS.topbar)} className="h-12 bg-surface-850 flex items-stretch shrink-0">
@@ -144,18 +143,6 @@ export function TopBar({
             <span className="w-1.5 h-1.5 rounded-full bg-status-error animate-pulse" />
             offline
           </span>
-        )}
-
-        {tipsUnseen > 0 && (
-          <button
-            onClick={onOpenTips}
-            className="font-mono text-[11px] px-1.5 py-0.5 rounded-full bg-brand-600/15 text-brand-400 ring-1 ring-brand-500/30 flex items-center gap-1 hover:bg-brand-600/25 transition-colors cursor-pointer"
-            title={`${tipsUnseen} ${tipsUnseen === 1 ? "tip" : "tips"}`}
-            aria-label={`${tipsUnseen} ${tipsUnseen === 1 ? "tip" : "tips"}`}
-          >
-            <span aria-hidden="true">💡</span>
-            {tipsUnseen}
-          </button>
         )}
 
         {activeWorkspace && activeSession && (

--- a/web/src/components/__tests__/TipsModal.test.tsx
+++ b/web/src/components/__tests__/TipsModal.test.tsx
@@ -85,6 +85,31 @@ describe("TipsModal (tip of the day)", () => {
     expect(queryByText(/Tip \d+ of/)).toBeNull();
   });
 
+  it("navigates backward with Previous", () => {
+    const { getByRole, getByText } = renderModal({ startIndex: 1 });
+    fireEvent.click(getByRole("button", { name: "Previous" }));
+    expect(getByText("First tip")).toBeTruthy();
+    expect(getByText("Tip 1 of 2")).toBeTruthy();
+  });
+
+  it("closes from the Close button", () => {
+    const { getByRole, onClose } = renderModal();
+    fireEvent.click(getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes when the overlay is clicked", () => {
+    const { getByRole, onClose } = renderModal();
+    fireEvent.click(getByRole("dialog"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", () => {
+    const { onClose } = renderModal();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("renders an empty state with no tips", () => {
     const { getByText } = renderModal({ tips: [] });
     expect(getByText(/No tips right now/)).toBeTruthy();

--- a/web/src/components/__tests__/TipsModal.test.tsx
+++ b/web/src/components/__tests__/TipsModal.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 //
-// Behavior contract for the dashboard TipsModal: unseen tips lead, seen tips
-// collapse, expanding an unseen tip marks it seen, and the footer actions fire.
-// The end-to-end persistence round-trip (GET /api/tips, mark-seen, disable) is
-// covered by web/tests/live/tips.spec.ts; this suite is pure prop-driven.
+// Behavior contract for the tip-of-the-day modal: shows one tip at a time,
+// Previous/Next cycle through them, each shown tip is marked seen, and the
+// "Show tips on startup" checkbox reflects and toggles the preference. The
+// persistence round-trip (GET /api/tips, mark-seen, show toggle) is covered by
+// web/tests/live/tips.spec.ts; this suite is pure prop-driven.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render } from "@testing-library/react";
@@ -16,60 +17,75 @@ afterEach(() => {
 });
 
 const TIPS: TipDto[] = [
-  { id: "install-dashboard-pwa", title: "Install the dashboard as an app", body: "PWA body.", seen: false },
-  { id: "old-one", title: "An old tip", body: "Seen body.", seen: true },
+  { id: "a", title: "First tip", body: "First body.", seen: false },
+  { id: "b", title: "Second tip", body: "Second body.", seen: false },
 ];
 
-function renderModal(overrides: { tips?: TipDto[]; onMarkSeen?: () => void; onDisable?: () => void } = {}) {
+function renderModal(
+  overrides: {
+    tips?: TipDto[];
+    startIndex?: number;
+    enabled?: boolean;
+    onSetEnabled?: () => void;
+    onMarkSeen?: () => void;
+  } = {},
+) {
   const onClose = vi.fn();
   const onMarkSeen = overrides.onMarkSeen ?? vi.fn();
-  const onDisable = overrides.onDisable ?? vi.fn();
+  const onSetEnabled = overrides.onSetEnabled ?? vi.fn();
   const utils = render(
-    <TipsModal tips={overrides.tips ?? TIPS} onMarkSeen={onMarkSeen} onDisable={onDisable} onClose={onClose} />,
+    <TipsModal
+      tips={overrides.tips ?? TIPS}
+      startIndex={overrides.startIndex ?? 0}
+      enabled={overrides.enabled ?? true}
+      onMarkSeen={onMarkSeen}
+      onSetEnabled={onSetEnabled}
+      onClose={onClose}
+    />,
   );
-  return { ...utils, onClose, onMarkSeen, onDisable };
+  return { ...utils, onClose, onMarkSeen, onSetEnabled };
 }
 
-describe("TipsModal", () => {
-  it("shows unseen tips and hides seen ones behind a collapsed section", () => {
-    const { getByText, queryByText } = renderModal();
-    expect(getByText("Install the dashboard as an app")).toBeTruthy();
-    // Seen tip is behind the collapsed "Show seen (1)" toggle.
-    expect(queryByText("An old tip")).toBeNull();
-    expect(getByText("Show seen (1)")).toBeTruthy();
+describe("TipsModal (tip of the day)", () => {
+  it("opens on the start index and shows that tip with a counter", () => {
+    const { getByText } = renderModal({ startIndex: 1 });
+    expect(getByText("Second tip")).toBeTruthy();
+    expect(getByText("Second body.")).toBeTruthy();
+    expect(getByText("Tip 2 of 2")).toBeTruthy();
   });
 
-  it("expands the seen section on demand", () => {
-    const { getByText, queryByText } = renderModal();
-    fireEvent.click(getByText("Show seen (1)"));
-    expect(getByText("An old tip")).toBeTruthy();
-    expect(queryByText("Hide seen (1)")).toBeTruthy();
-  });
-
-  it("marks an unseen tip seen when it is expanded", () => {
+  it("cycles to the next tip and marks it seen", () => {
     const onMarkSeen = vi.fn();
-    const { getByText } = renderModal({ onMarkSeen });
-    fireEvent.click(getByText("Install the dashboard as an app"));
-    expect(getByText("PWA body.")).toBeTruthy();
-    expect(onMarkSeen).toHaveBeenCalledWith("install-dashboard-pwa");
+    const { getByRole, getByText } = renderModal({ onMarkSeen });
+    fireEvent.click(getByRole("button", { name: "Next" }));
+    expect(getByText("Second tip")).toBeTruthy();
+    expect(onMarkSeen).toHaveBeenCalledWith("b");
   });
 
-  it("does not re-mark an already-seen tip when expanded", () => {
-    const onMarkSeen = vi.fn();
-    const { getByText } = renderModal({ onMarkSeen });
-    fireEvent.click(getByText("Show seen (1)"));
-    fireEvent.click(getByText("An old tip"));
-    expect(onMarkSeen).not.toHaveBeenCalled();
+  it("wraps from the last tip to the first with Next", () => {
+    const { getByRole, getByText } = renderModal({ startIndex: 1 });
+    fireEvent.click(getByRole("button", { name: "Next" }));
+    expect(getByText("First tip")).toBeTruthy();
+    expect(getByText("Tip 1 of 2")).toBeTruthy();
   });
 
-  it("disables tips and closes from Don't show again", () => {
-    const { getByText, onDisable, onClose } = renderModal();
-    fireEvent.click(getByText("Don't show again"));
-    expect(onDisable).toHaveBeenCalledTimes(1);
-    expect(onClose).toHaveBeenCalledTimes(1);
+  it("reflects the enabled state and toggles it from the checkbox", () => {
+    const onSetEnabled = vi.fn();
+    const { getByRole } = renderModal({ enabled: true, onSetEnabled });
+    const checkbox = getByRole("checkbox", { name: "Show tips on startup" }) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    fireEvent.click(checkbox);
+    expect(onSetEnabled).toHaveBeenCalledWith(false);
   });
 
-  it("renders an empty state when there are no tips", () => {
+  it("disables navigation and hides the counter for a single tip", () => {
+    const { getByRole, queryByText } = renderModal({ tips: [TIPS[0]] });
+    expect((getByRole("button", { name: "Next" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((getByRole("button", { name: "Previous" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(queryByText(/Tip \d+ of/)).toBeNull();
+  });
+
+  it("renders an empty state with no tips", () => {
     const { getByText } = renderModal({ tips: [] });
     expect(getByText(/No tips right now/)).toBeTruthy();
   });

--- a/web/src/components/__tests__/TipsModal.test.tsx
+++ b/web/src/components/__tests__/TipsModal.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+//
+// Behavior contract for the dashboard TipsModal: unseen tips lead, seen tips
+// collapse, expanding an unseen tip marks it seen, and the footer actions fire.
+// The end-to-end persistence round-trip (GET /api/tips, mark-seen, disable) is
+// covered by web/tests/live/tips.spec.ts; this suite is pure prop-driven.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { TipsModal } from "../TipsModal";
+import type { TipDto } from "../../lib/api";
+
+afterEach(() => {
+  cleanup();
+});
+
+const TIPS: TipDto[] = [
+  { id: "install-dashboard-pwa", title: "Install the dashboard as an app", body: "PWA body.", seen: false },
+  { id: "old-one", title: "An old tip", body: "Seen body.", seen: true },
+];
+
+function renderModal(overrides: { tips?: TipDto[]; onMarkSeen?: () => void; onDisable?: () => void } = {}) {
+  const onClose = vi.fn();
+  const onMarkSeen = overrides.onMarkSeen ?? vi.fn();
+  const onDisable = overrides.onDisable ?? vi.fn();
+  const utils = render(
+    <TipsModal tips={overrides.tips ?? TIPS} onMarkSeen={onMarkSeen} onDisable={onDisable} onClose={onClose} />,
+  );
+  return { ...utils, onClose, onMarkSeen, onDisable };
+}
+
+describe("TipsModal", () => {
+  it("shows unseen tips and hides seen ones behind a collapsed section", () => {
+    const { getByText, queryByText } = renderModal();
+    expect(getByText("Install the dashboard as an app")).toBeTruthy();
+    // Seen tip is behind the collapsed "Show seen (1)" toggle.
+    expect(queryByText("An old tip")).toBeNull();
+    expect(getByText("Show seen (1)")).toBeTruthy();
+  });
+
+  it("expands the seen section on demand", () => {
+    const { getByText, queryByText } = renderModal();
+    fireEvent.click(getByText("Show seen (1)"));
+    expect(getByText("An old tip")).toBeTruthy();
+    expect(queryByText("Hide seen (1)")).toBeTruthy();
+  });
+
+  it("marks an unseen tip seen when it is expanded", () => {
+    const onMarkSeen = vi.fn();
+    const { getByText } = renderModal({ onMarkSeen });
+    fireEvent.click(getByText("Install the dashboard as an app"));
+    expect(getByText("PWA body.")).toBeTruthy();
+    expect(onMarkSeen).toHaveBeenCalledWith("install-dashboard-pwa");
+  });
+
+  it("does not re-mark an already-seen tip when expanded", () => {
+    const onMarkSeen = vi.fn();
+    const { getByText } = renderModal({ onMarkSeen });
+    fireEvent.click(getByText("Show seen (1)"));
+    fireEvent.click(getByText("An old tip"));
+    expect(onMarkSeen).not.toHaveBeenCalled();
+  });
+
+  it("disables tips and closes from Don't show again", () => {
+    const { getByText, onDisable, onClose } = renderModal();
+    fireEvent.click(getByText("Don't show again"));
+    expect(onDisable).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an empty state when there are no tips", () => {
+    const { getByText } = renderModal({ tips: [] });
+    expect(getByText(/No tips right now/)).toBeTruthy();
+  });
+});

--- a/web/src/components/__tests__/TopBar.test.tsx
+++ b/web/src/components/__tests__/TopBar.test.tsx
@@ -27,7 +27,6 @@ function renderTopBar(
     isOffline?: boolean;
     activeWorkspace?: Workspace;
     activeSession?: SessionResponse | null;
-    tipsUnseen?: number;
     onOpenTips?: () => void;
   } = {},
 ) {
@@ -46,7 +45,6 @@ function renderTopBar(
       loginRequired={false}
       isOffline={overrides.isOffline ?? false}
       isDevBuild={overrides.isDevBuild ?? false}
-      tipsUnseen={overrides.tipsUnseen ?? 0}
       onOpenTips={overrides.onOpenTips ?? vi.fn()}
       onGoDashboard={vi.fn()}
       sidebarColumnVisible={false}
@@ -101,23 +99,11 @@ describe("TopBar", () => {
     expect(getByLabelText("Debug build")).toBeTruthy();
   });
 
-  it("hides the tips badge when no tips are unseen", () => {
-    const { queryByLabelText } = renderTopBar({ tipsUnseen: 0 });
-    expect(queryByLabelText("1 tip")).toBeNull();
-    expect(queryByLabelText(/tips?$/)).toBeNull();
-  });
-
-  it("renders the tips badge with the count and fires onOpenTips on click", () => {
+  it("exposes a Tips entry in the overflow menu that fires onOpenTips", () => {
     const onOpenTips = vi.fn();
-    const { getByLabelText, getByText } = renderTopBar({ tipsUnseen: 3, onOpenTips });
-    const badge = getByLabelText("3 tips");
-    expect(getByText("3")).toBeTruthy();
-    fireEvent.click(badge);
+    const { getByRole } = renderTopBar({ onOpenTips });
+    fireEvent.click(getByRole("button", { name: "More options" }));
+    fireEvent.click(getByRole("menuitem", { name: "Tips" }));
     expect(onOpenTips).toHaveBeenCalledTimes(1);
-  });
-
-  it("uses the singular label for a single tip", () => {
-    const { getByLabelText } = renderTopBar({ tipsUnseen: 1 });
-    expect(getByLabelText("1 tip")).toBeTruthy();
   });
 });

--- a/web/src/components/__tests__/TopBar.test.tsx
+++ b/web/src/components/__tests__/TopBar.test.tsx
@@ -12,7 +12,7 @@
 // instances on ports 8081 / 8080 are visually distinguishable).
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { TopBar } from "../TopBar";
 import type { SessionResponse, Workspace } from "../../lib/types";
@@ -27,6 +27,8 @@ function renderTopBar(
     isOffline?: boolean;
     activeWorkspace?: Workspace;
     activeSession?: SessionResponse | null;
+    tipsUnseen?: number;
+    onOpenTips?: () => void;
   } = {},
 ) {
   return render(
@@ -44,6 +46,8 @@ function renderTopBar(
       loginRequired={false}
       isOffline={overrides.isOffline ?? false}
       isDevBuild={overrides.isDevBuild ?? false}
+      tipsUnseen={overrides.tipsUnseen ?? 0}
+      onOpenTips={overrides.onOpenTips ?? vi.fn()}
       onGoDashboard={vi.fn()}
       sidebarColumnVisible={false}
       rightColumnVisible={false}
@@ -95,5 +99,25 @@ describe("TopBar", () => {
     });
     expect(getByText("offline")).toBeTruthy();
     expect(getByLabelText("Debug build")).toBeTruthy();
+  });
+
+  it("hides the tips badge when no tips are unseen", () => {
+    const { queryByLabelText } = renderTopBar({ tipsUnseen: 0 });
+    expect(queryByLabelText("1 tip")).toBeNull();
+    expect(queryByLabelText(/tips?$/)).toBeNull();
+  });
+
+  it("renders the tips badge with the count and fires onOpenTips on click", () => {
+    const onOpenTips = vi.fn();
+    const { getByLabelText, getByText } = renderTopBar({ tipsUnseen: 3, onOpenTips });
+    const badge = getByLabelText("3 tips");
+    expect(getByText("3")).toBeTruthy();
+    fireEvent.click(badge);
+    expect(onOpenTips).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the singular label for a single tip", () => {
+    const { getByLabelText } = renderTopBar({ tipsUnseen: 1 });
+    expect(getByLabelText("1 tip")).toBeTruthy();
   });
 });

--- a/web/src/hooks/__tests__/useTips.test.ts
+++ b/web/src/hooks/__tests__/useTips.test.ts
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
 //
-// Hook tests for useTips (#2292): fetches the web-surface tips on mount,
-// derives the unseen/firstUnseen state the tip-of-the-day modal needs, and
-// persists mark-seen and the show-on-startup toggle through the api module
-// (mocked here so no network is touched).
+// Tests for useTips and shouldAutoPopTips (#2292): the hook fetches the
+// web-surface tips, derives unseen state, owns the modal open/close + the tip
+// it opens on, and persists mark-seen and the show-on-startup toggle through
+// the api module (mocked). shouldAutoPopTips is the pure startup-auto-pop gate.
 
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { useTips } from "../useTips";
+import { useTips, shouldAutoPopTips, type TipsAutoPopGate } from "../useTips";
 import type { TipsResponse } from "../../lib/api";
 
 vi.mock("../../lib/api", () => ({
@@ -47,16 +47,7 @@ describe("useTips", () => {
     expect(result.current.enabled).toBe(true);
     expect(result.current.tips).toHaveLength(2);
     expect(result.current.hasUnseen).toBe(true);
-    expect(result.current.firstUnseenIndex).toBe(1);
-  });
-
-  it("reports no unseen and index 0 when all tips are seen", async () => {
-    mockFetch.mockResolvedValue(resp({ tips: [{ id: "a", title: "A", body: "b", seen: true }] }));
-    const { result } = renderHook(() => useTips());
-
-    await waitFor(() => expect(result.current.loaded).toBe(true));
-    expect(result.current.hasUnseen).toBe(false);
-    expect(result.current.firstUnseenIndex).toBe(0);
+    expect(result.current.isOpen).toBe(false);
   });
 
   it("treats a failed fetch as loaded with no tips", async () => {
@@ -77,6 +68,32 @@ describe("useTips", () => {
     expect(result.current.hasUnseen).toBe(false);
   });
 
+  it("opens on the first unseen tip, marks it seen, and closes", async () => {
+    mockFetch.mockResolvedValue(resp());
+    mockMarkSeen.mockResolvedValue(true);
+    const { result } = renderHook(() => useTips());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.startIndex).toBe(1); // first unseen
+    expect(result.current.tips.find((t) => t.id === "b")?.seen).toBe(true);
+    expect(mockMarkSeen).toHaveBeenCalledWith("b");
+
+    act(() => result.current.close());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("opens at index 0 when every tip is already seen", async () => {
+    mockFetch.mockResolvedValue(resp({ tips: [{ id: "a", title: "A", body: "b", seen: true }] }));
+    const { result } = renderHook(() => useTips());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    act(() => result.current.open());
+    expect(result.current.startIndex).toBe(0);
+    expect(mockMarkSeen).not.toHaveBeenCalled();
+  });
+
   it("markSeen flips the tip locally and persists it", async () => {
     mockFetch.mockResolvedValue(resp());
     mockMarkSeen.mockResolvedValue(true);
@@ -84,7 +101,6 @@ describe("useTips", () => {
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     act(() => result.current.markSeen("b"));
-
     expect(result.current.tips.find((t) => t.id === "b")?.seen).toBe(true);
     expect(result.current.hasUnseen).toBe(false);
     expect(mockMarkSeen).toHaveBeenCalledWith("b");
@@ -97,9 +113,35 @@ describe("useTips", () => {
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     act(() => result.current.setEnabled(false));
-
     expect(result.current.enabled).toBe(false);
     expect(result.current.hasUnseen).toBe(false);
     expect(mockSetShow).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("shouldAutoPopTips", () => {
+  const ready: TipsAutoPopGate = {
+    loaded: true,
+    hasUnseen: true,
+    tourSeenAtLoad: true,
+    onboardingReady: true,
+    telemetryPending: false,
+    tourActive: false,
+    automated: false,
+  };
+
+  it("returns true when every gate is satisfied", () => {
+    expect(shouldAutoPopTips(ready)).toBe(true);
+  });
+
+  it("blocks each individual gate", () => {
+    expect(shouldAutoPopTips({ ...ready, loaded: false })).toBe(false);
+    expect(shouldAutoPopTips({ ...ready, hasUnseen: false })).toBe(false);
+    expect(shouldAutoPopTips({ ...ready, tourSeenAtLoad: false })).toBe(false);
+    expect(shouldAutoPopTips({ ...ready, tourSeenAtLoad: null })).toBe(false);
+    expect(shouldAutoPopTips({ ...ready, onboardingReady: false })).toBe(false);
+    expect(shouldAutoPopTips({ ...ready, telemetryPending: true })).toBe(false);
+    expect(shouldAutoPopTips({ ...ready, tourActive: true })).toBe(false);
+    expect(shouldAutoPopTips({ ...ready, automated: true })).toBe(false);
   });
 });

--- a/web/src/hooks/__tests__/useTips.test.ts
+++ b/web/src/hooks/__tests__/useTips.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+//
+// Hook tests for useTips (#2292): fetches the web-surface tips on mount,
+// derives the unseen/firstUnseen state the tip-of-the-day modal needs, and
+// persists mark-seen and the show-on-startup toggle through the api module
+// (mocked here so no network is touched).
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useTips } from "../useTips";
+import type { TipsResponse } from "../../lib/api";
+
+vi.mock("../../lib/api", () => ({
+  fetchTips: vi.fn(),
+  markTipSeen: vi.fn(),
+  setShowTips: vi.fn(),
+}));
+
+import { fetchTips, markTipSeen, setShowTips } from "../../lib/api";
+
+const mockFetch = vi.mocked(fetchTips);
+const mockMarkSeen = vi.mocked(markTipSeen);
+const mockSetShow = vi.mocked(setShowTips);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function resp(over: Partial<TipsResponse> = {}): TipsResponse {
+  return {
+    enabled: true,
+    tips: [
+      { id: "a", title: "A", body: "ba", seen: true },
+      { id: "b", title: "B", body: "bb", seen: false },
+    ],
+    ...over,
+  };
+}
+
+describe("useTips", () => {
+  it("loads tips and derives unseen state", async () => {
+    mockFetch.mockResolvedValue(resp());
+    const { result } = renderHook(() => useTips());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.tips).toHaveLength(2);
+    expect(result.current.hasUnseen).toBe(true);
+    expect(result.current.firstUnseenIndex).toBe(1);
+  });
+
+  it("reports no unseen and index 0 when all tips are seen", async () => {
+    mockFetch.mockResolvedValue(resp({ tips: [{ id: "a", title: "A", body: "b", seen: true }] }));
+    const { result } = renderHook(() => useTips());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.hasUnseen).toBe(false);
+    expect(result.current.firstUnseenIndex).toBe(0);
+  });
+
+  it("treats a failed fetch as loaded with no tips", async () => {
+    mockFetch.mockResolvedValue(null);
+    const { result } = renderHook(() => useTips());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.tips).toEqual([]);
+    expect(result.current.hasUnseen).toBe(false);
+  });
+
+  it("hasUnseen is false when tips are disabled even with unseen entries", async () => {
+    mockFetch.mockResolvedValue(resp({ enabled: false }));
+    const { result } = renderHook(() => useTips());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.hasUnseen).toBe(false);
+  });
+
+  it("markSeen flips the tip locally and persists it", async () => {
+    mockFetch.mockResolvedValue(resp());
+    mockMarkSeen.mockResolvedValue(true);
+    const { result } = renderHook(() => useTips());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    act(() => result.current.markSeen("b"));
+
+    expect(result.current.tips.find((t) => t.id === "b")?.seen).toBe(true);
+    expect(result.current.hasUnseen).toBe(false);
+    expect(mockMarkSeen).toHaveBeenCalledWith("b");
+  });
+
+  it("setEnabled flips enabled locally and persists it", async () => {
+    mockFetch.mockResolvedValue(resp());
+    mockSetShow.mockResolvedValue(true);
+    const { result } = renderHook(() => useTips());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    act(() => result.current.setEnabled(false));
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.hasUnseen).toBe(false);
+    expect(mockSetShow).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/src/hooks/useTips.ts
+++ b/web/src/hooks/useTips.ts
@@ -1,0 +1,55 @@
+// Web dashboard tips controller. Fetches the web-surface tips from the shared
+// catalog (GET /api/tips), exposes the unseen count for the TopBar badge, and
+// persists mark-seen-on-view and "don't show again" through the dedicated tips
+// endpoints so state stays shared with the TUI across devices. Rotation tips
+// are passive: the badge surfaces them, but nothing pops on its own, mirroring
+// the TUI's rotation semantics.
+import { useCallback, useEffect, useState } from "react";
+import { disableTips, fetchTips, markTipSeen, type TipDto } from "../lib/api";
+
+export interface UseTipsResult {
+  /** Whether tips are enabled (session.show_tips). */
+  enabled: boolean;
+  /** Web-eligible tips in catalog order, with seen state. */
+  tips: TipDto[];
+  /** Count of unseen tips; drives the badge (0 hides it). */
+  unseenCount: number;
+  /** Mark one tip seen locally and on the server (mark-seen-on-view). */
+  markSeen: (id: string) => void;
+  /** Turn tips off; clears local state so the badge and panel hide at once. */
+  disable: () => void;
+}
+
+export function useTips(): UseTipsResult {
+  const [enabled, setEnabled] = useState(false);
+  const [tips, setTips] = useState<TipDto[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    fetchTips().then((resp) => {
+      if (!active || !resp) return;
+      setEnabled(resp.enabled);
+      setTips(resp.tips);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const markSeen = useCallback((id: string) => {
+    // Optimistic: flip locally so the panel and badge update immediately, then
+    // persist. A failed write is nonfatal; the server stays authoritative on
+    // the next load.
+    setTips((prev) => prev.map((t) => (t.id === id ? { ...t, seen: true } : t)));
+    void markTipSeen(id);
+  }, []);
+
+  const disable = useCallback(() => {
+    setEnabled(false);
+    void disableTips();
+  }, []);
+
+  const unseenCount = enabled ? tips.filter((t) => !t.seen).length : 0;
+
+  return { enabled, tips, unseenCount, markSeen, disable };
+}

--- a/web/src/hooks/useTips.ts
+++ b/web/src/hooks/useTips.ts
@@ -1,35 +1,43 @@
 // Web dashboard tips controller. Fetches the web-surface tips from the shared
-// catalog (GET /api/tips), exposes the unseen count for the TopBar badge, and
-// persists mark-seen-on-view and "don't show again" through the dedicated tips
-// endpoints so state stays shared with the TUI across devices. Rotation tips
-// are passive: the badge surfaces them, but nothing pops on its own, mirroring
-// the TUI's rotation semantics.
+// catalog (GET /api/tips) and exposes what the tip-of-the-day modal needs: the
+// list, whether tips show on startup, and the first unseen tip to open on. Marks
+// tips seen on view and toggles the startup preference through the dedicated tips
+// endpoints, so state stays shared with the TUI across devices.
 import { useCallback, useEffect, useState } from "react";
-import { disableTips, fetchTips, markTipSeen, type TipDto } from "../lib/api";
+import { fetchTips, markTipSeen, setShowTips, type TipDto } from "../lib/api";
 
 export interface UseTipsResult {
-  /** Whether tips are enabled (session.show_tips). */
+  /** Whether tips show on startup (session.show_tips). */
   enabled: boolean;
   /** Web-eligible tips in catalog order, with seen state. */
   tips: TipDto[];
-  /** Count of unseen tips; drives the badge (0 hides it). */
-  unseenCount: number;
+  /** True once GET /api/tips has resolved, so callers don't act on empty state. */
+  loaded: boolean;
+  /** Whether any tip is unseen; gates the startup auto-pop. */
+  hasUnseen: boolean;
+  /** Index of the first unseen tip, or 0 when all are seen. The modal opens
+   *  here so new content leads. */
+  firstUnseenIndex: number;
   /** Mark one tip seen locally and on the server (mark-seen-on-view). */
   markSeen: (id: string) => void;
-  /** Turn tips off; clears local state so the badge and panel hide at once. */
-  disable: () => void;
+  /** Set "Show tips on startup" locally and on the server. */
+  setEnabled: (enabled: boolean) => void;
 }
 
 export function useTips(): UseTipsResult {
-  const [enabled, setEnabled] = useState(false);
+  const [enabled, setEnabledState] = useState(false);
   const [tips, setTips] = useState<TipDto[]>([]);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     let active = true;
     fetchTips().then((resp) => {
-      if (!active || !resp) return;
-      setEnabled(resp.enabled);
-      setTips(resp.tips);
+      if (!active) return;
+      if (resp) {
+        setEnabledState(resp.enabled);
+        setTips(resp.tips);
+      }
+      setLoaded(true);
     });
     return () => {
       active = false;
@@ -37,19 +45,28 @@ export function useTips(): UseTipsResult {
   }, []);
 
   const markSeen = useCallback((id: string) => {
-    // Optimistic: flip locally so the panel and badge update immediately, then
+    // Optimistic: flip locally so the modal reflects it immediately, then
     // persist. A failed write is nonfatal; the server stays authoritative on
     // the next load.
     setTips((prev) => prev.map((t) => (t.id === id ? { ...t, seen: true } : t)));
     void markTipSeen(id);
   }, []);
 
-  const disable = useCallback(() => {
-    setEnabled(false);
-    void disableTips();
+  const setEnabled = useCallback((next: boolean) => {
+    setEnabledState(next);
+    void setShowTips(next);
   }, []);
 
-  const unseenCount = enabled ? tips.filter((t) => !t.seen).length : 0;
+  const firstUnseen = tips.findIndex((t) => !t.seen);
+  const hasUnseen = enabled && firstUnseen !== -1;
 
-  return { enabled, tips, unseenCount, markSeen, disable };
+  return {
+    enabled,
+    tips,
+    loaded,
+    hasUnseen,
+    firstUnseenIndex: firstUnseen === -1 ? 0 : firstUnseen,
+    markSeen,
+    setEnabled,
+  };
 }

--- a/web/src/hooks/useTips.ts
+++ b/web/src/hooks/useTips.ts
@@ -1,23 +1,64 @@
-// Web dashboard tips controller. Fetches the web-surface tips from the shared
-// catalog (GET /api/tips) and exposes what the tip-of-the-day modal needs: the
-// list, whether tips show on startup, and the first unseen tip to open on. Marks
-// tips seen on view and toggles the startup preference through the dedicated tips
-// endpoints, so state stays shared with the TUI across devices.
+// Web dashboard tips controller. Owns everything the tip-of-the-day needs:
+// fetches the web-surface tips from the shared catalog (GET /api/tips), tracks
+// the modal open state and which tip it opens on, marks tips seen on view, and
+// toggles the show-on-startup preference. Keeping this in the hook (not the App
+// component) keeps the logic unit-testable and out of the App.tsx giant.
 import { useCallback, useEffect, useState } from "react";
 import { fetchTips, markTipSeen, setShowTips, type TipDto } from "../lib/api";
+
+/** Inputs to the startup auto-pop decision. Kept as primitives so the decision
+ *  is a pure function the App effect can call and tests can pin. */
+export interface TipsAutoPopGate {
+  /** GET /api/tips has resolved. */
+  loaded: boolean;
+  /** At least one eligible tip is unseen and tips are enabled. */
+  hasUnseen: boolean;
+  /** Whether the tour was already seen when the page loaded (not the live flag:
+   *  finishing the tour this session must not then pop tips on top of it). */
+  tourSeenAtLoad: boolean | null;
+  /** The dashboard has settled and the theme welcome is resolved. */
+  onboardingReady: boolean;
+  /** The telemetry consent modal is up. */
+  telemetryPending: boolean;
+  /** The tour is currently running. */
+  tourActive: boolean;
+  /** An automated browser session (Playwright), where modals must not auto-pop. */
+  automated: boolean;
+}
+
+/** Pure decision for the startup auto-pop, mirroring the tour's shouldAutoLaunch:
+ *  only for a settled dashboard, only when a tip is unseen, only for users who
+ *  already finished onboarding before this load, and never while another flow is
+ *  up or in an automated session. */
+export function shouldAutoPopTips(g: TipsAutoPopGate): boolean {
+  return (
+    g.loaded &&
+    g.hasUnseen &&
+    g.tourSeenAtLoad === true &&
+    g.onboardingReady &&
+    !g.telemetryPending &&
+    !g.tourActive &&
+    !g.automated
+  );
+}
 
 export interface UseTipsResult {
   /** Whether tips show on startup (session.show_tips). */
   enabled: boolean;
   /** Web-eligible tips in catalog order, with seen state. */
   tips: TipDto[];
-  /** True once GET /api/tips has resolved, so callers don't act on empty state. */
+  /** True once GET /api/tips has resolved. */
   loaded: boolean;
   /** Whether any tip is unseen; gates the startup auto-pop. */
   hasUnseen: boolean;
-  /** Index of the first unseen tip, or 0 when all are seen. The modal opens
-   *  here so new content leads. */
-  firstUnseenIndex: number;
+  /** Whether the tip-of-the-day modal is open. */
+  isOpen: boolean;
+  /** Tip index the modal opens on (the first unseen when opened). */
+  startIndex: number;
+  /** Open the modal on the first unseen tip and mark that tip seen. */
+  open: () => void;
+  /** Close the modal. */
+  close: () => void;
   /** Mark one tip seen locally and on the server (mark-seen-on-view). */
   markSeen: (id: string) => void;
   /** Set "Show tips on startup" locally and on the server. */
@@ -28,6 +69,8 @@ export function useTips(): UseTipsResult {
   const [enabled, setEnabledState] = useState(false);
   const [tips, setTips] = useState<TipDto[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [startIndex, setStartIndex] = useState(0);
 
   useEffect(() => {
     let active = true;
@@ -58,14 +101,28 @@ export function useTips(): UseTipsResult {
   }, []);
 
   const firstUnseen = tips.findIndex((t) => !t.seen);
-  const hasUnseen = enabled && firstUnseen !== -1;
+
+  // Open on the first unseen tip; capture the index before marking it seen,
+  // since marking shifts firstUnseen and would otherwise skip that tip.
+  const open = useCallback(() => {
+    const idx = firstUnseen === -1 ? 0 : firstUnseen;
+    setStartIndex(idx);
+    setIsOpen(true);
+    const tip = tips[idx];
+    if (tip && !tip.seen) markSeen(tip.id);
+  }, [tips, firstUnseen, markSeen]);
+
+  const close = useCallback(() => setIsOpen(false), []);
 
   return {
     enabled,
     tips,
     loaded,
-    hasUnseen,
-    firstUnseenIndex: firstUnseen === -1 ? 0 : firstUnseen,
+    hasUnseen: enabled && firstUnseen !== -1,
+    isOpen,
+    startIndex,
+    open,
+    close,
     markSeen,
     setEnabled,
   };

--- a/web/src/lib/__tests__/tipsApi.test.ts
+++ b/web/src/lib/__tests__/tipsApi.test.ts
@@ -1,0 +1,86 @@
+// Vitest coverage for the tips API client (#2292): the GET /api/tips read and
+// the two single-purpose writes (mark a tip seen, set the show-on-startup
+// preference). All swallow network and non-OK responses so the dashboard
+// degrades to no badge / no-op rather than throwing.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchTips, markTipSeen, setShowTips } from "../api";
+
+const fetchSpy = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchTips", () => {
+  it("returns the parsed payload from GET /api/tips", async () => {
+    const payload = {
+      enabled: true,
+      tips: [{ id: "install-dashboard-pwa", title: "T", body: "B", seen: false }],
+    };
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+
+    expect(await fetchTips()).toEqual(payload);
+    expect(fetchSpy.mock.calls[0][0]).toBe("/api/tips");
+  });
+
+  it("returns null on a non-OK response", async () => {
+    fetchSpy.mockResolvedValue(new Response("nope", { status: 500 }));
+    expect(await fetchTips()).toBeNull();
+  });
+
+  it("returns null when the request throws", async () => {
+    fetchSpy.mockRejectedValue(new Error("network down"));
+    expect(await fetchTips()).toBeNull();
+  });
+});
+
+describe("markTipSeen", () => {
+  it("POSTs the tip id and returns true on success", async () => {
+    fetchSpy.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    expect(await markTipSeen("pin-sessions")).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/app-state/tip-seen");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ id: "pin-sessions" });
+  });
+
+  it("returns false on a non-OK response (e.g. read-only 403)", async () => {
+    fetchSpy.mockResolvedValue(new Response("forbidden", { status: 403 }));
+    expect(await markTipSeen("x")).toBe(false);
+  });
+
+  it("returns false when the request throws", async () => {
+    fetchSpy.mockRejectedValue(new Error("network down"));
+    expect(await markTipSeen("x")).toBe(false);
+  });
+});
+
+describe("setShowTips", () => {
+  it("POSTs the enabled flag and returns true on success", async () => {
+    fetchSpy.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    expect(await setShowTips(false)).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/tips/show");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ enabled: false });
+  });
+
+  it("returns false on a non-OK response", async () => {
+    fetchSpy.mockResolvedValue(new Response("forbidden", { status: 403 }));
+    expect(await setShowTips(true)).toBe(false);
+  });
+
+  it("returns false when the request throws", async () => {
+    fetchSpy.mockRejectedValue(new Error("network down"));
+    expect(await setShowTips(true)).toBe(false);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -253,13 +253,16 @@ export async function markTipSeen(id: string): Promise<boolean> {
   }
 }
 
-/** Turn tips off ("don't show again"), setting `session.show_tips=false`.
- *  Dedicated endpoint, not `PATCH /api/settings`, so this cosmetic toggle stays
- *  off the passphrase/elevation wall. Returns false on read-only (403) or
- *  network failure. */
-export async function disableTips(): Promise<boolean> {
+/** Set "Show tips on startup" (`session.show_tips`). Dedicated endpoint, not
+ *  `PATCH /api/settings`, so this cosmetic toggle stays off the passphrase/
+ *  elevation wall. Returns false on read-only (403) or network failure. */
+export async function setShowTips(enabled: boolean): Promise<boolean> {
   try {
-    const res = await fetch("/api/tips/disable", { method: "POST" });
+    const res = await fetch("/api/tips/show", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled }),
+    });
     return res.ok;
   } catch {
     return false;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -216,6 +216,56 @@ export async function markWebTourSeen(): Promise<boolean> {
   }
 }
 
+// --- Tips ---
+
+export interface TipDto {
+  id: string;
+  title: string;
+  body: string;
+  seen: boolean;
+}
+
+export interface TipsResponse {
+  /** Mirror of `session.show_tips`; the badge and panel hide when false. */
+  enabled: boolean;
+  /** Web-eligible tips in catalog order, each flagged with its seen state. */
+  tips: TipDto[];
+}
+
+/** Fetch the web-surface tips and whether tips are enabled. Null on failure so
+ *  the caller simply shows no badge. */
+export function fetchTips(): Promise<TipsResponse | null> {
+  return fetchJson<TipsResponse>("/api/tips");
+}
+
+/** Mark one tip seen (mark-seen-on-view). Best-effort; returns success. Mirrors
+ *  {@link markWebTourSeen}: off the elevation wall, blocked on read-only. */
+export async function markTipSeen(id: string): Promise<boolean> {
+  try {
+    const res = await fetch("/api/app-state/tip-seen", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Turn tips off ("don't show again"), setting `session.show_tips=false`.
+ *  Dedicated endpoint, not `PATCH /api/settings`, so this cosmetic toggle stays
+ *  off the passphrase/elevation wall. Returns false on read-only (403) or
+ *  network failure. */
+export async function disableTips(): Promise<boolean> {
+  try {
+    const res = await fetch("/api/tips/disable", { method: "POST" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 // --- Web UI state sync (server-side mirror of synced localStorage keys) ---
 
 /** Fetch the server-side UI-state blob: a flat map of localStorage key ->

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -385,6 +385,27 @@
       "components": ["web/src/components/TopBar.tsx"]
     },
     {
+      "id": "app-shell.tips-badge",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/__tests__/TopBar.test.tsx"],
+      "components": ["web/src/components/TopBar.tsx"]
+    },
+    {
+      "id": "tips.panel",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/__tests__/TipsModal.test.tsx"],
+      "components": ["web/src/components/TipsModal.tsx"]
+    },
+    {
+      "id": "tips.persistence",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/tips.spec.ts"],
+      "components": ["web/src/components/TipsModal.tsx", "web/src/hooks/useTips.ts", "web/src/lib/api.ts"]
+    },
+    {
       "id": "app-shell.routing",
       "kind": "mocked-playwright",
       "risk": "high",

--- a/web/tests/live/tips.spec.ts
+++ b/web/tests/live/tips.spec.ts
@@ -1,0 +1,102 @@
+// User stories (issue #2292): the web dashboard mirrors the TUI tips system.
+// A fresh server has one web-eligible rotation tip ("Install the dashboard as
+// an app"), so the 💡 badge shows in the TopBar. Opening the panel and reading
+// a tip marks it seen (persisted via POST /api/app-state/tip-seen, shared with
+// the TUI), and "Don't show again" turns tips off (POST /api/tips/disable). Both
+// survive a reload via GET /api/tips. The TUI-only shortcut tip never appears.
+import { test as base, expect, type Page } from "@playwright/test";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+const PWA_TIP = "Install the dashboard as an app";
+
+// A fresh $HOME shows the theme welcome modal first; dismiss it so the TopBar
+// badge is clickable. The tour does not auto-launch here (Playwright presents
+// navigator.webdriver = true, which suppresses it).
+async function dismissWelcome(page: Page) {
+  const welcome = page.getByText("Choose your theme");
+  if (await welcome.isVisible().catch(() => false)) {
+    await page.getByRole("button", { name: "Continue" }).click();
+  }
+}
+
+base("tips: badge surfaces a tip, reading it marks it seen across reloads", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
+    await dismissWelcome(page);
+
+    // Story 1: the badge shows for the single unseen web tip.
+    const badge = page.getByRole("button", { name: "1 tip" });
+    await expect(badge).toBeVisible({ timeout: 10_000 });
+
+    // Story 2: opening the panel lists the web tip (and never the TUI-only one).
+    await badge.click();
+    await expect(page.getByRole("heading", { name: "Tips" })).toBeVisible();
+    await expect(page.getByText(PWA_TIP)).toBeVisible();
+    await expect(page.getByText("Reuse the selected session's settings")).toBeHidden();
+
+    // Story 3: reading (expanding) an unseen tip marks it seen on the server.
+    const postSeen = page.waitForResponse(
+      (r) => r.url().includes("/api/app-state/tip-seen") && r.request().method() === "POST",
+      { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: new RegExp(PWA_TIP) }).click();
+    expect((await postSeen).status()).toBe(200);
+    await page.getByRole("button", { name: "Close" }).click();
+
+    // Badge clears once the only tip is seen, and stays gone after a reload
+    // (seen state is server-side, so a new page load reads it back).
+    await expect(page.getByRole("button", { name: /tips?$/ })).toHaveCount(0);
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("button", { name: /tips?$/ })).toHaveCount(0);
+  } finally {
+    await serve.stop();
+  }
+});
+
+base("tips: Don't show again turns tips off across reloads", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
+    await dismissWelcome(page);
+
+    const badge = page.getByRole("button", { name: "1 tip" });
+    await expect(badge).toBeVisible({ timeout: 10_000 });
+    await badge.click();
+
+    const postDisable = page.waitForResponse(
+      (r) => r.url().includes("/api/tips/disable") && r.request().method() === "POST",
+      { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: "Don't show again" }).click();
+    expect((await postDisable).status()).toBe(200);
+
+    // Badge gone immediately and after a reload; GET /api/tips reports disabled.
+    await expect(page.getByRole("button", { name: /tips?$/ })).toHaveCount(0);
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("button", { name: /tips?$/ })).toHaveCount(0);
+    expect(
+      await page.evaluate(async () => {
+        const res = await fetch("/api/tips", { cache: "no-store" });
+        if (!res.ok) return true;
+        return (await res.json())?.enabled;
+      }),
+    ).toBe(false);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/tips.spec.ts
+++ b/web/tests/live/tips.spec.ts
@@ -1,25 +1,17 @@
-// User stories (issue #2292): the web dashboard mirrors the TUI tips system.
-// A fresh server has one web-eligible rotation tip ("Install the dashboard as
-// an app"), so the 💡 badge shows in the TopBar. Opening the panel and reading
-// a tip marks it seen (persisted via POST /api/app-state/tip-seen, shared with
-// the TUI), and "Don't show again" turns tips off (POST /api/tips/disable). Both
-// survive a reload via GET /api/tips. The TUI-only shortcut tip never appears.
-import { test as base, expect, type Page } from "@playwright/test";
+// User stories (issue #2292): the web dashboard mirrors the TUI tips system as a
+// GIMP/DBeaver-style tip-of-the-day. A fresh server has one web-eligible tip
+// ("Install the dashboard as an app"). The modal auto-pops on startup (once
+// onboarding settles), is reopenable from the top-bar menu, marks tips seen as
+// they are shown (persisted, shared with the TUI), and the "Show tips on
+// startup" checkbox persists via the dedicated endpoint. The TUI-only shortcut
+// tip never appears.
+import { test as base, expect } from "@playwright/test";
 import { spawnAoeServe } from "../helpers/aoeServe";
 
 const PWA_TIP = "Install the dashboard as an app";
+const TUI_TIP = "Reuse the selected session's settings";
 
-// A fresh $HOME shows the theme welcome modal first; dismiss it so the TopBar
-// badge is clickable. The tour does not auto-launch here (Playwright presents
-// navigator.webdriver = true, which suppresses it).
-async function dismissWelcome(page: Page) {
-  const welcome = page.getByText("Choose your theme");
-  if (await welcome.isVisible().catch(() => false)) {
-    await page.getByRole("button", { name: "Continue" }).click();
-  }
-}
-
-base("tips: badge surfaces a tip, reading it marks it seen across reloads", async ({ page }, testInfo) => {
+base("tips: auto-pops on startup and marks the shown tip seen", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
     authMode: "none",
     workerIndex: testInfo.workerIndex,
@@ -27,41 +19,42 @@ base("tips: badge surfaces a tip, reading it marks it seen across reloads", asyn
   });
 
   try {
-    await page.goto(serve.baseUrl);
-    await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
-    await dismissWelcome(page);
+    // Auto-pop is suppressed in automated sessions (navigator.webdriver) so the
+    // modal never intercepts the rest of the suite; present as a real browser to
+    // exercise it, and clear the other onboarding phases so tips pops cleanly:
+    // mark the theme welcome seen (localStorage) and the tour seen (server).
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "webdriver", { get: () => false });
+      window.localStorage.setItem("aoe-welcome-seen", "1");
+    });
+    await page.request.post(`${serve.baseUrl}/api/app-state/web-tour-seen`);
 
-    // Story 1: the badge shows for the single unseen web tip.
-    const badge = page.getByRole("button", { name: "1 tip" });
-    await expect(badge).toBeVisible({ timeout: 10_000 });
-
-    // Story 2: opening the panel lists the web tip (and never the TUI-only one).
-    await badge.click();
-    await expect(page.getByRole("heading", { name: "Tips" })).toBeVisible();
-    await expect(page.getByText(PWA_TIP)).toBeVisible();
-    await expect(page.getByText("Reuse the selected session's settings")).toBeHidden();
-
-    // Story 3: reading (expanding) an unseen tip marks it seen on the server.
     const postSeen = page.waitForResponse(
       (r) => r.url().includes("/api/app-state/tip-seen") && r.request().method() === "POST",
-      { timeout: 10_000 },
+      { timeout: 15_000 },
     );
-    await page.getByRole("button", { name: new RegExp(PWA_TIP) }).click();
+    await page.goto(serve.baseUrl);
+
+    // Story 1: the tip-of-the-day modal auto-pops, showing the web tip and never
+    // the TUI-only one.
+    await expect(page.getByRole("heading", { name: "Tip of the day" })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole("heading", { name: PWA_TIP })).toBeVisible();
+    await expect(page.getByText(TUI_TIP)).toBeHidden();
+
+    // Story 2: showing a tip marks it seen on the server.
     expect((await postSeen).status()).toBe(200);
     await page.getByRole("button", { name: "Close" }).click();
 
-    // Badge clears once the only tip is seen, and stays gone after a reload
-    // (seen state is server-side, so a new page load reads it back).
-    await expect(page.getByRole("button", { name: /tips?$/ })).toHaveCount(0);
+    // Once the only tip is seen, a reload does not re-pop it (no nagging).
     await page.reload();
     await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByRole("button", { name: /tips?$/ })).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "Tip of the day" })).toBeHidden();
   } finally {
     await serve.stop();
   }
 });
 
-base("tips: Don't show again turns tips off across reloads", async ({ page }, testInfo) => {
+base("tips: reopen from the menu and persist the startup toggle", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
     authMode: "none",
     workerIndex: testInfo.workerIndex,
@@ -69,26 +62,29 @@ base("tips: Don't show again turns tips off across reloads", async ({ page }, te
   });
 
   try {
+    // Default automated session: no auto-pop, so this drives the menu path.
     await page.goto(serve.baseUrl);
     await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
-    await dismissWelcome(page);
 
-    const badge = page.getByRole("button", { name: "1 tip" });
-    await expect(badge).toBeVisible({ timeout: 10_000 });
-    await badge.click();
+    // Story 3: reopen tips from the top-bar overflow menu.
+    await page.getByRole("button", { name: "More options" }).click();
+    await page.getByRole("menuitem", { name: "Tips" }).click();
+    await expect(page.getByRole("heading", { name: "Tip of the day" })).toBeVisible();
+    const checkbox = page.getByRole("checkbox", { name: "Show tips on startup" });
+    await expect(checkbox).toBeChecked();
 
-    const postDisable = page.waitForResponse(
-      (r) => r.url().includes("/api/tips/disable") && r.request().method() === "POST",
+    // Story 4: unchecking "Show tips on startup" persists through the dedicated
+    // endpoint and survives a reload.
+    const postShow = page.waitForResponse(
+      (r) => r.url().includes("/api/tips/show") && r.request().method() === "POST",
       { timeout: 10_000 },
     );
-    await page.getByRole("button", { name: "Don't show again" }).click();
-    expect((await postDisable).status()).toBe(200);
+    await checkbox.uncheck();
+    expect((await postShow).status()).toBe(200);
+    await page.getByRole("button", { name: "Close" }).click();
 
-    // Badge gone immediately and after a reload; GET /api/tips reports disabled.
-    await expect(page.getByRole("button", { name: /tips?$/ })).toHaveCount(0);
     await page.reload();
     await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByRole("button", { name: /tips?$/ })).toHaveCount(0);
     expect(
       await page.evaluate(async () => {
         const res = await fetch("/api/tips", { cache: "no-store" });
@@ -96,6 +92,11 @@ base("tips: Don't show again turns tips off across reloads", async ({ page }, te
         return (await res.json())?.enabled;
       }),
     ).toBe(false);
+
+    // Reopening from the menu shows the checkbox unchecked.
+    await page.getByRole("button", { name: "More options" }).click();
+    await page.getByRole("menuitem", { name: "Tips" }).click();
+    await expect(page.getByRole("checkbox", { name: "Show tips on startup" })).not.toBeChecked();
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/tips.spec.ts
+++ b/web/tests/live/tips.spec.ts
@@ -50,14 +50,20 @@ base("tips: auto-pops on startup and marks the shown tip seen", async ({ page },
     await page.getByRole("button", { name: "Close" }).click();
     await page.reload();
     await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
-    expect(
-      await page.evaluate(async () => {
-        const res = await fetch("/api/tips", { cache: "no-store" });
-        if (!res.ok) return false;
-        const data = await res.json();
-        return data.tips.find((t: { id: string }) => t.id === "install-dashboard-pwa")?.seen === true;
-      }),
-    ).toBe(true);
+    // The mark-seen POST returns 200 before the flag is flushed to config.toml
+    // (same as the tour-seen write), so poll rather than assert once.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async () => {
+            const res = await fetch("/api/tips", { cache: "no-store" });
+            if (!res.ok) return false;
+            const data = await res.json();
+            return data.tips.find((t: { id: string }) => t.id === "install-dashboard-pwa")?.seen === true;
+          }),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/tips.spec.ts
+++ b/web/tests/live/tips.spec.ts
@@ -35,20 +35,29 @@ base("tips: auto-pops on startup and marks the shown tip seen", async ({ page },
     );
     await page.goto(serve.baseUrl);
 
-    // Story 1: the tip-of-the-day modal auto-pops, showing the web tip and never
-    // the TUI-only one.
+    // Story 1: the tip-of-the-day modal auto-pops on the first unseen tip and
+    // never shows the TUI-only one. The PWA tip is the first web tip in the
+    // catalog, so it leads.
     await expect(page.getByRole("heading", { name: "Tip of the day" })).toBeVisible({ timeout: 15_000 });
     await expect(page.getByRole("heading", { name: PWA_TIP })).toBeVisible();
     await expect(page.getByText(TUI_TIP)).toBeHidden();
+    // Several web tips ship, so the carousel counter and navigation are present.
+    await expect(page.getByText(/Tip 1 of \d+/)).toBeVisible();
 
-    // Story 2: showing a tip marks it seen on the server.
+    // Story 2: showing a tip marks it seen on the server, and a reload reads
+    // that back (the PWA tip no longer leads).
     expect((await postSeen).status()).toBe(200);
     await page.getByRole("button", { name: "Close" }).click();
-
-    // Once the only tip is seen, a reload does not re-pop it (no nagging).
     await page.reload();
     await expect(page.getByRole("button", { name: "Go to dashboard" })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByRole("heading", { name: "Tip of the day" })).toBeHidden();
+    expect(
+      await page.evaluate(async () => {
+        const res = await fetch("/api/tips", { cache: "no-store" });
+        if (!res.ok) return false;
+        const data = await res.json();
+        return data.tips.find((t: { id: string }) => t.id === "install-dashboard-pwa")?.seen === true;
+      }),
+    ).toBe(true);
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -35,7 +35,10 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
     // Tips also auto-pop for returning users (tour seen) in a non-automated
     // session. This spec reloads into exactly that state, so turn tips off here
     // to keep the tour the only modal under test; tips have their own spec.
-    await page.request.post(`${serve.baseUrl}/api/tips/show`, { data: { enabled: false } });
+    const disableTipsRes = await page.request.post(`${serve.baseUrl}/api/tips/show`, {
+      data: { enabled: false },
+    });
+    expect(disableTipsRes.ok(), "failed to disable tips before tutorial isolation").toBeTruthy();
 
     await page.goto(serve.baseUrl);
 

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -32,6 +32,11 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
       Object.defineProperty(navigator, "webdriver", { get: () => false });
     });
 
+    // Tips also auto-pop for returning users (tour seen) in a non-automated
+    // session. This spec reloads into exactly that state, so turn tips off here
+    // to keep the tour the only modal under test; tips have their own spec.
+    await page.request.post(`${serve.baseUrl}/api/tips/show`, { data: { enabled: false } });
+
     await page.goto(serve.baseUrl);
 
     // Phase 1 of onboarding (#1834): the theme welcome modal shows first on a


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Surfaces the tips system on the web dashboard, mirroring the TUI (the follow-up tracked by #2292 after the TUI tips landed in #2282), and populates the catalog with tips for the dashboard's features.

The shared `crate::tips` engine is now surface-aware: each `Tip` lists the surfaces it applies to (TUI and/or Web) and every eligibility query takes a `TipSurface`, so keyboard-only hints stay out of the web and web-only hints stay out of the TUI.

On the web the tips render as a GIMP/DBeaver-style **tip-of-the-day modal**: one tip at a time with Previous / "Tip X of N" / Next, a "Show tips on startup" checkbox, and Close. It auto-pops once on startup when a tip is unseen and tips are on (gated behind first-run onboarding and suppressed in automated browser sessions so it can't intercept the rest of the suite), and is reopenable any time from the top-bar overflow menu (More options > Tips). Each tip is marked seen as it is shown; seen and the on/off preference persist server-side, shared with the TUI across devices.

Server endpoints (all read projections / single-purpose writes off the elevation wall, since `PATCH /api/settings` is passphrase-gated): `GET /api/tips` returns the web-surface tips with `enabled` and per-tip `seen`; `POST /api/app-state/tip-seen {id}` marks one seen (rejecting ids not in the catalog); `POST /api/tips/show {enabled}` is the "Show tips on startup" toggle.

Catalog: seven web feature-discovery tips (pin, archive, snooze, grouping, sorting, scratch sessions, multi-repo) written in web-gesture language, plus three grouped TUI keyboard-shortcut tips (core views, triage, power moves) whose key labels are resolved live so they stay correct in strict-hotkey mode. All rotation. No migration; the new rotation tips light the badge/modal once as a feature announcement, opt-out via Show tips.

Closes #2292

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe serve` on a fresh config. Open More options > Tips; confirm the "Tip of the day" modal opens and steps through the web tips with Next/Previous.
- [ ] Confirm the modal shows web tips (Install as an app, pin, archive, snooze, grouping, sorting, scratch, multi-repo) and never the TUI-only "Reuse the selected session's settings" tip.
- [ ] Read a tip, close, reload; confirm it does not re-show that tip (seen persists server-side; `GET /api/tips` reports `seen: true`).
- [ ] Uncheck "Show tips on startup"; reload and confirm it no longer auto-pops, and Settings > Interaction > Show tips is now off. Re-check it (or the setting) to turn it back on.
- [ ] On a fresh browser, get past the theme welcome + tour; confirm the tip-of-the-day auto-pops once on the first unseen tip.
- [ ] In the TUI, confirm the `N` / new-from-selection tip still earns and pops, and the new keyboard-shortcut tips show the correct keys (including in strict-hotkey mode).

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Live Playwright (`web/tests/live/tips.spec.ts`) covers the startup auto-pop marking the shown tip seen (persisted, no TUI-tip leak) and the menu-reopen path with the "Show tips on startup" toggle persisting. Vitest covers the TipsModal carousel (start index, Next/Previous + wrap, mark-seen on navigate, the checkbox, single-tip and empty states) and the TopBar "Tips" menu entry. Rust unit tests cover surface filtering, web-tips-carry-no-placeholders, the keybinding placeholder resolver, and id validation; the server read-only-guard audit covers the new write handlers.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The TUI gains three rotation tips and a generalized placeholder resolver; both are covered by the engine and home-view unit tests (the existing tips/overlay/home suites were extended).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, plan (with a multi-model `/debate` consult), and implementation drafted by Claude under my direction. I made the design calls, including pivoting from an initial badge to the tip-of-the-day modal and overriding the debate's "reuse PATCH /api/settings" verdict once it surfaced that path is elevation-gated. I reviewed each commit and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784731700&installation_id=139138837&pr_number=2332&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2332&signature=7c54fa66790a59570628e2e09c9def29e7aca999698c310d0ee482cdcf63c7ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR brings the existing “tips of the day” system to the web dashboard. It reuses the same shared Rust tips engine that powers the TUI, adds “where this tip should appear” rules (Web vs TUI), and then renders the web version as a one-tip-at-a-time modal with navigation, onboarding-safe auto-pop, and user-controlled “show on startup” + “seen” persistence.

## What changed

### Shared tips engine (Rust)
- Added **per-tip surface targeting** so Web-only tips don’t show up in the TUI, and TUI keyboard-shortcut tips don’t leak into the web.
- Updated the eligibility API to require a **target surface** (Web or TUI).
- Expanded the tip catalog with **Web feature-discovery tips** (multiple app/product discovery actions).
- Added **tip id validation** before marking tips as seen.
- Updated TUI tip rendering to **substitute all supported shortcut placeholders** (so keyboard labels resolve correctly in strict mode).

### Server API (web dashboard)
- Added **`GET /api/tips`** to return Web-eligible tips, including:
  - whether tips are enabled
  - per-tip `seen` status
- Added **`POST /api/app-state/tip-seen`** to mark a tip as seen (server persisted).
- Added **`POST /api/tips/show`** to toggle **“Show tips on startup”** (server persisted).
- All persistence is shared across web and TUI so the same user/tip state carries across devices.

### Web UI (React)
- Added a **Tip of the day modal** with:
  - one tip at a time
  - Previous/Next navigation (wraps)
  - Close + Escape handling
  - “Show tips on startup” checkbox
  - auto-marking tips as seen when shown/navigated to
- Implemented startup behavior to **auto-open once on page load** when conditions are met and suppresses auto-popup in automated browser sessions.
- Rewired modal opening into the **top-bar overflow menu**: **More options → Tips**.
- Refactored tips modal orchestration into a `useTips()` hook using a dedicated startup gate (`shouldAutoPopTips`).

## Testing
- Added **Vitest + React Testing Library** tests for the modal (navigation, close paths, checkbox behavior, edge cases).
- Added **unit tests** for `useTips()` and the startup gate logic.
- Added **Playwright live tests** validating:
  - correct Web-only tip selection vs TUI-only tip suppression
  - persistence of `seen` and enabled/disabled settings across reloads
  - the tutorial flow explicitly disables tips so the tutorial modal isn’t competing.
- Updated `web/tests/coverage-matrix.json` to include new coverage areas.

## Benefits
- **Consistent cross-platform onboarding**: one shared tips system with shared persistence across web and TUI.
- **Correct targeting**: surface tagging prevents the wrong style of tips (e.g., keyboard-shortcuts) from appearing on the web.
- **Better user control**: users can disable “show on startup,” close the modal, and reopen it later from the menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->