### PR TITLE
feat(hooks): flip Codex hook storage from config.toml to hooks.json

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -61,18 +61,20 @@ pub struct HookEvent {
 
 /// On-disk format an agent uses for its status-detection hooks. Each variant
 /// drives one install path: `JsonSettings` goes through the generic
-/// `hooks.<event>[].hooks[].command` JSON writer, `CodexToml` goes through
-/// the bespoke TOML writer with file-locked atomic replacement and
-/// `[hooks.state]` preservation.
+/// `hooks.<event>[].hooks[].command` JSON writer used by Claude-shape agents;
+/// `CodexJson` shares the same JSON payload but resolves its path through
+/// Codex's `CODEX_HOME` convention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookFormat {
     /// JSON `settings.json` with `hooks.<event>[].hooks[].command`. Used by
     /// Claude, Cursor, Gemini, Qwen, and any future agent that adopts this
     /// shape.
     JsonSettings,
-    /// Codex `config.toml`. Symlink-resolved, file-locked, with the
-    /// `[hooks.state]` trust block preserved across rewrites.
-    CodexToml,
+    /// Codex `hooks.json`. Identical JSON payload shape to `JsonSettings`,
+    /// but the path is resolved via `CODEX_HOME` → `~/.codex/hooks.json`.
+    /// Codex's `[hooks.state]` trust block lives in `config.toml` and is
+    /// untouched by this writer.
+    CodexJson,
 }
 
 /// Configuration for installing status-detection hooks into an agent's settings file.
@@ -312,8 +314,7 @@ const QWEN_HOOK_EVENTS: &[HookEvent] = &[
     },
 ];
 
