### PR TITLE
fix: prefill group profile for new sessions

### DIFF
--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -527,6 +527,11 @@ impl NewSessionDialog {
         self.group.value()
     }
 
+    #[cfg(test)]
+    pub fn profile_value(&self) -> &str {
+        self.selected_profile()
+    }
+
     /// Push a hook progress message into the dialog state
     pub fn push_hook_progress(&mut self, progress: HookProgress) {
         match progress {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2456,6 +2456,7 @@ impl HomeView {
             self.show_no_agents();
             return;
         }
+        let selected_group = self.new_session_group_prefill_from_cursor();
         let prefill_path = self
             .selected_session
             .as_ref()
@@ -2466,9 +2467,9 @@ impl HomeView {
                 // `'N'` on a group header): borrow a member's repo path so the
                 // new session lands in the same project, matching the web
                 // sidebar's per-project "+".
-                self.selected_group
+                selected_group
                     .as_ref()
-                    .and_then(|g| self.group_repo_path(g))
+                    .and_then(|(group, _)| self.group_repo_path(group))
             });
         let prefill_group = self
             .selected_session
@@ -2481,7 +2482,7 @@ impl HomeView {
                     Some(inst.group_path.clone())
                 }
             })
-            .or_else(|| self.selected_group.clone());
+            .or_else(|| selected_group.map(|(group, _)| group));
 
         if prefill_path.is_some() || prefill_group.is_some() {
             let existing_groups: Vec<String> =
@@ -2549,6 +2550,32 @@ impl HomeView {
                     None
                 }
             })
