### PR TITLE
fix(acp): stop agent messages rendering twice from leaked consolidated chunk with absent id

### DIFF
--- a/acp-worker/test-shim/shim.mjs
+++ b/acp-worker/test-shim/shim.mjs
@@ -99,7 +99,7 @@ class ShimAgent {
         name: "@agentclientprotocol/claude-agent-acp",
         // Keep at (or above) the agent_compat floor in
         // src/acp/agent_compat.rs, or the gate rejects the shim's handshake.
-        version: "0.47.0",
+        version: "0.49.0",
       },
     };
   }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN npm install -g @qwen-code/qwen-code
 # `gemini --acp`, `vibe-acp`) are already provided by their respective
 # CLIs above.
 RUN npm install -g \
-    @agentclientprotocol/claude-agent-acp@^0.47.0 \
+    @agentclientprotocol/claude-agent-acp@^0.49.0 \
     @zed-industries/codex-acp \
     pi-acp
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3155,14 +3155,21 @@ fn is_compact_completion(text: &str) -> bool {
 /// switch, intermittent otherwise), so both reach us and every reducer appends
 /// both, doubling the message. See #2281.
 ///
-/// The schema guarantees that a change in `message_id` marks a new message, and
-/// the streamed deltas plus the empty block-start marker all share the streamed
-/// id while the leaked restatement carries a different one. So a non-empty chunk
-/// whose id differs from the open block and whose text restates the block's
-/// accumulated text is the leak; a same-id chunk is always a genuine delta and
-/// is never dropped (a legitimately repeated delta keeps the same id). Absent
-/// ids on either side degrade to never-drop, which leaves that rarer leak shape
-/// in place rather than risk corrupting real output.
+/// The adapter's `message_id` only ever marks a new message, never reuses one
+/// across messages, so a same-id chunk is always a genuine delta and is never
+/// dropped (a legitimately repeated delta keeps the same id, for example
+/// streamed "ha" then "ha"). Any other chunk whose text restates the open
+/// block's accumulated text verbatim is the leaked consolidated copy, regardless
+/// of whether its id is present, absent, or merely different from the block's.
+/// Matching on content rather than on both ids being present closes the
+/// id-presence-asymmetry hole the adapter hits when `message_start` carries no
+/// id: the streamed deltas then arrive id-less while the restatement still
+/// carries a fallback uuid, so the two ids differ and the restatement is caught.
+/// claude-agent-acp >=0.49.0 dedups by content upstream (#800), so this is a
+/// backstop for that and for any other adapter that leaks the copy. The only
+/// shape left unfiltered is both sides genuinely id-less, where a verbatim
+/// repeat is indistinguishable from a leak; that degrades to the same-id append
+/// path rather than risk corrupting real output.
 #[derive(Default)]
 struct AgentMessageDedup {
     block: Option<AgentTextBlock>,
@@ -3213,11 +3220,11 @@ impl AgentMessageDedup {
                 block.text.push_str(&t.text);
                 false
             }
-            Some(block)
-                if block.id.is_some() && chunk.message_id.is_some() && block.text == t.text =>
-            {
-                // Different message id restating the whole block verbatim: the
-                // leaked consolidated copy. Drop it and close the block.
+            Some(block) if block.text == t.text => {
+                // Arm 1 already consumed the equal-id case, so the ids differ
+                // here (present-and-different, or one side absent). A non-empty
+                // chunk restating the whole block verbatim under a different id
+                // is the leaked consolidated copy. Drop it and close the block.
                 self.block = None;
                 true
             }
@@ -7825,6 +7832,22 @@ mod tests {
         assert!(d.observe(&text_chunk(
             "Concrete repro. Let me inspect the events around lgtm and the \"Plan approved\" message in that session.",
             Some("m2")
+        )));
+    }
+
+    #[test]
+    fn dedup_drops_restatement_when_delta_ids_absent() {
+        // The recurrence (sessions 0c425453, 614231): when `message_start`
+        // carries no id, the streamed deltas arrive id-less, but the leaked
+        // consolidated copy still carries a fallback uuid. The ids differ by
+        // presence, so the verbatim restatement must still be dropped.
+        let mut d = AgentMessageDedup::default();
+        assert!(!d.observe(&text_chunk("", None)));
+        assert!(!d.observe(&text_chunk("Getting the real failure log,", None)));
+        assert!(!d.observe(&text_chunk(" not guessing this time.", None)));
+        assert!(d.observe(&text_chunk(
+            "Getting the real failure log, not guessing this time.",
+            Some("uuid-1")
         )));
     }
 

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -36,7 +36,7 @@ use super::state::StartupErrorDetail;
 /// sandbox image stuck below the host floor. User docs deliberately do not
 /// restate the number; the startup-error path reports the exact floor
 /// dynamically at rejection time.
-pub const CLAUDE_AGENT_ACP_MIN_VERSION: &str = "0.47.0";
+pub const CLAUDE_AGENT_ACP_MIN_VERSION: &str = "0.49.0";
 
 /// Parsed form of [`CLAUDE_AGENT_ACP_MIN_VERSION`]. Runs once per adapter
 /// initialize, not in a hot path, so parsing on demand is fine.

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -346,12 +346,12 @@ const INITIALIZE_RESULT = {
   agentInfo: {
     name: "@agentclientprotocol/claude-agent-acp",
     // Keep at (or above) the agent_compat floor in src/acp/agent_compat.rs
-    // (>=0.47.0, which adds the duplicate-message fix on top of 0.46's
-    // per-question "Other" boxes and PromptResponse-hang fix); the gate
+    // (>=0.49.0, which dedups streamed assistant blocks by content so the
+    // leaked consolidated restatement no longer doubles a message); the gate
     // rejects the fake's handshake otherwise, which fails every live
     // Playwright acp spec and the acp live-daemon e2e suite (#2077 bumped
     // the floor without this fixture and broke both).
-    version: "0.47.0",
+    version: "0.49.0",
   },
   // No authMethods key at all. An empty array is interpreted by some
   // ACP client implementations as "auth methods listed but none


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Agent messages were rendering twice in the structured view / web UI, the same doubling #2281 closed but reaching users again through a different trigger. Two fresh reproductions: session `0c425453db3b41b2` showed `Getting the real failure log, not guessing this time.` twice, and session `614231db...` doubled a streamed intro line.

Root cause is two layers. claude-agent-acp streams a text block as deltas, then re-sends the whole block as one consolidated `agent_message_chunk`. Its own dedup keys on the Anthropic message id; when `message_start` carries no id, the streamed deltas arrive id-less while the consolidated copy still carries a fallback uuid, so the ids do not match and the copy is forwarded. aoe's backstop (`AgentMessageDedup::observe`, added in #2308) had the same blind spot: it only dropped the restatement when both message ids were present, so the id-less-delta plus uuid-restatement shape fell through and the reducer appended it.

This PR fixes both ends:

- Backstop (`src/acp/acp_client.rs`): match the leaked restatement by content alone. Arm 1 already consumes the genuine equal-id delta case, so any later chunk that restates the whole accumulated block verbatim under a non-equal id is the leak and is dropped, whether its id is present, absent, or merely different. Both sides genuinely id-less still degrade to the append path, unchanged.
- Adapter floor (`src/acp/agent_compat.rs` and peers): raise the claude-agent-acp floor to `0.49.0`, which dedups streamed assistant blocks by content upstream (#800) and removes the leak at the source. Bumps the single-source const plus the Dockerfile npm pin and the two Node handshake fixtures that restate it.

User-observable impact: agent replies render once again.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run a structured-view session against claude-agent-acp and send a prompt that produces a multi-sentence reply; confirm the reply text appears once, not doubled.
- [ ] Stress the previous trigger (a model switch mid-session, e.g. Opus to Sonnet, then another prompt) and confirm replies still render once.
- [ ] Confirm the adapter gate: with claude-agent-acp `<0.49.0` installed, the handshake is rejected with a message naming the `0.49.0` floor; with `>=0.49.0` it connects.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

(Docs: no change. The fix is internal dedup logic plus a floor bump; the floor number is reported dynamically by the startup-error path and is deliberately not restated in user docs.)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The doubling is in the adapter-boundary dedup, not the dashboard. It is covered by a Rust unit test (`dedup_drops_restatement_when_delta_ids_absent` in `src/acp/acp_client.rs`), which fails on the pre-fix tree and passes after, alongside the existing `dedup_*` suite. The floor bump is guarded by `dockerfile_pin_matches_floor`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (both layers, content-primary matching) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784736263&installation_id=139138837&pr_number=2334&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2334&signature=13d5d9439ce38a2f0b44dac86e35285eb177a1f337dd683aa15288678e8f7644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a bug where agent messages were rendering twice in the structured view/web UI by addressing a message duplication issue in the ACP (Agent Client Protocol) handling.

## What Changed

**Core Fix (High Impact)**
- Updated the message deduplication logic in `src/acp/acp_client.rs` to correctly identify and drop duplicate message chunks. The dedup system now matches duplicate messages by comparing their content verbatim, rather than relying solely on message ID matching. This handles cases where streamed message deltas have no ID while the consolidated message copy has a fallback ID.
- Added a new unit test to validate that the deduplication works correctly when delta chunks lack IDs.

**Version Upgrades (Infrastructure)**
- Bumped the minimum required version of the `@agentclientprotocol/claude-agent-acp` package from `0.47.0` to `0.49.0` in:
  - `src/acp/agent_compat.rs` (the exported version constant)
  - `docker/Dockerfile` (Docker image npm installation)
  - `acp-worker/test-shim/shim.mjs` (test shim agent)
  - `web/tests/helpers/fakeAcpAgent.mjs` (test fake agent)

The version bump brings in native deduplication of streamed assistant blocks upstream, providing a preventative fix at the source.

## Key Benefits

- **Eliminates message duplication**: Agent replies now render once instead of twice in the UI
- **Two-layer fix**: Combines an upstream fix (native dedup in v0.49.0) with a backstop fix (content-based matching) for robustness
- **Backward compatible improvements**: The content-based matching handles edge cases where message IDs are absent or mismatched

<!-- end of auto-generated comment: release notes by coderabbit.ai -->