### PR TITLE
fix(tui): translate Shift+Enter to ESC+CR in live mode so it inserts a newline

### DIFF
--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1022,6 +1022,17 @@ pub fn translate(key: KeyEvent) -> LiveDispatch {
         return LiveDispatch::Send(TmuxKey::Literal(c.to_string()));
     }
 
+    // Shift+Enter: tmux delivers the `S-Enter` named key as a bare CR
+    // (0x0d), identical to plain Enter, so the agent can't tell them
+    // apart and submits instead of inserting a soft newline (#2316).
+    // Emit ESC+CR explicitly, the same bytes Option/Alt+Enter produces,
+    // which Claude Code (and other agents that follow the Meta+Enter
+    // convention) read as "insert newline". Scoped to the bare chord;
+    // Ctrl/Alt+Enter keep their existing named-key translation.
+    if key.code == KeyCode::Enter && shift && !ctrl && !alt {
+        return LiveDispatch::Send(TmuxKey::HexBytes(vec![0x1b, 0x0d]));
+    }
+
     // Named-key path: Shift IS meaningful (S-Up vs Up for editor text
     // selection). BackTab is shift+Tab semantically by its own keycode,
     // so it gets the no-shift prefix.
@@ -1096,6 +1107,32 @@ mod tests {
     // Exit-chord detection moved out of translate() into
     // handle_live_send_key. Translate now never emits Exit; the
     // chord-list tests below cover the configurable exit path.
+
+    #[test]
+    fn translate_shift_enter_emits_esc_cr() {
+        // tmux flattens `S-Enter` to a bare CR, so the agent can't tell
+        // it from plain Enter and submits. We remap Shift+Enter to ESC+CR
+        // (the Option/Alt+Enter newline bytes) so it inserts a soft
+        // newline instead of submitting (#2316).
+        match translate(k_mod(KeyCode::Enter, KeyModifiers::SHIFT)) {
+            LiveDispatch::Send(TmuxKey::HexBytes(bytes)) => {
+                assert_eq!(bytes, vec![0x1b, 0x0d]);
+            }
+            other => panic!("expected HexBytes([1b, 0d]) for Shift+Enter, got {other:?}"),
+        }
+        // Plain Enter still rides the named-key path unchanged.
+        assert_named(translate(k(KeyCode::Enter)), "Enter");
+        // Ctrl+Enter and Alt+Enter keep their existing named translation;
+        // only the bare Shift+Enter chord is remapped.
+        assert_named(
+            translate(k_mod(KeyCode::Enter, KeyModifiers::CONTROL)),
+            "C-Enter",
+        );
+        assert_named(
+            translate(k_mod(KeyCode::Enter, KeyModifiers::ALT)),
+            "M-Enter",
+        );
+    }
 
     #[test]
     fn translate_never_emits_exit_for_ctrl_q() {


### PR DESCRIPTION
## Description

In live mode, Shift+Enter was forwarded to the agent pane as the tmux named key `S-Enter`, which tmux delivers as a bare carriage return (`0x0d`), identical to a plain Enter. The agent (Claude Code and others) cannot tell the two apart, so Shift+Enter submitted the prompt instead of inserting a soft newline. Reported in #2316.

This remaps the bare Shift+Enter chord in `translate` to ESC+CR (`0x1b 0x0d`), the same bytes Option/Alt+Enter already produces and which agents following the Meta+Enter convention read as "insert newline". Ctrl+Enter and Alt+Enter keep their existing named-key translation; only the bare Shift+Enter chord is remapped.

I traced this at the byte level against a raw-mode pane (how Claude runs its input):

| Key (via live-send dispatch) | Bytes delivered |
|---|---|
| Enter | `0x0d` |
| Shift+Enter (old path) | `0x0d` (indistinguishable from Enter) |
| Option/Alt+Enter | `0x1b 0x0d` |

After this change Shift+Enter takes the Option+Enter byte path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test: unit test `translate_shift_enter_emits_esc_cr` in `src/tui/home/live_send.rs` asserts Shift+Enter maps to `HexBytes([0x1b, 0x0d])` while plain Enter, Ctrl+Enter, and Alt+Enter keep their existing translation. `translate` is the pure key-to-tmux mapping for live mode, so a unit test covers the behavior deterministically without standing up a pane.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation and patch drafted with Claude Code; the byte-level repro, root cause, and decision to map Shift+Enter onto the Option+Enter sequence were reviewed and approved by me.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784903585&installation_id=139138837&pr_number=2359&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2359&signature=72e0b278ecca1ed82d29a87b5da846c9480be8b050fd7ee26523b34e6e01bb73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change updates the live TUI so Shift+Enter no longer sends a normal submit key in tmux. Instead, it now inserts a newline, matching the behavior users expect when composing multi-line input.

What changed:
- Shift+Enter is now handled separately from other Enter combinations.
- It is translated into the same newline-friendly byte sequence used by Option/Alt+Enter.
- Existing behavior for plain Enter, Ctrl+Enter, and Alt+Enter stays the same.
- Added a test to confirm the new Shift+Enter behavior.

Benefit:
- Prevents accidental prompt submission when users try to add a line break.
- Makes live-mode input behavior more consistent and reliable.

Technical note:
- `Shift+Enter` now maps to `ESC + CR` (`0x1b 0x0d`) instead of tmux’s `S-Enter` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->