### PR TITLE
refactor: lift worker-process + event-log substrate out of src/acp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@
 - `src/tui/`: ratatui UI and input handling.
 - `src/session/`: session storage, configuration, and group management.
 - `src/tmux/`: tmux integration and status detection.
-- `src/process/`: OS-specific process handling (`macos.rs`, `linux.rs`).
+- `src/process/`: OS-specific process handling (`macos.rs`, `linux.rs`) plus `worker.rs`, the protocol-agnostic worker-subprocess substrate (process-group signalling, liveness, on-disk worker paths) that `src/acp/` consumes and the plugin host will reuse.
+- `src/events/`: protocol-agnostic durable event-log storage core (topic-keyed SQLite seq log, retention, keyset scans, attachments); `src/acp/`'s `EventStore` is the first consumer.
 - `src/docker/`: Docker sandboxing and container management.
 - `src/git/`: git worktree operations and template resolution.
 - `src/server/`: web dashboard backend (axum server, REST API, WebSocket PTY relay, auth).

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -88,9 +88,27 @@ Both fields are additive (`#[serde(default, skip_serializing_if = ...)]`):
 absent in older on-disk rows, so they deserialize to empty and need no data
 migration.
 
+## Shared substrate
+
+Two neutral modules hold the protocol-agnostic plumbing that both `src/acp/`
+and the future plugin host build on, so the host never depends on ACP (the
+dependency arrow runs consumer -> substrate):
+
+- `src/process/worker.rs`: worker-subprocess plumbing, process-group
+  signalling (terminate/kill/reap), pid liveness, the runner self-inspection
+  state machine, and the `<dir>/<id>.{json,sock,log,restart}` path builders.
+  The consumer supplies the base directory and a pid extractor for record
+  inspection.
+- `src/events/`: a durable event-log storage core, a topic-keyed SQLite seq
+  log with retention, keyset scans, seq bookkeeping, and attachment blobs over
+  opaque JSON payloads. The consumer holds the `Connection` and owns its
+  payload type and replay semantics. `acp::event_store::EventStore` is the
+  first consumer (`Schema::new("acp")` keeps the existing `acp_events` tables,
+  so no migration).
+
 ## What comes next
 
 Each deferred piece returns as its own PR once the core is proven: the
-contribution schema and registries, the JSON-RPC worker runtime and event bus,
-the capability model, external (GitHub/local) installation, and the
-discovery/featured supply-chain layer.
+contribution schema and registries, the JSON-RPC worker runtime built on the
+substrate above, the capability model, external (GitHub/local) installation,
+and the discovery/featured supply-chain layer.

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -56,6 +56,7 @@ use tracing::{debug, trace, warn};
 
 use super::approvals::Nonce;
 use super::state::{Event, Plan, RateLimitInfo};
+use crate::events::{self, Order, SeqBound};
 
 /// Externally-tagged JSON discriminants for non-substantive structured view
 /// events: lifecycle and metadata snapshots the agent emits once per
@@ -71,16 +72,6 @@ const NON_SUBSTANTIVE_EVENT_DISCRIMINANTS: &[&str] = &[
     "AcpSessionAssigned",
     "PromptCapabilities",
 ];
-
-/// Build the `AND event_json NOT LIKE '{"Name":%'` SQL fragment for every
-/// non-substantive discriminant, newline-joined for readable queries.
-fn non_substantive_not_like_clauses() -> String {
-    NON_SUBSTANTIVE_EVENT_DISCRIMINANTS
-        .iter()
-        .map(|name| format!("AND event_json NOT LIKE '{{\"{name}\":%'"))
-        .collect::<Vec<_>>()
-        .join("\n               ")
-}
 
 /// One page of replayed events plus the cursor metadata a paginating
 /// client needs to fetch the next page.
@@ -118,42 +109,17 @@ fn is_user_turn_boundary(ev: &Event) -> bool {
     )
 }
 
-/// Highest seq stored for `session_id`, or 0 if none. Free fn so both
-/// the public [`EventStore::highest_seq`] and the single-snapshot
-/// [`EventStore::replay_page`] can share it under one held lock.
-fn query_highest_seq(conn: &Connection, session_id: &str) -> u64 {
-    match conn
-        .query_row(
-            "SELECT MAX(seq) FROM acp_events WHERE session_id = ?1",
-            params![session_id],
-            |row| row.get::<_, Option<i64>>(0),
-        )
-        .optional()
-    {
-        Ok(Some(Some(max))) => max as u64,
-        _ => 0,
-    }
-}
-
-/// Lowest seq still stored for `session_id`, or `None` when empty.
-/// Companion to [`query_highest_seq`].
-fn query_lowest_seq(conn: &Connection, session_id: &str) -> Option<u64> {
-    match conn
-        .query_row(
-            "SELECT MIN(seq) FROM acp_events WHERE session_id = ?1",
-            params![session_id],
-            |row| row.get::<_, Option<i64>>(0),
-        )
-        .optional()
-    {
-        Ok(Some(Some(m))) => Some(m as u64),
-        _ => None,
-    }
-}
-
 /// SQLite-backed structured view event log. One row per (session_id, seq).
+///
+/// The generic storage mechanics (schema, append, retention prune, keyset
+/// scans, seq bookkeeping, attachment blobs, topic deletion) live in
+/// `crate::events`; this type is the ACP consumer: it owns the connection,
+/// serializes/deserializes the `Event` payload, and keeps the ACP-specific
+/// replay semantics and `json_extract` accessors. The dependency arrow runs
+/// acp -> events.
 pub struct EventStore {
     conn: Mutex<Connection>,
+    schema: events::Schema,
     /// Per-session retention cap. Older events are pruned on insert
     /// once the count exceeds this value. Bytes are not enforced here
     /// (the in-memory ring still has a byte cap); the row count keeps
@@ -167,49 +133,10 @@ impl EventStore {
     /// enabled so concurrent writers (publish path) and readers
     /// (replay endpoint) don't block each other.
     pub fn open(db_path: &Path, max_events_per_session: usize) -> Result<Self> {
-        if let Some(parent) = db_path.parent() {
-            if !parent.exists() {
-                std::fs::create_dir_all(parent).with_context(|| {
-                    format!(
-                        "create parent dir for structured view DB at {}",
-                        parent.display()
-                    )
-                })?;
-            }
-        }
-        let conn = Connection::open(db_path)
-            .with_context(|| format!("open structured view DB at {}", db_path.display()))?;
-        conn.pragma_update(None, "journal_mode", "WAL")
-            .context("enable WAL mode")?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .context("set synchronous=NORMAL")?;
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS acp_events (
-                session_id  TEXT    NOT NULL,
-                seq         INTEGER NOT NULL,
-                event_json  TEXT    NOT NULL,
-                created_at  INTEGER NOT NULL,
-                PRIMARY KEY (session_id, seq)
-            );
-            CREATE INDEX IF NOT EXISTS idx_acp_events_session_seq
-                ON acp_events(session_id, seq);
-            CREATE INDEX IF NOT EXISTS idx_acp_events_session_created_at
-                ON acp_events(session_id, created_at);
-            CREATE TABLE IF NOT EXISTS acp_attachments (
-                session_id    TEXT    NOT NULL,
-                seq           INTEGER NOT NULL,
-                attachment_id TEXT    NOT NULL,
-                kind          TEXT    NOT NULL,
-                mime_type     TEXT    NOT NULL,
-                name          TEXT,
-                data          BLOB    NOT NULL,
-                created_at    INTEGER NOT NULL,
-                PRIMARY KEY (session_id, attachment_id)
-            );
-            CREATE INDEX IF NOT EXISTS idx_acp_attachments_session_seq
-                ON acp_attachments(session_id, seq);",
-        )
-        .context("create acp_events schema")?;
+        // Prefix "acp" maps to the existing acp_events / acp_attachments
+        // tables, so an established database opens unchanged (no migration).
+        let schema = events::Schema::new("acp")?;
+        let conn = events::open(db_path, &schema)?;
         debug!(
             target: "acp.event_store",
             path = %db_path.display(),
@@ -218,6 +145,7 @@ impl EventStore {
         );
         Ok(Self {
             conn: Mutex::new(conn),
+            schema,
             max_events_per_session,
         })
     }
@@ -238,13 +166,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let inserted = conn
-            .execute(
-                "INSERT OR IGNORE INTO acp_events (session_id, seq, event_json, created_at)
-             VALUES (?1, ?2, ?3, ?4)",
-                params![session_id, seq as i64, json, now_ms],
-            )
-            .with_context(|| format!("insert {session_id}@{seq}"))?;
+        let inserted = events::insert_event(&conn, &self.schema, session_id, seq, &json, now_ms)?;
         if inserted == 0 {
             // Primary-key collision: same (session_id, seq) seen before.
             // Logged at trace because the cause is usually a benign retry
@@ -269,80 +191,20 @@ impl EventStore {
                 "recorded event"
             );
         }
-        // Prune oldest beyond the retention cap. Cheap when below the cap
-        // (the subquery returns 0 rows). We do it on every insert rather
-        // than periodically so the upper bound on per-session disk usage
-        // is strict rather than amortised.
-        //
-        // Snapshot events (the slash-command list, mode list, ACP session
-        // id) are exempt from pruning: the agent only emits them once per
-        // session lifecycle, near the start of the seq range, so a long
-        // session blows past the cap and evicts them; leaving the
-        // composer's `/` palette and the mode picker empty on reconnect.
-        // See #1049. The `event_json NOT LIKE` clauses match the
-        // externally-tagged JSON discriminant for each pinned variant.
-        if self.max_events_per_session > 0 {
-            // Compute the prune cutoff seq once so the events delete and
-            // the attachments delete agree on the same threshold. Doing
-            // the events delete first would shift the OFFSET row out from
-            // under the attachments delete and leave orphaned blobs.
-            let cutoff: Option<i64> = conn
-                .query_row(
-                    "SELECT seq FROM acp_events
-                     WHERE session_id = ?1
-                     ORDER BY seq DESC
-                     LIMIT 1 OFFSET ?2",
-                    params![session_id, self.max_events_per_session as i64],
-                    |row| row.get(0),
-                )
-                .optional()
-                .unwrap_or(None);
-            if let Some(cutoff) = cutoff {
-                // The `non_substantive_not_like_clauses()` helper pins the
-                // snapshot variants (slash-command list, mode list, ACP
-                // session id) so a long session can't evict them. See #1049.
-                let prune_sql = format!(
-                    "DELETE FROM acp_events
-                     WHERE session_id = ?1
-                       AND seq <= ?2
-                       {clauses}",
-                    clauses = non_substantive_not_like_clauses()
-                );
-                match conn.execute(&prune_sql, params![session_id, cutoff]) {
-                    Ok(0) => {}
-                    Ok(pruned) => {
-                        trace!(
-                            target: "acp.event_store",
-                            session = %session_id,
-                            pruned,
-                            cap = self.max_events_per_session,
-                            "pruned oldest events past retention cap"
-                        );
-                    }
-                    Err(e) => {
-                        // Prune failure isn't fatal; the row is recorded,
-                        // we just exceed the cap until the next prune
-                        // succeeds. Log + swallow so callers don't have to
-                        // distinguish "record failed" from "trim failed".
-                        warn!(target: "acp.event_store", "prune {session_id}: {e}");
-                    }
-                }
-                // Drop attachment blobs whose owning UserPromptSent has
-                // (or is about to be) pruned. Attachments only ever hang
-                // off prompts, never the pinned snapshot variants, so a
-                // flat `seq <= cutoff` delete cannot strand a blob whose
-                // event survived. This is what keeps the attachment table
-                // bounded alongside the event log rather than growing
-                // without limit as screenshots accumulate.
-                if let Err(e) = conn.execute(
-                    "DELETE FROM acp_attachments
-                     WHERE session_id = ?1 AND seq <= ?2",
-                    params![session_id, cutoff],
-                ) {
-                    warn!(target: "acp.event_store", "prune attachments {session_id}: {e}");
-                }
-            }
-        }
+        // Prune oldest beyond the retention cap on every insert so the
+        // per-session disk bound stays strict rather than amortised.
+        // NON_SUBSTANTIVE_EVENT_DISCRIMINANTS are exempt: the agent emits
+        // those snapshot events (slash-command list, mode list, ACP session
+        // id) once per session lifecycle near the start of the seq range, so
+        // a long session would otherwise evict them and leave the composer's
+        // `/` palette and the mode picker empty on reconnect. See #1049.
+        events::prune_retention(
+            &conn,
+            &self.schema,
+            session_id,
+            self.max_events_per_session,
+            NON_SUBSTANTIVE_EVENT_DISCRIMINANTS,
+        );
         Ok(())
     }
 
@@ -355,42 +217,26 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let mut stmt = match conn.prepare(
-            "SELECT seq, event_json FROM acp_events
-             WHERE session_id = ?1 AND seq < ?2
-             ORDER BY seq ASC",
-        ) {
-            Ok(s) => s,
+        events::scan(
+            &conn,
+            &self.schema,
+            session_id,
+            SeqBound::Before(before),
+            Order::Asc,
+            None,
+        )
+        .into_iter()
+        .filter_map(|(seq, json)| match serde_json::from_str::<Event>(&json) {
+            Ok(event) => Some((seq, event)),
             Err(e) => {
-                warn!(target: "acp.event_store", "prepare replay_before for {session_id}: {e}");
-                return Vec::new();
+                warn!(
+                    target: "acp.event_store",
+                    "deserialise event {session_id}@{seq}: {e}"
+                );
+                None
             }
-        };
-        let rows = match stmt.query_map(params![session_id, before as i64], |row| {
-            let seq: i64 = row.get(0)?;
-            let json: String = row.get(1)?;
-            Ok((seq as u64, json))
-        }) {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(target: "acp.event_store", "query replay_before for {session_id}: {e}");
-                return Vec::new();
-            }
-        };
-        let mut out = Vec::new();
-        for row in rows {
-            match row {
-                Ok((seq, json)) => match serde_json::from_str::<Event>(&json) {
-                    Ok(event) => out.push((seq, event)),
-                    Err(e) => warn!(
-                        target: "acp.event_store",
-                        "deserialise event {session_id}@{seq}: {e}"
-                    ),
-                },
-                Err(e) => warn!(target: "acp.event_store", "row error: {e}"),
-            }
-        }
-        out
+        })
+        .collect()
     }
 
     /// Return all events for `session_id` with `seq > since`, oldest
