### PR TITLE
feat(plugins): manifest contribution schema, capability grants, external install + lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +111,7 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "dirs",
+ "flate2",
  "fs2",
  "futures-util",
  "getrandom 0.4.2",
@@ -865,6 +872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1352,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2409,6 +2435,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -4008,6 +4044,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "notify",
  "nucleo-matcher",
  "p256",
+ "percent-encoding",
  "portable-pty",
  "pulldown-cmark",
  "qrcode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,12 +156,13 @@ agent-client-protocol = { version = "0.14", optional = true, features = ["unstab
 # Semver parsing for ACP adapter compatibility checks (see src/acp/agent_compat.rs).
 semver = { version = "1", optional = true }
 
-# Node tarball download + extraction for the structured view's bundled-Node
-# fallback. xz2 needs the system liblzma; we use it for tar.xz
-# extraction. The `tar` crate handles the tarball stream. Hex used
-# for nonce display lives in the structured view/approvals module's local
-# hex helper, no crate needed.
-tar = { version = "0.4", optional = true }
+# Tar stream handling. Used by the structured view's bundled-Node fallback
+# (with xz2 for tar.xz) and by external plugin install (with flate2 for
+# tar.gz). The `tar` and `flate2` crates are pure Rust and unconditional so
+# plugin install works in a TUI-only build; xz2 needs system liblzma and stays
+# gated to the structured view (serve).
+tar = "0.4"
+flate2 = "1"
 xz2 = { version = "0.1", optional = true }
 
 # WebSocket client for the structured view-in-TUI view: subscribes to the daemon's
@@ -212,7 +213,6 @@ serve = [
     # under src/acp/).
     "agent-client-protocol",
     "semver",
-    "tar",
     "xz2",
     "tokio-tungstenite",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # HTTP client (for updates)
 reqwest = { version = "0.13", features = ["json", "rustls", "stream"], default-features = false }
 
+# Percent-encode path segments (release tags) for GitHub API URLs.
+percent-encoding = "2"
+
 # Unix sockets + futures-compat for ACP byte streams
 tokio-util = { version = "0.7", features = ["codec", "compat"] }
 

--- a/aoe-plugin-api/Cargo.toml
+++ b/aoe-plugin-api/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1"
 thiserror = "2.0"
+sha2 = "0.11"

--- a/aoe-plugin-api/src/capability.rs
+++ b/aoe-plugin-api/src/capability.rs
@@ -1,0 +1,113 @@
+//! Capability taxonomy and trust levels for the plugin system.
+//!
+//! A capability gates runtime access to a resource that can affect user data,
+//! host state, the OS, or the network. Static contributions (commands,
+//! keybinds, themes, ui, status, panes) are NOT capabilities; they are plain
+//! manifest sections that need no grant. A capability is what the one-time
+//! install prompt asks the user to approve, and what a persisted grant is
+//! pinned to.
+//!
+//! Capabilities are open strings rather than a closed enum so a follow-up issue
+//! can introduce a new permission without bumping `api_version`. The host
+//! validates a requested capability against [`KNOWN_CAPABILITIES`] at install
+//! and grant time, rejecting an unknown one rather than silently granting it.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// A capability a plugin requests in its manifest `capabilities = [...]` array.
+///
+/// Stored as a free string; [`CapabilityId::is_known`] reports whether this
+/// host version recognizes it. The host never grants an unknown capability.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CapabilityId(String);
+
+impl CapabilityId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether this host version recognizes the capability. An unknown
+    /// capability is rejected at install (`unsupported capability; upgrade
+    /// aoe`), never silently granted.
+    pub fn is_known(&self) -> bool {
+        KNOWN_CAPABILITIES.contains(&self.0.as_str())
+    }
+}
+
+impl fmt::Display for CapabilityId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for CapabilityId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+/// Resource/effect capabilities this host version understands.
+///
+/// Each gates a runtime resource that the worker (#2095) or a contribution
+/// handler reaches. A plugin's own declared settings need no `config.*`:
+/// `config.read` / `config.write` mean host/global or other-plugin
+/// configuration, not the plugin's own table.
+pub const KNOWN_CAPABILITIES: &[&str] = &[
+    // Executing plugin code at all is materially different from loading static
+    // metadata, so it is its own capability.
+    "runtime.worker",
+    // Reading and mutating the session the plugin is attached to.
+    "session.read",
+    "session.write",
+    // Host/global or other-plugin configuration (NOT the plugin's own settings).
+    "config.read",
+    "config.write",
+    // Spawning OS subprocesses beyond the plugin's own worker.
+    "process.spawn",
+    // Outbound network access.
+    "net",
+    // Filesystem access outside the plugin's own directory. Read is split from
+    // write because the two carry very different risk.
+    "fs.read",
+    "fs.write",
+    // Clipboard read is far more sensitive than write, so they are separate.
+    "clipboard.read",
+    "clipboard.write",
+    // Posting desktop / TUI notifications.
+    "notifications",
+];
+
+/// How far a plugin is trusted. Host-assigned at load time, never declared in
+/// the manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TrustLevel {
+    /// Compiled into the binary. Fully trusted: capabilities are auto-granted,
+    /// no install prompt.
+    Builtin,
+    /// Installed from an external source (GitHub or a local dir). Untrusted:
+    /// every requested capability must be granted by the user.
+    Community,
+}
+
+impl TrustLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TrustLevel::Builtin => "builtin",
+            TrustLevel::Community => "community",
+        }
+    }
+}
+
+impl fmt::Display for TrustLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -1,20 +1,27 @@
 //! Plugin manifest types for the Agent of Empires plugin system.
 //!
 //! This crate is the stable surface a plugin author (and the in-tree host)
-//! compiles against: the `aoe-plugin.toml` manifest schema and the validation
-//! rules that gate a manifest before it loads. This is the minimal core;
-//! contribution sections (settings, keybinds, themes, commands, status
-//! detection, UI, panes, runtime workers) and the capability taxonomy return in
-//! follow-up PRs. See `docs/development/internals/plugin-system.md`.
+//! compiles against: the `aoe-plugin.toml` manifest schema, the capability
+//! taxonomy, and the validation rules that gate a manifest before it loads.
+//! The contribution sections (settings, keybinds, themes, commands, status,
+//! ui, panes, runtime worker) are defined here but consumed by follow-up PRs
+//! (#2094 / #2095 / #2366). See
+//! `docs/development/internals/plugin-system.md`.
 
+mod capability;
 mod id;
 mod manifest;
 
+pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
-pub use manifest::{ManifestError, PluginManifest};
+pub use manifest::{
+    CommandContribution, KeybindContribution, ManifestError, PaneContribution, PluginManifest,
+    RuntimeSpec, SettingContribution, StatusContribution, ThemeContribution, UiContribution,
+};
 
 /// Version of the manifest schema and host API this crate describes.
 ///
 /// A manifest declares the `api_version` it was written against; the host
-/// refuses manifests targeting a newer version than it understands.
-pub const API_VERSION: u32 = 1;
+/// refuses manifests targeting a newer version than it understands. Bumped to
+/// 2 when the contribution sections and capability taxonomy were added.
+pub const API_VERSION: u32 = 2;

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -3,10 +3,10 @@
 //! This crate is the stable surface a plugin author (and the in-tree host)
 //! compiles against: the `aoe-plugin.toml` manifest schema, the capability
 //! taxonomy, and the validation rules that gate a manifest before it loads.
-//! The contribution sections (settings, keybinds, themes, commands, status,
-//! ui, panes, runtime worker) are defined here but consumed by follow-up PRs
-//! (#2094 / #2095 / #2366). See
-//! `docs/development/internals/plugin-system.md`.
+//! The contribution sections (capabilities, commands, keybinds, settings, ui,
+//! runtime worker) are defined here but consumed by follow-up PRs (#2094 /
+//! #2095 / #2366). Themes, status, and panes are deferred until a consumer
+//! exists. See `docs/development/internals/plugin-system.md`.
 
 mod capability;
 mod id;
@@ -15,8 +15,8 @@ mod manifest;
 pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
-    CommandContribution, KeybindContribution, ManifestError, PaneContribution, PluginManifest,
-    RuntimeSpec, SettingContribution, StatusContribution, ThemeContribution, UiContribution,
+    CommandContribution, KeybindContribution, ManifestError, PluginManifest, RuntimeSpec,
+    SettingContribution, UiContribution,
 };
 
 /// Version of the manifest schema and host API this crate describes.

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -1,13 +1,15 @@
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
-use crate::{PluginId, API_VERSION};
+use crate::{CapabilityId, PluginId, API_VERSION};
 
 /// Parsed `aoe-plugin.toml`.
 ///
-/// This is the minimal core schema: a plugin's identity and the manifest/API
-/// version it targets. Contribution sections (settings, keybinds, themes,
-/// commands, status detection, UI slots, panes, runtime workers) return in
-/// follow-up PRs; see `docs/development/internals/plugin-system.md`.
+/// Identity (`id`, `name`, `version`, `api_version`, `description`) plus the
+/// contribution sections a plugin declares. The contribution sections are
+/// defined here but consumed by later issues: the settings registry (#2094),
+/// the runtime host (#2095), and the command/keybind/UI surfaces (#2366). This
+/// host parses and validates them; it does not yet act on them.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
@@ -20,6 +22,133 @@ pub struct PluginManifest {
     pub api_version: u32,
     #[serde(default)]
     pub description: String,
+
+    /// Resource/effect capabilities the plugin requests. Static contributions
+    /// below are NOT listed here; only runtime resource access is. The user
+    /// grants these once at install (community plugins); builtins are
+    /// auto-granted. See [`crate::capability`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<CapabilityId>,
+
+    /// Commands the plugin contributes (palette / CLI). Consumed by #2366.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub commands: Vec<CommandContribution>,
+
+    /// Keybinds the plugin contributes. Consumed by #2366.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keybinds: Vec<KeybindContribution>,
+
+    /// Settings the plugin declares. The typed schema that validates and
+    /// renders them lands with #2094.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub settings: Vec<SettingContribution>,
+
+    /// Themes the plugin ships. Consumed by #2366.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub themes: Vec<ThemeContribution>,
+
+    /// UI slots the plugin renders into. Consumed by #2366.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ui: Vec<UiContribution>,
+
+    /// Status detectors the plugin contributes. Consumed by #2366.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status: Vec<StatusContribution>,
+
+    /// Panes the plugin contributes. Consumed by #2366.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub panes: Vec<PaneContribution>,
+
+    /// The worker entrypoint. Defined here so installation can fetch a
+    /// release-binary worker; actually launching it is #2095.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<RuntimeSpec>,
+}
+
+/// A command the plugin contributes. The host namespaces it as
+/// `plugin.<plugin-id>.<id>`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandContribution {
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A keybind the plugin contributes, binding a key chord to a command.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeybindContribution {
+    /// Command id this binds to (a plugin command or a core command).
+    pub command: String,
+    /// Key chord, e.g. `Ctrl+K`. Parsed by the consuming surface (#2366).
+    pub key: String,
+}
+
+/// A setting the plugin declares. The typed schema arrives with #2094; here it
+/// is just the key and human-facing labels.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SettingContribution {
+    pub key: String,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A theme the plugin ships, by name and a path relative to the plugin dir.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThemeContribution {
+    pub name: String,
+    pub path: String,
+}
+
+/// A UI contribution targeting a named slot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiContribution {
+    pub slot: String,
+    #[serde(default)]
+    pub id: String,
+}
+
+/// A status detector the plugin contributes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusContribution {
+    pub id: String,
+    #[serde(default)]
+    pub label: String,
+}
+
+/// A pane the plugin contributes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaneContribution {
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+}
+
+/// How the plugin's worker is launched. Defined here; executed by #2095.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum RuntimeSpec {
+    /// A worker launched by running a command from the plugin directory (a
+    /// script, an interpreter invocation, or an in-tree binary).
+    Command {
+        /// argv; the first element is the program, the rest its arguments.
+        command: Vec<String>,
+    },
+    /// A worker binary downloaded from the source repo's GitHub release assets.
+    /// Installation resolves the asset for the host platform, downloads it, and
+    /// places the binary in the plugin directory.
+    ReleaseBinary {
+        /// Asset name template. `${os}`, `${arch}`, and `${target}` are
+        /// substituted with the host's values before matching the release.
+        asset: String,
+        /// Executable to run after extraction (the path within an archive). The
+        /// downloaded asset itself when omitted (a raw, non-archive binary).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        bin: Option<String>,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -57,8 +186,31 @@ impl PluginManifest {
         Ok(manifest)
     }
 
+    /// sha256 over the raw `aoe-plugin.toml` bytes as installed, formatted
+    /// `sha256:<hex>`. A capability grant is pinned to this; an update whose
+    /// manifest bytes (hence possibly its capability set) change re-prompts.
+    /// Hashing the raw bytes, not a reserialized struct, avoids depending on
+    /// serializer canonicalization.
+    pub fn hash_bytes(bytes: &[u8]) -> String {
+        use std::fmt::Write;
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let digest = hasher.finalize();
+        let mut out = String::with_capacity(7 + digest.len() * 2);
+        out.push_str("sha256:");
+        for byte in digest {
+            let _ = write!(out, "{byte:02x}");
+        }
+        out
+    }
+
     /// Structural validation; collects every problem instead of stopping at
     /// the first so a plugin author sees the full list in one pass.
+    ///
+    /// Capability strings are deliberately not validated here: they are open
+    /// strings (forward-compatible), and the host rejects an unknown one at
+    /// install rather than at parse, so a manifest targeting a newer host still
+    /// parses on an older one.
     pub fn validate(&self) -> Result<(), ManifestError> {
         let mut errors = Vec::new();
         let mut check = |ok: bool, msg: String| {
@@ -76,6 +228,19 @@ impl PluginManifest {
         );
         check(!self.version.is_empty(), "version must not be empty".into());
         check(!self.name.is_empty(), "name must not be empty".into());
+
+        if let Some(RuntimeSpec::Command { command }) = &self.runtime {
+            check(
+                !command.is_empty(),
+                "runtime command must not be empty".into(),
+            );
+        }
+        if let Some(RuntimeSpec::ReleaseBinary { asset, .. }) = &self.runtime {
+            check(
+                !asset.is_empty(),
+                "runtime release-binary asset must not be empty".into(),
+            );
+        }
 
         if errors.is_empty() {
             Ok(())

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -234,12 +234,71 @@ impl PluginManifest {
                 !command.is_empty(),
                 "runtime command must not be empty".into(),
             );
+            check(
+                command.iter().all(|arg| !arg.is_empty()),
+                "runtime command must not contain empty arguments".into(),
+            );
         }
-        if let Some(RuntimeSpec::ReleaseBinary { asset, .. }) = &self.runtime {
+        if let Some(RuntimeSpec::ReleaseBinary { asset, bin }) = &self.runtime {
             check(
                 !asset.is_empty(),
                 "runtime release-binary asset must not be empty".into(),
             );
+            check(
+                bin.as_ref().map(|b| !b.is_empty()).unwrap_or(true),
+                "runtime release-binary bin must not be empty".into(),
+            );
+        }
+
+        // Contribution sections declare required identifiers; an empty one would
+        // install and persist a malformed manifest, so reject it here rather
+        // than push the cleanup onto the later consumers (#2094 / #2095 / #2366).
+        for (i, c) in self.commands.iter().enumerate() {
+            check(
+                !c.id.is_empty(),
+                format!("commands[{i}].id must not be empty"),
+            );
+        }
+        for (i, k) in self.keybinds.iter().enumerate() {
+            check(
+                !k.command.is_empty(),
+                format!("keybinds[{i}].command must not be empty"),
+            );
+            check(
+                !k.key.is_empty(),
+                format!("keybinds[{i}].key must not be empty"),
+            );
+        }
+        for (i, s) in self.settings.iter().enumerate() {
+            check(
+                !s.key.is_empty(),
+                format!("settings[{i}].key must not be empty"),
+            );
+        }
+        for (i, t) in self.themes.iter().enumerate() {
+            check(
+                !t.name.is_empty(),
+                format!("themes[{i}].name must not be empty"),
+            );
+            check(
+                !t.path.is_empty(),
+                format!("themes[{i}].path must not be empty"),
+            );
+        }
+        for (i, u) in self.ui.iter().enumerate() {
+            check(
+                !u.slot.is_empty(),
+                format!("ui[{i}].slot must not be empty"),
+            );
+        }
+        for (i, s) in self.status.iter().enumerate() {
+            check(
+                !s.id.is_empty(),
+                format!("status[{i}].id must not be empty"),
+            );
+        }
+        for (i, p) in self.panes.iter().enumerate() {
+            check(!p.id.is_empty(), format!("panes[{i}].id must not be empty"));
         }
 
         if errors.is_empty() {

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -43,21 +43,9 @@ pub struct PluginManifest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub settings: Vec<SettingContribution>,
 
-    /// Themes the plugin ships. Consumed by #2366.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub themes: Vec<ThemeContribution>,
-
     /// UI slots the plugin renders into. Consumed by #2366.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ui: Vec<UiContribution>,
-
-    /// Status detectors the plugin contributes. Consumed by #2366.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub status: Vec<StatusContribution>,
-
-    /// Panes the plugin contributes. Consumed by #2366.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub panes: Vec<PaneContribution>,
 
     /// The worker entrypoint. Defined here so installation can fetch a
     /// release-binary worker; actually launching it is #2095.
@@ -96,35 +84,12 @@ pub struct SettingContribution {
     pub description: String,
 }
 
-/// A theme the plugin ships, by name and a path relative to the plugin dir.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ThemeContribution {
-    pub name: String,
-    pub path: String,
-}
-
 /// A UI contribution targeting a named slot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiContribution {
     pub slot: String,
     #[serde(default)]
     pub id: String,
-}
-
-/// A status detector the plugin contributes.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StatusContribution {
-    pub id: String,
-    #[serde(default)]
-    pub label: String,
-}
-
-/// A pane the plugin contributes.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PaneContribution {
-    pub id: String,
-    #[serde(default)]
-    pub title: String,
 }
 
 /// How the plugin's worker is launched. Defined here; executed by #2095.
