### PR TITLE
fix(session): prefer authoritative hook sidecar over mtime scan on Claude resume

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -783,6 +783,16 @@ pub(crate) fn persist_session_to_storage(
     }
 }
 
+/// Emit `fresh` only when it differs from the stored session id, the
+/// "override only when distinct" contract shared by both branches of
+/// `capture_freshest_session_id` (sidecar and mtime fallback).
+fn override_if_distinct(stored: Option<&str>, fresh: String) -> Option<String> {
+    match stored {
+        Some(known) if known == fresh => None,
+        _ => Some(fresh),
+    }
+}
+
 /// Publish a captured session ID to the tmux environment only.
 ///
 /// Background threads (poller on_change) call this so that
@@ -1601,32 +1611,38 @@ impl Instance {
     /// For Claude the authoritative per-instance sidecar
     /// (`/tmp/aoe-hooks-<euid>/<instance_id>/session_id`, written by the
     /// SessionStart / UserPromptSubmit hooks) is consulted first. It is keyed
-    /// by instance id, so it can never name a peer instance's conversation —
+    /// by instance id, so it can never name a peer instance's conversation,
     /// unlike the mtime disk scan, which picks the most-recent jsonl in the
     /// shared `~/.claude/projects/<encoded-cwd>/` dir and so can select a
     /// co-located peer's session when several AoE sessions share one cwd
     /// (#2344). The mtime scan is only used as a fallback when no fresh
     /// sidecar exists (e.g. an old session resumed after the 5-minute
     /// sidecar window), matching the ordering already used by
-    /// `claude_poll_fn`.
+    /// `claude_poll_fn`. Sandboxed Claude is included: its `SessionStart`
+    /// hook writes through the `/tmp/aoe-hooks/<id>` bind-mount onto the
+    /// host path, so `read_hook_session_id` reads it the same way, and the
+    /// mtime fallback below still routes through the container-aware branch
+    /// of `try_retroactive_capture`.
+    ///
+    /// Two deliberate divergences from `claude_poll_fn`, both correct for the
+    /// resume context: (1) an excluded sidecar id returns `None` here rather
+    /// than falling through to the mtime scan, since falling through is what
+    /// re-opens #2344; (2) this reader and `claude_poll_fn` read the same
+    /// sidecar without a shared snapshot, so a hook rotation between the two
+    /// reads can briefly surface different UUIDs, benign under the existing
+    /// eventual-consistency capture model.
     pub(crate) fn capture_freshest_session_id(&self) -> Option<String> {
-        if self.tool == "claude" && !self.is_sandboxed() {
+        if self.tool == "claude" {
             if let Some(authoritative) = crate::hooks::read_hook_session_id(&self.id) {
                 if self.retroactive_capture_excludes.contains(&authoritative) {
                     return None;
                 }
-                return match self.agent_session_id.as_deref() {
-                    Some(known) if known == authoritative => None,
-                    _ => Some(authoritative),
-                };
+                return override_if_distinct(self.agent_session_id.as_deref(), authoritative);
             }
         }
 
         let live = self.try_retroactive_capture()?;
-        match self.agent_session_id.as_deref() {
-            Some(known) if known == live => None,
-            _ => Some(live),
-        }
+        override_if_distinct(self.agent_session_id.as_deref(), live)
     }
 
     fn apply_session_flags(&mut self, cmd: &mut String, context: &str) -> bool {
@@ -7051,6 +7067,65 @@ mod tests {
 
                 // The authoritative sidecar matches the stored sid, so no
                 // override happens despite the peer's fresher jsonl.
+                assert_eq!(sid.as_deref(), Some(mine));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some(mine));
+            }
+
+            // #2344 follow-up: a sandboxed Claude session must also consult the
+            // sidecar. Its SessionStart hook writes through the
+            // `/tmp/aoe-hooks/<id>` bind-mount onto the host path, so
+            // `read_hook_session_id` reads it the same way a host session's is
+            // read. Without the sidecar short-circuit the sandbox-aware mtime
+            // branch would pick a peer's fresher jsonl in the shared cwd.
+            #[test]
+            #[serial]
+            fn sidecar_consulted_for_sandboxed_claude() {
+                let temp = tempdir().unwrap();
+                let _guard = ClaudeHomeGuard::set(&temp);
+
+                let project_path = "/tmp/aoe-test-2344-sandbox";
+                let claude_dir = temp
+                    .path()
+                    .join(".claude")
+                    .join("projects")
+                    .join(encode_claude_project_path(project_path));
+                fs::create_dir_all(&claude_dir).unwrap();
+
+                let mine = "eeeeeeee-5555-4555-8555-eeeeeeeeeeee";
+                let peer = "ffffffff-6666-4666-8666-ffffffffffff";
+                let now = SystemTime::now();
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{mine}.jsonl")),
+                    now - Duration::from_secs(120),
+                );
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{peer}.jsonl")),
+                    now - Duration::from_secs(5),
+                );
+
+                let mut inst = Instance::new("verify-2344-sandbox", project_path);
+                inst.tool = "claude".to_string();
+                inst.agent_session_id = Some(mine.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+                inst.sandbox_info = Some(crate::session::SandboxInfo {
+                    enabled: true,
+                    container_id: None,
+                    image: "test-image".to_string(),
+                    container_name: "verify-2344-sandbox".to_string(),
+                    extra_env: None,
+                    custom_instruction: None,
+                    before_start_env: Vec::new(),
+                });
+                assert!(inst.is_sandboxed());
+
+                let dir = super::write_sidecar(&inst.id, mine);
+                let (sid, is_existing) = inst.acquire_session_id();
+                std::fs::remove_dir_all(&dir).ok();
+
+                // Sidecar (host-readable) names this instance's conversation, so
+                // the peer's fresher jsonl does not win even though sandbox would
+                // otherwise route through the container-aware mtime branch.
                 assert_eq!(sid.as_deref(), Some(mine));
                 assert!(is_existing);
                 assert_eq!(inst.agent_session_id.as_deref(), Some(mine));

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -7042,10 +7042,15 @@ mod tests {
                     .join(encode_claude_project_path(project_path));
                 fs::create_dir_all(&claude_dir).unwrap();
 
-                // This instance's real conversation (named by its sidecar) and a
-                // peer's conversation that happens to be the freshest on disk.
+                // `mine` is this instance's real conversation (named by its
+                // sidecar). `peer` is a co-located peer's conversation that is
+                // strictly freshest on disk. `stored` is a stale id distinct
+                // from `mine`, so asserting `sid == mine` proves the sidecar
+                // actively overrode the stored value rather than the stored
+                // value passing through unchanged.
                 let mine = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
                 let peer = "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb";
+                let stored = "cccccccc-3333-4333-8333-cccccccccccc";
                 let now = SystemTime::now();
                 write_jsonl_with_mtime(
                     &claude_dir.join(format!("{mine}.jsonl")),
@@ -7058,15 +7063,15 @@ mod tests {
 
                 let mut inst = Instance::new("verify-2344-shared-cwd", project_path);
                 inst.tool = "claude".to_string();
-                inst.agent_session_id = Some(mine.to_string());
+                inst.agent_session_id = Some(stored.to_string());
                 inst.resume_intent = ResumeIntent::Default;
 
                 let dir = super::write_sidecar(&inst.id, mine);
                 let (sid, is_existing) = inst.acquire_session_id();
                 std::fs::remove_dir_all(&dir).ok();
 
-                // The authoritative sidecar matches the stored sid, so no
-                // override happens despite the peer's fresher jsonl.
+                // The authoritative sidecar overrides the stale stored sid;
+                // the peer's fresher jsonl never wins.
                 assert_eq!(sid.as_deref(), Some(mine));
                 assert!(is_existing);
                 assert_eq!(inst.agent_session_id.as_deref(), Some(mine));
@@ -7092,8 +7097,11 @@ mod tests {
                     .join(encode_claude_project_path(project_path));
                 fs::create_dir_all(&claude_dir).unwrap();
 
+                // `stored` is distinct from the sidecar `mine`, so the assertion
+                // proves the sidecar actively overrode the stale stored value.
                 let mine = "eeeeeeee-5555-4555-8555-eeeeeeeeeeee";
                 let peer = "ffffffff-6666-4666-8666-ffffffffffff";
+                let stored = "dddddddd-7777-4777-8777-dddddddddddd";
                 let now = SystemTime::now();
                 write_jsonl_with_mtime(
                     &claude_dir.join(format!("{mine}.jsonl")),
@@ -7106,7 +7114,7 @@ mod tests {
 
                 let mut inst = Instance::new("verify-2344-sandbox", project_path);
                 inst.tool = "claude".to_string();
-                inst.agent_session_id = Some(mine.to_string());
+                inst.agent_session_id = Some(stored.to_string());
                 inst.resume_intent = ResumeIntent::Default;
                 inst.sandbox_info = Some(crate::session::SandboxInfo {
                     enabled: true,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1598,12 +1598,30 @@ impl Instance {
     /// contract (mtime, SQLite ordering, exclusion set, host/container)
     /// stays encapsulated in each tool's existing capture function.
     ///
-    /// Known limitation: when a non-AoE Claude session writes to the same
-    /// `project_path` (manual `claude` invocation outside the pane), its sid
-    /// is not in the tmux-env exclusion set and a fresher mtime there can
-    /// supersede the stored sid on resume. Co-located non-AoE peers are an
-    /// uncommon layout; the steady-state case (no peer) is unaffected.
+    /// For Claude the authoritative per-instance sidecar
+    /// (`/tmp/aoe-hooks-<euid>/<instance_id>/session_id`, written by the
+    /// SessionStart / UserPromptSubmit hooks) is consulted first. It is keyed
+    /// by instance id, so it can never name a peer instance's conversation —
+    /// unlike the mtime disk scan, which picks the most-recent jsonl in the
+    /// shared `~/.claude/projects/<encoded-cwd>/` dir and so can select a
+    /// co-located peer's session when several AoE sessions share one cwd
+    /// (#2344). The mtime scan is only used as a fallback when no fresh
+    /// sidecar exists (e.g. an old session resumed after the 5-minute
+    /// sidecar window), matching the ordering already used by
+    /// `claude_poll_fn`.
     pub(crate) fn capture_freshest_session_id(&self) -> Option<String> {
+        if self.tool == "claude" && !self.is_sandboxed() {
+            if let Some(authoritative) = crate::hooks::read_hook_session_id(&self.id) {
+                if self.retroactive_capture_excludes.contains(&authoritative) {
+                    return None;
+                }
+                return match self.agent_session_id.as_deref() {
+                    Some(known) if known == authoritative => None,
+                    _ => Some(authoritative),
+                };
+            }
+        }
+
         let live = self.try_retroactive_capture()?;
         match self.agent_session_id.as_deref() {
             Some(known) if known == live => None,
@@ -6985,6 +7003,96 @@ mod tests {
                 assert_eq!(sid.as_deref(), Some("stored-cursor-sid"));
                 assert!(is_existing);
                 assert_eq!(inst.agent_session_id.as_deref(), Some("stored-cursor-sid"));
+            }
+
+            // #2344: when several AoE Claude sessions share one cwd, the
+            // most-recent jsonl in the shared `~/.claude/projects/<encoded-cwd>/`
+            // dir is often a *peer* session's conversation. The mtime scan would
+            // pick it and clobber this instance's stored sid on resume. The
+            // per-instance hook sidecar is authoritative and must win over the
+            // mtime guess: here the sidecar names the instance's own conversation
+            // while a peer's jsonl is strictly fresher on disk.
+            #[test]
+            #[serial]
+            fn sidecar_wins_over_fresher_peer_jsonl() {
+                let temp = tempdir().unwrap();
+                let _guard = ClaudeHomeGuard::set(&temp);
+
+                let project_path = "/tmp/aoe-test-2344-shared-cwd";
+                let claude_dir = temp
+                    .path()
+                    .join(".claude")
+                    .join("projects")
+                    .join(encode_claude_project_path(project_path));
+                fs::create_dir_all(&claude_dir).unwrap();
+
+                // This instance's real conversation (named by its sidecar) and a
+                // peer's conversation that happens to be the freshest on disk.
+                let mine = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+                let peer = "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb";
+                let now = SystemTime::now();
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{mine}.jsonl")),
+                    now - Duration::from_secs(120),
+                );
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{peer}.jsonl")),
+                    now - Duration::from_secs(5),
+                );
+
+                let mut inst = Instance::new("verify-2344-shared-cwd", project_path);
+                inst.tool = "claude".to_string();
+                inst.agent_session_id = Some(mine.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let dir = super::write_sidecar(&inst.id, mine);
+                let (sid, is_existing) = inst.acquire_session_id();
+                std::fs::remove_dir_all(&dir).ok();
+
+                // The authoritative sidecar matches the stored sid, so no
+                // override happens despite the peer's fresher jsonl.
+                assert_eq!(sid.as_deref(), Some(mine));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some(mine));
+            }
+
+            // Companion to the above: without a sidecar (e.g. a session resumed
+            // after the 5-minute sidecar window) the mtime fallback still
+            // applies, preserving the #2291 daemon-mode fix.
+            #[test]
+            #[serial]
+            fn mtime_fallback_applies_without_sidecar() {
+                let temp = tempdir().unwrap();
+                let _guard = ClaudeHomeGuard::set(&temp);
+
+                let project_path = "/tmp/aoe-test-2344-no-sidecar";
+                let claude_dir = temp
+                    .path()
+                    .join(".claude")
+                    .join("projects")
+                    .join(encode_claude_project_path(project_path));
+                fs::create_dir_all(&claude_dir).unwrap();
+
+                let stale = "cccccccc-3333-4333-8333-cccccccccccc";
+                let fresh = "dddddddd-4444-4444-8444-dddddddddddd";
+                let now = SystemTime::now();
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{stale}.jsonl")),
+                    now - Duration::from_secs(120),
+                );
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{fresh}.jsonl")),
+                    now - Duration::from_secs(5),
+                );
+
+                let mut inst = Instance::new("verify-2344-no-sidecar", project_path);
+                inst.tool = "claude".to_string();
+                inst.agent_session_id = Some(stale.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, _is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some(fresh));
+                assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
             }
         }
 


### PR DESCRIPTION
## Description

Fixes the wrong-conversation half of #2344: resuming a stopped Claude session can land on a *different* session's conversation when several AoE sessions share one working directory.

### Root cause

The verify-on-resume mtime scan added in #2298 (the fix for #2291) lives in `capture_freshest_session_id` (`src/session/instance.rs`). It calls `try_retroactive_capture` → `capture_claude_session_id` → `scan_claude_project_dir`, which selects the most-recent `*.jsonl` in `~/.claude/projects/<encoded-cwd>/`.

That directory is keyed by cwd, not by session. When multiple AoE Claude sessions run in the same `project_path` (a single monorepo dir is a common layout for autonomous/dispatched sessions), they all map to the same encoded-cwd dir. The "freshest" jsonl is then frequently a *peer* session's conversation — the one most recently touched — not this instance's.

On resume, `acquire_session_id`'s `Some(stored)` branch calls `capture_freshest_session_id`; when it returns a peer's id, the stored id is overwritten and the launch runs `claude --resume <peer-uuid>`. Observed in the wild as a stored `agent_session_id` being replaced by an unrelated session's conversation, logged as `Replacing stored session id with fresher live observation stale=… fresh=… tool=claude`.

The exclusion set (`build_exclusion_set`) is meant to prevent exactly this — it reads peers' `AOE_CAPTURED_SESSION_ID` from tmux env — but a *stopped* peer has no live tmux session, so its id isn't in the set, and its jsonl is fair game for the scan. The existing doc note on `capture_freshest_session_id` framed this as a "co-located non-AoE Claude peer" edge case; the dominant trigger is actually AoE peers sharing a cwd.

### Fix

Consult the per-instance hook sidecar (`read_hook_session_id`, written by the SessionStart/UserPromptSubmit hooks under `/tmp/aoe-hooks-<euid>/<instance_id>/session_id`) before the mtime scan, mirroring the ordering already used by `claude_poll_fn`. The sidecar is keyed by instance id, so it can never name a peer instance's conversation. When present and fresh it authoritatively decides whether an override is warranted:

- sidecar == stored → no override (steady state)
- sidecar != stored → override to the sidecar value (legitimate fresh id for *this* instance, e.g. post-`/clear`)
- sidecar in this instance's `retroactive_capture_excludes` → no override (cascade re-poison guard)

The mtime scan remains the fallback when no fresh sidecar exists (daemon-only mode where the poller never drained, or a session resumed after the 5-minute sidecar window), preserving the #2291 fix. `supersedes_stale_claude_sid_after_clear` continues to pass.

### Scope / known remaining gap

This closes the case where a fresh sidecar disagrees with the mtime guess — the common interactive trigger. It does **not** fully cover the case where the sidecar is also stale (>5 min) *and* a stopped peer's jsonl is the freshest in the shared dir: with no authoritative source, the mtime fallback can still mis-select. A complete fix would widen the exclusion set to include session ids owned by stopped/idle peers (e.g. from `sessions.json`), not just live tmux env. That's a larger change; happy to follow up in a separate PR if you'd like that direction.

The secondary symptom in #2344 (the `AOE_CAPTURED_SESSION_ID` tmux write-back targeting an `aoe_` `Session` name when the live pane is an `aoe_term_` `TerminalSession`, so every write fails with `no such session`) is left for a separate change — it's adjacent (it's why stopped peers fall out of the exclusion set) but mechanically distinct.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording <!-- N/A: no UI changes -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is exercised by deterministic unit tests at the `acquire_session_id` boundary (`tests::resume_fallback::verify_on_resume`): `sidecar_wins_over_fresher_peer_jsonl` (peer jsonl strictly fresher on disk, sidecar names this instance's conversation → no override) and `mtime_fallback_applies_without_sidecar` (no sidecar → #2291 bascule still applies). A full e2e for multi-session shared-cwd resume would need a real `claude` binary plus several live tmux sessions racing on one project dir, which the existing `tests/e2e/` harness doesn't model; the unit tests pin the exact decision point that regressed.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Used to investigate the issue (tracing the resume path and the #2298 interaction against `main`) and to draft the patch and tests. All file/line references and the root-cause reasoning were verified against the code, and the fix was built and tested locally (`cargo fmt --check`, `cargo clippy --lib --tests`, full `session::instance` and `session::capture` suites green).

- [ ] I am an AI Agent filling out this form (check box if true)

Related: #2344, #2291, #2298, #2304


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR fixes a resume bug for stopped Claude sessions in Agent-of-Empires where resuming could jump into a different (peer) session’s conversation when multiple sessions share the same working directory.

**What changed**
- Updated `Instance::capture_freshest_session_id` to use an **instance-specific sidecar value** (when available) as the primary source of truth for Claude session selection.
- Added a small helper (`override_if_distinct`) to ensure the system only overrides the stored session when the sidecar’s session ID is meaningfully different.
- Kept the existing **freshness/mtime-based fallback** behavior when the sidecar is missing/expired, so prior safeguards remain intact.
- Extended the behavior to cover **sandboxed Claude** flows consistently.

**Why this helps**
- Prevents incorrectly resuming the “most recently modified” peer conversation in shared directories.
- Preserves prior fixes for cases where sidecar data isn’t available.

**Tests added/updated**
- `sidecar_wins_over_fresher_peer_jsonl`: confirms the sidecar overrides a fresher peer JSONL.
- `sidecar_consulted_for_sandboxed_claude`: confirms the same sidecar priority for sandboxed Claude sessions.
- `mtime_fallback_applies_without_sidecar`: confirms the fallback selection still works when the sidecar is absent.

**Known remaining limitation**
- If the sidecar is stale (>5 minutes) *and* a stopped peer’s JSONL is the freshest in the shared directory, the mtime fallback can still misselect. A full fix would require widening the exclusion set to include stopped/idle peers, deferred to a future PR.

## Technical Details (optional)

- For **Claude**, `capture_freshest_session_id` now prefers `read_hook_session_id(self.id)` (instance-keyed), and uses the fallback freshness scan only when the sidecar is absent.
- The override decision is centralized so overrides only occur when the sidecar-derived ID differs from the currently stored `agent_session_id`.
- For **non-Claude**, the previous freshness behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->