### PR TITLE
fix(tui): scope group identity by profile to stop same-named group key conflicts

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3845,8 +3845,16 @@ impl HomeView {
                 .clone()
                 .unwrap_or_else(|| self.config_profile());
             let profiles = list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-            let existing_groups: Vec<String> =
-                self.all_groups().iter().map(|g| g.path.clone()).collect();
+            // Duplicate-name validation is per-profile (rename_selected_group
+            // checks only the target profile's tree), so the dialog's existing
+            // names must be scoped to this group's profile too. Spanning all
+            // profiles would falsely block renaming to a name that only
+            // collides with a same-named group in a different profile.
+            let existing_groups: Vec<String> = self
+                .group_trees
+                .get(&current_profile)
+                .map(|t| t.get_all_groups().iter().map(|g| g.path.clone()).collect())
+                .unwrap_or_default();
             self.group_rename_context = Some(super::GroupRenameContext {
                 old_path: group_path.clone(),
                 old_profile: current_profile.clone(),
@@ -3990,16 +3998,31 @@ impl HomeView {
                 self.info_dialog = Some(InfoDialog::new("Cannot Modify Project Groups", hint));
                 return;
             }
+            // Scope the count to the selected group's profile: two groups in
+            // different profiles can share a path, and counting by path alone
+            // would pop the "delete N sessions" options dialog for an empty
+            // group whose same-named twin in another profile still has rows.
+            let owning_profile = self.selected_group_profile.clone();
             let prefix = format!("{}/", group_path);
             let session_count = self
                 .instances
                 .iter()
-                .filter(|i| i.group_path == *group_path || i.group_path.starts_with(&prefix))
+                .filter(|i| {
+                    (i.group_path == *group_path || i.group_path.starts_with(&prefix))
+                        && owning_profile
+                            .as_ref()
+                            .is_none_or(|p| &i.source_profile == p)
+                })
                 .count();
 
             if session_count > 0 {
-                let has_managed_worktrees = self.group_has_managed_worktrees(group_path, &prefix);
-                let has_containers = self.group_has_containers(group_path, &prefix);
+                let has_managed_worktrees = self.group_has_managed_worktrees(
+                    group_path,
+                    &prefix,
+                    owning_profile.as_deref(),
+                );
+                let has_containers =
+                    self.group_has_containers(group_path, &prefix, owning_profile.as_deref());
                 self.group_delete_options_dialog = Some(GroupDeleteOptionsDialog::new(
                     group_path.clone(),
                     session_count,

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -711,9 +711,15 @@ impl HomeView {
         Ok(())
     }
 
-    pub(super) fn group_has_managed_worktrees(&self, group_path: &str, prefix: &str) -> bool {
+    pub(super) fn group_has_managed_worktrees(
+        &self,
+        group_path: &str,
+        prefix: &str,
+        owning_profile: Option<&str>,
+    ) -> bool {
         self.instances().iter().any(|i| {
             (i.group_path == group_path || i.group_path.starts_with(prefix))
+                && owning_profile.is_none_or(|p| i.source_profile == p)
                 && (i.worktree_info.as_ref().is_some_and(|wt| wt.managed_by_aoe)
                     || i.workspace_info
                         .as_ref()
@@ -721,9 +727,15 @@ impl HomeView {
         })
     }
 
-    pub(super) fn group_has_containers(&self, group_path: &str, prefix: &str) -> bool {
+    pub(super) fn group_has_containers(
+        &self,
+        group_path: &str,
+        prefix: &str,
+        owning_profile: Option<&str>,
+    ) -> bool {
         self.instances().iter().any(|i| {
             (i.group_path == group_path || i.group_path.starts_with(prefix))
+                && owning_profile.is_none_or(|p| i.source_profile == p)
                 && i.sandbox_info.as_ref().is_some_and(|s| s.enabled)
         })
     }
@@ -1104,6 +1116,13 @@ impl HomeView {
                             }
                         }
                     })?;
+
+                    // Drop the source profile's now-empty copy of the group so
+                    // it does not linger as a duplicate header alongside the
+                    // target profile's copy in unified view. `current_group` is
+                    // the session's pre-move path; the restart-with-edits path
+                    // does the same after its own `move_to_profile`.
+                    self.prune_empty_group(&current_profile, &current_group);
 
                     self.rebuild_group_trees();
                     if !effective_group.is_empty() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2344,8 +2344,8 @@ fn test_group_has_managed_worktrees() {
     view.flat_items = view.build_flat_items();
     view.update_selected();
 
-    assert!(view.group_has_managed_worktrees("work", "work/"));
-    assert!(!view.group_has_managed_worktrees("other", "other/"));
+    assert!(view.group_has_managed_worktrees("work", "work/", None));
+    assert!(!view.group_has_managed_worktrees("other", "other/", None));
 }
 
 #[test]
@@ -2394,8 +2394,8 @@ fn test_group_has_containers() {
     view.flat_items = view.build_flat_items();
     view.update_selected();
 
-    assert!(view.group_has_containers("work", "work/"));
-    assert!(!view.group_has_containers("other", "other/"));
+    assert!(view.group_has_containers("work", "work/", None));
+    assert!(!view.group_has_containers("other", "other/", None));
 }
 
 #[test]
@@ -4592,6 +4592,136 @@ fn test_delete_group_scoped_to_owning_profile() {
     assert_eq!(
         beta_inst.group_path, "work",
         "beta's instance should still be in 'work'"
+    );
+}
+
+/// Opening the group-delete dialog must scope its session count to the
+/// selected group's profile. Two profiles can own a same-named group; an
+/// empty group in one profile should open the simple confirm, not the
+/// "delete N sessions" options dialog driven by its populated twin in
+/// another profile. Regression for the group-key conflict where the empty
+/// group was not the one the delete modal acted on.
+#[test]
+#[serial]
+fn test_group_delete_dialog_scoped_to_owning_profile() {
+    use crate::session::GroupTree;
+
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    // alpha owns an EMPTY "work" group (group exists, no sessions).
+    let storage_a = Storage::new_unwatched("alpha").unwrap();
+    let mut tree_a = GroupTree::new_with_groups(&[], &[]);
+    tree_a.create_group("work");
+    storage_a
+        .update(|i, g| {
+            *i = vec![];
+            *g = tree_a.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    // beta owns a same-named "work" group that still has a session.
+    let storage_b = Storage::new_unwatched("beta").unwrap();
+    let mut inst_b = Instance::new("B1", "/tmp/b");
+    inst_b.group_path = "work".to_string();
+    let tree_b = GroupTree::new_with_groups(&[inst_b.clone()], &[]);
+    storage_b
+        .update(|i, g| {
+            *i = [inst_b].to_vec();
+            *g = tree_b.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools, crate::file_watch::FileWatchService::noop()).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    // Select alpha's (empty) "work" group.
+    let work_indices: Vec<usize> = view
+        .flat_items
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, item)| match item {
+            Item::Group { path, .. } if path == "work" => Some(idx),
+            _ => None,
+        })
+        .collect();
+    for idx in work_indices {
+        view.cursor = idx;
+        view.update_selected();
+        if view.selected_group_profile.as_deref() == Some("alpha") {
+            break;
+        }
+    }
+    assert_eq!(view.selected_group_profile.as_deref(), Some("alpha"));
+
+    view.open_delete_for_selected();
+
+    assert!(
+        view.group_delete_options_dialog.is_none(),
+        "empty group must not trigger the with-sessions options dialog from a same-named group in another profile"
+    );
+    assert!(
+        view.confirm_dialog.is_some(),
+        "empty group should open the simple delete-group confirm"
+    );
+}
+
+/// Changing a session's profile via the rename dialog must prune the
+/// source profile's now-empty group, just like the restart-with-edits
+/// path does. Without the prune the source keeps an empty group with the
+/// same name as the target's copy, which renders as a duplicate header and
+/// collides on the shared group key.
+#[test]
+#[serial]
+fn test_rename_profile_change_prunes_source_group() {
+    use crate::session::GroupTree;
+
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    // alpha has one session in "work"; beta exists but is empty.
+    let storage_a = Storage::new_unwatched("alpha").unwrap();
+    let mut inst_a = Instance::new("A1", "/tmp/a");
+    inst_a.group_path = "work".to_string();
+    let id = inst_a.id.clone();
+    let tree_a = GroupTree::new_with_groups(&[inst_a.clone()], &[]);
+    storage_a
+        .update(|i, g| {
+            *i = [inst_a].to_vec();
+            *g = tree_a.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+    let _storage_b = Storage::new_unwatched("beta").unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools, crate::file_watch::FileWatchService::noop()).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.selected_session = Some(id.clone());
+
+    // Move the session alpha -> beta, keeping the same group name.
+    view.rename_selected("", None, Some("beta"), false).unwrap();
+
+    let moved = view.instances().iter().find(|i| i.id == id).unwrap();
+    assert_eq!(moved.source_profile, "beta");
+    assert_eq!(moved.group_path, "work");
+    assert!(
+        view.group_trees.get("beta").unwrap().group_exists("work"),
+        "beta should own the 'work' group after the move"
+    );
+    assert!(
+        !view
+            .group_trees
+            .get("alpha")
+            .map(|t| t.group_exists("work"))
+            .unwrap_or(false),
+        "alpha's now-empty 'work' group should be pruned after the profile move"
     );
 }
 


### PR DESCRIPTION
## Description

Session groups are really keyed by `(profile, path)`, but three TUI paths keyed by `path` alone. When a session's profile is changed and then changed back, the source profile keeps an empty group with the same name as the target profile's copy, and the two collide on the shared key. Symptoms: a duplicate 0-session group appears, and deleting/renaming it acts on the wrong group.

This only affects the native TUI (the web sidebar derives groups from sessions, so a 0-session group never renders there).

### Fixes

- **`rename_selected` (`operations.rs`)** — after a session's profile changes, prune the source profile's now-empty group, mirroring the restart-with-edits path that already does this. This is the root cause: it's what created the duplicate empty group in the first place.
- **`open_delete_for_selected` (`input.rs`)** — scope the group session count (and the managed-worktree / container checks) to the selected group's profile. Previously the count was path-only, so selecting an empty group counted its populated same-named twin in another profile and popped the "delete N sessions" options dialog instead of the empty-group confirm. (`delete_group_with_sessions` was already profile-scoped; only the dialog's count wasn't.)
- **Group rename dialog (`input.rs`)** — scope `existing_groups` to the group's own profile so the duplicate-name validation matches the per-profile backend check (`rename_selected_group`) instead of falsely blocking on a name that only collides in a different profile.

### Behavior note

This prevents new duplicates and makes existing ones deletable correctly. A duplicate empty group already persisted in `groups.json` won't auto-clean until a move next touches it, but it can now be deleted directly because the delete dialog targets the right group.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (n/a)
- [x] For UI changes: included screenshot or recording (n/a — no visual change; behavior fix in TUI dialog routing)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (TUI-only; web groups derive from sessions and never show a 0-session group)

**TUI / CLI (e2e test)**
- [x] Skipped a full `tests/e2e/` test, because: the change is profile-keying logic in the HomeView layer, fully exercised by two new integration tests in `src/tui/home/tests.rs` that drive the real selection + dialog code:
  - `test_group_delete_dialog_scoped_to_owning_profile` — selecting an empty group whose name is shared by a populated group in another profile opens the simple confirm, not the with-sessions options dialog.
  - `test_rename_profile_change_prunes_source_group` — moving a session's profile via `rename_selected` prunes the source profile's now-empty group.
  - Helper signature change covered by updated `test_group_has_managed_worktrees` / `test_group_has_containers`.

How tested: `cargo fmt --check`, `cargo clippy --lib`, `cargo test --lib tui::home::` (606 pass).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784764755&installation_id=139138837&pr_number=2343&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2343&signature=98b04bc8c80bbe75409c5bf59f7b8070c815466d3c996ec2da4f08a2292028bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request fixes a bug in the native TUI where session groups with the same name in different profiles were interfering with each other, causing incorrect dialogs to appear, wrong groups to be deleted, and duplicate group headers to appear when users switched a session between profiles.

## What Changed

**Three core fixes were made to scope group operations by profile:**

1. **Group deletion** (`input.rs`): When checking whether to show options for deleting a group, the code now counts sessions only within that group's profile instead of counting across all profiles with the same group name. This prevents showing "delete N sessions" dialogs when the selected group is actually empty.

2. **Group renaming** (`input.rs`): When validating group names during a rename, the code now checks for duplicates only within the same profile instead of globally. This prevents incorrectly blocking renames when the new name exists in a different profile.

3. **Profile changes** (`operations.rs`): When a session is moved to a different profile, the code now removes the empty group left behind in the original profile, preventing duplicate group headers from appearing.

**Tests added**: Two new regression tests verify that the delete dialog correctly handles profile-scoped groups and that moving a session between profiles properly cleans up empty groups.

## Benefits

- Users can now have identically-named session groups in different profiles without conflicts
- Delete and rename operations target the correct group
- No duplicate empty group headers appear after profile changes
- The fix is contained to the TUI layer and doesn't affect the web interface

---

## Technical Details

The root cause was that three TUI code paths were keying groups by `path` alone, while the backend uses composite keys of `(profile, path)`. This mismatch caused same-named groups in different profiles to collide in the TUI logic.

**Changes made:**

- `group_has_managed_worktrees()` and `group_has_containers()` in `operations.rs` now accept an `owning_profile` parameter to scope session filtering by both group path and profile
- `open_delete_for_selected()` in `input.rs` now passes the selected group's profile when checking for managed worktrees/containers
- `open_rename_for_selected()` in `input.rs` now collects existing group names only from the current profile's group tree
- `rename_selected()` in `operations.rs` now calls `prune_empty_group()` after moving a group to a different profile
- Updated call sites in `tests.rs` to pass the new `owning_profile` parameter (passing `None` where profile-scoping isn't needed)

The changes align the TUI's group keying with the backend's `(profile, path)` composite key semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->