### PR TITLE
fix(acp): demote premature orphan cancel to prompt_complete on late cost frame

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -890,7 +890,12 @@ impl SilentOrphanWatchdog {
 /// recovery (#2237) deliberately sets NONE of these flags and breaks the
 /// loop, so it falls through to `prompt_complete`: the turn finished, the
 /// adapter just never sent the PromptResponse, so it must NOT collapse
-/// into `prompt_orphaned` (which would trigger a worker restart).
+/// into `prompt_orphaned` (which would trigger a worker restart). Its
+/// post-cancel sibling `finished_after_orphan_cancel` (#2370) covers the
+/// case where the cost marker arrives only AFTER the grace already expired
+/// and the orphan cancel fired: the cancel was premature, so the turn is
+/// demoted back to `prompt_complete` unless the adapter is still wedged on
+/// the RPC (`agent_unresponsive` / `shutdown`), which keeps the restart.
 fn terminal_stop_reason(
     rate_limited: bool,
     force_stopped: bool,
@@ -898,11 +903,24 @@ fn terminal_stop_reason(
     agent_unresponsive: bool,
     shutdown: bool,
     prompt_cancelled: bool,
+    finished_after_orphan_cancel: bool,
 ) -> &'static str {
     if rate_limited {
         "rate_limited"
     } else if force_stopped {
         "user_forced"
+    } else if finished_after_orphan_cancel && !agent_unresponsive && !shutdown {
+        // A cost-populated UsageUpdate that lands after a timer-driven orphan
+        // cancel proves the turn actually finished; the cancel was premature.
+        // End cleanly as prompt_complete (no worker restart, no "didn't notify
+        // the daemon" banner), the post-cancel sibling of the pre-grace #2237
+        // recovery. The cancel makes the adapter resolve as
+        // StopReason::Cancelled, so this must outrank both prompt_orphaned and
+        // prompt_cancelled. A genuinely RPC-wedged adapter (cancel-escalation
+        // grace fired, so agent_unresponsive / shutdown) is excluded here and
+        // still restarts the worker, since the connection may be unusable for
+        // the next prompt. See #2370.
+        "prompt_complete"
     } else if prompt_orphaned {
         "prompt_orphaned"
     } else if agent_unresponsive {
@@ -5749,6 +5767,30 @@ async fn run_connection_task<W, R>(
                         //   - the finished-but-unacked recovery breaks with
                         //     no flag set, falling through to prompt_complete
                         //     so the turn does NOT restart the worker (#2237).
+                        // Apply any lifecycle signal still queued when the loop
+                        // broke. A cost-populated UsageUpdate can land in the
+                        // same tick prompt_fut resolves, so without this drain
+                        // the watchdog state read below could miss it and
+                        // misclassify a finished turn. Mirrors the
+                        // start-of-prompt drain. See #2370.
+                        while let Ok(env) = lifecycle_signal_rx.try_recv() {
+                            if env.epoch == this_prompt_epoch {
+                                watchdog.apply_signal(
+                                    env.signal,
+                                    tokio::time::Instant::now(),
+                                    chrono::Utc::now(),
+                                    watchdog_cfg,
+                                );
+                            }
+                        }
+                        // A cost-populated UsageUpdate after a timer-driven
+                        // orphan cancel proves the turn finished; the cancel was
+                        // premature. terminal_stop_reason demotes it to
+                        // prompt_complete unless the adapter is still RPC-wedged.
+                        // See #2370.
+                        let finished_after_orphan_cancel = orphan_cancel_sent
+                            && watchdog.cost_seen()
+                            && watchdog.off_protocol_work_seen().is_none();
                         let reason = terminal_stop_reason(
                             rate_limited,
                             force_stopped,
@@ -5756,6 +5798,7 @@ async fn run_connection_task<W, R>(
                             agent_unresponsive,
                             shutdown,
                             prompt_cancelled,
+                            finished_after_orphan_cancel,
                         );
                         let _ = event_tx_for_block
                             .send(Event::Stopped {
@@ -6754,7 +6797,7 @@ mod tests {
     #[test]
     fn terminal_stop_reason_all_false_is_prompt_complete() {
         assert_eq!(
-            terminal_stop_reason(false, false, false, false, false, false),
+            terminal_stop_reason(false, false, false, false, false, false, false),
             "prompt_complete"
         );
     }
@@ -6763,22 +6806,55 @@ mod tests {
     fn terminal_stop_reason_precedence_is_preserved() {
         // rate_limited wins over everything.
         assert_eq!(
-            terminal_stop_reason(true, true, true, true, true, true),
+            terminal_stop_reason(true, true, true, true, true, true, true),
             "rate_limited"
         );
         // force_stopped beats a prompt_orphaned flag set earlier.
         assert_eq!(
-            terminal_stop_reason(false, true, true, false, false, false),
+            terminal_stop_reason(false, true, true, false, false, false, false),
             "user_forced"
         );
         // prompt_orphaned (genuine wedge) wins over a later shutdown/cancel.
         assert_eq!(
-            terminal_stop_reason(false, false, true, false, true, false),
+            terminal_stop_reason(false, false, true, false, true, false, false),
             "prompt_orphaned"
         );
         assert_eq!(
-            terminal_stop_reason(false, false, false, false, false, true),
+            terminal_stop_reason(false, false, false, false, false, true, false),
             "cancelled"
+        );
+    }
+
+    #[test]
+    fn terminal_stop_reason_late_cost_demotes_orphan_and_cancelled() {
+        // #2370: the orphan cancel fired on the timer, the adapter then
+        // resolved the prompt as Cancelled (because we cancelled), but a
+        // cost-populated UsageUpdate proved the turn finished. The demotion
+        // must outrank BOTH prompt_orphaned and prompt_cancelled.
+        assert_eq!(
+            terminal_stop_reason(false, false, true, false, false, true, true),
+            "prompt_complete"
+        );
+    }
+
+    #[test]
+    fn terminal_stop_reason_late_cost_does_not_mask_rpc_wedge_or_user_intent() {
+        // #2370: a cost frame proves the model work finished, but if the
+        // adapter is still wedged on the RPC (cancel-escalation grace fired)
+        // the worker connection may be unusable for the next prompt, so the
+        // genuine-wedge restart must survive.
+        assert_eq!(
+            terminal_stop_reason(false, false, true, true, true, true, true),
+            "prompt_orphaned"
+        );
+        // rate_limited and user force_stopped still win over the demotion.
+        assert_eq!(
+            terminal_stop_reason(true, false, true, false, false, true, true),
+            "rate_limited"
+        );
+        assert_eq!(
+            terminal_stop_reason(false, true, true, false, false, true, true),
+            "user_forced"
         );
     }
 
@@ -6999,6 +7075,39 @@ mod tests {
         assert!(!w.should_fire(t0 + std::time::Duration::from_secs(60), cfg));
         // And must eventually fire after the full base grace.
         assert!(w.should_fire(t0 + std::time::Duration::from_secs(125), cfg));
+    }
+
+    #[tokio::test]
+    async fn watchdog_cost_seen_clears_when_progress_resumes() {
+        // #2370: finished_after_orphan_cancel reads cost_seen() directly to
+        // demote a premature orphan cancel. If a cost marker arrives but the
+        // turn then resumes real work, cost_seen() must flip back to false so a
+        // turn that did NOT finish is never demoted to prompt_complete.
+        let cfg = watchdog_test_cfg();
+        let t0 = tokio::time::Instant::now();
+        let wall = chrono::Utc::now();
+        let mut w = SilentOrphanWatchdog::new();
+        w.apply_signal(LifecycleSignal::Progress, t0, wall, cfg);
+        w.apply_signal(
+            LifecycleSignal::TerminalUsage,
+            t0 + std::time::Duration::from_secs(1),
+            wall,
+            cfg,
+        );
+        assert!(
+            w.cost_seen(),
+            "cost marker must be observable after TerminalUsage"
+        );
+        w.apply_signal(
+            LifecycleSignal::Progress,
+            t0 + std::time::Duration::from_secs(2),
+            wall,
+            cfg,
+        );
+        assert!(
+            !w.cost_seen(),
+            "progress after the cost marker means the turn resumed; must not demote"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On large-context structured-view turns, claude-agent-acp's end-of-turn accounting flush can lag the last protocol event by more than the 120s silent-orphan base grace. When that happens the cost-populated `UsageUpdate` (the adapter's end-of-turn marker) arrives a second or two AFTER the watchdog already fired. At fire time `cost_seen()` is still false, so the #2239 cost-marker guard is skipped, the orphan path sends `session/cancel` and latches `prompt_orphaned`, and a turn that actually finished restarts the worker and shows the misleading "Agent finished but didn't notify the daemon" banner.

This fix adds `finished_after_orphan_cancel`. At prompt-loop exit it drains any lifecycle signal still queued (a cost frame can land in the same tick `prompt_fut` resolves), then computes the flag from current watchdog state: `orphan_cancel_sent && cost_seen() && off_protocol_work_seen().is_none()`. `terminal_stop_reason` demotes such a turn to `prompt_complete`, the post-cancel sibling of the pre-grace #2237 recovery. It outranks `prompt_orphaned` and `prompt_cancelled` (our cancel makes the adapter resolve as `Cancelled`), but never `rate_limited` or user `force_stopped`. A genuinely RPC-wedged adapter, where the 10s cancel-escalation grace fires and sets `agent_unresponsive` / `shutdown`, is excluded and still restarts the worker, since the connection may be unusable for the next prompt.

Confirmed against two real occurrences of session `90a0eb5fe9df4635` (release `aoe 1.11.1`): both show `ToolCompleted` then a `cost:null` usage then ~120s of silence then a cost-populated `UsageUpdate` followed 1ms later by `Stopped{prompt_orphaned}` on a turn whose work had completed. With this change both resolve to `prompt_complete` with no restart and no banner.

User-visible impact: successful long turns no longer get killed, relabeled, and restarted when the adapter's wrap-up is slow.

Closes #2370

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run a large-context structured-view turn (heavy enough that claude-agent-acp's end-of-turn accounting takes longer than ~120s after the last tool finishes); confirm the turn ends normally with no "Agent finished but didn't notify the daemon" banner and no worker restart.
- [ ] Confirm a genuinely wedged turn still recovers: a turn that goes silent past the grace and never emits a cost-populated `UsageUpdate` still ends `prompt_orphaned` and restarts the worker.
- [ ] Click Force Stop mid-turn; confirm the turn ends `user_forced` regardless of any late cost frame.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The change is internal to the ACP runner's terminal-reason classification. The decision logic is the pure `terminal_stop_reason` function, covered by unit tests asserting: a late cost frame demotes both `prompt_orphaned` and `prompt_cancelled` to `prompt_complete`; it does NOT mask `agent_unresponsive` / `shutdown` (genuine RPC wedge still restarts) nor `rate_limited` / `force_stopped`; plus a `SilentOrphanWatchdog` test that `cost_seen()` clears when progress resumes so a turn that did not finish is never demoted.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Skipped a test, because: the affected path is the per-prompt silent-orphan watchdog inside the ACP runner. Its decision is exercised by the pure-function and watchdog-state unit tests in `src/acp/acp_client.rs`; reproducing the >120s adapter-flush race end to end is non-deterministic.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult (gpt-5.5 + gemini-3.1-pro) that corrected the precedence placement. I made the design calls, reviewed each commit, and verified the fix against two captured real-session traces.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784956657&installation_id=139138837&pr_number=2378&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2378&signature=ea9729019e223a7e40f04c1406c2f0e6b4db07fd8a99f1d610577bde8bf43358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change fixes a race where a successful prompt could be incorrectly treated as orphaned and restarted if final accounting arrived a little late.

What changed:
- Added a new “finished after orphan cancel” recovery path.
- Waits to drain any late lifecycle signals before deciding the final stop reason.
- If the turn actually finished and a cost marker arrived late, the result now stays as `prompt_complete` instead of being mislabeled as `prompt_orphaned` or `prompt_cancelled`.
- Keeps force-stop, rate-limit, and real wedge/restart behavior unchanged.

Tests added/updated:
- Late cost frame now resolves to `prompt_complete`.
- Missing cost frame still resolves to `prompt_orphaned`.
- Force stop still wins as `user_forced`.
- Watchdog behavior was tightened so progress resets the cost-seen state as expected.

Benefits:
- Prevents unnecessary worker restarts.
- Removes misleading “finished but didn’t notify” failures for successful turns.
- Preserves recovery for genuinely stuck sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->