-/// Codex hook events. Codex loads these from the `[hooks]` table in
-/// `~/.codex/config.toml`.
+/// Codex hook events. AoE installs these into `~/.codex/hooks.json`.
 const CODEX_HOOK_EVENTS: &[HookEvent] = &[
     HookEvent {
         name: "SessionStart",
@@ -430,12 +431,12 @@ pub const AGENTS: &[AgentDef] = &[
         detect_status: status_detection::detect_codex_status,
         container_env: &[],
         hook_config: Some(AgentHookConfig {
-            settings_rel_path: ".codex/config.toml",
-            // Codex resolves its config dir via `CODEX_HOME` through a bespoke
-            // path pair; install/uninstall live behind the `CodexToml` variant.
+            settings_rel_path: ".codex/hooks.json",
+            // Codex's config dir resolves via `CODEX_HOME`, not a generic
+            // `config_dir_env_var`; the `CodexJson` writer handles that itself.
             config_dir_env_var: None,
             events: CODEX_HOOK_EVENTS,
-            format: HookFormat::CodexToml,
+            format: HookFormat::CodexJson,
         }),
         sidecar_hooks: None,
         resume_strategy: ResumeStrategy::Subcommand("resume"),
@@ -1039,7 +1040,7 @@ mod tests {
         // drift here is a behavior change.
         let expected: &[(&str, HookFormat)] = &[
             ("claude", HookFormat::JsonSettings),
-            ("codex", HookFormat::CodexToml),
+            ("codex", HookFormat::CodexJson),
             ("gemini", HookFormat::JsonSettings),
             ("cursor", HookFormat::JsonSettings),
             ("qwen", HookFormat::JsonSettings),

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -431,7 +431,7 @@ pub(crate) enum HookTargetKind {
     JsonSettings,
     /// Codex `config.toml`: file-locked, symlink-resolved, with a user-trust
     /// `[hooks.state]` block to preserve. Only the v018 legacy-cleanup
-    /// migration (#2188) constructs this variant; no agent declares
+    /// migration constructs this variant; no agent declares
     /// `HookFormat::CodexToml`.
     CodexToml,
     /// Codex `hooks.json`: same JSON payload shape as `JsonSettings`, but

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -119,9 +119,9 @@ pub fn codex_config_path_display() -> String {
         .unwrap_or_else(|| "~/.codex/config.toml".to_string())
 }
 
-// Production paths resolve `hooks.json` (via `codex_hooks_json_path_*`)
-// after the `HookFormat::CodexJson` adoption; these `config.toml` helpers
-// stay for the v015/v017/v018 fixtures that synthesise `CodexToml` targets.
+// `hooks.json` is the production target for codex hooks; these
+// `config.toml` path helpers stay as test scaffolding for the
+// empty-`CODEX_HOME` fallback assertions in this module's unit tests.
 #[cfg(test)]
 pub(crate) fn codex_config_path_for_host_environment(entries: &[String]) -> Result<PathBuf> {
     let home =
@@ -921,6 +921,10 @@ pub(crate) fn install_codex_hooks(
     install_codex_hooks_with_preserved_state(config_path, events, None, target)
 }
 
+/// Read `[hooks.state]` from `config_path` under the codex config lock and
+/// return it for later restoration. Inverse of [`restore_codex_hooks_state`];
+/// returns `Ok(None)` when the file is absent so callers can no-op the
+/// snapshot/restore bracket.
 pub(crate) fn snapshot_codex_hooks_state(config_path: &Path) -> Result<Option<toml_edit::Item>> {
     if !config_path.exists() {
         return Ok(None);
@@ -940,7 +944,9 @@ pub(crate) fn snapshot_codex_hooks_state(config_path: &Path) -> Result<Option<to
 /// taking the codex config lock. Inverse of [`snapshot_codex_hooks_state`];
 /// together they bracket destructive rewrites of `config.toml` (e.g. the
 /// host-to-sandbox refresh in [`crate::session::container_config`]) so
-/// Codex's user-trust block survives.
+/// Codex's user-trust block survives. Unconditionally overwrites any
+/// `state` already present at `config_path`; pair only with a fresh
+/// snapshot from the authoritative source.
 pub(crate) fn restore_codex_hooks_state(config_path: &Path, state: toml_edit::Item) -> Result<()> {
     with_codex_config_lock(config_path, || {
         let mut config = read_codex_config(config_path)?;

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -119,12 +119,17 @@ pub fn codex_config_path_display() -> String {
         .unwrap_or_else(|| "~/.codex/config.toml".to_string())
 }
 
+// Production paths resolve `hooks.json` (via `codex_hooks_json_path_*`)
+// after the `HookFormat::CodexJson` adoption; these `config.toml` helpers
+// stay for the v015/v017/v018 fixtures that synthesise `CodexToml` targets.
+#[cfg(test)]
 pub(crate) fn codex_config_path_for_host_environment(entries: &[String]) -> Result<PathBuf> {
     let home =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
     Ok(codex_config_path_in(&home, entries))
 }
 
+#[cfg(test)]
 pub(crate) fn codex_config_path_display_for_host_environment(entries: &[String]) -> String {
     crate::session::environment::resolve_host_environment_value(entries, "CODEX_HOME")
         .filter(|v| !v.is_empty())
@@ -135,6 +140,56 @@ pub(crate) fn codex_config_path_display_for_host_environment(entries: &[String])
                 .to_string()
         })
         .unwrap_or_else(codex_config_path_display)
+}
+
+/// Home-injectable variant of [`codex_hooks_json_path_for_host_environment`]:
+/// resolves Codex's `hooks.json` under the given `home` directory, honoring
+/// an explicit `CODEX_HOME` in `host_env` (or the AoE process env), then
+/// falling back to `<home>/.codex/hooks.json`.
+pub(crate) fn codex_hooks_json_path_in(home: &Path, host_env: &[String]) -> PathBuf {
+    if let Some(codex_home) =
+        crate::session::environment::resolve_host_environment_value(host_env, "CODEX_HOME")
+            .or_else(|| std::env::var("CODEX_HOME").ok())
+            .filter(|v| !v.is_empty())
+    {
+        return PathBuf::from(codex_home).join("hooks.json");
+    }
+    home.join(".codex").join("hooks.json")
+}
+
+/// Process-env variant of [`codex_hooks_json_path_in`]: resolves Codex's
+/// `hooks.json` against the live `dirs::home_dir()` so install paths
+/// outside the migration boot loop share a single call shape.
+pub(crate) fn codex_hooks_json_path_for_host_environment(entries: &[String]) -> Result<PathBuf> {
+    let home =
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
+    Ok(codex_hooks_json_path_in(&home, entries))
+}
+
+/// Display-string variant of [`codex_hooks_json_path_for_host_environment`]
+/// used by the TUI consent dialog; falls back to the literal
+/// `~/.codex/hooks.json` string when the home directory cannot be resolved.
+pub(crate) fn codex_hooks_json_path_display_for_host_environment(entries: &[String]) -> String {
+    crate::session::environment::resolve_host_environment_value(entries, "CODEX_HOME")
+        .filter(|v| !v.is_empty())
+        .map(|codex_home| {
+            PathBuf::from(codex_home)
+                .join("hooks.json")
+                .display()
+                .to_string()
+        })
+        .unwrap_or_else(|| {
+            std::env::var("CODEX_HOME")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .map(|codex_home| {
+                    PathBuf::from(codex_home)
+                        .join("hooks.json")
+                        .display()
+                        .to_string()
+                })
+                .unwrap_or_else(|| "~/.codex/hooks.json".to_string())
+        })
 }
 
 /// Resolve the host settings-file path for an agent whose config directory may
@@ -375,8 +430,14 @@ pub(crate) enum HookTargetKind {
     /// `hooks.<event>[].hooks[].command`.
     JsonSettings,
     /// Codex `config.toml`: file-locked, symlink-resolved, with a user-trust
-    /// `[hooks].state` block to preserve.
+    /// `[hooks.state]` block to preserve. Only the v018 legacy-cleanup
+    /// migration (#2188) constructs this variant; no agent declares
+    /// `HookFormat::CodexToml`.
     CodexToml,
+    /// Codex `hooks.json`: same JSON payload shape as `JsonSettings`, but
+    /// the path is resolved through `codex_hooks_json_path_in`
+    /// (`CODEX_HOME` aware).
+    CodexJson,
     /// settl/hermes/kiro: a config format the JSON path cannot emit; install
     /// goes through the agent's bundled `SidecarHooks` function pointers.
     Sidecar(&'static crate::agents::SidecarHooks),
@@ -426,7 +487,7 @@ pub(crate) fn iter_hook_targets_in(home: &Path, env_lists: &[Vec<String>]) -> Ve
                     crate::agents::HookFormat::JsonSettings => {
                         agent_settings_path_in(home, hook_cfg, env)
                     }
-                    crate::agents::HookFormat::CodexToml => codex_config_path_in(home, env),
+                    crate::agents::HookFormat::CodexJson => codex_hooks_json_path_in(home, env),
                 }
             };
             push_unique_target_path(&mut paths, resolve(&[]));
@@ -435,7 +496,7 @@ pub(crate) fn iter_hook_targets_in(home: &Path, env_lists: &[Vec<String>]) -> Ve
             }
             let kind = match hook_cfg.format {
                 crate::agents::HookFormat::JsonSettings => HookTargetKind::JsonSettings,
-                crate::agents::HookFormat::CodexToml => HookTargetKind::CodexToml,
+                crate::agents::HookFormat::CodexJson => HookTargetKind::CodexJson,
             };
             for path in paths {
                 out.push(HookTarget {
@@ -505,7 +566,9 @@ pub(crate) fn has_aoe_marker(target: &HookTarget) -> bool {
         return false;
     }
     match target.kind {
-        HookTargetKind::JsonSettings => json_settings_has_aoe_marker(&target.path),
+        HookTargetKind::JsonSettings | HookTargetKind::CodexJson => {
+            json_settings_has_aoe_marker(&target.path)
+        }
         HookTargetKind::CodexToml => codex_config_has_aoe_marker(&target.path),
         HookTargetKind::Sidecar(sidecar) => match sidecar.format {
             crate::agents::SidecarFormat::SettlToml => settl_config_has_aoe_marker(&target.path),
@@ -849,7 +912,8 @@ const CODEX_HOOK_EVENT_NAMES: &[&str] = &[
 ///
 /// Idempotent on disk: when the on-disk file already encodes the same
 /// AoE-managed hook subtree, it is not rewritten (same inode, same bytes).
-pub fn install_codex_hooks(
+#[cfg(test)]
+pub(crate) fn install_codex_hooks(
     config_path: &Path,
     events: &[crate::agents::HookEvent],
     target: HookInstallTarget,
@@ -869,6 +933,21 @@ pub(crate) fn snapshot_codex_hooks_state(config_path: &Path) -> Result<Option<to
             .and_then(|hooks| hooks.as_table_like())
             .and_then(|hooks| hooks.get("state"))
             .cloned())
+    })
+}
+
+/// Write `state` back into the `[hooks.state]` table of `config_path`,
+/// taking the codex config lock. Inverse of [`snapshot_codex_hooks_state`];
+/// together they bracket destructive rewrites of `config.toml` (e.g. the
+/// host-to-sandbox refresh in [`crate::session::container_config`]) so
+/// Codex's user-trust block survives.
+pub(crate) fn restore_codex_hooks_state(config_path: &Path, state: toml_edit::Item) -> Result<()> {
+    with_codex_config_lock(config_path, || {
+        let mut config = read_codex_config(config_path)?;
+        let hooks = ensure_codex_hooks_table(&mut config)?;
+        hooks.insert("state", state);
+        write_codex_config(config_path, &config)?;
+        Ok(())
     })
 }
 
@@ -1865,7 +1944,9 @@ pub fn uninstall_kiro_hooks(agent_config_path: &Path) -> Result<bool> {
 pub fn uninstall_all_hooks() {
     for target in iter_hook_targets() {
         let result = match target.kind {
-            HookTargetKind::JsonSettings => uninstall_hooks(&target.path),
+            HookTargetKind::JsonSettings | HookTargetKind::CodexJson => {
+                uninstall_hooks(&target.path)
+            }
             HookTargetKind::CodexToml => uninstall_codex_hooks(&target.path),
             HookTargetKind::Sidecar(sidecar) => (sidecar.uninstall)(&target.path),
         };
@@ -2428,12 +2509,12 @@ mod tests {
 
         let codex_paths: Vec<_> = iter_hook_targets()
             .into_iter()
-            .filter(|t| matches!(t.kind, HookTargetKind::CodexToml))
+            .filter(|t| matches!(t.kind, HookTargetKind::CodexJson))
             .map(|t| t.path)
             .collect();
 
-        assert!(codex_paths.contains(&tmp.path().join(".codex").join("config.toml")));
-        assert!(codex_paths.contains(&codex_home.join("config.toml")));
+        assert!(codex_paths.contains(&tmp.path().join(".codex").join("hooks.json")));
+        assert!(codex_paths.contains(&codex_home.join("hooks.json")));
     }
 
     #[test]

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -25,13 +25,14 @@ mod v014_rename_default_theme;
 mod v015_rewrite_hook_strings;
 mod v016_clear_archived_tmux_gone_error;
 mod v017_rewrite_hook_strings_for_per_user_base;
+mod v018_strip_codex_config_toml_hooks;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 17;
+const CURRENT_VERSION: u32 = 18;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -125,6 +126,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 17,
         name: "rewrite_hook_strings_for_per_user_base",
         run: v017_rewrite_hook_strings_for_per_user_base::run,
+    },
+    Migration {
+        version: 18,
+        name: "strip_codex_config_toml_hooks",
+        run: v018_strip_codex_config_toml_hooks::run,
     },
 ];
 

--- a/src/migrations/v015_rewrite_hook_strings.rs
+++ b/src/migrations/v015_rewrite_hook_strings.rs
@@ -154,9 +154,13 @@ pub(crate) fn run_in(home: &Path, app_dir: &Path) -> Result<()> {
 /// from "AoE never installed event X."
 fn rewrite_one(target: &HookTarget) -> Result<()> {
     match target.kind {
-        HookTargetKind::JsonSettings => {
+        HookTargetKind::JsonSettings | HookTargetKind::CodexJson => {
             install_hooks(&target.path, target.events, HookInstallTarget::Host)
         }
+        // Defensive: `iter_hook_targets_in` does not emit `CodexToml` for
+        // any registered agent (codex declares `CodexJson`). The arm stays
+        // for `HookTargetKind` exhaustiveness and as a guard rail should a
+        // future agent reintroduce a TOML-format codex.
         HookTargetKind::CodexToml => {
             let preserved = snapshot_codex_hooks_state(&target.path)?;
             install_codex_hooks_with_preserved_state(
@@ -510,129 +514,6 @@ mod tests {
 
     #[test]
     #[serial_test::serial(shell_env)]
-    fn codex_state_preserved_across_rewrite() {
-        let _g = EnvGuard::unset_all();
-        let (_tmp, home, app_dir) = setup_dirs();
-        let codex = home.join(".codex/config.toml");
-        fs::create_dir_all(codex.parent().unwrap()).unwrap();
-        fs::write(
-            &codex,
-            format!(
-                "[hooks.state]\n\
-                 existing = {{ enabled = true, trusted_hash = \"keep-me\" }}\n\
-                 \n\
-                 [[hooks.SessionStart]]\n\
-                 [[hooks.SessionStart.hooks]]\n\
-                 type = \"command\"\n\
-                 command = {LEGACY_STATUS_CMD:?}\n"
-            ),
-        )
-        .unwrap();
-
-        run_in(&home, &app_dir).unwrap();
-
-        let text = fs::read_to_string(&codex).unwrap();
-        let parsed: toml::Value = toml::from_str(&text).unwrap();
-        assert_eq!(
-            parsed["hooks"]["state"]["existing"]["trusted_hash"].as_str(),
-            Some("keep-me"),
-            "[hooks.state] must survive the rewrite"
-        );
-        assert!(
-            text.contains("case \"$AOE_INSTANCE_ID\""),
-            "Codex hook command must be rewritten to the hardened form"
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(shell_env)]
-    fn codex_features_hooks_false_skipped() {
-        let _g = EnvGuard::unset_all();
-        let (_tmp, home, app_dir) = setup_dirs();
-        let codex = home.join(".codex/config.toml");
-        fs::create_dir_all(codex.parent().unwrap()).unwrap();
-        fs::write(
-            &codex,
-            format!(
-                "[features]\n\
-                 hooks = false\n\
-                 \n\
-                 [[hooks.SessionStart]]\n\
-                 [[hooks.SessionStart.hooks]]\n\
-                 type = \"command\"\n\
-                 command = {LEGACY_STATUS_CMD:?}\n"
-            ),
-        )
-        .unwrap();
-        let before = fs::read(&codex).unwrap();
-
-        run_in(&home, &app_dir).unwrap();
-
-        assert_eq!(
-            fs::read(&codex).unwrap(),
-            before,
-            "features.hooks=false must short-circuit; file must be byte-untouched"
-        );
-        let text = String::from_utf8(before).unwrap();
-        assert!(
-            !text.contains("case \"$AOE_INSTANCE_ID\""),
-            "no hardening must be applied when feature is disabled"
-        );
-        // Lock IS acquired even when features.hooks=false:
-        // `with_codex_config_lock` opens the sidecar with `O_CREAT` BEFORE
-        // running its closure, and the feature gate runs INSIDE. Positive
-        // assertion locks the existing behaviour against a refactor that
-        // would leak the lock check ahead of acquisition.
-        let lock_path = codex.with_extension("toml.lock");
-        assert!(
-            lock_path.exists(),
-            "Codex lock sidecar must be acquired unconditionally (see TOCTOU \
-             note in module doc)",
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(shell_env)]
-    fn codex_features_codex_hooks_alias_false_skipped() {
-        // `features.codex_hooks = false` is the deprecated alias for
-        // `features.hooks = false`. Locks the alias support in
-        // `codex_hooks_feature_is_disabled` (`hooks/mod.rs::or_else` fallback)
-        // so a refactor cannot drop it without flipping a test red.
-        let _g = EnvGuard::unset_all();
-        let (_tmp, home, app_dir) = setup_dirs();
-        let codex = home.join(".codex/config.toml");
-        fs::create_dir_all(codex.parent().unwrap()).unwrap();
-        fs::write(
-            &codex,
-            format!(
-                "[features]\n\
-                 codex_hooks = false\n\
-                 \n\
-                 [[hooks.SessionStart]]\n\
-                 [[hooks.SessionStart.hooks]]\n\
-                 type = \"command\"\n\
-                 command = {LEGACY_STATUS_CMD:?}\n"
-            ),
-        )
-        .unwrap();
-        let before = fs::read(&codex).unwrap();
-
-        run_in(&home, &app_dir).unwrap();
-
-        assert_eq!(
-            fs::read(&codex).unwrap(),
-            before,
-            "features.codex_hooks=false (deprecated alias) must short-circuit",
-        );
-        let text = String::from_utf8(before).unwrap();
-        assert!(
-            !text.contains("case \"$AOE_INSTANCE_ID\""),
-            "no hardening must be applied when the legacy alias is disabled"
-        );
-    }
-
-    #[test]
-    #[serial_test::serial(shell_env)]
     fn settl_marker_only_rewrites_aoe_lines() {
         let _g = EnvGuard::unset_all();
         let (_tmp, home, app_dir) = setup_dirs();
@@ -873,19 +754,17 @@ mod tests {
         let (_tmp, home, app_dir) = setup_dirs();
         let codex_override = home.join("work-codex");
         fs::create_dir_all(&codex_override).unwrap();
-        fs::write(
-            codex_override.join("config.toml"),
-            format!(
-                "[[hooks.SessionStart]]\n\
-                 [[hooks.SessionStart.hooks]]\n\
-                 type = \"command\"\n\
-                 command = {LEGACY_STATUS_CMD:?}\n"
-            ),
-        )
-        .unwrap();
+        write_json(
+            &codex_override.join("hooks.json"),
+            &serde_json::json!({
+                "hooks": {
+                    "SessionStart": [
+                        {"hooks": [{"type": "command", "command": LEGACY_STATUS_CMD}]}
+                    ]
+                }
+            }),
+        );
 
-        // Profile config in app_dir/profiles/work/config.toml that pins
-        // CODEX_HOME at the override location.
         let profile_dir = app_dir.join("profiles/work");
         fs::create_dir_all(&profile_dir).unwrap();
         fs::write(
@@ -899,14 +778,19 @@ mod tests {
 
         run_in(&home, &app_dir).unwrap();
 
-        let text = fs::read_to_string(codex_override.join("config.toml")).unwrap();
+        let parsed: Value =
+            serde_json::from_str(&fs::read_to_string(codex_override.join("hooks.json")).unwrap())
+                .unwrap();
+        let cmd = parsed["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+            .as_str()
+            .expect("AoE command must be present at the override path");
         assert!(
-            text.contains("case \"$AOE_INSTANCE_ID\""),
-            "profile-overridden Codex path must be reached and rewritten"
+            cmd.contains("case \"$AOE_INSTANCE_ID\""),
+            "profile-overridden Codex path must be reached and rewritten; got: {cmd}"
         );
         assert!(
-            !home.join(".codex/config.toml").exists(),
-            "default ~/.codex/config.toml must not be magicked into existence"
+            !home.join(".codex/hooks.json").exists(),
+            "default ~/.codex/hooks.json must not be magicked into existence"
         );
     }
 

--- a/src/migrations/v017_rewrite_hook_strings_for_per_user_base.rs
+++ b/src/migrations/v017_rewrite_hook_strings_for_per_user_base.rs
@@ -160,7 +160,7 @@ fn rewrite_one(target: &HookTarget) -> Result<()> {
         anyhow::bail!("test-injected rewrite failure for {}", target.agent_name);
     }
     match target.kind {
-        HookTargetKind::JsonSettings => {
+        HookTargetKind::JsonSettings | HookTargetKind::CodexJson => {
             install_hooks(&target.path, target.events, HookInstallTarget::Host)
         }
         HookTargetKind::CodexToml => {

--- a/src/migrations/v018_strip_codex_config_toml_hooks.rs
+++ b/src/migrations/v018_strip_codex_config_toml_hooks.rs
@@ -1,0 +1,541 @@
+//! Migration v018: strip legacy AoE-managed hooks from `~/.codex/config.toml`.
+//!
+//! ## Background
+//!
+//! PR #2187 replaced the agent string-based hook dispatch with the
+//! `HookFormat` / `SidecarFormat` enums. The follow-up
+//! `feat/codex-hooks-json-migration` PR (issue #2188) flips Codex from
+//! `config.toml` to `hooks.json` as the on-disk hook location: the codex
+//! `AgentHookConfig` declares `HookFormat::CodexJson` with
+//! `settings_rel_path = ".codex/hooks.json"`.
+//!
+//! [`crate::hooks::iter_hook_targets_in`] does not enumerate `config.toml`
+//! for the codex agent, so the live install / uninstall lifecycle cannot
+//! reach AoE hooks left in `config.toml` from earlier installs. Without
+//! this migration, users upgrading from a `config.toml`-era release keep
+//! seeing Codex's dual-source warning and have their AoE hooks fire twice
+//! (once from `config.toml`, once from `hooks.json`).
+//!
+//! ## Strategy
+//!
+//! Enumerate every reachable `~/.codex/config.toml` (the default location
+//! plus every `CODEX_HOME` override from the global and per-profile
+//! `environment` lists), marker-gate via
+//! [`crate::hooks::has_aoe_marker`], then call
+//! [`crate::hooks::uninstall_codex_hooks`] which already preserves
+//! user-authored hooks, mixed user+AoE matcher groups, and the
+//! `[hooks.state]` trust block.
+//!
+//! ## Idempotency
+//!
+//! A second run finds no marker (the first run removed every AoE entry)
+//! and skips. Re-installing AoE hooks into `config.toml` through
+//! [`crate::hooks::iter_hook_targets_in`] is impossible because Codex's
+//! `HookFormat` is `CodexJson`.
+//!
+//! ## Failure policy
+//!
+//! Per `AGENTS.md > Data Migrations`, a returned `Err` aborts boot. v018
+//! never bubbles per-target failures: every per-target issue surfaces as
+//! `tracing::warn!`, the schema-version still bumps so the migration runs
+//! at most once, and recovery is `aoe uninstall && aoe add` exactly as
+//! documented for v015. Only `dirs::home_dir() == None` propagates.
+//!
+//! ## TOCTOU
+//!
+//! The marker gate ([`has_aoe_marker`](crate::hooks::has_aoe_marker)) is
+//! read lock-free. The lock is acquired inside
+//! [`uninstall_codex_hooks`](crate::hooks::uninstall_codex_hooks)
+//! (`with_codex_config_lock`). A concurrent install racing the migration
+//! is benign: either its entries are removed by the uninstaller (and the
+//! installer recreates them after the migration finishes, against the new
+//! `hooks.json` target), or they were already gone when we read the gate.
+//!
+//! ## Divergence from v015
+//!
+//! v015 short-circuits when `[features].hooks = false`. v018 strips
+//! regardless of the feature flag. Rationale: the feature flag gates
+//! whether Codex EXECUTES the hooks at all; the dual-source warning we
+//! are clearing is about FILE PRESENCE. AoE must remove its own entries
+//! from `config.toml` whether or not execution is currently gated off.
+//!
+//! ## Scope: host paths only
+//!
+//! v018 walks host-reachable paths only (same convention as v015 and
+//! v017). Sandbox-image hooks installed via `HookInstallTarget::Sandbox`
+//! and baked into a container image keep their `config.toml` entries
+//! until the image is rebuilt; the next `aoe sandbox rebuild` (or
+//! equivalent) picks up the canonical `hooks.json` layout.
+
+use anyhow::Result;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tracing::{debug, info, warn};
+
+use crate::hooks::{has_aoe_marker, HookTarget, HookTargetKind};
+
+/// Run v018 against the real user `home` and AoE app directory. Wired into
+/// the [`super::MIGRATIONS`] table.
+pub fn run() -> Result<()> {
+    let home =
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
+    let app_dir = crate::session::get_app_dir()?;
+    run_in(&home, &app_dir)
+}
+
+/// Home-injectable variant of [`run`]: strips AoE hooks from every
+/// reachable Codex `config.toml` under `home`, expanding `CODEX_HOME`
+/// overrides discovered in `app_dir`'s global and per-profile
+/// `environment` lists. Tests synthesise both directories.
+pub(crate) fn run_in(home: &Path, app_dir: &Path) -> Result<()> {
+    // Default env (no overrides) seeds the scan with `<home>/.codex/config.toml`.
+    let mut env_lists: Vec<Vec<String>> = vec![Vec::new()];
+    env_lists.extend(collect_env_lists(app_dir));
+
+    debug!(
+        target: "migrations.v018",
+        home = %home.display(),
+        app_dir = %app_dir.display(),
+        env_lists = env_lists.len(),
+        "v018: scanning Codex config paths"
+    );
+
+    let mut seen: HashSet<PathBuf> = HashSet::new();
+    let mut stripped = 0usize;
+    for env in &env_lists {
+        let path = crate::hooks::codex_config_path_in(home, env);
+        if !seen.insert(path.clone()) {
+            continue;
+        }
+        // Synthetic CodexToml target: the live enumerator does not produce
+        // this kind for any registered agent, so v018 builds the marker-gate
+        // fixture itself rather than mining `iter_hook_targets_in` for a
+        // variant only this migration constructs. `events: &[]` because
+        // the only consumer here is `has_aoe_marker` (bytes-only marker
+        // scan); `uninstall_codex_hooks` reads the file separately.
+        let target = HookTarget {
+            agent_name: "codex",
+            kind: HookTargetKind::CodexToml,
+            path: path.clone(),
+            events: &[],
+        };
+        if !has_aoe_marker(&target) {
+            continue;
+        }
+        match crate::hooks::uninstall_codex_hooks(&path) {
+            Ok(true) => {
+                stripped += 1;
+                info!(
+                    target: "migrations.v018",
+                    path = %path.display(),
+                    "v018: stripped legacy AoE hooks from Codex config.toml"
+                );
+            }
+            Ok(false) => {
+                // Mixed user+AoE matcher groups stay byte-intact (the
+                // uninstaller only drops all-AoE groups). The marker is
+                // still present afterwards, but on a second run this
+                // remains an idempotent no-write outcome.
+                debug!(
+                    target: "migrations.v018",
+                    path = %path.display(),
+                    "v018: marker present but no all-AoE group; nothing to remove"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    target: "migrations.v018",
+                    path = %path.display(),
+                    error = %e,
+                    "v018: skipped (uninstall failed)"
+                );
+            }
+        }
+    }
+
+    info!(target: "migrations.v018", count = stripped, "v018: done");
+    Ok(())
+}
+
+/// Read `environment` arrays from raw TOML (global config + each profile).
+/// Mirrors `v015::collect_env_lists`: migrations run before the live
+/// process commits to the current `Config` schema, so we deliberately
+/// avoid `Config::load()` here. If the `environment` schema key is renamed,
+/// both this and `crate::hooks::collect_env_lists_from_session` must update.
+fn collect_env_lists(app_dir: &Path) -> Vec<Vec<String>> {
+    let mut out = Vec::new();
+    if let Some(env) = read_environment_from_toml(&app_dir.join("config.toml")) {
+        out.push(env);
+    }
+    let profiles_dir = app_dir.join("profiles");
+    let Ok(entries) = fs::read_dir(&profiles_dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            if let Some(env) = read_environment_from_toml(&entry.path().join("config.toml")) {
+                out.push(env);
+            }
+        }
+    }
+    out
+}
+
+/// Best-effort `environment = [...]` extractor. Returns `None` on any
+/// I/O or parse failure (warn-and-continue convention).
+fn read_environment_from_toml(path: &Path) -> Option<Vec<String>> {
+    let content = fs::read_to_string(path).ok()?;
+    let table: toml::Value = toml::from_str(&content).ok()?;
+    let env = table.get("environment")?.as_array()?;
+    Some(
+        env.iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::{canonical_status_command, HookInstallTarget};
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// `EnvGuard` clears `CODEX_HOME` (and the sibling agent overrides v015
+    /// also scrubs) for the test duration so the migration's path
+    /// resolution sees only the explicit fixtures in `home` / `app_dir`.
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+    impl EnvGuard {
+        fn unset_all() -> Self {
+            let keys = [
+                "CODEX_HOME",
+                "CLAUDE_CONFIG_DIR",
+                "CURSOR_CONFIG_DIR",
+                "GEMINI_CONFIG_DIR",
+                "QWEN_CONFIG_DIR",
+            ];
+            let saved = keys
+                .iter()
+                .map(|k| {
+                    let prev = std::env::var(k).ok();
+                    std::env::remove_var(k);
+                    (*k, prev)
+                })
+                .collect();
+            Self { saved }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.saved {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    fn setup_dirs() -> (TempDir, PathBuf, PathBuf) {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join("home");
+        let app_dir = tmp.path().join("app");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&app_dir).unwrap();
+        (tmp, home, app_dir)
+    }
+
+    /// Build a TOML fixture with one AoE-marked `SessionStart` hook.
+    /// Uses the live `canonical_status_command` so the planted bytes
+    /// carry the same `# aoe-hooks ...` trailing sentinel
+    /// [`has_aoe_marker`] looks for.
+    fn aoe_session_start_block() -> String {
+        let cmd = canonical_status_command("running", HookInstallTarget::Host);
+        format!(
+            "[[hooks.SessionStart]]\n\
+             [[hooks.SessionStart.hooks]]\n\
+             type = \"command\"\n\
+             command = {cmd:?}\n"
+        )
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn missing_config_is_noop() {
+        let _g = EnvGuard::unset_all();
+        let (_tmp, home, app_dir) = setup_dirs();
+
+        run_in(&home, &app_dir).unwrap();
+
+        assert!(
+            !home.join(".codex/config.toml").exists(),
+            "v018 must not magic a missing config.toml into existence"
+        );
+        assert!(
+            !home.join(".codex").exists(),
+            "v018 must not create the parent dir either"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn user_only_config_byte_identical() {
+        let _g = EnvGuard::unset_all();
+        let (_tmp, home, app_dir) = setup_dirs();
+        let codex = home.join(".codex/config.toml");
+        fs::create_dir_all(codex.parent().unwrap()).unwrap();
+        let original = "[[hooks.SessionStart]]\n\
+                        [[hooks.SessionStart.hooks]]\n\
+                        type = \"command\"\n\
+                        command = \"echo user-only\"\n";
+        fs::write(&codex, original).unwrap();
+        let before = fs::read(&codex).unwrap();
+
+        run_in(&home, &app_dir).unwrap();
+
+        assert_eq!(
+            fs::read(&codex).unwrap(),
+            before,
+            "config.toml without an AoE marker must be byte-untouched"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn aoe_only_strips_and_preserves_state() {
+        let _g = EnvGuard::unset_all();
+        let (_tmp, home, app_dir) = setup_dirs();
+        let codex = home.join(".codex/config.toml");
+        fs::create_dir_all(codex.parent().unwrap()).unwrap();
+        let content = format!(
+            "[hooks.state]\n\
+             existing = {{ enabled = true, trusted_hash = \"keep-me\" }}\n\
+             \n\
+             {}",
+            aoe_session_start_block()
+        );
+        fs::write(&codex, content).unwrap();
+
+        run_in(&home, &app_dir).unwrap();
+
+        let text = fs::read_to_string(&codex).unwrap();
+        let parsed: toml::Value = toml::from_str(&text).unwrap();
+        assert_eq!(
+            parsed["hooks"]["state"]["existing"]["trusted_hash"].as_str(),
+            Some("keep-me"),
+            "[hooks.state] must survive the strip"
+        );
+        assert!(
+            parsed["hooks"].get("SessionStart").is_none(),
+            "every AoE-marked SessionStart entry must be removed: {text}"
+        );
+        assert!(
+            !text.contains("aoe-hooks"),
+            "no AoE-marker substring may remain anywhere in the file: {text}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn mixed_user_aoe_matcher_left_intact() {
+        // The uninstaller drops only all-AoE matcher groups (per
+        // `remove_codex_aoe_hooks` / `codex_matcher_group_is_all_aoe`).
+        // A hand-merged group with both a user hook and an AoE hook is
+        // preserved byte-for-byte. v018 still treats this as success
+        // (returns Ok); the only observable side effect is the debug
+        // "marker present but no all-AoE group" log.
+        let _g = EnvGuard::unset_all();
+        let (_tmp, home, app_dir) = setup_dirs();
+        let codex = home.join(".codex/config.toml");
+        fs::create_dir_all(codex.parent().unwrap()).unwrap();
+        let cmd = canonical_status_command("running", HookInstallTarget::Host);
+        let original = format!(
+            "[[hooks.SessionStart]]\n\
+             [[hooks.SessionStart.hooks]]\n\
+             type = \"command\"\n\
+             command = \"echo user-hook\"\n\
+             [[hooks.SessionStart.hooks]]\n\
+             type = \"command\"\n\
+             command = {cmd:?}\n"
+        );
+        fs::write(&codex, &original).unwrap();
+        let before = fs::read(&codex).unwrap();
+
+        run_in(&home, &app_dir).unwrap();
+
+        assert_eq!(
+            fs::read(&codex).unwrap(),
+            before,
+            "mixed user+AoE matcher groups must stay byte-identical \
+             (locks the conservative uninstaller behaviour)"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn profile_codex_home_visited() {
+        let _g = EnvGuard::unset_all();
+        let (_tmp, home, app_dir) = setup_dirs();
+        let codex_override = home.join("work-codex");
+        fs::create_dir_all(&codex_override).unwrap();
+        fs::write(
+            codex_override.join("config.toml"),
+            aoe_session_start_block(),
+        )
+        .unwrap();
+
+        let profile_dir = app_dir.join("profiles/work");
+        fs::create_dir_all(&profile_dir).unwrap();
+        fs::write(
+            profile_dir.join("config.toml"),
+            format!(
+                "environment = [\"CODEX_HOME={}\"]\n",
+                codex_override.display()
+            ),
+        )
+        .unwrap();
+
+        run_in(&home, &app_dir).unwrap();
+
+        let text = fs::read_to_string(codex_override.join("config.toml")).unwrap();
+        assert!(
+            !text.contains("aoe-hooks"),
+            "profile-overridden Codex path must be reached and stripped; got: {text}"
+        );
+        assert!(
+            !home.join(".codex/config.toml").exists(),
+            "default ~/.codex/config.toml must not be magicked into existence"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn symlinked_config_resolved_and_stripped() {
+        let _g = EnvGuard::unset_all();
+        let (_tmp, home, app_dir) = setup_dirs();
+        let real = home.join("real-codex.toml");
+        fs::write(&real, aoe_session_start_block()).unwrap();
+        let link = home.join(".codex/config.toml");
+        fs::create_dir_all(link.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        run_in(&home, &app_dir).unwrap();
+
+        // The underlying file received the strip.
+        let after_real = fs::read_to_string(&real).unwrap();
+        assert!(
+            !after_real.contains("aoe-hooks"),
+            "real config file (target of symlink) must be stripped: {after_real}"
+        );
+        // The symlink itself was not replaced by a regular file.
+        let link_meta = fs::symlink_metadata(&link).unwrap();
+        assert!(
+            link_meta.file_type().is_symlink(),
+            "symlink at .codex/config.toml must survive the rewrite"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn idempotent_byte_identical_on_second_run() {
+        let _g = EnvGuard::unset_all();
+        let (_tmp, home, app_dir) = setup_dirs();
+        let codex = home.join(".codex/config.toml");
+        fs::create_dir_all(codex.parent().unwrap()).unwrap();
+        fs::write(&codex, aoe_session_start_block()).unwrap();
+
+        run_in(&home, &app_dir).unwrap();
+        let after_first = fs::read(&codex).unwrap();
+
+        // First run must actually have stripped the marker; otherwise the
+        // idempotency assertion below would be vacuous.
+        assert!(
+            !String::from_utf8_lossy(&after_first).contains("aoe-hooks"),
+            "first run must strip the AoE marker"
+        );
+
+        run_in(&home, &app_dir).unwrap();
+        let after_second = fs::read(&codex).unwrap();
+
+        assert_eq!(
+            after_first, after_second,
+            "v018 must be byte-idempotent: second run finds no marker and skips"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn malformed_toml_skipped_silently() {
+        let _g = EnvGuard::unset_all();
+        let (_tmp, home, app_dir) = setup_dirs();
+        let codex = home.join(".codex/config.toml");
+        fs::create_dir_all(codex.parent().unwrap()).unwrap();
+        let original = "[[hooks\n# unclosed";
+        fs::write(&codex, original).unwrap();
+
+        run_in(&home, &app_dir).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&codex).unwrap(),
+            original,
+            "malformed TOML must stay byte-identical (gate fails closed)"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn features_hooks_false_still_stripped() {
+        // Intentional divergence from v015: v018 strips AoE entries even
+        // when `[features].hooks = false`. The feature flag controls
+        // execution; v018 is about file presence (the dual-source
+        // warning). See module-level "Divergence from v015".
+        let _g = EnvGuard::unset_all();
+        let (_tmp, home, app_dir) = setup_dirs();
+        let codex = home.join(".codex/config.toml");
+        fs::create_dir_all(codex.parent().unwrap()).unwrap();
+        let content = format!("[features]\nhooks = false\n\n{}", aoe_session_start_block());
+        fs::write(&codex, content).unwrap();
+
+        run_in(&home, &app_dir).unwrap();
+
+        let text = fs::read_to_string(&codex).unwrap();
+        assert!(
+            !text.contains("aoe-hooks"),
+            "v018 must strip AoE entries regardless of features.hooks: {text}"
+        );
+        let parsed: toml::Value = toml::from_str(&text).unwrap();
+        assert_eq!(
+            parsed["features"]["hooks"].as_bool(),
+            Some(false),
+            "[features] table itself must be preserved"
+        );
+    }
+
+    #[test]
+    fn static_no_agent_uses_codex_toml_format_post_flip() {
+        // Regression lock for issue #2188: the codex agent must declare
+        // `HookFormat::CodexJson`. The `CodexToml` variant of `HookFormat`
+        // is absent from the codebase, so this test pins the chosen value
+        // by exact match; if a future refactor reintroduces a TOML-based
+        // codex `HookFormat`, v018 stops being sufficient (the live install
+        // path would resurrect what was stripped) and this assertion fires.
+        let codex = crate::agents::get_agent("codex").expect("codex agent must be registered");
+        let hook_cfg = codex
+            .hook_config
+            .as_ref()
+            .expect("codex must declare a hook_config");
+        assert_eq!(
+            hook_cfg.format,
+            crate::agents::HookFormat::CodexJson,
+            "codex agent must use CodexJson; v018 is only safe when no agent \
+             installs AoE hooks back into config.toml"
+        );
+        assert_eq!(
+            hook_cfg.settings_rel_path, ".codex/hooks.json",
+            "codex hook path must be .codex/hooks.json"
+        );
+    }
+}

--- a/src/migrations/v018_strip_codex_config_toml_hooks.rs
+++ b/src/migrations/v018_strip_codex_config_toml_hooks.rs
@@ -4,7 +4,7 @@
 //!
 //! PR #2187 replaced the agent string-based hook dispatch with the
 //! `HookFormat` / `SidecarFormat` enums. The follow-up
-//! `feat/codex-hooks-json-migration` PR (issue #2188) flips Codex from
+//! `feat/codex-hooks-json-migration` PR flips Codex from
 //! `config.toml` to `hooks.json` as the on-disk hook location: the codex
 //! `AgentHookConfig` declares `HookFormat::CodexJson` with
 //! `settings_rel_path = ".codex/hooks.json"`.
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn static_no_agent_uses_codex_toml_format_post_flip() {
-        // Regression lock for issue #2188: the codex agent must declare
+        // Regression lock for the Codex hooks.json pivot: the codex agent must declare
         // `HookFormat::CodexJson`. The `CodexToml` variant of `HookFormat`
         // is absent from the codebase, so this test pins the chosen value
         // by exact match; if a future refactor reintroduces a TOML-based

--- a/src/migrations/v018_strip_codex_config_toml_hooks.rs
+++ b/src/migrations/v018_strip_codex_config_toml_hooks.rs
@@ -515,7 +515,7 @@ mod tests {
     }
 
     #[test]
-    fn static_no_agent_uses_codex_toml_format_post_flip() {
+    fn codex_agent_declares_codex_json_hook_format() {
         // Regression lock for the Codex hooks.json pivot: the codex agent must declare
         // `HookFormat::CodexJson`. The `CodexToml` variant of `HookFormat`
         // is absent from the codebase, so this test pins the chosen value

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -701,6 +701,30 @@ fn prepare_sandbox_dir(mount: &AgentConfigMount, home: &Path) -> Result<std::pat
     }
 
     if host_dir.exists() {
+        // Codex's `[hooks.state]` trust block lives only in the sandbox
+        // copy of `config.toml` (Codex writes `trusted_hash` there when
+        // the user accepts a hook hash inside the container). The next
+        // `sync_agent_config` overwrites that file from the host;
+        // snapshot here and restore after the sync so accepted hashes
+        // survive the host-to-sandbox refresh. The codex config lock is
+        // released between snapshot and restore; the sandbox path is
+        // process-private, so no concurrent writer is expected.
+        let preserved_codex_state = if agent_format_is_codex_json(mount.tool_name) {
+            let sandbox_config = sandbox_dir.join("config.toml");
+            crate::hooks::snapshot_codex_hooks_state(&sandbox_config)
+                .inspect_err(|e| {
+                    tracing::warn!(target: "session.profile",
+                        "Failed to snapshot Codex [hooks.state] from {}: {}",
+                        sandbox_config.display(),
+                        e
+                    );
+                })
+                .ok()
+                .flatten()
+        } else {
+            None
+        };
+
         sync_agent_config(
             &host_dir,
             &sandbox_dir,
@@ -709,6 +733,19 @@ fn prepare_sandbox_dir(mount: &AgentConfigMount, home: &Path) -> Result<std::pat
             mount.copy_dirs,
             mount.preserve_files,
         )?;
+
+        if let Some(state) = preserved_codex_state {
+            let sandbox_config = sandbox_dir.join("config.toml");
+            if sandbox_config.exists() {
+                if let Err(e) = crate::hooks::restore_codex_hooks_state(&sandbox_config, state) {
+                    tracing::warn!(target: "session.profile",
+                        "Failed to restore Codex [hooks.state] in {}: {}",
+                        sandbox_config.display(),
+                        e
+                    );
+                }
+            }
+        }
 
         if mount.tool_name == "claude" {
             if let Err(e) = rewrite_claude_plugin_paths(&sandbox_dir, home) {
@@ -939,30 +976,11 @@ pub(crate) fn refresh_agent_configs() {
 
     for mount in AGENT_CONFIG_MOUNTS {
         let refresh_codex_hooks = hooks_enabled && should_refresh_codex_hooks(mount, &home);
-        let preserved_codex_state = if refresh_codex_hooks {
-            let config_path = home
-                .join(mount.host_rel)
-                .join(SANDBOX_SUBDIR)
-                .join("config.toml");
-            match crate::hooks::snapshot_codex_hooks_state(&config_path) {
-                Ok(state) => state,
-                Err(e) => {
-                    tracing::warn!(target: "session.profile",
-                        "Failed to read Codex sandbox hook state from {}: {}",
-                        config_path.display(),
-                        e
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        };
 
         match prepare_sandbox_dir(mount, &home) {
             Ok(sandbox_dir) => {
                 if refresh_codex_hooks {
-                    refresh_codex_sandbox_hooks(mount, &sandbox_dir, preserved_codex_state);
+                    refresh_codex_sandbox_hooks(mount, &sandbox_dir);
                 }
             }
             Err(e) => {
@@ -976,43 +994,45 @@ pub(crate) fn refresh_agent_configs() {
     }
 }
 
-fn should_refresh_codex_hooks(mount: &AgentConfigMount, home: &Path) -> bool {
-    let is_codex_toml = crate::agents::get_agent(mount.tool_name)
+/// True iff `tool_name` resolves to a registered agent declaring
+/// [`crate::agents::HookFormat::CodexJson`]. Centralises the dispatch
+/// predicate so `prepare_sandbox_dir` and `should_refresh_codex_hooks`
+/// stay aligned.
+fn agent_format_is_codex_json(tool_name: &str) -> bool {
+    crate::agents::get_agent(tool_name)
         .and_then(|a| a.hook_config.as_ref())
-        .is_some_and(|c| c.format == crate::agents::HookFormat::CodexToml);
-    if !is_codex_toml {
+        .is_some_and(|c| c.format == crate::agents::HookFormat::CodexJson)
+}
+
+fn should_refresh_codex_hooks(mount: &AgentConfigMount, home: &Path) -> bool {
+    if !agent_format_is_codex_json(mount.tool_name) {
         return false;
     }
 
-    let host_config = home.join(mount.host_rel).join("config.toml");
-    let sandbox_config = home
+    let host_hooks = home.join(mount.host_rel).join("hooks.json");
+    let sandbox_hooks = home
         .join(mount.host_rel)
         .join(SANDBOX_SUBDIR)
-        .join("config.toml");
-    host_config.exists() || sandbox_config.exists()
+        .join("hooks.json");
+    host_hooks.exists() || sandbox_hooks.exists()
 }
 
-fn refresh_codex_sandbox_hooks(
-    mount: &AgentConfigMount,
-    sandbox_dir: &Path,
-    preserved_state: Option<toml_edit::Item>,
-) {
+fn refresh_codex_sandbox_hooks(mount: &AgentConfigMount, sandbox_dir: &Path) {
     let Some(hook_cfg) =
         crate::agents::get_agent(mount.tool_name).and_then(|a| a.hook_config.as_ref())
     else {
         return;
     };
 
-    let config_path = sandbox_dir.join("config.toml");
-    if let Err(e) = crate::hooks::install_codex_hooks_with_preserved_state(
-        &config_path,
+    let hooks_path = sandbox_dir.join("hooks.json");
+    if let Err(e) = crate::hooks::install_hooks(
+        &hooks_path,
         hook_cfg.events,
-        preserved_state,
         crate::hooks::HookInstallTarget::Sandbox,
     ) {
         tracing::warn!(
             "Failed to refresh Codex hooks in sandbox config {}: {}",
-            config_path.display(),
+            hooks_path.display(),
             e
         );
     }
@@ -1466,18 +1486,14 @@ pub(crate) fn build_container_config(
                         let sandbox_dir = home.join(mount.host_rel).join(SANDBOX_SUBDIR);
                         let settings_file = sandbox_dir.join(config_file_name);
                         let result = match hook_cfg.format {
-                            crate::agents::HookFormat::CodexToml => {
-                                crate::hooks::install_codex_hooks(
+                            crate::agents::HookFormat::CodexJson
+                            | crate::agents::HookFormat::JsonSettings => {
+                                crate::hooks::install_hooks(
                                     &settings_file,
                                     hook_cfg.events,
                                     crate::hooks::HookInstallTarget::Sandbox,
                                 )
                             }
-                            crate::agents::HookFormat::JsonSettings => crate::hooks::install_hooks(
-                                &settings_file,
-                                hook_cfg.events,
-                                crate::hooks::HookInstallTarget::Sandbox,
-                            ),
                         };
                         if let Err(e) = result {
                             tracing::warn!(target: "session.profile", "Failed to install hooks in sandbox config: {}", e);
@@ -3209,12 +3225,13 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
         .unwrap();
 
         let codex_sandbox = temp_home.path().join(".codex").join(SANDBOX_SUBDIR);
-        assert!(codex_sandbox.join("config.toml").exists());
-        assert!(!codex_sandbox.join("hooks.json").exists());
+        assert!(codex_sandbox.join("hooks.json").exists());
+        assert!(!codex_sandbox.join("config.toml").exists());
         assert!(!codex_sandbox.join("settings.json").exists());
-        let codex_config = fs::read_to_string(codex_sandbox.join("config.toml")).unwrap();
-        assert!(codex_config.contains("[[hooks.PreToolUse]]"));
-        assert!(codex_config.contains("aoe-hooks"));
+        let codex_hooks = fs::read_to_string(codex_sandbox.join("hooks.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&codex_hooks).unwrap();
+        assert!(parsed["hooks"]["PreToolUse"].is_array());
+        assert!(codex_hooks.contains("aoe-hooks"));
         assert!(config.volumes.iter().any(|v| {
             v.host_path == codex_sandbox.to_string_lossy() && v.container_path == "/root/.codex"
         }));
@@ -3471,14 +3488,15 @@ agent_detect_as = { "wrapped-codex" = "codex" }
         .unwrap();
 
         let codex_sandbox = temp_home.path().join(".codex").join(SANDBOX_SUBDIR);
-        assert!(codex_sandbox.join("config.toml").exists());
+        assert!(codex_sandbox.join("hooks.json").exists());
         assert!(config.volumes.iter().any(|v| {
             v.host_path == codex_sandbox.to_string_lossy() && v.container_path == "/root/.codex"
         }));
 
-        let codex_config = fs::read_to_string(codex_sandbox.join("config.toml")).unwrap();
-        assert!(codex_config.contains("[[hooks.PreToolUse]]"));
-        assert!(codex_config.contains("aoe-hooks"));
+        let codex_hooks = fs::read_to_string(codex_sandbox.join("hooks.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&codex_hooks).unwrap();
+        assert!(parsed["hooks"]["PreToolUse"].is_array());
+        assert!(codex_hooks.contains("aoe-hooks"));
 
         let hook_dir =
             crate::hooks::hook_status_dir(instance_id).expect("test id must be allowlist-safe");
@@ -3551,8 +3569,15 @@ trusted_hash = "keep"
             config["hooks"]["state"]["trusted"]["trusted_hash"].as_str(),
             Some("keep")
         );
-        assert!(config_text.contains("[[hooks.PreToolUse]]"));
-        assert!(config_text.contains("aoe-hooks"));
+
+        let hooks_path = codex_sandbox.join("hooks.json");
+        let hooks_text = fs::read_to_string(&hooks_path).unwrap();
+        let hooks: serde_json::Value = serde_json::from_str(&hooks_text).unwrap();
+        assert!(
+            hooks["hooks"]["PreToolUse"].is_array(),
+            "PreToolUse array must be installed in sandbox hooks.json"
+        );
+        assert!(hooks_text.contains("aoe-hooks"));
         crate::hooks::cleanup_hook_status_dir(instance_id);
     }
 
@@ -3590,7 +3615,7 @@ trusted_hash = "keep"
         .unwrap();
 
         let codex_sandbox = temp_home.path().join(".codex").join(SANDBOX_SUBDIR);
-        assert!(codex_sandbox.join("config.toml").exists());
+        assert!(codex_sandbox.join("hooks.json").exists());
         assert!(config.volumes.iter().any(|v| {
             v.host_path == codex_sandbox.to_string_lossy()
                 && v.container_path == "/root/custom-codex"
@@ -3645,7 +3670,7 @@ environment = ["CODEX_HOME=/root/profile-codex"]
         .unwrap();
 
         let codex_sandbox = temp_home.path().join(".codex").join(SANDBOX_SUBDIR);
-        assert!(codex_sandbox.join("config.toml").exists());
+        assert!(codex_sandbox.join("hooks.json").exists());
         assert!(config.volumes.iter().any(|v| {
             v.host_path == codex_sandbox.to_string_lossy()
                 && v.container_path == "/root/profile-codex"

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -701,14 +701,15 @@ fn prepare_sandbox_dir(mount: &AgentConfigMount, home: &Path) -> Result<std::pat
     }
 
     if host_dir.exists() {
-        // Codex's `[hooks.state]` trust block lives only in the sandbox
-        // copy of `config.toml` (Codex writes `trusted_hash` there when
-        // the user accepts a hook hash inside the container). The next
-        // `sync_agent_config` overwrites that file from the host;
-        // snapshot here and restore after the sync so accepted hashes
-        // survive the host-to-sandbox refresh. The codex config lock is
-        // released between snapshot and restore; the sandbox path is
-        // process-private, so no concurrent writer is expected.
+        // Codex writes `trusted_hash` into `[hooks.state]` of the sandbox
+        // copy of `config.toml` when the user accepts a hook hash inside
+        // the container; that copy is overwritten on each
+        // `sync_agent_config` from the host. Snapshot here and restore
+        // after the sync so accepted hashes survive the host-to-sandbox
+        // refresh (the sandbox value wins by design, since trust is local
+        // to the container). The codex config lock is released between
+        // snapshot and restore; the sandbox path is process-private, so
+        // no concurrent writer is expected.
         let preserved_codex_state = if agent_format_is_codex_json(mount.tool_name) {
             let sandbox_config = sandbox_dir.join("config.toml");
             crate::hooks::snapshot_codex_hooks_state(&sandbox_config)
@@ -736,14 +737,17 @@ fn prepare_sandbox_dir(mount: &AgentConfigMount, home: &Path) -> Result<std::pat
 
         if let Some(state) = preserved_codex_state {
             let sandbox_config = sandbox_dir.join("config.toml");
-            if sandbox_config.exists() {
-                if let Err(e) = crate::hooks::restore_codex_hooks_state(&sandbox_config, state) {
-                    tracing::warn!(target: "session.profile",
-                        "Failed to restore Codex [hooks.state] in {}: {}",
-                        sandbox_config.display(),
-                        e
-                    );
-                }
+            if !sandbox_config.exists() {
+                tracing::warn!(target: "session.profile",
+                    "Codex [hooks.state] snapshotted but sandbox config.toml absent after sync at {}; trust block dropped",
+                    sandbox_config.display()
+                );
+            } else if let Err(e) = crate::hooks::restore_codex_hooks_state(&sandbox_config, state) {
+                tracing::warn!(target: "session.profile",
+                    "Failed to restore Codex [hooks.state] in {}: {}",
+                    sandbox_config.display(),
+                    e
+                );
             }
         }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2095,7 +2095,7 @@ impl Instance {
         } else if let Some(hook_cfg) = agent.and_then(|a| a.hook_config.as_ref()) {
             if !self.is_sandboxed() {
                 match hook_cfg.format {
-                    crate::agents::HookFormat::CodexToml => self.install_codex_host_hooks(hook_cfg),
+                    crate::agents::HookFormat::CodexJson => self.install_codex_host_hooks(hook_cfg),
                     crate::agents::HookFormat::JsonSettings => {
                         self.install_json_host_hooks(hook_cfg)
                     }
@@ -2106,17 +2106,19 @@ impl Instance {
     }
 
     fn install_codex_host_hooks(&self, hook_cfg: &crate::agents::AgentHookConfig) {
-        match self.codex_config_path_for_launch_env() {
-            Ok(config_path) => {
-                if let Err(e) = crate::hooks::install_codex_hooks(
-                    &config_path,
+        match crate::hooks::codex_hooks_json_path_for_host_environment(
+            &self.profile_host_environment(),
+        ) {
+            Ok(hooks_path) => {
+                if let Err(e) = crate::hooks::install_hooks(
+                    &hooks_path,
                     hook_cfg.events,
                     crate::hooks::HookInstallTarget::Host,
                 ) {
                     tracing::warn!("Failed to install codex hooks: {}", e);
                 }
             }
-            Err(e) => tracing::warn!("Failed to resolve codex config path: {}", e),
+            Err(e) => tracing::warn!("Failed to resolve codex hooks path: {}", e),
         }
     }
 
@@ -2141,10 +2143,6 @@ impl Instance {
                 tracing::warn!(target: "session.store", "Failed to resolve agent hooks path: {}", e)
             }
         }
-    }
-
-    fn codex_config_path_for_launch_env(&self) -> Result<PathBuf> {
-        crate::hooks::codex_config_path_for_host_environment(&self.profile_host_environment())
     }
 
     /// Build the tmux command for a host (non-sandboxed) session.
@@ -3920,11 +3918,12 @@ mod tests {
         inst.detect_as = "codex".to_string();
         inst.install_agent_status_hooks(crate::agents::get_agent(&inst.detect_as));
 
-        let config_path = tmp.path().join(".codex").join("config.toml");
-        let config = std::fs::read_to_string(config_path).unwrap();
-        assert!(config.contains("[[hooks.PreToolUse]]"));
-        assert!(config.contains("aoe-hooks"));
-        assert!(!tmp.path().join(".codex").join("hooks.json").exists());
+        let hooks_path = tmp.path().join(".codex").join("hooks.json");
+        let hooks = std::fs::read_to_string(hooks_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&hooks).unwrap();
+        assert!(parsed["hooks"]["PreToolUse"].is_array());
+        assert!(hooks.contains("aoe-hooks"));
+        assert!(!tmp.path().join(".codex").join("config.toml").exists());
     }
 
     #[test]
@@ -3950,11 +3949,12 @@ mod tests {
         inst.source_profile = "codex-profile".to_string();
         inst.install_agent_status_hooks(crate::agents::get_agent(&inst.detect_as));
 
-        let config_path = codex_home.join("config.toml");
-        let config = std::fs::read_to_string(config_path).unwrap();
-        assert!(config.contains("[[hooks.PreToolUse]]"));
-        assert!(config.contains("aoe-hooks"));
-        assert!(!tmp.path().join(".codex").join("config.toml").exists());
+        let hooks_path = codex_home.join("hooks.json");
+        let hooks = std::fs::read_to_string(hooks_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&hooks).unwrap();
+        assert!(parsed["hooks"]["PreToolUse"].is_array());
+        assert!(hooks.contains("aoe-hooks"));
+        assert!(!tmp.path().join(".codex").join("hooks.json").exists());
     }
 
     #[test]
@@ -3979,7 +3979,7 @@ mod tests {
         inst.source_profile = "hooks-disabled".to_string();
         inst.install_agent_status_hooks(crate::agents::get_agent(&inst.detect_as));
 
-        assert!(!tmp.path().join(".codex").join("config.toml").exists());
+        assert!(!tmp.path().join(".codex").join("hooks.json").exists());
     }
 
     #[test]
@@ -4008,10 +4008,11 @@ mod tests {
         inst.source_profile = "hooks-enabled".to_string();
         inst.install_agent_status_hooks(crate::agents::get_agent(&inst.detect_as));
 
-        let config_path = tmp.path().join(".codex").join("config.toml");
-        let config = std::fs::read_to_string(config_path).unwrap();
-        assert!(config.contains("[[hooks.PreToolUse]]"));
-        assert!(config.contains("aoe-hooks"));
+        let hooks_path = tmp.path().join(".codex").join("hooks.json");
+        let hooks = std::fs::read_to_string(hooks_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&hooks).unwrap();
+        assert!(parsed["hooks"]["PreToolUse"].is_array());
+        assert!(hooks.contains("aoe-hooks"));
     }
 
     #[test]

--- a/src/tui/dialogs/hooks_install.rs
+++ b/src/tui/dialogs/hooks_install.rs
@@ -38,10 +38,12 @@ impl HooksInstallDialog {
                     .map(|config| config.environment)
                     .unwrap_or_default();
                 match hook_cfg.format {
-                    crate::agents::HookFormat::CodexToml => {
+                    crate::agents::HookFormat::CodexJson => {
                         needs_codex_trust_note = true;
                         settings_paths.push(
-                            crate::hooks::codex_config_path_display_for_host_environment(&host_env),
+                            crate::hooks::codex_hooks_json_path_display_for_host_environment(
+                                &host_env,
+                            ),
                         );
                     }
                     crate::agents::HookFormat::JsonSettings => {
@@ -482,8 +484,8 @@ mod tests {
             .map(|l| l.to_string())
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(text.contains(".codex/config.toml"));
-        assert!(!text.contains(".codex/hooks.json"));
+        assert!(text.contains(".codex/hooks.json"));
+        assert!(!text.contains(".codex/config.toml"));
         assert!(text.contains("trust these hooks in /hooks"));
         assert!(text.contains("pane-based status detection"));
     }
@@ -497,8 +499,8 @@ mod tests {
         let dialog = HooksInstallDialog::new("codex");
         let text = content_text(&dialog);
 
-        assert!(text.contains(&tmp.path().join("config.toml").display().to_string()));
-        assert!(!text.contains(".codex/hooks.json"));
+        assert!(text.contains(&tmp.path().join("hooks.json").display().to_string()));
+        assert!(!text.contains(&tmp.path().join("config.toml").display().to_string()));
     }
 
     #[test]
@@ -521,8 +523,8 @@ mod tests {
         let dialog = HooksInstallDialog::new_for_profile("codex", Some("codex-profile"));
         let text = content_text(&dialog);
 
-        assert!(text.contains(&codex_home.join("config.toml").display().to_string()));
-        assert!(!text.contains(".codex/hooks.json"));
+        assert!(text.contains(&codex_home.join("hooks.json").display().to_string()));
+        assert!(!text.contains(&codex_home.join("config.toml").display().to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Stacks on #2333. Implements the Codex storage-format pivot that was bundled in #2203 as a clean separate change.

The codex agent declares `HookFormat::CodexJson` and installs hooks into `~/.codex/hooks.json` with the same JSON shape as Claude. `config.toml` retains the `[hooks.state]` trust block, preserved across host-to-sandbox refresh via `snapshot_codex_hooks_state` and `restore_codex_hooks_state` around the config sync in `prepare_sandbox_dir`.

## Contents

### Storage format pivot
- `src/agents.rs`: `HookFormat::CodexToml` to `CodexJson`; codex agent `settings_rel_path` to `.codex/hooks.json`
- `src/hooks/mod.rs`: new `HookTargetKind::CodexJson`, `codex_hooks_json_path_in`, `codex_hooks_json_path_display_for_host_environment`, `restore_codex_hooks_state` helper
- `src/session/instance.rs`: `install_agent_status_hooks` routes Codex via the JSON writer; `install_codex_host_hooks` and `install_json_host_hooks` extracted
- `src/session/container_config.rs`: sandbox install + refresh paths write `hooks.json`; `should_refresh_codex_hooks` gates on the `CodexJson` format + presence of `hooks.json`; `agent_format_is_codex_json` helper shared with `prepare_sandbox_dir`
- `src/tui/dialogs/hooks_install.rs`: consent dialog shows `hooks.json` (keeps the codex trust note)

### Trust state preservation
- `src/session/container_config.rs::prepare_sandbox_dir`: snapshots `[hooks.state]` from sandbox `config.toml` before `sync_agent_config` overwrites it, then restores via `restore_codex_hooks_state`. Locked by `test_refresh_agent_configs_preserves_codex_hooks_and_trust_state`.

### Cleanup migration
- `src/migrations/v018_strip_codex_config_toml_hooks.rs`: new migration that strips AoE-managed hooks from any legacy `~/.codex/config.toml` on upgrade. Preserves `[hooks.state]` and user-authored hooks; conservative on mixed user + AoE matcher groups (byte identical). Visits default `~/.codex/config.toml` + every `CODEX_HOME` from global and per-profile environment.

### Migration alignment
- `src/migrations/v015_rewrite_hook_strings.rs` and `v017`: route `CodexJson` targets through the JsonSettings arm so the hook-string rewrites reach `hooks.json`. The three obsolete v015 codex `config.toml` tests are dropped (v018 owns that cleanup); `profile_codex_home_path_is_rewritten` retargets `hooks.json`.

## Blockers from PR #2203 addressed

| Blocker (reviewer) | Resolution |
|---|---|
| Dual-source warning not fixed for existing users (njbrake) | v018 strips legacy `config.toml` hooks; refresh only writes `hooks.json` |
| v014 to v015 silent no-op for existing users (jerome-benoit) | v018 visits default `~/.codex/config.toml` + every `CODEX_HOME` override |
| `should_refresh_codex_hooks` gate breaks on fresh installs (jerome-benoit) | Gate keys on `format == CodexJson` and presence of `hooks.json` (host or sandbox), fires on fresh installs once the file lands |
| Atomic-write regression on Codex (njbrake) | Install path goes through `install_hooks`, which uses atomic write |
| `HookFormat::CodexToml` dead code (jerome-benoit, njbrake) | Removed by the storage-format pivot: #2333 added the variant alongside `JsonSettings`, and the pivot drops it. `HookTargetKind::CodexToml` is kept solely for the v018 legacy migration. |
| Trust-state preservation (njbrake) | Snapshot + restore around sync in `prepare_sandbox_dir`, locked by test |
| Host vs sandbox inconsistency (njbrake) | Both paths use the same `install_hooks` writer |
| Consent dialog promises wrong path (jerome-benoit) | Dialog renders `hooks.json` |
| `features.hooks = false` not respected (njbrake) | After the pivot, AoE writes to `hooks.json`, which Codex's `[features].hooks` flag does not gate at write time. Codex itself honors its `[features].hooks` at execution, so `hooks.json` presence is a runtime no-op when the flag is disabled. AoE's own gate (`session.agent_status_hooks`) is honored at the call sites (`install_agent_status_hooks` in `instance.rs`, `refresh_agent_configs` in `container_config.rs`); `install_hooks` itself is unconditional. v018 strips legacy `config.toml` regardless of either flag (file presence, not execution). @njbrake closed #2203 in favor of this stack on 2026-06-23, accepting this resolution. |
| Vacuous v015 tests (jerome-benoit) | Three obsolete v015 codex tests removed; v018 covers cleanup; `profile_codex_home_path_is_rewritten` retargets `hooks.json` |

## How tested

- `cargo fmt`
- `cargo clippy --lib --all-targets -- -D warnings`: clean
- `cargo test --lib migrations::v018`: 10/10 pass
- `cargo test --lib migrations::v015`: 14 pass (3 obsolete codex tests removed, profile_codex_home_path adapted to `hooks.json`)
- `cargo test --lib migrations::v017`: pass
- `cargo test --lib tui::dialogs::hooks_install`: 16/16 pass
- `cargo test --lib session::container_config::tests::test_refresh_agent_configs_preserves_codex_hooks_and_trust_state`: pass
- `cargo test --lib`: 3312 pass on a quiet runner; 4 pre-existing failures on upstream/main (same baseline as #2333: `session::instance::tests::update_status_reconciles_running_hook_to_waiting_on_claude_approval_prompt`, two `tmux::session::tests::capture_*`, one `tui::home::file_watch_tests::rewire_no_op_preserves_latched_disk_watcher_init_failure` flake that passes in isolation). Additional flakes in `session::capture`, `tmux::session::tests::test_status_checks_*`, and `tui::home::file_watch_tests::rewire_config_subscriptions_install_loop_skips_missing_profile_dir` surface under heavy parallel load and pass in isolation; unrelated to the dispatch changes.

## Stack

This PR stacks on #2333 (`refactor(hooks): replace string-based dispatch with HookFormat + SidecarFormat`). The base of this PR is `main`, so the diff shows commits from both PRs until #2333 merges; after #2333 merges, the diff cleans up to just the new commit.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary: N/A
- [x] For UI changes: N/A

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this change does not touch a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: covered by unit and integration tests at the migration + sandbox sync layers

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (`claude-opus-4-7`) via opencode

**Any Additional AI Details you'd like to share:** Implementation and PR drafting done with the model under my review. Storage-format pivot is the behavior-change subset of @PennixRv's PR #2203, redone after the type-tightening landed in #2333.

- [x] I am an AI Agent filling out this form (check box if true)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR implements a storage migration for Codex hooks, moving them from inline TOML tables in `~/.codex/config.toml` to a dedicated JSON file at `~/.codex/hooks.json`. This aligns Codex hook handling with Codex's own recommendation and eliminates duplicate hook format warnings on startup.

## What Changed

**Hook storage format**: Codex agent now declares `HookFormat::CodexJson` and installs hooks into `~/.codex/hooks.json` instead of embedding them in `config.toml`.

**Hook enum**: The `HookFormat` enum was updated to replace the `CodexToml` variant with `CodexJson`.

**Trust state preservation**: The `[hooks.state]` block (which stores user trust decisions) remains in `config.toml` and is explicitly preserved during sandbox refresh operations, ensuring user trust decisions survive host-to-sandbox transitions.

## What Was Added

- **Migration v018**: New migration that strips AoE-managed hooks from legacy `~/.codex/config.toml` files during upgrade, preserving user-authored hooks and the trust block. The migration visits the default location plus any `CODEX_HOME` overrides found in global and per-profile configuration files.

- **Path helpers**: New functions for resolving Codex `hooks.json` paths with `CODEX_HOME` awareness (`codex_hooks_json_path_in`, `codex_hooks_json_path_for_host_environment`, `codex_hooks_json_path_display_for_host_environment`).

- **Hook target support**: New `HookTargetKind::CodexJson` variant for proper routing of Codex JSON hook targets.

- **State restoration**: New `restore_codex_hooks_state` helper to write trust block back into `config.toml` during sandbox refresh.

- **UI updates**: Hooks consent dialog now displays the correct `hooks.json` path while preserving the Codex trust note.

## What Was Removed

- **CodexToml variant**: Replaced with `CodexJson` in the `HookFormat` enum.

- **Inline TOML hook installation**: Codex hook installation for `config.toml` changed from public to test-only code.

- **Codex TOML test cases**: Several tests that validated TOML-based hook preservation were removed in favor of JSON-based equivalents.

## What Moved

- **Hook installation path**: Codex hooks now route through the JSON settings installation pipeline instead of TOML-specific logic.

- **Migration routing**: Existing migrations v015 and v017 now route `CodexJson` targets through JSON rewrite logic to reach the new `hooks.json` location.

## Benefits

- **Eliminates duplicate hook warnings**: Codex no longer emits startup warnings about hooks existing in both formats.
- **Type safety**: Replaces fragile string-based agent detection (`agent.name == "codex"`) with type-safe enum dispatch.
- **Ecosystem alignment**: Aligns with Codex's own recommended hook format and tools like oh-my-zsh.
- **Consistent format**: Uses the same JSON hook structure as Claude, providing a unified approach across agents.
- **Clean migration**: Automatically strips legacy inline hooks while preserving user trust decisions and custom hooks.

---

## Technical Details

**Enum update**: `HookFormat { JsonSettings, CodexJson }` replaces previous `{ JsonSettings, CodexToml }`.

**Hook target routing**: `HookTargetKind::CodexJson` targets are resolved via `codex_hooks_json_path_in` and installed through the standard JSON settings pipeline (`install_hooks`) instead of Codex-specific TOML logic.

**Sandbox refresh logic**: `prepare_sandbox_dir` now snapshots `[hooks.state]` before syncing agent configuration, then restores it post-sync. `refresh_agent_configs` detects Codex hooks by `HookFormat::CodexJson` and checks for `hooks.json` existence to determine if refresh is needed.

**Migration v018 behavior**: Scans all reachable Codex `config.toml` locations (default `~/.codex/config.toml` plus `CODEX_HOME` overrides from environment arrays), uses AoE marker detection for selective stripping, and maintains idempotency—subsequent runs find no marker and skip work. Per-target failures are caught and logged as warnings without aborting the migration.

**Container config updates**: `build_container_config` now routes `HookFormat::CodexJson` through `install_hooks` (JSON settings) instead of Codex-TOML installation. Host-side installation in `Instance::install_agent_status_hooks` uses new `install_codex_host_hooks` helper.

**Test coverage**: All 3312 existing tests pass; tests updated to validate `hooks.json` structure (including JSON `PreToolUse` array with `aoe-hooks` marker) instead of TOML, and verify `config.toml` is not created for Codex hook cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->