@@ -275,30 +240,11 @@ impl PluginManifest {
                 format!("settings[{i}].key must not be empty"),
             );
         }
-        for (i, t) in self.themes.iter().enumerate() {
-            check(
-                !t.name.is_empty(),
-                format!("themes[{i}].name must not be empty"),
-            );
-            check(
-                !t.path.is_empty(),
-                format!("themes[{i}].path must not be empty"),
-            );
-        }
         for (i, u) in self.ui.iter().enumerate() {
             check(
                 !u.slot.is_empty(),
                 format!("ui[{i}].slot must not be empty"),
             );
-        }
-        for (i, s) in self.status.iter().enumerate() {
-            check(
-                !s.id.is_empty(),
-                format!("status[{i}].id must not be empty"),
-            );
-        }
-        for (i, p) in self.panes.iter().enumerate() {
-            check(!p.id.is_empty(), format!("panes[{i}].id must not be empty"));
         }
 
         if errors.is_empty() {

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -1,4 +1,4 @@
-use aoe_plugin_api::{ManifestError, PluginManifest};
+use aoe_plugin_api::{ManifestError, PluginManifest, RuntimeSpec};
 
 #[test]
 fn minimal_manifest_parses_and_round_trips() {
@@ -6,18 +6,31 @@ fn minimal_manifest_parses_and_round_trips() {
 id = "aoe.web"
 name = "Web Dashboard"
 version = "1.0.0"
-api_version = 1
+api_version = 2
 description = "The aoe serve web dashboard."
 "#;
     let manifest = PluginManifest::from_toml_str(toml).expect("valid manifest parses");
     assert_eq!(manifest.id.as_str(), "aoe.web");
     assert_eq!(manifest.name, "Web Dashboard");
     assert_eq!(manifest.version, "1.0.0");
-    assert_eq!(manifest.api_version, 1);
+    assert_eq!(manifest.api_version, 2);
 
     let serialized = toml::to_string(&manifest).expect("serializes");
     let reparsed = PluginManifest::from_toml_str(&serialized).expect("round-trips");
     assert_eq!(reparsed.id.as_str(), "aoe.web");
+}
+
+#[test]
+fn api_version_1_still_parses() {
+    // The bundled aoe.web manifest still targets api_version 1; an older
+    // manifest must keep loading on a newer host.
+    let toml = r#"
+id = "aoe.web"
+name = "Web Dashboard"
+version = "1.0.0"
+api_version = 1
+"#;
+    PluginManifest::from_toml_str(toml).expect("api_version 1 stays supported");
 }
 
 #[test]
@@ -26,10 +39,131 @@ fn description_defaults_to_empty() {
 id = "acme.thing"
 name = "Thing"
 version = "0.1.0"
-api_version = 1
+api_version = 2
 "#;
     let manifest = PluginManifest::from_toml_str(toml).expect("description is optional");
     assert!(manifest.description.is_empty());
+}
+
+#[test]
+fn contribution_sections_parse() {
+    let toml = r#"
+id = "acme.kit"
+name = "Kit"
+version = "0.1.0"
+api_version = 2
+capabilities = ["session.read", "net"]
+
+[[commands]]
+id = "do-thing"
+title = "Do Thing"
+
+[[keybinds]]
+command = "plugin.acme.kit.do-thing"
+key = "Ctrl+K"
+
+[[settings]]
+key = "endpoint"
+label = "Endpoint"
+
+[[themes]]
+name = "midnight"
+path = "themes/midnight.toml"
+
+[[ui]]
+slot = "sidebar"
+id = "panel"
+
+[[status]]
+id = "build"
+
+[[panes]]
+id = "logs"
+title = "Logs"
+"#;
+    let m = PluginManifest::from_toml_str(toml).expect("contribution sections parse");
+    assert_eq!(m.capabilities.len(), 2);
+    assert!(m.capabilities[0].is_known());
+    assert_eq!(m.commands.len(), 1);
+    assert_eq!(m.keybinds[0].key, "Ctrl+K");
+    assert_eq!(m.settings[0].key, "endpoint");
+    assert_eq!(m.themes[0].name, "midnight");
+    assert_eq!(m.ui[0].slot, "sidebar");
+    assert_eq!(m.status[0].id, "build");
+    assert_eq!(m.panes[0].title, "Logs");
+}
+
+#[test]
+fn unknown_capability_string_parses_but_reports_unknown() {
+    // Capabilities are open strings: a capability this host does not recognize
+    // still parses (forward compatibility); the host rejects it at install.
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+capabilities = ["some.future.cap"]
+"#;
+    let m = PluginManifest::from_toml_str(toml).expect("unknown capability still parses");
+    assert!(!m.capabilities[0].is_known());
+}
+
+#[test]
+fn runtime_command_parses() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = ["python3", "worker.py"]
+"#;
+    let m = PluginManifest::from_toml_str(toml).expect("runtime command parses");
+    match m.runtime.expect("has runtime") {
+        RuntimeSpec::Command { command } => assert_eq!(command, ["python3", "worker.py"]),
+        other => panic!("expected command runtime, got {other:?}"),
+    }
+}
+
+#[test]
+fn runtime_release_binary_parses() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "release-binary"
+asset = "thing-${target}.tar.gz"
+bin = "thing"
+"#;
+    let m = PluginManifest::from_toml_str(toml).expect("runtime release-binary parses");
+    match m.runtime.expect("has runtime") {
+        RuntimeSpec::ReleaseBinary { asset, bin } => {
+            assert_eq!(asset, "thing-${target}.tar.gz");
+            assert_eq!(bin.as_deref(), Some("thing"));
+        }
+        other => panic!("expected release-binary runtime, got {other:?}"),
+    }
+}
+
+#[test]
+fn empty_runtime_command_is_rejected() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = []
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(matches!(err, ManifestError::Invalid(_)), "got {err:?}");
 }
 
 #[test]
@@ -38,11 +172,11 @@ fn unknown_fields_are_rejected() {
 id = "acme.thing"
 name = "Thing"
 version = "0.1.0"
-api_version = 1
-capabilities = ["pane-read"]
+api_version = 2
+frobnicate = true
 "#;
-    // Contribution sections are not part of the core schema yet, so an
-    // unrecognized key is a hard parse error rather than silently ignored.
+    // A top-level key outside the schema is a hard parse error, not silently
+    // ignored.
     let err = PluginManifest::from_toml_str(toml).unwrap_err();
     assert!(matches!(err, ManifestError::Parse(_)), "got {err:?}");
 }
@@ -53,7 +187,7 @@ fn empty_name_and_version_collect_all_problems() {
 id = "acme.thing"
 name = ""
 version = ""
-api_version = 1
+api_version = 2
 "#;
     let err = PluginManifest::from_toml_str(toml).unwrap_err();
     let messages = match err {
@@ -83,4 +217,14 @@ api_version = 9999
         ),
         "got {err:?}"
     );
+}
+
+#[test]
+fn manifest_hash_is_stable_and_prefixed() {
+    let bytes = b"id = \"acme.thing\"\n";
+    let a = PluginManifest::hash_bytes(bytes);
+    let b = PluginManifest::hash_bytes(bytes);
+    assert_eq!(a, b);
+    assert!(a.starts_with("sha256:"));
+    assert_ne!(a, PluginManifest::hash_bytes(b"different"));
 }

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -167,6 +167,59 @@ command = []
 }
 
 #[test]
+fn empty_contribution_fields_are_rejected() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[[commands]]
+id = ""
+
+[[themes]]
+name = "x"
+path = ""
+
+[[ui]]
+slot = ""
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    let messages = match err {
+        ManifestError::Invalid(m) => m,
+        other => panic!("expected Invalid, got {other:?}"),
+    };
+    assert!(
+        messages.iter().any(|m| m.contains("commands[0].id")),
+        "{messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("themes[0].path")),
+        "{messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("ui[0].slot")),
+        "{messages:?}"
+    );
+}
+
+#[test]
+fn empty_command_argument_is_rejected() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = [""]
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(matches!(err, ManifestError::Invalid(_)), "got {err:?}");
+}
+
+#[test]
 fn unknown_fields_are_rejected() {
     let toml = r#"
 id = "acme.thing"

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -66,20 +66,9 @@ key = "Ctrl+K"
 key = "endpoint"
 label = "Endpoint"
 
-[[themes]]
-name = "midnight"
-path = "themes/midnight.toml"
-
 [[ui]]
 slot = "sidebar"
 id = "panel"
-
-[[status]]
-id = "build"
-
-[[panes]]
-id = "logs"
-title = "Logs"
 "#;
     let m = PluginManifest::from_toml_str(toml).expect("contribution sections parse");
     assert_eq!(m.capabilities.len(), 2);
@@ -87,10 +76,33 @@ title = "Logs"
     assert_eq!(m.commands.len(), 1);
     assert_eq!(m.keybinds[0].key, "Ctrl+K");
     assert_eq!(m.settings[0].key, "endpoint");
-    assert_eq!(m.themes[0].name, "midnight");
     assert_eq!(m.ui[0].slot, "sidebar");
-    assert_eq!(m.status[0].id, "build");
-    assert_eq!(m.panes[0].title, "Logs");
+}
+
+#[test]
+fn deferred_sections_are_rejected() {
+    // themes / status / panes are deferred until a consumer exists; with
+    // deny_unknown_fields a manifest declaring one must fail to parse.
+    for section in ["themes", "status", "panes"] {
+        let toml = format!(
+            r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[[{section}]]
+id = "x"
+name = "x"
+path = "x"
+"#
+        );
+        let err = PluginManifest::from_toml_str(&toml).unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Parse(_)),
+            "[[{section}]] should be a hard parse error, got {err:?}"
+        );
+    }
 }
 
 #[test]
@@ -177,9 +189,9 @@ api_version = 2
 [[commands]]
 id = ""
 
-[[themes]]
-name = "x"
-path = ""
+[[keybinds]]
+command = ""
+key = ""
 
 [[ui]]
 slot = ""