@@ -422,88 +268,39 @@ impl EventStore {
         // land between these reads and the page query and make
         // `has_more`/`highest_seq` disagree (which would let the client's
         // paging cap stop early). See #1705 review.
-        let highest_seq = query_highest_seq(&conn, session_id);
-        let lowest_seq = query_lowest_seq(&conn, session_id);
-        // `seq` is a signed SQLite column; clamp before the cast so the
-        // status probe's `since = u64::MAX` doesn't wrap to -1 and match
-        // every row (`seq > -1`) instead of returning an empty page.
-        let since_i64 = i64::try_from(since).unwrap_or(i64::MAX);
-        // Probe one extra row beyond `limit` to detect `has_more` without
-        // a second query against `highest_seq`.
+        let highest_seq = events::highest_seq(&conn, &self.schema, session_id);
+        let lowest_seq = events::lowest_seq(&conn, &self.schema, session_id);
+        // Probe one extra row beyond `limit` to detect `has_more` without a
+        // second query against `highest_seq`. The signed-column clamp for a
+        // `u64::MAX` cursor lives in `events::scan`.
         let probe = limit.map(|n| n.saturating_add(1));
-        let sql = match probe {
-            Some(_) => {
-                "SELECT seq, event_json FROM acp_events
-                 WHERE session_id = ?1 AND seq > ?2
-                 ORDER BY seq ASC LIMIT ?3"
-            }
-            None => {
-                "SELECT seq, event_json FROM acp_events
-                 WHERE session_id = ?1 AND seq > ?2
-                 ORDER BY seq ASC"
-            }
-        };
-        let mut stmt = match conn.prepare(sql) {
-            Ok(s) => s,
-            Err(e) => {
-                warn!(target: "acp.event_store", "prepare replay for {session_id}: {e}");
-                return ReplayPage {
-                    events: Vec::new(),
-                    last_scanned_seq: None,
-                    has_more: false,
-                    highest_seq,
-                    lowest_seq,
-                };
-            }
-        };
-        let map_row = |row: &rusqlite::Row| {
-            let seq: i64 = row.get(0)?;
-            let json: String = row.get(1)?;
-            Ok((seq as u64, json))
-        };
-        let rows = match probe {
-            Some(p) => stmt.query_map(params![session_id, since_i64, p as i64], map_row),
-            None => stmt.query_map(params![session_id, since_i64], map_row),
-        };
-        let rows = match rows {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(target: "acp.event_store", "query replay for {session_id}: {e}");
-                return ReplayPage {
-                    events: Vec::new(),
-                    last_scanned_seq: None,
-                    has_more: false,
-                    highest_seq,
-                    lowest_seq,
-                };
-            }
-        };
+        let rows = events::scan(
+            &conn,
+            &self.schema,
+            session_id,
+            SeqBound::After(since),
+            Order::Asc,
+            probe,
+        );
         let mut out = Vec::new();
         let mut last_scanned_seq = None;
-        let mut scanned = 0usize;
         let mut has_more = false;