+    }
+
+    fn new_session_group_prefill_from_cursor(&self) -> Option<(String, Option<String>)> {
+        match self.flat_items.get(self.cursor) {
+            Some(Item::Group { path, .. }) if crate::session::is_archived_section_path(path) => {
+                None
+            }
+            Some(Item::Group {
+                path,
+                name,
+                profile,
+                ..
+            }) if crate::session::is_within_archived_section(path) => Some((
+                name.clone(),
+                profile
+                    .clone()
+                    .or_else(|| self.profile_for_cursor(self.cursor)),
+            )),
+            Some(Item::Group { path, profile, .. }) => Some((
+                path.clone(),
+                profile
+                    .clone()
+                    .or_else(|| self.profile_for_cursor(self.cursor)),
+            )),
+            _ => None,
+        }
     }
 
     fn attach_terminal_for_selected(&mut self) -> Option<Action> {
@@ -3612,14 +3639,22 @@ impl HomeView {
         }
         let existing_groups: Vec<String> =
             self.all_groups().iter().map(|g| g.path.clone()).collect();
-        let current_profile = self.config_profile();
+        let selected_group = self.new_session_group_prefill_from_cursor();
+        let current_profile = selected_group
+            .as_ref()
+            .and_then(|(_, profile)| profile.clone())
+            .unwrap_or_else(|| self.config_profile());
         let profiles = list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-        self.new_dialog = Some(NewSessionDialog::new(
+        let mut dialog = NewSessionDialog::new(
             self.available_tools.clone(),
             existing_groups,
             &current_profile,
             profiles,
-        ));
+        );
+        if let Some((group, _)) = selected_group {
+            dialog.set_group(group);
+        }
+        self.new_dialog = Some(dialog);
     }
 
     /// Open the tips overlay (the browsable list from `crate::tips`). Shared by

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4643,6 +4643,113 @@ fn test_shift_n_opens_prefilled_dialog_from_group() {
 
 #[test]
 #[serial]
+fn test_n_prefills_group_from_selected_group() {
+    let mut env = create_test_env_with_groups();
+
+    let group_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Group { path, .. } if path == "work"))
+        .expect("work group should exist in flat_items");
+    env.view.cursor = group_idx;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('n')), None);
+    let dialog = env.view.new_dialog.as_ref().expect("n should open dialog");
+    assert_eq!(dialog.group_value(), "work");
+}
+
+#[test]
+#[serial]
+fn test_n_prefilled_group_uses_group_profile() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let default_storage = Storage::new_unwatched("default").unwrap();
+    default_storage
+        .update(|i, g| {
+            let inst = Instance::new("Default", "/tmp/default");
+            *i = vec![inst.clone()];
+            *g = GroupTree::new_with_groups(&[inst], &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let alpha_storage = Storage::new_unwatched("alpha").unwrap();
+    alpha_storage
+        .update(|i, g| {
+            let mut inst = Instance::new("Security", "/tmp/security");
+            inst.group_path = "security".to_string();
+            *i = vec![inst.clone()];
+            *g = GroupTree::new_with_groups(&[inst], &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools, crate::file_watch::FileWatchService::noop()).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    let group_idx = view
+        .flat_items
+        .iter()
+        .position(|item| {
+            matches!(
+                item,
+                Item::Group { path, profile, .. }
+                    if path == "security" && profile.as_deref() == Some("alpha")
+            )
+        })
+        .expect("alpha security group should exist");
+    view.cursor = group_idx;
+    view.update_selected();
+
+    view.handle_key(key(KeyCode::Char('n')), None);
+    let dialog = view.new_dialog.as_ref().expect("n should open dialog");
+    assert_eq!(dialog.group_value(), "security");
+    assert_eq!(dialog.profile_value(), "alpha");
+}
+
+#[test]
+#[serial]
+fn test_n_prefills_group_from_archived_project_subgroup() {
+    use crate::session::config::GroupByMode;
+
+    let mut env = create_test_env_with_groups();
+    env.view
+        .instances
+        .iter_mut()
+        .find(|inst| inst.title == "work-project")
+        .expect("work-project session should exist")
+        .archive();
+    env.view.group_by = GroupByMode::Project;
+    env.view.archived_section_collapsed = false;
+    env.view.flat_items = env.view.build_flat_items();
+
+    let group_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| {
+            matches!(
+                item,
+                Item::Group { name, path, .. }
+                    if name == "work" && crate::session::is_within_archived_section(path)
+            )
+        })
+        .expect("archived work project subgroup should exist");
+    env.view.cursor = group_idx;
+    env.view.update_selected();
+    assert!(env.view.selected_group.is_none());
+
+    env.view.handle_key(key(KeyCode::Char('n')), None);
+    let dialog = env.view.new_dialog.as_ref().expect("n should open dialog");
+    assert_eq!(dialog.group_value(), "work");
+}
+
+#[test]
+#[serial]
 fn test_group_context_menu_new_session_prefills_path() {
     use crate::tui::dialogs::ContextMenuAction;
 


### PR DESCRIPTION
## Description
Use the group row under the TUI cursor to seed the New Session dialog.

This now carries both values from the selected row:
- Group, so rows like `security` do not open with a blank Group field
- Profile, so all-profiles mode creates the session under the selected group's profile instead of the default profile

## PR Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [x] New existing tests pass
- [x] Documentation updated where necessary
- [ ] For UI changes: included screenshot recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: PR does not change a user-facing dashboard flow
- [ ] Added or updated Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: PR does not change TUI rendering, CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: focused TUI unit tests cover key handling, dialog group state, and dialog profile state; no tmux or session lifecycle path changed.

## AI Usage
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Codex CLI

**Any Additional AI Details you'd like to share:** Codex CLI made the code changes and ran the checks.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

**Bug Fix**: The TUI “New Session” dialog now reliably pre-fills the **Group** field based on the **currently highlighted cursor row**, including when the row comes from an **archived project subgroup header** (where it could previously open with a blank Group).

**Key updates**
- `src/tui/home/input.rs`: Session creation now derives the prefill group (and, when available, the profile) from the cursor row instead of relying on `selected_group`.
- `src/tui/home/tests.rs`: Added unit tests covering:
  - normal group-header “new-from-selection”
  - profile-scoped group headers
  - archived subgroup header “new-from-selection”
- `src/tui/dialogs/new_session/mod.rs`: Added a small **test-only** helper to read the dialog’s selected profile (no production behavior change).

**What Was Added**
- A helper that computes the correct group to prefill from the cursor context (handling archived-section rows specially).
- Logic to set the dialog’s **Group** (and optionally **Profile**) before saving it for the user.

**What Was Removed**
- Dependence on `selected_group` for dialog prefill (since it can be unset for archived subgroup headers).

## Benefits

- **Correct context every time**: Creating a session from any TUI row now opens with the expected Group already filled in.
- **Fewer manual fixes**: Users no longer have to correct an empty Group field after opening the dialog.
- **More consistent behavior** across normal and archived sections.
- **Covered by unit tests**, including the archived subgroup edge case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->