### PR TITLE
feat(web): scroll structured-view transcript file links to the cited line

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -332,9 +332,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [selectedFile, setSelectedFile] = useState<{
     path: string;
     repoName?: string;
+    /** 1-based source line to scroll into view, when the file was opened from a
+     *  transcript `path:line` link. Undefined for plain file-list clicks. */
+    line?: number;
   } | null>(null);
   const selectedFilePath = selectedFile?.path ?? null;
   const selectedRepoName = selectedFile?.repoName;
+  const selectedFileLine = selectedFile?.line;
   const [diffCollapsed, setDiffCollapsed] = useState(() => {
     const stored = safeGetItem(RIGHT_PANEL_COLLAPSED_KEY);
     if (stored === "1") return true;
@@ -806,8 +810,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     setPickerOpen(false);
   }, []);
 
-  const handleSelectFile = useCallback((path: string, repoName?: string) => {
-    setSelectedFile({ path, repoName });
+  const handleSelectFile = useCallback((path: string, repoName?: string, line?: number) => {
+    setSelectedFile({ path, repoName, line });
   }, []);
 
   // Open a local file reference cited in an acp transcript (Codex
@@ -815,8 +819,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // repo-relative path for the active session and open it in the in-app
   // diff/file viewer, keeping the current session route. A path outside
   // the session's known repo roots surfaces a non-destructive toast
-  // rather than navigating away. Line/column are parsed but not yet
-  // wired to viewer scroll-to-line. See #1718.
+  // rather than navigating away. The parsed line is threaded through so the
+  // viewer scrolls it into view. See #1718, #1809.
   const handleOpenFileRef = useCallback(
     (ref: FileRef) => {
       if (!activeSession) return;
@@ -825,7 +829,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         toastBus.handler?.error(`Could not open ${ref.path}: not inside this session's repo`);
         return;
       }
-      handleSelectFile(resolved.relativePath, resolved.repoName);
+      handleSelectFile(resolved.relativePath, resolved.repoName, ref.line);
     },
     [activeSession, handleSelectFile],
   );
@@ -1110,6 +1114,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           webSettings={webSettings}
           selectedFilePath={selectedFilePath}
           selectedRepoName={selectedRepoName}
+          selectedFileLine={selectedFileLine}
           revision={revision}
           diffFiles={diffFiles}
           perRepoBases={perRepoBases}
@@ -1168,6 +1173,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                   sessionId={activeSessionId}
                   filePath={selectedFilePath}
                   repoName={selectedRepoName}
+                  targetLine={selectedFileLine}
                   revision={revision}
                   onClose={handleCloseFile}
                   commentsEnabled={commentsEnabled}

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -23,6 +23,7 @@ interface Props {
   webSettings: { persistentTerminals: boolean; maxPersistentTerminals: number };
   selectedFilePath: string | null;
   selectedRepoName: string | undefined;
+  selectedFileLine: number | undefined;
   revision: number;
   diffFiles: RichDiffFile[];
   perRepoBases: RepoBase[];
@@ -63,6 +64,7 @@ export function MobileMainPane({
   webSettings,
   selectedFilePath,
   selectedRepoName,
+  selectedFileLine,
   revision,
   diffFiles,
   perRepoBases,
@@ -136,6 +138,7 @@ export function MobileMainPane({
                 sessionId={activeSessionId}
                 filePath={selectedFilePath}
                 repoName={selectedRepoName}
+                targetLine={selectedFileLine}
                 revision={revision}
                 onClose={onCloseFile}
                 commentsEnabled={commentsEnabled}

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -23,6 +23,9 @@ interface Props {
   /** Workspace repo name; passed through to the diff endpoint so the file is
    *  resolved against the correct repo for multi-repo workspaces. See #1047. */
   repoName?: string;
+  /** 1-based new-side source line to scroll into view (and highlight) when the
+   *  file is opened from a transcript `path:line` link. See #1809. */
+  targetLine?: number;
   /** Triggers a re-fetch when the file list changes. */
   revision?: number;
   /** Called when the user wants to return to the terminal view. */
@@ -69,10 +72,42 @@ type AnnotationMeta = { kind: "card"; anchored: AnchoredComment } | { kind: "for
 const sideToAnnotation = (side: DiffSide) => (side === "old" ? ("deletions" as const) : ("additions" as const));
 const annotationToSide = (side: "deletions" | "additions"): DiffSide => (side === "deletions" ? "old" : "new");
 
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+
+/** Approximate scroll fraction (0..1) for a new-side source line. The
+ *  Virtualizer has no scroll-to-line API, so we map the cited line to the
+ *  rendered diff rows: find the nearest changed new-side line and return its
+ *  rank among all rendered changed rows (deletions and additions, in render
+ *  order). This tracks where the diff content actually sits, unlike a raw
+ *  line/total-lines fraction which is wrong when unchanged regions are
+ *  collapsed. Falls back to a file-line fraction when the diff has no changed
+ *  new-side rows (e.g. a deletion-only patch). See #1809. */
+function targetScrollFraction(
+  meta: Parameters<typeof changedLines>[0],
+  targetLine: number,
+  newLineCount: number,
+): number {
+  const lines = changedLines(meta);
+  let bestIdx = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.side !== "new") continue;
+    const dist = Math.abs(lines[i]!.lineNumber - targetLine);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestIdx = i;
+    }
+  }
+  if (bestIdx < 0) return clamp01((targetLine - 1) / Math.max(1, newLineCount));
+  if (lines.length <= 1) return 0;
+  return bestIdx / (lines.length - 1);
+}
+
 export function DiffFileViewer({
   sessionId,
   filePath,
   repoName,
+  targetLine,
   revision,
   onClose,
   commentsEnabled = false,
@@ -102,6 +137,10 @@ export function DiffFileViewer({
   const scrollResetRef = useRef<HTMLDivElement | null>(null);
   const scrollerRef = useRef<HTMLElement | null>(null);
   const userScrolledRef = useRef(false);
+  // Scroll fraction to hold the diff at while a cited line is targeted; null
+  // means "hold at the top" (the default). Maintained across the virtualizer's
+  // async reflows by the ResizeObserver below, until the user scrolls. #1809.
+  const targetFracRef = useRef<number | null>(null);
 
   // Reset transient state when the viewer switches files / repos / sessions.
   // Synced at render time (not in an effect) to avoid set-state-in-effect.
@@ -238,14 +277,15 @@ export function DiffFileViewer({
       diffStyle: splitActive ? "split" : "unified",
       theme,
       disableFileHeader: true,
-      // Enable selection for commenting, and also while find is open so the
-      // jumped-to match line renders its selection highlight.
-      enableLineSelection: commentsActive || findOpen,
+      // Enable selection for commenting, while find is open so the jumped-to
+      // match renders its highlight, and when a cited line was targeted so its
+      // scroll-to highlight renders even in a non-comment session (#1809).
+      enableLineSelection: commentsActive || findOpen || targetLine != null,
       controlledSelection: true,
       onLineSelectionChange: setSelected,
       onLineSelected: handleLineSelected,
     }),
-    [splitActive, theme, commentsActive, findOpen, handleLineSelected],
+    [splitActive, theme, commentsActive, findOpen, targetLine, handleLineSelected],
   );
 
   // Searchable line set for find: the diff's changed lines, read straight off
@@ -286,11 +326,14 @@ export function DiffFileViewer({
     }
   }, []);
 
-  // Keep the diff scrolled to the top when a file first opens. The
-  // virtualized renderer reconciles row heights asynchronously (and again
-  // when off-thread highlighting lands), which otherwise settles the scroll
-  // position at the bottom of large diffs. We force the top across those
-  // reflows until the user scrolls, then get out of the way.
+  // Position the diff scroll when a file first opens: held at the top by
+  // default, or at the cited line's approximate fraction when opened from a
+  // transcript `path:line` link (#1809). The virtualized renderer reconciles
+  // row heights asynchronously (and again when off-thread highlighting lands),
+  // which otherwise settles the scroll elsewhere, so we re-apply the desired
+  // position across those reflows until the user scrolls, then get out of the
+  // way. Co-opting one observer (rather than racing a second effect against
+  // this one) keeps the target stable without polling.
   useEffect(() => {
     const wrap = scrollResetRef.current;
     if (!wrap) return;
@@ -299,16 +342,21 @@ export function DiffFileViewer({
     if (!scroller || !content) return;
     scrollerRef.current = scroller;
     userScrolledRef.current = false;
+    targetFracRef.current =
+      targetLine != null && fileDiff ? targetScrollFraction(fileDiff, targetLine, newContent.split("\n").length) : null;
+    const apply = () => {
+      if (userScrolledRef.current) return;
+      const frac = targetFracRef.current;
+      scroller.scrollTop = frac == null ? 0 : frac * (scroller.scrollHeight - scroller.clientHeight);
+    };
     const markUser = () => {
       userScrolledRef.current = true;
     };
     scroller.addEventListener("wheel", markUser, { passive: true });
     scroller.addEventListener("pointerdown", markUser, { passive: true });
     scroller.addEventListener("keydown", markUser);
-    scroller.scrollTop = 0;
-    const ro = new ResizeObserver(() => {
-      if (!userScrolledRef.current) scroller.scrollTop = 0;
-    });
+    apply();
+    const ro = new ResizeObserver(apply);
     ro.observe(content);
     return () => {
       ro.disconnect();
@@ -317,7 +365,16 @@ export function DiffFileViewer({
       scroller.removeEventListener("keydown", markUser);
       if (scrollerRef.current === scroller) scrollerRef.current = null;
     };
-  }, [resolvedPath, repoName, splitActive, oldContent, newContent]);
+  }, [resolvedPath, repoName, splitActive, oldContent, newContent, fileDiff, targetLine]);
+
+  // Highlight the cited line via the selection overlay once a target is set
+  // (selection rendering is enabled for it in `options`). Synced at render
+  // time would fight the comment-draft selection, so do it in an effect keyed
+  // to the file + target line. #1809.
+  useEffect(() => {
+    if (targetLine == null) return;
+    setSelected({ start: targetLine, end: targetLine, side: "additions", endSide: "additions" });
+  }, [targetLine, viewKey]);
 
   if (loading && !contents) {
     return (

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -16,6 +16,7 @@ import { DiffWorkerPoolProvider } from "./pierre/DiffWorkerPoolProvider";
 import { FindBar } from "./find/FindBar";
 import { changedLines } from "./find/changedLines";
 import type { FindMatch } from "./find/findMatches";
+import { targetScrollFraction } from "./scrollFraction";
 
 interface Props {
   sessionId: string;
@@ -72,37 +73,6 @@ type AnnotationMeta = { kind: "card"; anchored: AnchoredComment } | { kind: "for
 const sideToAnnotation = (side: DiffSide) => (side === "old" ? ("deletions" as const) : ("additions" as const));
 const annotationToSide = (side: "deletions" | "additions"): DiffSide => (side === "deletions" ? "old" : "new");
 
-const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
-
-/** Approximate scroll fraction (0..1) for a new-side source line. The
- *  Virtualizer has no scroll-to-line API, so we map the cited line to the
- *  rendered diff rows: find the nearest changed new-side line and return its
- *  rank among all rendered changed rows (deletions and additions, in render
- *  order). This tracks where the diff content actually sits, unlike a raw
- *  line/total-lines fraction which is wrong when unchanged regions are
- *  collapsed. Falls back to a file-line fraction when the diff has no changed
- *  new-side rows (e.g. a deletion-only patch). See #1809. */
-function targetScrollFraction(
-  meta: Parameters<typeof changedLines>[0],
-  targetLine: number,
-  newLineCount: number,
-): number {
-  const lines = changedLines(meta);
-  let bestIdx = -1;
-  let bestDist = Infinity;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i]!.side !== "new") continue;
-    const dist = Math.abs(lines[i]!.lineNumber - targetLine);
-    if (dist < bestDist) {
-      bestDist = dist;
-      bestIdx = i;
-    }
-  }
-  if (bestIdx < 0) return clamp01((targetLine - 1) / Math.max(1, newLineCount));
-  if (lines.length <= 1) return 0;
-  return bestIdx / (lines.length - 1);
-}
-
 export function DiffFileViewer({
   sessionId,
   filePath,
@@ -142,14 +112,19 @@ export function DiffFileViewer({
   // async reflows by the ResizeObserver below, until the user scrolls. #1809.
   const targetFracRef = useRef<number | null>(null);
 
-  // Reset transient state when the viewer switches files / repos / sessions.
-  // Synced at render time (not in an effect) to avoid set-state-in-effect.
-  const syncKey = JSON.stringify([sessionId, repoName ?? null, filePath, revision]);
+  // Reset transient state when the viewer switches files / repos / sessions,
+  // or when a new cited line is targeted. Synced at render time (not in an
+  // effect) to avoid set-state-in-effect. When a `path:line` link opened this
+  // file, seed the selection with the cited line so it renders highlighted
+  // (the scroll-to it lives in the effect below). #1809.
+  const syncKey = JSON.stringify([sessionId, repoName ?? null, filePath, revision, targetLine ?? null]);
   const [handledSyncKey, setHandledSyncKey] = useState(syncKey);
   if (syncKey !== handledSyncKey) {
     setHandledSyncKey(syncKey);
     setDraft(null);
-    setSelected(null);
+    setSelected(
+      targetLine != null ? { start: targetLine, end: targetLine, side: "additions", endSide: "additions" } : null,
+    );
     setFindOpen(false);
   }
 
@@ -366,15 +341,6 @@ export function DiffFileViewer({
       if (scrollerRef.current === scroller) scrollerRef.current = null;
     };
   }, [resolvedPath, repoName, splitActive, oldContent, newContent, fileDiff, targetLine]);
-
-  // Highlight the cited line via the selection overlay once a target is set
-  // (selection rendering is enabled for it in `options`). Synced at render
-  // time would fight the comment-draft selection, so do it in an effect keyed
-  // to the file + target line. #1809.
-  useEffect(() => {
-    if (targetLine == null) return;
-    setSelected({ start: targetLine, end: targetLine, side: "additions", endSide: "additions" });
-  }, [targetLine, viewKey]);
 
   if (loading && !contents) {
     return (

--- a/web/src/components/diff/__tests__/scrollFraction.test.ts
+++ b/web/src/components/diff/__tests__/scrollFraction.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { targetScrollFraction } from "../scrollFraction";
+
+type Meta = Parameters<typeof targetScrollFraction>[0];
+
+// Minimal FileDiffMetadata shape that `changedLines` walks: one hunk with a
+// single "change" segment. `additionLineIndex` is 0-based; changedLines emits
+// 1-based new-side line numbers (index + 1).
+function metaWithNewLines(firstNewLine: number, count: number): Meta {
+  const additionLines = Array.from({ length: firstNewLine - 1 + count }, (_, i) => `line ${i + 1}\n`);
+  return {
+    hunks: [
+      {
+        hunkContent: [
+          { type: "change", deletions: 0, additions: count, deletionLineIndex: 0, additionLineIndex: firstNewLine - 1 },
+        ],
+      },
+    ],
+    deletionLines: [],
+    additionLines,
+  } as unknown as Meta;
+}
+
+function metaDeletionOnly(firstOldLine: number, count: number): Meta {
+  const deletionLines = Array.from({ length: firstOldLine - 1 + count }, (_, i) => `line ${i + 1}\n`);
+  return {
+    hunks: [
+      {
+        hunkContent: [
+          { type: "change", deletions: count, additions: 0, deletionLineIndex: firstOldLine - 1, additionLineIndex: 0 },
+        ],
+      },
+    ],
+    deletionLines,
+    additionLines: [],
+  } as unknown as Meta;
+}
+
+describe("targetScrollFraction", () => {
+  it("maps an exact changed new line to its rank among changed rows", () => {
+    const meta = metaWithNewLines(10, 3); // changed new lines 10, 11, 12
+    expect(targetScrollFraction(meta, 10, 100)).toBe(0);
+    expect(targetScrollFraction(meta, 11, 100)).toBe(0.5);
+    expect(targetScrollFraction(meta, 12, 100)).toBe(1);
+  });
+
+  it("snaps to the nearest changed new line when the target is unchanged", () => {
+    const meta = metaWithNewLines(10, 3);
+    expect(targetScrollFraction(meta, 11, 100)).toBe(0.5); // closest to 11
+    expect(targetScrollFraction(meta, 500, 100)).toBe(1); // beyond last changed -> last row
+    expect(targetScrollFraction(meta, 1, 100)).toBe(0); // before first changed -> first row
+  });
+
+  it("returns 0 when there is a single changed row", () => {
+    const meta = metaWithNewLines(42, 1);
+    expect(targetScrollFraction(meta, 42, 100)).toBe(0);
+    expect(targetScrollFraction(meta, 9, 100)).toBe(0);
+  });
+
+  it("falls back to a clamped file-line fraction with no changed new rows", () => {
+    const meta = metaDeletionOnly(5, 4); // only deletions, no new-side rows
+    expect(targetScrollFraction(meta, 50, 100)).toBeCloseTo(0.49, 5); // (50-1)/100
+    expect(targetScrollFraction(meta, 1, 100)).toBe(0);
+    expect(targetScrollFraction(meta, 999, 100)).toBe(1); // clamped
+    expect(targetScrollFraction(meta, 10, 0)).toBe(1); // guards divide-by-zero -> clamped
+  });
+});

--- a/web/src/components/diff/scrollFraction.ts
+++ b/web/src/components/diff/scrollFraction.ts
@@ -1,0 +1,32 @@
+import { changedLines } from "./find/changedLines";
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+
+/** Approximate scroll fraction (0..1) for a new-side source line. The Pierre
+ *  Virtualizer has no scroll-to-line API, so we map the cited line to the
+ *  rendered diff rows: find the nearest changed new-side line and return its
+ *  rank among all rendered changed rows (deletions and additions, in render
+ *  order). This tracks where the diff content actually sits, unlike a raw
+ *  line/total-lines fraction which is wrong when unchanged regions are
+ *  collapsed. Falls back to a clamped file-line fraction when the diff has no
+ *  changed new-side rows (e.g. a deletion-only patch). See #1809. */
+export function targetScrollFraction(
+  meta: Parameters<typeof changedLines>[0],
+  targetLine: number,
+  newLineCount: number,
+): number {
+  const lines = changedLines(meta);
+  let bestIdx = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.side !== "new") continue;
+    const dist = Math.abs(lines[i]!.lineNumber - targetLine);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestIdx = i;
+    }
+  }
+  if (bestIdx < 0) return clamp01((targetLine - 1) / Math.max(1, newLineCount));
+  if (lines.length <= 1) return 0;
+  return bestIdx / (lines.length - 1);
+}

--- a/web/src/lib/fileRef.ts
+++ b/web/src/lib/fileRef.ts
@@ -8,8 +8,8 @@
 // mailto, ...) are left untouched. See #1718.
 
 /** A parsed local file reference. `line`/`column` are 1-based when the
- *  href carried a suffix; they are parsed but not yet wired to viewer
- *  scroll-to-line (follow-up). */
+ *  href carried a suffix. `line` is threaded through to the diff viewer to
+ *  scroll the cited line into view (#1809); `column` is parsed but unused. */
 export interface FileRef {
   path: string;
   line?: number;

--- a/web/tests/live/acp-file-links.spec.ts
+++ b/web/tests/live/acp-file-links.spec.ts
@@ -1,12 +1,17 @@
-// Live-backend spec: structured view transcript local file links (#1718).
+// Live-backend spec: structured view transcript local file links (#1718, #1809).
 //
-// Seeds a git repo with a committed-then-modified file so the diff
+// Seeds a git repo with committed-then-modified files so the diff
 // endpoint returns real content, registers it as a structured view session, and
-// scripts the fake ACP agent to emit an assistant message containing two
-// markdown links: one local file reference inside the worktree and one
-// absolute path outside any repo root. Drives the real UI:
+// scripts the fake ACP agent to emit an assistant message containing three
+// markdown links: an in-worktree file reference, a `path:line` reference deep
+// into a fully-rewritten (tall) file, and an absolute path outside any repo
+// root. Drives the real UI:
 //   - clicking the in-repo link opens the file in the in-app diff viewer
 //     and keeps the /session/<id> route (no navigation away),
+//   - clicking the `path:line` link scrolls the cited line into view (#1809):
+//     the row is virtualized and only mounts once scrolled near, so asserting
+//     its content is visible proves the scroll happened (it stays off-screen
+//     at the top without the fix),
 //   - clicking the out-of-repo link surfaces a non-destructive toast and
 //     leaves the route unchanged.
 
@@ -19,91 +24,128 @@ import { spawnAoeServe, listSessions, resolveAoeBinary } from "../helpers/aoeSer
 import { commitAll, initWorkingRepo, writeFiles } from "../helpers/gitFixture";
 import { enableStructuredViewAndWait, waitForStructuredView } from "../helpers/acp";
 
-base("structured view transcript file links open in-app and toast on miss", async ({ page }, testInfo) => {
-  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-acp-filelink-"));
-  const scriptPath = join(scriptDir, "script.json");
-  const outsidePath = "/tmp/aoe-1718-not-a-repo/missing.ts:1";
+// A unique token that only appears on the cited line (line 80) of the tall
+// file's modified content, so a viewport visibility check is unambiguous.
+const SCROLL_SENTINEL = "TARGET_SENTINEL_424242";
 
-  const serve = await spawnAoeServe({
-    authMode: "none",
-    acp: true,
-    fakeAcpScript: scriptPath,
-    workerIndex: testInfo.workerIndex,
-    parallelIndex: testInfo.parallelIndex,
-    seedFn: ({ home, env }) => {
-      const projectDir = join(home, "project");
-      initWorkingRepo(projectDir);
-      writeFiles(projectDir, { "src/a.ts": "export const a = 1;\n" });
-      commitAll(projectDir, "baseline");
-      writeFiles(projectDir, { "src/a.ts": "export const a = 11;\n" });
+// Baseline / modified contents for a 100-line file where every line is
+// rewritten, so the diff is tall enough that line 80 sits well below the fold
+// when the file first opens.
+function tallFile(): { baseline: string; modified: string } {
+  const lines: string[] = [];
+  for (let i = 0; i < 100; i++) lines.push(`export const v${i} = ${i};`);
+  const baseline = lines.join("\n") + "\n";
+  const modified =
+    lines.map((l, i) => (i === 79 ? `export const ${SCROLL_SENTINEL} = ${i};` : `${l} // edited`)).join("\n") + "\n";
+  return { baseline, modified };
+}
 
-      // `aoe add <dir>` makes project_path the modified working tree,
-      // so an absolute path under projectDir resolves to a repo file.
-      // Bake that path into the agent message now that home is known.
-      const inRepoLink = `${projectDir}/src/a.ts:1`;
-      writeFileSync(
-        scriptPath,
-        JSON.stringify({
-          turns: [
-            {
-              updates: [
-                {
-                  sessionUpdate: "agent_message_chunk",
-                  content: {
-                    type: "text",
-                    text: `See [a.ts](${inRepoLink}) and [missing](${outsidePath}).`,
+base(
+  "structured view transcript file links open in-app, scroll to cited line, and toast on miss",
+  async ({ page }, testInfo) => {
+    const scriptDir = mkdtempSync(join(tmpdir(), "aoe-acp-filelink-"));
+    const scriptPath = join(scriptDir, "script.json");
+    const outsidePath = "/tmp/aoe-1718-not-a-repo/missing.ts:1";
+
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      acp: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: ({ home, env }) => {
+        const projectDir = join(home, "project");
+        const tall = tallFile();
+        initWorkingRepo(projectDir);
+        writeFiles(projectDir, { "src/a.ts": "export const a = 1;\n", "src/long.ts": tall.baseline });
+        commitAll(projectDir, "baseline");
+        writeFiles(projectDir, { "src/a.ts": "export const a = 11;\n", "src/long.ts": tall.modified });
+
+        // `aoe add <dir>` makes project_path the modified working tree,
+        // so an absolute path under projectDir resolves to a repo file.
+        // Bake that path into the agent message now that home is known.
+        const inRepoLink = `${projectDir}/src/a.ts:1`;
+        const deepLink = `${projectDir}/src/long.ts:80`;
+        writeFileSync(
+          scriptPath,
+          JSON.stringify({
+            turns: [
+              {
+                updates: [
+                  {
+                    sessionUpdate: "agent_message_chunk",
+                    content: {
+                      type: "text",
+                      text: `See [a.ts](${inRepoLink}), [deep](${deepLink}) and [missing](${outsidePath}).`,
+                    },
                   },
-                },
-              ],
-              stopReason: "end_turn",
-            },
-          ],
-        }),
-      );
+                ],
+                stopReason: "end_turn",
+              },
+            ],
+          }),
+        );
 
-      const addRes = spawnSync(resolveAoeBinary(), ["add", projectDir, "-t", "acp-filelink", "-c", "claude"], { env });
-      if (addRes.status !== 0) {
-        throw new Error(`aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`);
-      }
-    },
-  });
-
-  try {
-    const sessions = await listSessions(serve.baseUrl);
-    const sessionId: string = sessions[0]!.id;
-    await enableStructuredViewAndWait(serve.baseUrl, sessionId);
-
-    await page.goto(`${serve.baseUrl}/session/${sessionId}`);
-    await waitForStructuredView(page);
-
-    // Trigger the scripted agent turn that emits the two links.
-    const promptRes = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/prompt`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: "show me the file" }),
+        const addRes = spawnSync(resolveAoeBinary(), ["add", projectDir, "-t", "acp-filelink", "-c", "claude"], {
+          env,
+        });
+        if (addRes.status !== 0) {
+          throw new Error(`aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`);
+        }
+      },
     });
-    expect(promptRes.status).toBeGreaterThanOrEqual(200);
-    expect(promptRes.status).toBeLessThan(300);
 
-    const sessionUrl = new RegExp(`/session/${sessionId}`);
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableStructuredViewAndWait(serve.baseUrl, sessionId);
 
-    // Out-of-repo link: clicking surfaces a toast and does not navigate.
-    const missingLink = page.getByRole("link", { name: "missing" });
-    await expect(missingLink).toBeVisible({ timeout: 15_000 });
-    await missingLink.click();
-    await expect(page.locator('[role="alert"]')).toContainText(/Could not open/i, { timeout: 10_000 });
-    await expect(page).toHaveURL(sessionUrl);
+      await page.goto(`${serve.baseUrl}/session/${sessionId}`);
+      await waitForStructuredView(page);
 
-    // In-repo link: clicking opens the file in the in-app diff viewer,
-    // showing the modified content, still on the same session route.
-    const fileLink = page.getByRole("link", { name: "a.ts" });
-    await expect(fileLink).toBeVisible();
-    await fileLink.click();
-    await expect(page.getByText(/export const a = 11/).first()).toBeVisible({
-      timeout: 10_000,
-    });
-    await expect(page).toHaveURL(sessionUrl);
-  } finally {
-    await serve.stop();
-  }
-});
+      // Trigger the scripted agent turn that emits the two links.
+      const promptRes = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/prompt`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "show me the file" }),
+      });
+      expect(promptRes.status).toBeGreaterThanOrEqual(200);
+      expect(promptRes.status).toBeLessThan(300);
+
+      const sessionUrl = new RegExp(`/session/${sessionId}`);
+
+      // Out-of-repo link: clicking surfaces a toast and does not navigate.
+      const missingLink = page.getByRole("link", { name: "missing" });
+      await expect(missingLink).toBeVisible({ timeout: 15_000 });
+      await missingLink.click();
+      await expect(page.locator('[role="alert"]')).toContainText(/Could not open/i, { timeout: 10_000 });
+      await expect(page).toHaveURL(sessionUrl);
+
+      // In-repo link: clicking opens the file in the in-app diff viewer,
+      // showing the modified content, still on the same session route.
+      const fileLink = page.getByRole("link", { name: "a.ts" });
+      await expect(fileLink).toBeVisible();
+      await fileLink.click();
+      await expect(page.getByText(/export const a = 11/).first()).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(page).toHaveURL(sessionUrl);
+
+      // `path:line` link: close the open file to reveal the transcript again,
+      // then click the deep link. Line 80 is virtualized far below the fold, so
+      // its content is only in the DOM and visible once the viewer scrolls to
+      // it. Without the scroll-to-line wiring the file opens at the top and the
+      // sentinel never mounts. See #1809.
+      await page.getByRole("button", { name: "Back to terminal" }).click();
+      const deepFileLink = page.getByRole("link", { name: "deep" });
+      await expect(deepFileLink).toBeVisible();
+      await deepFileLink.click();
+      await expect(page.getByText(new RegExp(SCROLL_SENTINEL)).first()).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(page).toHaveURL(sessionUrl);
+    } finally {
+      await serve.stop();
+    }
+  },
+);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to #1718. Clicking a Codex `path:line` file link in a structured-view transcript already opened the cited file in the in-app diff viewer, but the parsed line was dropped, so the file opened at the top. This wires line targeting end to end.

The already-parsed `FileRef.line` is threaded through `App` `selectedFile` state and `MobileMainPane` into a new `DiffFileViewer` `targetLine` prop. The `@pierre/diffs` Virtualizer exposes no scroll-to-line API and rows are virtualized, so the cited new-side line is mapped to an approximate scroll fraction computed from the rendered changed rows (reusing the existing `changedLines` helper), snapping to the nearest changed row when the exact line is unchanged. Rather than racing a second scroll effect, the existing keep-at-top `ResizeObserver` is co-opted to hold that fraction across the virtualizer's async reflows until the user scrolls. The line is highlighted via the selection overlay, with selection enabled for it even in non-comment sessions. A cited line outside any changed hunk degrades to the nearest row and never throws.

The raw `line / total-lines` approximation that the in-diff Find feature uses is wrong when unchanged regions are collapsed; this PR uses the hunk-aware fraction for the new path and leaves Find untouched (it could adopt the shared approach in a later change). The unchanged-file full viewer stays out of scope per the issue.

Closes #1809

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view (ACP) session and have the agent emit a transcript message with a `path:line` link into a changed file, e.g. `[file.ts](/abs/path/to/file.ts:80)`.
- [ ] Click the link: the file opens in the in-app diff viewer and line 80 is scrolled into view and highlighted, still on the same `/session/<id>` route.
- [ ] Click a link whose line falls outside any changed hunk: the viewer scrolls to the nearest changed row and does not error.
- [ ] Click a plain link with no `:line` suffix (or open a file from the right-panel file list): it still opens at the top, unchanged.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

(The live spec `web/tests/live/acp-file-links.spec.ts` was extended; the `acp.file-links` matrix entry already maps the changed `DiffFileViewer` / `MobileMainPane` components and this spec, so no new entry was needed.)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (cross-checked with a multi-model `/debate`), and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784744824&installation_id=139138837&pr_number=2338&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2338&signature=ad1f7f7e33e0e3383c7c4235d24ac216882749b185dbaf4acb928561f3e4637d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR enables end-to-end “path:line” file links (e.g., `file.ts:42`) in structured-view transcripts to open the file and automatically scroll to (and highlight) the referenced line. Previously, the file would open but always land at the top, forcing users to manually find the cited location.

## What Changed

- **Line references are now preserved end-to-end**
  - The app keeps the parsed line number when selecting/opening a file from a transcript.
  - The selected line number is passed down to the mobile and desktop diff viewers.
- **Diff viewer now supports scroll-to-line with highlighting**
  - When a target line is present, the diff viewer positions itself near the closest matching changed row and highlights the relevant line.
  - If the exact line isn’t part of any changed hunk, it **falls back gracefully** to the nearest reasonable location instead of failing.
- **Scroll behavior works with virtualized rendering**
  - Added logic to reliably apply the initial “scroll to line” behavior even with asynchronous re-rendering/virtualization.
  - Auto-scrolling stops once the user begins interacting, preventing it from fighting user scroll.
- **Tests added/expanded**
  - Updated Playwright coverage for structured-view `path:line` links to verify the scroll-to-line behavior (including virtualized content).
  - Added unit tests for the scroll-fraction mapping logic.

## Benefits

- **Much faster navigation**: users jump directly to the cited code line instead of scrolling manually.
- **Clear visual confirmation**: the target area is highlighted when the file opens.
- **Robust in edge cases**: lines outside changed hunks degrade to the nearest valid spot without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->