-        for row in rows {
-            match row {
-                Ok((seq, json)) => {
-                    // The probe row proves another page exists; don't
-                    // consume it or advance the cursor onto it.
-                    if let Some(n) = limit {
-                        if scanned == n {
-                            has_more = true;
-                            break;
-                        }
-                    }
-                    scanned += 1;
-                    last_scanned_seq = Some(seq);
-                    match serde_json::from_str::<Event>(&json) {
-                        Ok(event) => out.push((seq, event)),
-                        Err(e) => warn!(
-                            target: "acp.event_store",
-                            "deserialise event {session_id}@{seq}: {e}"
-                        ),
-                    }
+        for (scanned, (seq, json)) in rows.into_iter().enumerate() {
+            // The probe row proves another page exists; don't consume it or
+            // advance the cursor onto it.
+            if let Some(n) = limit {
+                if scanned == n {
+                    has_more = true;
+                    break;
                 }
-                Err(e) => warn!(target: "acp.event_store", "row error: {e}"),
+            }
+            last_scanned_seq = Some(seq);
+            match serde_json::from_str::<Event>(&json) {
+                Ok(event) => out.push((seq, event)),
+                Err(e) => warn!(
+                    target: "acp.event_store",
+                    "deserialise event {session_id}@{seq}: {e}"
+                ),
             }
         }
         trace!(
@@ -549,89 +346,42 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let highest_seq = query_highest_seq(&conn, session_id);
-        let lowest_seq = query_lowest_seq(&conn, session_id);
-        // `seq` is a signed SQLite column; clamp before the cast so the
-        // tail request's `before = u64::MAX` stays positive (`seq < MAX`
-        // matches everything) instead of wrapping to a negative bound.
-        let before_i64 = i64::try_from(before).unwrap_or(i64::MAX);
+        let highest_seq = events::highest_seq(&conn, &self.schema, session_id);
+        let lowest_seq = events::lowest_seq(&conn, &self.schema, session_id);
+        // Probe one extra row beyond `limit` to detect `has_more`. The
+        // signed-column clamp for a `u64::MAX` tail cursor lives in
+        // `events::scan`.
         let probe = limit.map(|n| n.saturating_add(1));
-        let sql = match probe {
-            Some(_) => {
-                "SELECT seq, event_json FROM acp_events
-                 WHERE session_id = ?1 AND seq < ?2
-                 ORDER BY seq DESC LIMIT ?3"
-            }
-            None => {
-                "SELECT seq, event_json FROM acp_events
-                 WHERE session_id = ?1 AND seq < ?2
-                 ORDER BY seq DESC"
-            }
-        };
-        let mut stmt = match conn.prepare(sql) {
-            Ok(s) => s,
-            Err(e) => {
-                warn!(target: "acp.event_store", "prepare replay_page_before for {session_id}: {e}");
-                return ReplayPage {
-                    events: Vec::new(),
-                    last_scanned_seq: None,
-                    has_more: false,
-                    highest_seq,
-                    lowest_seq,
-                };
-            }
-        };
-        let map_row = |row: &rusqlite::Row| {
-            let seq: i64 = row.get(0)?;
-            let json: String = row.get(1)?;
-            Ok((seq as u64, json))
-        };
-        let rows = match probe {
-            Some(p) => stmt.query_map(params![session_id, before_i64, p as i64], map_row),
-            None => stmt.query_map(params![session_id, before_i64], map_row),
-        };
-        let rows = match rows {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(target: "acp.event_store", "query replay_page_before for {session_id}: {e}");
-                return ReplayPage {
-                    events: Vec::new(),
-                    last_scanned_seq: None,
-                    has_more: false,
-                    highest_seq,
-                    lowest_seq,
-                };
-            }
-        };
+        let rows = events::scan(
+            &conn,
+            &self.schema,
+            session_id,
+            SeqBound::Before(before),
+            Order::Desc,
+            probe,
+        );
         let mut out = Vec::new();
         let mut last_scanned_seq = None;
-        let mut scanned = 0usize;
         let mut has_more = false;
-        for row in rows {
-            match row {
-                Ok((seq, json)) => {
-                    // The probe row proves an older page exists; don't
-                    // consume it or move the cursor onto it.
-                    if let Some(n) = limit {
-                        if scanned == n {
-                            has_more = true;
-                            break;
-                        }
-                    }
-                    scanned += 1;
-                    // DESC scan, so each consumed row's seq is lower than
-                    // the last; the final one is the page's lowest, which
-                    // is the cursor for the next-older page.
-                    last_scanned_seq = Some(seq);
-                    match serde_json::from_str::<Event>(&json) {
-                        Ok(event) => out.push((seq, event)),
-                        Err(e) => warn!(
-                            target: "acp.event_store",
-                            "deserialise event {session_id}@{seq}: {e}"
-                        ),
-                    }
+        for (scanned, (seq, json)) in rows.into_iter().enumerate() {
+            // The probe row proves an older page exists; don't consume it or
+            // move the cursor onto it.
+            if let Some(n) = limit {
+                if scanned == n {
+                    has_more = true;
+                    break;
                 }
-                Err(e) => warn!(target: "acp.event_store", "row error: {e}"),
+            }
+            // DESC scan, so each consumed row's seq is lower than the last;
+            // the final one is the page's lowest, which is the cursor for
+            // the next-older page.
+            last_scanned_seq = Some(seq);
+            match serde_json::from_str::<Event>(&json) {
+                Ok(event) => out.push((seq, event)),
+                Err(e) => warn!(
+                    target: "acp.event_store",
+                    "deserialise event {session_id}@{seq}: {e}"
+                ),
             }
         }
         // Scanned newest-first; callers expect oldest-first.
@@ -1062,7 +812,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let max = query_highest_seq(&conn, session_id);
+        let max = events::highest_seq(&conn, &self.schema, session_id);
         trace!(
             target: "acp.event_store",
             session = %session_id,
@@ -1082,7 +832,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let min = query_lowest_seq(&conn, session_id);
+        let min = events::lowest_seq(&conn, &self.schema, session_id);
         trace!(
             target: "acp.event_store",
             session = %session_id,
@@ -1100,26 +850,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let mut stmt =
-            match conn.prepare("SELECT session_id, MAX(seq) FROM acp_events GROUP BY session_id") {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!(target: "acp.event_store", "prepare all_session_seqs: {e}");
-                    return Vec::new();
-                }
-            };
-        let rows = match stmt.query_map([], |row| {
-            let id: String = row.get(0)?;
-            let max: i64 = row.get(1)?;
-            Ok((id, max as u64))
-        }) {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(target: "acp.event_store", "query all_session_seqs: {e}");
-                return Vec::new();
-            }
-        };
-        let collected: Vec<(String, u64)> = rows.filter_map(|r| r.ok()).collect();
+        let collected = events::all_topic_seqs(&conn, &self.schema);
         debug!(
             target: "acp.event_store",
             sessions = collected.len(),
@@ -1361,17 +1092,6 @@ impl EventStore {
         &self,
         session_ids: &[String],
     ) -> std::collections::HashMap<String, i64> {
-        let mut out = std::collections::HashMap::new();
-        if session_ids.is_empty() {
-            return out;
-        }
-        let conn = match self.conn.lock() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
-        let placeholders = std::iter::repeat_n("?", session_ids.len())
-            .collect::<Vec<_>>()
-            .join(",");
         // Exclude non-substantive lifecycle/metadata events so they do not
         // reset the idle clock. AcpSessionAssigned in particular is emitted
         // on every cold-start resume (acp_client.rs), so counting it would
@@ -1379,41 +1099,19 @@ impl EventStore {
         // and the idle-reap (#1689) would never fire across restarts. Shares
         // NON_SUBSTANTIVE_EVENT_DISCRIMINANTS with the retention prune so the
         // two predicates cannot desync.
-        let sql = format!(
-            "SELECT session_id, MAX(created_at) FROM acp_events
-             WHERE session_id IN ({placeholders})
-               {clauses}
-             GROUP BY session_id",
-            clauses = non_substantive_not_like_clauses()
-        );
-        let mut stmt = match conn.prepare(&sql) {
-            Ok(s) => s,
-            Err(e) => {
-                warn!(target: "acp.event_store", "last_event_at_for_sessions prepare: {e}");
-                return out;
-            }
-        };
-        let rows = stmt.query_map(rusqlite::params_from_iter(session_ids.iter()), |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-        });
-        match rows {
-            Ok(iter) => {
-                for r in iter {
-                    match r {
-                        Ok((session_id, created_at)) => {
-                            out.insert(session_id, created_at);
-                        }
-                        Err(e) => {
-                            warn!(target: "acp.event_store", "last_event_at_for_sessions row: {e}");
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                warn!(target: "acp.event_store", "last_event_at_for_sessions query: {e}");
-            }
+        if session_ids.is_empty() {
+            return std::collections::HashMap::new();
         }
-        out
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        events::last_event_at_for_topics(
+            &conn,
+            &self.schema,
+            session_ids,
+            NON_SUBSTANTIVE_EVENT_DISCRIMINANTS,
+        )
     }
 
     /// Persist one decoded attachment blob, keyed to the seq of the
@@ -1433,30 +1131,18 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        if let Err(e) = conn.execute(
-            "INSERT OR IGNORE INTO acp_attachments
-                (session_id, seq, attachment_id, kind, mime_type, name, data, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            params![
-                session_id,
-                seq as i64,
-                blob.id,
-                blob.kind.as_str(),
-                blob.mime_type,
-                blob.name,
-                blob.data,
-                now_ms,
-            ],
-        ) {
-            warn!(
-                target: "acp.event_store",
-                session = %session_id,
-                attachment = %blob.id,
-                "insert attachment failed: {e}"
-            );
-            return false;
-        }
-        true
+        events::insert_attachment(
+            &conn,
+            &self.schema,
+            session_id,
+            seq,
+            &blob.id,
+            blob.kind.as_str(),
+            &blob.mime_type,
+            blob.name.as_deref(),
+            &blob.data,
+            now_ms,
+        )
     }
 
     /// Drop all attachment blobs owned by one prompt seq. Used as a
@@ -1467,17 +1153,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        if let Err(e) = conn.execute(
-            "DELETE FROM acp_attachments WHERE session_id = ?1 AND seq = ?2",
-            params![session_id, seq as i64],
-        ) {
-            warn!(
-                target: "acp.event_store",
-                session = %session_id,
-                seq,
-                "rollback attachments failed: {e}"
-            );
-        }
+        events::delete_attachments_for_seq(&conn, &self.schema, session_id, seq);
     }
 
     /// Fetch one attachment's MIME type and bytes for the replay GET
@@ -1492,22 +1168,7 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        conn.query_row(
-            "SELECT mime_type, data FROM acp_attachments
-             WHERE session_id = ?1 AND attachment_id = ?2",
-            params![session_id, attachment_id],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
-        )
-        .optional()
-        .unwrap_or_else(|e| {
-            warn!(
-                target: "acp.event_store",
-                session = %session_id,
-                attachment = %attachment_id,
-                "load attachment failed: {e}"
-            );
-            None
-        })
+        events::load_attachment(&conn, &self.schema, session_id, attachment_id)
     }
 
     /// Latest prompt capabilities the agent advertised for this session,
@@ -1549,30 +1210,15 @@ impl EventStore {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        match conn.execute(
-            "DELETE FROM acp_events WHERE session_id = ?1",
-            params![session_id],
-        ) {
-            Ok(deleted) => {
-                debug!(
-                    target: "acp.event_store",
-                    session = %session_id,
-                    deleted,
-                    "deleted session events"
-                );
-            }
-            Err(e) => {
-                warn!(target: "acp.event_store", "delete {session_id}: {e}");
-            }
-        }
-        // Cascade to attachment blobs so a deleted session leaves no
+        // Cascades to attachment blobs so a deleted session leaves no
         // orphaned bytes behind.
-        if let Err(e) = conn.execute(
-            "DELETE FROM acp_attachments WHERE session_id = ?1",
-            params![session_id],
-        ) {
-            warn!(target: "acp.event_store", "delete attachments {session_id}: {e}");
-        }
+        let deleted = events::delete_topic(&conn, &self.schema, session_id);
+        debug!(
+            target: "acp.event_store",
+            session = %session_id,
+            deleted,
+            "deleted session events"
+        );
     }
 }
 

--- a/src/acp/runner.rs
+++ b/src/acp/runner.rs
@@ -58,7 +58,8 @@ use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
-use super::worker_registry::{self, RunnerRecordState, WorkerRecord};
+use super::worker_registry::{self, WorkerRecord};
+use crate::process::worker::RunnerRecordState;
 
 /// How often the abandonment watchdog inspects its own registry record.
 const WATCHDOG_POLL_INTERVAL: Duration = Duration::from_secs(10);
@@ -484,7 +485,14 @@ async fn run_watchdog(
             return;
         }
 
-        match worker_registry::inspect_record_for_runner(&record_path, own_pid) {
+        // Parse the pid from our own record format here so `process::worker`
+        // stays payload-agnostic; a parse failure maps to `Unreadable`,
+        // preserving the "malformed record is non-fatal" watchdog semantics.
+        match crate::process::worker::inspect_record_for_runner(&record_path, own_pid, |bytes| {
+            serde_json::from_slice::<WorkerRecord>(bytes)
+                .ok()
+                .map(|rec| rec.pid)
+        }) {
             // Still ours, or a transient read hiccup we shouldn't act on.
             RunnerRecordState::Matches | RunnerRecordState::Unreadable => missing = 0,
             RunnerRecordState::Superseded => {
@@ -564,7 +572,7 @@ async fn self_terminate_agent_tree(
     // actually being the group leader so a failed setsid can't make us
     // SIGKILL the daemon's inherited group.
     if getpgrp() == getpid() {
-        worker_registry::kill_runner_group(own_pid);
+        crate::process::worker::kill_process_group(own_pid);
     } else {
         // setsid failed; we share another group. Never group-kill it. Kill
         // just the direct child and fall through to a normal runner exit.

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -2350,7 +2350,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         // also taken down by an explicit "kill them all" request, not left
         // orphaned under PID 1. See #1689.
         for (session_id, pid) in registry_pids {
-            super::worker_registry::terminate_runner_group(pid);
+            crate::process::worker::terminate_process_group(pid);
             super::worker_registry::delete(&session_id).ok();
         }
         #[cfg(not(unix))]

--- a/src/acp/worker_registry.rs
+++ b/src/acp/worker_registry.rs
@@ -28,6 +28,11 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
+// Generic worker-subprocess plumbing now lives in `process::worker`; the
+// registry is the ACP consumer of it. Re-exported so the names referenced
+// across the ACP code (and its tests) keep resolving here.
+pub use crate::process::worker::{is_pid_alive, validate_id as validate_session_id};
+
 /// Bump when the on-disk schema changes incompatibly. Older entries with
 /// a smaller `runner_version` are swept on startup instead of dialed.
 pub const RUNNER_VERSION: u32 = 1;
@@ -134,70 +139,25 @@ fn now_secs() -> u64 {
 /// unix sockets. Auto-created on first access.
 pub fn workers_dir() -> Result<PathBuf> {
     let dir = crate::session::get_app_dir()?.join("acp-workers");
-    if !dir.exists() {
-        std::fs::create_dir_all(&dir).with_context(|| {
-            format!("creating structured view workers dir at {}", dir.display())
-        })?;
-        // Owner-only on the directory itself so other users on a shared
-        // host can't enumerate session ids.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
-        }
-    }
+    crate::process::worker::ensure_dir(&dir)?;
     Ok(dir)
-}
-
-/// Defense-in-depth check on a session_id before it's interpolated into
-/// any `<workers_dir>/<session_id>.<ext>` path. Production session_ids
-/// come from `Uuid::new_v4()` so they satisfy this trivially, but the
-/// `aoe __acp-runner` subcommand accepts `--session-id` as a CLI
-/// arg, and we don't want a user invoking the runner with
-/// `--session-id "../../foo"` to write registry/socket/log files
-/// outside the dedicated worker directory. Not a privilege escalation
-/// (same UID), but a basic input-validation gap worth closing.
-///
-/// Accepts: alphanumeric, `-`, `_`. Rejects: empty, `/`, `\`, `.` (so
-/// `..` and leading-dot hidden files are both out), null bytes, and
-/// anything longer than 128 bytes (UUIDs are 36; this leaves room for
-/// prefixed test ids without permitting arbitrarily-long inputs).
-pub fn validate_session_id(session_id: &str) -> Result<()> {
-    if session_id.is_empty() {
-        anyhow::bail!("session_id must not be empty");
-    }
-    if session_id.len() > 128 {
-        anyhow::bail!("session_id too long ({} bytes, max 128)", session_id.len());
-    }
-    if !session_id
-        .bytes()
-        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
-    {
-        anyhow::bail!(
-            "session_id contains disallowed characters: must be ASCII alphanumeric, '-', or '_'"
-        );
-    }
-    Ok(())
 }
 
 /// `<workers_dir>/<session_id>.json`.
 pub fn record_path(session_id: &str) -> Result<PathBuf> {
-    validate_session_id(session_id)?;
-    Ok(workers_dir()?.join(format!("{session_id}.json")))
+    crate::process::worker::record_path(&workers_dir()?, session_id)
 }
 
 /// `<workers_dir>/<session_id>.sock`. Caller computes this once and threads
 /// the same path into both the runner spawn and the daemon connect.
 pub fn socket_path_for(session_id: &str) -> Result<PathBuf> {
-    validate_session_id(session_id)?;
-    Ok(workers_dir()?.join(format!("{session_id}.sock")))
+    crate::process::worker::socket_path(&workers_dir()?, session_id)
 }
 
 /// `<workers_dir>/<session_id>.log` is the runner-side stderr drain
 /// consumed by `aoe acp logs --session <id>`.
 pub fn log_path_for(session_id: &str) -> Result<PathBuf> {
-    validate_session_id(session_id)?;
-    Ok(workers_dir()?.join(format!("{session_id}.log")))
+    crate::process::worker::log_path(&workers_dir()?, session_id)
 }
 
 /// Sentinel file `<workers_dir>/<session_id>.restart`. Written by
@@ -210,8 +170,7 @@ pub fn log_path_for(session_id: &str) -> Result<PathBuf> {
 ///   - signal the reconciler to clear the `attempted` set for this id
 ///     so the next 2s tick actually spawns a fresh worker.
 pub fn restart_marker_path(session_id: &str) -> Result<PathBuf> {
-    validate_session_id(session_id)?;
-    Ok(workers_dir()?.join(format!("{session_id}.restart")))
+    crate::process::worker::restart_marker_path(&workers_dir()?, session_id)
 }
 
 /// Best-effort write of an empty restart-pending marker. Called by the
@@ -333,27 +292,6 @@ pub fn delete(session_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Probe whether `pid` is still alive. On Unix: `kill(pid, 0)` returns
-/// `Ok(())` for live and `Err(ESRCH)` for dead. Other errors (EPERM,
-/// etc.) mean the process exists but we lack permission to signal it —
-/// still alive.
-#[cfg(unix)]
-pub fn is_pid_alive(pid: u32) -> bool {
-    use nix::errno::Errno;
-    use nix::sys::signal::kill;
-    use nix::unistd::Pid;
-    match kill(Pid::from_raw(pid as i32), None) {
-        Ok(()) => true,
-        Err(Errno::ESRCH) => false,
-        Err(_) => true,
-    }
-}
-
-#[cfg(not(unix))]
-pub fn is_pid_alive(_pid: u32) -> bool {
-    false
-}
-
 /// Update the `last_attached_at` field in place. Best-effort: any I/O
 /// error is logged and swallowed because attach itself has already
 /// succeeded; the timestamp is purely for observability.
@@ -441,44 +379,6 @@ fn socket_exists(path: &Path) -> bool {
     }
 }
 
-/// Signal the runner's entire process group, then the runner pid itself.
-///
-/// The runner is spawned `setsid` (a fresh session, so it is the leader of
-/// a process group whose id equals its pid), and the agent subprocess plus
-/// the agent's own children (e.g. the node ACP wrapper and the SDK child it
-/// execs) inherit that group. Signalling the group reaps the whole tree in
-/// one shot. Signalling only the runner pid leaves the agent and its
-/// grandchildren orphaned under PID 1, which is the structured view-runner /
-/// `node` / `claude` process leak that accumulated across daemon restarts
-/// and superseded spawns (#1689). The trailing single-pid signal is a
-/// belt-and-suspenders for the unlikely case `setsid` failed and the
-/// runner is not a group leader. Best-effort; errors are ignored.
-#[cfg(unix)]
-fn signal_runner_group(pid: u32, sig: nix::sys::signal::Signal) {
-    use nix::sys::signal::{kill, killpg};
-    use nix::unistd::Pid;
-    let p = Pid::from_raw(pid as i32);
-    let _ = killpg(p, sig);
-    let _ = kill(p, sig);
-}
-
-/// SIGTERM the runner's process group (runner + agent + grandchildren).
-pub fn terminate_runner_group(pid: u32) {
-    #[cfg(unix)]
-    signal_runner_group(pid, nix::sys::signal::Signal::SIGTERM);
-    #[cfg(not(unix))]
-    let _ = pid;
-}
-
-/// SIGKILL the runner's process group; the escalation path when SIGTERM
-/// does not take.
-pub fn kill_runner_group(pid: u32) {
-    #[cfg(unix)]
-    signal_runner_group(pid, nix::sys::signal::Signal::SIGKILL);
-    #[cfg(not(unix))]
-    let _ = pid;
-}
-
 /// Reap the runner for `session_id`: SIGTERM its whole process group (if
 /// the registry entry exists), then remove the registry entry and socket.
 /// The canonical teardown used by the supervisor's shutdown paths and by a
@@ -489,61 +389,9 @@ pub fn kill_runner_group(pid: u32) {
 /// already-empty group is a harmless no-op. See #1689.
 pub fn terminate(session_id: &str) {
     if let Ok(Some(record)) = load(session_id) {
-        terminate_runner_group(record.pid);
+        crate::process::worker::terminate_process_group(record.pid);
     }
     delete(session_id).ok();
-}
-
-/// Reap a runner process group with SIGKILL escalation: SIGTERM the group,
-/// wait `grace` for it to exit, then SIGKILL the group. A bare SIGTERM can
-/// leave a node/`claude` grandchild that ignores it alive under PID 1, so
-/// the escalation is what actually guarantees the tree dies. `killpg`
-/// ignores ESRCH, so the SIGKILL on an already-empty group is a no-op.
-/// Used by the boot reconciler's orphan sweep. See #1921.
-#[cfg(unix)]
-pub async fn reap_group_escalating(pid: u32, grace: std::time::Duration) {
-    terminate_runner_group(pid);
-    tokio::time::sleep(grace).await;
-    kill_runner_group(pid);
-}
-
-/// What this runner's own registry record looks like from its watchdog's
-/// point of view. Computed from a non-creating read of a path captured at
-/// startup; see [`inspect_record_for_runner`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RunnerRecordState {
-    /// Record present and its `pid` matches ours: we are still the owner.
-    Matches,
-    /// Record file is gone (HOME deleted, or a daemon `delete`d it).
-    Missing,
-    /// Record present but owned by a different pid: a fresh runner has
-    /// superseded us (delete + respawn). We must exit without touching the
-    /// files, which now belong to the new owner.
-    Superseded,
-    /// Read or parse failed for a reason other than absence. Treated as
-    /// non-fatal (transient FS hiccup) by the watchdog.
-    Unreadable,
-}
-
-/// Inspect this runner's registry record WITHOUT creating the workers dir.
-///
-/// The watchdog cannot use [`load`], because `load` -> `record_path` ->
-/// `workers_dir` calls `create_dir_all`, which would recreate the very
-/// directory whose deletion is the watchdog's primary self-destruct signal
-/// (and resurrect a temp `$HOME` a test just removed). The caller captures
-/// the concrete `<session_id>.json` path once at startup, while the dir
-/// still exists, and polls it here. See #1921.
-pub fn inspect_record_for_runner(record_path: &Path, own_pid: u32) -> RunnerRecordState {
-    let bytes = match std::fs::read(record_path) {
-        Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return RunnerRecordState::Missing,
-        Err(_) => return RunnerRecordState::Unreadable,
-    };
-    match serde_json::from_slice::<WorkerRecord>(&bytes) {
-        Ok(rec) if rec.pid == own_pid => RunnerRecordState::Matches,
-        Ok(_) => RunnerRecordState::Superseded,
-        Err(_) => RunnerRecordState::Unreadable,
-    }
 }
 
 #[cfg(test)]

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -574,7 +574,7 @@ fn kill_now(session: &str) -> Result<()> {
     // liveness would skip the killpg and leak surviving descendants.
     // killpg ignores ESRCH, so signaling an already-empty group is a
     // harmless no-op.
-    worker_registry::kill_runner_group(record.pid);
+    crate::process::worker::kill_process_group(record.pid);
     println!("Killed agent worker for {} (PID {}).", session, record.pid);
     Ok(())
 }
@@ -585,7 +585,7 @@ async fn signal_and_wait(record: &crate::acp::worker_registry::WorkerRecord, tim
     // goes down together, not just the runner pid. Sent unconditionally:
     // the group can outlive its leader pid, so gating on leader liveness
     // would skip the SIGTERM and leak surviving descendants. See #1689.
-    worker_registry::terminate_runner_group(record.pid);
+    crate::process::worker::terminate_process_group(record.pid);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
     while std::time::Instant::now() < deadline {
         if !worker_registry::is_pid_alive(record.pid) {
@@ -593,7 +593,7 @@ async fn signal_and_wait(record: &crate::acp::worker_registry::WorkerRecord, tim
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
-    worker_registry::kill_runner_group(record.pid);
+    crate::process::worker::kill_process_group(record.pid);
 }
 
 fn logs(session: Option<String>, follow: bool) -> Result<()> {
@@ -672,7 +672,7 @@ fn restart(session: &str) -> Result<()> {
     // runner rather than orphaning under PID 1 before respawn (#1689).
     // Unconditional: the group can outlive its leader pid, so gating on
     // leader liveness would skip the killpg and leak descendants.
-    worker_registry::terminate_runner_group(record.pid);
+    crate::process::worker::terminate_process_group(record.pid);
     println!(
         "Stopped runner for {} (PID {}). `aoe serve` will respawn on its next reconciler tick.",
         session, record.pid

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,0 +1,678 @@
+//! Protocol-agnostic durable event log: the storage substrate behind the
+//! ACP transcript store and, in time, the plugin host's event bus.
+//!
+//! This module owns the SQLite mechanics that have nothing to do with any
+//! particular event payload: schema creation, the append + per-topic
+//! retention prune, keyset row scans, seq bookkeeping, attachment blob
+//! storage, and topic deletion. Events are opaque JSON strings keyed by an
+//! arbitrary `topic` (the partition key), with a caller-assigned monotonic
+//! `seq`. The consumer owns its payload type, its replay semantics, and any
+//! payload-aware queries; it holds the [`Connection`] and threads it plus a
+//! [`Schema`] into these free functions. The dependency arrow runs consumer
+//! -> here, never the reverse.
+//!
+//! ## On-disk shape
+//!
+//! Two tables per [`Schema`], named `<prefix>_events` and
+//! `<prefix>_attachments`. The partition key is physically the `session_id`
+//! column (kept under that name so an existing ACP database loads without a
+//! migration) even though the API speaks of "topics". The payload column is
+//! `event_json`. A consumer's payload-aware SQL may rely on those column
+//! names; they are part of this module's contract.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
+use tracing::{debug, warn};
+
+/// Names the two tables an [`EventLog`-style consumer](self) reads and
+/// writes, derived from a validated prefix. Construct once at open time and
+/// thread it into every call so table-name construction is centralized.
+#[derive(Debug, Clone)]
+pub struct Schema {
+    events_table: String,
+    attachments_table: String,
+}
+
+impl Schema {
+    /// Build a schema from `prefix`. The prefix is validated to
+    /// `[a-z_]+` so it can be interpolated into table/index names (SQLite
+    /// cannot bind identifiers as parameters) without any injection risk.
+    pub fn new(prefix: &str) -> Result<Self> {
+        if prefix.is_empty() || !prefix.bytes().all(|b| b.is_ascii_lowercase() || b == b'_') {
+            anyhow::bail!("event log table prefix must be non-empty and match [a-z_]+");
+        }
+        Ok(Self {
+            events_table: format!("{prefix}_events"),
+            attachments_table: format!("{prefix}_attachments"),
+        })
+    }
+
+    pub fn events_table(&self) -> &str {
+        &self.events_table
+    }
+
+    pub fn attachments_table(&self) -> &str {
+        &self.attachments_table
+    }
+}
+
+/// Which side of a seq cursor a [`scan`] window sits on.
+#[derive(Debug, Clone, Copy)]
+pub enum SeqBound {
+    /// Rows with `seq > value` (forward from a replay cursor).
+    After(u64),
+    /// Rows with `seq < value` (older history below a cursor).
+    Before(u64),
+}
+
+/// Row ordering for a [`scan`] window.
+#[derive(Debug, Clone, Copy)]
+pub enum Order {
+    Asc,
+    Desc,
+}
+
+/// Build the `AND event_json NOT LIKE '{"Name":%'` SQL fragment for every
+/// externally-tagged JSON discriminant in `prefixes`, newline-joined for
+/// readable queries. Used both to pin events against retention eviction and
+/// to exclude them from activity scans; the caller supplies the set so this
+/// module stays payload-agnostic.
+fn not_like_clauses(prefixes: &[&str]) -> String {
+    prefixes
+        .iter()
+        .map(|name| format!("AND event_json NOT LIKE '{{\"{name}\":%'"))
+        .collect::<Vec<_>>()
+        .join("\n               ")
+}
+
+/// Open or create the database at `db_path` and ensure `schema`'s tables
+/// and indexes exist. WAL mode is enabled so a writer (append path) and a
+/// reader (replay) don't block each other.
+pub fn open(db_path: &Path, schema: &Schema) -> Result<Connection> {
+    if let Some(parent) = db_path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("create parent dir for event log at {}", parent.display())
+            })?;
+        }
+    }
+    let conn = Connection::open(db_path)
+        .with_context(|| format!("open event log at {}", db_path.display()))?;
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .context("enable WAL mode")?;
+    conn.pragma_update(None, "synchronous", "NORMAL")
+        .context("set synchronous=NORMAL")?;
+    let events = schema.events_table();
+    let attachments = schema.attachments_table();
+    conn.execute_batch(&format!(
+        "CREATE TABLE IF NOT EXISTS {events} (
+            session_id  TEXT    NOT NULL,
+            seq         INTEGER NOT NULL,
+            event_json  TEXT    NOT NULL,
+            created_at  INTEGER NOT NULL,
+            PRIMARY KEY (session_id, seq)
+        );
+        CREATE INDEX IF NOT EXISTS idx_{events}_session_seq
+            ON {events}(session_id, seq);
+        CREATE INDEX IF NOT EXISTS idx_{events}_session_created_at
+            ON {events}(session_id, created_at);
+        CREATE TABLE IF NOT EXISTS {attachments} (
+            session_id    TEXT    NOT NULL,
+            seq           INTEGER NOT NULL,
+            attachment_id TEXT    NOT NULL,
+            kind          TEXT    NOT NULL,
+            mime_type     TEXT    NOT NULL,
+            name          TEXT,
+            data          BLOB    NOT NULL,
+            created_at    INTEGER NOT NULL,
+            PRIMARY KEY (session_id, attachment_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_{attachments}_session_seq
+            ON {attachments}(session_id, seq);"
+    ))
+    .context("create event log schema")?;
+    Ok(conn)
+}
+
+/// Append one opaque event payload. Idempotent on duplicate `(topic, seq)`
+/// thanks to the primary key; re-appending the same seq is a no-op.
+/// Returns the number of rows inserted (0 on a duplicate) so the caller can
+/// distinguish a fresh write from a benign retry.
+pub fn insert_event(
+    conn: &Connection,
+    schema: &Schema,
+    topic: &str,
+    seq: u64,
+    json: &str,
+    created_at: i64,
+) -> Result<usize> {
+    let sql = format!(
+        "INSERT OR IGNORE INTO {} (session_id, seq, event_json, created_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        schema.events_table()
+    );
+    conn.execute(&sql, params![topic, seq as i64, json, created_at])
+        .with_context(|| format!("insert {topic}@{seq}"))
+}
+
+/// Prune the oldest events for `topic` beyond `max_events`, exempting any
+/// event whose payload starts with one of `pinned_prefixes` (matched on the
+/// externally-tagged JSON discriminant). Attachment blobs at or below the
+/// prune cutoff are dropped in the same pass so they stay bounded alongside
+/// the log. No-op when `max_events` is 0. Failures are logged and swallowed:
+/// the row is already recorded, we just exceed the cap until the next prune.
+pub fn prune_retention(
+    conn: &Connection,
+    schema: &Schema,
+    topic: &str,
+    max_events: usize,
+    pinned_prefixes: &[&str],
+) {
+    if max_events == 0 {
+        return;
+    }
+    // Compute the prune cutoff seq once so the events delete and the
+    // attachments delete agree on the same threshold. Doing the events
+    // delete first would shift the OFFSET row out from under the
+    // attachments delete and leave orphaned blobs.
+    let events = schema.events_table();
+    let cutoff: Option<i64> = conn
+        .query_row(
+            &format!(
+                "SELECT seq FROM {events}
+                 WHERE session_id = ?1
+                 ORDER BY seq DESC
+                 LIMIT 1 OFFSET ?2"
+            ),
+            params![topic, max_events as i64],
+            |row| row.get(0),
+        )
+        .optional()
+        .unwrap_or(None);
+    let Some(cutoff) = cutoff else {
+        return;
+    };
+    let prune_sql = format!(
+        "DELETE FROM {events}
+         WHERE session_id = ?1
+           AND seq <= ?2
+           {clauses}",
+        clauses = not_like_clauses(pinned_prefixes)
+    );
+    match conn.execute(&prune_sql, params![topic, cutoff]) {
+        Ok(0) => {}
+        Ok(pruned) => {
+            debug!(
+                target: "events",
+                topic = %topic,
+                pruned,
+                cap = max_events,
+                "pruned oldest events past retention cap"
+            );
+        }
+        Err(e) => {
+            warn!(target: "events", "prune {topic}: {e}");
+        }
+    }
+    // Drop attachment blobs whose owning event has (or is about to be)
+    // pruned. A flat `seq <= cutoff` delete cannot strand a blob whose
+    // event survived, because attachments only ever hang off prunable
+    // events, never the pinned variants.
+    if let Err(e) = conn.execute(
+        &format!(
+            "DELETE FROM {} WHERE session_id = ?1 AND seq <= ?2",
+            schema.attachments_table()
+        ),
+        params![topic, cutoff],
+    ) {
+        warn!(target: "events", "prune attachments {topic}: {e}");
+    }
+}
+
+/// Fetch up to `limit` raw `(seq, json)` rows for `topic` on the given side
+/// of the cursor, in the given order. `limit` of `None` is unbounded. The
+/// caller owns deserialization, has-more probing (pass `limit + 1`), and
+/// cursor advancement; this just runs the keyset query. Rows that fail to
+/// decode at the SQLite layer are skipped (effectively never, given the NOT
+/// NULL schema).
+pub fn scan(
+    conn: &Connection,
+    schema: &Schema,
+    topic: &str,
+    bound: SeqBound,
+    order: Order,
+    limit: Option<usize>,
+) -> Vec<(u64, String)> {
+    // `seq` is a signed SQLite column; clamp before the cast so a
+    // `u64::MAX` cursor (the status probe / tail request) doesn't wrap to a
+    // negative bound and match the wrong rows.
+    let (op, value) = match bound {
+        SeqBound::After(v) => (">", v),
+        SeqBound::Before(v) => ("<", v),
+    };
+    let value_i64 = i64::try_from(value).unwrap_or(i64::MAX);
+    let order_sql = match order {
+        Order::Asc => "ASC",
+        Order::Desc => "DESC",
+    };
+    let events = schema.events_table();
+    let sql = match limit {
+        Some(_) => format!(
+            "SELECT seq, event_json FROM {events}
+             WHERE session_id = ?1 AND seq {op} ?2
+             ORDER BY seq {order_sql} LIMIT ?3"
+        ),
+        None => format!(
+            "SELECT seq, event_json FROM {events}
+             WHERE session_id = ?1 AND seq {op} ?2
+             ORDER BY seq {order_sql}"
+        ),
+    };
+    let mut stmt = match conn.prepare(&sql) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(target: "events", "prepare scan for {topic}: {e}");
+            return Vec::new();
+        }
+    };
+    let map_row = |row: &rusqlite::Row| {
+        let seq: i64 = row.get(0)?;
+        let json: String = row.get(1)?;
+        Ok((seq as u64, json))
+    };
+    let rows = match limit {
+        Some(n) => stmt.query_map(params![topic, value_i64, n as i64], map_row),
+        None => stmt.query_map(params![topic, value_i64], map_row),
+    };
+    let rows = match rows {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(target: "events", "query scan for {topic}: {e}");
+            return Vec::new();
+        }
+    };
+    let mut out = Vec::new();
+    for row in rows {
+        match row {
+            Ok(pair) => out.push(pair),
+            Err(e) => warn!(target: "events", "row error: {e}"),
+        }
+    }
+    out
+}
+
+/// Highest seq stored for `topic`, or 0 if none.
+pub fn highest_seq(conn: &Connection, schema: &Schema, topic: &str) -> u64 {
+    match conn
+        .query_row(
+            &format!(
+                "SELECT MAX(seq) FROM {} WHERE session_id = ?1",
+                schema.events_table()
+            ),
+            params![topic],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()
+    {
+        Ok(Some(Some(max))) => max as u64,
+        _ => 0,
+    }
+}
+
+/// Lowest seq still stored for `topic`, or `None` when empty.
+pub fn lowest_seq(conn: &Connection, schema: &Schema, topic: &str) -> Option<u64> {
+    match conn
+        .query_row(
+            &format!(
+                "SELECT MIN(seq) FROM {} WHERE session_id = ?1",
+                schema.events_table()
+            ),
+            params![topic],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()
+    {
+        Ok(Some(Some(m))) => Some(m as u64),
+        _ => None,
+    }
+}
+
+/// Every topic with at least one event, paired with its highest seq, in one
+/// query. Used to re-seed per-topic seq counters at startup.
+pub fn all_topic_seqs(conn: &Connection, schema: &Schema) -> Vec<(String, u64)> {
+    let sql = format!(
+        "SELECT session_id, MAX(seq) FROM {} GROUP BY session_id",
+        schema.events_table()
+    );
+    let mut stmt = match conn.prepare(&sql) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(target: "events", "prepare all_topic_seqs: {e}");
+            return Vec::new();
+        }
+    };
+    let rows = match stmt.query_map([], |row| {
+        let id: String = row.get(0)?;
+        let max: i64 = row.get(1)?;
+        Ok((id, max as u64))
+    }) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(target: "events", "query all_topic_seqs: {e}");
+            return Vec::new();
+        }
+    };
+    rows.filter_map(|r| r.ok()).collect()
+}
+
+/// Most recent `created_at` per topic among `topics`, excluding events
+/// whose payload matches one of `excluded_prefixes`. Topics with no
+/// qualifying event are absent from the map. Empty `topics` returns empty.
+pub fn last_event_at_for_topics(
+    conn: &Connection,
+    schema: &Schema,
+    topics: &[String],
+    excluded_prefixes: &[&str],
+) -> HashMap<String, i64> {
+    let mut out = HashMap::new();
+    if topics.is_empty() {
+        return out;
+    }
+    let placeholders = std::iter::repeat_n("?", topics.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT session_id, MAX(created_at) FROM {events}
+         WHERE session_id IN ({placeholders})
+           {clauses}
+         GROUP BY session_id",
+        events = schema.events_table(),
+        clauses = not_like_clauses(excluded_prefixes)
+    );
+    let mut stmt = match conn.prepare(&sql) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(target: "events", "last_event_at_for_topics prepare: {e}");
+            return out;
+        }
+    };
+    let rows = stmt.query_map(params_from_iter(topics.iter()), |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    });
+    match rows {
+        Ok(iter) => {
+            for r in iter {
+                match r {
+                    Ok((topic, created_at)) => {
+                        out.insert(topic, created_at);
+                    }
+                    Err(e) => warn!(target: "events", "last_event_at_for_topics row: {e}"),
+                }
+            }
+        }
+        Err(e) => warn!(target: "events", "last_event_at_for_topics query: {e}"),
+    }
+    out
+}
+
+/// Persist one attachment blob keyed to `(topic, attachment_id)`, riding
+/// with event `seq` so retention and topic deletion drop it in lockstep.
+/// Idempotent on `(topic, attachment_id)`. Returns `true` on success.
+#[allow(clippy::too_many_arguments)]
+pub fn insert_attachment(
+    conn: &Connection,
+    schema: &Schema,
+    topic: &str,
+    seq: u64,
+    attachment_id: &str,
+    kind: &str,
+    mime_type: &str,
+    name: Option<&str>,
+    data: &[u8],
+    created_at: i64,
+) -> bool {
+    let sql = format!(
+        "INSERT OR IGNORE INTO {}
+            (session_id, seq, attachment_id, kind, mime_type, name, data, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        schema.attachments_table()
+    );
+    if let Err(e) = conn.execute(
+        &sql,
+        params![
+            topic,
+            seq as i64,
+            attachment_id,
+            kind,
+            mime_type,
+            name,
+            data,
+            created_at
+        ],
+    ) {
+        warn!(
+            target: "events",
+            topic = %topic,
+            attachment = %attachment_id,
+            "insert attachment failed: {e}"
+        );
+        return false;
+    }
+    true
+}
+
+/// Drop all attachment blobs owned by one event seq (a rollback when the
+/// owning event could not be durably persisted).
+pub fn delete_attachments_for_seq(conn: &Connection, schema: &Schema, topic: &str, seq: u64) {
+    if let Err(e) = conn.execute(
+        &format!(
+            "DELETE FROM {} WHERE session_id = ?1 AND seq = ?2",
+            schema.attachments_table()
+        ),
+        params![topic, seq as i64],
+    ) {
+        warn!(
+            target: "events",
+            topic = %topic,
+            seq,
+            "rollback attachments failed: {e}"
+        );
+    }
+}
+
+/// Fetch one attachment's `(mime_type, data)`, scoped by `topic` so a token
+/// for one topic can't read another's blob by guessing ids.
+pub fn load_attachment(
+    conn: &Connection,
+    schema: &Schema,
+    topic: &str,
+    attachment_id: &str,
+) -> Option<(String, Vec<u8>)> {
+    conn.query_row(
+        &format!(
+            "SELECT mime_type, data FROM {} WHERE session_id = ?1 AND attachment_id = ?2",
+            schema.attachments_table()
+        ),
+        params![topic, attachment_id],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
+    )
+    .optional()
+    .unwrap_or_else(|e| {
+        warn!(
+            target: "events",
+            topic = %topic,
+            attachment = %attachment_id,
+            "load attachment failed: {e}"
+        );
+        None
+    })
+}
+
+/// Drop every event and attachment for `topic`. Returns the number of event
+/// rows deleted.
+pub fn delete_topic(conn: &Connection, schema: &Schema, topic: &str) -> usize {
+    let deleted = match conn.execute(
+        &format!(
+            "DELETE FROM {} WHERE session_id = ?1",
+            schema.events_table()
+        ),
+        params![topic],
+    ) {
+        Ok(n) => n,
+        Err(e) => {
+            warn!(target: "events", "delete {topic}: {e}");
+            0
+        }
+    };
+    if let Err(e) = conn.execute(
+        &format!(
+            "DELETE FROM {} WHERE session_id = ?1",
+            schema.attachments_table()
+        ),
+        params![topic],
+    ) {
+        warn!(target: "events", "delete attachments {topic}: {e}");
+    }
+    deleted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mem(schema: &Schema) -> Connection {
+        // An in-memory DB shares the schema-creation path with `open`.
+        let conn = Connection::open_in_memory().unwrap();
+        let events = schema.events_table();
+        let attachments = schema.attachments_table();
+        conn.execute_batch(&format!(
+            "CREATE TABLE {events} (session_id TEXT NOT NULL, seq INTEGER NOT NULL, event_json TEXT NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY (session_id, seq));
+             CREATE TABLE {attachments} (session_id TEXT NOT NULL, seq INTEGER NOT NULL, attachment_id TEXT NOT NULL, kind TEXT NOT NULL, mime_type TEXT NOT NULL, name TEXT, data BLOB NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY (session_id, attachment_id));"
+        ))
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn schema_rejects_bad_prefix() {
+        assert!(Schema::new("").is_err());
+        assert!(Schema::new("ACP").is_err());
+        assert!(Schema::new("plugin-host").is_err());
+        assert!(Schema::new("plugin1").is_err());
+        let s = Schema::new("plugin_host").unwrap();
+        assert_eq!(s.events_table(), "plugin_host_events");
+        assert_eq!(s.attachments_table(), "plugin_host_attachments");
+    }
+
+    /// The log is genuinely topic-keyed and payload-opaque: drive it with a
+    /// non-ACP prefix and two topics, proving append/scan/seq/delete all
+    /// partition correctly. This is what makes the substrate reusable.
+    #[test]
+    fn topic_keyed_append_scan_and_delete() {
+        let schema = Schema::new("demo").unwrap();
+        let conn = mem(&schema);
+        for (topic, seq) in [("a", 1u64), ("a", 2), ("a", 3), ("b", 1)] {
+            assert_eq!(
+                insert_event(
+                    &conn,
+                    &schema,
+                    topic,
+                    seq,
+                    &format!("\"e{seq}\""),
+                    seq as i64
+                )
+                .unwrap(),
+                1
+            );
+        }
+        // Duplicate (topic, seq) is a no-op.
+        assert_eq!(
+            insert_event(&conn, &schema, "a", 2, "\"dup\"", 0).unwrap(),
+            0
+        );
+
+        assert_eq!(highest_seq(&conn, &schema, "a"), 3);
+        assert_eq!(lowest_seq(&conn, &schema, "a"), Some(1));
+        assert_eq!(highest_seq(&conn, &schema, "b"), 1);
+        assert_eq!(highest_seq(&conn, &schema, "missing"), 0);
+        assert_eq!(lowest_seq(&conn, &schema, "missing"), None);
+
+        // Forward scan after a cursor, bounded.
+        let fwd = scan(&conn, &schema, "a", SeqBound::After(0), Order::Asc, Some(2));
+        assert_eq!(fwd, vec![(1, "\"e1\"".into()), (2, "\"e2\"".into())]);
+        // Backward scan below a cursor.
+        let back = scan(
+            &conn,
+            &schema,
+            "a",
+            SeqBound::Before(u64::MAX),
+            Order::Desc,
+            Some(2),
+        );
+        assert_eq!(back, vec![(3, "\"e3\"".into()), (2, "\"e2\"".into())]);
+
+        let mut seqs = all_topic_seqs(&conn, &schema);
+        seqs.sort();
+        assert_eq!(seqs, vec![("a".into(), 3), ("b".into(), 1)]);
+
+        assert_eq!(delete_topic(&conn, &schema, "a"), 3);
+        assert_eq!(highest_seq(&conn, &schema, "a"), 0);
+        assert_eq!(highest_seq(&conn, &schema, "b"), 1);
+    }
+
+    #[test]
+    fn retention_prunes_oldest_but_keeps_pinned() {
+        let schema = Schema::new("demo").unwrap();
+        let conn = mem(&schema);
+        // seq 1 is a pinned snapshot; 2..=5 are ordinary.
+        insert_event(&conn, &schema, "t", 1, "{\"Pinned\":{}}", 1).unwrap();
+        for seq in 2..=5u64 {
+            insert_event(&conn, &schema, "t", seq, "{\"Chunk\":{}}", seq as i64).unwrap();
+        }
+        // Cap of 2 with Pinned exempt: keep newest 2 (4,5) plus pinned 1.
+        prune_retention(&conn, &schema, "t", 2, &["Pinned"]);
+        let kept: Vec<u64> = scan(&conn, &schema, "t", SeqBound::After(0), Order::Asc, None)
+            .into_iter()
+            .map(|(s, _)| s)
+            .collect();
+        assert_eq!(kept, vec![1, 4, 5]);
+    }
+
+    #[test]
+    fn attachments_roundtrip_and_scope() {
+        let schema = Schema::new("demo").unwrap();
+        let conn = mem(&schema);
+        assert!(insert_attachment(
+            &conn,
+            &schema,
+            "t",
+            7,
+            "att-1",
+            "image",
+            "image/png",
+            Some("shot.png"),
+            b"bytes",
+            0
+        ));
+        let got = load_attachment(&conn, &schema, "t", "att-1");
+        assert_eq!(got, Some(("image/png".into(), b"bytes".to_vec())));
+        // Wrong topic can't read it.
+        assert_eq!(load_attachment(&conn, &schema, "other", "att-1"), None);
+        delete_attachments_for_seq(&conn, &schema, "t", 7);
+        assert_eq!(load_attachment(&conn, &schema, "t", "att-1"), None);
+    }
+
+    #[test]
+    fn last_event_at_excludes_prefixes() {
+        let schema = Schema::new("demo").unwrap();
+        let conn = mem(&schema);
+        insert_event(&conn, &schema, "t", 1, "{\"Chunk\":{}}", 100).unwrap();
+        // A later, but excluded, event must not advance the activity clock.
+        insert_event(&conn, &schema, "t", 2, "{\"Snapshot\":{}}", 200).unwrap();
+        let map = last_event_at_for_topics(&conn, &schema, &["t".into()], &["Snapshot"]);
+        assert_eq!(map.get("t"), Some(&100));
+    }
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use rusqlite::types::Value;
 use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
 use tracing::{debug, warn};
 
@@ -75,17 +76,26 @@ pub enum Order {
     Desc,
 }
 
-/// Build the `AND event_json NOT LIKE '{"Name":%'` SQL fragment for every
-/// externally-tagged JSON discriminant in `prefixes`, newline-joined for
-/// readable queries. Used both to pin events against retention eviction and
-/// to exclude them from activity scans; the caller supplies the set so this
-/// module stays payload-agnostic.
-fn not_like_clauses(prefixes: &[&str]) -> String {
-    prefixes
+/// Build an `AND event_json NOT LIKE ?` SQL fragment (one per discriminant in
+/// `prefixes`) plus the matching bound LIKE patterns, newline-joined for
+/// readable queries. Used both to pin events against retention eviction and to
+/// exclude them from activity scans; the caller supplies the set, so this
+/// module stays payload-agnostic. The discriminant is bound as a parameter
+/// rather than interpolated into the SQL text, so a future consumer's prefix
+/// containing a quote can't break or inject into the predicate. The clause
+/// uses anonymous `?` placeholders, so callers must build their full parameter
+/// list positionally (topic / cutoff first, then these patterns in order).
+fn not_like_clauses(prefixes: &[&str]) -> (String, Vec<String>) {
+    let fragment = prefixes
         .iter()
-        .map(|name| format!("AND event_json NOT LIKE '{{\"{name}\":%'"))
+        .map(|_| "AND event_json NOT LIKE ?")
         .collect::<Vec<_>>()
-        .join("\n               ")
+        .join("\n               ");
+    let patterns = prefixes
+        .iter()
+        .map(|name| format!("{{\"{name}\":%"))
+        .collect();
+    (fragment, patterns)
 }
 
 /// Open or create the database at `db_path` and ensure `schema`'s tables
@@ -179,6 +189,7 @@ pub fn prune_retention(
     // delete first would shift the OFFSET row out from under the
     // attachments delete and leave orphaned blobs.
     let events = schema.events_table();
+    let attachments = schema.attachments_table();
     let cutoff: Option<i64> = conn
         .query_row(
             &format!(
@@ -195,14 +206,35 @@ pub fn prune_retention(
     let Some(cutoff) = cutoff else {
         return;
     };
-    let prune_sql = format!(
-        "DELETE FROM {events}
-         WHERE session_id = ?1
-           AND seq <= ?2
-           {clauses}",
-        clauses = not_like_clauses(pinned_prefixes)
+    let (clauses, patterns) = not_like_clauses(pinned_prefixes);
+    // Drop attachment blobs owned by the events this prune deletes, using the
+    // same predicate (and ordered before the events delete so the subquery
+    // still sees those rows). Tying it to the event predicate keeps a pinned
+    // event's blobs instead of assuming pinned events never carry
+    // attachments, so a future consumer can't strand a surviving event's blob.
+    let attachment_prune_sql = format!(
+        "DELETE FROM {attachments}
+         WHERE session_id = ?
+           AND seq IN (
+               SELECT seq FROM {events}
+               WHERE session_id = ?
+                 AND seq <= ?
+                 {clauses}
+           )"
     );
-    match conn.execute(&prune_sql, params![topic, cutoff]) {
+    let mut attachment_params: Vec<Value> = vec![
+        Value::Text(topic.to_owned()),
+        Value::Text(topic.to_owned()),
+        Value::Integer(cutoff),
+    ];
+    attachment_params.extend(patterns.iter().cloned().map(Value::Text));
+    if let Err(e) = conn.execute(&attachment_prune_sql, params_from_iter(attachment_params)) {
+        warn!(target: "events", "prune attachments {topic}: {e}");
+    }
+    let prune_sql = format!("DELETE FROM {events} WHERE session_id = ? AND seq <= ? {clauses}");
+    let mut prune_params: Vec<Value> = vec![Value::Text(topic.to_owned()), Value::Integer(cutoff)];
+    prune_params.extend(patterns.into_iter().map(Value::Text));
+    match conn.execute(&prune_sql, params_from_iter(prune_params)) {
         Ok(0) => {}
         Ok(pruned) => {
             debug!(
@@ -216,19 +248,6 @@ pub fn prune_retention(
         Err(e) => {
             warn!(target: "events", "prune {topic}: {e}");
         }
-    }
-    // Drop attachment blobs whose owning event has (or is about to be)
-    // pruned. A flat `seq <= cutoff` delete cannot strand a blob whose
-    // event survived, because attachments only ever hang off prunable
-    // events, never the pinned variants.
-    if let Err(e) = conn.execute(
-        &format!(
-            "DELETE FROM {} WHERE session_id = ?1 AND seq <= ?2",
-            schema.attachments_table()
-        ),
-        params![topic, cutoff],
-    ) {
-        warn!(target: "events", "prune attachments {topic}: {e}");
     }
 }
 
@@ -384,13 +403,13 @@ pub fn last_event_at_for_topics(
     let placeholders = std::iter::repeat_n("?", topics.len())
         .collect::<Vec<_>>()
         .join(",");
+    let (clauses, patterns) = not_like_clauses(excluded_prefixes);
     let sql = format!(
         "SELECT session_id, MAX(created_at) FROM {events}
          WHERE session_id IN ({placeholders})
            {clauses}
          GROUP BY session_id",
         events = schema.events_table(),
-        clauses = not_like_clauses(excluded_prefixes)
     );
     let mut stmt = match conn.prepare(&sql) {
         Ok(s) => s,
@@ -399,7 +418,10 @@ pub fn last_event_at_for_topics(
             return out;
         }
     };
-    let rows = stmt.query_map(params_from_iter(topics.iter()), |row| {
+    // Positional params: the IN(...) topics first, then the NOT LIKE patterns.
+    let mut bind: Vec<Value> = topics.iter().map(|t| Value::Text(t.clone())).collect();
+    bind.extend(patterns.into_iter().map(Value::Text));
+    let rows = stmt.query_map(params_from_iter(bind), |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
     });
     match rows {
@@ -639,6 +661,54 @@ mod tests {
             .map(|(s, _)| s)
             .collect();
         assert_eq!(kept, vec![1, 4, 5]);
+    }
+
+    /// A pinned event's attachment must survive a prune (the prune ties the
+    /// attachment delete to the same predicate as the event delete, rather
+    /// than assuming pinned events never carry blobs). A pruned event's
+    /// attachment must be dropped.
+    #[test]
+    fn retention_keeps_pinned_event_attachments() {
+        let schema = Schema::new("demo").unwrap();
+        let conn = mem(&schema);
+        insert_event(&conn, &schema, "t", 1, "{\"Pinned\":{}}", 1).unwrap();
+        for seq in 2..=5u64 {
+            insert_event(&conn, &schema, "t", seq, "{\"Chunk\":{}}", seq as i64).unwrap();
+        }
+        // Blob on the pinned event (seq 1) and on a soon-pruned event (seq 2).
+        insert_attachment(
+            &conn,
+            &schema,
+            "t",
+            1,
+            "pinned-att",
+            "image",
+            "image/png",
+            None,
+            b"keep",
+            0,
+        );
+        insert_attachment(
+            &conn,
+            &schema,
+            "t",
+            2,
+            "pruned-att",
+            "image",
+            "image/png",
+            None,
+            b"drop",
+            0,
+        );
+        prune_retention(&conn, &schema, "t", 2, &["Pinned"]);
+        assert!(
+            load_attachment(&conn, &schema, "t", "pinned-att").is_some(),
+            "blob owned by a pinned (surviving) event must be kept"
+        );
+        assert!(
+            load_attachment(&conn, &schema, "t", "pruned-att").is_none(),
+            "blob owned by a pruned event must be dropped"
+        );
     }
 
     #[test]

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -207,35 +207,14 @@ pub fn prune_retention(
         return;
     };
     let (clauses, patterns) = not_like_clauses(pinned_prefixes);
-    // Drop attachment blobs owned by the events this prune deletes, using the
-    // same predicate (and ordered before the events delete so the subquery
-    // still sees those rows). Tying it to the event predicate keeps a pinned
-    // event's blobs instead of assuming pinned events never carry
-    // attachments, so a future consumer can't strand a surviving event's blob.
-    let attachment_prune_sql = format!(
-        "DELETE FROM {attachments}
-         WHERE session_id = ?
-           AND seq IN (
-               SELECT seq FROM {events}
-               WHERE session_id = ?
-                 AND seq <= ?
-                 {clauses}
-           )"
-    );
-    let mut attachment_params: Vec<Value> = vec![
-        Value::Text(topic.to_owned()),
-        Value::Text(topic.to_owned()),
-        Value::Integer(cutoff),
-    ];
-    attachment_params.extend(patterns.iter().cloned().map(Value::Text));
-    if let Err(e) = conn.execute(&attachment_prune_sql, params_from_iter(attachment_params)) {
-        warn!(target: "events", "prune attachments {topic}: {e}");
-    }
+    // Prune the events first. If this fails, return before touching
+    // attachments: deleting blobs while their owning events survive would
+    // leave replay events pointing at missing data.
     let prune_sql = format!("DELETE FROM {events} WHERE session_id = ? AND seq <= ? {clauses}");
     let mut prune_params: Vec<Value> = vec![Value::Text(topic.to_owned()), Value::Integer(cutoff)];
     prune_params.extend(patterns.into_iter().map(Value::Text));
     match conn.execute(&prune_sql, params_from_iter(prune_params)) {
-        Ok(0) => {}
+        Ok(0) => return,
         Ok(pruned) => {
             debug!(
                 target: "events",
@@ -247,7 +226,24 @@ pub fn prune_retention(
         }
         Err(e) => {
             warn!(target: "events", "prune {topic}: {e}");
+            return;
         }
+    }
+    // Drop blobs whose owning event was just pruned (no longer present at or
+    // below the cutoff). Tying the delete to event existence rather than a
+    // flat `seq <= cutoff` keeps a pinned event's blobs, instead of assuming
+    // pinned variants never carry attachments, so a future consumer can't
+    // strand a surviving event's blob.
+    if let Err(e) = conn.execute(
+        &format!(
+            "DELETE FROM {attachments}
+             WHERE session_id = ?1
+               AND seq <= ?2
+               AND seq NOT IN (SELECT seq FROM {events} WHERE session_id = ?1)"
+        ),
+        params![topic, cutoff],
+    ) {
+        warn!(target: "events", "prune attachments {topic}: {e}");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,11 @@ pub mod build_info;
 pub mod claude_settings;
 pub mod cli;
 pub mod containers;
+/// Protocol-agnostic durable event log, the storage substrate behind the
+/// ACP transcript store and (later) the plugin host's event bus. Serve-gated
+/// because its only consumer today is the serve-gated acp module.
+#[cfg(feature = "serve")]
+pub mod events;
 pub mod file_watch;
 pub mod git;
 pub mod github;

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -16,6 +16,12 @@ mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
 
+/// Protocol-agnostic plumbing for supervised worker subprocesses, lifted
+/// out of `src/acp/` so the future plugin host can reuse it. Serve-gated
+/// because its only consumer today is the serve-gated `acp` module.
+#[cfg(feature = "serve")]
+pub mod worker;
+
 /// Get the PID of the shell process running in a tmux pane
 pub fn get_pane_pid(session_name: &str) -> Option<u32> {
     // Use `^.0` to target the first window's first pane regardless of

--- a/src/process/worker.rs
+++ b/src/process/worker.rs
@@ -1,0 +1,336 @@
+//! Protocol-agnostic plumbing for supervised worker subprocesses.
+//!
+//! This is the neutral substrate that both `src/acp/` and the future
+//! plugin host build on: process-group signalling and liveness probes,
+//! the on-disk layout helpers for a `<dir>/<id>.{json,sock,log,restart}`
+//! worker directory, and the runner self-inspection state machine. None
+//! of it knows about ACP, agents, or any specific worker payload; the
+//! consumer supplies the base directory and (for record inspection) how
+//! to pull a pid out of its own record format. The dependency arrow runs
+//! consumer -> here, never the reverse.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// Probe whether `pid` is still alive. On Unix: `kill(pid, 0)` returns
+/// `Ok(())` for live and `Err(ESRCH)` for dead. Other errors (EPERM,
+/// etc.) mean the process exists but we lack permission to signal it,
+/// still alive.
+#[cfg(unix)]
+pub fn is_pid_alive(pid: u32) -> bool {
+    use nix::errno::Errno;
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    match kill(Pid::from_raw(pid as i32), None) {
+        Ok(()) => true,
+        Err(Errno::ESRCH) => false,
+        Err(_) => true,
+    }
+}
+
+#[cfg(not(unix))]
+pub fn is_pid_alive(_pid: u32) -> bool {
+    false
+}
+
+/// Signal a worker's entire process group, then the worker pid itself.
+///
+/// A worker is spawned `setsid` (a fresh session, so it is the leader of
+/// a process group whose id equals its pid), and any subprocess it
+/// launches plus their children inherit that group. Signalling the group
+/// reaps the whole tree in one shot. Signalling only the leader pid leaves
+/// descendants orphaned under PID 1, which is the process-leak that
+/// accumulated across daemon restarts and superseded spawns (#1689). The
+/// trailing single-pid signal is a belt-and-suspenders for the unlikely
+/// case `setsid` failed and the leader is not a group leader. Best-effort;
+/// errors are ignored.
+#[cfg(unix)]
+fn signal_process_group(pid: u32, sig: nix::sys::signal::Signal) {
+    use nix::sys::signal::{kill, killpg};
+    use nix::unistd::Pid;
+    let p = Pid::from_raw(pid as i32);
+    let _ = killpg(p, sig);
+    let _ = kill(p, sig);
+}
+
+/// SIGTERM the worker's process group (leader + descendants).
+pub fn terminate_process_group(pid: u32) {
+    #[cfg(unix)]
+    signal_process_group(pid, nix::sys::signal::Signal::SIGTERM);
+    #[cfg(not(unix))]
+    let _ = pid;
+}
+
+/// SIGKILL the worker's process group; the escalation path when SIGTERM
+/// does not take.
+pub fn kill_process_group(pid: u32) {
+    #[cfg(unix)]
+    signal_process_group(pid, nix::sys::signal::Signal::SIGKILL);
+    #[cfg(not(unix))]
+    let _ = pid;
+}
+
+/// Reap a worker process group with SIGKILL escalation: SIGTERM the group,
+/// wait `grace` for it to exit, then SIGKILL the group. A bare SIGTERM can
+/// leave a grandchild that ignores it alive under PID 1, so the escalation
+/// is what actually guarantees the tree dies. `killpg` ignores ESRCH, so
+/// the SIGKILL on an already-empty group is a no-op. See #1921.
+#[cfg(unix)]
+pub async fn reap_group_escalating(pid: u32, grace: std::time::Duration) {
+    terminate_process_group(pid);
+    tokio::time::sleep(grace).await;
+    kill_process_group(pid);
+}
+
+/// Defense-in-depth check on a worker id before it is interpolated into
+/// any `<dir>/<id>.<ext>` path. Production ids come from `Uuid::new_v4()`
+/// so they satisfy this trivially, but ids can also arrive from a CLI arg,
+/// and we don't want an id like `"../../foo"` to write files outside the
+/// dedicated worker directory. Not a privilege escalation (same UID), but
+/// a basic input-validation gap worth closing.
+///
+/// Accepts: alphanumeric, `-`, `_`. Rejects: empty, `/`, `\`, `.` (so
+/// `..` and leading-dot hidden files are both out), null bytes, and
+/// anything longer than 128 bytes (UUIDs are 36; this leaves room for
+/// prefixed test ids without permitting arbitrarily-long inputs).
+pub fn validate_id(id: &str) -> Result<()> {
+    if id.is_empty() {
+        anyhow::bail!("worker id must not be empty");
+    }
+    if id.len() > 128 {
+        anyhow::bail!("worker id too long ({} bytes, max 128)", id.len());
+    }
+    if !id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        anyhow::bail!(
+            "worker id contains disallowed characters: must be ASCII alphanumeric, '-', or '_'"
+        );
+    }
+    Ok(())
+}
+
+/// Create the worker directory if absent, owner-only (0700) so other users
+/// on a shared host cannot enumerate worker ids.
+pub fn ensure_dir(dir: &Path) -> Result<()> {
+    if !dir.exists() {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("creating worker dir at {}", dir.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+    Ok(())
+}
+
+/// `<dir>/<id>.json`, the worker record path.
+pub fn record_path(dir: &Path, id: &str) -> Result<PathBuf> {
+    validate_id(id)?;
+    Ok(dir.join(format!("{id}.json")))
+}
+
+/// `<dir>/<id>.sock`. The caller threads the same path into both the
+/// worker spawn and the connect side.
+pub fn socket_path(dir: &Path, id: &str) -> Result<PathBuf> {
+    validate_id(id)?;
+    Ok(dir.join(format!("{id}.sock")))
+}
+
+/// `<dir>/<id>.log`, the worker-side stderr drain.
+pub fn log_path(dir: &Path, id: &str) -> Result<PathBuf> {
+    validate_id(id)?;
+    Ok(dir.join(format!("{id}.log")))
+}
+
+/// `<dir>/<id>.restart`, a sentinel that distinguishes a restart-driven
+/// teardown from a stop/kill so the reaper can react accordingly.
+pub fn restart_marker_path(dir: &Path, id: &str) -> Result<PathBuf> {
+    validate_id(id)?;
+    Ok(dir.join(format!("{id}.restart")))
+}
+
+/// What a worker's own registry record looks like from its watchdog's
+/// point of view. Computed from a non-creating read of a path captured at
+/// startup; see [`inspect_record_for_runner`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerRecordState {
+    /// Record present and its pid matches ours: we are still the owner.
+    Matches,
+    /// Record file is gone (HOME deleted, or someone `delete`d it).
+    Missing,
+    /// Record present but owned by a different pid: a fresh worker has
+    /// superseded us. We must exit without touching the files, which now
+    /// belong to the new owner.
+    Superseded,
+    /// Read or parse failed for a reason other than absence. Treated as
+    /// non-fatal (transient FS hiccup) by the watchdog.
+    Unreadable,
+}
+
+/// Inspect a worker's registry record WITHOUT creating its directory.
+///
+/// The watchdog cannot go through the normal load path, because that path
+/// recreates the worker directory whose deletion is the watchdog's primary
+/// self-destruct signal (and would resurrect a temp `$HOME` a test just
+/// removed). The caller captures the concrete record path once at startup,
+/// while the dir still exists, and polls it here. See #1921.
+///
+/// `extract_pid` pulls the owner pid out of the consumer's own record
+/// bytes; returning `None` means the bytes did not parse and the record is
+/// reported [`RunnerRecordState::Unreadable`]. Keeping the parse on the
+/// consumer side is what lets this module stay payload-agnostic while
+/// preserving the consumer's exact "malformed record is non-fatal"
+/// semantics.
+pub fn inspect_record_for_runner(
+    record_path: &Path,
+    own_pid: u32,
+    extract_pid: impl FnOnce(&[u8]) -> Option<u32>,
+) -> RunnerRecordState {
+    let bytes = match std::fs::read(record_path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return RunnerRecordState::Missing,
+        Err(_) => return RunnerRecordState::Unreadable,
+    };
+    match extract_pid(&bytes) {
+        Some(pid) if pid == own_pid => RunnerRecordState::Matches,
+        Some(_) => RunnerRecordState::Superseded,
+        None => RunnerRecordState::Unreadable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn is_pid_alive_self() {
+        assert!(is_pid_alive(std::process::id()));
+    }
+
+    #[test]
+    fn is_pid_alive_unlikely_pid() {
+        // A very high value that won't realistically be allocated.
+        assert!(!is_pid_alive(2_000_000_000));
+    }
+
+    #[test]
+    fn validate_id_accepts_uuids_and_test_ids() {
+        assert!(validate_id("550e8400-e29b-41d4-a716-446655440000").is_ok());
+        assert!(validate_id("test_session_42").is_ok());
+        assert!(validate_id("a").is_ok());
+        assert!(validate_id("Z-0").is_ok());
+    }
+
+    #[test]
+    fn validate_id_rejects_path_traversal_and_separators() {
+        for bad in [
+            "",
+            "..",
+            "../../etc/passwd",
+            "foo/bar",
+            "foo\\bar",
+            ".hidden",
+            "with space",
+            "with\0null",
+            "trailing.",
+            "good-then/../bad",
+        ] {
+            assert!(validate_id(bad).is_err(), "expected rejection for {bad:?}");
+        }
+    }
+
+    #[test]
+    fn validate_id_rejects_overlong() {
+        assert!(validate_id(&"a".repeat(129)).is_err());
+        assert!(validate_id(&"a".repeat(128)).is_ok());
+    }
+
+    /// The path builders are parameterized by an arbitrary base dir, not a
+    /// hardcoded ACP one: this is what makes them reusable by the plugin
+    /// host. Prove they compose against a non-ACP directory and reject bad
+    /// ids regardless of dir.
+    #[test]
+    fn path_builders_use_arbitrary_dir_and_validate() {
+        let dir = Path::new("/var/lib/example-workers");
+        assert_eq!(
+            record_path(dir, "abc").unwrap(),
+            PathBuf::from("/var/lib/example-workers/abc.json")
+        );
+        assert_eq!(
+            socket_path(dir, "abc").unwrap(),
+            PathBuf::from("/var/lib/example-workers/abc.sock")
+        );
+        assert_eq!(
+            log_path(dir, "abc").unwrap(),
+            PathBuf::from("/var/lib/example-workers/abc.log")
+        );
+        assert_eq!(
+            restart_marker_path(dir, "abc").unwrap(),
+            PathBuf::from("/var/lib/example-workers/abc.restart")
+        );
+        assert!(record_path(dir, "../escape").is_err());
+        assert!(socket_path(dir, "foo/bar").is_err());
+        assert!(log_path(dir, "").is_err());
+        assert!(restart_marker_path(dir, ".hidden").is_err());
+    }
+
+    #[test]
+    fn ensure_dir_creates_owner_only() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("workers");
+        assert!(!dir.exists());
+        ensure_dir(&dir).unwrap();
+        assert!(dir.is_dir());
+        // Idempotent.
+        ensure_dir(&dir).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&dir).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o700);
+        }
+    }
+
+    /// The pid extractor closure preserves the consumer's exact semantics:
+    /// a parse failure is non-fatal (`Unreadable`), a matching pid is
+    /// `Matches`, a foreign pid is `Superseded`, and an absent file is
+    /// `Missing`.
+    #[test]
+    fn inspect_record_states() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("rec.json");
+        // Parses to our pid -> Matches.
+        std::fs::write(&path, br#"{"pid":42}"#).unwrap();
+        let extract = |b: &[u8]| -> Option<u32> {
+            serde_json::from_slice::<serde_json::Value>(b)
+                .ok()
+                .and_then(|v| v.get("pid").and_then(|p| p.as_u64()).map(|p| p as u32))
+        };
+        assert_eq!(
+            inspect_record_for_runner(&path, 42, extract),
+            RunnerRecordState::Matches
+        );
+        // Parses to a foreign pid -> Superseded.
+        assert_eq!(
+            inspect_record_for_runner(&path, 7, extract),
+            RunnerRecordState::Superseded
+        );
+        // Unparseable bytes -> Unreadable (non-fatal), NOT Matches.
+        std::fs::write(&path, b"{not json").unwrap();
+        assert_eq!(
+            inspect_record_for_runner(&path, 42, extract),
+            RunnerRecordState::Unreadable
+        );
+        // Absent file -> Missing.
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(
+            inspect_record_for_runner(&path, 42, extract),
+            RunnerRecordState::Missing
+        );
+    }
+}

--- a/src/process/worker.rs
+++ b/src/process/worker.rs
@@ -112,17 +112,28 @@ pub fn validate_id(id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Create the worker directory if absent, owner-only (0700) so other users
-/// on a shared host cannot enumerate worker ids.
+/// Create the worker directory if absent and enforce owner-only (0700) so
+/// other users on a shared host cannot enumerate worker ids. The permission
+/// is (re)applied on every call, including a pre-existing directory, and a
+/// failure to set it is propagated rather than swallowed: the isolation
+/// guarantee is load-bearing, so callers fail closed instead of proceeding
+/// with a world-readable worker dir.
 pub fn ensure_dir(dir: &Path) -> Result<()> {
     if !dir.exists() {
         std::fs::create_dir_all(dir)
             .with_context(|| format!("creating worker dir at {}", dir.display()))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
-        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).with_context(
+            || {
+                format!(
+                    "setting owner-only perms on worker dir at {}",
+                    dir.display()
+                )
+            },
+        )?;
     }
     Ok(())
 }
@@ -207,6 +218,9 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    // On non-Unix `is_pid_alive` deliberately returns false, so this
+    // liveness expectation only holds under Unix.
+    #[cfg(unix)]
     #[test]
     fn is_pid_alive_self() {
         assert!(is_pid_alive(std::process::id()));

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1427,7 +1427,7 @@ async fn sweep_orphan_workers(state: &Arc<AppState>, live: &HashSet<&String>) {
         // signal; the next daemon boot re-sweeps it, so this is acceptable.
         // See #1921.
         #[cfg(unix)]
-        tokio::spawn(crate::acp::worker_registry::reap_group_escalating(
+        tokio::spawn(crate::process::worker::reap_group_escalating(
             record.pid,
             std::time::Duration::from_secs(2),
         ));


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Plugins 02 (part of #268, follows the minimal core in #2311): lift the protocol-agnostic substrate out of `src/acp/` so the future plugin host (#2095) can reuse it without depending on ACP. The dependency arrow now runs `acp -> {process, events}`, never the reverse.

This is a pure substrate lift with **zero behavior change**. Scoped per discussion to a true decomposition (not a whole-file move), touching the worker_registry utilities only and leaving `runner.rs` / `supervisor.rs` in place as consumers.

**Part A, event bus -> `src/events/`.** A new generic event-log storage core: `Schema` (validated table prefix), `open`, `insert_event`, per-topic `prune_retention` with caller-supplied pinned discriminants, keyset `scan` (`SeqBound` + `Order`), seq bookkeeping, attachment blob storage, topic deletion, and an activity-time query with caller-supplied exclusions. It is keyed by an opaque `topic` over opaque JSON payloads and knows nothing about ACP. `acp::event_store::EventStore` keeps its byte-identical public API (it still owns the `Connection`, so existing tests that reach `store.conn` pass unmodified) and delegates the generic mechanics to `crate::events`, keeping the ACP-specific layer (Event serialization, the replay has-more / cursor / turn-boundary logic, and the `json_extract` accessors) behind. `Schema::new("acp")` maps to the existing `acp_events` / `acp_attachments` tables, so there is **no data migration**.

**Part B, worker process utils -> `src/process/`.** A new `src/process/worker.rs`: process-group signalling (terminate/kill/reap), pid liveness, the runner self-inspection state machine, and the `<dir>/<id>.{json,sock,log,restart}` path builders. None of it knows about ACP: the consumer supplies the base directory and a pid extractor for record inspection, which preserves the exact `Unreadable`-on-parse-failure watchdog semantics. `acp::worker_registry` keeps the ACP `WorkerRecord` and its persistence and now delegates the generic plumbing.

A couple of notes on the issue text, confirmed against the code during investigation: the "best-effort broadcast" the issue places in `event_store.rs` actually lives in `supervisor::ChannelSink`, so generalizing it ships with the deferred supervisor decomposition, not here; and `runner.rs` / `supervisor.rs` are mostly ACP-specific, so only the worker_registry utilities and the event log actually lift.

Closes #2092

## PR Type

- [ ] New Feature
- [x] Refactor
- [ ] Bug Fix
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

Behavioral checks that should all behave exactly as on `main` (the point of the refactor is that nothing changes):

- [ ] Start `aoe serve`, open a structured-view session, run a turn, then reload the page: the transcript replays from the event store as before.
- [ ] Scroll up in a long structured-view session: older history pages in (recent-first) aligned to user-turn boundaries, with no seamed/split turns.
- [ ] Restart the daemon mid-session and reattach: the transcript rehydrates and seq counters resume without colliding.
- [ ] Attach a screenshot to a prompt, reload, and fetch it: the attachment still loads; deleting the session leaves no orphaned blobs.
- [ ] `aoe acp stop|kill|restart <session>`: the worker and its child tree are reaped (no orphaned `node` / agent processes), and restart respawns on the next reconciler tick.
- [ ] Leave a session idle past `acp.auto_stop_idle_secs`: the idle-reap still fires (lifecycle/metadata events do not reset the idle clock).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Behavior is unchanged, so the existing ACP e2e / integration tests pass unmodified and remain the regression net. New unit tests cover the extracted substrate directly: `src/events` is driven with a non-ACP table prefix and two topics (append / scan / retention / attachments / activity-time) to prove it is genuinely reusable, and `src/process/worker` covers the parameterized path builders, `ensure_dir` permissions, and the pid-extractor inspection state machine.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, design (pressure-tested with a multi-model debate), and implementation were drafted by Claude under my direction. I made the scope calls (decompose vs move; worker_registry utils only; one PR with staged commits), reviewed each commit, and ran the validation.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784925596&installation_id=139138837&pr_number=2374&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2374&signature=aee9f8b6571b232c4d377a9a9698f92a1c5d627c4dbe0859dc3a3cf389003af7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change lifts ACP-specific infrastructure into shared, protocol-neutral modules so it can be reused by a future plugin host without pulling in ACP-specific dependencies, while keeping existing behavior intact.

## What changed
- Added a new shared durable event-log core in `src/events/` (topic-keyed SQLite storage) with:
  - idempotent event append + bounded replay/scan
  - per-topic sequence bookkeeping
  - retention pruning with “pinned/non-substantive” exclusions
  - durable attachment blob support and topic deletion
- Added a new shared supervised worker substrate in `src/process/worker.rs` with:
  - PID liveness checks
  - process-group termination/kill/escalation
  - runner record inspection/state classification
  - validated path builders for worker artifacts
- Refactored ACP to delegate the generic parts to these shared modules:
  - `acp::event_store::EventStore` keeps its public API but uses `crate::events` for the durable storage mechanics (while retaining ACP-specific serialization/replay logic).
  - `acp::worker_registry` keeps ACP record persistence responsibilities, but uses `crate::process::worker` for the shared process/subprocess plumbing.
- Updated ACP shutdown/watchdog/CLI/reconciler code paths to consistently use the shared worker process-group helpers.
- Updated docs and repo guidance to document the new “shared substrate” modules and their intended reuse.
- Kept everything feature-gated under `serve` for the server runtime.

## What moved
- Durable event-log mechanics: `src/acp/` → `src/events/`
- Worker subprocess/process-group substrate: `src/acp/` → `src/process/worker.rs`
- ACP remains the “consumer” for both durable events and worker supervision, preserving existing table naming via an ACP schema prefix.

## Benefits
- Clear separation between “protocol semantics” (ACP) and reusable infrastructure (durable event-log + supervised worker plumbing).
- Less duplication and a cleaner foundation for adding the plugin host while reusing the same durability and worker-lifecycle primitives.
- No migration expected: ACP continues using the same underlying table naming strategy, and ACP tests are intended to pass unchanged.
- Retention correctness: pruning now deletes eligible event rows and cleans up attachments in a way that preserves blobs for pinned events that should survive pruning.

## Potential follow-ups
- Validate (via targeted tests if needed) the retention edge cases around “pinned” items and attachment lifecycles across prune failures and paging/replay boundaries, especially as the plugin host starts using the shared substrate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->