### PR TITLE
feat(plugins): per-session plugin_meta + persisted plugin settings (#2091)

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -64,6 +64,29 @@ path, and reloads the registry. The three surfaces are thin twins over it:
 The one behavior wired to a plugin's state today: `aoe serve` refuses to start
 while `aoe.web` is disabled (`src/cli/serve.rs`).
 
+## Persisted plugin state (#2091)
+
+Two storage slots hold plugin data on disk ahead of the APIs that read and
+write them, so no migration is needed later when those APIs land:
+
+- **Per-plugin settings.** `PluginConfig.settings` (`src/session/config.rs`) is
+  an opaque `toml::Table` persisted as `[plugins."<id>".settings]` in
+  `config.toml`. It is kept schema-free on purpose: values survive on disk even
+  while the plugin is disabled, and the typed schema that validates and renders
+  them arrives with the Tier 0 settings registry (#2094). `enabled` serializes
+  before `settings` so the value precedes the nested table, as TOML requires;
+  an empty table is omitted.
+- **Per-session plugin data.** `Instance.plugin_meta`
+  (`src/session/instance.rs`) is a `BTreeMap<String, serde_json::Value>` keyed
+  by plugin id, persisted per session in `sessions.json`. Each plugin owns only
+  its own slot; data for an uninstalled plugin is retained (cheap, and
+  reinstalling restores it). The read/write/cas host API over it
+  (`session.meta.{get,set,cas}`) lands with the Tier 1 host (#2095).
+
+Both fields are additive (`#[serde(default, skip_serializing_if = ...)]`):
+absent in older on-disk rows, so they deserialize to empty and need no data
+migration.
+
 ## What comes next
 
 Each deferred piece returns as its own PR once the core is proven: the

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -67,15 +67,16 @@ while `aoe.web` is disabled (`src/cli/serve.rs`).
 ## Persisted plugin state (#2091)
 
 Two storage slots hold plugin data on disk ahead of the APIs that read and
-write them, so no migration is needed later when those APIs land:
+write them, so the later API PRs (#2094, #2095) stay focused on behavior:
 
 - **Per-plugin settings.** `PluginConfig.settings` (`src/session/config.rs`) is
   an opaque `toml::Table` persisted as `[plugins."<id>".settings]` in
   `config.toml`. It is kept schema-free on purpose: values survive on disk even
   while the plugin is disabled, and the typed schema that validates and renders
-  them arrives with the Tier 0 settings registry (#2094). `enabled` serializes
-  before `settings` so the value precedes the nested table, as TOML requires;
-  an empty table is omitted.
+  them arrives with the Tier 0 settings registry (#2094). `enabled` is declared
+  before `settings` so the scalar reads above the nested table; the toml
+  serializer emits scalars before subtables regardless, so the order is for
+  readability. An empty table is omitted.
 - **Per-session plugin data.** `Instance.plugin_meta`
   (`src/session/instance.rs`) is a `BTreeMap<String, serde_json::Value>` keyed
   by plugin id, persisted per session in `sessions.json`. Each plugin owns only

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1146,6 +1146,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn from_env_no_vars() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::remove_var("AOE_LOG_LEVEL");
@@ -1159,6 +1160,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn from_env_aoe_log_level() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::set_var("AOE_LOG_LEVEL", "trace");
@@ -1169,6 +1171,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn from_env_legacy_debug_flag() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::remove_var("AOE_LOG_LEVEL");

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -1043,7 +1043,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_git_sanitize_branch_name_replaces_forbidden_chars() {
         assert_eq!(git_sanitize_branch_name("has spaces"), "has-spaces");
         assert_eq!(git_sanitize_branch_name("a:b?c*d"), "a-b-c-d");

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -1043,6 +1043,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_git_sanitize_branch_name_replaces_forbidden_chars() {
         assert_eq!(git_sanitize_branch_name("has spaces"), "has-spaces");
         assert_eq!(git_sanitize_branch_name("a:b?c*d"), "a-b-c-d");

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -96,14 +96,22 @@ pub struct Config {
     pub plugins: std::collections::BTreeMap<String, PluginConfig>,
 }
 
-/// Configuration for one bundled plugin: just whether it is enabled. Richer
-/// per-plugin settings return in a follow-up PR.
+/// Configuration for one bundled plugin: whether it is enabled, plus its
+/// schema-free persisted settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginConfig {
     /// Whether the plugin is active. A disabled plugin contributes nothing to
     /// any surface.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
+
+    /// The plugin's persisted settings (`[plugins."<id>".settings]`). Kept as
+    /// an opaque `toml::Table` so values survive on disk even while the plugin
+    /// is disabled; the typed schema that validates and renders them lands
+    /// with Tier 0 registries (#2094). `enabled` is serialized before this so
+    /// the value precedes the nested table, as TOML requires.
+    #[serde(default, skip_serializing_if = "toml::Table::is_empty")]
+    pub settings: toml::Table,
 }
 
 fn default_enabled() -> bool {
@@ -114,6 +122,7 @@ impl Default for PluginConfig {
     fn default() -> Self {
         Self {
             enabled: default_enabled(),
+            settings: toml::Table::new(),
         }
     }
 }
@@ -2455,6 +2464,46 @@ mod tests {
         assert!(
             !serialized.contains("[plugins"),
             "empty plugins map must not serialize a stray section"
+        );
+    }
+
+    #[test]
+    fn test_plugin_settings_persist_even_while_disabled() {
+        // Disabling a plugin hides its settings from every surface but must
+        // never destroy them: the values survive a save/load round-trip.
+        let toml_in = r#"
+            [plugins."aoe.status"]
+            enabled = false
+
+            [plugins."aoe.status".settings]
+            poll_interval_ms = 1000
+            verbose = true
+        "#;
+        let config: Config = toml::from_str(toml_in).unwrap();
+        let plugin = &config.plugins["aoe.status"];
+        assert!(!plugin.enabled);
+        assert_eq!(plugin.settings["poll_interval_ms"].as_integer(), Some(1000));
+
+        let serialized = toml::to_string(&config).unwrap();
+        let reloaded: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            reloaded.plugins["aoe.status"].settings["verbose"].as_bool(),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_plugin_empty_settings_omitted_from_toml() {
+        let toml_in = r#"
+            [plugins."aoe.web"]
+            enabled = true
+        "#;
+        let config: Config = toml::from_str(toml_in).unwrap();
+        assert!(config.plugins["aoe.web"].settings.is_empty());
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(
+            !serialized.contains("settings"),
+            "empty plugin settings must not serialize a stray section"
         );
     }
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -108,8 +108,9 @@ pub struct PluginConfig {
     /// The plugin's persisted settings (`[plugins."<id>".settings]`). Kept as
     /// an opaque `toml::Table` so values survive on disk even while the plugin
     /// is disabled; the typed schema that validates and renders them lands
-    /// with Tier 0 registries (#2094). `enabled` is serialized before this so
-    /// the value precedes the nested table, as TOML requires.
+    /// with Tier 0 registries (#2094). Declared after `enabled` so the scalar
+    /// reads above the nested table; the toml serializer emits scalars before
+    /// subtables regardless, so the order is for readability. Empty is omitted.
     #[serde(default, skip_serializing_if = "toml::Table::is_empty")]
     pub settings: toml::Table,
 }

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -917,6 +917,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_host_environment_prefix_dollar_var_reads_host_env() {
         std::env::set_var("AOE_TEST_HOST_ENV_PREFIX", "from-host");
         let prefix = host_environment_prefix(&["FORWARDED=$AOE_TEST_HOST_ENV_PREFIX".to_string()]);
@@ -925,6 +926,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_host_environment_prefix_dollar_var_missing_is_skipped() {
         std::env::remove_var("AOE_TEST_DEFINITELY_NOT_SET");
         let prefix = host_environment_prefix(&[
@@ -935,6 +937,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_host_environment_prefix_bare_key_passthrough() {
         std::env::set_var("AOE_TEST_BARE_PASSTHROUGH", "v");
         let prefix = host_environment_prefix(&["AOE_TEST_BARE_PASSTHROUGH".to_string()]);
@@ -950,6 +953,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_resolve_host_environment_value_uses_last_resolved_entry() {
         std::env::remove_var("AOE_TEST_MISSING_HOST_ENV_VALUE");
         let entries = vec![
@@ -966,6 +970,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_resolve_host_environment_value_matches_host_env_grammar() {
         std::env::set_var("AOE_TEST_CODEX_HOME_REF", "/from-host");
         let entries = vec!["CODEX_HOME=$AOE_TEST_CODEX_HOME_REF".to_string()];
@@ -984,6 +989,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_collect_environment_passthrough() {
         std::env::set_var("AOE_TEST_ENV_PT", "test_value");
         let config = SandboxConfig {
@@ -1008,6 +1014,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_resolve_host_env_pairs_grammar() {
         std::env::set_var("AOE_TEST_HOST_PAIR_REF", "from_host");
         std::env::set_var("AOE_TEST_HOST_PAIR_BARE", "bare_val");
@@ -1217,6 +1224,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_collect_environment_extra_env() {
         std::env::set_var("AOE_TEST_EXTRA", "extra_val");
         let config = SandboxConfig::default();
@@ -1284,6 +1292,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_collect_environment_dollar_ref() {
         std::env::set_var("AOE_TEST_HOST_REF", "host_val");
         let config = SandboxConfig {
@@ -1330,6 +1339,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_validate_env_entry_bare_key_present() {
         std::env::set_var("AOE_TEST_VALIDATE_BARE", "exists");
         assert_eq!(validate_env_entry("AOE_TEST_VALIDATE_BARE"), None);
@@ -1337,6 +1347,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_validate_env_entry_bare_key_missing() {
         std::env::remove_var("AOE_TEST_VALIDATE_MISSING_BARE");
         let result = validate_env_entry("AOE_TEST_VALIDATE_MISSING_BARE");
@@ -1345,6 +1356,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_validate_env_entry_key_dollar_var_present() {
         std::env::set_var("AOE_TEST_VALIDATE_REF", "value");
         assert_eq!(validate_env_entry("MY_KEY=$AOE_TEST_VALIDATE_REF"), None);
@@ -1352,6 +1364,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_validate_env_entry_key_dollar_var_missing() {
         std::env::remove_var("AOE_TEST_VALIDATE_MISSING_REF");
         let result = validate_env_entry("MY_KEY=$AOE_TEST_VALIDATE_MISSING_REF");
@@ -1370,6 +1383,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_validate_env_entries_returns_one_warning_per_missing_var() {
         // Use unique names to avoid collisions with other tests' env state.
         std::env::remove_var("AOE_TEST_BATCH_MISSING_A");
@@ -1440,6 +1454,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_build_docker_env_args_inherit_uses_key_only_in_args() {
         // Inherited (secret) env vars must NOT have values in docker_args.
         // Values are in exports for injection via tmux send-keys.
@@ -1478,6 +1493,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_build_docker_env_args_inherit_with_different_key() {
         std::env::set_var("AOE_TEST_SOURCE", "secret456");
         let sandbox = SandboxInfo {
@@ -1512,6 +1528,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_build_docker_env_args_bare_key_uses_export() {
         // Bare keys (pass-through from host) are Inherit entries,
         // so they must use exports, not inline values.
@@ -1580,6 +1597,7 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_build_docker_env_args_mixed_inherit_and_literal() {
         std::env::set_var("AOE_TEST_SECRET", "mysecret");
         let sandbox = SandboxInfo {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -454,6 +454,15 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pinned_at: Option<DateTime<Utc>>,
 
+    /// Namespaced per-session plugin data, keyed by plugin id. Each plugin
+    /// owns only its own slot (`plugin_meta["<id>"]`), an opaque JSON value it
+    /// reads and writes through the host API that lands with the Tier 1 host
+    /// (#2095). Data for an uninstalled plugin is retained, since it is cheap
+    /// and reinstalling restores the session's state. Additive: absent in
+    /// older `sessions.json` rows, so no migration is needed.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub plugin_meta: std::collections::BTreeMap<String, serde_json::Value>,
+
     /// Scratch-session marker. When true, `project_path` points at an
     /// auto-provisioned directory under `<app_dir>/scratch/<id>/` that the
     /// deletion path removes on `aoe rm` (unless the user opts in to keeping
@@ -831,6 +840,7 @@ impl Instance {
             unread: false,
             idle_dormant_since: None,
             pinned_at: None,
+            plugin_meta: std::collections::BTreeMap::new(),
             scratch: false,
             worktree_info: None,
             workspace_info: None,
@@ -4194,6 +4204,37 @@ mod tests {
             json.get("unread").is_none(),
             "false must skip serialization"
         );
+    }
+
+    #[test]
+    fn test_plugin_meta_serde_round_trip() {
+        // Empty map is omitted from disk.
+        let inst = Instance::new("t", "/tmp");
+        let json = serde_json::to_value(&inst).unwrap();
+        assert!(
+            json.get("plugin_meta").is_none(),
+            "empty plugin_meta must skip serialization"
+        );
+
+        // A plugin's namespaced slot round-trips.
+        let mut set = Instance::new("t", "/tmp");
+        set.plugin_meta
+            .insert("aoe.status".to_string(), serde_json::json!({ "score": 3 }));
+        let json = serde_json::to_value(&set).unwrap();
+        let back: Instance = serde_json::from_value(json).unwrap();
+        assert_eq!(back.plugin_meta["aoe.status"]["score"], 3);
+
+        // Rows written before the field existed deserialize to an empty map.
+        let inst: Instance = serde_json::from_value(serde_json::json!({
+            "id": "abc",
+            "title": "t",
+            "project_path": "/tmp",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00Z",
+        }))
+        .expect("deserialize without plugin_meta");
+        assert!(inst.plugin_meta.is_empty());
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4927,6 +4927,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_yolo_envvar_command_is_quoted() {
         // EnvVar values containing JSON must be shell-escaped to prevent
         // the inner bash from expanding special characters ({, *, ").


### PR DESCRIPTION
Closes #2091

## Description

Plugins 01 (#2091): the storage groundwork left after the minimal plugin core (#2311). Adds the two on-disk slots that later plugin APIs read/write, ahead of those APIs, so no migration is needed when they land.

- **`PluginConfig.settings`** (`src/session/config.rs`): an opaque `toml::Table` persisted as `[plugins."<id>".settings]` in `config.toml`. Kept schema-free on purpose so values survive on disk even while the plugin is disabled; the typed schema that validates/renders them lands with the Tier 0 settings registry (#2094). `enabled` serializes before `settings` so the value precedes the nested table (TOML requirement); an empty table is omitted.
- **`Instance.plugin_meta`** (`src/session/instance.rs`): `BTreeMap<String, serde_json::Value>` keyed by plugin id, persisted per session in `sessions.json`. Each plugin owns only its own slot; data for an uninstalled plugin is retained (cheap, reinstall restores it). The `session.meta.{get,set,cas}` host API over it lands with the Tier 1 host (#2095).

Both fields are additive (`#[serde(default, skip_serializing_if = ...)]`): absent in older on-disk rows, deserialize to empty, no data migration. Design doc (`docs/development/internals/plugin-system.md`) updated.

### Drive-by: fix a flaky test

While running the suite, `test_capture_claude_session_active_newer_wins_over_anchor` flaked under the parallel run ("No active Claude session found"). Root cause is a global env-var data race: `capture_claude_session_id` reads `CLAUDE_CONFIG_DIR` via `std::env::var`, and a concurrent `set_var`/`remove_var` in an unrelated test corrupts that read (libc `setenv`/`getenv` are not thread-safe together), so the var reads as unset and capture falls back to `~/.claude` and bails. The capture tests already use the crate-wide default `#[serial]` group, but 23 env-mutating tests in `logging`/`builder`/`environment`/`instance` had no serialization against it (logging used only a file-local `ENV_LOCK`, which does not coordinate across modules). They are now in the default `#[serial_test::serial]` group.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: storage-layer serde fields with no TUI/CLI/session-lifecycle behavior change

Added serde round-trip unit tests for both fields (round-trip, empty-omission, legacy-row backfill) in `config.rs` and `instance.rs`.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Idea, decisions, and scoping are mine; Claude handled investigation and drafting.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784916357&installation_id=139138837&pr_number=2368&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2368&signature=50dee3fb8ec9531af5d01e0150a5a0ddbe57eebd91255a471ddce786ab130812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR lays the storage groundwork for the plugin system.

- Adds persistent per-plugin settings in `config.toml`, so plugin options can be saved even when a plugin is disabled.
- Adds persistent per-session plugin metadata in `sessions.json`, giving each plugin its own stored data slot.
- Keeps both additions backward-compatible, so older saved data still loads without migration.
- Updates the plugin system internals docs to explain the new storage model.
- Adds round-trip tests to cover saving, loading, empty-field omission, and legacy data handling.
- Fixes flaky tests by making environment-mutating tests run one at a time.

Benefits:
- Plugin data can now survive disable/reload cycles.
- Existing user data continues to work unchanged.
- The storage model is ready for later plugin features without requiring a schema migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->