@@ -194,7 +206,7 @@ slot = ""
         "{messages:?}"
     );
     assert!(
-        messages.iter().any(|m| m.contains("themes[0].path")),
+        messages.iter().any(|m| m.contains("keybinds[0].command")),
         "{messages:?}"
     );
     assert!(

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -677,7 +677,7 @@ Manage plugins (list, info, enable, disable, install, update, uninstall)
 * `enable` — Enable a plugin's contributions
 * `disable` — Disable a plugin; its settings stay on disk for re-enabling
 * `install` — Install an external plugin from a `gh:owner/repo[@ref]` slug or a local directory. Community plugins run at your own risk
-* `update` — Update an installed external plugin from its recorded source
+* `update` — Update an installed external plugin from its recorded source. Prompts to re-approve capabilities if the update changes the capability set
 * `uninstall` — Uninstall an external plugin, removing its files and capability grant
 
 
@@ -744,7 +744,7 @@ Install an external plugin from a `gh:owner/repo[@ref]` slug or a local director
 
 ## `aoe plugin update`
 
-Update an installed external plugin from its recorded source
+Update an installed external plugin from its recorded source. Prompts to re-approve capabilities if the update changes the capability set
 
 **Usage:** `aoe plugin update <ID>`
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -43,6 +43,9 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe plugin info`↴](#aoe-plugin-info)
 * [`aoe plugin enable`↴](#aoe-plugin-enable)
 * [`aoe plugin disable`↴](#aoe-plugin-disable)
+* [`aoe plugin install`↴](#aoe-plugin-install)
+* [`aoe plugin update`↴](#aoe-plugin-update)
+* [`aoe plugin uninstall`↴](#aoe-plugin-uninstall)
 * [`aoe profile`↴](#aoe-profile)
 * [`aoe profile list`↴](#aoe-profile-list)
 * [`aoe profile create`↴](#aoe-profile-create)
@@ -118,7 +121,7 @@ Run without arguments to launch the TUI dashboard.
 * `killall` — Force-stop everything aoe is running: the serve daemon, all agent workers, and all aoe tmux sessions. Destructive and unprompted
 * `session` — Manage session lifecycle (start, stop, attach, etc.)
 * `group` — Manage groups for organizing sessions
-* `plugin` — Manage plugins (list, info, enable, disable)
+* `plugin` — Manage plugins (list, info, enable, disable, install, update, uninstall)
 * `profile` — Manage profiles (separate workspaces)
 * `project` — Manage the project registry used by multi-repo session pickers
 * `worktree` — Manage git worktrees for parallel development
@@ -663,22 +666,25 @@ Move session to group
 
 ## `aoe plugin`
 
-Manage plugins (list, info, enable, disable)
+Manage plugins (list, info, enable, disable, install, update, uninstall)
 
 **Usage:** `aoe plugin <COMMAND>`
 
 ###### **Subcommands:**
 
-* `list` — List every known plugin with version and state
+* `list` — List every known plugin with version, trust, and state
 * `info` — Show one plugin's manifest details
 * `enable` — Enable a plugin's contributions
 * `disable` — Disable a plugin; its settings stay on disk for re-enabling
+* `install` — Install an external plugin from a `gh:owner/repo[@ref]` slug or a local directory. Community plugins run at your own risk
+* `update` — Update an installed external plugin from its recorded source
+* `uninstall` — Uninstall an external plugin, removing its files and capability grant
 
 
 
 ## `aoe plugin list`
 
-List every known plugin with version and state
+List every known plugin with version, trust, and state
 
 **Usage:** `aoe plugin list`
 
@@ -713,6 +719,46 @@ Enable a plugin's contributions
 Disable a plugin; its settings stay on disk for re-enabling
 
 **Usage:** `aoe plugin disable <ID>`
+
+###### **Arguments:**
+
+* `<ID>` — Plugin id
+
+
+
+## `aoe plugin install`
+
+Install an external plugin from a `gh:owner/repo[@ref]` slug or a local directory. Community plugins run at your own risk
+
+**Usage:** `aoe plugin install [OPTIONS] <SOURCE>`
+
+###### **Arguments:**
+
+* `<SOURCE>` — `gh:owner/repo[@ref]` or a local directory path
+
+###### **Options:**
+
+* `--yes` — Grant all requested capabilities without prompting
+
+
+
+## `aoe plugin update`
+
+Update an installed external plugin from its recorded source
+
+**Usage:** `aoe plugin update <ID>`
+
+###### **Arguments:**
+
+* `<ID>` — Plugin id
+
+
+
+## `aoe plugin uninstall`
+
+Uninstall an external plugin, removing its files and capability grant
+
+**Usage:** `aoe plugin uninstall <ID>`
 
 ###### **Arguments:**
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -109,13 +109,18 @@ dependency arrow runs consumer -> substrate):
 ## Contribution schema (#2093)
 
 `PluginManifest` extends past identity to the contribution sections a plugin
-declares: `commands`, `keybinds`, `settings`, `themes`, `ui`, `status`,
-`panes`, and a `runtime` worker entrypoint. These are defined in
-`aoe-plugin-api` and parsed/validated by the host, but consumed by later issues
-(the settings registry in #2094, the runtime host in #2095, the
-command/keybind/UI surfaces in #2366). `api_version` is bumped to 2; an
-`api_version` 1 manifest still loads. Unknown top-level keys remain a hard
-parse error (`deny_unknown_fields`).
+declares: `capabilities`, `commands`, `keybinds`, `settings`, `ui`, and a
+`runtime` worker entrypoint. These are the sections the first external plugin
+declares; they are defined in `aoe-plugin-api` and parsed/validated by the
+host, but consumed by later issues (the settings registry in #2094, the runtime
+host in #2095, the command/keybind/UI surfaces in #2366). `api_version` is
+bumped to 2; an `api_version` 1 manifest still loads. Unknown top-level keys
+remain a hard parse error (`deny_unknown_fields`).
+
+The `themes`, `status`, and `panes` sections are deferred until a consumer
+exists, so no schema lands in core ahead of one (#2386). With
+`deny_unknown_fields`, a manifest declaring `[[themes]]`, `[[status]]`, or
+`[[panes]]` is a hard parse error today.
 
 The `runtime` section is one of two kinds: `command` (an argv launched from the
 plugin directory) or `release-binary` (a compiled worker shipped as a GitHub

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -182,5 +182,5 @@ sha256.
 
 Each deferred piece returns as its own PR once the core is proven: the
 contribution registries and the JSON-RPC worker runtime and event bus built on
-the substrate above (#2094 / #2095 / #2366), and the discovery / featured
-supply-chain layer with integrity hashing (#2364 / #2365).
+the substrate above (issues 2094, 2095, and 2366), and the discovery / featured
+supply-chain layer with integrity hashing (issues 2364 and 2365).

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -106,9 +106,81 @@ dependency arrow runs consumer -> substrate):
   first consumer (`Schema::new("acp")` keeps the existing `acp_events` tables,
   so no migration).
 
+## Contribution schema (#2093)
+
+`PluginManifest` extends past identity to the contribution sections a plugin
+declares: `commands`, `keybinds`, `settings`, `themes`, `ui`, `status`,
+`panes`, and a `runtime` worker entrypoint. These are defined in
+`aoe-plugin-api` and parsed/validated by the host, but consumed by later issues
+(the settings registry in #2094, the runtime host in #2095, the
+command/keybind/UI surfaces in #2366). `api_version` is bumped to 2; an
+`api_version` 1 manifest still loads. Unknown top-level keys remain a hard
+parse error (`deny_unknown_fields`).
+
+The `runtime` section is one of two kinds: `command` (an argv launched from the
+plugin directory) or `release-binary` (a compiled worker shipped as a GitHub
+release asset). Only installation acts on `release-binary` today (it downloads
+the asset); launching either worker is #2095.
+
+## Capabilities and grants (#2093)
+
+Static contributions are not capabilities; a theme or a command needs no
+approval. A capability gates runtime access to a resource that can affect user
+data, host state, the OS, or the network. The v1 set
+(`aoe_plugin_api::KNOWN_CAPABILITIES`): `runtime.worker`, `session.read`,
+`session.write`, `config.read`, `config.write`, `process.spawn`, `net`,
+`fs.read`, `fs.write`, `clipboard.read`, `clipboard.write`, `notifications`. A
+plugin's own declared settings need no `config.*`; that gates host/global or
+other-plugin config.
+
+Capabilities are open strings (`CapabilityId`), so a follow-up can add one
+without an `api_version` bump. An unknown capability still parses (forward
+compatibility) but is rejected at install (`unsupported capability; upgrade
+aoe`), never silently granted.
+
+A grant (`PluginConfig.grant`, in `config.toml`) records the capabilities the
+user approved and is pinned to the `sha256` of the installed manifest bytes
+(`PluginManifest::hash_bytes`). The registry treats a community plugin as
+active only when enabled AND the grant covers the installed manifest (same hash,
+all declared capabilities present). A changed manifest, hence a changed hash or
+capability set, invalidates the grant: the plugin stays installed but inactive
+(`needs_reapproval`) until `aoe plugin update` re-prompts and re-approves.
+Builtins are first-party, auto-granted, and never store a grant.
+
+## External install, trust, and the lockfile (#2093)
+
+`aoe plugin install <source>` installs an external plugin under
+`<app_dir>/plugins/<id>/`; `aoe plugin` stays reserved for management (D4), so
+there is no web install path. A source is a `gh:owner/repo[@ref]` slug or a
+local directory (`src/plugin/source.rs`).
+
+`src/plugin/fetch.rs` stages a plugin before install. A GitHub source is
+`git clone`d (shallow when possible, a full clone plus checkout for a commit
+ref), the exact commit is resolved, and `.git` is stripped; the clone base
+defaults to `https://github.com` and is overridable via `AOE_GITHUB_CLONE_BASE`
+(a GitHub Enterprise host, or a local `file://` base in tests). A local source
+is copied (minus `.git` and symlinks). When the manifest declares a
+`release-binary` runtime, the matching release asset for the host platform
+(`${os}`/`${arch}`/`${version}` in the asset template) is downloaded via the
+GitHub client and unpacked (raw or `.tar.gz`) into the tree, made executable.
+The staging tree lives under the plugins dir so the final move into place is an
+atomic same-filesystem rename.
+
+Trust is host-assigned (`TrustLevel`): `builtin` (compiled in, auto-granted) or
+`community` (external, capabilities gated). An external plugin whose id sits in
+a reserved namespace (`aoe.*` / `agent-of-empires.*`, lifted only by featured
+verification in #2364) or collides with a builtin is rejected at install and
+skipped at load.
+
+`plugins.lock` (`<app_dir>/plugins.lock`, TOML, keyed by id, deterministic and
+timestamp-free like `Cargo.lock`) records each external plugin's resolved
+identity: source slug, requested ref, resolved commit, version, manifest hash,
+trust, and (for a release-binary) the release tag, asset name, and asset
+sha256.
+
 ## What comes next
 
 Each deferred piece returns as its own PR once the core is proven: the
-contribution schema and registries, the JSON-RPC worker runtime built on the
-substrate above, the capability model, external (GitHub/local) installation,
-and the discovery/featured supply-chain layer.
+contribution registries and the JSON-RPC worker runtime and event bus built on
+the substrate above (#2094 / #2095 / #2366), and the discovery / featured
+supply-chain layer with integrity hashing (#2364 / #2365).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,18 +1,20 @@
 # Plugins
 
-Agent of Empires keeps its core small (sessions, tmux, worktrees) and is
-growing a plugin system so optional capabilities can be enabled or disabled at
-runtime instead of bloating the core. This first release is deliberately
-minimal: a registry of first-party plugins bundled with the binary, each one
-something you can turn on or off. Installing external plugins, per-plugin
-settings, and plugin-contributed UI all land in follow-up releases.
+Agent of Empires keeps its core small (sessions, tmux, worktrees) and grows a
+plugin system so optional capabilities can be enabled or disabled at runtime
+instead of bloating the core. The core ships first-party plugins bundled with
+the binary and can install external community plugins from GitHub or a local
+directory. Per-plugin settings and plugin-contributed UI land in follow-up
+releases; running plugin code is not wired up yet, so an installed external
+plugin records its grant and files but does not execute until a later release.
 
 ## Managing plugins
 
 Three equivalent surfaces:
 
 - **CLI**: `aoe plugin list`, `aoe plugin info <id>`, `aoe plugin enable <id>`,
-  `aoe plugin disable <id>`.
+  `aoe plugin disable <id>`, `aoe plugin install <source>`,
+  `aoe plugin update <id>`, `aoe plugin uninstall <id>`.
 - **TUI**: open the command palette and run "Manage plugins", or open Settings
   and select the Plugins tab (the same manager, hosted inline). Space toggles
   enable/disable.
@@ -36,5 +38,46 @@ empty registry and `aoe plugin list` reports no plugins. That is expected, not a
 bug.
 
 The bundled set is deliberately minimal while the system is proven out. More
-first-party plugins land as each piece is verified, followed by external plugin
-installation and richer per-plugin capabilities.
+first-party plugins land as each piece is verified.
+
+## Installing external plugins
+
+External plugins are community code that you install at your own risk. Install,
+update, and uninstall are CLI-only (`aoe plugin` is reserved for management);
+the TUI and web surfaces show the result but do not install.
+
+```sh
+aoe plugin install gh:owner/repo          # latest default branch
+aoe plugin install gh:owner/repo@v1.2.3   # a tag, branch, or commit
+aoe plugin install ./path/to/plugin       # a local directory
+aoe plugin update <id>
+aoe plugin uninstall <id>
+```
+
+A plugin lands under `<app_dir>/plugins/<id>/`. A GitHub source is cloned and
+pinned to the exact commit; if the plugin ships a compiled worker as a release
+binary, the asset for your platform is downloaded into the plugin directory. To
+install from a GitHub Enterprise host, set `AOE_GITHUB_CLONE_BASE` to its base
+URL.
+
+### Trust and capabilities
+
+Bundled plugins are `builtin` and fully trusted. Installed plugins are
+`community` and untrusted: their manifest declares the capabilities they need
+(network access, filesystem access, spawning processes, and so on), and install
+prompts you once to grant that exact set. Run non-interactively with `--yes` to
+grant without prompting. A capability this version of aoe does not recognize is
+rejected rather than granted; upgrade aoe.
+
+A grant is pinned to the installed manifest. If an update changes the
+capability set, the plugin is left installed but inactive and
+`aoe plugin update <id>` re-prompts you to approve the new set. `aoe plugin
+list` and `aoe plugin info <id>` show each plugin's trust level and whether it
+is granted. An external plugin cannot use the reserved `aoe.*` /
+`agent-of-empires.*` id namespace.
+
+Resolved versions live in `<app_dir>/plugins.lock` (the exact commit, manifest
+hash, and release asset per plugin), so an install is reproducible.
+
+Running plugin code, per-plugin settings, and plugin-contributed UI land in
+follow-up releases.

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -127,7 +127,7 @@ pub enum Commands {
         command: GroupCommands,
     },
 
-    /// Manage plugins (list, info, enable, disable)
+    /// Manage plugins (list, info, enable, disable, install, update, uninstall)
     Plugin {
         #[command(subcommand)]
         command: PluginCommands,

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -32,7 +32,8 @@ pub enum PluginCommands {
         #[arg(long)]
         yes: bool,
     },
-    /// Update an installed external plugin from its recorded source
+    /// Update an installed external plugin from its recorded source. Prompts to
+    /// re-approve capabilities if the update changes the capability set.
     Update {
         /// Plugin id
         id: String,

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -1,11 +1,12 @@
-//! `aoe plugin`: plugin management (list, info, enable, disable).
+//! `aoe plugin`: plugin management (list, info, enable, disable, install,
+//! update, uninstall).
 
 use anyhow::Result;
 use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum PluginCommands {
-    /// List every known plugin with version and state
+    /// List every known plugin with version, trust, and state
     List,
     /// Show one plugin's manifest details
     Info {
@@ -22,22 +23,46 @@ pub enum PluginCommands {
         /// Plugin id
         id: String,
     },
+    /// Install an external plugin from a `gh:owner/repo[@ref]` slug or a local
+    /// directory. Community plugins run at your own risk.
+    Install {
+        /// `gh:owner/repo[@ref]` or a local directory path
+        source: String,
+        /// Grant all requested capabilities without prompting
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Update an installed external plugin from its recorded source
+    Update {
+        /// Plugin id
+        id: String,
+    },
+    /// Uninstall an external plugin, removing its files and capability grant
+    Uninstall {
+        /// Plugin id
+        id: String,
+    },
 }
 
-pub fn run(command: PluginCommands) -> Result<()> {
+pub async fn run(command: PluginCommands) -> Result<()> {
     match command {
         PluginCommands::List => run_list(),
         PluginCommands::Info { id } => run_info(&id),
         PluginCommands::Enable { id } => run_set_enabled(&id, true),
         PluginCommands::Disable { id } => run_set_enabled(&id, false),
+        PluginCommands::Install { source, yes } => run_install(&source, yes).await,
+        PluginCommands::Update { id } => run_update(&id).await,
+        PluginCommands::Uninstall { id } => run_uninstall(&id),
     }
 }
 
 fn state_label(plugin: &crate::plugin::LoadedPlugin) -> &'static str {
-    if plugin.enabled {
-        "enabled"
-    } else {
+    if !plugin.enabled {
         "disabled"
+    } else if plugin.needs_reapproval() {
+        "needs approval"
+    } else {
+        "enabled"
     }
 }
 
@@ -46,12 +71,13 @@ fn run_list() -> Result<()> {
     if registry.all().is_empty() {
         println!("No plugins installed.");
     } else {
-        println!("{:<18} {:<9} STATE", "ID", "VERSION");
+        println!("{:<20} {:<9} {:<10} STATE", "ID", "VERSION", "TRUST");
         for plugin in registry.all() {
             println!(
-                "{:<18} {:<9} {}",
+                "{:<20} {:<9} {:<10} {}",
                 plugin.id(),
                 plugin.manifest.version,
+                plugin.trust,
                 state_label(plugin),
             );
         }
@@ -70,7 +96,25 @@ fn run_info(id: &str) -> Result<()> {
     let m = &plugin.manifest;
     println!("{} ({})", m.name, m.id);
     println!("  version:  {}", m.version);
+    println!("  trust:    {}", plugin.trust);
     println!("  state:    {}", state_label(plugin));
+    if let Some(source) = &plugin.source {
+        println!("  source:   {source}");
+    }
+    if m.capabilities.is_empty() {
+        println!("  caps:     none");
+    } else {
+        let caps: Vec<&str> = m.capabilities.iter().map(|c| c.as_str()).collect();
+        println!(
+            "  caps:     {} ({})",
+            caps.join(", "),
+            if plugin.granted {
+                "granted"
+            } else {
+                "not granted"
+            }
+        );
+    }
     if !m.description.is_empty() {
         println!("  about:    {}", m.description);
     }
@@ -80,5 +124,40 @@ fn run_info(id: &str) -> Result<()> {
 fn run_set_enabled(id: &str, enabled: bool) -> Result<()> {
     crate::plugin::install::set_enabled(id, enabled)?;
     println!("{} {id}.", if enabled { "Enabled" } else { "Disabled" });
+    Ok(())
+}
+
+fn print_report(report: &crate::plugin::install::InstallReport, verb: &str) {
+    println!("{verb} {} {}.", report.id, report.version);
+    if report.capabilities.is_empty() {
+        println!("  capabilities: none");
+    } else {
+        println!(
+            "  capabilities: {} ({})",
+            report.capabilities.join(", "),
+            if report.granted {
+                "granted"
+            } else {
+                "not granted, plugin inactive"
+            }
+        );
+    }
+}
+
+async fn run_install(source: &str, yes: bool) -> Result<()> {
+    let report = crate::plugin::install::install(source, yes).await?;
+    print_report(&report, "Installed");
+    Ok(())
+}
+
+async fn run_update(id: &str) -> Result<()> {
+    let report = crate::plugin::install::update(id).await?;
+    print_report(&report, "Updated");
+    Ok(())
+}
+
+fn run_uninstall(id: &str) -> Result<()> {
+    crate::plugin::install::uninstall(id)?;
+    println!("Uninstalled {id}.");
     Ok(())
 }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -28,13 +28,24 @@ pub struct GitHubClient {
     api_base: String,
 }
 
-/// A GitHub release, the only DTO needed by the current callers.
+/// A GitHub release.
 #[derive(Debug, Clone, Deserialize)]
 pub struct GitHubRelease {
     pub tag_name: String,
     #[serde(default)]
     pub body: Option<String>,
     pub published_at: Option<String>,
+    /// Release assets (downloadable binaries). Empty for the update check; used
+    /// by plugin install to fetch a release-binary worker.
+    #[serde(default)]
+    pub assets: Vec<GitHubAsset>,
+}
+
+/// A single downloadable asset attached to a release.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubAsset {
+    pub name: String,
+    pub browser_download_url: String,
 }
 
 #[derive(Deserialize)]
@@ -85,6 +96,20 @@ impl GitHubClient {
     /// `GET /repos/{owner}/{repo}/releases/latest`
     pub async fn latest_release(&self, owner: &str, repo: &str) -> Result<GitHubRelease> {
         let url = format!("{}/repos/{}/{}/releases/latest", self.api_base, owner, repo);
+        self.send_json(self.http.get(url)).await
+    }
+
+    /// `GET /repos/{owner}/{repo}/releases/tags/{tag}`
+    pub async fn release_by_tag(
+        &self,
+        owner: &str,
+        repo: &str,
+        tag: &str,
+    ) -> Result<GitHubRelease> {
+        let url = format!(
+            "{}/repos/{}/{}/releases/tags/{}",
+            self.api_base, owner, repo, tag
+        );
         self.send_json(self.http.get(url)).await
     }
 

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -5,8 +5,21 @@
 //! typed [`GitHubError`] taxonomy. Only unauthenticated public reads (such as
 //! the update check) are wired up today via [`GitHubClient::unauthenticated`].
 
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT};
 use reqwest::StatusCode;
+
+/// Characters to percent-encode inside a single URL path segment (a release
+/// tag). Encodes the path separator and other reserved/query characters while
+/// leaving unreserved ones like `.`, `-`, `_` intact.
+const TAG_SEGMENT: &AsciiSet = &CONTROLS
+    .add(b'/')
+    .add(b' ')
+    .add(b'?')
+    .add(b'#')
+    .add(b'%')
+    .add(b'&')
+    .add(b'+');
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use std::time::Duration;
@@ -106,6 +119,9 @@ impl GitHubClient {
         repo: &str,
         tag: &str,
     ) -> Result<GitHubRelease> {
+        // A tag like `release/1.2.3` is valid and must not split into extra path
+        // segments, or the API 404s on a real tag.
+        let tag = utf8_percent_encode(tag, TAG_SEGMENT);
         let url = format!(
             "{}/repos/{}/{}/releases/tags/{}",
             self.api_base, owner, repo, tag
@@ -345,5 +361,17 @@ mod tests {
     #[test]
     fn api_message_falls_back_to_raw_body() {
         assert_eq!(api_message("plain text error"), "plain text error");
+    }
+
+    #[test]
+    fn tag_segment_encodes_slash_but_keeps_dots() {
+        assert_eq!(
+            utf8_percent_encode("release/1.2.3", TAG_SEGMENT).to_string(),
+            "release%2F1.2.3"
+        );
+        assert_eq!(
+            utf8_percent_encode("v1.2.3", TAG_SEGMENT).to_string(),
+            "v1.2.3"
+        );
     }
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -9,7 +9,7 @@
 pub mod client;
 pub mod error;
 
-pub use client::{GitHubClient, GitHubClientConfig, GitHubRelease};
+pub use client::{GitHubAsset, GitHubClient, GitHubClientConfig, GitHubRelease};
 pub use error::{GitHubError, Result};
 
 /// Default GitHub REST API base.

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,7 +313,7 @@ async fn main() -> Result<()> {
         Some(Commands::Killall(args)) => cli::killall::run(args).await,
         Some(Commands::Session { command }) => cli::session::run(&profile, command).await,
         Some(Commands::Group { command }) => cli::group::run(&profile, command).await,
-        Some(Commands::Plugin { command }) => cli::plugin::run(command),
+        Some(Commands::Plugin { command }) => cli::plugin::run(command).await,
         Some(Commands::Profile { command }) => cli::profile::run(command).await,
         Some(Commands::Project { command }) => {
             cli::project::run(&profile, profile_explicit, command).await

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -330,13 +330,29 @@ fn install_asset_into(
             .with_context(|| format!("unpacking {asset_name}"))?;
         let bin_rel =
             bin.ok_or_else(|| anyhow!("a release-binary archive asset must set `bin`"))?;
-        ensure_executable(&tree.join(bin_rel))
+        ensure_executable(&safe_tree_path(tree, bin_rel)?)
     } else {
         let name = bin.unwrap_or(asset_name);
-        let path = tree.join(name);
+        let path = safe_tree_path(tree, name)?;
         std::fs::write(&path, bytes).with_context(|| format!("writing {}", path.display()))?;
         ensure_executable(&path)
     }
+}
+
+/// Join a manifest-provided relative path onto the plugin tree, rejecting
+/// anything that would escape it. `bin` is untrusted manifest input, so an
+/// absolute path or a `..` component must not turn install into an arbitrary
+/// write or chmod outside the staging dir.
+fn safe_tree_path(tree: &Path, rel: &str) -> Result<PathBuf> {
+    use std::path::Component;
+    let candidate = Path::new(rel);
+    let safe = candidate
+        .components()
+        .all(|c| matches!(c, Component::Normal(_) | Component::CurDir));
+    if !safe || candidate.as_os_str().is_empty() {
+        bail!("plugin path {rel:?} must be a relative path inside the plugin (no absolute path or `..`)");
+    }
+    Ok(tree.join(candidate))
 }
 
 #[cfg(unix)]
@@ -376,6 +392,19 @@ mod tests {
         assert!(rendered.ends_with("-1.2.3.tar.gz"));
         assert!(rendered.contains(std::env::consts::OS));
         assert!(rendered.contains(std::env::consts::ARCH));
+    }
+
+    #[test]
+    fn safe_tree_path_rejects_escapes() {
+        let tree = Path::new("/plugins/acme");
+        assert!(safe_tree_path(tree, "bin/worker").is_ok());
+        assert!(safe_tree_path(tree, "worker").is_ok());
+        for bad in ["../../.bashrc", "/etc/passwd", "a/../../b", ""] {
+            assert!(
+                safe_tree_path(tree, bad).is_err(),
+                "{bad} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -1,0 +1,407 @@
+//! Fetching an external plugin into a staging tree, ready to be moved into
+//! place by [`crate::plugin::install`].
+//!
+//! Two source kinds, selected by [`PluginSource`]:
+//!
+//! - A GitHub repo is `git clone`d (shallow when possible), the requested ref
+//!   is checked out, and the exact commit is resolved for the lockfile. The
+//!   `.git` directory is stripped; the working tree is the plugin.
+//! - A local directory is copied verbatim (minus `.git`).
+//!
+//! If the manifest declares a `release-binary` runtime, the matching release
+//! asset for the host platform is downloaded from the repo's GitHub releases
+//! and unpacked into the tree. The worker is not launched here; that is #2095.
+//! A local source never fetches a release: its binary must already be present.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use aoe_plugin_api::{PluginManifest, RuntimeSpec};
+
+use crate::github::{GitHubClient, GitHubClientConfig, DEFAULT_USER_AGENT};
+
+use super::source::PluginSource;
+
+/// A plugin fetched into a staging tree, not yet installed.
+pub struct FetchedPlugin {
+    /// Keeps the staging directory alive until the tree is moved into place.
+    _staging: tempfile::TempDir,
+    /// The plugin tree to move to `<app_dir>/plugins/<id>/`.
+    pub tree: PathBuf,
+    pub manifest: PluginManifest,
+    /// Raw `aoe-plugin.toml` bytes, for hashing the grant against.
+    pub manifest_bytes: Vec<u8>,
+    pub source: PluginSource,
+    pub requested_ref: Option<String>,
+    pub resolved_commit: Option<String>,
+    pub release_tag: Option<String>,
+    pub asset_name: Option<String>,
+    pub asset_sha256: Option<String>,
+}
+
+/// Fetch a plugin from its source into a staging tree.
+pub async fn fetch(source: &PluginSource) -> Result<FetchedPlugin> {
+    let plugins_root = super::plugins_dir()?;
+    std::fs::create_dir_all(&plugins_root)
+        .with_context(|| format!("creating {}", plugins_root.display()))?;
+    // Stage under the plugins dir so the final rename into place is same-filesystem.
+    let staging = tempfile::Builder::new()
+        .prefix(".staging-")
+        .tempdir_in(&plugins_root)
+        .context("creating plugin staging dir")?;
+    let tree = staging.path().join("tree");
+
+    let (requested_ref, resolved_commit) = match source {
+        PluginSource::Github { reference, .. } => {
+            let url = source
+                .github_clone_url()
+                .expect("github source yields a clone url");
+            let reference = reference.clone();
+            let tree_clone = tree.clone();
+            let sha = tokio::task::spawn_blocking(move || {
+                git_clone_checkout(&url, reference.as_deref(), &tree_clone)
+            })
+            .await
+            .context("git clone task panicked")??;
+            (source.reference().map(String::from), Some(sha))
+        }
+        PluginSource::Local(path) => {
+            if !path.is_dir() {
+                bail!("local plugin source {} is not a directory", path.display());
+            }
+            copy_tree(path, &tree)?;
+            (None, None)
+        }
+    };
+
+    let (manifest, manifest_bytes) = read_manifest(&tree)?;
+
+    let mut release_tag = None;
+    let mut asset_name = None;
+    let mut asset_sha256 = None;
+    if let Some(RuntimeSpec::ReleaseBinary { asset, bin }) = &manifest.runtime {
+        match source {
+            PluginSource::Github { .. } => {
+                let (tag, name, sha) = download_release_binary(
+                    source,
+                    &manifest,
+                    asset,
+                    bin.as_deref(),
+                    &tree,
+                    requested_ref.as_deref(),
+                )
+                .await?;
+                release_tag = Some(tag);
+                asset_name = Some(name);
+                asset_sha256 = Some(sha);
+            }
+            PluginSource::Local(_) => {
+                // A local source ships its binary in the directory already; there
+                // is no release to pull from.
+            }
+        }
+    }
+
+    Ok(FetchedPlugin {
+        _staging: staging,
+        tree,
+        manifest,
+        manifest_bytes,
+        source: source.clone(),
+        requested_ref,
+        resolved_commit,
+        release_tag,
+        asset_name,
+        asset_sha256,
+    })
+}
+
+fn read_manifest(tree: &Path) -> Result<(PluginManifest, Vec<u8>)> {
+    let path = tree.join("aoe-plugin.toml");
+    let bytes = std::fs::read(&path)
+        .with_context(|| format!("no aoe-plugin.toml at {}", path.display()))?;
+    let text = std::str::from_utf8(&bytes).context("aoe-plugin.toml is not valid UTF-8")?;
+    let manifest = PluginManifest::from_toml_str(text).map_err(|e| anyhow!("{e}"))?;
+    Ok((manifest, bytes))
+}
+
+/// Run `git` with the given args, returning trimmed stdout. Surfaces stderr on
+/// failure and a clear hint when git is not installed.
+// ponytail: no explicit timeout; git fails on its own for unreachable remotes.
+fn run_git(args: &[&str], cwd: Option<&Path>) -> Result<String> {
+    let mut cmd = Command::new("git");
+    cmd.args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| anyhow!("failed to run git (is it installed and on PATH?): {e}"))?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn path_arg(path: &Path) -> Result<&str> {
+    path.to_str()
+        .ok_or_else(|| anyhow!("non-UTF-8 path: {}", path.display()))
+}
+
+/// Clone `url` into `dest`, check out `reference` (if any), strip `.git`, and
+/// return the resolved commit. A shallow clone of the ref is tried first; an
+/// arbitrary commit ref falls back to a full clone plus checkout.
+fn git_clone_checkout(url: &str, reference: Option<&str>, dest: &Path) -> Result<String> {
+    let dest_str = path_arg(dest)?;
+
+    let shallow = match reference {
+        Some(reference) => run_git(
+            &[
+                "clone", "--depth", "1", "--branch", reference, "--", url, dest_str,
+            ],
+            None,
+        )
+        .is_ok(),
+        None => run_git(&["clone", "--depth", "1", "--", url, dest_str], None).is_ok(),
+    };
+
+    if !shallow {
+        // A partial clone may have created dest; clear it before retrying.
+        let _ = std::fs::remove_dir_all(dest);
+        run_git(&["clone", "--", url, dest_str], None)?;
+        if let Some(reference) = reference {
+            run_git(
+                &["-c", "advice.detachedHead=false", "checkout", reference],
+                Some(dest),
+            )?;
+        }
+    }
+
+    let sha = run_git(&["rev-parse", "HEAD"], Some(dest))?;
+    // The plugin is the working tree, not a git checkout; drop the history.
+    let _ = std::fs::remove_dir_all(dest.join(".git"));
+    Ok(sha)
+}
+
+/// Recursively copy `src` into `dst`, skipping `.git` and symlinks.
+// ponytail: symlinks are skipped rather than followed; a local plugin dir with
+// symlinked content is rare and following them risks escaping the tree.
+fn copy_tree(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst).with_context(|| format!("creating {}", dst.display()))?;
+    for entry in std::fs::read_dir(src).with_context(|| format!("reading {}", src.display()))? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if name == ".git" {
+            continue;
+        }
+        let file_type = entry.file_type()?;
+        let from = entry.path();
+        let to = dst.join(&name);
+        if file_type.is_symlink() {
+            continue;
+        } else if file_type.is_dir() {
+            copy_tree(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)
+                .with_context(|| format!("copying {} to {}", from.display(), to.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn github_api_base() -> String {
+    std::env::var("AOE_UPDATE_API_BASE")
+        .unwrap_or_else(|_| crate::github::DEFAULT_GITHUB_API_BASE.to_string())
+}
+
+/// Resolve the release for the host platform, download the matching asset, and
+/// unpack it into `tree`. Returns `(release_tag, asset_name, asset_sha256)`.
+async fn download_release_binary(
+    source: &PluginSource,
+    manifest: &PluginManifest,
+    asset_template: &str,
+    bin: Option<&str>,
+    tree: &Path,
+    requested_ref: Option<&str>,
+) -> Result<(String, String, String)> {
+    let (owner, repo) = match source {
+        PluginSource::Github { owner, repo, .. } => (owner.as_str(), repo.as_str()),
+        PluginSource::Local(_) => bail!("a release-binary worker requires a GitHub source"),
+    };
+
+    let client = GitHubClient::unauthenticated(GitHubClientConfig {
+        api_base: github_api_base(),
+        user_agent: DEFAULT_USER_AGENT.to_string(),
+        timeout: Duration::from_secs(60),
+    })?;
+
+    let release = match requested_ref {
+        Some(tag) => client
+            .release_by_tag(owner, repo, tag)
+            .await
+            .with_context(|| format!("no release tagged {tag:?} for {owner}/{repo}"))?,
+        None => client
+            .latest_release(owner, repo)
+            .await
+            .with_context(|| format!("no latest release for {owner}/{repo}"))?,
+    };
+
+    let wanted = render_asset_template(asset_template, &manifest.version);
+    let asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == wanted)
+        .ok_or_else(|| {
+            let available: Vec<&str> = release.assets.iter().map(|a| a.name.as_str()).collect();
+            anyhow!(
+                "release {} has no asset {wanted:?} for this platform; available: [{}]",
+                release.tag_name,
+                available.join(", ")
+            )
+        })?;
+
+    let bytes = http_get_bytes(&asset.browser_download_url).await?;
+    let sha = sha256_hex(&bytes);
+    install_asset_into(tree, &asset.name, bin, &bytes)?;
+    Ok((release.tag_name.clone(), asset.name.clone(), sha))
+}
+
+/// Substitute the platform tokens in an asset name template. Supported:
+/// `${os}` (e.g. `linux`, `macos`), `${arch}` (e.g. `x86_64`, `aarch64`), and
+/// `${version}` (the manifest version).
+fn render_asset_template(template: &str, version: &str) -> String {
+    template
+        .replace("${os}", std::env::consts::OS)
+        .replace("${arch}", std::env::consts::ARCH)
+        .replace("${version}", version)
+}
+
+async fn http_get_bytes(url: &str) -> Result<Vec<u8>> {
+    let client = reqwest::Client::builder()
+        .user_agent(DEFAULT_USER_AGENT)
+        .timeout(Duration::from_secs(300))
+        .build()?;
+    let response = client.get(url).send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        bail!("downloading {url} failed: HTTP {status}");
+    }
+    Ok(response.bytes().await?.to_vec())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(7 + digest.len() * 2);
+    out.push_str("sha256:");
+    for byte in digest {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Place a downloaded asset into the plugin tree. A `.tar.gz` archive is
+/// unpacked and `bin` (required) names the executable within; any other asset
+/// is treated as a raw binary written as `bin` (or the asset name). The result
+/// is made executable.
+fn install_asset_into(
+    tree: &Path,
+    asset_name: &str,
+    bin: Option<&str>,
+    bytes: &[u8],
+) -> Result<()> {
+    if asset_name.ends_with(".tar.gz") || asset_name.ends_with(".tgz") {
+        let decoder = flate2::read::GzDecoder::new(bytes);
+        let mut archive = tar::Archive::new(decoder);
+        archive
+            .unpack(tree)
+            .with_context(|| format!("unpacking {asset_name}"))?;
+        let bin_rel =
+            bin.ok_or_else(|| anyhow!("a release-binary archive asset must set `bin`"))?;
+        ensure_executable(&tree.join(bin_rel))
+    } else {
+        let name = bin.unwrap_or(asset_name);
+        let path = tree.join(name);
+        std::fs::write(&path, bytes).with_context(|| format!("writing {}", path.display()))?;
+        ensure_executable(&path)
+    }
+}
+
+#[cfg(unix)]
+fn ensure_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    if !path.exists() {
+        bail!(
+            "expected binary {} missing after extraction",
+            path.display()
+        );
+    }
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(perms.mode() | 0o755);
+    std::fs::set_permissions(path, perms)
+        .with_context(|| format!("making {} executable", path.display()))
+}
+
+#[cfg(not(unix))]
+fn ensure_executable(path: &Path) -> Result<()> {
+    if !path.exists() {
+        bail!(
+            "expected binary {} missing after extraction",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_platform_tokens() {
+        let rendered = render_asset_template("w-${os}-${arch}-${version}.tar.gz", "1.2.3");
+        assert!(rendered.starts_with("w-"));
+        assert!(rendered.ends_with("-1.2.3.tar.gz"));
+        assert!(rendered.contains(std::env::consts::OS));
+        assert!(rendered.contains(std::env::consts::ARCH));
+    }
+
+    #[test]
+    fn raw_asset_is_written_executable() {
+        let dir = tempfile::tempdir().unwrap();
+        install_asset_into(dir.path(), "thing", Some("thing"), b"#!/bin/sh\n").unwrap();
+        let path = dir.path().join("thing");
+        assert!(path.exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert!(mode & 0o111 != 0, "should be executable, mode {mode:o}");
+        }
+    }
+
+    #[test]
+    fn copy_tree_skips_git_and_symlinks() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("aoe-plugin.toml"), b"x").unwrap();
+        std::fs::create_dir(src.path().join(".git")).unwrap();
+        std::fs::write(src.path().join(".git").join("config"), b"y").unwrap();
+        let dst = tempfile::tempdir().unwrap();
+        let into = dst.path().join("tree");
+        copy_tree(src.path(), &into).unwrap();
+        assert!(into.join("aoe-plugin.toml").exists());
+        assert!(!into.join(".git").exists());
+    }
+}

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -179,8 +179,16 @@ fn git_clone_checkout(url: &str, reference: Option<&str>, dest: &Path) -> Result
         let _ = std::fs::remove_dir_all(dest);
         run_git(&["clone", "--", url, dest_str], None)?;
         if let Some(reference) = reference {
+            // `--` separates the revision from pathspecs so a ref that begins
+            // with a dash is not parsed as a flag.
             run_git(
-                &["-c", "advice.detachedHead=false", "checkout", reference],
+                &[
+                    "-c",
+                    "advice.detachedHead=false",
+                    "checkout",
+                    reference,
+                    "--",
+                ],
                 Some(dest),
             )?;
         }

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -1,9 +1,16 @@
-//! Plugin enable/disable. (Installing/updating/uninstalling external plugins
-//! returns in a follow-up PR; this is the builtin-only core.)
+//! Plugin enable/disable and external install / update / uninstall.
 
-use anyhow::{bail, Result};
+use std::collections::BTreeSet;
+use std::io::{self, IsTerminal, Write};
 
-use crate::session::{save_config, Config, PluginConfig};
+use anyhow::{anyhow, bail, Context, Result};
+use aoe_plugin_api::{PluginManifest, TrustLevel};
+
+use crate::session::{save_config, CapabilityGrant, Config, PluginConfig};
+
+use super::fetch::{self, FetchedPlugin};
+use super::lockfile::{LockedPlugin, Lockfile};
+use super::source::PluginSource;
 
 /// Set the enabled flag for a known plugin id in the global config, then reload
 /// the registry so the change takes effect.
@@ -25,4 +32,291 @@ fn enable_in_config(plugin_id: &str, enabled: bool) -> Result<()> {
         .or_insert_with(PluginConfig::default)
         .enabled = enabled;
     save_config(&config)
+}
+
+/// What an install or update did, for the caller to report.
+#[derive(Debug)]
+pub struct InstallReport {
+    pub id: String,
+    pub version: String,
+    /// Capabilities the manifest declares.
+    pub capabilities: Vec<String>,
+    /// Whether the plugin is granted and live after the operation.
+    pub granted: bool,
+}
+
+/// Install an external plugin from `input` (`gh:owner/repo[@ref]` or a local
+/// dir). Prompts once for the manifest's capabilities unless `assume_yes`.
+pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
+    let source = PluginSource::parse(input)?;
+    let fetched = fetch::fetch(&source).await?;
+
+    let id = fetched.manifest.id.as_str().to_string();
+    reject_reserved_or_builtin(&fetched.manifest)?;
+
+    let final_dir = super::plugins_dir()?.join(&id);
+    if final_dir.exists() {
+        bail!("{id} is already installed; run `aoe plugin update {id}` or uninstall it first");
+    }
+
+    let capabilities = capability_strings(&fetched)?;
+    let granted = if capabilities.is_empty() || assume_yes {
+        true
+    } else {
+        confirm_capabilities(&id, &capabilities)?
+    };
+    if !granted {
+        bail!("install cancelled; no capabilities were granted");
+    }
+
+    move_into_place(&fetched, &final_dir)?;
+
+    let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
+    persist_install(input, &id, &capabilities, &manifest_hash)?;
+    write_lock(&id, &fetched, &manifest_hash)?;
+    super::reload_registry();
+
+    Ok(InstallReport {
+        id,
+        version: fetched.manifest.version.clone(),
+        capabilities,
+        granted: true,
+    })
+}
+
+/// Re-fetch an installed external plugin from its recorded source. A changed
+/// capability set re-prompts; until re-approved the plugin's contributions stay
+/// inactive (the grant no longer covers the installed manifest).
+pub async fn update(id: &str) -> Result<InstallReport> {
+    let config = Config::load()?;
+    let plugin_config = config
+        .plugins
+        .get(id)
+        .ok_or_else(|| anyhow!("{id} is not installed; see `aoe plugin list`"))?;
+    let source_str = plugin_config
+        .source
+        .clone()
+        .ok_or_else(|| anyhow!("{id} is a builtin plugin; there is nothing to update"))?;
+    let prior_grant = plugin_config.grant.clone();
+
+    let source = PluginSource::parse(&source_str)?;
+    let fetched = fetch::fetch(&source).await?;
+    if fetched.manifest.id.as_str() != id {
+        bail!(
+            "source {source_str:?} now resolves to plugin {:?}, not {id}",
+            fetched.manifest.id.as_str()
+        );
+    }
+    reject_reserved_or_builtin(&fetched.manifest)?;
+
+    let capabilities = capability_strings(&fetched)?;
+    let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
+
+    let prior_caps: BTreeSet<&str> = prior_grant
+        .as_ref()
+        .map(|g| g.capabilities.iter().map(String::as_str).collect())
+        .unwrap_or_default();
+    let new_caps: BTreeSet<&str> = capabilities.iter().map(String::as_str).collect();
+    let caps_changed = prior_caps != new_caps;
+
+    let final_dir = super::plugins_dir()?.join(id);
+    move_into_place(&fetched, &final_dir)?;
+
+    // Decide the grant. Unchanged caps: re-pin the prior grant to the new
+    // manifest hash. Changed caps: re-prompt; if declined or non-interactive,
+    // leave the plugin ungranted so its contributions stay inactive.
+    let grant = if !caps_changed {
+        prior_grant.map(|g| CapabilityGrant {
+            manifest_hash: manifest_hash.clone(),
+            capabilities: g.capabilities,
+            granted_at: g.granted_at,
+        })
+    } else if capabilities.is_empty() {
+        Some(CapabilityGrant {
+            manifest_hash: manifest_hash.clone(),
+            capabilities: vec![],
+            granted_at: chrono::Utc::now(),
+        })
+    } else if confirm_capabilities(id, &capabilities)? {
+        Some(CapabilityGrant {
+            manifest_hash: manifest_hash.clone(),
+            capabilities: capabilities.clone(),
+            granted_at: chrono::Utc::now(),
+        })
+    } else {
+        None
+    };
+
+    let granted = grant.is_some();
+    persist_update(id, &source_str, grant)?;
+    write_lock(id, &fetched, &manifest_hash)?;
+    super::reload_registry();
+
+    if caps_changed && !granted {
+        eprintln!(
+            "{id} updated but its capability set changed; it stays inactive until you re-approve with `aoe plugin update {id}`."
+        );
+    }
+
+    Ok(InstallReport {
+        id: id.to_string(),
+        version: fetched.manifest.version.clone(),
+        capabilities,
+        granted,
+    })
+}
+
+/// Remove an installed external plugin: its tree, its config entry, and its
+/// lockfile entry.
+pub fn uninstall(id: &str) -> Result<()> {
+    let dir = super::plugins_dir()?.join(id);
+    let mut config = Config::load()?;
+    let is_external = config
+        .plugins
+        .get(id)
+        .and_then(|p| p.source.as_ref())
+        .is_some();
+    if !dir.exists() && !is_external {
+        bail!("{id} is not an installed external plugin");
+    }
+
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir).with_context(|| format!("removing {}", dir.display()))?;
+    }
+    if config.plugins.remove(id).is_some() {
+        save_config(&config)?;
+    }
+    let mut lock = Lockfile::load()?;
+    if lock.remove(id) {
+        lock.save()?;
+    }
+    super::reload_registry();
+    Ok(())
+}
+
+/// Reject a manifest whose id is reserved for first-party plugins (`aoe.*` /
+/// `agent-of-empires.*`, lifted only by featured verification in #2364) or
+/// collides with a compiled-in builtin.
+fn reject_reserved_or_builtin(manifest: &PluginManifest) -> Result<()> {
+    let id = manifest.id.as_str();
+    if manifest.id.is_reserved_namespace() {
+        bail!("plugin id {id:?} uses a reserved namespace (aoe.* / agent-of-empires.*); external plugins cannot");
+    }
+    if super::registry::is_builtin_id(id) {
+        bail!("plugin id {id:?} collides with a builtin plugin");
+    }
+    Ok(())
+}
+
+/// The manifest's capabilities as strings, rejecting any this host does not
+/// recognize (never silently granted).
+fn capability_strings(fetched: &FetchedPlugin) -> Result<Vec<String>> {
+    let unknown: Vec<&str> = fetched
+        .manifest
+        .capabilities
+        .iter()
+        .filter(|c| !c.is_known())
+        .map(|c| c.as_str())
+        .collect();
+    if !unknown.is_empty() {
+        bail!(
+            "plugin requests capabilities this host does not support: {}; upgrade aoe",
+            unknown.join(", ")
+        );
+    }
+    Ok(fetched
+        .manifest
+        .capabilities
+        .iter()
+        .map(|c| c.as_str().to_string())
+        .collect())
+}
+
+/// Prompt the user to grant a plugin's capabilities. Fails on a non-interactive
+/// stdin rather than silently granting; the caller can pass `--yes` there.
+fn confirm_capabilities(id: &str, capabilities: &[String]) -> Result<bool> {
+    if !io::stdin().is_terminal() {
+        bail!(
+            "{id} requests capabilities [{}] but stdin is not a terminal; re-run with --yes to grant them",
+            capabilities.join(", ")
+        );
+    }
+    println!("Plugin {id} requests these capabilities:");
+    for capability in capabilities {
+        println!("  - {capability}");
+    }
+    print!("Grant them and install? [y/N] ");
+    io::stdout().flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    Ok(matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+/// Move a fetched plugin's staging tree into its final directory.
+fn move_into_place(fetched: &FetchedPlugin, final_dir: &std::path::Path) -> Result<()> {
+    // The staging tree lives under the plugins dir, so this rename is
+    // same-filesystem and atomic. On update, the old dir is replaced.
+    if final_dir.exists() {
+        std::fs::remove_dir_all(final_dir)
+            .with_context(|| format!("replacing {}", final_dir.display()))?;
+    }
+    std::fs::rename(&fetched.tree, final_dir).with_context(|| {
+        format!(
+            "moving plugin into {} (cross-device staging?)",
+            final_dir.display()
+        )
+    })
+}
+
+fn persist_install(
+    input: &str,
+    id: &str,
+    capabilities: &[String],
+    manifest_hash: &str,
+) -> Result<()> {
+    let mut config = Config::load()?;
+    let entry = config
+        .plugins
+        .entry(id.to_string())
+        .or_insert_with(PluginConfig::default);
+    entry.source = Some(input.to_string());
+    entry.grant = Some(CapabilityGrant {
+        manifest_hash: manifest_hash.to_string(),
+        capabilities: capabilities.to_vec(),
+        granted_at: chrono::Utc::now(),
+    });
+    save_config(&config)
+}
+
+fn persist_update(id: &str, source: &str, grant: Option<CapabilityGrant>) -> Result<()> {
+    let mut config = Config::load()?;
+    let entry = config
+        .plugins
+        .entry(id.to_string())
+        .or_insert_with(PluginConfig::default);
+    entry.source = Some(source.to_string());
+    entry.grant = grant;
+    save_config(&config)
+}
+
+fn write_lock(id: &str, fetched: &FetchedPlugin, manifest_hash: &str) -> Result<()> {
+    let mut lock = Lockfile::load()?;
+    lock.upsert(
+        id,
+        LockedPlugin {
+            source: fetched.source.slug(),
+            requested_ref: fetched.requested_ref.clone(),
+            resolved_commit: fetched.resolved_commit.clone(),
+            version: fetched.manifest.version.clone(),
+            manifest_hash: manifest_hash.to_string(),
+            trust: TrustLevel::Community.as_str().to_string(),
+            release_tag: fetched.release_tag.clone(),
+            asset_name: fetched.asset_name.clone(),
+            asset_sha256: fetched.asset_sha256.clone(),
+        },
+    );
+    lock.save()
 }

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -72,7 +72,12 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
     move_into_place(&fetched, &final_dir)?;
 
     let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
-    persist_install(input, &id, &capabilities, &manifest_hash)?;
+    persist_install(
+        &persisted_source(&source, input),
+        &id,
+        &capabilities,
+        &manifest_hash,
+    )?;
     write_lock(&id, &fetched, &manifest_hash)?;
     super::reload_registry();
 
@@ -119,23 +124,22 @@ pub async fn update(id: &str) -> Result<InstallReport> {
     let new_caps: BTreeSet<&str> = capabilities.iter().map(String::as_str).collect();
     let caps_changed = prior_caps != new_caps;
 
-    let final_dir = super::plugins_dir()?.join(id);
-    move_into_place(&fetched, &final_dir)?;
-
-    // Decide the grant. Unchanged caps: re-pin the prior grant to the new
-    // manifest hash. Changed caps: re-prompt; if declined or non-interactive,
-    // leave the plugin ungranted so its contributions stay inactive.
-    let grant = if !caps_changed {
-        prior_grant.map(|g| CapabilityGrant {
-            manifest_hash: manifest_hash.clone(),
-            capabilities: g.capabilities,
-            granted_at: g.granted_at,
-        })
-    } else if capabilities.is_empty() {
+    // Decide the grant BEFORE touching the installed tree, so a declined or
+    // non-interactive prompt bails while the old install, config, and lockfile
+    // are still consistent. An empty capability set always (re)grants, so an
+    // update that drops all capabilities reactivates the plugin even if it was
+    // previously left ungranted.
+    let grant = if capabilities.is_empty() {
         Some(CapabilityGrant {
             manifest_hash: manifest_hash.clone(),
             capabilities: vec![],
             granted_at: chrono::Utc::now(),
+        })
+    } else if !caps_changed {
+        prior_grant.map(|g| CapabilityGrant {
+            manifest_hash: manifest_hash.clone(),
+            capabilities: g.capabilities,
+            granted_at: g.granted_at,
         })
     } else if confirm_capabilities(id, &capabilities)? {
         Some(CapabilityGrant {
@@ -146,6 +150,9 @@ pub async fn update(id: &str) -> Result<InstallReport> {
     } else {
         None
     };
+
+    let final_dir = super::plugins_dir()?.join(id);
+    move_into_place(&fetched, &final_dir)?;
 
     let granted = grant.is_some();
     persist_update(id, &source_str, grant)?;
@@ -271,8 +278,21 @@ fn move_into_place(fetched: &FetchedPlugin, final_dir: &std::path::Path) -> Resu
     })
 }
 
+/// The source string to persist for a later `update`. A GitHub source keeps the
+/// original `gh:owner/repo[@ref]` so the ref survives; a local source is
+/// canonicalized to an absolute path so `update` does not resolve relative to
+/// whatever directory happened to be current at install time.
+fn persisted_source(source: &PluginSource, input: &str) -> String {
+    match source {
+        PluginSource::Github { .. } => input.to_string(),
+        PluginSource::Local(path) => std::fs::canonicalize(path)
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| input.to_string()),
+    }
+}
+
 fn persist_install(
-    input: &str,
+    source: &str,
     id: &str,
     capabilities: &[String],
     manifest_hash: &str,
@@ -282,7 +302,7 @@ fn persist_install(
         .plugins
         .entry(id.to_string())
         .or_insert_with(PluginConfig::default);
-    entry.source = Some(input.to_string());
+    entry.source = Some(source.to_string());
     entry.grant = Some(CapabilityGrant {
         manifest_hash: manifest_hash.to_string(),
         capabilities: capabilities.to_vec(),

--- a/src/plugin/lockfile.rs
+++ b/src/plugin/lockfile.rs
@@ -76,7 +76,20 @@ impl Lockfile {
         }
         let text = std::fs::read_to_string(&path)
             .with_context(|| format!("reading {}", path.display()))?;
-        toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))
+        let lockfile: Lockfile =
+            toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
+        // Refuse a lockfile written by a newer aoe: saving it back would silently
+        // drop fields this version does not know, breaking the forward-migration
+        // contract. The user should upgrade rather than downgrade-corrupt it.
+        if lockfile.lock_version > LOCK_VERSION {
+            anyhow::bail!(
+                "{} is lock_version {} but this aoe understands {}; upgrade aoe",
+                path.display(),
+                lockfile.lock_version,
+                LOCK_VERSION
+            );
+        }
+        Ok(lockfile)
     }
 
     /// Persist the lockfile.

--- a/src/plugin/lockfile.rs
+++ b/src/plugin/lockfile.rs
@@ -1,0 +1,155 @@
+//! `plugins.lock`: the exact resolved identity of every externally installed
+//! plugin.
+//!
+//! Lives at `<app_dir>/plugins.lock` and is TOML, matching `config.toml` and
+//! `aoe-plugin.toml`. Like `Cargo.lock` it is deterministic and merge-friendly:
+//! plugins are keyed by id (a `BTreeMap`, stable order) and no timestamps are
+//! stored. It records what was actually resolved so an install can be
+//! reproduced and an update can tell whether anything changed.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Current lockfile schema version.
+const LOCK_VERSION: u32 = 1;
+
+/// The parsed `plugins.lock`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Lockfile {
+    /// Lockfile schema version, for forward migrations.
+    pub lock_version: u32,
+    /// External plugins keyed by id.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub plugins: BTreeMap<String, LockedPlugin>,
+}
+
+impl Default for Lockfile {
+    fn default() -> Self {
+        Self {
+            lock_version: LOCK_VERSION,
+            plugins: BTreeMap::new(),
+        }
+    }
+}
+
+/// One external plugin's resolved identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockedPlugin {
+    /// Canonical source slug: `gh:owner/repo` or a local path.
+    pub source: String,
+    /// The ref the user asked for (branch / tag / commit), if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_ref: Option<String>,
+    /// The exact commit the source resolved to (GitHub sources only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_commit: Option<String>,
+    /// The plugin version from its manifest.
+    pub version: String,
+    /// `sha256:<hex>` of the installed manifest bytes.
+    pub manifest_hash: String,
+    /// `builtin` or `community`.
+    pub trust: String,
+    /// The release tag the worker binary was pulled from (release-binary only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release_tag: Option<String>,
+    /// The release asset name downloaded (release-binary only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_name: Option<String>,
+    /// `sha256:<hex>` of the downloaded asset (release-binary only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_sha256: Option<String>,
+}
+
+impl Lockfile {
+    fn path() -> Result<PathBuf> {
+        Ok(crate::session::get_app_dir()?.join("plugins.lock"))
+    }
+
+    /// Load the lockfile, returning an empty one if the file does not exist.
+    pub fn load() -> Result<Self> {
+        let path = Self::path()?;
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let text = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    /// Persist the lockfile.
+    pub fn save(&self) -> Result<()> {
+        let path = Self::path()?;
+        let text = toml::to_string_pretty(self).context("serializing plugins.lock")?;
+        std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))
+    }
+
+    pub fn get(&self, id: &str) -> Option<&LockedPlugin> {
+        self.plugins.get(id)
+    }
+
+    /// Insert or replace a plugin's lock entry.
+    pub fn upsert(&mut self, id: &str, locked: LockedPlugin) {
+        self.lock_version = LOCK_VERSION;
+        self.plugins.insert(id.to_string(), locked);
+    }
+
+    /// Remove a plugin's lock entry; returns whether one was present.
+    pub fn remove(&mut self, id: &str) -> bool {
+        self.plugins.remove(id).is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_through_toml() {
+        let mut lf = Lockfile::default();
+        lf.upsert(
+            "acme.widget",
+            LockedPlugin {
+                source: "gh:acme/widget".into(),
+                requested_ref: Some("v1.0.0".into()),
+                resolved_commit: Some("deadbeef".into()),
+                version: "1.0.0".into(),
+                manifest_hash: "sha256:abc".into(),
+                trust: "community".into(),
+                release_tag: Some("v1.0.0".into()),
+                asset_name: Some("widget-x86_64.tar.gz".into()),
+                asset_sha256: Some("sha256:def".into()),
+            },
+        );
+        let text = toml::to_string_pretty(&lf).unwrap();
+        let back: Lockfile = toml::from_str(&text).unwrap();
+        assert_eq!(back.lock_version, LOCK_VERSION);
+        assert_eq!(
+            back.plugins.get("acme.widget"),
+            lf.plugins.get("acme.widget")
+        );
+    }
+
+    #[test]
+    fn remove_reports_presence() {
+        let mut lf = Lockfile::default();
+        lf.upsert(
+            "acme.widget",
+            LockedPlugin {
+                source: "/local/path".into(),
+                requested_ref: None,
+                resolved_commit: None,
+                version: "0.1.0".into(),
+                manifest_hash: "sha256:abc".into(),
+                trust: "community".into(),
+                release_tag: None,
+                asset_name: None,
+                asset_sha256: None,
+            },
+        );
+        assert!(lf.remove("acme.widget"));
+        assert!(!lf.remove("acme.widget"));
+    }
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -6,13 +6,21 @@
 //! installs, capability grants, and the Tier 0 / Tier 1 contribution surface
 //! return in follow-up PRs.
 
+pub mod fetch;
 pub mod install;
 pub mod lockfile;
 pub mod registry;
 pub mod source;
 pub mod view;
 
+use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
+
+/// Directory holding externally installed plugins, one subdir per plugin id:
+/// `<app_dir>/plugins/<id>/`.
+pub fn plugins_dir() -> anyhow::Result<PathBuf> {
+    Ok(crate::session::get_app_dir()?.join("plugins"))
+}
 
 pub use registry::{LoadedPlugin, PluginRegistry};
 pub use view::PluginView;

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -7,7 +7,9 @@
 //! return in follow-up PRs.
 
 pub mod install;
+pub mod lockfile;
 pub mod registry;
+pub mod source;
 pub mod view;
 
 use std::sync::{Arc, RwLock};

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -1,14 +1,17 @@
-//! Plugin registry: the compiled-in first-party plugins and their
-//! enabled/disabled state.
+//! Plugin registry: the compiled-in first-party plugins, the externally
+//! installed ones, and each plugin's enabled / granted state.
 //!
-//! Builtin plugins are embedded from `plugins/` in this repository. Disabling
-//! one removes it from the active set on the next reload, with no residue
-//! (acceptance criterion 3 of #268). External (installed) plugins return in a
-//! follow-up PR.
+//! Builtin plugins are embedded from `plugins/` in this repository and are
+//! fully trusted: their capabilities are auto-granted. External plugins are
+//! loaded from `<app_dir>/plugins/<id>/`; they are community-trusted, so their
+//! contributions go live only once the user has granted the capability set the
+//! installed manifest declares (the grant is pinned to the manifest hash).
 
-use aoe_plugin_api::PluginManifest;
+use std::path::PathBuf;
 
-use crate::session::Config;
+use aoe_plugin_api::{PluginManifest, TrustLevel};
+
+use crate::session::{CapabilityGrant, Config};
 
 /// A plugin compiled into the aoe binary.
 pub struct BuiltinPlugin {
@@ -21,18 +24,39 @@ pub struct BuiltinPlugin {
 pub static BUILTINS: &[BuiltinPlugin] = &[
     // The web dashboard's management marker is present whenever the dashboard
     // is compiled in (`feature = "serve"`), so serve and release builds always
-    // surface aoe.web; a TUI-only build has an empty registry.
+    // surface aoe.web; a TUI-only build has an empty builtin set.
     #[cfg(feature = "serve")]
     BuiltinPlugin {
         manifest_toml: include_str!("../../plugins/aoe-web/aoe-plugin.toml"),
     },
 ];
 
-/// One loaded plugin: its manifest and whether it is enabled.
+/// Whether `id` belongs to a compiled-in builtin plugin.
+pub fn is_builtin_id(id: &str) -> bool {
+    BUILTINS.iter().any(|b| {
+        PluginManifest::from_toml_str(b.manifest_toml)
+            .map(|m| m.id.as_str() == id)
+            .unwrap_or(false)
+    })
+}
+
+/// One loaded plugin: its manifest, trust, and enabled / granted state.
 pub struct LoadedPlugin {
     pub manifest: PluginManifest,
-    /// Resolved from `Config.plugins`; builtins default on.
+    /// Resolved from `Config.plugins`; defaults on.
     pub enabled: bool,
+    /// Builtin (auto-granted) or community (capabilities gated).
+    pub trust: TrustLevel,
+    /// Install source for an external plugin; `None` for builtins.
+    pub source: Option<String>,
+    /// On-disk directory for an external plugin; `None` for builtins.
+    pub dir: Option<PathBuf>,
+    /// `sha256:<hex>` of the installed manifest bytes (builtins: of the embedded
+    /// TOML). A grant must be pinned to this exact hash to count.
+    pub manifest_hash: String,
+    /// Whether the user's grant covers the installed manifest's capability set.
+    /// Always true for builtins.
+    pub granted: bool,
 }
 
 impl LoadedPlugin {
@@ -40,11 +64,32 @@ impl LoadedPlugin {
         self.manifest.id.as_str()
     }
 
-    /// Whether the plugin's contributions are live. Builtins are first-party
-    /// and always granted, so this is just `enabled`.
-    pub fn active(&self) -> bool {
-        self.enabled
+    pub fn builtin(&self) -> bool {
+        matches!(self.trust, TrustLevel::Builtin)
     }
+
+    /// Whether the plugin's contributions are live: enabled, and (for community
+    /// plugins) granted against the installed manifest. An ungranted or
+    /// stale-grant community plugin contributes nothing until re-approved.
+    pub fn active(&self) -> bool {
+        self.enabled && self.granted
+    }
+
+    /// A community plugin whose grant does not cover the installed manifest:
+    /// installed but inactive, awaiting `aoe plugin update` / re-approval.
+    pub fn needs_reapproval(&self) -> bool {
+        !self.builtin() && !self.granted
+    }
+}
+
+/// Whether a stored grant covers the installed manifest: it must be pinned to
+/// the same manifest hash and include every capability the manifest declares.
+fn grant_covers(grant: &CapabilityGrant, manifest: &PluginManifest, manifest_hash: &str) -> bool {
+    grant.manifest_hash == manifest_hash
+        && manifest
+            .capabilities
+            .iter()
+            .all(|c| grant.capabilities.iter().any(|g| g == c.as_str()))
 }
 
 /// The set of plugins loaded for a config, plus any load problems.
@@ -57,6 +102,7 @@ impl PluginRegistry {
     pub fn load(config: &Config) -> Self {
         let mut plugins = Vec::new();
         let mut load_errors = Vec::new();
+
         for builtin in BUILTINS {
             match PluginManifest::from_toml_str(builtin.manifest_toml) {
                 Ok(manifest) => {
@@ -65,7 +111,17 @@ impl PluginRegistry {
                         .get(manifest.id.as_str())
                         .map(|p| p.enabled)
                         .unwrap_or(true);
-                    plugins.push(LoadedPlugin { manifest, enabled });
+                    let manifest_hash =
+                        PluginManifest::hash_bytes(builtin.manifest_toml.as_bytes());
+                    plugins.push(LoadedPlugin {
+                        manifest,
+                        enabled,
+                        trust: TrustLevel::Builtin,
+                        source: None,
+                        dir: None,
+                        manifest_hash,
+                        granted: true,
+                    });
                 }
                 Err(e) => {
                     // A broken builtin manifest is a build defect; tested in CI.
@@ -73,6 +129,9 @@ impl PluginRegistry {
                 }
             }
         }
+
+        load_external(config, &mut plugins, &mut load_errors);
+
         Self {
             plugins,
             load_errors,
@@ -84,7 +143,7 @@ impl PluginRegistry {
         &self.plugins
     }
 
-    /// Plugins whose contributions are live (enabled).
+    /// Plugins whose contributions are live (enabled and granted).
     pub fn active(&self) -> impl Iterator<Item = &LoadedPlugin> {
         self.plugins.iter().filter(|p| p.active())
     }
@@ -95,6 +154,87 @@ impl PluginRegistry {
 
     pub fn load_errors(&self) -> &[String] {
         &self.load_errors
+    }
+}
+
+/// Load external plugins from `<app_dir>/plugins/<id>/aoe-plugin.toml`. Each
+/// problem is collected as a non-fatal load error rather than aborting the set.
+fn load_external(config: &Config, plugins: &mut Vec<LoadedPlugin>, load_errors: &mut Vec<String>) {
+    let root = match super::plugins_dir() {
+        Ok(root) => root,
+        Err(e) => {
+            load_errors.push(format!("cannot resolve plugins dir: {e}"));
+            return;
+        }
+    };
+    let entries = match std::fs::read_dir(&root) {
+        Ok(entries) => entries,
+        // No plugins dir yet is normal; anything else is worth surfacing.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            load_errors.push(format!("reading {}: {e}", root.display()));
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // Skip the staging scratch dirs and other dotfiles.
+        if name.starts_with('.') || !dir.is_dir() {
+            continue;
+        }
+        let manifest_path = dir.join("aoe-plugin.toml");
+        let bytes = match std::fs::read(&manifest_path) {
+            Ok(bytes) => bytes,
+            Err(_) => continue, // not a plugin dir
+        };
+        let manifest = match std::str::from_utf8(&bytes)
+            .map_err(|e| e.to_string())
+            .and_then(|t| PluginManifest::from_toml_str(t).map_err(|e| e.to_string()))
+        {
+            Ok(manifest) => manifest,
+            Err(e) => {
+                load_errors.push(format!("plugin at {}: {e}", dir.display()));
+                continue;
+            }
+        };
+        let id = manifest.id.as_str().to_string();
+
+        if manifest.id.is_reserved_namespace() {
+            load_errors.push(format!(
+                "plugin {id:?} at {} uses a reserved namespace and was skipped",
+                dir.display()
+            ));
+            continue;
+        }
+        if is_builtin_id(&id) || plugins.iter().any(|p| p.id() == id) {
+            load_errors.push(format!(
+                "plugin {id:?} at {} collides with an existing plugin id and was skipped",
+                dir.display()
+            ));
+            continue;
+        }
+
+        let manifest_hash = PluginManifest::hash_bytes(&bytes);
+        let plugin_config = config.plugins.get(&id);
+        let enabled = plugin_config.map(|p| p.enabled).unwrap_or(true);
+        let source = plugin_config.and_then(|p| p.source.clone());
+        let granted = plugin_config
+            .and_then(|p| p.grant.as_ref())
+            .map(|g| grant_covers(g, &manifest, &manifest_hash))
+            .unwrap_or(false);
+
+        plugins.push(LoadedPlugin {
+            manifest,
+            enabled,
+            trust: TrustLevel::Community,
+            source,
+            dir: Some(dir),
+            manifest_hash,
+            granted,
+        });
     }
 }
 
@@ -114,5 +254,42 @@ mod tests {
                 manifest.id
             );
         }
+    }
+
+    #[test]
+    fn grant_covers_requires_matching_hash_and_caps() {
+        let manifest = PluginManifest::from_toml_str(
+            r#"
+id = "acme.thing"
+name = "Thing"
+version = "1.0.0"
+api_version = 2
+capabilities = ["net", "fs.read"]
+"#,
+        )
+        .unwrap();
+        let hash = "sha256:abc";
+
+        let full = CapabilityGrant {
+            manifest_hash: hash.to_string(),
+            capabilities: vec!["net".into(), "fs.read".into()],
+            granted_at: chrono::Utc::now(),
+        };
+        assert!(grant_covers(&full, &manifest, hash));
+
+        // Wrong hash (manifest changed since the grant): not covered.
+        let stale = CapabilityGrant {
+            manifest_hash: "sha256:old".to_string(),
+            ..full.clone()
+        };
+        assert!(!grant_covers(&stale, &manifest, hash));
+
+        // Missing a capability: not covered.
+        let partial = CapabilityGrant {
+            manifest_hash: hash.to_string(),
+            capabilities: vec!["net".into()],
+            granted_at: chrono::Utc::now(),
+        };
+        assert!(!grant_covers(&partial, &manifest, hash));
     }
 }

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -177,7 +177,14 @@ fn load_external(config: &Config, plugins: &mut Vec<LoadedPlugin>, load_errors: 
         }
     };
 
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                load_errors.push(format!("reading an entry in {}: {e}", root.display()));
+                continue;
+            }
+        };
         let dir = entry.path();
         let name = entry.file_name();
         let name = name.to_string_lossy();
@@ -188,7 +195,13 @@ fn load_external(config: &Config, plugins: &mut Vec<LoadedPlugin>, load_errors: 
         let manifest_path = dir.join("aoe-plugin.toml");
         let bytes = match std::fs::read(&manifest_path) {
             Ok(bytes) => bytes,
-            Err(_) => continue, // not a plugin dir
+            // A directory without a manifest is simply not a plugin; anything
+            // else (a permission error, a short read) is worth surfacing.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                load_errors.push(format!("reading {}: {e}", manifest_path.display()));
+                continue;
+            }
         };
         let manifest = match std::str::from_utf8(&bytes)
             .map_err(|e| e.to_string())

--- a/src/plugin/source.rs
+++ b/src/plugin/source.rs
@@ -1,0 +1,138 @@
+//! Parsing an external plugin install source.
+//!
+//! A source is either a GitHub slug (`gh:owner/repo` with an optional `@ref`)
+//! or a local directory path. Parsing is pure: it does not touch the network or
+//! the filesystem, so the same parser interprets a freshly typed argument and a
+//! source string read back from config on update.
+
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+
+/// Where a plugin is installed from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginSource {
+    /// A GitHub repository, written `gh:owner/repo` with an optional `@ref`
+    /// (branch, tag, or commit).
+    Github {
+        owner: String,
+        repo: String,
+        reference: Option<String>,
+    },
+    /// A local directory containing an `aoe-plugin.toml`.
+    Local(PathBuf),
+}
+
+impl PluginSource {
+    /// Parse an install source argument. A `gh:` prefix selects GitHub;
+    /// anything else is treated as a local path.
+    pub fn parse(input: &str) -> Result<Self> {
+        let input = input.trim();
+        if input.is_empty() {
+            bail!("empty plugin source");
+        }
+        if let Some(rest) = input.strip_prefix("gh:") {
+            let (slug, reference) = match rest.split_once('@') {
+                Some((slug, reference)) => {
+                    if reference.is_empty() {
+                        bail!("empty ref after '@' in {input:?}");
+                    }
+                    (slug, Some(reference.to_string()))
+                }
+                None => (rest, None),
+            };
+            let (owner, repo) = slug
+                .split_once('/')
+                .filter(|(o, r)| !o.is_empty() && !r.is_empty() && !r.contains('/'))
+                .ok_or_else(|| anyhow::anyhow!("expected gh:owner/repo, got {input:?}"))?;
+            Ok(PluginSource::Github {
+                owner: owner.to_string(),
+                repo: repo.to_string(),
+                reference,
+            })
+        } else {
+            Ok(PluginSource::Local(PathBuf::from(input)))
+        }
+    }
+
+    /// The canonical source string persisted in config and the lockfile. For
+    /// GitHub this drops the `@ref` (the ref is recorded separately); for a
+    /// local source it is the path.
+    pub fn slug(&self) -> String {
+        match self {
+            PluginSource::Github { owner, repo, .. } => format!("gh:{owner}/{repo}"),
+            PluginSource::Local(path) => path.display().to_string(),
+        }
+    }
+
+    /// The requested git ref, if any. Always `None` for a local source.
+    pub fn reference(&self) -> Option<&str> {
+        match self {
+            PluginSource::Github { reference, .. } => reference.as_deref(),
+            PluginSource::Local(_) => None,
+        }
+    }
+
+    /// The `https://github.com/owner/repo.git` clone URL for a GitHub source.
+    pub fn github_clone_url(&self) -> Option<String> {
+        match self {
+            PluginSource::Github { owner, repo, .. } => {
+                Some(format!("https://github.com/{owner}/{repo}.git"))
+            }
+            PluginSource::Local(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_github_with_and_without_ref() {
+        let s = PluginSource::parse("gh:acme/widget").unwrap();
+        assert_eq!(
+            s,
+            PluginSource::Github {
+                owner: "acme".into(),
+                repo: "widget".into(),
+                reference: None
+            }
+        );
+        assert_eq!(s.slug(), "gh:acme/widget");
+        assert_eq!(s.reference(), None);
+
+        let s = PluginSource::parse("gh:acme/widget@v1.2.3").unwrap();
+        assert_eq!(s.reference(), Some("v1.2.3"));
+        assert_eq!(s.slug(), "gh:acme/widget");
+        assert_eq!(
+            s.github_clone_url().as_deref(),
+            Some("https://github.com/acme/widget.git")
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_github() {
+        for bad in [
+            "gh:",
+            "gh:acme",
+            "gh:acme/",
+            "gh:/widget",
+            "gh:a/b/c",
+            "gh:acme/widget@",
+        ] {
+            assert!(
+                PluginSource::parse(bad).is_err(),
+                "{bad} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn treats_non_gh_as_local_path() {
+        let s = PluginSource::parse("/tmp/my-plugin").unwrap();
+        assert_eq!(s, PluginSource::Local(PathBuf::from("/tmp/my-plugin")));
+        assert_eq!(s.reference(), None);
+        assert_eq!(s.github_clone_url(), None);
+    }
+}

--- a/src/plugin/source.rs
+++ b/src/plugin/source.rs
@@ -73,11 +73,16 @@ impl PluginSource {
         }
     }
 
-    /// The `https://github.com/owner/repo.git` clone URL for a GitHub source.
+    /// The clone URL for a GitHub source. The host base defaults to
+    /// `https://github.com` and is overridable via `AOE_GITHUB_CLONE_BASE` (a
+    /// GitHub Enterprise host, or a local path/`file://` base in tests).
     pub fn github_clone_url(&self) -> Option<String> {
         match self {
             PluginSource::Github { owner, repo, .. } => {
-                Some(format!("https://github.com/{owner}/{repo}.git"))
+                let base = std::env::var("AOE_GITHUB_CLONE_BASE")
+                    .unwrap_or_else(|_| "https://github.com".to_string());
+                let base = base.trim_end_matches('/');
+                Some(format!("{base}/{owner}/{repo}.git"))
             }
             PluginSource::Local(_) => None,
         }

--- a/src/plugin/view.rs
+++ b/src/plugin/view.rs
@@ -16,9 +16,19 @@ pub struct PluginView {
     pub version: String,
     pub description: String,
     pub enabled: bool,
-    /// First-party builtin (always true in the current core; installed plugins
-    /// return in a follow-up).
+    /// First-party builtin (compiled in) versus an externally installed plugin.
     pub builtin: bool,
+    /// `builtin` or `community`.
+    pub trust: String,
+    /// Install source for an external plugin (`gh:owner/repo` or a path).
+    pub source: Option<String>,
+    /// Capabilities the plugin's manifest declares.
+    pub capabilities: Vec<String>,
+    /// Whether the user's grant covers the installed manifest (always true for
+    /// builtins).
+    pub granted: bool,
+    /// Installed but inactive: a community plugin awaiting capability approval.
+    pub needs_reapproval: bool,
 }
 
 impl LoadedPlugin {
@@ -30,7 +40,17 @@ impl LoadedPlugin {
             version: self.manifest.version.clone(),
             description: self.manifest.description.clone(),
             enabled: self.enabled,
-            builtin: true,
+            builtin: self.builtin(),
+            trust: self.trust.as_str().to_string(),
+            source: self.source.clone(),
+            capabilities: self
+                .manifest
+                .capabilities
+                .iter()
+                .map(|c| c.as_str().to_string())
+                .collect(),
+            granted: self.granted,
+            needs_reapproval: self.needs_reapproval(),
         }
     }
 }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -96,8 +96,9 @@ pub struct Config {
     pub plugins: std::collections::BTreeMap<String, PluginConfig>,
 }
 
-/// Configuration for one bundled plugin: whether it is enabled, plus its
-/// schema-free persisted settings.
+/// Configuration for one plugin: whether it is enabled, its install source and
+/// capability grant (external plugins only), plus its schema-free persisted
+/// settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginConfig {
     /// Whether the plugin is active. A disabled plugin contributes nothing to
@@ -105,14 +106,41 @@ pub struct PluginConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
+    /// Install source for an external plugin: a `gh:owner/repo[@ref]` slug or a
+    /// local path. Absent for builtins, which are compiled in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
     /// The plugin's persisted settings (`[plugins."<id>".settings]`). Kept as
     /// an opaque `toml::Table` so values survive on disk even while the plugin
     /// is disabled; the typed schema that validates and renders them lands
-    /// with Tier 0 registries (#2094). Declared after `enabled` so the scalar
-    /// reads above the nested table; the toml serializer emits scalars before
-    /// subtables regardless, so the order is for readability. Empty is omitted.
+    /// with Tier 0 registries (#2094). The toml serializer emits scalars before
+    /// subtables regardless, so field order here is for readability. Empty is
+    /// omitted.
     #[serde(default, skip_serializing_if = "toml::Table::is_empty")]
     pub settings: toml::Table,
+
+    /// The capability grant the user approved for an external plugin, pinned to
+    /// the manifest hash it was approved against. Absent until granted;
+    /// builtins are auto-granted and never store one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grant: Option<CapabilityGrant>,
+}
+
+/// A user's approval of an external plugin's requested capabilities, pinned to
+/// the exact manifest it was approved against. When the installed manifest hash
+/// later differs (an update that changed the capability set), the grant no
+/// longer applies and the plugin's runtime contributions stay inactive until
+/// re-approved.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilityGrant {
+    /// `sha256:<hex>` of the manifest bytes this grant was approved against.
+    pub manifest_hash: String,
+    /// The capabilities the user approved.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    /// When the user approved the grant.
+    pub granted_at: chrono::DateTime<chrono::Utc>,
 }
 
 fn default_enabled() -> bool {
@@ -123,7 +151,9 @@ impl Default for PluginConfig {
     fn default() -> Self {
         Self {
             enabled: default_enabled(),
+            source: None,
             settings: toml::Table::new(),
+            grant: None,
         }
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -34,10 +34,10 @@ pub use crate::status_hooks::StatusHookConfig;
 pub(crate) use capture::is_valid_session_id;
 pub use config::{
     get_telemetry_settings, get_update_settings, load_config, save_config,
-    validate_snooze_duration, ClickAction, Config, ContainerRuntimeName, DefaultTerminalMode,
-    GroupByMode, NewSessionAttachMode, PluginConfig, RowTagMode, SandboxConfig, SessionConfig,
-    TelemetryConfig, ThemeConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode,
-    UpdatesConfig, VolumeIgnoresStrategy, WorktreeConfig,
+    validate_snooze_duration, CapabilityGrant, ClickAction, Config, ContainerRuntimeName,
+    DefaultTerminalMode, GroupByMode, NewSessionAttachMode, PluginConfig, RowTagMode,
+    SandboxConfig, SessionConfig, TelemetryConfig, ThemeConfig, TmuxClipboardMode, TmuxMouseMode,
+    TmuxStatusBarMode, UpdatesConfig, VolumeIgnoresStrategy, WorktreeConfig,
 };
 pub(crate) use environment::user_shell;
 pub use environment::{validate_env_entries, validate_env_entry};

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -1,7 +1,8 @@
-//! Plugin manager: list builtin plugins and enable/disable them from the TUI.
-//! The TUI twin of `aoe plugin list` and the web Plugins tab. This is the
-//! minimal core: a browse list with an enable/disable toggle. Install, update,
-//! uninstall, discovery, and capability approval return in follow-up PRs.
+//! Plugin manager: list plugins (builtin and external) with their trust and
+//! enabled/approval state, and enable/disable them from the TUI. The TUI twin
+//! of `aoe plugin list` and the web Plugins tab. Installing, updating, and
+//! capability approval are CLI-driven (`aoe plugin install`); the TUI shows the
+//! resulting state but does not perform installs.
 
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::prelude::*;
@@ -174,17 +175,23 @@ impl PluginManagerDialog {
             .rows
             .iter()
             .map(|row| {
-                let state = if row.enabled {
-                    ("enabled", theme.running)
-                } else {
+                let state = if !row.enabled {
                     ("disabled", theme.dimmed)
+                } else if row.needs_reapproval {
+                    ("needs approval", theme.error)
+                } else {
+                    ("enabled", theme.running)
                 };
                 let spans = vec![
                     Span::styled(
                         format!("{:<28}", format!("{} v{}", row.name, row.version)),
                         Style::default().fg(theme.text),
                     ),
-                    Span::styled(format!("{:<12}", state.0), Style::default().fg(state.1)),
+                    Span::styled(
+                        format!("{:<10}", row.trust),
+                        Style::default().fg(theme.dimmed),
+                    ),
+                    Span::styled(format!("{:<14}", state.0), Style::default().fg(state.1)),
                 ];
                 ListItem::new(Line::from(spans))
             })

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -178,7 +178,9 @@ impl PluginManagerDialog {
                 let state = if !row.enabled {
                     ("disabled", theme.dimmed)
                 } else if row.needs_reapproval {
-                    ("needs approval", theme.error)
+                    // Waiting on the user to re-approve, not failed: use the
+                    // attention-needed color, not the error color.
+                    ("needs approval", theme.waiting)
                 } else {
                     ("enabled", theme.running)
                 };

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -1,0 +1,300 @@
+//! External plugin install / update / uninstall, exercised in-process against
+//! the library with an isolated app dir. Hermetic: GitHub sources clone a local
+//! bare repo via `AOE_GITHUB_CLONE_BASE` and release assets come from a local
+//! axum fixture via `AOE_UPDATE_API_BASE`. Never touches the network.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use agent_of_empires::plugin::install;
+use agent_of_empires::plugin::lockfile::Lockfile;
+use agent_of_empires::plugin::registry::PluginRegistry;
+use agent_of_empires::session::Config;
+use serial_test::serial;
+use tempfile::TempDir;
+
+/// Isolate the app dir under a fresh temp HOME for the duration of a test.
+fn isolate() -> TempDir {
+    let home = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("HOME", home.path());
+    std::env::set_var("XDG_CONFIG_HOME", home.path().join(".config"));
+    home
+}
+
+fn write_plugin_dir(parent: &Path, manifest: &str) -> PathBuf {
+    let dir = parent.join("src-plugin");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("aoe-plugin.toml"), manifest).unwrap();
+    dir
+}
+
+fn load_registry() -> PluginRegistry {
+    PluginRegistry::load(&Config::load().expect("config"))
+}
+
+fn git(args: &[&str], cwd: &Path) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+/// Build a bare repo at `<base>/<owner>/<repo>.git` whose tree contains the
+/// given files, and point `AOE_GITHUB_CLONE_BASE` at `<base>`.
+fn make_bare_repo(base: &Path, owner: &str, repo: &str, files: &[(&str, &str)]) {
+    let work = base.join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    git(&["init", "-q", "-b", "main"], &work);
+    git(&["config", "user.email", "t@t.test"], &work);
+    git(&["config", "user.name", "Test"], &work);
+    for (name, contents) in files {
+        std::fs::write(work.join(name), contents).unwrap();
+    }
+    git(&["add", "."], &work);
+    git(&["commit", "-q", "-m", "init"], &work);
+
+    let bare = base.join(owner).join(format!("{repo}.git"));
+    std::fs::create_dir_all(bare.parent().unwrap()).unwrap();
+    git(
+        &[
+            "clone",
+            "-q",
+            "--bare",
+            work.to_str().unwrap(),
+            bare.to_str().unwrap(),
+        ],
+        base,
+    );
+    std::env::set_var("AOE_GITHUB_CLONE_BASE", base);
+}
+
+#[tokio::test]
+#[serial]
+async fn local_install_lists_and_uninstalls() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.local"
+name = "Local"
+version = "0.1.0"
+api_version = 2
+"#,
+    );
+
+    let report = install::install(dir.to_str().unwrap(), true).await.unwrap();
+    assert_eq!(report.id, "acme.local");
+    assert!(report.granted);
+
+    let reg = load_registry();
+    let plugin = reg.get("acme.local").expect("installed plugin loads");
+    assert!(!plugin.builtin());
+    assert!(
+        plugin.active(),
+        "no-capability community plugin is active once installed"
+    );
+    assert_eq!(plugin.trust.as_str(), "community");
+    assert!(Lockfile::load().unwrap().get("acme.local").is_some());
+
+    install::uninstall("acme.local").unwrap();
+    assert!(load_registry().get("acme.local").is_none());
+    assert!(Lockfile::load().unwrap().get("acme.local").is_none());
+}
+
+#[tokio::test]
+#[serial]
+async fn reserved_namespace_is_rejected() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "aoe.evil"
+name = "Evil"
+version = "0.1.0"
+api_version = 2
+"#,
+    );
+    let err = install::install(dir.to_str().unwrap(), true)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("reserved namespace"), "got: {err}");
+}
+
+#[tokio::test]
+#[serial]
+async fn unknown_capability_is_rejected() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.future"
+name = "Future"
+version = "0.1.0"
+api_version = 2
+capabilities = ["totally.unknown"]
+"#,
+    );
+    let err = install::install(dir.to_str().unwrap(), true)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("does not support"), "got: {err}");
+}
+
+#[tokio::test]
+#[serial]
+async fn grant_is_pinned_to_manifest_hash() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.caps"
+name = "Caps"
+version = "0.1.0"
+api_version = 2
+capabilities = ["net"]
+"#,
+    );
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+    assert!(load_registry().get("acme.caps").unwrap().active());
+
+    // Tamper with the installed manifest so its hash changes; the grant no
+    // longer covers it, so the plugin deactivates and needs re-approval.
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.caps")
+        .join("aoe-plugin.toml");
+    let mut text = std::fs::read_to_string(&installed).unwrap();
+    text.push_str("\n# tampered\n");
+    std::fs::write(&installed, text).unwrap();
+
+    let reg = load_registry();
+    let plugin = reg.get("acme.caps").unwrap();
+    assert!(!plugin.active(), "stale grant must deactivate the plugin");
+    assert!(plugin.needs_reapproval());
+}
+
+#[tokio::test]
+#[serial]
+async fn github_source_clones_and_records_commit() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "widget",
+        &[(
+            "aoe-plugin.toml",
+            r#"
+id = "acme.widget"
+name = "Widget"
+version = "1.0.0"
+api_version = 2
+"#,
+        )],
+    );
+
+    let report = install::install("gh:acme/widget", true).await.unwrap();
+    assert_eq!(report.id, "acme.widget");
+
+    let lock = Lockfile::load().unwrap();
+    let locked = lock.get("acme.widget").expect("lock entry");
+    assert_eq!(locked.source, "gh:acme/widget");
+    assert!(
+        locked
+            .resolved_commit
+            .as_deref()
+            .is_some_and(|c| c.len() >= 7),
+        "resolved commit recorded: {:?}",
+        locked.resolved_commit
+    );
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn release_binary_is_downloaded_and_placed() {
+    let _home = isolate();
+
+    let asset_name = format!("bin-{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+
+    // Fake GitHub API + asset download server.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let release_json = format!(
+        r#"{{"tag_name":"v1.0.0","assets":[{{"name":"{asset_name}","browser_download_url":"{base_url}/dl"}}]}}"#
+    );
+    let app = axum::Router::new()
+        .route(
+            "/repos/acme/bin/releases/latest",
+            axum::routing::get(move || {
+                let body = release_json.clone();
+                async move {
+                    (
+                        [(axum::http::header::CONTENT_TYPE, "application/json")],
+                        body,
+                    )
+                }
+            }),
+        )
+        .route(
+            "/dl",
+            axum::routing::get(|| async { b"#!/bin/sh\necho hi\n".to_vec() }),
+        );
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    std::env::set_var("AOE_UPDATE_API_BASE", &base_url);
+
+    let base = tempfile::tempdir().unwrap();
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "bin",
+        &[(
+            "aoe-plugin.toml",
+            r#"
+id = "acme.bin"
+name = "Bin"
+version = "1.0.0"
+api_version = 2
+
+[runtime]
+kind = "release-binary"
+asset = "bin-${os}-${arch}"
+"#,
+        )],
+    );
+
+    install::install("gh:acme/bin", true).await.unwrap();
+
+    let placed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.bin")
+        .join(&asset_name);
+    assert!(
+        placed.exists(),
+        "release binary placed at {}",
+        placed.display()
+    );
+
+    let lock = Lockfile::load().unwrap();
+    let locked = lock.get("acme.bin").unwrap();
+    assert_eq!(locked.release_tag.as_deref(), Some("v1.0.0"));
+    assert_eq!(locked.asset_name.as_deref(), Some(asset_name.as_str()));
+    assert!(locked
+        .asset_sha256
+        .as_deref()
+        .is_some_and(|h| h.starts_with("sha256:")));
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+    std::env::remove_var("AOE_UPDATE_API_BASE");
+    server.abort();
+}

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -4,7 +4,9 @@ import { fetchPlugins, setPluginEnabled, type PluginListResponse, type PluginVie
 import { reportInfo } from "../../lib/toastBus";
 
 /// Plugin management: list every known plugin (name, version, description,
-/// enabled state) and toggle it on or off. The toggle POSTs to
+/// trust level, capabilities, and enabled / approval state) and toggle it on or
+/// off. Installing and capability approval are CLI-driven (`aoe plugin
+/// install`); this panel shows the resulting state. The toggle POSTs to
 /// `/api/plugins/{id}/enabled`; it is a host mutation, so it needs read-write
 /// mode and (when login is enabled) an elevated session. A `403
 /// elevation_required` response pops the global passphrase prompt via the
@@ -93,13 +95,33 @@ export function PluginsSettings() {
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="font-medium">{plugin.name}</span>
                   <span className="text-xs text-text-dim">v{plugin.version}</span>
-                  {plugin.builtin && (
-                    <span className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500">
-                      builtin
+                  <span
+                    className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500"
+                    data-testid={`plugin-trust-${plugin.id}`}
+                  >
+                    {plugin.trust}
+                  </span>
+                  {plugin.needs_reapproval && (
+                    <span
+                      className="rounded bg-status-warning/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-status-warning"
+                      data-testid={`plugin-needs-approval-${plugin.id}`}
+                    >
+                      needs approval
                     </span>
                   )}
                 </div>
                 <p className="mt-1 text-xs text-text-dim">{plugin.description}</p>
+                {plugin.capabilities.length > 0 && (
+                  <p className="mt-1 text-[11px] text-text-dim">
+                    Capabilities: {plugin.capabilities.join(", ")}
+                    {plugin.granted ? "" : " (not granted)"}
+                  </p>
+                )}
+                {plugin.needs_reapproval && (
+                  <p className="mt-1 text-[11px] text-status-warning">
+                    Installed but inactive. Re-approve with <code>aoe plugin update {plugin.id}</code>.
+                  </p>
+                )}
               </div>
               <label className="flex shrink-0 items-center gap-1 text-xs">
                 <input

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -37,6 +37,11 @@ function listResponse(overrides: Partial<PluginListResponse> = {}): PluginListRe
         description: "Detects agent session status.",
         enabled: true,
         builtin: true,
+        trust: "builtin",
+        source: null,
+        capabilities: [],
+        granted: true,
+        needs_reapproval: false,
       },
       {
         id: "example.plugin",
@@ -45,6 +50,11 @@ function listResponse(overrides: Partial<PluginListResponse> = {}): PluginListRe
         description: "A community plugin.",
         enabled: false,
         builtin: false,
+        trust: "community",
+        source: "gh:example/plugin",
+        capabilities: ["net"],
+        granted: true,
+        needs_reapproval: false,
       },
     ],
     load_errors: [],
@@ -65,6 +75,34 @@ describe("PluginsSettings", () => {
     await findByText("Agent Status Detection");
     await findByText("v1.1.0");
     await findByText("A community plugin.");
+  });
+
+  it("shows trust badges and a needs-approval state for an ungranted community plugin", async () => {
+    fetchPlugins.mockResolvedValue(
+      listResponse({
+        plugins: [
+          {
+            id: "example.plugin",
+            name: "Example",
+            version: "0.2.0",
+            description: "A community plugin.",
+            enabled: true,
+            builtin: false,
+            trust: "community",
+            source: "gh:example/plugin",
+            capabilities: ["net", "fs.read"],
+            granted: false,
+            needs_reapproval: true,
+          },
+        ],
+      }),
+    );
+    const { findByTestId, getByText } = render(<PluginsSettings />);
+    const trust = await findByTestId("plugin-trust-example.plugin");
+    expect(trust.textContent).toBe("community");
+    await findByTestId("plugin-needs-approval-example.plugin");
+    expect(getByText(/net, fs\.read/)).toBeTruthy();
+    expect(getByText(/not granted/)).toBeTruthy();
   });
 
   it("disable toggle POSTs setPluginEnabled(id, false) and adopts the refreshed list", async () => {
@@ -94,6 +132,11 @@ describe("PluginsSettings", () => {
       description: "The web dashboard.",
       enabled: true,
       builtin: true,
+      trust: "builtin",
+      source: null,
+      capabilities: [],
+      granted: true,
+      needs_reapproval: false,
     };
     fetchPlugins.mockResolvedValue(listResponse({ plugins: [web] }));
     setPluginEnabled.mockResolvedValue({

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -188,6 +188,11 @@ export interface PluginView {
   description: string;
   enabled: boolean;
   builtin: boolean;
+  trust: string;
+  source: string | null;
+  capabilities: string[];
+  granted: boolean;
+  needs_reapproval: boolean;
 }
 
 export interface PluginListResponse {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Third plugins PR (part of #268). The minimal core (#2311) shipped the registry and enable/disable; #2091 added the persisted plugin state. This builds the manifest contribution schema, the capability/grant model, external installation, and the lockfile on top of it.

What lands:

- **Manifest contribution schema.** `aoe-plugin-api` extends `PluginManifest` past identity to the contribution sections the first external plugin (`agent-of-empires/plugin-github`) actually declares: `capabilities`, `commands`, `keybinds`, `settings`, `ui`, and a `runtime` worker entrypoint (`command` or `release-binary`). `API_VERSION` is bumped to 2; an `api_version` 1 manifest still loads. The host parses and validates these; consuming each section is its later issue (#2094 / #2095 / #2366). Per maintainer review, `themes` / `status` / `panes` are deferred so no schema lands ahead of a consumer (#2386); `deny_unknown_fields` makes a manifest declaring one of them a hard parse error.
- **Capabilities and grants.** Static contributions are not capabilities; a capability gates a runtime resource (network, filesystem, process spawn, session/config access, clipboard, notifications). They are open strings, so a follow-up adds one without an `api_version` bump; an unknown capability is rejected at install, never silently granted. A grant is pinned to the `sha256` of the installed manifest; a community plugin is active only while its grant covers the installed manifest. A changed capability set on update re-prompts and leaves the plugin inactive until re-approved.
- **External install / update / uninstall.** `aoe plugin install gh:owner/repo[@ref]` or a local dir installs under `<app_dir>/plugins/<id>/`. A GitHub source is `git clone`d and pinned to the exact commit; a compiled worker shipped as a release asset is downloaded and unpacked for the host platform (dual fetch). Running plugin code is still #2095, so an installed plugin records its grant and files but does not execute yet. `aoe plugin` stays reserved for management (no web install, D4).
- **Trust + lockfile.** Builtins are trusted and auto-granted; external plugins are community and gated. A reserved-namespace (`aoe.*` / `agent-of-empires.*`) or id-colliding external plugin is rejected. `plugins.lock` records each external plugin's resolved commit, manifest hash, trust, and release asset.

List/info show trust and grant state across CLI, TUI, and web. `tar` and `flate2` become unconditional (pure Rust) so install works in a TUI-only build.

Closes #2093

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `cargo run -- plugin list` shows a `TRUST` column (`builtin` for `aoe.web` on a `--features serve` build).
- [ ] Make a local plugin dir with an `aoe-plugin.toml` declaring `capabilities = ["net"]`, run `cargo run -- plugin install ./that-dir`, and confirm it prompts once to grant `net` before installing.
- [ ] `cargo run -- plugin list` then shows the plugin as `community` / `enabled`; `plugin info <id>` shows its capabilities as granted.
- [ ] Append a line to the installed `<app_dir>/plugins/<id>/aoe-plugin.toml`, then `plugin list` shows `needs approval`; `plugin update <id>` re-prompts and re-activates it.
- [ ] `cargo run -- plugin install gh:owner/repo` against a real repo clones it and records a resolved commit in `<app_dir>/plugins.lock`.
- [ ] `cargo run -- plugin install aoe.web` style reserved id (e.g. a local dir whose manifest id is `aoe.x`) is rejected as a reserved namespace.
- [ ] `cargo run -- plugin uninstall <id>` removes the tree, the config entry, and the lockfile entry.
- [ ] In the web dashboard Settings, the Plugins tab shows the trust badge and, for an ungranted community plugin, a "needs approval" state with its capabilities.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

The Plugins panel change is display-only and covered by the existing `settings.plugins` matrix entry; the Vitest contract test (`PluginsSettings.test.tsx`) was extended to assert the trust badge, the needs-approval state, and the capabilities line. No new matrix entry was needed (the existing one maps the changed component).

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

The new CLI surface is covered by hermetic integration tests in `tests/plugin_install.rs` (in-process, never touches the network): local install/list/uninstall, reserved-namespace and unknown-capability rejection, grant pinning to the manifest hash, GitHub install via a local bare repo, and release-binary download via a fake API server.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. The three open design calls (fetch mechanism, lockfile format, capability taxonomy) went through a `/debate` between two models; I made the final calls, including extending it to dual-fetch for compiled-binary plugins. I reviewed each commit and ran the validation.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784925602&installation_id=139138837&pr_number=2375&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2375&signature=6e268694e202bfd74b8e10aaa92083c3ce2d02af6e5b0d0bd227e4f2972a1347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### What changed
- Expanded plugin manifests from “identity only” to include contribution sections: commands, keybinds, settings, themes, UI pieces, status, and panes, plus optional runtime worker metadata.
- Introduced a capability-based approval model for external/community plugins:
  - Plugins declare capabilities in their manifest.
  - Install-time validation rejects unknown capabilities.
  - Grants are pinned to the installed manifest’s content hash, so capability changes on update require re-approval (the plugin can remain installed but inactive).
- Added external plugin lifecycle management via CLI only:
  - `install` from `gh:owner/repo[`@ref`]` or a local directory
  - `update`
  - `uninstall`
- Added reproducibility/audit support with a `plugins.lock` file recording resolved source/version identity, manifest hash, trust level, and (for release-binary plugins) release/asset details including checksums.
- Implemented trust and safety rules:
  - Builtin vs community trust is tracked and shown in views.
  - External plugins are prevented from using reserved `aoe.*` / `agent-of-empires.*` namespaces and are rejected on ID collisions with builtins.
  - Manifest/API version support bumps to API v2 while still handling v1 manifests.
- Updated CLI/TUI/web plugin displays to surface trust, capability lists, whether grants exist, and when a plugin “needs approval” after an update.
- Added robustness improvements for plugin fetching/install (staging, safe extraction/path handling, and release-tag URL encoding) and expanded tests/docs for the new behavior.

### Benefits
- Safer community plugin usage with explicit, user-visible approval and trust status.
- Capability changes can’t silently broaden permissions; updates force re-approval when needed.
- External plugin installs are reproducible and easier to audit/verify thanks to the lockfile and manifest hashing.
- Clearer plugin state across CLI, TUI, and web (granted vs not granted, and re-approval requirements).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
