### PR TITLE
fix(session): delete workspace dir when removing a multi-repo session

### DIFF
--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -35,9 +35,7 @@ pub struct RemoveArgs {
 }
 
 fn needs_worktree_cleanup(inst: &Instance, args: &RemoveArgs) -> bool {
-    inst.worktree_info
-        .as_ref()
-        .is_some_and(|wt| wt.managed_by_aoe && args.delete_worktree)
+    args.delete_worktree && inst.has_managed_worktree_or_workspace()
 }
 
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
@@ -91,11 +89,20 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     }
 
     if !delete_worktree {
-        if let Some(wt_info) = &inst.worktree_info {
-            if wt_info.managed_by_aoe {
+        if inst
+            .worktree_info
+            .as_ref()
+            .is_some_and(|wt| wt.managed_by_aoe)
+        {
+            println!(
+                "Worktree preserved at: {} (use --delete-worktree to remove)",
+                inst.project_path
+            );
+        } else if let Some(ws_info) = &inst.workspace_info {
+            if ws_info.cleanup_on_delete {
                 println!(
-                    "Worktree preserved at: {} (use --delete-worktree to remove)",
-                    inst.project_path
+                    "Workspace preserved at: {} (use --delete-worktree to remove)",
+                    ws_info.workspace_dir
                 );
             }
         }
@@ -136,4 +143,47 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{WorkspaceInfo, WorkspaceRepo};
+    use chrono::Utc;
+
+    fn args(delete_worktree: bool) -> RemoveArgs {
+        RemoveArgs {
+            identifier: "x".to_string(),
+            delete_worktree,
+            delete_branch: false,
+            force: false,
+            keep_container: false,
+            keep_scratch: false,
+        }
+    }
+
+    // Regression for #2363: a multi-repo workspace session has no
+    // `worktree_info`, so the old worktree_info-only check returned false and
+    // `--delete-worktree` silently left the workspace dir on disk.
+    #[test]
+    fn needs_worktree_cleanup_true_for_workspace_session() {
+        let mut inst = Instance::new("WS", "/tmp/ws/repo-a");
+        inst.workspace_info = Some(WorkspaceInfo {
+            branch: "feature/abc".to_string(),
+            workspace_dir: "/tmp/ws".to_string(),
+            repos: vec![WorkspaceRepo {
+                name: "repo-a".to_string(),
+                source_path: "/tmp/src/repo-a".to_string(),
+                branch: "feature/abc".to_string(),
+                worktree_path: "/tmp/ws/repo-a".to_string(),
+                main_repo_path: "/tmp/src/repo-a".to_string(),
+                managed_by_aoe: true,
+            }],
+            created_at: Utc::now(),
+            cleanup_on_delete: true,
+        });
+
+        assert!(needs_worktree_cleanup(&inst, &args(true)));
+        assert!(!needs_worktree_cleanup(&inst, &args(false)));
+    }
 }

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -96,7 +96,18 @@ pub struct SessionResponse {
     /// `theme.unread`.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub unread: bool,
+    /// Strictly a single-repo aoe-managed worktree (`worktree_info`). Drives
+    /// the sidebar "Edit workdir name" action and the tie-workdir overlay,
+    /// neither of which applies to multi-repo workspace sessions. For
+    /// "is there worktree state to clean up on delete", use
+    /// `has_cleanable_worktree` instead.
     pub has_managed_worktree: bool,
+    /// Whether deleting this session has aoe-managed worktree state to remove,
+    /// covering single-repo worktrees AND multi-repo workspaces. Only the
+    /// delete dialog's worktree/branch checkboxes consume this; keeping it
+    /// separate from `has_managed_worktree` avoids lighting up worktree-only
+    /// actions (Edit workdir) for workspace sessions (#2363).
+    pub has_cleanable_worktree: bool,
     /// Whether renaming this session also moves its worktree directory (the
     /// resolved `session.tie_workdir_to_name` for an aoe-managed worktree).
     /// Populated by `list_sessions` from the per-profile config; single-session
@@ -306,7 +317,11 @@ impl SessionResponse {
             // Surface the marker (omitted when read); the web gates the
             // visual on the `session.unread_indicator` setting.
             unread: inst.unread,
-            has_managed_worktree: inst.has_managed_worktree_or_workspace(),
+            has_managed_worktree: inst
+                .worktree_info
+                .as_ref()
+                .is_some_and(|w| w.managed_by_aoe),
+            has_cleanable_worktree: inst.has_managed_worktree_or_workspace(),
             // Overlaid per-profile in list_sessions; see the field doc.
             tie_workdir_to_name: false,
             // Overlaid in list_sessions; single-session responses stay inactive.
@@ -5234,9 +5249,11 @@ mod tests {
     }
 
     // Regression for #2363: a multi-repo workspace session carries
-    // `workspace_info` and no `worktree_info`. The DTO must still report
-    // `has_managed_worktree: true`, otherwise the web delete dialog hides the
-    // "Delete worktree" checkbox and the workspace directory leaks on disk.
+    // `workspace_info` and no `worktree_info`. The DTO must report
+    // `has_cleanable_worktree: true` so the web delete dialog shows the
+    // "Delete worktree" checkbox, while keeping `has_managed_worktree: false`
+    // so worktree-only actions (sidebar "Edit workdir name", tie overlay) stay
+    // hidden for workspace sessions.
     #[test]
     fn from_instance_reports_managed_worktree_for_workspace_session() {
         let mut inst = make_test_instance();
@@ -5257,8 +5274,12 @@ mod tests {
 
         let resp = SessionResponse::from_instance(&inst, false);
         assert!(
-            resp.has_managed_worktree,
-            "workspace session must report a managed worktree"
+            resp.has_cleanable_worktree,
+            "workspace session must report a cleanable worktree so the delete checkbox shows"
+        );
+        assert!(
+            !resp.has_managed_worktree,
+            "workspace session must NOT report a single-repo managed worktree (keeps Edit-workdir hidden)"
         );
     }
 
@@ -7192,6 +7213,7 @@ mod workspace_ordering_tests {
             is_sandboxed: false,
             scratch: false,
             has_managed_worktree: false,
+            has_cleanable_worktree: false,
             tie_workdir_to_name: false,
             smart_rename: crate::session::smart_rename::SmartRenameState::Inactive,
             default_name: false,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -306,10 +306,7 @@ impl SessionResponse {
             // Surface the marker (omitted when read); the web gates the
             // visual on the `session.unread_indicator` setting.
             unread: inst.unread,
-            has_managed_worktree: inst
-                .worktree_info
-                .as_ref()
-                .is_some_and(|w| w.managed_by_aoe),
+            has_managed_worktree: inst.has_managed_worktree_or_workspace(),
             // Overlaid per-profile in list_sessions; see the field doc.
             tie_workdir_to_name: false,
             // Overlaid in list_sessions; single-session responses stay inactive.
@@ -5234,6 +5231,35 @@ mod tests {
         upsert_instance(&mut instances, other);
         assert_eq!(instances.len(), 2);
         assert!(instances.iter().any(|i| i.id == other_id));
+    }
+
+    // Regression for #2363: a multi-repo workspace session carries
+    // `workspace_info` and no `worktree_info`. The DTO must still report
+    // `has_managed_worktree: true`, otherwise the web delete dialog hides the
+    // "Delete worktree" checkbox and the workspace directory leaks on disk.
+    #[test]
+    fn from_instance_reports_managed_worktree_for_workspace_session() {
+        let mut inst = make_test_instance();
+        inst.workspace_info = Some(crate::session::WorkspaceInfo {
+            branch: "feature/abc".to_string(),
+            workspace_dir: "/tmp/ws".to_string(),
+            repos: vec![crate::session::WorkspaceRepo {
+                name: "repo-a".to_string(),
+                source_path: "/tmp/src/repo-a".to_string(),
+                branch: "feature/abc".to_string(),
+                worktree_path: "/tmp/ws/repo-a".to_string(),
+                main_repo_path: "/tmp/src/repo-a".to_string(),
+                managed_by_aoe: true,
+            }],
+            created_at: chrono::Utc::now(),
+            cleanup_on_delete: true,
+        });
+
+        let resp = SessionResponse::from_instance(&inst, false);
+        assert!(
+            resp.has_managed_worktree,
+            "workspace session must report a managed worktree"
+        );
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -898,6 +898,24 @@ impl Instance {
                 .is_some_and(|w| w.managed_by_aoe)
     }
 
+    /// Whether deleting this session has aoe-managed worktree state to clean
+    /// up, covering BOTH single-repo and multi-repo (workspace) sessions.
+    /// Single-repo sessions carry an aoe-managed `worktree_info`; workspace
+    /// sessions carry `workspace_info` instead (with `worktree_info = None`),
+    /// and opt into cleanup via `cleanup_on_delete`. Entry points use this to
+    /// decide whether to set `delete_worktree`; gating on `worktree_info`
+    /// alone silently leaks the workspace directory (#2363). Mirrors the TUI
+    /// group-delete predicate so every surface agrees.
+    pub fn has_managed_worktree_or_workspace(&self) -> bool {
+        self.worktree_info
+            .as_ref()
+            .is_some_and(|w| w.managed_by_aoe)
+            || self
+                .workspace_info
+                .as_ref()
+                .is_some_and(|ws| ws.cleanup_on_delete)
+    }
+
     /// Stamp `last_accessed_at` to the current time AND wake the session
     /// from any sink state. Call this on user-initiated interactions
     /// (attach, send keys, etc.); every existing call site already does.
@@ -5266,6 +5284,48 @@ mod tests {
         let wt = deserialized.worktree_info.unwrap();
         assert_eq!(wt.branch, "feature/abc");
         assert!(wt.managed_by_aoe);
+    }
+
+    #[test]
+    fn has_managed_worktree_or_workspace_covers_both_shapes() {
+        // Single-repo aoe-managed worktree.
+        let mut wt = Instance::new("WT", "/tmp/wt");
+        wt.worktree_info = Some(WorktreeInfo {
+            branch: "feature/abc".to_string(),
+            main_repo_path: "/tmp/main".to_string(),
+            managed_by_aoe: true,
+            created_at: Utc::now(),
+            base_branch: None,
+        });
+        assert!(wt.has_managed_worktree_or_workspace());
+
+        // Multi-repo workspace opting into cleanup (worktree_info is None).
+        let mut ws = Instance::new("WS", "/tmp/ws/repo-a");
+        ws.workspace_info = Some(WorkspaceInfo {
+            branch: "feature/abc".to_string(),
+            workspace_dir: "/tmp/ws".to_string(),
+            repos: vec![WorkspaceRepo {
+                name: "repo-a".to_string(),
+                source_path: "/tmp/src/repo-a".to_string(),
+                branch: "feature/abc".to_string(),
+                worktree_path: "/tmp/ws/repo-a".to_string(),
+                main_repo_path: "/tmp/src/repo-a".to_string(),
+                managed_by_aoe: true,
+            }],
+            created_at: Utc::now(),
+            cleanup_on_delete: true,
+        });
+        assert!(ws.has_managed_worktree_or_workspace());
+
+        // Workspace that opted out of cleanup: nothing to clean.
+        if let Some(info) = ws.workspace_info.as_mut() {
+            info.cleanup_on_delete = false;
+        }
+        assert!(!ws.has_managed_worktree_or_workspace());
+
+        // Plain session: neither worktree nor workspace.
+        let plain = Instance::new("Plain", "/tmp/plain");
+        assert!(!plain.has_managed_worktree_or_workspace());
     }
 
     #[test]

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -706,10 +706,7 @@ impl HomeView {
         self.instances().iter().any(|i| {
             (i.group_path == group_path || i.group_path.starts_with(prefix))
                 && owning_profile.is_none_or(|p| i.source_profile == p)
-                && (i.worktree_info.as_ref().is_some_and(|wt| wt.managed_by_aoe)
-                    || i.workspace_info
-                        .as_ref()
-                        .is_some_and(|ws| ws.cleanup_on_delete))
+                && i.has_managed_worktree_or_workspace()
         })
     }
 

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -631,24 +631,10 @@ impl HomeView {
 
             for session_id in &sessions_to_delete {
                 if let Some(inst) = self.get_instance(session_id) {
-                    let delete_worktree = options.delete_worktrees
-                        && (inst
-                            .worktree_info
-                            .as_ref()
-                            .is_some_and(|wt| wt.managed_by_aoe)
-                            || inst
-                                .workspace_info
-                                .as_ref()
-                                .is_some_and(|ws| ws.cleanup_on_delete));
-                    let delete_branch = options.delete_branches
-                        && (inst
-                            .worktree_info
-                            .as_ref()
-                            .is_some_and(|wt| wt.managed_by_aoe)
-                            || inst
-                                .workspace_info
-                                .as_ref()
-                                .is_some_and(|ws| ws.cleanup_on_delete));
+                    let delete_worktree =
+                        options.delete_worktrees && inst.has_managed_worktree_or_workspace();
+                    let delete_branch =
+                        options.delete_branches && inst.has_managed_worktree_or_workspace();
                     let delete_sandbox = options.delete_containers
                         && inst.sandbox_info.as_ref().is_some_and(|s| s.enabled);
                     let request = DeletionRequest {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1502,7 +1502,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           <DeleteSessionDialog
             sessionTitle={deletingSession.title}
             branchName={deletingSession.branch}
-            hasManagedWorktree={deletingSession.has_managed_worktree}
+            hasManagedWorktree={deletingSession.has_cleanable_worktree ?? false}
             isSandboxed={deletingSession.is_sandboxed}
             isScratch={deletingSession.scratch}
             cleanupDefaults={deletingSession.cleanup_defaults}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -72,6 +72,12 @@ export interface SessionResponse {
    *  session currently open, which also clears the marker. */
   unread?: boolean;
   has_managed_worktree: boolean;
+  /** True when deleting this session has aoe-managed worktree state to clean
+   *  up, covering single-repo worktrees AND multi-repo workspaces. Only the
+   *  delete dialog's worktree/branch checkboxes read this; worktree-only
+   *  actions (Edit workdir) keep reading `has_managed_worktree`. Always sent
+   *  by the server; optional only so existing test fixtures need not set it. */
+  has_cleanable_worktree?: boolean;
   /** True when renaming this session also moves its worktree directory (the
    *  resolved `session.tie_workdir_to_name` for an aoe-managed worktree). The
    *  sidebar uses this to collapse the standalone "edit workdir name" action


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Deleting a multi-repo (workspace) session left its workspace directory and every per-repo worktree on disk, plus dangling git worktree registrations in each source repo. Single-repo sessions cleaned up fine, so the leak was specific to workspace sessions deleted from the CLI or the web dashboard.

The deletion engine (`perform_deletion`) already iterates `workspace_info.repos`, removes each worktree, and `remove_dir_all`s the workspace parent, but the whole block is gated on `request.delete_worktree`. Two entry points computed that flag from `worktree_info` alone, which is always `None` for a workspace session (its multi-repo state lives in `workspace_info`): the CLI `needs_worktree_cleanup` and the server's `has_managed_worktree` DTO field. So `delete_worktree` stayed `false`, the engine skipped cleanup, and on the web the "Delete worktree" checkbox was hidden entirely. The TUI was unaffected because it already checked `workspace_info`.

This adds `Instance::has_managed_worktree_or_workspace()`, mirroring the TUI group-delete predicate (an aoe-managed worktree, or a workspace with `cleanup_on_delete`), and routes the CLI predicate, the server DTO field, and the TUI group-delete checks through it so every surface agrees. No engine change. The web checkbox now renders for workspace sessions because the server reports `has_managed_worktree: true`.

Closes #2363

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a multi-repo workspace session, then `aoe remove --delete-worktree <session>`; confirm the workspace directory and each per-repo worktree are gone and `git worktree list` in each source repo no longer lists them.
- [ ] Create a multi-repo workspace session, open the web dashboard delete dialog; confirm a "Delete worktree" checkbox now appears, and confirming with it checked removes the workspace directory.
- [ ] Create a workspace session, leave uncommitted changes in one repo, delete without force; confirm the workspace directory is preserved and a warning is surfaced (no silent data loss).
- [ ] Delete a single-repo worktree session via CLI and web; confirm cleanup behavior is unchanged.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The web fix is entirely server-side (the `has_managed_worktree` DTO value); no `web/src` file changed. The dialog already renders the worktree checkbox off that prop, and the existing `DeleteSessionDialog` Vitest covers both prop values.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the fix is a pure cleanup-decision predicate. It is covered by reproduce-then-fix Rust unit tests on the predicate (`Instance`), the CLI `needs_worktree_cleanup`, and the server `from_instance` DTO; each was confirmed red on a tree with the workspace arm neutralized and green with the fix. The engine cleanup path is already covered, so an e2e would add slow tmux setup for no extra signal.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the predicate design call, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784916625&installation_id=139138837&pr_number=2369&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2369&signature=999550fd4f5e1135616a426b919da4155516c854146dda80c51b529e79f493b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes deletion of multi-repo/workspace sessions so their managed workspace directory and related worktrees are cleaned up correctly across the CLI, web API, and TUI.

What changed:
- Added a shared `Instance` helper (`has_managed_worktree_or_workspace`) to detect whether a session’s managed worktree cleanup should apply (including workspace sessions when cleanup is enabled).
- Updated CLI delete behavior to use the shared predicate, ensuring `--delete-worktree` triggers the existing cleanup logic for workspace sessions too.
- Expanded CLI “preserved” messaging so it can report preserved workspace directories (not just single-repo worktrees) when cleanup isn’t requested.
- Updated the session API response to introduce/drive `has_cleanable_worktree` for workspace sessions, while keeping `has_managed_worktree` reserved for single-repo worktrees (so UI actions don’t accidentally appear for idle workspace sessions).
- Updated TUI delete-group checks (including delete-worktree and delete-branch visibility) to rely on the shared cleanup predicate.
- Updated the web delete dialog to use `has_cleanable_worktree` (via a `hasManagedWorktree` prop) so the “Delete worktree” checkbox reappears for applicable workspace sessions.
- Added/updated regression tests to lock in the intended workspace-vs-single-repo distinction and the cleanup gating behavior.

Benefits:
- Deletion decisions are consistent across CLI, server, and TUI, reducing drift between entry points.
- Workspace sessions correctly expose the “Delete worktree” UI option on the web when cleanup is applicable.
- Workspace cleanup is restored for multi-repo/workspace sessions when the user requests it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->