### PR TITLE
fix(session): publish captured sid to live tmux pane

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -745,9 +745,9 @@ pub(crate) fn compose_exclusion(
 
 /// Build the set of session IDs already claimed by other live AoE instances.
 ///
-/// Reads every other AoE-prefixed tmux session's hidden env to find which
-/// session IDs are currently bound to which instance, and returns the set
-/// of captured IDs that belong to instances OTHER than `current_instance_id`.
+/// Reads every other live AoE tmux session's hidden env to find which session
+/// IDs are currently bound to which instance, and returns the set of captured
+/// IDs that belong to instances OTHER than `current_instance_id`.
 /// Used by post-launch poll closures to avoid re-importing another
 /// instance's session via filesystem scan.
 ///
@@ -769,8 +769,7 @@ fn build_exclusion_set(current_instance_id: &str) -> HashSet<String> {
         .lines()
         .filter(|name| {
             name.starts_with(crate::tmux::SESSION_PREFIX)
-                && !name.starts_with(crate::tmux::TERMINAL_PREFIX)
-                && !name.starts_with(crate::tmux::CONTAINER_TERMINAL_PREFIX)
+                && !name.starts_with(crate::tmux::TOOL_PREFIX)
         })
         .collect();
 
@@ -785,7 +784,11 @@ fn build_exclusion_set(current_instance_id: &str) -> HashSet<String> {
 
     let other_sessions: Vec<&str> = instance_ids
         .iter()
-        .filter(|(_, owner)| owner.as_deref() != Some(current_instance_id))
+        .filter(|(_, owner)| {
+            owner
+                .as_deref()
+                .is_some_and(|owner| owner != current_instance_id)
+        })
         .map(|(name, _)| name.as_str())
         .collect();
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::cli::truncate_id;
 use crate::containers::{self, DockerContainer};
 use crate::tmux;
 
@@ -793,18 +794,53 @@ fn override_if_distinct(stored: Option<&str>, fresh: String) -> Option<String> {
     }
 }
 
+fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
+    let suffix = format!("_{}", truncate_id(instance_id, 8));
+    let output = std::process::Command::new("tmux")
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let mut agent = None;
+    let mut terminal = None;
+    let mut container = None;
+    for name in String::from_utf8_lossy(&output.stdout).lines() {
+        if !name.ends_with(&suffix)
+            || name.starts_with(tmux::TOOL_PREFIX)
+            || crate::tmux::utils::is_pane_dead(name)
+        {
+            continue;
+        }
+
+        if name.starts_with(tmux::TERMINAL_PREFIX) {
+            terminal.get_or_insert_with(|| name.to_string());
+        } else if name.starts_with(tmux::CONTAINER_TERMINAL_PREFIX) {
+            container.get_or_insert_with(|| name.to_string());
+        } else if name.starts_with(tmux::SESSION_PREFIX) {
+            agent.get_or_insert_with(|| name.to_string());
+        }
+    }
+
+    agent.or(terminal).or(container)
+}
+
 /// Publish a captured session ID to the tmux environment only.
 ///
 /// Background threads (poller on_change) call this so that
 /// `build_exclusion_set()` on other instances can see the captured ID
 /// without racing with the TUI thread's `save()`.
-fn publish_session_to_tmux_env(tmux_session_name: &str, session_id: &str) {
-    if let Err(e) = crate::tmux::env::set_hidden_env(
-        tmux_session_name,
-        crate::tmux::env::AOE_CAPTURED_SESSION_ID_KEY,
-        session_id,
-    ) {
-        tracing::warn!(target: "session.store", "Failed to write captured session ID to tmux env: {}", e);
+fn publish_session_to_tmux_env(tmux_session_name: &str, instance_id: &str, session_id: &str) {
+    for (key, value) in [
+        (crate::tmux::env::AOE_INSTANCE_ID_KEY, instance_id),
+        (crate::tmux::env::AOE_CAPTURED_SESSION_ID_KEY, session_id),
+    ] {
+        if let Err(e) = crate::tmux::env::set_hidden_env(tmux_session_name, key, value) {
+            tracing::warn!(target: "session.store", "Failed to write {} to tmux env: {}", key, e);
+            return;
+        }
     }
 }
 
@@ -1689,6 +1725,10 @@ impl Instance {
         tmux::Session::new(&self.id, &self.title)
     }
 
+    pub(crate) fn tmux_env_session_name(&self) -> Option<String> {
+        tmux_env_session_name_for_instance_id(&self.id)
+    }
+
     pub fn terminal_tmux_session(&self) -> Result<tmux::TerminalSession> {
         tmux::TerminalSession::new(&self.id, &self.title)
     }
@@ -1756,9 +1796,7 @@ impl Instance {
     /// `exists()` alone is insufficient: a pane can exist while its agent
     /// has died. Used by recovery, status polling, and TUI reload.
     pub fn has_live_tmux_pane(&self) -> bool {
-        self.tmux_session()
-            .map(|s| s.exists() && !s.is_pane_dead())
-            .unwrap_or(false)
+        self.tmux_env_session_name().is_some()
     }
 
     pub fn start_container_terminal_with_size(&mut self, size: Option<(u16, u16)>) -> Result<()> {
@@ -2698,8 +2736,8 @@ impl Instance {
         let tool = self.tool.as_str();
 
         let tmux_session_name = self
-            .tmux_session()
-            .map(|s| s.name().to_string())
+            .tmux_env_session_name()
+            .or_else(|| self.tmux_session().ok().map(|s| s.name().to_string()))
             .unwrap_or_default();
         let mut poller = SessionPoller::new(tmux_session_name.clone());
         let instance_id = self.id.clone();
@@ -2863,15 +2901,11 @@ impl Instance {
         };
 
         let cb_instance_id = self.id.clone();
-        let cb_tmux_name = self
-            .tmux_session()
-            .map(|s| s.name().to_string())
-            .unwrap_or_default();
 
         let on_change: Box<dyn Fn(&str) + Send + 'static> = Box::new(move |new_id: &str| {
             tracing::info!(target: "session.store", "Session ID changed for {}: {}", cb_instance_id, new_id);
-            if !cb_tmux_name.is_empty() {
-                publish_session_to_tmux_env(&cb_tmux_name, new_id);
+            if let Some(tmux_name) = tmux_env_session_name_for_instance_id(&cb_instance_id) {
+                publish_session_to_tmux_env(&tmux_name, &cb_instance_id, new_id);
             }
         });
 
@@ -7689,8 +7723,9 @@ mod tests {
     }
 
     mod publish_captured_sid {
-        use super::super::{Instance, ResumeIntent};
+        use super::super::{publish_session_to_tmux_env, Instance, ResumeIntent};
         use serial_test::serial;
+        use std::collections::HashSet;
         use std::process::Command;
         use tempfile::{tempdir, TempDir};
 
@@ -7701,7 +7736,14 @@ mod tests {
 
         impl TmuxSession {
             fn create(id: &str, title: &str) -> Self {
-                let name = crate::tmux::Session::generate_name(id, title);
+                Self::create_named(crate::tmux::Session::generate_name(id, title))
+            }
+
+            fn create_terminal(id: &str, title: &str) -> Self {
+                Self::create_named(crate::tmux::TerminalSession::generate_name(id, title))
+            }
+
+            fn create_named(name: String) -> Self {
                 let _ = Command::new("tmux")
                     .args(["kill-session", "-t", &name])
                     .output();
@@ -7712,6 +7754,7 @@ mod tests {
                 assert!(status.success(), "tmux new-session failed for {}", name);
                 Self(name)
             }
+
             fn name(&self) -> &str {
                 &self.0
             }
@@ -7743,6 +7786,10 @@ mod tests {
             crate::tmux::env::get_hidden_env(name, crate::tmux::env::AOE_CAPTURED_SESSION_ID_KEY)
         }
 
+        fn instance_env(name: &str) -> Option<String> {
+            crate::tmux::env::get_hidden_env(name, crate::tmux::env::AOE_INSTANCE_ID_KEY)
+        }
+
         fn make_inst(profile: &str, title: &str) -> Instance {
             let mut inst = Instance::new(title, "/tmp/x");
             inst.tool = "claude".to_string();
@@ -7764,6 +7811,52 @@ mod tests {
                     Ok(())
                 })
                 .unwrap();
+        }
+
+        #[test]
+        #[serial]
+        fn poller_publish_writes_terminal_session_env() {
+            if skip_if_no_tmux() {
+                return;
+            }
+
+            let mut inst = make_inst("publish-terminal", "tailscale-operator-followup");
+            inst.terminal_info = Some(crate::session::TerminalInfo { created: true });
+            let tmux = TmuxSession::create_terminal(&inst.id, &inst.title);
+            inst.title = "renamed-after-terminal-create".to_string();
+
+            assert_eq!(inst.tmux_env_session_name().as_deref(), Some(tmux.name()));
+            assert!(tmux.name().starts_with(crate::tmux::TERMINAL_PREFIX));
+            assert!(tmux.name().contains("tailscale-operator-f"));
+
+            let agent_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            publish_session_to_tmux_env(tmux.name(), &inst.id, VALID_SID);
+
+            assert!(captured_env(&agent_name).is_none());
+            assert_eq!(instance_env(tmux.name()).as_deref(), Some(inst.id.as_str()));
+            assert_eq!(captured_env(tmux.name()).as_deref(), Some(VALID_SID));
+        }
+
+        #[test]
+        #[serial]
+        fn terminal_publish_feeds_exclusion_set_for_other_instances() {
+            if skip_if_no_tmux() {
+                return;
+            }
+
+            let mut peer = make_inst("publish-terminal-exclusion", "peer-terminal");
+            peer.terminal_info = Some(crate::session::TerminalInfo { created: true });
+            let tmux = TmuxSession::create_terminal(&peer.id, &peer.title);
+
+            publish_session_to_tmux_env(tmux.name(), &peer.id, PEER_SID);
+
+            let extra = HashSet::new();
+            let other_exclusion =
+                crate::session::capture::compose_exclusion("other-instance", &extra);
+            assert!(other_exclusion.contains(PEER_SID));
+
+            let own_exclusion = crate::session::capture::compose_exclusion(&peer.id, &extra);
+            assert!(!own_exclusion.contains(PEER_SID));
         }
 
         #[test]

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -211,17 +211,9 @@ fn publish_tmux_env(
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             continue;
         };
-        let tmux_name = match inst.tmux_session() {
-            Ok(s) if s.exists() && !s.is_pane_dead() => s.name().to_string(),
-            Ok(_) => continue,
-            Err(e) => {
-                tracing::warn!(
-                    target: "session.sync",
-                    instance = %id,
-                    "Skipping tmux env publish; tmux_session() error: {e}",
-                );
-                continue;
-            }
+        let tmux_name = match inst.tmux_env_session_name() {
+            Some(name) => name,
+            None => continue,
         };
         match &inst.agent_session_id {
             Some(sid) => set_batch.push((

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -191,6 +191,10 @@ impl TerminalSession {
         PairedTerminal::generate_name(TerminalKind::Host, id, title)
     }
 
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
+
     pub fn exists(&self) -> bool {
         self.inner.exists()
     }
@@ -244,6 +248,10 @@ impl ContainerTerminalSession {
 
     pub fn generate_name(id: &str, title: &str) -> String {
         PairedTerminal::generate_name(TerminalKind::Container, id, title)
+    }
+
+    pub fn name(&self) -> &str {
+        &self.inner.name
     }
 
     pub fn exists(&self) -> bool {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1572,9 +1572,8 @@ impl HomeView {
             let mut set_batch: Vec<(String, String, String)> = Vec::new();
             let mut unset_batch: Vec<(String, String)> = Vec::new();
             for inst in &view.instances {
-                let tmux_name = match inst.tmux_session() {
-                    Ok(s) if s.exists() && !s.is_pane_dead() => s.name().to_string(),
-                    _ => continue,
+                let Some(tmux_name) = inst.tmux_env_session_name() else {
+                    continue;
                 };
 
                 set_batch.push((

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -13424,7 +13424,14 @@ mod apply_session_id_updates {
 
     impl TmuxSession {
         fn create(id: &str, title: &str) -> Self {
-            let name = crate::tmux::Session::generate_name(id, title);
+            Self::create_named(crate::tmux::Session::generate_name(id, title))
+        }
+
+        fn create_terminal(id: &str, title: &str) -> Self {
+            Self::create_named(crate::tmux::TerminalSession::generate_name(id, title))
+        }
+
+        fn create_named(name: String) -> Self {
             let _ = Command::new("tmux")
                 .args(["kill-session", "-t", &name])
                 .output();
@@ -13527,6 +13534,31 @@ mod apply_session_id_updates {
 
         let updated = view.apply_session_id_updates();
         assert!(updated, "Applied CAS must report a touch");
+        assert_eq!(captured_env(tmux.name()).as_deref(), Some(NEW_SID));
+    }
+
+    #[test]
+    #[serial]
+    fn apply_session_id_updates_publishes_to_terminal_session() {
+        if skip_if_no_tmux() {
+            return;
+        }
+        let temp = TempDir::new().unwrap();
+        setup_test_home(&temp);
+
+        let profile = "apply-terminal-publish";
+        let mut inst = fresh_instance(profile, "terminal-post-cas");
+        inst.terminal_info = Some(crate::session::TerminalInfo { created: true });
+        let mut view = build_view_with_inst(profile, &inst);
+
+        let tmux = TmuxSession::create_terminal(&inst.id, &inst.title);
+        let agent_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+
+        attach_poller_with_update(&mut view, &inst.id, NEW_SID);
+
+        let updated = view.apply_session_id_updates();
+        assert!(updated, "Applied CAS must report a touch");
+        assert!(captured_env(&agent_name).is_none());
         assert_eq!(captured_env(tmux.name()).as_deref(), Some(NEW_SID));
     }
 


### PR DESCRIPTION
## Description

Fixes #2356.

This updates captured session ID tmux env publishing so session lifecycle code writes to the live AoE tmux pane for the instance, including terminal and container-terminal panes, instead of reconstructing the default agent session name from the current title.

Changes:
- resolve the env-carrying tmux session by the instance ID suffix across agent, terminal, and container-terminal sessions
- publish both `AOE_INSTANCE_ID` and `AOE_CAPTURED_SESSION_ID` to the resolved live pane
- use the live tmux pane resolver during poller callbacks, sync publishing, and initial TUI env sync
- include terminal/container sessions in the captured-session exclusion scan while still excluding tool sessions
- add tmux-backed regression coverage for terminal-session write-back and exclusion visibility

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No docs or screenshots are needed for this session/tmux env fix.

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this is tmux env plumbing covered by tmux-backed unit/regression tests rather than a CLI subcommand or rendered TUI flow.

Validation:
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=../cargo-target cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=../cargo-target cargo test --lib publish_captured_sid -- --nocapture`
- `CARGO_TARGET_DIR=../cargo-target cargo test --lib apply_session_id_updates_publishes_to_terminal_session -- --nocapture`
- `CARGO_TARGET_DIR=../cargo-target cargo test --workspace --lib --bins`

Local note: tmux is not installed in my local environment, so the tmux-backed regression tests compiled and then used the repository's `skip_if_no_tmux()` guard. CI installs tmux for the Linux full suite.

Also checked `cargo test --workspace --all-targets`; it fails locally in unrelated `tests/acp_runner_orphan.rs` behavior where the ACP runner registry record is never written / `aoe __acp-runner` is unavailable in this environment. That failure is outside this session/tmux env change.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used for code navigation, implementation, validation, and PR preparation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784904797&installation_id=139138837&pr_number=2361&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2361&signature=d196a9552d93cdbbbc0dab72daf31cba4589acde22269ebaa27fbd405023bed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR improves how captured session IDs are written back into tmux by targeting the actual live pane for each instance instead of reconstructing a session name from the current title. It now handles both standard agent sessions and terminal/container-terminal sessions, which makes env publishing more reliable when session names are truncated or the live pane shape differs.

It also broadens the exclusion scan so terminal-backed sessions are included where appropriate, while still keeping tool sessions excluded. New regression coverage was added to confirm tmux env updates work for terminal sessions and that those updates are reflected in the exclusion logic.

Benefits:
- more reliable tmux env write-back
- better support for terminal-shaped sessions
- fewer failures from truncated or mismatched session names
- stronger regression coverage for session publishing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->