### PR TITLE
fix(tui): treat Ctrl+J (bare LF) as a newline in agent message inputs

### DIFF
--- a/src/tui/dialogs/send_message.rs
+++ b/src/tui/dialogs/send_message.rs
@@ -104,6 +104,17 @@ impl SendMessageDialog {
                 self.text_area.insert_newline();
                 DialogResult::Continue
             }
+            // Ctrl+J is how crossterm decodes a bare line feed (\n, 0x0A) once
+            // raw mode is on; some terminals send that for Shift+Enter (e.g. a
+            // Ghostty `keybind = shift+enter=text:\n`). Treat it as a newline
+            // like the rest of the Enter family. Without this it falls through
+            // to the textarea, whose default binds Ctrl+J to delete-to-line-head
+            // and silently wipes the input.
+            KeyCode::Char('j') if ctrl => {
+                self.restore_armed = false;
+                self.text_area.insert_newline();
+                DialogResult::Continue
+            }
             // Plain Enter sends
             KeyCode::Enter => {
                 let value = self.get_text().trim().to_string();
@@ -282,6 +293,20 @@ mod tests {
         let mut dialog = SendMessageDialog::new("Test Session");
         dialog.handle_key(key(KeyCode::Char('a')));
         let result = dialog.handle_key(shift_key(KeyCode::Enter));
+        assert!(matches!(result, DialogResult::Continue));
+        dialog.handle_key(key(KeyCode::Char('b')));
+        assert_eq!(dialog.get_text(), "a\nb");
+    }
+
+    #[test]
+    fn test_ctrl_j_adds_newline() {
+        // crossterm decodes a bare line feed (\n, 0x0A) as Ctrl+J in raw mode;
+        // some terminals send that for Shift+Enter (e.g. Ghostty
+        // `keybind = shift+enter=text:\n`). It must insert a newline, not fall
+        // through to the textarea's delete-to-line-head default.
+        let mut dialog = SendMessageDialog::new("Test Session");
+        dialog.handle_key(key(KeyCode::Char('a')));
+        let result = dialog.handle_key(ctrl_key(KeyCode::Char('j')));
         assert!(matches!(result, DialogResult::Continue));
         dialog.handle_key(key(KeyCode::Char('b')));
         assert_eq!(dialog.get_text(), "a\nb");

--- a/src/tui/structured_view/input.rs
+++ b/src/tui/structured_view/input.rs
@@ -141,6 +141,14 @@ fn composer_keys(key: &KeyEvent, slash_picker_open: bool, mention_picker_open: b
         (m, KeyCode::Enter) if m.is_empty() => Intent::SubmitPrompt,
         // Shift+Enter inserts a newline (passed through to textarea).
         (m, KeyCode::Enter) if m.contains(KeyModifiers::SHIFT) => Intent::Compose(*key),
+        // Ctrl+J is crossterm's raw-mode decoding of a bare line feed (\n),
+        // which some terminals send for Shift+Enter (e.g. a Ghostty
+        // `keybind = shift+enter=text:\n`). Forward a plain Enter so the
+        // textarea inserts a newline; passing the raw Ctrl+J through would hit
+        // the textarea's default delete-to-line-head binding and wipe the line.
+        (m, KeyCode::Char('j')) if m == KeyModifiers::CONTROL => {
+            Intent::Compose(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        }
         // Esc moves focus to the transcript so the user can scroll or
         // pick an approval card. This also dismisses any accidental
         // composer focus (e.g. after typing then changing their mind).
@@ -363,6 +371,23 @@ mod tests {
             ctx(),
         );
         assert!(matches!(intent, Intent::Compose(_)));
+    }
+
+    #[test]
+    fn ctrl_j_in_composer_inserts_newline() {
+        // A bare line feed (\n) decodes to Ctrl+J in raw mode; some terminals
+        // send it for Shift+Enter (e.g. Ghostty `shift+enter=text:\n`). It must
+        // forward a plain Enter so the textarea inserts a newline rather than
+        // running its default Ctrl+J delete-to-line-head binding.
+        let intent = dispatch(
+            Focus::Composer,
+            &key_mod(KeyCode::Char('j'), KeyModifiers::CONTROL),
+            ctx(),
+        );
+        assert_eq!(
+            intent,
+            Intent::Compose(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Pressing **Shift+Enter** in the send-message dialog (the `m` command) and in the structured-view composer could **silently wipe the entire typed input** instead of inserting a newline.

### How it was discovered

Initial guess was that Shift+Enter was indistinguishable from plain Enter (so it "submitted"). A maintainer correctly pushed back: it doesn't submit, it *clears* the input. Rather than have anyone reproduce by hand, the terminal's own keymap was inspected:

```
$ ghostty +list-keybinds | grep enter
keybind = shift+enter=text:\n     # present
$ ghostty +list-keybinds --default | grep enter
# (shift+enter absent — this is a user override, not a Ghostty default)
```

That surfaced the real chain:

1. The user's Ghostty has `keybind = shift+enter=text:\n`, so Shift+Enter emits a **literal line feed** (`\n`, `0x0A`).
2. **crossterm** in raw mode maps `0x0A` → **Ctrl+J**, not Enter. This is deliberate (`crossterm .../parse.rs`): a bare `\n` only means Enter when raw mode is *off*; in raw mode it's decoded as Ctrl+J.
3. Neither the dialog nor the composer had a Ctrl+J branch, so the event fell through to `ratatui-textarea`.
4. ratatui-textarea's default binds **Ctrl+J → `delete_line_by_head()`** (delete from cursor to start of line). On a single-line message that deletes everything — the observed "clears the input".

Plain Enter is unaffected: it arrives as `\r` (`0x0D`) → `KeyCode::Enter` → submit.

### Why someone would have this Ghostty override

It is a **very common** Ghostty config for chat/REPL/AI-agent tooling. Out of the box Ghostty has no `shift+enter` binding, so Shift+Enter sends the same bytes as Enter and apps can't tell them apart. To get the familiar "Enter sends, Shift+Enter adds a newline" behavior (Slack/Discord/ChatGPT-style), users add `keybind = shift+enter=text:\n` (or `text:\x1b\r`). So the people most likely to hit this bug are exactly the ones who set up their terminal to make multi-line agent prompts pleasant.

### Fix

Treat Ctrl+J (a bare LF in raw mode) as a newline — Enter-family semantics — in both message-to-agent inputs:

- `src/tui/dialogs/send_message.rs`: new `Char('j') if ctrl` branch → `insert_newline()`.
- `src/tui/structured_view/input.rs`: Ctrl+J forwards a plain Enter so the composer textarea inserts a newline.

Nothing is lost by overriding the textarea's obscure Ctrl+J default: Ctrl+U is already the documented kill-to-line-start in the dialog.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (the change is in native TUI key dispatch)

**TUI / CLI (e2e test)**
- [x] Added or updated a test: unit regression tests `test_ctrl_j_adds_newline` (send-message dialog) and `ctrl_j_in_composer_inserts_newline` (structured-view composer), alongside the existing Shift+Enter / Alt+Enter newline tests.

## How I tested

- `cargo test --features serve` — dialog + composer suites pass, including the two new Ctrl+J regression tests.
- `cargo fmt`, `cargo clippy --features serve` clean (one unrelated pre-existing warning in `dialogs/serve.rs`).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Used to investigate the root cause (inspecting crossterm and ratatui-textarea source + the Ghostty keymap) and implement the fix with regression tests.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784763757&installation_id=139138837&pr_number=2342&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2342&signature=07795ae56fff3891b0159fdf9c9c4995841afec9c06836126c10fec8039e45bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->